### PR TITLE
[BugFix] Check column reader is null when get segment memory usage

### DIFF
--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -423,7 +423,9 @@ Status Segment::get_short_key_index(std::vector<std::string>* sk_index_values) {
 size_t Segment::_column_index_mem_usage() {
     size_t size = 0;
     for (auto& r : _column_readers) {
-        size += r->mem_usage();
+        if (r != nullptr) {
+            size += r->mem_usage();
+        }
     }
     return size;
 }


### PR DESCRIPTION
column reader may be nullptr if tablet schema is not same as segment footer.

delete will generate an empty segment, and footer schema is different from tablet schema.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
