### PR TITLE
[BugFix] enable non-general jdbc class can be loaded

### DIFF
--- a/be/src/exec/jdbc_scanner.cpp
+++ b/be/src/exec/jdbc_scanner.cpp
@@ -284,8 +284,13 @@ StatusOr<LogicalType> JDBCScanner::_precheck_data_type(const std::string& java_c
         }
         return TYPE_VARCHAR;
     } else {
-        return Status::NotSupported(fmt::format("Type is not supported on column[{}], JDBC result type is [{}]",
-                                                slot_desc->col_name(), java_class));
+        if (type != TYPE_VARCHAR) {
+            return Status::NotSupported(
+                    fmt::format("JDBC result type of column[{}] is [{}], StarRocks does not recognize it, please set "
+                                "the type of this column to varchar to avoid information loss.",
+                                slot_desc->col_name(), java_class));
+        }
+        return TYPE_VARCHAR;
     }
     __builtin_unreachable();
 }

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/DataSourceCache.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/DataSourceCache.java
@@ -22,14 +22,22 @@ import java.util.function.Supplier;
 
 // a cache for get datasource
 public class DataSourceCache {
-    private final Map<String, HikariDataSource> sources = new ConcurrentHashMap<>();
+    public static class DataSourceCacheItem {
+        public HikariDataSource hikariDataSource;
+        public ClassLoader classLoader;
+        public DataSourceCacheItem(HikariDataSource hikariDataSource, ClassLoader classLoader) {
+            this.hikariDataSource = hikariDataSource;
+            this.classLoader = classLoader;
+        }
+    }
+    private final Map<String, DataSourceCacheItem> sources = new ConcurrentHashMap<>();
     private static final DataSourceCache INSTANCE = new DataSourceCache();
 
     public static DataSourceCache getInstance() {
         return INSTANCE;
     }
 
-    public HikariDataSource getSource(String driverId, Supplier<HikariDataSource> provider) {
+    public DataSourceCacheItem getSource(String driverId, Supplier<DataSourceCacheItem> provider) {
         return sources.computeIfAbsent(driverId, k -> provider.get());
     }
 }

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/DataSourceCache.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/DataSourceCache.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 // a cache for get datasource
-// the following code was genereated by chatgpt: https://github.com/StarRocks/starrocks/pull/32702/files#r1357812002
 public class DataSourceCache {
     public static final class DataSourceCacheItem {
         private final HikariDataSource hikariDataSource;

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCBridge.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCBridge.java
@@ -14,10 +14,6 @@
 
 package com.starrocks.jdbcbridge;
 
-import java.io.File;
-import java.net.URL;
-import java.net.URLClassLoader;
-
 /*
  * In order to simplify the implementation of jni cpp code, we add JDBCBridge as a bridge,
  * encapsulate some complex logic, and only provide the simplest interface for C++ calls.
@@ -33,10 +29,6 @@ public class JDBCBridge {
     private String driverLocation = null;
 
     public void setClassLoader(String driverLocation) throws Exception {
-        URLClassLoader loader = URLClassLoader.newInstance(new URL[] {
-                new File(driverLocation).toURI().toURL(),
-        });
-        Thread.currentThread().setContextClassLoader(loader);
         this.driverLocation = driverLocation;
     }
 

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
@@ -17,14 +17,25 @@ package com.starrocks.jdbcbridge;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 
+import java.io.File;
 import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+
 
 public class JDBCScanner {
     private String driverLocation;
@@ -37,6 +48,8 @@ public class JDBCScanner {
     private List<String> resultColumnClassNames;
     private List<Object[]> resultChunk;
     private int resultNumRows = 0;
+    ClassLoader classLoader;
+
 
     public JDBCScanner(String driverLocation, JDBCScanContext scanContext) {
         this.driverLocation = driverLocation;
@@ -45,7 +58,12 @@ public class JDBCScanner {
 
     public void open() throws Exception {
         String key = scanContext.getUser() + "/" + scanContext.getJdbcURL();
-        dataSource = DataSourceCache.getInstance().getSource(key, () -> {
+        URL driverURL = new File(driverLocation).toURI().toURL();
+        DataSourceCache.DataSourceCacheItem cacheItem = DataSourceCache.getInstance().getSource(key, () -> {
+            ClassLoader classLoader = URLClassLoader.newInstance(new URL[] {
+                    driverURL,
+            });
+            Thread.currentThread().setContextClassLoader(classLoader);
             HikariConfig config = new HikariConfig();
             config.setDriverClassName(scanContext.getDriverClassName());
             config.setJdbcUrl(scanContext.getJdbcURL());
@@ -54,9 +72,14 @@ public class JDBCScanner {
             config.setMaximumPoolSize(scanContext.getConnectionPoolSize());
             config.setMinimumIdle(scanContext.getMinimumIdleConnections());
             config.setIdleTimeout(scanContext.getConnectionIdleTimeoutMs());
-            dataSource = new HikariDataSource(config);
-            return dataSource;
+            HikariDataSource hikariDataSource = new HikariDataSource(config);
+            // hikari doesn't support user-provided class loader, we should save them ourselves to ensure that
+            // the classes of result data are loaded by the same class loader, otherwise we may encounter
+            // ArrayStoreException in getChunk
+            return new DataSourceCache.DataSourceCacheItem(hikariDataSource, classLoader);
         });
+        dataSource = cacheItem.hikariDataSource;
+        classLoader = cacheItem.classLoader;
 
         connection = dataSource.getConnection();
         connection.setAutoCommit(false);
@@ -73,9 +96,32 @@ public class JDBCScanner {
         resultChunk = new ArrayList<>(resultSetMetaData.getColumnCount());
         for (int i = 1; i <= resultSetMetaData.getColumnCount(); i++) {
             resultColumnClassNames.add(resultSetMetaData.getColumnClassName(i));
-            Class<?> clazz = Class.forName(resultSetMetaData.getColumnClassName(i));
-            resultChunk.add((Object[]) Array.newInstance(clazz, scanContext.getStatementFetchSize()));
+            Class<?> clazz = classLoader.loadClass(resultSetMetaData.getColumnClassName(i));
+            if (isGeneralJDBCClassType(clazz)) {
+                resultChunk.add((Object[]) Array.newInstance(clazz, scanContext.getStatementFetchSize()));
+            } else {
+                resultChunk.add((Object[]) Array.newInstance(String.class, scanContext.getStatementFetchSize()));
+            }
         }
+    }
+
+    private static final Set<Class<?>> GENERAL_JDBC_CLASS_SET =  new HashSet<>(Arrays.asList(
+            Boolean.class,
+            Short.class,
+            Integer.class,
+            Long.class,
+            Float.class,
+            Double.class,
+            BigInteger.class,
+            BigDecimal.class,
+            java.sql.Date.class,
+            Timestamp.class,
+            LocalDateTime.class,
+            String.class
+    ));
+
+    private boolean isGeneralJDBCClassType(Class<?> clazz) {
+        return GENERAL_JDBC_CLASS_SET.contains(clazz);
     }
 
     // used for cpp interface
@@ -113,8 +159,15 @@ public class JDBCScanner {
                     dataColumn[resultNumRows] = ((Number) resultObject).floatValue();
                 } else if (dataColumn instanceof Double[]) {
                     dataColumn[resultNumRows] = ((Number) resultObject).doubleValue();
-                } else {
+                } else if (dataColumn instanceof String[] && resultObject instanceof String) {
+                    // if both sides are String, assign value directly to avoid additional calls to getString
                     dataColumn[resultNumRows] = resultObject;
+                } else if (!(dataColumn instanceof String[])) {
+                    // for other general class type, assign value directly
+                    dataColumn[resultNumRows] = resultObject;
+                } else {
+                    // for non-general class type, use string representation
+                    dataColumn[resultNumRows] = resultSet.getString(i + 1);
                 }
             }
             resultNumRows++;

--- a/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
+++ b/java-extensions/jdbc-bridge/src/main/java/com/starrocks/jdbcbridge/JDBCScanner.java
@@ -75,11 +75,11 @@ public class JDBCScanner {
             HikariDataSource hikariDataSource = new HikariDataSource(config);
             // hikari doesn't support user-provided class loader, we should save them ourselves to ensure that
             // the classes of result data are loaded by the same class loader, otherwise we may encounter
-            // ArrayStoreException in getChunk
+            // ArrayStoreException in getNextChunk
             return new DataSourceCache.DataSourceCacheItem(hikariDataSource, classLoader);
         });
-        dataSource = cacheItem.hikariDataSource;
-        classLoader = cacheItem.classLoader;
+        dataSource = cacheItem.getHikariDataSource();
+        classLoader = cacheItem.getClassLoader();
 
         connection = dataSource.getConnection();
         connection.setAutoCommit(false);

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -309,6 +309,11 @@ public class UDFHelper {
                     getStringLargeIntResult(numRows, (BigInteger[]) boxedResult, columnAddr);
                 } else if (boxedResult instanceof String[]) {
                     getStringBoxedResult(numRows, (String[]) boxedResult, columnAddr);
+                } else if (boxedResult instanceof Object[]) {
+                    String[] objStrings =
+                            Arrays.stream((Object[]) boxedResult)
+                                    .map(item -> item == null ? null : item.toString()).toArray(String[]::new);
+                    getStringBoxedResult(numRows, objStrings, columnAddr);
                 } else {
                     throw new UnsupportedOperationException("unsupported type:" + boxedResult);
                 }

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -309,11 +309,6 @@ public class UDFHelper {
                     getStringLargeIntResult(numRows, (BigInteger[]) boxedResult, columnAddr);
                 } else if (boxedResult instanceof String[]) {
                     getStringBoxedResult(numRows, (String[]) boxedResult, columnAddr);
-                } else if (boxedResult instanceof Object[]) {
-                    String[] objStrings =
-                            Arrays.stream((Object[]) boxedResult)
-                                    .map(item -> item == null ? null : item.toString()).toArray(String[]::new);
-                    getStringBoxedResult(numRows, objStrings, columnAddr);
                 } else {
                     throw new UnsupportedOperationException("unsupported type:" + boxedResult);
                 }


### PR DESCRIPTION
Fixes #32718

root casue: JDBCScanner used the wrong class loader, causing the jdbc driver's custom class to not be loaded correctly.

The current behavior of jdbc external table query is to ensure that the returned data is complete. If the data type of SR cannot fully represent the data in the external table, the query will directly report an error, such as a varchar's length overflow or the data exceeds the value range.

Going back to the bug itself, the results returned by many jdbc drivers may be represented by internally defined java classes. For example, Oracle will use `orcale.sql.TIMESTAMP` to represent the timestamp type. Before this, because SR did not know how to convert it into its own internal type, the query would directly report an error, which was not user-friendly.

After this change, for unrecognized JDBC result type, SR will return an error and recommend that users specify it as string type when creating a table, and then directly return the string representation of the data, and then the user can process the data himself.

so, for this issue,  if we recreate external table like the following, the query will execute successfully.
```sql
create external table jdbc_ext_tbl_oracle_type_timestamp_test (
type_timestamp string
) ENGINE=jdbc PROPERTIES (
    "resource"="oracle_test",
    "table"="tbl_oracle_type_text_date"
);
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
