### PR TITLE
[BugFix] Only remove partition vision infos when mv's partition has been dropped

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -274,6 +274,8 @@ public class AlterJobMgr {
     }
 
     public void alterMaterializedViewStatus(MaterializedView materializedView, String status, boolean isReplay) {
+        LOG.info("process change materialized view {} status to {}, isReplay: {}",
+                materializedView.getName(), status, isReplay);
         if (AlterMaterializedViewStatusClause.ACTIVE.equalsIgnoreCase(status)) {
             ConnectContext context = new ConnectContext();
             context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
@@ -424,13 +426,14 @@ public class AlterJobMgr {
                     MvUtils.getMaxTablePartitionInfoRefreshTime(
                             log.getAsyncRefreshContext().getBaseTableVisibleVersionMap().values());
             newMvRefreshScheme.setLastRefreshTime(maxChangedTableRefreshTime);
+
             oldMaterializedView.setRefreshScheme(newMvRefreshScheme);
             LOG.info(
                     "Replay materialized view [{}]'s refresh type to {}, start time to {}, " +
-                            "interval step to {}, timeunit to {}, id: {}",
+                            "interval step to {}, timeunit to {}, id: {}, maxChangedTableRefreshTime:{}",
                     oldMaterializedView.getName(), refreshType.name(), asyncRefreshContext.getStartTime(),
                     asyncRefreshContext.getStep(),
-                    asyncRefreshContext.getTimeUnit(), oldMaterializedView.getId());
+                    asyncRefreshContext.getTimeUnit(), oldMaterializedView.getId(), maxChangedTableRefreshTime);
         } catch (Throwable e) {
             if (oldMaterializedView != null) {
                 oldMaterializedView.setInactiveAndReason("replay failed: " + e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -188,8 +188,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         @SerializedName("baseTableInfoVisibleVersionMap")
         private final Map<BaseTableInfo, Map<String, BasePartitionInfo>> baseTableInfoVisibleVersionMap;
 
-        // Materialized view partition is updated/added associated with ref-base-table. This meta
-        // is kept to track materialized view's partition change and update associated ref-base-table
+        // Materialized view partition is updated/added associated with ref-base-table partitions. This meta
+        // is kept to track materialized view's partition change and update associated ref-base-table partitions
         // at the same time.
         @SerializedName("mvPartitionNameRefBaseTablePartitionMap")
         private final Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -229,6 +229,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         }
 
         public void clearVisibleVersionMap() {
+            LOG.info("Clear materialized view's version map");
             this.baseTableInfoVisibleVersionMap.clear();
             this.baseTableVisibleVersionMap.clear();
             this.mvPartitionNameRefBaseTablePartitionMap.clear();
@@ -281,6 +282,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             AsyncRefreshContext arc = new AsyncRefreshContext();
             arc.baseTableVisibleVersionMap.putAll(this.baseTableVisibleVersionMap);
             arc.baseTableInfoVisibleVersionMap.putAll(this.baseTableInfoVisibleVersionMap);
+            arc.mvPartitionNameRefBaseTablePartitionMap.putAll(this.mvPartitionNameRefBaseTablePartitionMap);
             arc.defineStartTime = this.defineStartTime;
             arc.startTime = this.startTime;
             arc.step = this.step;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -177,14 +177,22 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     public static class AsyncRefreshContext {
+        // Olap base table refreshed meta infos
         // base table id -> (partition name -> partition info (id, version))
         // partition id maybe changed after insert overwrite, so use partition name as key.
         // partition id which in BasePartitionInfo can be used to check partition is changed
         @SerializedName("baseTableVisibleVersionMap")
         private final Map<Long, Map<String, BasePartitionInfo>> baseTableVisibleVersionMap;
 
+        // External base table refreshed meta infos
         @SerializedName("baseTableInfoVisibleVersionMap")
         private final Map<BaseTableInfo, Map<String, BasePartitionInfo>> baseTableInfoVisibleVersionMap;
+
+        // Materialized view partition is updated/added associated with ref-base-table. This meta
+        // is kept to track materialized view's partition change and update associated ref-base-table
+        // at the same time.
+        @SerializedName("mvPartitionNameRefBaseTablePartitionMap")
+        private final Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap;
 
         @SerializedName(value = "defineStartTime")
         private boolean defineStartTime;
@@ -201,6 +209,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         public AsyncRefreshContext() {
             this.baseTableVisibleVersionMap = Maps.newConcurrentMap();
             this.baseTableInfoVisibleVersionMap = Maps.newConcurrentMap();
+            this.mvPartitionNameRefBaseTablePartitionMap = Maps.newConcurrentMap();
             this.defineStartTime = false;
             this.startTime = Utils.getLongFromDateTime(LocalDateTime.now());
             this.step = 0;
@@ -215,9 +224,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return baseTableInfoVisibleVersionMap;
         }
 
+        public Map<String, Set<String>> getMvPartitionNameRefBaseTablePartitionMap() {
+            return mvPartitionNameRefBaseTablePartitionMap;
+        }
+
         public void clearVisibleVersionMap() {
             this.baseTableInfoVisibleVersionMap.clear();
             this.baseTableVisibleVersionMap.clear();
+            this.mvPartitionNameRefBaseTablePartitionMap.clear();
         }
 
         public boolean isDefineStartTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -119,6 +119,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -516,8 +517,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                                Set<String> mvRefreshedPartitions,
                                                Map<Table, Set<String>> refTableAndPartitionNames) {
         Map<String, Set<String>> mvToBaseNameRef = mvContext.getMvRefBaseTableIntersectedPartitions();
-        if (mvToBaseNameRef != null) {
+        if (!Objects.isNull(mvToBaseNameRef) && !Objects.isNull(refTableAndPartitionNames) &&
+                !refTableAndPartitionNames.isEmpty()) {
             try {
+                Preconditions.checkState(refTableAndPartitionNames.size() == 1);
                 Table refBaseTable = refTableAndPartitionNames.keySet().iterator().next();
                 Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =
                         refreshContext.getMvPartitionNameRefBaseTablePartitionMap();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -482,15 +482,17 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             // update materialized view partition to ref base table partition names meta
             Map<String, Set<String>> mvToBaseNameRef = mvContext.getMvRefBaseTableIntersectedPartitions();
-            for (String mvRefreshedPartition : mvRefreshedPartitions) {
-                if (mvToBaseNameRef.containsKey(mvRefreshedPartition)) {
-                    Set<String> refBaseTableAssociatedPartitions = mvToBaseNameRef.get(mvRefreshedPartition);
-                    refreshContext.getMvPartitionNameRefBaseTablePartitionMap()
-                            .put(mvRefreshedPartition, refBaseTableAssociatedPartitions);
-                } else {
-                    LOG.warn("MV task run context not contains the associated ref base table partitions of" +
-                            " the refreshed mv partition {} in materialized view{}", mvRefreshedPartition,
-                            materializedView.getName());
+            if (mvToBaseNameRef != null) {
+                for (String mvRefreshedPartition : mvRefreshedPartitions) {
+                    if (mvToBaseNameRef.containsKey(mvRefreshedPartition)) {
+                        Set<String> refBaseTableAssociatedPartitions = mvToBaseNameRef.get(mvRefreshedPartition);
+                        refreshContext.getMvPartitionNameRefBaseTablePartitionMap()
+                                .put(mvRefreshedPartition, refBaseTableAssociatedPartitions);
+                    } else {
+                        LOG.warn("MV task run context not contains the associated ref base table partitions of" +
+                                        " the refreshed mv partition {} in materialized view{}", mvRefreshedPartition,
+                                materializedView.getName());
+                    }
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -573,11 +573,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         if (!changedTablePartitionInfos.isEmpty()) {
             ChangeMaterializedViewRefreshSchemeLog changeRefreshSchemeLog =
                     new ChangeMaterializedViewRefreshSchemeLog(materializedView);
-            GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(changeRefreshSchemeLog);
-
             long maxChangedTableRefreshTime =
                     MvUtils.getMaxTablePartitionInfoRefreshTime(changedTablePartitionInfos.values());
             materializedView.getRefreshScheme().setLastRefreshTime(maxChangedTableRefreshTime);
+            GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(changeRefreshSchemeLog);
         }
     }
 
@@ -616,10 +615,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         if (!changedTablePartitionInfos.isEmpty()) {
             ChangeMaterializedViewRefreshSchemeLog changeRefreshSchemeLog =
                     new ChangeMaterializedViewRefreshSchemeLog(materializedView);
-            GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(changeRefreshSchemeLog);
             long maxChangedTableRefreshTime =
                     MvUtils.getMaxTablePartitionInfoRefreshTime(changedTablePartitionInfos.values());
             materializedView.getRefreshScheme().setLastRefreshTime(maxChangedTableRefreshTime);
+            GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(changeRefreshSchemeLog);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -481,20 +481,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             MaterializedView.AsyncRefreshContext refreshContext = mvRefreshScheme.getAsyncRefreshContext();
 
             // update materialized view partition to ref base table partition names meta
-            Map<String, Set<String>> mvToBaseNameRef = mvContext.getMvRefBaseTableIntersectedPartitions();
-            if (mvToBaseNameRef != null) {
-                for (String mvRefreshedPartition : mvRefreshedPartitions) {
-                    if (mvToBaseNameRef.containsKey(mvRefreshedPartition)) {
-                        Set<String> refBaseTableAssociatedPartitions = mvToBaseNameRef.get(mvRefreshedPartition);
-                        refreshContext.getMvPartitionNameRefBaseTablePartitionMap()
-                                .put(mvRefreshedPartition, refBaseTableAssociatedPartitions);
-                    } else {
-                        LOG.warn("MV task run context not contains the associated ref base table partitions of" +
-                                        " the refreshed mv partition {} in materialized view{}", mvRefreshedPartition,
-                                materializedView.getName());
-                    }
-                }
-            }
+            updateAssociatedPartitionMeta(refreshContext, mvRefreshedPartitions, refTableAndPartitionNames);
 
             Map<Long, Map<String, MaterializedView.BasePartitionInfo>> changedOlapTablePartitionInfos =
                     getSelectedPartitionInfosOfOlapTable(baseTableAndPartitionNames);
@@ -522,6 +509,32 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             throw e;
         } finally {
             database.writeUnlock();
+        }
+    }
+
+    private void updateAssociatedPartitionMeta(MaterializedView.AsyncRefreshContext refreshContext,
+                                               Set<String> mvRefreshedPartitions,
+                                               Map<Table, Set<String>> refTableAndPartitionNames) {
+        Map<String, Set<String>> mvToBaseNameRef = mvContext.getMvRefBaseTableIntersectedPartitions();
+        if (mvToBaseNameRef != null) {
+            try {
+                Table refBaseTable = refTableAndPartitionNames.keySet().iterator().next();
+                Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =
+                        refreshContext.getMvPartitionNameRefBaseTablePartitionMap();
+                for (String mvRefreshedPartition : mvRefreshedPartitions) {
+                    Set<String> realBaseTableAssociatedPartitions = Sets.newHashSet();
+                    for (String refBaseTableAssociatedPartition : mvToBaseNameRef.get(mvRefreshedPartition)) {
+                        realBaseTableAssociatedPartitions.addAll(
+                                convertMVPartitionNameToRealPartitionName(refBaseTable, refBaseTableAssociatedPartition));
+                    }
+                    mvPartitionNameRefBaseTablePartitionMap
+                            .put(mvRefreshedPartition, realBaseTableAssociatedPartitions);
+                }
+
+            } catch (Exception e) {
+                LOG.warn("Update materialized view {} with the associated ref base table partitions failed: ",
+                        materializedView.getName(), e);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -678,7 +678,8 @@ public class SyncPartitionUtils {
                     tableId.toString(), mvPartitionName);
         } else {
             long refreshedRefBaseTablePartitionSize = baseTableVersionInfoMap.size();
-            long refreshAssociatedRefTablePartitionSize = mvPartitionNameRefBaseTablePartitionMap.values().size();
+            long refreshAssociatedRefTablePartitionSize = mvPartitionNameRefBaseTablePartitionMap.values()
+                    .stream().map(x -> x.size()).reduce(0, (x, y) -> x + y);
             if (refreshedRefBaseTablePartitionSize == refreshAssociatedRefTablePartitionSize) {
                 // It's safe here that only log warning rather than remove all the ref base table info from version map,
                 // because mvPartitionNameRefBaseTablePartitionMap should track all the changed materialized view
@@ -720,9 +721,10 @@ public class SyncPartitionUtils {
             dropRefBaseTableFromVersionMap(mv, baseTableVersionInfoMap,
                     mvPartitionNameRefBaseTablePartitionMap, baseTableInfo.getTableName(), mvPartitionName);
         } else {
-            long refreshedRefBaseTablePartitionSize = baseTableVersionInfoMap.keySet()
-                    .stream().filter(x -> !x.equals(ICEBERG_ALL_PARTITION)).count();
-            long refreshAssociatedRefTablePartitionSize = mvPartitionNameRefBaseTablePartitionMap.values().size();
+            long refreshedRefBaseTablePartitionSize = baseTableVersionInfoMap.keySet().size();
+            //.stream().filter(x -> !x.equals(ICEBERG_ALL_PARTITION)).count();
+            long refreshAssociatedRefTablePartitionSize = mvPartitionNameRefBaseTablePartitionMap.values()
+                    .stream().map(x -> x.size()).reduce(0, (x, y) -> x + y);
             if (refreshedRefBaseTablePartitionSize == refreshAssociatedRefTablePartitionSize) {
                 // It's safe here that only log warning rather than remove all the ref base table info from version map,
                 // because mvPartitionNameRefBaseTablePartitionMap should track all the changed materialized view

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -649,6 +649,10 @@ public class SyncPartitionUtils {
         for (String refBaseTableAssociatedPartition : refBaseTableAssociatedPartitions) {
             baseTableVersionInfoMap.remove(refBaseTableAssociatedPartition);
         }
+
+        // finally remove the dropped materialized view partition
+        mvPartitionNameRefBaseTablePartitionMap.remove(mvPartitionName);
+
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -647,9 +647,6 @@ public class SyncPartitionUtils {
                 refBaseTable, Joiner.on(",").join(refBaseTableAssociatedPartitions),
                 mv.getName(), mvPartitionName);
         for (String refBaseTableAssociatedPartition : refBaseTableAssociatedPartitions) {
-            if (refBaseTableAssociatedPartition.equals(ICEBERG_ALL_PARTITION)) {
-                continue;
-            }
             baseTableVersionInfoMap.remove(refBaseTableAssociatedPartition);
         }
         return true;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -51,6 +51,7 @@ import com.starrocks.sql.LoadPlanner;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.statistic.StatisticsMetaManager;
@@ -73,6 +74,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -2761,5 +2763,110 @@ public class PartitionBasedMvRefreshProcessorTest {
         List<String> partitions = materializedView.getPartitions().stream()
                 .map(Partition::getName).sorted().collect(Collectors.toList());
         Assert.assertEquals(ImmutableList.of("p20230801_20230802"), partitions);
+    }
+
+    @Test
+    public void testDropBaseVersionMetaOfOlapTable() throws Exception {
+        starRocksAssert.withMaterializedView("create materialized view test_drop_partition_mv1\n" +
+                "PARTITION BY k1\n" +
+                "distributed by hash(k2) buckets 3\n" +
+                "refresh async \n" +
+                "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        Table tbl1 = testDb.getTable("tbl1");
+        MaterializedView mv = ((MaterializedView) testDb.getTable("test_drop_partition_mv1"));
+        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> versionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getMvPartitionNameRefBaseTablePartitionMap();
+        Map<String, MaterializedView.BasePartitionInfo> tableMap = Maps.newHashMap();
+        // case1: version map cannot decide whether it's safe to drop p1, drop the table from version map.
+        {
+            tableMap.put("p1", new MaterializedView.BasePartitionInfo(1, 2, -1));
+            tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
+            versionMap.put(tbl1.getId(), tableMap);
+
+            SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
+            Assert.assertFalse(versionMap.containsKey(tbl1.getId()));
+        }
+        {
+            tableMap.put("p1", new MaterializedView.BasePartitionInfo(1, 2, -1));
+            tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
+            versionMap.put(tbl1.getId(), tableMap);
+
+            mvPartitionNameRefBaseTablePartitionMap.put("p1", Sets.newHashSet("p1"));
+            mvPartitionNameRefBaseTablePartitionMap.put("p2", Sets.newHashSet("p2"));
+
+            SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
+            Assert.assertTrue(versionMap.containsKey(tbl1.getId()));
+            Assert.assertTrue(tableMap.containsKey("p2"));
+        }
+        {
+            tableMap.put("p1", new MaterializedView.BasePartitionInfo(1, 2, -1));
+            tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
+            versionMap.put(tbl1.getId(), tableMap);
+
+            mvPartitionNameRefBaseTablePartitionMap.put("p1", Sets.newHashSet("p1"));
+            mvPartitionNameRefBaseTablePartitionMap.put("p2", Sets.newHashSet("p2"));
+
+            SyncPartitionUtils.dropBaseVersionMeta(mv, "p3", null);
+            Assert.assertTrue(versionMap.containsKey(tbl1.getId()));
+            Assert.assertTrue(tableMap.containsKey("p2"));
+        }
+        starRocksAssert.dropMaterializedView("test_drop_partition_mv1");
+    }
+
+    @Test
+    public void testDropBaseVersionMetaOfExternalTable() throws Exception {
+        starRocksAssert.withMaterializedView("create materialized view test_drop_partition_mv1\n" +
+                "PARTITION BY date_trunc('day', l_shipdate) \n" +
+                "distributed by hash(l_orderkey) buckets 3\n" +
+                "refresh async every (interval 1 day)\n" +
+                "as SELECT `l_orderkey`, `l_suppkey`, `l_shipdate`  FROM `hive0`.`partitioned_db`.`lineitem_par` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView mv = ((MaterializedView) testDb.getTable("test_drop_partition_mv1"));
+        Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> versionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap();
+        Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getMvPartitionNameRefBaseTablePartitionMap();
+        Map<String, MaterializedView.BasePartitionInfo> tableMap = Maps.newHashMap();
+        // TODO: how to get hive table meta from catalog.
+        BaseTableInfo baseTableInfo = new BaseTableInfo("hive0", "partitioned_db", "lineitem_par", "lineitem_par:0");
+        // case1: version map cannot decide whether it's safe to drop p1, drop the table from version map.
+        {
+            tableMap.put("p1", new MaterializedView.BasePartitionInfo(1, 2, -1));
+            tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
+            versionMap.put(baseTableInfo, tableMap);
+
+            SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
+            Assert.assertFalse(versionMap.containsKey(baseTableInfo));
+        }
+        {
+            tableMap.put("p1", new MaterializedView.BasePartitionInfo(1, 2, -1));
+            tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
+            versionMap.put(baseTableInfo, tableMap);
+
+            mvPartitionNameRefBaseTablePartitionMap.put("p1", Sets.newHashSet("p1"));
+            mvPartitionNameRefBaseTablePartitionMap.put("p2", Sets.newHashSet("p2"));
+
+            SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
+            Assert.assertTrue(versionMap.containsKey(baseTableInfo));
+            Assert.assertTrue(tableMap.containsKey("p2"));
+        }
+        {
+            tableMap.put("p1", new MaterializedView.BasePartitionInfo(1, 2, -1));
+            tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
+            versionMap.put(baseTableInfo, tableMap);
+
+            mvPartitionNameRefBaseTablePartitionMap.put("p1", Sets.newHashSet("p1"));
+            mvPartitionNameRefBaseTablePartitionMap.put("p2", Sets.newHashSet("p2"));
+
+            SyncPartitionUtils.dropBaseVersionMeta(mv, "p3", null);
+            Assert.assertTrue(versionMap.containsKey(baseTableInfo));
+            Assert.assertTrue(tableMap.containsKey("p2"));
+        }
+        starRocksAssert.dropMaterializedView("test_drop_partition_mv1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -23,22 +23,13 @@ import com.starrocks.analysis.DateLiteral;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.Database;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
-import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DateUtils;
-import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionValue;
-import com.starrocks.utframe.StarRocksAssert;
-import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -608,47 +599,6 @@ public class SyncPartitionUtilsTest {
         Assert.assertEquals("2020-07-01 00:00:00",
                 adds.get("p202006_202007").upperEndpoint().getKeys().get(0).getStringValue());
         Assert.assertEquals(0, deletes.size());
-    }
-
-    @Test
-    public void testDropBaseVersionMeta() throws Exception {
-        FeConstants.runningUnitTest = true;
-        Config.enable_experimental_mv = true;
-        UtFrameUtils.createMinStarRocksCluster();
-        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
-        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
-        starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE test.tbl1\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("create materialized view mv1\n" +
-                        "PARTITION BY k1\n" +
-                        "distributed by hash(k2) buckets 3\n" +
-                        "refresh async\n" +
-                        "as select k1, k2, sum(v1) as total from tbl1 group by k1, k2;");
-
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        Table tbl1 = testDb.getTable("tbl1");
-        MaterializedView mv = ((MaterializedView) testDb.getTable("mv1"));
-        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> versionMap =
-                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
-        Map<String, MaterializedView.BasePartitionInfo> tableMap = Maps.newHashMap();
-        tableMap.put("p1", new MaterializedView.BasePartitionInfo(1, 2, -1));
-        tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
-        versionMap.put(tbl1.getId(), tableMap);
-        SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
-        // TODO: add more tests
-        Assert.assertNotNull(tableMap.get("p1"));
     }
 
     private PartitionRange buildPartitionRange(String name, String start, String end) throws AnalysisException {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -647,8 +647,8 @@ public class SyncPartitionUtilsTest {
         tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
         versionMap.put(tbl1.getId(), tableMap);
         SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
-
-        Assert.assertNull(tableMap.get("p1"));
+        // TODO: add more tests
+        Assert.assertNotNull(tableMap.get("p1"));
     }
 
     private PartitionRange buildPartitionRange(String name, String start, String end) throws AnalysisException {


### PR DESCRIPTION
### Before PR
For now, when one MV's partition has been dropped because of MV's TTL,  MV's versionMap will remove all partition info about all the table and this mv cannot be used for rewrite,  and need to be refreshed the total table for mv rewrite later.

### After PR
1. Collect materialized view partition -> ref base table's partitions info in refreshing materialized view;
2. When one materialized view's partition is dropped, only drop the associated ref base table's partition. other materialized view's partitions are not affected and can be used for rewrite.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
