### PR TITLE
[BugFix] Table using light schema change will lost bloom filter in rowset data.

### DIFF
--- a/be/src/storage/olap_meta_reader.cpp
+++ b/be/src/storage/olap_meta_reader.cpp
@@ -95,7 +95,7 @@ Status OlapMetaReader::_build_collect_context(const OlapMetaReaderParams& read_p
         }
         _has_count_agg |= (collect_field == "count");
     }
-    _collect_context.seg_collecter_params.tablet_schema = read_params.tablet->tablet_schema();
+    _collect_context.seg_collecter_params.tablet_schema = read_params.tablet_schema;
     return Status::OK();
 }
 

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -478,15 +478,7 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
     _num_key_columns = 0;
     _num_columns = 0;
     bool has_bf_columns = false;
-    // There is no record on the FE for which columns need to have bloom filter indexes generated.
-    // And we will lost bloom filter when we build new tablet schema according to FE.
-    // So we need to set bloom filter column to the new column according to current BE tablet schema.
-    std::set<ColumnUID> bf_column_uids;
-    for (const auto& col : _cols) {
-        if (col.is_bf_column()) {
-            bf_column_uids.insert(col.unique_id());
-        }
-    }
+
     _cols.clear();
     _unique_id_to_index.clear();
     _sort_key_uids.clear();
@@ -500,10 +492,6 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
                 _num_key_columns++;
             }
             if (column.is_bf_column()) {
-                has_bf_columns = true;
-            }
-            if (bf_column_uids.count(column.unique_id()) > 0) {
-                column.set_is_bf_column(true);
                 has_bf_columns = true;
             }
             _unique_id_to_index[column.unique_id()] = _num_columns;

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -482,7 +482,7 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
     // And we will lost bloom filter when we build new tablet schema according to FE.
     // So we need to set bloom filter column to the new column according to current BE tablet schema.
     std::set<ColumnUID> bf_column_uids;
-    for (auto col : _cols) {
+    for (const auto& col : _cols) {
         if (col.is_bf_column()) {
             bf_column_uids.insert(col.unique_id());
         }
@@ -502,7 +502,7 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
             if (column.is_bf_column()) {
                 has_bf_columns = true;
             }
-            if (bf_column_uids.find(column.unique_id()) != bf_column_uids.end()) {
+            if (bf_column_uids.count(column.unique_id()) > 0) {
                 column.set_is_bf_column(true);
                 has_bf_columns = true;
             }

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -478,6 +478,15 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
     _num_key_columns = 0;
     _num_columns = 0;
     bool has_bf_columns = false;
+    // There is no record on the FE for which columns need to have bloom filter indexes generated.
+    // And we will lost bloom filter when we build new tablet schema according to FE.
+    // So we need to set bloom filter column to the new column according to current BE tablet schema.
+    std::set<ColumnUID> bf_column_uids;
+    for (auto col : _cols) {
+        if (col.is_bf_column()) {
+            bf_column_uids.insert(col.unique_id());
+        }
+    }
     _cols.clear();
     _unique_id_to_index.clear();
     _sort_key_uids.clear();
@@ -491,6 +500,10 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
                 _num_key_columns++;
             }
             if (column.is_bf_column()) {
+                has_bf_columns = true;
+            }
+            if (bf_column_uids.find(column.unique_id()) != bf_column_uids.end()) {
+                column.set_is_bf_column(true);
                 has_bf_columns = true;
             }
             _unique_id_to_index[column.unique_id()] = _num_columns;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -66,6 +66,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.starrocks.common.util.DateUtils.DATE_TIME_FORMATTER;
 
@@ -769,7 +770,7 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return this.uniqueId;
     }
 
-    public void setIndexFlag(TColumn tColumn, List<Index> indexes) {
+    public void setIndexFlag(TColumn tColumn, List<Index> indexes, Set<String> bfColumns) {
         for (Index index : indexes) {
             if (index.getIndexType() == IndexDef.IndexType.BITMAP) {
                 List<String> columns = index.getColumns();
@@ -777,6 +778,9 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
                     tColumn.setHas_bitmap_index(true);
                 }
             }
+        }
+        if (bfColumns != null && bfColumns.contains(this.name)) {
+            tColumn.setIs_bloom_filter_column(true);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -43,6 +43,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
+import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
@@ -782,13 +783,15 @@ public class OlapScanNode extends ScanNode {
         List<String> keyColumnNames = new ArrayList<String>();
         List<TPrimitiveType> keyColumnTypes = new ArrayList<TPrimitiveType>();
         List<TColumn> columnsDesc = new ArrayList<TColumn>();
+        Set<String> bfColumns = olapTable.getBfColumns();
 
         if (selectedIndexId != -1) {
             MaterializedIndexMeta indexMeta = olapTable.getIndexMetaByIndexId(selectedIndexId);
             if (indexMeta != null) {
                 for (Column col : olapTable.getSchemaByIndexId(selectedIndexId)) {
                     TColumn tColumn = col.toThrift();
-                    col.setIndexFlag(tColumn, olapTable.getIndexes());
+                    tColumn.setColumn_name(col.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX));
+                    col.setIndexFlag(tColumn, olapTable.getIndexes(), bfColumns);
                     columnsDesc.add(tColumn);
                 }
                 if (KeysType.PRIMARY_KEYS == olapTable.getKeysType() && indexMeta.getSortKeyIdxes() != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -286,7 +286,7 @@ public class OlapTableSink extends DataSink {
             for (Column column : indexMeta.getSchema()) {
                 TColumn tColumn = column.toThrift();
                 tColumn.setColumn_name(column.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX));
-                column.setIndexFlag(tColumn, table.getIndexes());
+                column.setIndexFlag(tColumn, table.getIndexes(), table.getBfColumns());
                 columnsDesc.add(tColumn);
             }
             if (indexMeta.getSortKeyUniqueIds() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ColumnTest.java
@@ -54,6 +54,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.starrocks.sql.ast.ColumnDef.DefaultValueDef.CURRENT_TIMESTAMP_VALUE;
 import static com.starrocks.sql.ast.ColumnDef.DefaultValueDef.NOT_SET;
@@ -337,10 +339,13 @@ public class ColumnTest {
         Index i0 = new Index("i0",
                 Collections.singletonList("f0"), IndexType.BITMAP, "");
 
+        Set<String> bfColumns = new HashSet<>();
+        bfColumns.add("f0");
         TColumn t0 = f0.toThrift();
-        f0.setIndexFlag(t0, Collections.singletonList(i0));
+        f0.setIndexFlag(t0, Collections.singletonList(i0), bfColumns);
 
         Assert.assertEquals(t0.has_bitmap_index, true);
+        Assert.assertEquals(t0.is_bloom_filter_column, true);
 
         Assert.assertEquals(f0.getUniqueId(), 0);
         f0.setUniqueId(1);


### PR DESCRIPTION
When we create a table using light schema change, we will rebuild tablet schema according to the schema in FE. But we lost the bloom filter property in the column. So we will lost the bloom filter in the rowset data.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
