### PR TITLE
[BugFix] Ban compression codec of bz2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -77,7 +77,6 @@ public class OutFileClause implements ParseNode {
         PARQUET_COMPRESSION_TYPE_MAP.put("brotli", TCompressionType.BROTLI);
         PARQUET_COMPRESSION_TYPE_MAP.put("zstd", TCompressionType.ZSTD);
         PARQUET_COMPRESSION_TYPE_MAP.put("lz4", TCompressionType.LZ4);
-        PARQUET_COMPRESSION_TYPE_MAP.put("bz2", TCompressionType.BZIP2);
         PARQUET_COMPRESSION_TYPE_MAP.put("zlib", TCompressionType.ZLIB);
         PARQUET_COMPRESSION_TYPE_MAP.put("uncompressed", TCompressionType.NO_COMPRESSION);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -303,12 +303,12 @@ public class InsertStmt extends DmlStmt {
         if (compressionType == null) {
             throw new SemanticException("compression is a mandatory property. " +
                     "Use \"compression\" = \"your_chosen_compression_type\". Supported compression types are" +
-                    "(uncompressed, gzip, brotli, zstd, lz4, bz2).");
+                    "(uncompressed, gzip, brotli, zstd, lz4).");
         }
 
         if (!PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionType)) {
             throw new SemanticException("compression type " + compressionType + " is not supported. " +
-                    "Use any of (uncompressed, gzip, brotli, zstd, lz4, bz2).");
+                    "Use any of (uncompressed, gzip, brotli, zstd, lz4).");
         }
 
         if (writeSingleFile && partitionBy != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -259,7 +259,7 @@ public class AnalyzeInsertTest {
                         "Use any of (uncompressed, gzip, brotli, zstd, lz4).");
 
         analyzeFail("insert into files ( \n" +
-                        "\t\"path\" = \"oss://starrocks-dla-data-zhangjiakou/jiangletian/unload/test_partby_varchar/\", \n" +
+                        "\t\"path\" = \"s3://path/to/directory/\", \n" +
                         "\t\"format\"=\"parquet\", \n" +
                         "\t\"compression\" = \"uncompressed\", \n" +
                         "\t\"partition_by\"=\"k1\",\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -248,7 +248,7 @@ public class AnalyzeInsertTest {
                         "select \"abc\" as k1",
                 "compression is a mandatory property. " +
                 "Use \"compression\" = \"your_chosen_compression_type\". Supported compression types are" +
-                "(uncompressed, gzip, brotli, zstd, lz4, bz2).");
+                "(uncompressed, gzip, brotli, zstd, lz4).");
 
         analyzeFail("insert into files ( \n" +
                         "\t\"path\" = \"s3://path/to/directory/\", \n" +
@@ -256,7 +256,7 @@ public class AnalyzeInsertTest {
                         "\t\"compression\" = \"unknown\" ) \n" +
                         "select \"abc\" as k1",
                 "compression type unknown is not supported. " +
-                        "Use any of (uncompressed, gzip, brotli, zstd, lz4, bz2).");
+                        "Use any of (uncompressed, gzip, brotli, zstd, lz4).");
 
         analyzeFail("insert into files ( \n" +
                         "\t\"path\" = \"oss://starrocks-dla-data-zhangjiakou/jiangletian/unload/test_partby_varchar/\", \n" +


### PR DESCRIPTION
Bz2 is not supported by arrow parquet writer.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
