### PR TITLE
[BugFix] Only remove partition vision infos when mv's partition has been dropped 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -166,14 +166,22 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     public static class AsyncRefreshContext {
+        // Olap base table refreshed meta infos
         // base table id -> (partition name -> partition info (id, version))
         // partition id maybe changed after insert overwrite, so use partition name as key.
         // partition id which in BasePartitionInfo can be used to check partition is changed
         @SerializedName("baseTableVisibleVersionMap")
         private final Map<Long, Map<String, BasePartitionInfo>> baseTableVisibleVersionMap;
 
+        // External base table refreshed meta infos
         @SerializedName("baseTableInfoVisibleVersionMap")
         private final Map<BaseTableInfo, Map<String, BasePartitionInfo>> baseTableInfoVisibleVersionMap;
+
+        // Materialized view partition is updated/added associated with ref-base-table. This meta
+        // is kept to track materialized view's partition change and update associated ref-base-table
+        // at the same time.
+        @SerializedName("mvPartitionNameRefBaseTablePartitionMap")
+        private final Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap;
 
         @SerializedName(value = "defineStartTime")
         private boolean defineStartTime;
@@ -190,6 +198,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         public AsyncRefreshContext() {
             this.baseTableVisibleVersionMap = Maps.newConcurrentMap();
             this.baseTableInfoVisibleVersionMap = Maps.newConcurrentMap();
+            this.mvPartitionNameRefBaseTablePartitionMap = Maps.newConcurrentMap();
             this.defineStartTime = false;
             this.startTime = Utils.getLongFromDateTime(LocalDateTime.now());
             this.step = 0;
@@ -204,9 +213,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return baseTableInfoVisibleVersionMap;
         }
 
+        public Map<String, Set<String>> getMvPartitionNameRefBaseTablePartitionMap() {
+            return mvPartitionNameRefBaseTablePartitionMap;
+        }
+
         public void clearVisibleVersionMap() {
             this.baseTableInfoVisibleVersionMap.clear();
             this.baseTableVisibleVersionMap.clear();
+            this.mvPartitionNameRefBaseTablePartitionMap.clear();
         }
 
         public boolean isDefineStartTime() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -447,15 +447,17 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             // update materialized view partition to ref base table partition names meta
             Map<String, Set<String>> mvToBaseNameRef = mvContext.getMvRefBaseTableIntersectedPartitions();
