### PR TITLE
[Enhancement] prune partitions when creating partitions for mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1379,8 +1379,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return getVisiblePartitionNames();
         }
         Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = getRangePartitionMap();
+        // TODO: prune the partitions based on ttl
         RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, partitionInfo.second,
-                basePartitionNameToRangeMap, mvPartitionNameToRangeMap);
+                basePartitionNameToRangeMap, mvPartitionNameToRangeMap, null);
         needRefreshMvPartitionNames.addAll(rangePartitionDiff.getDeletes().keySet());
         for (String deleted : rangePartitionDiff.getDeletes().keySet()) {
             mvPartitionNameToRangeMap.remove(deleted);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -54,6 +54,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.DmlException;
+import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.common.UnsupportedException;
@@ -645,15 +646,16 @@ public class PartitionUtil {
 
     public static RangePartitionDiff getPartitionDiff(Expr partitionExpr, Column partitionColumn,
                                                       Map<String, Range<PartitionKey>> basePartitionMap,
-                                                      Map<String, Range<PartitionKey>> mvPartitionMap) {
+                                                      Map<String, Range<PartitionKey>> mvPartitionMap,
+                                                      PartitionDiffer differ) {
         if (partitionExpr instanceof SlotRef) {
-            return SyncPartitionUtils.getRangePartitionDiffOfSlotRef(basePartitionMap, mvPartitionMap);
+            return SyncPartitionUtils.getRangePartitionDiffOfSlotRef(basePartitionMap, mvPartitionMap, differ);
         } else if (partitionExpr instanceof FunctionCallExpr) {
             FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
             if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.DATE_TRUNC) ||
                     functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
                 return SyncPartitionUtils.getRangePartitionDiffOfExpr(basePartitionMap,
-                        mvPartitionMap, functionCallExpr, null);
+                        mvPartitionMap, functionCallExpr, differ);
             } else {
                 throw new SemanticException("Materialized view partition function " +
                         functionCallExpr.getFnName().getFunction() +

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -669,8 +669,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     if (start != null || end != null) {
                         rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
                     }
+                    SyncPartitionUtils.PartitionDiffer differ =
+                            new SyncPartitionUtils.PartitionDiffer(rangeToInclude, partitionTTLNumber);
                     rangePartitionDiff = SyncPartitionUtils.getRangePartitionDiffOfExpr(refBaseTablePartitionMap,
-                            mvRangePartitionMap, functionCallExpr, rangeToInclude);
+                            mvRangePartitionMap, functionCallExpr, differ);
                 } else {
                     throw new SemanticException("Materialized view partition function " +
                             functionCallExpr.getFnName().getFunction() +
@@ -1208,7 +1210,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                 snapshotTable, partitionColumn, MaterializedView.getPartitionExpr(materializedView));
                         Map<String, Range<PartitionKey>> currentPartitionMap = PartitionUtil.getPartitionKeyRange(
                                 table, partitionColumn, MaterializedView.getPartitionExpr(materializedView));
-                        return SyncPartitionUtils.hasRangePartitionChanged(snapshotPartitionMap, currentPartitionMap);
+                        return SyncPartitionUtils.hasPartitionChange(snapshotPartitionMap, currentPartitionMap);
                     }
                 }
             } catch (UserException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -655,16 +655,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         refBaseTablePartitionColumn, PartitionUtil.getPartitionNames(refBaseTable));
             }
 
-            Range<PartitionKey> rangeToInclude = null;
             Column partitionColumn =
                     ((RangePartitionInfo) materializedView.getPartitionInfo()).getPartitionColumns().get(0);
