### PR TITLE
[Enhancement] Avoid build slice when building GlobalRuntimeFilter

### DIFF
--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -42,7 +42,7 @@ public:
 
         Slice operator[](size_t index) const { return _column.get_slice(index); }
 
-        size_t size() { return _column.size(); }
+        size_t size() const { return _column.size(); }
 
     private:
         const BinaryColumnBase& _column;

--- a/be/src/exprs/runtime_filter.h
+++ b/be/src/exprs/runtime_filter.h
@@ -410,18 +410,15 @@ public:
         }
     }
 
-    void insert(CppType* value) {
-        if (value == nullptr) {
-            _has_null = true;
-            return;
-        }
-
-        size_t hash = compute_hash(*value);
+    void insert(const CppType& value) {
+        size_t hash = compute_hash(value);
         _bf.insert_hash(hash);
 
-        _min = std::min(*value, _min);
-        _max = std::max(*value, _max);
+        _min = std::min(value, _min);
+        _max = std::max(value, _max);
     }
+
+    void insert_null() { _has_null = true; }
 
     CppType min_value() const { return _min; }
 

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -123,41 +123,20 @@ struct FilterIniter {
 
         if (column->is_nullable()) {
             auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(column);
-            if constexpr (lt_is_string<ltype> || lt_is_binary<ltype>) {
-                const auto& data_array =
-                        ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_proxy_data();
-                for (size_t j = column_offset; j < data_array.size(); j++) {
-                    if (!nullable_column->is_null(j)) {
-                        filter->insert(data_array[j]);
-                    } else {
-                        if (eq_null) {
-                            filter->insert_null();
-                        }
-                    }
-                }
-            } else {
-                auto& data_array = ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_data();
-                for (size_t j = column_offset; j < data_array.size(); j++) {
-                    if (!nullable_column->is_null(j)) {
-                        filter->insert(data_array[j]);
-                    } else {
-                        if (eq_null) {
-                            filter->insert_null();
-                        }
+            const auto& data_array = GetContainer<ltype>().get_data(nullable_column->data_column().get());
+            for (size_t j = column_offset; j < data_array.size(); j++) {
+                if (!nullable_column->is_null(j)) {
+                    filter->insert(data_array[j]);
+                } else {
+                    if (eq_null) {
+                        filter->insert_null();
                     }
                 }
             }
         } else {
-            if constexpr (lt_is_string<ltype> || lt_is_binary<ltype>) {
-                const auto& data_ptr = ColumnHelper::as_raw_column<ColumnType>(column)->get_proxy_data();
-                for (size_t j = column_offset; j < data_ptr.size(); j++) {
-                    filter->insert(data_ptr[j]);
-                }
-            } else {
-                auto& data_ptr = ColumnHelper::as_raw_column<ColumnType>(column)->get_data();
-                for (size_t j = column_offset; j < data_ptr.size(); j++) {
-                    filter->insert(data_ptr[j]);
-                }
+            const auto& data_array = GetContainer<ltype>().get_data(column.get());
+            for (size_t j = column_offset; j < data_array.size(); j++) {
+                filter->insert(data_array[j]);
             }
         }
         return nullptr;

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -123,21 +123,41 @@ struct FilterIniter {
 
         if (column->is_nullable()) {
             auto* nullable_column = ColumnHelper::as_raw_column<NullableColumn>(column);
-            auto& data_array = ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_data();
-            for (size_t j = column_offset; j < data_array.size(); j++) {
-                if (!nullable_column->is_null(j)) {
-                    filter->insert(&data_array[j]);
-                } else {
-                    if (eq_null) {
-                        filter->insert(nullptr);
+            if constexpr (lt_is_string<ltype> || lt_is_binary<ltype>) {
+                const auto& data_array =
+                        ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_proxy_data();
+                for (size_t j = column_offset; j < data_array.size(); j++) {
+                    if (!nullable_column->is_null(j)) {
+                        filter->insert(data_array[j]);
+                    } else {
+                        if (eq_null) {
+                            filter->insert_null();
+                        }
+                    }
+                }
+            } else {
+                auto& data_array = ColumnHelper::as_raw_column<ColumnType>(nullable_column->data_column())->get_data();
+                for (size_t j = column_offset; j < data_array.size(); j++) {
+                    if (!nullable_column->is_null(j)) {
+                        filter->insert(data_array[j]);
+                    } else {
+                        if (eq_null) {
+                            filter->insert_null();
+                        }
                     }
                 }
             }
-
         } else {
-            auto& data_ptr = ColumnHelper::as_raw_column<ColumnType>(column)->get_data();
-            for (size_t j = column_offset; j < data_ptr.size(); j++) {
-                filter->insert(&data_ptr[j]);
+            if constexpr (lt_is_string<ltype> || lt_is_binary<ltype>) {
+                const auto& data_ptr = ColumnHelper::as_raw_column<ColumnType>(column)->get_proxy_data();
+                for (size_t j = column_offset; j < data_ptr.size(); j++) {
+                    filter->insert(data_ptr[j]);
+                }
+            } else {
+                auto& data_ptr = ColumnHelper::as_raw_column<ColumnType>(column)->get_data();
+                for (size_t j = column_offset; j < data_ptr.size(); j++) {
+                    filter->insert(data_ptr[j]);
+                }
             }
         }
         return nullptr;

--- a/be/src/types/logical_type_infra.h
+++ b/be/src/types/logical_type_infra.h
@@ -52,6 +52,12 @@ namespace starrocks {
     M(TYPE_MAP)                   \
     M(TYPE_ARRAY)
 
+#define APPLY_FOR_ALL_STRING_TYPE(M) \
+    M(TYPE_VARCHAR)                  \
+    M(TYPE_CHAR)                     \
+    M(TYPE_BINARY)                   \
+    M(TYPE_VARBINARY)
+
 #define APPLY_FOR_ALL_SCALAR_TYPE_WITH_NULL(M) \
     APPLY_FOR_ALL_SCALAR_TYPE(M)               \
     M(TYPE_NULL)

--- a/be/test/exprs/runtime_filter_test.cpp
+++ b/be/test/exprs/runtime_filter_test.cpp
@@ -126,7 +126,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilter) {
     JoinRuntimeFilter* rf = &bf;
     bf.init(100);
     for (int i = 0; i <= 200; i += 17) {
-        bf.insert(&i);
+        bf.insert(i);
     }
     EXPECT_EQ(bf.min_value(), 0);
     EXPECT_EQ(bf.max_value(), 187);
@@ -135,7 +135,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilter) {
         EXPECT_FALSE(bf._test_data(i + 1));
     }
     EXPECT_FALSE(rf->has_null());
-    bf.insert(nullptr);
+    bf.insert_null();
     EXPECT_TRUE(rf->has_null());
     EXPECT_EQ(bf.min_value(), 0);
     EXPECT_EQ(bf.max_value(), 187);
@@ -170,7 +170,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterSlice) {
     }
     bf.init(100);
     for (auto& s : values) {
-        bf.insert(&s);
+        bf.insert(s);
     }
     EXPECT_EQ(bf.min_value(), values[0]);
     EXPECT_EQ(bf.max_value(), values[values.size() - 1]);
@@ -189,7 +189,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterSerialize) {
     bf0.init(100);
     int rf_version = RF_VERSION_V2;
     for (int i = 0; i <= 200; i += 17) {
-        bf0.insert(&i);
+        bf0.insert(i);
     }
 
     size_t max_size = RuntimeFilterHelper::max_runtime_filter_serialized_size(rf0);
@@ -208,7 +208,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterSerialize2) {
     JoinRuntimeFilter* rf0 = &bf0;
     bf0.init(100);
     for (int i = 0; i <= 200; i += 17) {
-        bf0.insert(&i);
+        bf0.insert(i);
     }
     EXPECT_EQ(bf0.min_value(), 0);
     EXPECT_EQ(bf0.max_value(), 187);
@@ -222,7 +222,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterSerialize2) {
     }
     bf1.init(200);
     for (auto& s : values) {
-        bf1.insert(&s);
+        bf1.insert(s);
     }
     EXPECT_EQ(bf1.min_value(), values[0]);
     EXPECT_EQ(bf1.max_value(), values[values.size() - 1]);
@@ -253,7 +253,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterMerge) {
     JoinRuntimeFilter* rf0 = &bf0;
     bf0.init(100);
     for (int i = 0; i <= 200; i += 17) {
-        bf0.insert(&i);
+        bf0.insert(i);
     }
     EXPECT_EQ(bf0.min_value(), 0);
     EXPECT_EQ(bf0.max_value(), 187);
@@ -262,7 +262,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterMerge) {
     JoinRuntimeFilter* rf1 = &bf1;
     bf1.init(100);
     for (int i = 1; i <= 200; i += 17) {
-        bf1.insert(&i);
+        bf1.insert(i);
     }
     EXPECT_EQ(bf1.min_value(), 1);
     EXPECT_EQ(bf1.max_value(), 188);
@@ -291,7 +291,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterMerge2) {
         }
         bf0.init(100);
         for (auto& s : values) {
-            bf0.insert(&s);
+            bf0.insert(s);
         }
         // bb - dd
         EXPECT_EQ(bf0.min_value(), values[0]);
@@ -309,7 +309,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterMerge2) {
         }
         bf1.init(100);
         for (auto& s : values) {
-            bf1.insert(&s);
+            bf1.insert(s);
         }
         // aa - dc
         EXPECT_EQ(bf1.min_value(), values[0]);
@@ -335,7 +335,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterMerge3) {
         }
         bf0.init(100);
         for (auto& s : values) {
-            bf0.insert(&s);
+            bf0.insert(s);
         }
 
         size_t max_size = RuntimeFilterHelper::max_runtime_filter_serialized_size(rf0);
@@ -360,7 +360,7 @@ TEST_F(RuntimeFilterTest, TestJoinRuntimeFilterMerge3) {
         }
         bf1.init(100);
         for (auto& s : values) {
-            bf1.insert(&s);
+            bf1.insert(s);
         }
 
         size_t max_size = RuntimeFilterHelper::max_runtime_filter_serialized_size(rf1);
@@ -406,7 +406,7 @@ void test_grf_helper_template(size_t num_rows, size_t num_partitions, const Part
 
     for (auto i = 0; i < num_rows; ++i) {
         auto slice = column->get_slice(i);
-        bfs[hash_values[i]].insert(&slice);
+        bfs[hash_values[i]].insert(slice);
     }
 
     int rf_version = RF_VERSION_V2;
@@ -607,7 +607,7 @@ TEST_F(RuntimeFilterTest, TestGlobalRuntimeFilterMinMax) {
         local.init(10);
         for (int j = 0; j < 4; j++) {
             int value = (i + 1) * 10 + j;
-            local.insert(&value);
+            local.insert(value);
         }
         global->concat(&local);
     }
@@ -685,7 +685,7 @@ void TestMultiColumnsOnRuntimeFilter(TRuntimeFilterBuildJoinMode::type join_mode
         for (auto j = 0; j < num_rows; ++j) {
             auto ele = column->get(j).get_int32();
             auto pp = expected_hash_values[j] + (i * num_partitions);
-            bfs[pp].insert(&ele);
+            bfs[pp].insert(ele);
         }
         for (auto p = 0; p < num_partitions; ++p) {
             auto pp = p + (i * num_partitions);


### PR DESCRIPTION
In the scenario of built `GlobalRuntimeFilter`, build slice cache takes up a lot of memory and does not improve performance.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