-            for (String mvRefreshedPartition : mvRefreshedPartitions) {
-                if (mvToBaseNameRef.containsKey(mvRefreshedPartition)) {
-                    Set<String> refBaseTableAssociatedPartitions = mvToBaseNameRef.get(mvRefreshedPartition);
-                    refreshContext.getMvPartitionNameRefBaseTablePartitionMap()
-                            .put(mvRefreshedPartition, refBaseTableAssociatedPartitions);
-                } else {
-                    LOG.warn("MV task run context not contains the associated ref base table partitions of" +
-                            " the refreshed mv partition {} in materialized view{}", mvRefreshedPartition,
-                            materializedView.getName());
+            if (mvToBaseNameRef != null) {
+                for (String mvRefreshedPartition : mvRefreshedPartitions) {
+                    if (mvToBaseNameRef.containsKey(mvRefreshedPartition)) {
+                        Set<String> refBaseTableAssociatedPartitions = mvToBaseNameRef.get(mvRefreshedPartition);
+                        refreshContext.getMvPartitionNameRefBaseTablePartitionMap()
+                                .put(mvRefreshedPartition, refBaseTableAssociatedPartitions);
+                    } else {
+                        LOG.warn("MV task run context not contains the associated ref base table partitions of" +
+                                        " the refreshed mv partition {} in materialized view{}", mvRefreshedPartition,
+                                materializedView.getName());
+                    }
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -442,8 +442,23 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 baseTableAndPartitionNames.putAll(nonRefTableAndPartitionNames);
             }
 
-            MaterializedView.AsyncRefreshContext refreshContext =
-                    materializedView.getRefreshScheme().getAsyncRefreshContext();
+            MaterializedView.MvRefreshScheme mvRefreshScheme = materializedView.getRefreshScheme();
+            MaterializedView.AsyncRefreshContext refreshContext = mvRefreshScheme.getAsyncRefreshContext();
+
+            // update materialized view partition to ref base table partition names meta
+            Map<String, Set<String>> mvToBaseNameRef = mvContext.getMvRefBaseTableIntersectedPartitions();
+            for (String mvRefreshedPartition : mvRefreshedPartitions) {
+                if (mvToBaseNameRef.containsKey(mvRefreshedPartition)) {
+                    Set<String> refBaseTableAssociatedPartitions = mvToBaseNameRef.get(mvRefreshedPartition);
+                    refreshContext.getMvPartitionNameRefBaseTablePartitionMap()
+                            .put(mvRefreshedPartition, refBaseTableAssociatedPartitions);
+                } else {
+                    LOG.warn("MV task run context not contains the associated ref base table partitions of" +
+                            " the refreshed mv partition {} in materialized view{}", mvRefreshedPartition,
+                            materializedView.getName());
+                }
+            }
+
             Map<Long, Map<String, MaterializedView.BasePartitionInfo>> changedOlapTablePartitionInfos =
                     getSelectedPartitionInfosOfOlapTable(baseTableAndPartitionNames);
             Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> changedExternalTablePartitionInfos

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.common;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -576,6 +577,104 @@ public class SyncPartitionUtils {
         return Range.closedOpen(lowerBoundPartitionKey, upperBoundPartitionKey);
     }
 
+    private static boolean dropRefBaseTableFromVersionMap(
+            MaterializedView mv,
+            Map<String, MaterializedView.BasePartitionInfo> baseTableVersionInfoMap,
+            String refBaseTable,
+            String mvPartitionName) {
+        Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getMvPartitionNameRefBaseTablePartitionMap();
+        if (!mvPartitionNameRefBaseTablePartitionMap.containsKey(mvPartitionName)) {
+            return false;
+        }
+        Set<String> refBaseTableAssociatedPartitions =
+                mvPartitionNameRefBaseTablePartitionMap.get(mvPartitionName);
+        LOG.info("Remove ref base table {} associated partitions {} from materialized view {}'s " +
+                        "version meta because materialized view's partition {} has been dropped",
+                refBaseTable, Joiner.on(",").join(refBaseTableAssociatedPartitions),
+                mv.getName(), mvPartitionName);
+        for (String refBaseTableAssociatedPartition : refBaseTableAssociatedPartitions) {
+            if (refBaseTableAssociatedPartition.equals(ICEBERG_ALL_PARTITION)) {
+                continue;
+            }
+            baseTableVersionInfoMap.remove(refBaseTableAssociatedPartition);
+        }
+        return true;
+    }
+
+    private static void dropRefBaseTableFromVersionMapForOlapTable(
+            MaterializedView mv,
+            Map<Long, Map<String, MaterializedView.BasePartitionInfo>> versionMap,
+            Long tableId,
+            String mvPartitionName) {
+        if (!versionMap.containsKey(tableId)) {
+            // version map should always contain ref base table's version info.
+            LOG.warn("Base ref table {} is not found in the base table version info map when " +
+                            "materialized view {} drops partition:{}",
+                    tableId, mv.getName(), mvPartitionName);
+            return;
+        }
+
+        Map<String, MaterializedView.BasePartitionInfo> baseTableVersionInfoMap = versionMap.get(tableId);
+        Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getMvPartitionNameRefBaseTablePartitionMap();
+        if (mvPartitionNameRefBaseTablePartitionMap.containsKey(mvPartitionName)) {
+            dropRefBaseTableFromVersionMap(mv, baseTableVersionInfoMap, tableId.toString(), mvPartitionName);
+        } else  {
+            long refreshedRefBaseTablePartitionSize = baseTableVersionInfoMap.size();
+            long refreshAssociatedRefTablePartitionSize = mvPartitionNameRefBaseTablePartitionMap.values().size();
+            if (refreshedRefBaseTablePartitionSize == refreshAssociatedRefTablePartitionSize) {
+                // It's safe here that only log warning rather than remove all the ref base table info from version map,
+                // because mvPartitionNameRefBaseTablePartitionMap should track all the changed materialized view
+                // partitions.
+                LOG.info("Remove ref base table {} from materialized view {}'s version meta because " +
+                                "materialized view's partition {} has been dropped",
+                        tableId, mv.getName(), mvPartitionName);
+            } else {
+                // NOTE: If the materialized view has created in old version, mvPartitionNameRefBaseTablePartitionMap
+                // may not contain enough info to track associated ref base change partitions.
+                versionMap.remove(tableId);
+            }
+        }
+    }
+
+    private static void dropRefBaseTableFromVersionMapForExternalTable(
+            MaterializedView mv,
+            Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> versionMap,
+            BaseTableInfo baseTableInfo,
+            String mvPartitionName) {
+        if (!versionMap.containsKey(baseTableInfo)) {
+            // version map should always contain ref base table's version info.
+            LOG.warn("Base ref table {} is not found in the base table version info map when " +
+                    "materialized view {} drops partition:{}",
+                    baseTableInfo, mv.getName(), mvPartitionName);
+            return;
+        }
+
+        Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getMvPartitionNameRefBaseTablePartitionMap();
+        Map<String, MaterializedView.BasePartitionInfo> baseTableVersionInfoMap = versionMap.get(baseTableInfo);
+        if (mvPartitionNameRefBaseTablePartitionMap.containsKey(mvPartitionName)) {
+            dropRefBaseTableFromVersionMap(mv, baseTableVersionInfoMap,
+                    baseTableInfo.getTableName(), mvPartitionName);
+        } else  {
+            long refreshedRefBaseTablePartitionSize = baseTableVersionInfoMap.size();
+            long refreshAssociatedRefTablePartitionSize = mvPartitionNameRefBaseTablePartitionMap.values().size();
+            if (refreshedRefBaseTablePartitionSize == refreshAssociatedRefTablePartitionSize) {
+                // It's safe here that only log warning rather than remove all the ref base table info from version map,
+                // because mvPartitionNameRefBaseTablePartitionMap should track all the changed materialized view
+                // partitions.
+                LOG.warn("Remove ref base table {} from materialized view {}'s version meta because " +
+                                "materialized view's partition {} has been dropped",
+                        baseTableInfo, mv.getName(), mvPartitionName);
+            } else {
+                // NOTE: If the materialized view has created in old version, mvPartitionNameRefBaseTablePartitionMap
+                // may not contain enough info to track associated ref base change partitions.
+                versionMap.remove(baseTableInfo);
+            }
+        }
+    }
+
     private static void dropBaseVersionMetaForOlapTable(MaterializedView mv, String mvPartitionName,
                                                         Range<PartitionKey> mvPartitionRange,
                                                         MaterializedView.AsyncRefreshContext refreshContext,
@@ -596,13 +695,8 @@ public class SyncPartitionUtils {
             return;
         }
         long tableId = baseTable.getId();
-        if (expr instanceof SlotRef) {
-            Map<String, MaterializedView.BasePartitionInfo> mvTableVersionMap = versionMap.get(tableId);
-            // mv partition name same as base table.
-            if (mvTableVersionMap != null) {
-                mvTableVersionMap.remove(mvPartitionName);
-            }
-        } else if (expr instanceof FunctionCallExpr) {
+        if (expr instanceof FunctionCallExpr) {
+            // TODO: use `dropRefBaseTableFromVersionMapForOlapTable` either.
             Map<String, MaterializedView.BasePartitionInfo> mvTableVersionMap = versionMap.get(tableId);
             if (mvTableVersionMap != null && mvPartitionRange != null && baseTable instanceof OlapTable) {
                 // use range derive connect base partition
@@ -612,8 +706,7 @@ public class SyncPartitionUtils {
                 mvToBaseMapping.values().forEach(parts -> parts.forEach(mvTableVersionMap::remove));
             }
         } else {
-            // This is a bad case for refreshing, and this problem will be optimized later.
-            versionMap.remove(tableId);
+            dropRefBaseTableFromVersionMapForOlapTable(mv, versionMap, tableId, mvPartitionName);
         }
     }
 
@@ -633,6 +726,7 @@ public class SyncPartitionUtils {
             return;
         }
         if (expr instanceof SlotRef) {
+            // TODO: use `dropRefBaseTableFromVersionMapForExternalTable` later.
             Column partitionColumn = baseTable.getColumn(((SlotRef) expr).getColumnName());
             BaseTableInfo baseTableInfo = new BaseTableInfo(tableName.getCatalog(), tableName.getDb(),
                     baseTable.getName(), baseTable.getTableIdentifier());
@@ -654,9 +748,9 @@ public class SyncPartitionUtils {
                 });
             }
         } else {
-            // This is a bad case for refreshing, and this problem will be optimized later.
-            versionMap.remove(new BaseTableInfo(tableName.getCatalog(), tableName.getDb(),
-                    baseTable.getName(), baseTable.getTableIdentifier()));
+            BaseTableInfo baseTableInfo = new BaseTableInfo(tableName.getCatalog(), tableName.getDb(),
+                    baseTable.getName(), baseTable.getTableIdentifier());
+            dropRefBaseTableFromVersionMapForExternalTable(mv, versionMap, baseTableInfo, mvPartitionName);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -596,6 +596,10 @@ public class SyncPartitionUtils {
         for (String refBaseTableAssociatedPartition : refBaseTableAssociatedPartitions) {
             baseTableVersionInfoMap.remove(refBaseTableAssociatedPartition);
         }
+
+        // finally remove the dropped materialized view partition
+        mvPartitionNameRefBaseTablePartitionMap.remove(mvPartitionName);
+
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -594,9 +594,6 @@ public class SyncPartitionUtils {
                 refBaseTable, Joiner.on(",").join(refBaseTableAssociatedPartitions),
                 mv.getName(), mvPartitionName);
         for (String refBaseTableAssociatedPartition : refBaseTableAssociatedPartitions) {
-            if (refBaseTableAssociatedPartition.equals(ICEBERG_ALL_PARTITION)) {
-                continue;
-            }
             baseTableVersionInfoMap.remove(refBaseTableAssociatedPartition);
         }
         return true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/common/SyncPartitionUtilsTest.java
@@ -608,8 +608,8 @@ public class SyncPartitionUtilsTest {
         tableMap.put("p2", new MaterializedView.BasePartitionInfo(3, 4, -1));
         versionMap.put(tbl1.getId(), tableMap);
         SyncPartitionUtils.dropBaseVersionMeta(mv, "p1", null);
-
-        Assert.assertNull(tableMap.get("p1"));
+        // TODO: add more tests
+        Assert.assertNotNull(tableMap.get("p1"));
     }
 
     private PartitionRange buildPartitionRange(String name, String start, String end) throws AnalysisException {


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
