### PR TITLE
[Enhancement] Upgrade libcurl due to CVE-2023-38545/CVE-2023-38546

### DIFF
--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -169,10 +169,10 @@ SIMDJSON_SOURCE=simdjson-2.2.0
 SIMDJSON_MD5SUM="9bd0ced53281484d8842a9429065943d"
 
 # curl
-CURL_DOWNLOAD="https://curl.se/download/curl-7.79.0.tar.gz"
-CURL_NAME=curl-7.79.0.tar.gz
-CURL_SOURCE=curl-7.79.0
-CURL_MD5SUM="b40e4dc4bbc9e109c330556cd58c8ec8"
+CURL_DOWNLOAD="https://curl.se/download/curl-8.4.0.tar.gz"
+CURL_NAME=curl-8.4.0.tar.gz
+CURL_SOURCE=curl-8.4.0
+CURL_MD5SUM="533e8a3b1228d5945a6a512537bea4c7"
 
 # RE2
 RE2_DOWNLOAD="https://github.com/google/re2/archive/refs/tags/2022-12-01.tar.gz"


### PR DESCRIPTION
more info see: https://github.com/curl/curl/discussions/12026
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