-            String start = context.getProperties().get(TaskRun.PARTITION_START);
-            String end = context.getProperties().get(TaskRun.PARTITION_END);
-            if (start != null || end != null) {
-                rangeToInclude = SyncPartitionUtils.createRange(start, end, partitionColumn);
-            }
-            PartitionDiffer differ =
-                    new PartitionDiffer(rangeToInclude, partitionTTLNumber, materializedView.getPartitionInfo());
+            PartitionDiffer differ = PartitionDiffer.build(materializedView, context);
             rangePartitionDiff = PartitionUtil.getPartitionDiff(
                     partitionExpr, partitionColumn, refBaseTablePartitionMap, mvPartitionMap, differ);
         } catch (UserException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -667,23 +667,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     new PartitionDiffer(rangeToInclude, partitionTTLNumber, materializedView.getPartitionInfo());
             rangePartitionDiff = PartitionUtil.getPartitionDiff(
                     partitionExpr, partitionColumn, refBaseTablePartitionMap, mvPartitionMap, differ);
-
-            //            if (partitionExpr instanceof SlotRef) {
-            //                rangePartitionDiff = SyncPartitionUtils.getRangePartitionDiffOfSlotRef(refBaseTablePartitionMap,
-            //                        mvPartitionMap, differ);
-            //            } else if (partitionExpr instanceof FunctionCallExpr) {
-            //                FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
-            //                if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.DATE_TRUNC) ||
-            //                        functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
-            //
-            //                    rangePartitionDiff = SyncPartitionUtils.getRangePartitionDiffOfExpr(refBaseTablePartitionMap,
-            //                            mvRangePartitionMap, functionCallExpr, differ);
-            //                } else {
-            //                    throw new SemanticException("Materialized view partition function " +
-            //                            functionCallExpr.getFnName().getFunction() +
-            //                            " is not supported yet.", functionCallExpr.getPos());
-            //                }
-            //            }
         } catch (UserException e) {
             LOG.warn("Materialized view compute partition difference with base table failed.", e);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -104,8 +105,9 @@ public class PartitionDiffer {
      */
     private Map<String, Range<PartitionKey>> pruneAddedPartitions(Map<String, Range<PartitionKey>> addPartitions)
             throws NotImplementedException, AnalysisException {
+        Map<String, Range<PartitionKey>> res = new HashMap<>(addPartitions);
         if (rangeToInclude != null) {
-            addPartitions.entrySet().removeIf(entry -> !isRangeIncluded(entry.getValue(), rangeToInclude));
+            res.entrySet().removeIf(entry -> !isRangeIncluded(entry.getValue(), rangeToInclude));
         }
         if (partitionTTLNumber > 0 && partitionInfo instanceof RangePartitionInfo) {
             List<PartitionRange> sorted =
@@ -150,10 +152,10 @@ public class PartitionDiffer {
             Set<String> prunedPartitions =
                     ttlCandidate.stream().map(PartitionRange::getPartitionName)
                             .collect(Collectors.toSet());
-            addPartitions.keySet().removeIf(prunedPartitions::contains);
+            res.keySet().removeIf(prunedPartitions::contains);
         }
 
-        return addPartitions;
+        return res;
     }
 
     public static RangePartitionDiff simpleDiff(Map<String, Range<PartitionKey>> srcRangeMap,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -158,10 +158,9 @@ public class PartitionDiffer {
 
     public static RangePartitionDiff simpleDiff(Map<String, Range<PartitionKey>> srcRangeMap,
                                                 Map<String, Range<PartitionKey>> dstRangeMap) {
-        PartitionDiffer differ = new PartitionDiffer();
         RangePartitionDiff res = new RangePartitionDiff();
-        res.setAdds(differ.diffRange(srcRangeMap, dstRangeMap));
-        res.setDeletes(differ.diffRange(dstRangeMap, srcRangeMap));
+        res.setAdds(diffRange(srcRangeMap, dstRangeMap));
+        res.setDeletes(diffRange(dstRangeMap, srcRangeMap));
         return res;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -120,7 +120,7 @@ public class PartitionDiffer {
             Type partitionType = partitionColumns.get(0).getType();
             Predicate<PartitionRange> isShadowKey = Predicates.alwaysFalse();
             Predicate<PartitionRange> isInFuture = Predicates.alwaysFalse();
-            if (partitionType.isDatetime()) {
+            if (partitionType.isDateType()) {
                 PartitionKey currentPartitionKey;
                 PartitionKey shadowPartitionKey;
                 shadowPartitionKey = PartitionKey.createShadowPartitionKey(partitionColumns);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -1,0 +1,195 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Range;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.NotImplementedException;
+import com.starrocks.common.util.RangeUtils;
+import org.apache.commons.collections4.ListUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+// TODO: refactor all related code into this class
+
+/**
+ * Compute the Materialized View partition mapping from base table
+ * e.g. the MV is PARTITION BY date_trunc('month', dt), and the base table is daily partition, the resulted mv
+ * should be monthly partition
+ */
+public class PartitionDiffer {
+
+    private static final Logger LOG = LogManager.getLogger(PartitionDiffer.class);
+
+    private Range<PartitionKey> rangeToInclude;
+    private int partitionTTLNumber;
+    private PartitionInfo partitionInfo;
+
+    public PartitionDiffer(Range<PartitionKey> rangeToInclude, int partitionTTLNumber, PartitionInfo partitionInfo) {
+        this.rangeToInclude = rangeToInclude;
+        this.partitionTTLNumber = partitionTTLNumber;
+        this.partitionInfo = partitionInfo;
+    }
+
+    public PartitionDiffer() {
+    }
+
+    /**
+     * Diff considering refresh range and TTL
+     */
+    public RangePartitionDiff diff(Map<String, Range<PartitionKey>> srcRangeMap,
+                                   Map<String, Range<PartitionKey>> dstRangeMap) {
+        RangePartitionDiff res = new RangePartitionDiff();
+        try {
+            Map<String, Range<PartitionKey>> prunedAdd = pruneAddedPartitions(srcRangeMap);
+            res.setAdds(diffRange(prunedAdd, dstRangeMap));
+        } catch (Exception e) {
+            LOG.warn("failed to prune partitions when creating");
+            throw new RuntimeException(e);
+        }
+        res.setDeletes(diffRange(dstRangeMap, srcRangeMap));
+        return res;
+    }
+
+    /**
+     * Prune based on TTL and refresh range
+     */
+    private Map<String, Range<PartitionKey>> pruneAddedPartitions(Map<String, Range<PartitionKey>> addPartitions)
+            throws NotImplementedException, AnalysisException {
+        if (rangeToInclude != null) {
+            addPartitions.entrySet().removeIf(entry -> !isRangeIncluded(entry.getValue(), rangeToInclude));
+        }
+        if (partitionTTLNumber > 0 && partitionInfo instanceof RangePartitionInfo) {
+            List<PartitionRange> sorted =
+                    addPartitions.entrySet()
+                            .stream().map(entry -> new PartitionRange(entry.getKey(), entry.getValue()))
+                            .sorted(Comparator.reverseOrder())
+                            .collect(Collectors.toList());
+
+            List<Column> partitionColumns = partitionInfo.getPartitionColumns();
+            Type partitionType = partitionColumns.get(0).getType();
+            Predicate<PartitionRange> isShadowKey = Predicates.alwaysFalse();
+            Predicate<PartitionRange> isInFuture = Predicates.alwaysFalse();
+            if (partitionType.isDatetime()) {
+                PartitionKey currentPartitionKey;
+                PartitionKey shadowPartitionKey;
+                shadowPartitionKey = PartitionKey.createShadowPartitionKey(partitionColumns);
+                currentPartitionKey = partitionType.isDatetime() ?
+                        PartitionKey.ofDateTime(LocalDateTime.now()) : PartitionKey.ofDate(LocalDate.now());
+                isShadowKey = (p) -> p.getPartitionKeyRange().lowerEndpoint().compareTo(shadowPartitionKey) == 0;
+                isInFuture = (p) -> p.getPartitionKeyRange().lowerEndpoint().compareTo(currentPartitionKey) > 0;
+            }
+            // TODO: convert string type to date as predicate
+
+            // keep partition that either is shadow partition, or larger than current_time
+            // and keep only partition_ttl_number of partitions
+            Predicate<PartitionRange> finalIsShadowKey = isShadowKey;
+            Predicate<PartitionRange> finalIsInFuture = isInFuture;
+            List<PartitionRange> ttlCandidate =
+                    sorted.stream()
+                            .filter(x -> !finalIsShadowKey.test(x) && !finalIsInFuture.test(x))
+                            .collect(Collectors.toList());
+
+            // keep only ttl_number of candidates,
+            // since ths list already reversed sorted, grab the sublist
+            if (ttlCandidate.size() > partitionTTLNumber) {
+                ttlCandidate = ttlCandidate.subList(partitionTTLNumber, ttlCandidate.size());
+            } else {
+                ttlCandidate.clear();
+            }
+
+            // remove partitions in ttl candidate
+            Set<String> prunedPartitions =
+                    ttlCandidate.stream().map(PartitionRange::getPartitionName)
+                            .collect(Collectors.toSet());
+            addPartitions.keySet().removeIf(prunedPartitions::contains);
+        }
+
+        return addPartitions;
+    }
+
+    public static RangePartitionDiff simpleDiff(Map<String, Range<PartitionKey>> srcRangeMap,
+                                                Map<String, Range<PartitionKey>> dstRangeMap) {
+        PartitionDiffer differ = new PartitionDiffer();
+        RangePartitionDiff res = new RangePartitionDiff();
+        res.setAdds(differ.diffRange(srcRangeMap, dstRangeMap));
+        res.setDeletes(differ.diffRange(dstRangeMap, srcRangeMap));
+        return res;
+    }
+
+    public static Map<String, Range<PartitionKey>> diffRange(Map<String, Range<PartitionKey>> srcRangeMap,
+                                                             Map<String, Range<PartitionKey>> dstRangeMap) {
+        Map<String, Range<PartitionKey>> result = Maps.newHashMap();
+        for (Map.Entry<String, Range<PartitionKey>> srcEntry : srcRangeMap.entrySet()) {
+            if (!dstRangeMap.containsKey(srcEntry.getKey()) ||
+                    !RangeUtils.isRangeEqual(srcEntry.getValue(), dstRangeMap.get(srcEntry.getKey()))) {
+                result.put(srcEntry.getKey(), SyncPartitionUtils.convertToDatePartitionRange(srcEntry.getValue()));
+            }
+        }
+        return result;
+    }
+
+    public static Map<String, Range<PartitionKey>> diffRange(List<PartitionRange> srcRanges,
+                                                             List<PartitionRange> dstRanges) {
+        if (!srcRanges.isEmpty() && !dstRanges.isEmpty()) {
+            List<PrimitiveType> srcTypes = srcRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
+            List<PrimitiveType> dstTypes = dstRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
+            Preconditions.checkArgument(Objects.equals(srcTypes, dstTypes), "types must be identical");
+        }
+        List<PartitionRange> diffs = ListUtils.subtract(srcRanges, dstRanges);
+        return diffs.stream()
+                .collect(Collectors.toMap(PartitionRange::getPartitionName,
+                        diff -> SyncPartitionUtils.convertToDatePartitionRange(diff).getPartitionKeyRange()
+                ));
+    }
+
+    /**
+     * Check whether `range` is included in `rangeToInclude`. Here we only want to
+     * create partitions which is between `start` and `end` when executing
+     * `refresh materialized view xxx partition start (xxx) end (xxx)`
+     *
+     * @param range          range to check
+     * @param rangeToInclude range to check whether the to be checked range is in
+     * @return true if included, else false
+     */
+    private static boolean isRangeIncluded(Range<PartitionKey> rangeToCheck, Range<PartitionKey> rangeToInclude) {
+        if (rangeToInclude == null) {
+            return true;
+        }
+        int lowerCmp = rangeToInclude.lowerEndpoint().compareTo(rangeToCheck.upperEndpoint());
+        int upperCmp = rangeToInclude.upperEndpoint().compareTo(rangeToCheck.lowerEndpoint());
+        return !(lowerCmp >= 0 || upperCmp <= 0);
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
@@ -53,13 +53,6 @@ public class PartitionRange implements Comparable<PartitionRange> {
         return this.partitionKeyRange.lowerEndpoint().compareTo(o.partitionKeyRange.lowerEndpoint());
     }
 
-    public static int compareRangePartition(Range<PartitionKey> left, Range<PartitionKey> right) {
-        if (left.isConnected(right)) {
-            return 0;
-        }
-        return left.lowerEndpoint().compareTo(right.lowerEndpoint());
-    }
-
     /**
      * Check two partition range is `interact` which is a bit different from Range's `isConnected` method, eg:
      * [2, 4) and [4, 6) are not interact;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionRange.java
@@ -53,6 +53,13 @@ public class PartitionRange implements Comparable<PartitionRange> {
         return this.partitionKeyRange.lowerEndpoint().compareTo(o.partitionKeyRange.lowerEndpoint());
     }
 
+    public static int compareRangePartition(Range<PartitionKey> left, Range<PartitionKey> right) {
+        if (left.isConnected(right)) {
+            return 0;
+        }
+        return left.lowerEndpoint().compareTo(right.lowerEndpoint());
+    }
+
     /**
      * Check two partition range is `interact` which is a bit different from Range's `isConnected` method, eg:
      * [2, 4) and [4, 6) are not interact;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -327,16 +327,8 @@ public class PartitionBasedMvRefreshProcessorTest {
                         "\"replication_num\" = \"1\",\n" +
                         "\"partition_refresh_number\" = \"1\"" +
                         ") " +
-                        "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;")
-                .withMaterializedView("create materialized view jdbc_parttbl_str2date " +
-                        "partition by date_trunc('month', ss) " +
-                        "distributed by hash(a) buckets 10 " +
-                        "REFRESH DEFERRED MANUAL " +
-                        "PROPERTIES (\n" +
-                        "\"replication_num\" = \"1\",\n" +
-                        "\"partition_refresh_number\" = \"1\"" +
-                        ") " +
                         "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
+
 
         new MockUp<StmtExecutor>() {
             @Mock
@@ -1163,12 +1155,9 @@ public class PartitionBasedMvRefreshProcessorTest {
         taskRun.executeTaskRun();
         Collection<Partition> partitions = materializedView.getPartitions();
 
-        Assert.assertEquals(6, partitions.size());
+        Assert.assertEquals(2, partitions.size());
         Assert.assertEquals(2, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(2, materializedView.getPartition("p19980102").getVisibleVersion());
-        Assert.assertEquals(1, materializedView.getPartition("p19980103").getVisibleVersion());
-        Assert.assertEquals(1, materializedView.getPartition("p19980104").getVisibleVersion());
-        Assert.assertEquals(1, materializedView.getPartition("p19980105").getVisibleVersion());
 
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
@@ -1379,7 +1368,6 @@ public class PartitionBasedMvRefreshProcessorTest {
                 partitions);
     }
 
-    @Ignore
     @Test
     public void test_str2date_date_trunc() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
@@ -1388,6 +1376,15 @@ public class PartitionBasedMvRefreshProcessorTest {
         mockedJDBCMetadata.initPartitions();
 
         String mvName = "jdbc_parttbl_str2date";
+        starRocksAssert.withMaterializedView("create materialized view jdbc_parttbl_str2date " +
+                "partition by date_trunc('month', ss) " +
+                "distributed by hash(a) buckets 10 " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"partition_refresh_number\" = \"1\"" +
+                ") " +
+                "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
 
@@ -1397,7 +1394,7 @@ public class PartitionBasedMvRefreshProcessorTest {
             List<String> partitions =
                     materializedView.getPartitions().stream().map(Partition::getName).sorted()
                             .collect(Collectors.toList());
-            Assert.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
+            Assert.assertEquals(Arrays.asList("p202308_202309"), partitions);
         }
 
         // partial range refresh 1
@@ -1410,9 +1407,7 @@ public class PartitionBasedMvRefreshProcessorTest {
             List<String> partitions =
                     materializedView.getPartitions().stream().map(Partition::getName).sorted()
                             .collect(Collectors.toList());
-            Assert.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
-            Assert.assertEquals(partitionVersionMap.get("p000101_202308").longValue(),
-                    materializedView.getPartition("p000101_202308").getVisibleVersion());
+            Assert.assertEquals(Arrays.asList("p202308_202309"), partitions);
             Assert.assertTrue(partitionVersionMap.get("p202308_202309") <
                     materializedView.getPartition("p202308_202309").getVisibleVersion());
         }
@@ -1427,12 +1422,55 @@ public class PartitionBasedMvRefreshProcessorTest {
             List<String> partitions =
                     materializedView.getPartitions().stream().map(Partition::getName).sorted()
                             .collect(Collectors.toList());
-            Assert.assertEquals(Arrays.asList("p000101_202308", "p202308_202309"), partitions);
-            Assert.assertEquals(partitionVersionMap.get("p000101_202308") + 1,
-                    materializedView.getPartition("p000101_202308").getVisibleVersion());
+            Assert.assertEquals(Arrays.asList("p202308_202309"), partitions);
             Assert.assertEquals(partitionVersionMap.get("p202308_202309").longValue(),
                     materializedView.getPartition("p202308_202309").getVisibleVersion());
         }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void test_str2date_ttl() throws Exception {
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
+        MockedJDBCMetadata mockedJDBCMetadata =
+                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+        mockedJDBCMetadata.initPartitions();
+
+        String mvName = "jdbc_parttbl_str2date";
+        starRocksAssert.withMaterializedView("create materialized view jdbc_parttbl_str2date " +
+                "partition by ss " +
+                "distributed by hash(a) buckets 10 " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"partition_refresh_number\" = \"1\"," +
+                "'partition_ttl_number'='2'" +
+                ") " +
+                "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230802_20230803", "p20230803_20230804"), partitions);
+
+        // modify TTL
+        {
+            starRocksAssert.getCtx().executeSql(
+                    String.format("alter materialized view %s set ('partition_ttl_number'='1')", mvName));
+            starRocksAssert.getCtx().executeSql(String.format("refresh materialized view %s with sync mode", mvName));
+            GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
+
+            partitions =
+                    materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                            .collect(Collectors.toList());
+            Assert.assertEquals(Arrays.asList("p20230803_20230804"), partitions);
+        }
+        starRocksAssert.dropMaterializedView(mvName);
     }
 
     @Ignore

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
@@ -142,6 +142,6 @@ public class SyncPartitionBench {
 
     @Benchmark
     public void diffRangeBench() {
-        SyncPartitionUtils.PartitionDiffer.diffRange(srcRangeMap, dstRangeMap);
+        PartitionDiffer.diffRange(srcRangeMap, dstRangeMap);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionBench.java
@@ -142,6 +142,6 @@ public class SyncPartitionBench {
 
     @Benchmark
     public void diffRangeBench() {
-        SyncPartitionUtils.diffRange(srcRangeMap, dstRangeMap);
+        SyncPartitionUtils.PartitionDiffer.diffRange(srcRangeMap, dstRangeMap);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -166,14 +166,14 @@ public class SyncPartitionUtilsTest {
         Map<String, Range<PartitionKey>> dstRange = Maps.newHashMap();
         dstRange.put("p20200101", createRange("2020-01-01", "2020-01-02"));
 
-        Map<String, Range<PartitionKey>> diff = SyncPartitionUtils.PartitionDiffer.diffRange(srcRange, dstRange);
+        Map<String, Range<PartitionKey>> diff = PartitionDiffer.diffRange(srcRange, dstRange);
         Assert.assertEquals(1, diff.size());
         Assert.assertEquals("2020-01-02 00:00:00",
                 diff.get("p20200102").lowerEndpoint().getKeys().get(0).getStringValue());
         Assert.assertEquals("2020-01-03 00:00:00",
                 diff.get("p20200102").upperEndpoint().getKeys().get(0).getStringValue());
 
-        diff = SyncPartitionUtils.PartitionDiffer.diffRange(dstRange, srcRange);
+        diff = PartitionDiffer.diffRange(dstRange, srcRange);
         Assert.assertEquals(0, diff.size());
 
         // two range
@@ -189,7 +189,7 @@ public class SyncPartitionUtilsTest {
         dstRange.put("p20200102", createRange("2020-01-02", "2020-01-06"));
         dstRange.put("p20200106", createRange("2020-01-06", "2020-01-07"));
 
-        diff = SyncPartitionUtils.PartitionDiffer.diffRange(srcRange, dstRange);
+        diff = PartitionDiffer.diffRange(srcRange, dstRange);
         Assert.assertEquals(2, diff.size());
         Assert.assertEquals("2020-01-02 00:00:00",
                 diff.get("p20200102").lowerEndpoint().getKeys().get(0).getStringValue());
@@ -200,7 +200,7 @@ public class SyncPartitionUtilsTest {
         Assert.assertEquals("2020-01-06 00:00:00",
                 diff.get("p20200105").upperEndpoint().getKeys().get(0).getStringValue());
 
-        diff = SyncPartitionUtils.PartitionDiffer.diffRange(dstRange, srcRange);
+        diff = PartitionDiffer.diffRange(dstRange, srcRange);
         Assert.assertEquals(1, diff.size());
         Assert.assertEquals("2020-01-02 00:00:00",
                 diff.get("p20200102").lowerEndpoint().getKeys().get(0).getStringValue());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -166,14 +166,14 @@ public class SyncPartitionUtilsTest {
         Map<String, Range<PartitionKey>> dstRange = Maps.newHashMap();
         dstRange.put("p20200101", createRange("2020-01-01", "2020-01-02"));
 
-        Map<String, Range<PartitionKey>> diff = SyncPartitionUtils.diffRange(srcRange, dstRange);
+        Map<String, Range<PartitionKey>> diff = SyncPartitionUtils.PartitionDiffer.diffRange(srcRange, dstRange);
         Assert.assertEquals(1, diff.size());
         Assert.assertEquals("2020-01-02 00:00:00",
                 diff.get("p20200102").lowerEndpoint().getKeys().get(0).getStringValue());
         Assert.assertEquals("2020-01-03 00:00:00",
                 diff.get("p20200102").upperEndpoint().getKeys().get(0).getStringValue());
 
-        diff = SyncPartitionUtils.diffRange(dstRange, srcRange);
+        diff = SyncPartitionUtils.PartitionDiffer.diffRange(dstRange, srcRange);
         Assert.assertEquals(0, diff.size());
 
         // two range
@@ -189,7 +189,7 @@ public class SyncPartitionUtilsTest {
         dstRange.put("p20200102", createRange("2020-01-02", "2020-01-06"));
         dstRange.put("p20200106", createRange("2020-01-06", "2020-01-07"));
 
-        diff = SyncPartitionUtils.diffRange(srcRange, dstRange);
+        diff = SyncPartitionUtils.PartitionDiffer.diffRange(srcRange, dstRange);
         Assert.assertEquals(2, diff.size());
         Assert.assertEquals("2020-01-02 00:00:00",
                 diff.get("p20200102").lowerEndpoint().getKeys().get(0).getStringValue());
@@ -200,7 +200,7 @@ public class SyncPartitionUtilsTest {
         Assert.assertEquals("2020-01-06 00:00:00",
                 diff.get("p20200105").upperEndpoint().getKeys().get(0).getStringValue());
 
-        diff = SyncPartitionUtils.diffRange(dstRange, srcRange);
+        diff = SyncPartitionUtils.PartitionDiffer.diffRange(dstRange, srcRange);
         Assert.assertEquals(1, diff.size());
         Assert.assertEquals("2020-01-02 00:00:00",
                 diff.get("p20200102").lowerEndpoint().getKeys().get(0).getStringValue());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -332,10 +332,14 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
         }
 
         // increase the ttl number, and add more ttl partitions
+        cluster.runSql("test", String.format("alter materialized view %s set('partition_ttl_number'='5')", mvName));
+        refreshMaterializedView("test", mvName);
         GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
-        Assert.assertEquals(1, mv.getPartitions().size());
+        Assert.assertEquals(5, mv.getPartitions().size());
 
         // decrease the ttl number, and drop some ttl partitions
+        cluster.runSql("test", String.format("alter materialized view %s set('partition_ttl_number'='1')", mvName));
+        refreshMaterializedView("test", mvName);
         GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
         Assert.assertEquals(1, mv.getPartitions().size());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -317,7 +317,8 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                 " DISTRIBUTED BY HASH(k1) BUCKETS 10\n" +
                 " REFRESH ASYNC\n" +
                 " PROPERTIES(\n" +
-                " \"partition_ttl_number\"=\"2\"\n" +
+                " 'partition_refresh_number'='1',\n" +
+                " 'partition_ttl_number'='2' \n" +
                 " )\n" +
                 " AS SELECT k1, sum(v1) as sum_v1 FROM ttl_base_table group by k1;");
         MaterializedView mv = getMv("test", mvName);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -291,6 +291,60 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
     }
 
     @Test
+    public void testPartitionTTL() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE ttl_base_table (\n" +
+                "                            k1 INT,\n" +
+                "                            v1 INT,\n" +
+                "                            v2 INT)\n" +
+                "                        DUPLICATE KEY(k1)\n" +
+                "                        PARTITION BY RANGE(`k1`)\n" +
+                "                        (\n" +
+                "                        PARTITION `p1` VALUES LESS THAN ('2'),\n" +
+                "                        PARTITION `p2` VALUES LESS THAN ('3'),\n" +
+                "                        PARTITION `p3` VALUES LESS THAN ('4'),\n" +
+                "                        PARTITION `p4` VALUES LESS THAN ('5'),\n" +
+                "                        PARTITION `p5` VALUES LESS THAN ('6'),\n" +
+                "                        PARTITION `p6` VALUES LESS THAN ('7')\n" +
+                "                        )\n" +
+                "                        DISTRIBUTED BY HASH(k1) properties('replication_num'='1');");
+        cluster.runSql("test", "insert into ttl_base_table values (1,1,1),(1,1,2),(1,2,1),(1,2,2),\n" +
+                "                                              (2,1,1),(2,1,2),(2,2,1),(2,2,2),\n" +
+                "                                              (3,1,1),(3,1,2),(3,2,1),(3,2,2);");
+
+        String mvName = "ttl_mv_3";
+        createAndRefreshMv("test", mvName, "CREATE MATERIALIZED VIEW " + mvName +
+                " PARTITION BY k1\n" +
+                " DISTRIBUTED BY HASH(k1) BUCKETS 10\n" +
+                " REFRESH ASYNC\n" +
+                " PROPERTIES(\n" +
+                " \"partition_ttl_number\"=\"1\"\n" +
+                " )\n" +
+                " AS SELECT k1, sum(v1) as sum_v1 FROM ttl_base_table group by k1;");
+        MaterializedView mv = getMv("test", mvName);
+
+        // initial mv should create only 1 partition
+        Assert.assertEquals(1, mv.getPartitions().size());
+
+        // refresh multiple times, should not change the live partition number
+        for (int i = 0; i < 10; i++) {
+            refreshMaterializedView("test", mvName);
+            Assert.assertEquals("refresh " + i, 1, mv.getPartitions().size());
+        }
+
+        // increase the ttl number, and add more ttl partitions
+        GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
+        Assert.assertEquals(1, mv.getPartitions().size());
+
+        // decrease the ttl number, and drop some ttl partitions
+        GlobalStateMgr.getCurrentState().getDynamicPartitionScheduler().runOnceForTest();
+        Assert.assertEquals(1, mv.getPartitions().size());
+
+        // cleanup
+        dropMv("test", mvName);
+        starRocksAssert.dropTable("ttl_base_table");
+    }
+
+    @Test
     public void testHivePartialPartitionWithTTL() throws Exception {
         starRocksAssert.getCtx().getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
         createAndRefreshMv("test", "hive_parttbl_mv",
@@ -723,4 +777,5 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
             dropMv("test", mvName);
         }
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -317,18 +317,18 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
                 " DISTRIBUTED BY HASH(k1) BUCKETS 10\n" +
                 " REFRESH ASYNC\n" +
                 " PROPERTIES(\n" +
-                " \"partition_ttl_number\"=\"1\"\n" +
+                " \"partition_ttl_number\"=\"2\"\n" +
                 " )\n" +
                 " AS SELECT k1, sum(v1) as sum_v1 FROM ttl_base_table group by k1;");
         MaterializedView mv = getMv("test", mvName);
 
         // initial mv should create only 1 partition
-        Assert.assertEquals(1, mv.getPartitions().size());
+        Assert.assertEquals(2, mv.getPartitions().size());
 
         // refresh multiple times, should not change the live partition number
         for (int i = 0; i < 10; i++) {
             refreshMaterializedView("test", mvName);
-            Assert.assertEquals("refresh " + i, 1, mv.getPartitions().size());
+            Assert.assertEquals("refresh " + i, 2, mv.getPartitions().size());
         }
 
         // increase the ttl number, and add more ttl partitions

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1502,8 +1502,8 @@ public class MvRewriteTest extends MvRewriteTestBase {
             String query = "select k1, sum(v1) FROM test_partition_tbl1 where k1>='2020-02-11' group by k1;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "test_partition_tbl_mv1");
-            PlanTestBase.assertContains(plan, "PREDICATES: 5: k1 >= '2020-02-11'\n" +
-                    "     partitions=4/4");
+            PlanTestBase.assertContains(plan, "PREDICATES: 5: k1 >= '2020-02-11'");
+            PlanTestBase.assertContains(plan, "partitions=4/4");
         }
         {
             String query = "select k1, sum(v1) FROM test_partition_tbl1 where k1>='2020-02-01' group by k1;";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -1503,13 +1503,13 @@ public class MvRewriteTest extends MvRewriteTestBase {
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "test_partition_tbl_mv1");
             PlanTestBase.assertContains(plan, "PREDICATES: 5: k1 >= '2020-02-11'\n" +
-                    "     partitions=4/6");
+                    "     partitions=4/4");
         }
         {
             String query = "select k1, sum(v1) FROM test_partition_tbl1 where k1>='2020-02-01' group by k1;";
             String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "test_partition_tbl_mv1");
-            PlanTestBase.assertContains(plan, "partitions=4/6\n" +
+            PlanTestBase.assertContains(plan, "partitions=4/4\n" +
                     "     rollup: test_partition_tbl_mv1");
         }
     }


### PR DESCRIPTION
Fixes #issue

If the mv contains `partition_ttl_number` property, we should consider this property when creating partitions.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
