### PR TITLE
[BugFix] Specify the maven-antrun-plugin version as 1.8

### DIFF
--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -966,6 +966,7 @@ under the License.
             <!-- also parse the proto for FE -->
             <plugin>
                 <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>generate-sources</id>


### PR DESCRIPTION
When I run `mvn install -DskipTests` in the FE directory, I encountered an error that says: “You are using ‘tasks’ which has been removed from the maven-antrun-plugin. Please use ‘target’ and refer to the ‘Major Version Upgrade to version 3.0.0’ on the plugin site.” The reason for this is those deprecated parameters `tasks`, `sourceRoot` or `testSourceRoot` are used is pom.xml, and I think we should ensure the maven-antrun-plugin version to 1.8 to ensure correct syntax.

refs:
https://issues.apache.org/jira/browse/MANTRUN-202
https://blogsarchive.apache.org/maven/entry/apache-maven-antrun-plugin-version
https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-antrun-plugin

Fixes #issue
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
