### PR TITLE
[BugFix] check the schema when trying to activate the mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -315,7 +315,7 @@ public class AlterJobMgr {
             } catch (SemanticException e) {
                 throw new SemanticException("Can not active materialized view [" + materializedView.getName() +
                         "] because analyze materialized view define sql: \n\n" + createMvSql +
-                        "\n\nCause an error: " + e.getDetailMsg());
+                        "\n\nCause an error: " + e.getDetailMsg(), e);
             }
 
             // Skip checks to maintain eventual consistency when replay

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -284,7 +284,7 @@ public class AlterJobMgr {
             String createMvSql = materializedView.getMaterializedViewDdlStmt(false);
             QueryStatement mvQueryStatement = null;
             try {
-                mvQueryStatement = tryActiveMV(materializedView, context);
+                mvQueryStatement = recreateMVQuery(materializedView, context);
             } catch (SemanticException e) {
                 throw new SemanticException("Can not active materialized view [" + materializedView.getName() +
                         "] because analyze materialized view define sql: \n\n" + createMvSql +
@@ -304,10 +304,10 @@ public class AlterJobMgr {
         }
     }
 
-    /**
-     * Try to activate the new mv. Throw exception if fail
+    /*
+     * Recreate the MV query and validate the correctness of syntax and schema
      */
-    private static QueryStatement tryActiveMV(MaterializedView materializedView, ConnectContext context) {
+    private static QueryStatement recreateMVQuery(MaterializedView materializedView, ConnectContext context) {
         // If we could parse the MV sql successfully, and the schema of mv does not change,
         // we could reuse the existing MV
         String createMvSql = materializedView.getMaterializedViewDdlStmt(false);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -460,6 +460,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      */
     public void setActive() {
         this.active = true;
+        this.inactiveReason = null;
         // reset mv rewrite cache when it is active again
         CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -702,7 +702,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "  |  <slot 20> : 20: total_num\n" +
                 "  |  <slot 23> : 17: v1 + 1");
 
-
         dropMv("test", "agg_join_mv_1");
 
         createAndRefreshMv("test", "agg_join_mv_2", "create materialized view agg_join_mv_2" +
@@ -1016,19 +1015,17 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 "        dt;");
         refreshMaterializedView("test", "test_cache_mv1");
 
-        {
-            String sql = "select\n" +
-                    "      col1,\n" +
-                    "        sum(col2) AS sum_col2,\n" +
-                    "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
-                    "    FROM\n" +
-                    "        test_base_tbl AS f\n" +
-                    "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                    "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                    "    GROUP BY col1;";
-            String plan = getFragmentPlan(sql);
-            PlanTestBase.assertContains(plan, "test_cache_mv1");
-        }
+        String sql = "select\n" +
+                "      col1,\n" +
+                "        sum(col2) AS sum_col2,\n" +
+                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                "    FROM\n" +
+                "        test_base_tbl AS f\n" +
+                "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                "    GROUP BY col1;";
+        String plan = getFragmentPlan(sql);
+        PlanTestBase.assertContains(plan, "test_cache_mv1");
 
         {
             // invalid base table
@@ -1042,18 +1039,24 @@ public class MvRewriteTest extends MvRewriteTestBase {
             Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
             MaterializedView mv1 = ((MaterializedView) testDb.getTable("test_cache_mv1"));
             Assert.assertFalse(mv1.isActive());
+            try {
+                cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
+                Assert.fail("could not active the mv");
+            } catch (Exception e) {
+                Assert.assertTrue(e.getMessage().contains("mv schema changed"));
+            }
 
-            String sql = "select\n" +
-                    "      col1,\n" +
-                    "        sum(col2) AS sum_col2,\n" +
-                    "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
-                    "    FROM\n" +
-                    "        test_base_tbl AS f\n" +
-                    "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                    "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                    "    GROUP BY col1;";
-            String plan = getFragmentPlan(sql);
+            plan = getFragmentPlan(sql);
             PlanTestBase.assertNotContains(plan, "test_cache_mv1");
+        }
+
+        {
+            // alter the column to original one
+            String alterSql = "alter table test_base_tbl modify column col1 bigint;";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql,
+                    connectContext);
+            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterTableStmt);
+            waitForSchemaChangeAlterJobFinish();
 
             cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
             plan = getFragmentPlan(sql);

--- a/test/sql/test_materialized_view/R/test_materialized_view_status
+++ b/test/sql/test_materialized_view/R/test_materialized_view_status
@@ -89,10 +89,11 @@ AS SELECT k1,v1 FROM t1;
 drop table t1;
 -- result:
 -- !result
-CREATE TABLE t1 (
-    k1 INT,
-    v1 INT,
-    v2 INT)
+CREATE TABLE `t1` (
+  `k1` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
 DUPLICATE KEY(k1)
 DISTRIBUTED BY HASH(k1)
 PROPERTIES(

--- a/test/sql/test_materialized_view/R/test_mv_on_view
+++ b/test/sql/test_materialized_view/R/test_mv_on_view
@@ -56,7 +56,7 @@ ALTER MATERIALIZED VIEW mv_on_view_1 ACTIVE;
 SELECT IS_ACTIVE, INACTIVE_REASON FROM information_schema.materialized_views 
     WHERE table_name = 'mv_on_view_1';
 -- result:
-true	base view view1 changed
+true	
 -- !result
 [UC]REFRESH MATERIALIZED VIEW mv_on_view_1 with sync mode;
 SELECT * FROM mv_on_view_1 ORDER BY event_day;

--- a/test/sql/test_materialized_view/T/test_materialized_view_status
+++ b/test/sql/test_materialized_view/T/test_materialized_view_status
@@ -62,15 +62,17 @@ REFRESH MANUAL
 AS SELECT k1,v1 FROM t1;
 
 drop table t1;
-CREATE TABLE t1 (
-    k1 INT,
-    v1 INT,
-    v2 INT)
+CREATE TABLE `t1` (
+  `k1` date NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
 DUPLICATE KEY(k1)
 DISTRIBUTED BY HASH(k1)
 PROPERTIES(
     "replication_num" = "1"
 );
+
 alter materialized view mv2 active;
 refresh materialized view mv2  with sync mode;
 select * from mv2 order by k1;


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:


If the materialized view underlying schema changed, any attempt that try to active the MV should fail, otherwise the mv data would be incorrect.

So we need validate the resulted schema before active the MV, some column type changing should be rejected.

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
