### PR TITLE
[BugFix] Make sure all bthread only has process level memtracker

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -67,7 +67,12 @@ SinkBuffer::~SinkBuffer() {
 
     DCHECK(is_finished());
 
-    _buffers.clear();
+    {
+        // Since the deallocation of _buffers may happen inside bthread, make sure all the allocations and
+        // deallocations are executed using the process level MemTracker
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+        _buffers.clear();
+    }
 }
 
 void SinkBuffer::incr_sinker(RuntimeState* state) {
@@ -89,7 +94,12 @@ Status SinkBuffer::add_request(TransmitChunkInfo& request) {
     }
     {
         auto& instance_id = request.fragment_instance_id;
-        RETURN_IF_ERROR(_try_to_send_rpc(instance_id, [&]() { _buffers[instance_id.lo].push(request); }));
+        RETURN_IF_ERROR(_try_to_send_rpc(instance_id, [&]() {
+            // Since the deallocation of _buffers may happen inside bthread, make sure all the allocations and
+            // deallocations are executed using the process level MemTracker
+            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+            _buffers[instance_id.lo].push(request);
+        }));
     }
 
     return Status::OK();
@@ -286,16 +296,17 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         TransmitChunkInfo& request = buffer.front();
         bool need_wait = false;
-        DeferOp pop_defer([&need_wait, &buffer, mem_tracker = _mem_tracker]() {
+        DeferOp pop_defer([&need_wait, &buffer]() {
             if (need_wait) {
                 return;
             }
 
-            // The request memory is acquired by ExchangeSinkOperator,
-            // so use the instance_mem_tracker passed from ExchangeSinkOperator to release memory.
-            // This must be invoked before decrease_defer desctructed to avoid sink_buffer and fragment_ctx released.
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
-            buffer.pop();
+            {
+                // Since the deallocation of _buffers may happen inside bthread, make sure all the allocations and
+                // deallocations are executed using the process level MemTracker
+                SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
+                buffer.pop();
+            }
         });
 
         // The order of data transmiting in IO level may not be strictly the same as
@@ -411,6 +422,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         if (bthread_self()) {
             st = _send_rpc(closure, request);
         } else {
+            // Since the deallocation of protobuf request must be done in the bthread.
             // When the driver worker thread sends request and creates the protobuf request,
             // also use process_mem_tracker to record the memory of the protobuf request.
             SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -286,15 +286,10 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
 
         TransmitChunkInfo& request = buffer.front();
         bool need_wait = false;
-        DeferOp pop_defer([&need_wait, &buffer, mem_tracker = _mem_tracker]() {
+        DeferOp pop_defer([&need_wait, &buffer]() {
             if (need_wait) {
                 return;
             }
-
-            // The request memory is acquired by ExchangeSinkOperator,
-            // so use the instance_mem_tracker passed from ExchangeSinkOperator to release memory.
-            // This must be invoked before decrease_defer desctructed to avoid sink_buffer and fragment_ctx released.
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(mem_tracker);
             buffer.pop();
         });
 
@@ -407,17 +402,7 @@ Status SinkBuffer::_try_to_send_rpc(const TUniqueId& instance_id, const std::fun
         closure->cntl.Reset();
         closure->cntl.set_timeout_ms(_brpc_timeout_ms);
 
-        Status st;
-        if (bthread_self()) {
-            st = _send_rpc(closure, request);
-        } else {
-            // When the driver worker thread sends request and creates the protobuf request,
-            // also use process_mem_tracker to record the memory of the protobuf request.
-            SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(nullptr);
-            // must in the same scope following the above
-            st = _send_rpc(closure, request);
-        }
-        return st;
+        return _send_rpc(closure, request);
     }
     return Status::OK();
 }

--- a/be/src/runtime/current_thread.h
+++ b/be/src/runtime/current_thread.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <bthread/bthread.h>
+
 #include <cstdint>
 #include <string>
 
@@ -43,6 +45,23 @@
             RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit(err_msg));          \
         }                                                                                     \
     } while (0)
+
+// Multiple bthread may share a single pthread, and thereby share a single thread local variable(i.e. tls_thread_status).
+// Using bthread::Mutex will trigger bthread context switch, but still holding the same thread local variable, and
+// different brpc process may come from different instances of a same query or evern different queries. And holding
+// the MemTracker of another instance may lead to be crash because the MemTracker has been released.
+#define RETURN_NULL_IF_BTHREAD() \
+    do {                         \
+        if (bthread_self()) {    \
+            return nullptr;      \
+        }                        \
+    } while (false)
+#define RETURN_IF_BTHREAD()   \
+    do {                      \
+        if (bthread_self()) { \
+            return;           \
+        }                     \
+    } while (false)
 
 namespace starrocks {
 
@@ -219,6 +238,7 @@ public:
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_mem_tracker(starrocks::MemTracker* mem_tracker) {
+        RETURN_NULL_IF_BTHREAD();
         release_reserved();
         mem_tracker_ctx_shift();
         auto* prev = tls_mem_tracker;
@@ -228,6 +248,7 @@ public:
 
     // Return prev memory tracker.
     starrocks::MemTracker* set_operator_mem_tracker(starrocks::MemTracker* operator_mem_tracker) {
+        RETURN_NULL_IF_BTHREAD();
         operator_mem_tracker_ctx_shift();
         auto* prev = tls_operator_mem_tracker;
         tls_operator_mem_tracker = operator_mem_tracker;
@@ -247,7 +268,10 @@ public:
 
     static CurrentThread& current();
 
-    static void set_exceed_mem_tracker(starrocks::MemTracker* mem_tracker) { tls_exceed_mem_tracker = mem_tracker; }
+    static void set_exceed_mem_tracker(starrocks::MemTracker* mem_tracker) {
+        RETURN_IF_BTHREAD();
+        tls_exceed_mem_tracker = mem_tracker;
+    }
 
     bool set_is_catched(bool is_catched) {
         bool old = _is_catched;


### PR DESCRIPTION
## Background

#32228 may lead to be crash. Becase multiply bthreads may share the same pthread, and thereby share the memory related `thread_local` variables, like `tls_mem_tracker`. 

Changing from `SpinLock` to `bthread::Mutex` may allow switch context of different brpc process(of different instances of a same query or even different queries), and use instance level `MemTracker` of another instance or another query may lead to illegal memory access, because the corresponding `MemTracker` may be released that time.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
