### PR TITLE
[Refactor] Disable base compaction overrun

### DIFF
--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -231,8 +231,7 @@ bool CompactionManager::_check_precondition(const CompactionCandidate& candidate
             return false;
         }
         uint16_t num = running_base_tasks_num_for_dir(data_dir);
-        if (config::base_compaction_num_threads_per_disk > 0 &&
-            num >= config::base_compaction_num_threads_per_disk * 2) {
+        if (config::base_compaction_num_threads_per_disk > 0 && num >= config::base_compaction_num_threads_per_disk) {
             VLOG(2) << "skip tablet:" << tablet->tablet_id()
                     << " for limit of base compaction task per disk. disk path:" << data_dir->path()
                     << ", running num:" << num;


### PR DESCRIPTION
base compaction overrun will affect cumulative compaction, Especially when the base compaction data volume is relatively large and the execution is slow, cumulative compaction may not be executed in time and a too many version error may occur.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
