### PR TITLE
[Enhancement] Avoid build slice for array_max and array_min

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -512,13 +512,13 @@ struct ChunkSliceTemplate {
 template <LogicalType ltype>
 struct GetContainer {
     using ColumnType = typename RunTimeTypeTraits<ltype>::ColumnType;
-    const auto& get_data(Column* column) { return ColumnHelper::as_raw_column<ColumnType>(column)->get_data(); }
+    const auto& get_data(const Column* column) { return ColumnHelper::as_raw_column<ColumnType>(column)->get_data(); }
 };
 
 #define GET_CONTAINER(ltype)                                                            \
     template <>                                                                         \
     struct GetContainer<ltype> {                                                        \
-        const auto& get_data(Column* column) {                                          \
+        const auto& get_data(const Column* column) {                                    \
             return ColumnHelper::as_raw_column<BinaryColumn>(column)->get_proxy_data(); \
         }                                                                               \
     };

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -803,7 +803,8 @@ private:
                 res.set_null(i);
                 continue;
             }
-            const auto& datum_array = src_column->get(i).get_array();
+            auto tmp_datum = src_column->get(i);
+            const auto& datum_array = tmp_datum.get_array();
             bool append = false;
             Slice sep_slice = sep_column->get(i).get_slice();
             Slice null_slice = null_replace_column->get(i).get_slice();
@@ -839,7 +840,8 @@ private:
                 continue;
             }
 
-            const auto& datum_array = src_column->get(i).get_array();
+            auto tmp_datum = src_column->get(i);
+            const auto& datum_array = tmp_datum.get_array();
             bool append = false;
             Slice sep_slice = sep_column->get(i).get_slice();
             for (const auto& datum : datum_array) {

--- a/be/src/exprs/array_functions.tpp
+++ b/be/src/exprs/array_functions.tpp
@@ -803,8 +803,7 @@ private:
                 res.set_null(i);
                 continue;
             }
-            auto datum = src_column->get(i);
-            const auto& datum_array = datum.get_array();
+            const auto& datum_array = src_column->get(i).get_array();
             bool append = false;
             Slice sep_slice = sep_column->get(i).get_slice();
             Slice null_slice = null_replace_column->get(i).get_slice();
@@ -840,8 +839,7 @@ private:
                 continue;
             }
 
-            auto datum = src_column->get(i);
-            const auto& datum_array = datum.get_array();
+            const auto& datum_array = src_column->get(i).get_array();
             bool append = false;
             Slice sep_slice = sep_column->get(i).get_slice();
             for (const auto& datum : datum_array) {
@@ -1166,7 +1164,7 @@ public:
         if constexpr (HasNull) {
             elements_nulls = elements_null_col->get_data().data();
         }
-        auto* elements_data = down_cast<const RunTimeColumnType<ElementType>*>(elements)->get_data().data();
+        const auto& elements_data = GetContainer<ElementType>().get_data(elements);
 
         auto* offsets_ptr = offsets->get_data().data();
         auto* null_ptr = null_cols->get_data().data();
@@ -1222,7 +1220,7 @@ public:
                 }
 
                 has_data = true;
-                auto& value = elements_data[offset + index];
+                const auto& value = elements_data[offset + index];
                 if constexpr (isMin) {
                     result = result < value ? result : value;
                 } else {


### PR DESCRIPTION
```
# lo_orderkey is string
select count(array_max(lo_orderkey)) from t2;
```

Optimizate from 1.7s to 1.1s

Before Opt:

```
             - AggregateFunctions: count(array_max(2: lo_orderkey))
             - AggComputeTime: 1s740ms
             - AggFuncComputeTime: 1s740ms
```

After opt:

```
             - AggregateFunctions: count(array_max(2: lo_orderkey))
             - AggComputeTime: 1s162ms
             - AggFuncComputeTime: 1s162ms
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
