### PR TITLE
[BugFix] Change materialized view choose sort key policy when sort keys are not set

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -808,6 +808,10 @@ public class OlapTable extends Table {
         return new ArrayList<Column>();
     }
 
+    /**
+     * NOTE: The result key columns are not in the creating order because `nameToColumn`
+     * uses unordered hashmap to keeps name to column's mapping.
+     */
     public List<Column> getKeyColumns() {
         return getColumns().stream().filter(Column::isKey).collect(Collectors.toList());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -52,6 +52,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.qe.ConnectContext;
@@ -97,7 +98,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -253,14 +254,19 @@ public class MaterializedViewAnalyzer {
             statement.setBaseTableInfos(Lists.newArrayList(baseTableInfos));
 
             // set the columns into createMaterializedViewStatement
-            List<Column> mvColumns = genMaterializedViewColumns(statement);
+            List<Pair<Column, Integer>> mvColumnPairs = genMaterializedViewColumns(statement);
+            List<Column> mvColumns = mvColumnPairs.stream().map(pair -> pair.first).collect(Collectors.toList());
             statement.setMvColumnItems(mvColumns);
 
             Map<TableName, Table> aliasTableMap = getNormalizedBaseTables(queryStatement, context);
             Map<Column, Expr> columnExprMap = Maps.newHashMap();
+
+            // columns' order may be changed for sort keys' reorder, need to
+            // change `queryStatement.getQueryRelation`'s outputs at the same time.
             List<Expr> outputExpressions = queryStatement.getQueryRelation().getOutputExpression();
-            for (int i = 0; i < outputExpressions.size(); ++i) {
-                columnExprMap.put(mvColumns.get(i), outputExpressions.get(i));
+            for (Pair<Column, Integer> pair : mvColumnPairs) {
+                Preconditions.checkState(pair.second < outputExpressions.size());
+                columnExprMap.put(pair.first, outputExpressions.get(pair.second));
             }
             // some check if partition exp exists
             if (statement.getPartitionExpDesc() != null) {
@@ -372,13 +378,69 @@ public class MaterializedViewAnalyzer {
             }
         }
 
-        private List<Column> genMaterializedViewColumns(CreateMaterializedViewStatement statement) {
+        /**
+         * when the materialized view's sort keys are not set by hand, choose the sort keys by iterating the columns
+         *  and find the satisfied columns as sort keys.
+         */
+        List<String> chooseSortKeysByDefault(List<Column> mvColumns) {
+            List<String> keyCols = Lists.newArrayList();
+            int theBeginIndexOfValue = 0;
+            int keySizeByte = 0;
+
+            // skip the firth nth columns which can not be used for keys.
+            for (; theBeginIndexOfValue < mvColumns.size(); theBeginIndexOfValue++) {
+                Column column = mvColumns.get(theBeginIndexOfValue);
+                if (column.getType().canBeMVKey()) {
+                    break;
+                }
+            }
+            if (theBeginIndexOfValue == mvColumns.size()) {
+                throw new SemanticException("All columns of materialized view cannot be used for keys");
+            }
+
+            int skip = theBeginIndexOfValue;
+            for (; theBeginIndexOfValue < mvColumns.size(); theBeginIndexOfValue++) {
+                Column column = mvColumns.get(theBeginIndexOfValue);
+                keySizeByte += column.getType().getIndexSize();
+                if (keySizeByte > FeConstants.SHORTKEY_MAXSIZE_BYTES) {
+                    if (column.getType().getPrimitiveType().isCharFamily()) {
+                        keyCols.add(column.getName());
+                        theBeginIndexOfValue++;
+                    }
+                    break;
+                }
+
+                if (!column.getType().canBeMVKey()) {
+                    continue;
+                }
+
+                if (column.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
+                    keyCols.add(column.getName());
+                    theBeginIndexOfValue++;
+                    break;
+                }
+
+                keyCols.add(column.getName());
+            }
+            if (theBeginIndexOfValue == skip) {
+                throw new SemanticException("Data type of first column cannot be " +
+                        mvColumns.get(theBeginIndexOfValue).getType());
+            }
+            return keyCols;
+        }
+
+        /**
+         * NOTE: order or column names of the defined query may be changed when generating.
+         * @param statement : creating materialized view statement
+         * @return          : Generate materialized view's columns and corresponding output expression index pair
+         *                      from creating materialized view statement.
+         */
+        private List<Pair<Column, Integer>> genMaterializedViewColumns(CreateMaterializedViewStatement statement) {
             List<String> columnNames = statement.getQueryStatement().getQueryRelation()
                     .getRelationFields().getAllFields().stream()
                     .map(Field::getName).collect(Collectors.toList());
             Scope queryScope = statement.getQueryStatement().getQueryRelation().getScope();
             List<Field> relationFields = queryScope.getRelationFields().getAllFields();
-
             List<Column> mvColumns = Lists.newArrayList();
             for (int i = 0; i < relationFields.size(); ++i) {
                 Type type = AnalyzerUtils.transformTableColumnType(relationFields.get(i).getType(), false);
@@ -405,33 +467,7 @@ public class MaterializedViewAnalyzer {
             // set duplicate key, when sort key is set, it is dup key col.
             List<String> keyCols = statement.getSortKeys();
             if (CollectionUtils.isEmpty(keyCols)) {
-                keyCols = Lists.newArrayList();
-                int theBeginIndexOfValue = 0;
-                int keySizeByte = 0;
-                for (; theBeginIndexOfValue < mvColumns.size(); theBeginIndexOfValue++) {
-                    Column column = mvColumns.get(theBeginIndexOfValue);
-                    keySizeByte += column.getType().getIndexSize();
-                    if (theBeginIndexOfValue + 1 > FeConstants.SHORTKEY_MAX_COLUMN_COUNT ||
-                            keySizeByte > FeConstants.SHORTKEY_MAXSIZE_BYTES) {
-                        if (theBeginIndexOfValue == 0 && column.getType().getPrimitiveType().isCharFamily()) {
-                            keyCols.add(column.getName());
-                            theBeginIndexOfValue++;
-                        }
-                        break;
-                    }
-                    if (!column.getType().canBeMVKey()) {
-                        break;
-                    }
-                    if (column.getType().getPrimitiveType() == PrimitiveType.VARCHAR) {
-                        keyCols.add(column.getName());
-                        theBeginIndexOfValue++;
-                        break;
-                    }
-                    keyCols.add(column.getName());
-                }
-                if (theBeginIndexOfValue == 0) {
-                    throw new SemanticException("Data type of first column cannot be " + mvColumns.get(0).getType());
-                }
+                keyCols = chooseSortKeysByDefault(mvColumns);
             }
 
             if (keyCols.isEmpty()) {
@@ -442,41 +478,38 @@ public class MaterializedViewAnalyzer {
                 throw new SemanticException("The number of sort key should be less than the number of columns.");
             }
 
-            // Without specified sortkeys, set keys from columns
-            // Map<String, Column> columnMap = mvColumns.stream().collect(Collectors.toMap(Column::getName, col -> col));
-            Map<String, Column> columnMap = new HashMap<>();
-            for (Column col : mvColumns) {
-                if (columnMap.putIfAbsent(col.getName(), col) != null) {
+            // Reorder the MV columns according to sort-key
+            Map<String, Pair<Column, Integer>> columnMap = new HashMap<>();
+            for (int i = 0; i < mvColumns.size(); i++) {
+                Column col = mvColumns.get(i);
+                if (columnMap.putIfAbsent(col.getName(), Pair.create(col, i)) != null) {
                     throw new SemanticException("Duplicate column name " + Strings.quote(col.getName()));
                 }
             }
-            if (CollectionUtils.isEmpty(statement.getSortKeys())) {
-                for (String col : keyCols) {
-                    columnMap.get(col).setIsKey(true);
-                }
-                return mvColumns;
-            }
 
-            // Reorder the MV columns according to sort-key
-            List<Column> reorderedColumns = new ArrayList<>();
-            Set<String> usedColumns = new HashSet<>();
+            List<Pair<Column, Integer>> reorderedColumns = new ArrayList<>();
+            Set<String> usedColumns = new LinkedHashSet<>();
             for (String columnName : keyCols) {
-                Column keyColumn = columnMap.get(columnName);
-                if (keyColumn == null) {
+                Pair<Column, Integer> columnPair = columnMap.get(columnName);
+                if (columnPair == null || columnPair.first == null) {
                     throw new SemanticException("Sort key not exists: " + columnName);
                 }
+                Column keyColumn = columnPair.first;
                 Type keyColType = keyColumn.getType();
                 if (!keyColType.canBeMVKey()) {
                     throw new SemanticException("Type %s cannot be sort key: %s", keyColType, columnName);
                 }
                 keyColumn.setIsKey(true);
                 keyColumn.setAggregationType(null, false);
-                reorderedColumns.add(keyColumn);
+
+                reorderedColumns.add(columnPair);
                 usedColumns.add(columnName);
             }
             for (Column col : mvColumns) {
-                if (!usedColumns.contains(col.getName())) {
-                    reorderedColumns.add(col);
+                String colName = col.getName();
+                if (!usedColumns.contains(colName)) {
+                    Preconditions.checkState(columnMap.containsKey(colName));
+                    reorderedColumns.add(columnMap.get(colName));
                 }
             }
             return reorderedColumns;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -55,6 +55,7 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -78,6 +79,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
@@ -110,6 +112,12 @@ public class CreateMaterializedViewTest {
         // create connect context
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
+
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
+
         starRocksAssert.withDatabase("test").useDatabase("test")
                 .withTable("CREATE TABLE test.tbl1\n" +
                         "(\n" +
@@ -354,13 +362,8 @@ public class CreateMaterializedViewTest {
                 ")\n" +
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         try {
-            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(4000L);
-            Table mv1 = testDb.getTable("mv1");
-            Assert.assertTrue(mv1 instanceof MaterializedView);
             // test partition
-            MaterializedView materializedView = (MaterializedView) mv1;
+            MaterializedView materializedView = getMaterializedViewChecked(sql);
             PartitionInfo partitionInfo = materializedView.getPartitionInfo();
             Assert.assertEquals(1, partitionInfo.getPartitionColumns().size());
             Assert.assertTrue(partitionInfo instanceof ExpressionRangePartitionInfo);
@@ -2337,8 +2340,9 @@ public class CreateMaterializedViewTest {
                 "distributed by hash(s2)\n" +
                 "order by (`s2`, `k1`)\n" +
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
-        Assert.assertThrows("Sort columns should be a ordered prefix of select cols", Exception.class,
-                () -> UtFrameUtils.parseStmtWithNewParser(sql, connectContext));
+        List<Column> sortKeys = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(sortKeys.get(0).getName().equals("s2"));
+        Assert.assertTrue(sortKeys.get(1).getName().equals("k1"));
     }
 
     @Test
@@ -2752,7 +2756,7 @@ public class CreateMaterializedViewTest {
         try {
             starRocksAssert.withMaterializedView(sql2);
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("Data type of first column cannot be DOUBLE"));
+            Assert.assertTrue(e.getMessage().contains("All columns of materialized view cannot be used for keys."));
         }
     }
 
@@ -3304,12 +3308,7 @@ public class CreateMaterializedViewTest {
                 ")\n" +
                 "as select tb1.k1, k2 s2 from tbl1 tb1;";
         try {
-            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-            currentState.createMaterializedView((CreateMaterializedViewStatement) statementBase);
-            ThreadUtil.sleepAtLeastIgnoreInterrupts(4000L);
-            Table mv1 = testDb.getTable("mv_with_rewrite_staleness");
-            Assert.assertTrue(mv1 instanceof MaterializedView);
-
+            Table mv1 = getMaterializedViewChecked(sql);
             // test partition
             MaterializedView materializedView = (MaterializedView) mv1;
             Assert.assertEquals(materializedView.getMaxMVRewriteStaleness(), 60);
@@ -3762,5 +3761,234 @@ public class CreateMaterializedViewTest {
             GlobalStateMgr.getCurrentState().getMetadata().createMaterializedView(createTableStmt);
         });
         Assert.assertTrue(e.getMessage().contains("Do not support create synchronous materialized view(rollup) on"));
+    }
+
+    MaterializedView getMaterializedViewChecked(String sql) {
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            CreateMaterializedViewStatement createMaterializedViewStatement =
+                    (CreateMaterializedViewStatement) statementBase;
+
+            currentState.createMaterializedView(createMaterializedViewStatement);
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(4000L);
+
+            TableName mvName = createMaterializedViewStatement.getTableName();
+            Table table = testDb.getTable(mvName.getTbl());
+            Assert.assertNotNull(table);
+            Assert.assertTrue(table instanceof MaterializedView);
+            return (MaterializedView) table;
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+        return null;
+    }
+
+    List<Column> getMaterializedViewKeysChecked(String sql) {
+        String mvName = null;
+        try {
+            StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+            CreateMaterializedViewStatement createMaterializedViewStatement =
+                    (CreateMaterializedViewStatement) statementBase;
+
+            currentState.createMaterializedView(createMaterializedViewStatement);
+            ThreadUtil.sleepAtLeastIgnoreInterrupts(4000L);
+
+            TableName mvTableName = createMaterializedViewStatement.getTableName();
+            mvName = mvTableName.getTbl();
+
+            Table table = testDb.getTable(mvName);
+            Assert.assertNotNull(table);
+            Assert.assertTrue(table instanceof MaterializedView);
+            MaterializedView mv = (MaterializedView) table;
+
+            return mv.getFullSchema().stream().filter(Column::isKey).collect(Collectors.toList());
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        } finally {
+            if (!Objects.isNull(mvName)) {
+                try {
+                    starRocksAssert.dropMaterializedView(mvName);
+                } catch (Exception e) {
+                    Assert.fail();
+                }
+            }
+        }
+        return Lists.newArrayList();
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_Partitioned_1() {
+        // sort key by default
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "partition by c_1_3 " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_3, c_1_0, c_1_4, c_1_5 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_0"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_Partitioned_2() {
+        // random distribution : double key is in the first
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "partition by c_1_3 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_3, c_1_0 , c_1_4, c_1_5 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_0"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_Partitioned_3() {
+        // random distribution : double key is in the first
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "partition by c_1_3 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_5, c_1_3, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_0"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_Partitioned_4() {
+        // order by with double columns
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "partition by c_1_3 " +
+                "distributed by random " +
+                "order by (c_1_0, c_1_3)  " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_5, c_1_3, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_3"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_Partitioned_5() {
+        // random distribution : double key is in the first, c_1_10 is varchar
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "partition by c_1_3 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_5, c_1_10, c_1_3, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_10"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_Partitioned_6() {
+        // random distribution : double key is in the first, c_1_10 is varchar
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "partition by c_1_3 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_3, c_1_10, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_10"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_UnPartitioned_1() {
+        // sort key by default
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_3, c_1_0, c_1_4, c_1_5 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_0"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_UnPartitioned_2() {
+        // random distribution : double key is in the first
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_3, c_1_0 , c_1_4, c_1_5 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_0"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_UnPartitioned_3() {
+        // random distribution : double key is in the first
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_5, c_1_3, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_0"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_UnPartitioned_4() {
+        // order by with double columns
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "distributed by random " +
+                "order by (c_1_0, c_1_3)  " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_5, c_1_3, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_3"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_UnPartitioned_5() {
+        // random distribution : double key is in the first, c_1_10 is varchar
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_5, c_1_10, c_1_3, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_10"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithoutSortKeys_UnPartitioned_6() {
+        // random distribution : double key is in the first, c_1_10 is varchar
+        String sql = "create materialized view test_mv_sort_key1 " +
+                "distributed by random " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select c_1_4, c_1_3, c_1_10, c_1_0 from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_3"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_10"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -203,9 +203,9 @@ public class MaterializedViewAnalyzerTest {
         ShowExecutor showExecutor = new ShowExecutor(starRocksAssert.getCtx(),
                 (ShowStmt) analyzeSuccess("show full columns from mv1"));
         ShowResultSet showResultSet = showExecutor.execute();
-        Assert.assertEquals("[[a, date, , YES, YES, null, NONE, , a1]," +
-                        " [b, int, , YES, YES, null, NONE, , b2]," +
-                        " [c, int, , YES, YES, null, NONE, , ]]",
+        Assert.assertEquals("[[a, date, , YES, YES, null, , , a1]," +
+                        " [b, int, , YES, YES, null, , , b2]," +
+                        " [c, int, , YES, YES, null, , , ]]",
                 showResultSet.getResultRows().toString());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PushDownTopnNTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PushDownTopnNTest.java
@@ -32,7 +32,6 @@ public class PushDownTopnNTest extends PlanTestBase {
                 "select v4 as a, v5 as b, v6 as c from t1) AS t \n" +
                 "ORDER BY t.b desc limit 20";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         assertContains(plan, "6:TOP-N\n" +
                 "  |  order by: <slot 5> 5: v5 DESC\n" +
                 "  |  offset: 0\n" +
@@ -57,7 +56,6 @@ public class PushDownTopnNTest extends PlanTestBase {
                 "select v4 as a, v5 as b, v6 as c from t1) AS t \n" +
                 "ORDER BY t.b desc limit 20";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         // t0 should be added `topn` for limit 1 is less than limit 20
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 02\n" +
@@ -104,7 +102,6 @@ public class PushDownTopnNTest extends PlanTestBase {
                 "select v4, v5 , v6  from t1) AS t \n" +
                 "ORDER BY t.b desc limit 20";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         assertContains(plan, "6:TOP-N\n" +
                 "  |  order by: <slot 5> 5: v5 DESC\n" +
                 "  |  offset: 0\n" +
@@ -130,7 +127,6 @@ public class PushDownTopnNTest extends PlanTestBase {
                 "select v4, v5 , v6  from t1) AS t \n" +
                 "ORDER BY t.b desc limit " + (context.getSessionVariable().getCboPushDownTopNLimit() + 1);
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 02\n" +
                 "    RANDOM\n" +
@@ -154,7 +150,6 @@ public class PushDownTopnNTest extends PlanTestBase {
                 "select v4, v5 , v6  from t1) AS t \n" +
                 "ORDER BY t.b desc limit " + (context.getSessionVariable().getCboPushDownTopNLimit() + 1);
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         assertContains(plan, "STREAM DATA SINK\n" +
                 "    EXCHANGE ID: 02\n" +
                 "    RANDOM\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -206,7 +206,6 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         // check outer join with isNull predicate on inner table
         // The estimate cardinality of join should not be 0.
         Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(getDumpInfoFromFile("query_dump/tpcds78"));
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second, replayPair.second.contains("3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE)\n" +
                 "  |  equal join conjunct: [257: ss_ticket_number, INT, false] = [280: sr_ticket_number, INT, true]\n" +
@@ -598,7 +597,6 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
     public void testHiveTPCH02UsingResource() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/hive_tpch02_resource"), null, TExplainLevel.COSTS);
-        System.out.println(replayPair.second);
         Assert.assertTrue(replayPair.second, replayPair.second.contains("6:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  equal join conjunct: [24: n_regionkey, INT, true] = [26: r_regionkey, INT, true]\n" +
@@ -698,7 +696,6 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         connectContext.getSessionVariable().disableJoinReorder();
         Pair<String, ExecPlan> result = UtFrameUtils.getNewPlanAndFragmentFromDump(connectContext,
                 getDumpInfoFromJson(jsonStr));
-        System.out.println(result.second.getPhysicalPlan().debugString());
         OptExpression expression = result.second.getPhysicalPlan().inputAt(1);
         Assert.assertEquals(new CTEProperty(1), expression.getLogicalProperty().getUsedCTEs());
         Assert.assertEquals(4, result.second.getCteProduceFragments().size());
@@ -781,7 +778,6 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/union_all_with_topn_runtime_filter"),
                         sessionVariable, TExplainLevel.VERBOSE);
-        System.out.println(replayPair.second);
         String plan = replayPair.second;
 
         // tbl_mock_015


### PR DESCRIPTION
Now there are some limitations in creating a materialized view:
- the first column cannot be `float/double` column because those columns cannot be used for keys.
- sort key columns must be the prefix columns of the materialized view-defined output columns even if you set sort keys.

To be better used,  we may optimize the choose-sort-keys policy:
1. When the materialized view's sort keys are not set by hand, we can choose the sort keys by iterating the columns and find the satisfied columns as sort keys.
2. When sort keys are not the prefix of output expressions, we can adjust the output columns' reorder so can be created successfully.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
