### PR TITLE
[BugFix] Distinguish materialized view refreshed partitions are empty or cannot be rewritten

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -794,8 +794,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             result.addAll(getUpdatedPartitionNamesOfOlapTable(olapBaseTable, isQueryRewrite));
 
             if (withMv && baseTable.isMaterializedView()) {
-                Set<String> partitionNames = ((MaterializedView) baseTable).getPartitionNamesToRefreshForMv(isQueryRewrite);
-                result.addAll(partitionNames);
+                ((MaterializedView) baseTable).getPartitionNamesToRefreshForMv(result, isQueryRewrite);
             }
             return result;
         } else {
@@ -1225,10 +1224,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      *                    the update check.
      * @return          : Collect all need refreshed partitions of materialized view.
      */
-    public Set<String> getPartitionNamesToRefreshForMv(boolean isQueryRewrite) {
+    public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions,
+                                                   boolean isQueryRewrite) {
         // Skip check for sync materialized view.
         if (refreshScheme.isSync()) {
-            return Sets.newHashSet();
+            return true;
         }
 
         // check mv's query rewrite consistency mode property only in query rewrite.
@@ -1237,9 +1237,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     = tableProperty.getQueryRewriteConsistencyMode();
             switch (mvConsistencyRewriteMode) {
                 case DISABLE:
-                    return getVisiblePartitionNames();
+                    return false;
                 case LOOSE:
-                    return Sets.newHashSet();
+                    return true;
                 case CHECKED:
                 default:
                     break;
@@ -1247,13 +1247,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
 
         if (partitionInfo instanceof SinglePartitionInfo) {
-            return getNonPartitionedMVRefreshPartitions(isQueryRewrite);
+            return getNonPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
         } else if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             // partitions to refresh
             // 1. dropped partitions
             // 2. newly added partitions
             // 3. partitions loaded with new data
-            return getPartitionedMVRefreshPartitions(isQueryRewrite);
+            return getPartitionedMVRefreshPartitions(toRefreshPartitions, isQueryRewrite);
         } else {
             throw UnsupportedException.unsupportedException("unsupported partition info type:"
                     + partitionInfo.getClass().getName());
@@ -1265,7 +1265,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * materialized view's totally.
      * @return : non-partitioned materialized view's all need updated partition names.
      */
-    private Set<String> getNonPartitionedMVRefreshPartitions(boolean isQueryRewrite) {
+    private boolean getNonPartitionedMVRefreshPartitions(Set<String> toRefreshPartitions,
+                                                         boolean isQueryRewrite) {
         Preconditions.checkState(partitionInfo instanceof SinglePartitionInfo);
         for (BaseTableInfo tableInfo : baseTableInfos) {
             Table table = tableInfo.getTable();
@@ -1277,7 +1278,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             // skip check external table if the external does not support rewrite.
             if (!table.isNativeTableOrMaterializedView()) {
                 if (tableProperty.getForceExternalTableQueryRewrite() == TableProperty.QueryRewriteConsistencyMode.DISABLE) {
-                    return getVisiblePartitionNames();
+                    toRefreshPartitions.addAll(getVisiblePartitionNames());
+                    return false;
                 }
             }
 
@@ -1285,10 +1287,11 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             Set<String> partitionNames = getUpdatedPartitionNamesOfTable(
                     table, true, isQueryRewrite, MaterializedView.getPartitionExpr(this));
             if (CollectionUtils.isNotEmpty(partitionNames)) {
-                return getVisiblePartitionNames();
+                toRefreshPartitions.addAll(getVisiblePartitionNames());
+                return true;
             }
         }
-        return Sets.newHashSet();
+        return true;
     }
 
     /**
@@ -1310,7 +1313,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      *
      * @return : partitioned materialized view's all need updated partition names.
      */
-    private Set<String> getPartitionedMVRefreshPartitions(boolean isQueryRewrite) {
+    private boolean getPartitionedMVRefreshPartitions(Set<String> toRefreshedPartitioins,
+                                                      boolean isQueryRewrite) {
         Preconditions.checkState(partitionInfo instanceof ExpressionRangePartitionInfo);
         // If non-partition-by table has changed, should refresh all mv partitions
         Expr partitionExpr = getPartitionRefTableExprs().get(0);
@@ -1333,7 +1337,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             // skip check external table if the external does not support rewrite.
             if (!baseTable.isNativeTableOrMaterializedView()) {
                 if (tableProperty.getForceExternalTableQueryRewrite() == TableProperty.QueryRewriteConsistencyMode.DISABLE) {
-                    return getVisiblePartitionNames();
+                    toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                    return false;
                 }
             }
             if (baseTable.getTableIdentifier().equals(refBaseTable.getTableIdentifier())) {
@@ -1342,7 +1347,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             // If the non ref table has already changed, need refresh all materialized views' partitions.
             Set<String> partitionNames = getUpdatedPartitionNamesOfTable(baseTable, true, isQueryRewrite, partitionExpr);
             if (CollectionUtils.isNotEmpty(partitionNames)) {
-                return getVisiblePartitionNames();
+                toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                return true;
             }
         }
 
@@ -1355,7 +1361,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             basePartitionNameToRangeMap = PartitionUtil.getPartitionKeyRange(refBaseTable, refBasePartitionCol, partitionExpr);
         } catch (UserException e) {
             LOG.warn("Materialized view compute partition difference with base table failed.", e);
-            return getVisiblePartitionNames();
+            toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+            return false;
         }
 
         Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = getRangePartitionMap();
@@ -1383,7 +1390,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         Set<String> baseChangedPartitionNames =
                 getUpdatedPartitionNamesOfTable(refBaseTable, true, isQueryRewrite, partitionExpr);
         if (baseChangedPartitionNames == null) {
-            return mvToBaseNameRef.keySet();
+            toRefreshedPartitioins.addAll(mvToBaseNameRef.keySet());
+            return true;
         }
 
         if (partitionExpr instanceof SlotRef) {
@@ -1395,7 +1403,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
                     baseToMvNameRef, mvToBaseNameRef);
         }
-        return needRefreshMvPartitionNames;
+        toRefreshedPartitioins.addAll(needRefreshMvPartitionNames);
+        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -241,7 +241,12 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        Set<String> partitionNamesToRefresh = mv.getPartitionNamesToRefreshForMv(true);
+        Set<String> partitionNamesToRefresh = Sets.newHashSet();
+        if (!mv.getPartitionNamesToRefreshForMv(partitionNamesToRefresh, true)) {
+            logMVPrepare(connectContext, mv, "[SYNC={}] MV {} cannot be used for rewrite, " +
+                    "stale partitions {}", isSyncMV, mv.getName(), partitionNamesToRefresh);
+            return;
+        }
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (partitionInfo instanceof SinglePartitionInfo) {
             if (!partitionNamesToRefresh.isEmpty()) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -164,25 +164,31 @@ public class RefreshMaterializedViewTest {
         cluster.runSql(dbName, String.format("refresh materialized view %s with sync mode", mvName));
     }
 
+    public Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {
+        Set<String> toRefreshPartitions = Sets.newHashSet();
+        mv.getPartitionNamesToRefreshForMv(toRefreshPartitions, true);
+        return toRefreshPartitions;
+    }
+
     @Test
     public void testRefreshExecution() throws Exception {
         cluster.runSql("test", "insert into tbl_with_mv values(\"2022-02-20\", 1, 10)");
         refreshMaterializedView("test", "mv_to_refresh");
         MaterializedView mv1 = getMv("test", "mv_to_refresh");
-        Set<String> partitionsToRefresh1 = mv1.getPartitionNamesToRefreshForMv(true);
+        Set<String> partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv1);
         Assert.assertTrue(partitionsToRefresh1.isEmpty());
         refreshMaterializedView("test", "mv2_to_refresh");
         MaterializedView mv2 = getMv("test", "mv2_to_refresh");
-        Set<String> partitionsToRefresh2 = mv2.getPartitionNamesToRefreshForMv(true);
+        Set<String> partitionsToRefresh2 = getPartitionNamesToRefreshForMv(mv2);
         Assert.assertTrue(partitionsToRefresh2.isEmpty());
         cluster.runSql("test", "insert into tbl_with_mv partition(p2) values(\"2022-02-20\", 2, 10)");
         OlapTable table = (OlapTable) getTable("test", "tbl_with_mv");
         Partition p1 = table.getPartition("p1");
         Partition p2 = table.getPartition("p2");
         if (p2.getVisibleVersion() == 3) {
-            partitionsToRefresh1 = mv1.getPartitionNamesToRefreshForMv(true);
+            partitionsToRefresh1 = getPartitionNamesToRefreshForMv(mv1);
             Assert.assertEquals(Sets.newHashSet("mv_to_refresh"), partitionsToRefresh1);
-            partitionsToRefresh2 = mv2.getPartitionNamesToRefreshForMv(true);
+            partitionsToRefresh2 = getPartitionNamesToRefreshForMv(mv2);
             Assert.assertTrue(partitionsToRefresh2.contains("p2"));
         } else {
             // publish version is async, so version update may be late
@@ -237,26 +243,29 @@ public class RefreshMaterializedViewTest {
         cluster.runSql("test", "insert into tbl_staleness1 values(\"2022-02-20\", 1, 10)");
         {
             MaterializedView mv1 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv(true);
-            Assert.assertTrue(partitionsToRefresh.isEmpty());
-
+            checkToRefreshPartitionsEmpty(mv1);
         }
+
         // no refresh partitions if there is no new data.
         {
             refreshMaterializedView("test", "mv_with_mv_rewrite_staleness");
             MaterializedView mv2 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv(true);
-            Assert.assertTrue(partitionsToRefresh.isEmpty());
+            checkToRefreshPartitionsEmpty(mv2);
         }
         // no refresh partitions if there is new data & no refresh but is set `mv_rewrite_staleness`.
         {
             cluster.runSql("test", "insert into tbl_staleness1 values(\"2022-02-22\", 1, 10)");
             MaterializedView mv1 = getMv("test", "mv_with_mv_rewrite_staleness");
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv(true);
-            Assert.assertTrue(partitionsToRefresh.isEmpty());
+            checkToRefreshPartitionsEmpty(mv1);
         }
         starRocksAssert.dropTable("tbl_staleness1");
         starRocksAssert.dropMaterializedView("mv_with_mv_rewrite_staleness");
+    }
+
+    private void checkToRefreshPartitionsEmpty(MaterializedView mv) {
+        Set<String> partitionsToRefresh = Sets.newHashSet();
+        Assert.assertTrue(mv.getPartitionNamesToRefreshForMv(partitionsToRefresh, true));
+        Assert.assertTrue(partitionsToRefresh.isEmpty());
     }
 
     @Test
@@ -324,7 +333,7 @@ public class RefreshMaterializedViewTest {
             Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
             Assert.assertTrue(mv1.isStalenessSatisfied());
 
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv(true);
+            Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv1);
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropTable("tbl_staleness2");
@@ -422,7 +431,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
                 Assert.assertTrue(mv1.isStalenessSatisfied());
 
-                Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv(true);
+                Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv1);
                 Assert.assertTrue(partitionsToRefresh.isEmpty());
             }
             {
@@ -443,7 +452,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertTrue((tblMaxPartitionRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
                 Assert.assertTrue(mv2.isStalenessSatisfied());
 
-                Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv(true);
+                Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv2);
                 Assert.assertTrue(partitionsToRefresh.isEmpty());
             }
         }
@@ -468,7 +477,7 @@ public class RefreshMaterializedViewTest {
                 Assert.assertFalse(mv1.isStalenessSatisfied());
                 Assert.assertFalse(mv2.maxBaseTableRefreshTimestamp().isPresent());
 
-                Set<String> partitionsToRefresh = mv2.getPartitionNamesToRefreshForMv(true);
+                Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv2);
                 Assert.assertFalse(partitionsToRefresh.isEmpty());
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -69,8 +69,9 @@ public class MaterializedViewTestBase extends PlanTestBase {
 
         new MockUp<MaterializedView>() {
             @Mock
-            Set<String> getPartitionNamesToRefreshForMv(boolean isQueryRewrite) {
-                return Sets.newHashSet();
+            public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions,
+                                                           boolean isQueryRewrite) {
+                return true;
             }
         };
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -231,7 +231,6 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
                     "WHERE l_shipdate = '1998-01-01' GROUP BY `l_orderkey`, `l_suppkey`;";
 
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertNotContains(plan, "AGGREGATE");
             PlanTestBase.assertContains(plan, "partitions=1/6\n" +
                     "     rollup: hive_partition_prune_mv1");
@@ -242,7 +241,6 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
                     "WHERE l_shipdate = '1998-01-01' and l_orderkey=1 GROUP BY `l_suppkey`;";
 
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertNotContains(plan, "AGGREGATE");
             PlanTestBase.assertContains(plan, "PREDICATES: 18: l_orderkey = 1\n" +
                     "     partitions=1/6\n" +
@@ -253,7 +251,6 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
             String query = "SELECT l_suppkey, sum(l_orderkey)  FROM `hive0`.`partitioned_db`.`lineitem_par` " +
                     "WHERE l_orderkey>1 GROUP BY `l_suppkey`;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, "1:AGGREGATE (update serialize)\n" +
                             "  |  STREAMING\n" +
                             "  |  output: sum(21: sum(l_orderkey))\n" +
@@ -263,5 +260,89 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
                     "     rollup: hive_partition_prune_mv1");
         }
         starRocksAssert.dropMaterializedView("hive_partition_prune_mv1");
+    }
+
+    @Test
+    public void testHiveEmptyMV_UnPartitioned_NotRewritten() throws Exception {
+                starRocksAssert.withMaterializedView("create materialized view hive_empty_mv " +
+                        " distributed by hash(s_suppkey) " +
+                        " refresh deferred manual  " +
+                        "PROPERTIES (\n" +
+                        "\"force_external_table_query_rewrite\" = \"false\"\n" +
+                        ") " +
+                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5");
+        // mv is not refreshed, even mv has no partitions, it should not be rewritten.
+        String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertNotContains(plan, "hive_empty_mv");
+        dropMv("test", "hive_empty_mv");
+    }
+
+    @Test
+    public void testHiveEmptyMV_UnPartitioned_Rewritten() throws Exception {
+        starRocksAssert.withMaterializedView("create materialized view hive_empty_mv " +
+                " distributed by hash(s_suppkey) " +
+                " refresh deferred manual  " +
+                "PROPERTIES (\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ") " +
+                " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5");
+        refreshMaterializedView("test", "hive_empty_mv");
+
+        // mv is not refreshed, even mv has no partitions, it should not be rewritten.
+        String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan, "hive_empty_mv");
+        dropMv("test", "hive_empty_mv");
+    }
+
+    @Test
+    public void testHiveEmptyMV_Partitioned_NotRewritten() throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `hive_partitioned_mv`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "PARTITION BY (`l_shipdate`)\n" +
+                        "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"force_external_table_query_rewrite\" = \"false\"" +
+                        ")\n" +
+                        "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
+                        "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
+                        "GROUP BY " +
+                        "`l_orderkey`, `l_suppkey`, `l_shipdate`;");
+        // mv is not refreshed, even mv has no partitions, it should not be rewritten.
+        String query1 = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
+                "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
+                "GROUP BY " +
+                "`l_orderkey`, `l_suppkey`, `l_shipdate`;";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertNotContains(plan, "hive_partitioned_mv");
+        dropMv("test", "hive_partitioned_mv");
+    }
+
+    @Test
+    public void testHiveEmptyMV_Partitioned_Rewritten() throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `hive_partitioned_mv`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "PARTITION BY (`l_shipdate`)\n" +
+                "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"" +
+                ")\n" +
+                "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
+                "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
+                "GROUP BY " +
+                "`l_orderkey`, `l_suppkey`, `l_shipdate`;");
+        refreshMaterializedView("test", "hive_partitioned_mv");
+        String query1 = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
+                "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
+                "GROUP BY " +
+                "`l_orderkey`, `l_suppkey`, `l_shipdate`;";
+        String plan = getFragmentPlan(query1);
+        PlanTestBase.assertContains(plan, "hive_partitioned_mv");
+        dropMv("test", "hive_partitioned_mv");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -202,7 +202,7 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
             Assert.assertTrue((mvMaxBaseTableRefreshTimestamp - mvRefreshTimeStamp) / 1000 < 60);
             Assert.assertTrue(mv1.isStalenessSatisfied());
 
