### PR TITLE
[BugFix] Fix balance cause schema change failed bug (#17404)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/DiskAndTabletLoadReBalancer.java
@@ -1379,6 +1379,12 @@ public class DiskAndTabletLoadReBalancer extends Rebalancer {
                     }
 
                     OlapTable olapTbl = (OlapTable) table;
+                    // Table not in NORMAL state is not allowed to do balance,
+                    // because the change of tablet location can cause Schema change or rollup failed
+                    if (olapTbl.getState() != OlapTable.OlapTableState.NORMAL) {
+                        continue;
+                    }
+
                     for (Partition partition : catalog.getAllPartitionsIncludeRecycleBin(olapTbl)) {
                         if (partition.getState() != PartitionState.NORMAL) {
                             // when alter job is in FINISHING state, partition state will be set to NORMAL,

--- a/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/DiskAndTabletLoadReBalancerTest.java
@@ -174,6 +174,10 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertTrue(tablets.stream().allMatch(t -> (t.getDestBackendId() == beId3)));
         Assert.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcBackendId() == beId1)));
         Assert.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcBackendId() == beId2)));
+
+        // set table state to schema_change, balance should be ignored
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        Assert.assertEquals(0, rebalancer.selectAlternativeTablets().size());
     }
 
     /**
@@ -518,6 +522,10 @@ public class DiskAndTabletLoadReBalancerTest {
         Assert.assertTrue(tablets.stream().anyMatch(t -> (t.getDestPathHash() == pathHash14)));
         Assert.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcPathHash() == pathHash10)));
         Assert.assertTrue(tablets.stream().anyMatch(t -> (t.getSrcPathHash() == pathHash13)));
+
+        // set table state to schema_change, balance should be ignored
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+        Assert.assertEquals(0, rebalancer.selectAlternativeTablets().size());
     }
 
     private Backend genBackend(long beId, String host, long availableCapB, long dataUsedCapB, long totalCapB,


### PR DESCRIPTION
backport #17404

Table not in NORMAL state is not allowed to do balance, because the change of tablet location can cause Schema change or rollup failed

Signed-off-by: gengjun-git <gengjun@starrocks.com>
