### PR TITLE
[BugFix] Add dicts of offspring fragments of cached fragments into digest computation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -57,6 +57,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -812,6 +813,7 @@ public class FragmentNormalizer {
         fragment.getPlanRoot().collect(ExchangeNode.class, exchangeNodes);
         List<PlanFragment> fragments = exchangeNodes.stream()
                 .flatMap(ex -> ex.getChildren().stream().map(PlanNode::getFragment))
+                .sorted(Comparator.comparingInt(frag -> frag.getFragmentId().asInt()))
                 .distinct().collect(Collectors.toList());
         fragments.add(fragment);
         return fragments;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -44,6 +44,7 @@ import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TCacheParam;
 import com.starrocks.thrift.TExpr;
+import com.starrocks.thrift.TGlobalDict;
 import com.starrocks.thrift.TNormalPlanNode;
 import org.apache.thrift.TException;
 import org.apache.thrift.TSerializer;
@@ -104,6 +105,7 @@ public class FragmentNormalizer {
 
     private Set<Integer> cachedPlanNodeIds = Sets.newHashSet();
     private boolean assignScanRangesAcrossDrivers = false;
+
     public FragmentNormalizer(ExecPlan execPlan, PlanFragment fragment) {
         this.execPlan = execPlan;
         this.fragment = fragment;
@@ -307,9 +309,13 @@ public class FragmentNormalizer {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
             for (TNormalPlanNode node : normalizedPlanNodes) {
-                byte[] data = serializer.serialize(node);
-                digest.update(data);
+                digest.update(serializer.serialize(node));
             }
+            List<TGlobalDict> dicts = normalizeDicts(getAllOffspringFragments(fragment));
+            for (TGlobalDict dict : dicts) {
+                digest.update(serializer.serialize(dict));
+            }
+
             List<SlotId> slotIds = cachePointNode.getOutputSlotIds(execPlan.getDescTbl());
             List<Integer> remappedSlotIds = remapSlotIds(slotIds);
             Map<Integer, Integer> outputSlotIdRemapping = Maps.newHashMap();
@@ -706,7 +712,7 @@ public class FragmentNormalizer {
         // Get leftmost path
         List<PlanNode> leftNodesTopDown = Lists.newArrayList();
         for (PlanNode currNode = root; currNode != null && currNode.getFragment() == fragment;
-                currNode = currNode.getChild(0)) {
+             currNode = currNode.getChild(0)) {
             leftNodesTopDown.add(currNode);
         }
 
@@ -795,8 +801,34 @@ public class FragmentNormalizer {
         normalizeSubTree(leftNodeIds, topMostDigestNode, Sets.newHashSet());
         List<PlanNode> cachedPlanNodes = leftNodesTopDown.stream().skip(firstAggNodeIdx).collect(Collectors.toList());
         fragment.setAssignScanRangesPerDriverSeq(canAssignScanRangesAcrossDrivers(cachedPlanNodes));
-        cachedPlanNodeIds = cachedPlanNodes.stream().map(node->node.getId().asInt()).collect(Collectors.toSet());
+        cachedPlanNodeIds = cachedPlanNodes.stream().map(node -> node.getId().asInt()).collect(Collectors.toSet());
         return computeDigest(firstAggNode);
+    }
+
+    // get All of offspring fragments of the current fragment, the current fragment
+    // is also included. fragments containing MulticastSink are counted once.
+    private List<PlanFragment> getAllOffspringFragments(PlanFragment fragment) {
+        List<ExchangeNode> exchangeNodes = Lists.newArrayList();
+        fragment.getPlanRoot().collect(ExchangeNode.class, exchangeNodes);
+        List<PlanFragment> fragments = exchangeNodes.stream()
+                .flatMap(ex -> ex.getChildren().stream().map(PlanNode::getFragment))
+                .distinct().collect(Collectors.toList());
+        fragments.add(fragment);
+        return fragments;
+    }
+
+    // Normalize global dicts of the given fragments
+    private List<TGlobalDict> normalizeDicts(List<PlanFragment> fragments) {
+        List<TGlobalDict> dicts = Lists.newArrayList();
+        for (PlanFragment fragment : fragments) {
+            if (fragment.getQueryGlobalDicts() != null) {
+                dicts.addAll(fragment.normalizeDicts(fragment.getQueryGlobalDicts(), this));
+            }
+            if (fragment.getLoadGlobalDicts() != null) {
+                dicts.addAll(fragment.normalizeDicts(fragment.getLoadGlobalDicts(), this));
+            }
+        }
+        return dicts;
     }
 
     private UnionFind<SlotId> equivRelation = new UnionFind<>();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -458,7 +458,6 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // normalize dicts of the fragment, it is different from dictToThrift in three points:
     // 1. SlotIds must be replaced by remapped SlotIds;
     // 2. dict should be sorted according to its corresponding remapped SlotIds;
-    // 3. codes and items of the dict must be in sorted order.
     public List<TGlobalDict> normalizeDicts(List<Pair<Integer, ColumnDict>> dicts, FragmentNormalizer normalizer) {
         List<TGlobalDict> result = Lists.newArrayList();
         // replace slot id with the remapped slot id, sort dicts according to remapped slot ids.
@@ -469,16 +468,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         for (Pair<Integer, ColumnDict> dictPair : sortedDicts) {
             TGlobalDict globalDict = new TGlobalDict();
             globalDict.setColumnId(dictPair.first);
-            // sort dict entries according to dict codes.
-            List<Map.Entry<ByteBuffer, Integer>> itemToCodes =
-                    dictPair.second.getDict().entrySet().stream().sorted(Comparator.comparingInt(Map.Entry::getValue))
-                            .collect(Collectors.toList());
-
-            List<ByteBuffer> strings = itemToCodes.stream().map(Map.Entry::getKey).collect(Collectors.toList());
-            List<Integer> integers = itemToCodes.stream().map(Map.Entry::getValue).collect(Collectors.toList());
             globalDict.setVersion(dictPair.second.getCollectedVersionTime());
-            globalDict.setStrings(strings);
-            globalDict.setIds(integers);
             result.add(globalDict);
         }
         return result;

--- a/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
@@ -40,9 +40,8 @@ insert into t0 values('2023-01-02', 'foo_0001', 'bar_0011', 1);
 insert into t0 values('2023-01-03', 'foo_0001', 'bar_0012', 1);
 -- result:
 -- !result
-analyze full table t0;
+[UC]analyze full table t0;
 -- result:
-test_db_fcdc8bd6699711ee8bbe00163e04d4c2.t0	analyze	status	OK
 -- !result
 select sleep(10);
 -- result:
@@ -97,9 +96,8 @@ insert into t0 values('2023-01-05', 'foo_0002', 'bar_0002', 1);
 insert into t0 values('2023-01-06', 'foo_0002', 'bar_0003', 1);
 -- result:
 -- !result
-analyze full table t0;
+[UC]analyze full table t0;
 -- result:
-test_db_fcdc8bd6699711ee8bbe00163e04d4c2.t0	analyze	status	OK
 -- !result
 select sleep(10);
 -- result:

--- a/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
@@ -1,0 +1,147 @@
+-- name: test_query_cache_use_fresh_global_dict
+DROP TABLE IF EXISTS `t0`;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `dt` date NOT NULL COMMENT "",
+  `k1` varchar(100) NOT NULL COMMENT "",
+  `k2` varchar(100) NOT NULL COMMENT "",
+  `v1` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`dt`, `k1`, `k2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`dt`)
+(PARTITION p20230101 VALUES [("2023-01-01"), ("2023-01-02")),
+PARTITION p20230102 VALUES [("2023-01-02"), ("2023-01-03")),
+PARTITION p20230103 VALUES [("2023-01-03"), ("2023-01-04")),
+PARTITION p20230104 VALUES [("2023-01-04"), ("2023-01-05")),
+PARTITION p20230105 VALUES [("2023-01-05"), ("2023-01-06")),
+PARTITION p20230106 VALUES [("2023-01-06"), ("2023-01-07")),
+PARTITION p20230107 VALUES [("2023-01-07"), ("2023-01-08")),
+PARTITION p20230108 VALUES [("2023-01-08"), ("2023-01-09")),
+PARTITION p20230109 VALUES [("2023-01-09"), ("2023-01-10")))
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 4 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 values('2023-01-01', 'foo_0001', 'bar_0010', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-02', 'foo_0001', 'bar_0011', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-03', 'foo_0001', 'bar_0012', 1);
+-- result:
+-- !result
+analyze full table t0;
+-- result:
+test_db_fcdc8bd6699711ee8bbe00163e04d4c2.t0	analyze	status	OK
+-- !result
+select sleep(10);
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+insert into t0 values('2023-01-04', 'foo_0002', 'bar_0001', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-05', 'foo_0002', 'bar_0002', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-06', 'foo_0002', 'bar_0003', 1);
+-- result:
+-- !result
+analyze full table t0;
+-- result:
+test_db_fcdc8bd6699711ee8bbe00163e04d4c2.t0	analyze	status	OK
+-- !result
+select sleep(10);
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result

--- a/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
@@ -1,0 +1,59 @@
+-- name: test_query_cache_use_fresh_global_dict
+DROP TABLE IF EXISTS `t0`;
+CREATE TABLE `t0` (
+  `dt` date NOT NULL COMMENT "",
+  `k1` varchar(100) NOT NULL COMMENT "",
+  `k2` varchar(100) NOT NULL COMMENT "",
+  `v1` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`dt`, `k1`, `k2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`dt`)
+(PARTITION p20230101 VALUES [("2023-01-01"), ("2023-01-02")),
+PARTITION p20230102 VALUES [("2023-01-02"), ("2023-01-03")),
+PARTITION p20230103 VALUES [("2023-01-03"), ("2023-01-04")),
+PARTITION p20230104 VALUES [("2023-01-04"), ("2023-01-05")),
+PARTITION p20230105 VALUES [("2023-01-05"), ("2023-01-06")),
+PARTITION p20230106 VALUES [("2023-01-06"), ("2023-01-07")),
+PARTITION p20230107 VALUES [("2023-01-07"), ("2023-01-08")),
+PARTITION p20230108 VALUES [("2023-01-08"), ("2023-01-09")),
+PARTITION p20230109 VALUES [("2023-01-09"), ("2023-01-10")))
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 4 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+insert into t0 values('2023-01-01', 'foo_0001', 'bar_0010', 1);
+insert into t0 values('2023-01-02', 'foo_0001', 'bar_0011', 1);
+insert into t0 values('2023-01-03', 'foo_0001', 'bar_0012', 1);
+analyze full table t0;
+select sleep(10);
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+insert into t0 values('2023-01-04', 'foo_0002', 'bar_0001', 1);
+insert into t0 values('2023-01-05', 'foo_0002', 'bar_0002', 1);
+insert into t0 values('2023-01-06', 'foo_0002', 'bar_0003', 1);
+analyze full table t0;
+select sleep(10);
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;

--- a/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
@@ -30,7 +30,7 @@ PROPERTIES (
 insert into t0 values('2023-01-01', 'foo_0001', 'bar_0010', 1);
 insert into t0 values('2023-01-02', 'foo_0001', 'bar_0011', 1);
 insert into t0 values('2023-01-03', 'foo_0001', 'bar_0012', 1);
-analyze full table t0;
+[UC]analyze full table t0;
 select sleep(10);
 select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
 select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
@@ -45,7 +45,7 @@ select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_tr
 insert into t0 values('2023-01-04', 'foo_0002', 'bar_0001', 1);
 insert into t0 values('2023-01-05', 'foo_0002', 'bar_0002', 1);
 insert into t0 values('2023-01-06', 'foo_0002', 'bar_0003', 1);
-analyze full table t0;
+[UC]analyze full table t0;
 select sleep(10);
 select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
 select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;


### PR DESCRIPTION
Query cache reuse the cached intermediate per-tablet result encoded with old-version global dict, while decode that with new-version global dict.  Tablets acessed by the query are not changed, but other tablets can ingest new items, so a new-version global dict is generated.  

The cache key should percept the version changes of global dicts, so when compute digest of normalized fragments that is one of parts of cache key,  global dicts should be taken into consideration, thus when version of global dicts change, different cache key shall be generated.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