-            Set<String> partitionsToRefresh = mv1.getPartitionNamesToRefreshForMv(true);
+            Set<String> partitionsToRefresh = getPartitionNamesToRefreshForMv(mv1);
             Assert.assertTrue(partitionsToRefresh.isEmpty());
         }
         starRocksAssert.dropMaterializedView("hive_staleness_1");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteHiveTest.java
@@ -264,13 +264,13 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
 
     @Test
     public void testHiveEmptyMV_UnPartitioned_NotRewritten() throws Exception {
-                starRocksAssert.withMaterializedView("create materialized view hive_empty_mv " +
-                        " distributed by hash(s_suppkey) " +
-                        " refresh deferred manual  " +
-                        "PROPERTIES (\n" +
-                        "\"force_external_table_query_rewrite\" = \"false\"\n" +
-                        ") " +
-                        " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5");
+        starRocksAssert.withMaterializedView("create materialized view hive_empty_mv " +
+                " distributed by hash(s_suppkey) " +
+                " refresh deferred manual  " +
+                "PROPERTIES (\n" +
+                "\"force_external_table_query_rewrite\" = \"false\"\n" +
+                ") " +
+                " as select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 5");
         // mv is not refreshed, even mv has no partitions, it should not be rewritten.
         String query1 = "select s_suppkey, s_name, s_address, s_acctbal from hive0.tpch.supplier where s_suppkey < 10";
         String plan = getFragmentPlan(query1);
@@ -299,18 +299,18 @@ public class MvRewriteHiveTest extends MvRewriteTestBase {
     @Test
     public void testHiveEmptyMV_Partitioned_NotRewritten() throws Exception {
         starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `hive_partitioned_mv`\n" +
-                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
-                        "PARTITION BY (`l_shipdate`)\n" +
-                        "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
-                        "REFRESH DEFERRED MANUAL\n" +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"force_external_table_query_rewrite\" = \"false\"" +
-                        ")\n" +
-                        "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
-                        "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
-                        "GROUP BY " +
-                        "`l_orderkey`, `l_suppkey`, `l_shipdate`;");
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "PARTITION BY (`l_shipdate`)\n" +
+                "DISTRIBUTED BY HASH(`l_orderkey`) BUCKETS 10\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"force_external_table_query_rewrite\" = \"false\"" +
+                ")\n" +
+                "AS SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
+                "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +
+                "GROUP BY " +
+                "`l_orderkey`, `l_suppkey`, `l_shipdate`;");
         // mv is not refreshed, even mv has no partitions, it should not be rewritten.
         String query1 = "SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`, sum(l_orderkey)  " +
                 "FROM `hive0`.`partitioned_db`.`lineitem_par` as a \n " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.LocalTablet;
@@ -64,6 +65,7 @@ import org.junit.rules.TemporaryFolder;
 
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Set;
 
 public class MvRewriteTestBase {
     private static final Logger LOG = LogManager.getLogger(MvRewriteTestBase.class);
@@ -392,5 +394,11 @@ public class MvRewriteTestBase {
         for (OptExpression child : root.getInputs()) {
             getScanOperators(child, name, results);
         }
+    }
+
+    public static Set<String> getPartitionNamesToRefreshForMv(MaterializedView mv) {
+        Set<String> toRefreshPartitions = Sets.newHashSet();
+        mv.getPartitionNamesToRefreshForMv(toRefreshPartitions, true);
+        return toRefreshPartitions;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.plan;
 
-import com.google.common.collect.Sets;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -42,8 +42,9 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
 
         new MockUp<MaterializedView>() {
             @Mock
-            Set<String> getPartitionNamesToRefreshForMv(boolean isQueryRewrite) {
-                return Sets.newHashSet();
+            public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions,
+                                                           boolean isQueryRewrite) {
+                return true;
             }
         };
 


### PR DESCRIPTION
`getPartitionNamesToRefreshForMv ` is confused for :
   - MV can not be used for rewrite and to-refreshed partitions are empty, MV cannot be used for rewrite when
      - `query_rewrite_consistency` is `disabled`
      - external table rewrite is `disabled`
   - MV can be used for rewrite and to-refreshed  partitions are empty

This PR changes `getPartitionNamesToRefreshForMv` to distinguish materialized view refreshed partitions that are empty or cannot be rewritten. 

After the change, when `getPartitionNamesToRefreshForMv` is false, the mv cannot be used for rewrite.
```
-- Before
  public Set<String> getPartitionNamesToRefreshForMv(boolean isQueryRewrite)

-- After
  public boolean getPartitionNamesToRefreshForMv(Set<String> toRefreshPartitions, boolean isQueryRewrite) 
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
