### PR TITLE
[BugFix] Fix auto spill error when binary column exceed 4G

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -916,6 +916,10 @@ CONF_String(spill_local_storage_dir, "${STARROCKS_HOME}/spill");
 CONF_mBool(experimental_spill_skip_sync, "true");
 // spill Initial number of partitions
 CONF_mInt32(spill_init_partition, "16");
+// make sure 2^spill_max_partition_level < spill_max_partition_size
+CONF_Int32(spill_max_partition_level, "7");
+CONF_Int32(spill_max_partition_size, "1024");
+
 // The maximum size of a single log block container file, this is not a hard limit.
 // If the file size exceeds this limit, a new file will be created to store the block.
 CONF_Int64(spill_max_log_block_container_bytes, "10737418240"); // 10GB

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -215,15 +215,18 @@ std::function<StatusOr<ChunkPtr>()> SpillableHashJoinBuildOperator::_convert_has
     auto build_chunk = _join_builder->hash_join_builder()->hash_table().get_build_chunk();
     DCHECK_GT(build_chunk->num_rows(), 0);
 
+    auto st = build_chunk->upgrade_if_overflow();
     _hash_table_build_chunk_slice.reset(build_chunk);
     _hash_table_build_chunk_slice.skip(kHashJoinKeyColumnOffset);
 
-    return [this]() -> StatusOr<ChunkPtr> {
+    return [this, st]() -> StatusOr<ChunkPtr> {
+        RETURN_IF_ERROR(st);
         if (_hash_table_build_chunk_slice.empty()) {
             _join_builder->hash_join_builder()->reset(_join_builder->hash_table_param());
             return Status::EndOfFile("eos");
         }
         auto chunk = _hash_table_build_chunk_slice.cutoff(runtime_state()->chunk_size());
+        RETURN_IF_ERROR(chunk->downgrade());
         RETURN_IF_ERROR(append_hash_columns(chunk));
         _join_builder->update_build_rows(chunk->num_rows());
         return chunk;

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/spill/spill_components.h"
 
+#include "common/config.h"
 #include "exec/spill/executor.h"
 #include "exec/spill/serde.h"
 #include "exec/spill/spiller.h"
@@ -136,7 +137,7 @@ PartitionedSpillerWriter::PartitionedSpillerWriter(Spiller* spiller, RuntimeStat
 
 void PartitionedSpillerWriter::prepare(RuntimeState* state) {
     DCHECK_GT(options().init_partition_nums, 0);
-    _partition_set.resize(max_partition_size);
+    _partition_set.resize(config::spill_max_partition_size);
     _init_with_partition_nums(state, options().init_partition_nums);
     for (auto [_, partition] : _id_to_partitions) {
         partition->spill_writer->prepare(state);
@@ -187,7 +188,7 @@ void PartitionedSpillerWriter::reset_partition(const std::vector<const SpillPart
 
 void PartitionedSpillerWriter::reset_partition(RuntimeState* state, size_t num_partitions) {
     num_partitions = BitUtil::next_power_of_two(num_partitions);
-    num_partitions = std::min<size_t>(num_partitions, 1 << max_partition_level);
+    num_partitions = std::min<size_t>(num_partitions, 1 << config::spill_max_partition_level);
     num_partitions = std::max<size_t>(num_partitions, _spiller->options().init_partition_nums);
 
     _level_to_partitions.clear();
@@ -262,7 +263,7 @@ Status PartitionedSpillerWriter::_choose_partitions_to_flush(bool is_final_flush
         for (const auto& [pid, partition] : _id_to_partitions) {
             const auto& mem_table = partition->spill_writer->mem_table();
             // partition not in memory
-            if (!partition->in_mem && partition->level < max_partition_level &&
+            if (!partition->in_mem && partition->level < config::spill_max_partition_level &&
                 mem_table->mem_usage() + partition->bytes > options().spill_mem_table_bytes_size) {
                 RETURN_IF_ERROR(mem_table->done());
                 partition->in_mem = false;

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -207,8 +207,6 @@ struct SpilledPartition : public SpillPartitionInfo {
 
 class PartitionedSpillerWriter final : public SpillerWriter {
 public:
-    static const constexpr auto max_partition_size = 1024;
-    static const constexpr auto max_partition_level = 6;
     PartitionedSpillerWriter(Spiller* spiller, RuntimeState* state);
 
     void prepare(RuntimeState* state) override;


### PR DESCRIPTION
```
Internal error: vector::_M_range_insert

W0913 08:01:33.747268  4896 stack_util.cpp:350] 2023-09-13 08:01:33.746477, query_id=6bb00706-520b-11ee-b42b-02420a080272, fragment_instance_id=6bb00706-520b-11ee-b42b-02420a080276 throws exception: std::length_error, trace:
     @          0x9b17651  std::__throw_length_error()
    @          0x38b6b16  std::vector<>::_M_range_insert<>()
    @          0x38ba646  starrocks::BinaryColumnBase<>::append()
    @          0x3a6fc7e  starrocks::NullableColumn::append()
    @          0x38e5c9a  starrocks::Chunk::append()
    @          0x3a840d4  starrocks::ChunkSliceTemplate<>::cutoff()
    @          0x405a779  _ZNSt17_Function_handlerIFN9starrocks8StatusOrISt10shared_ptrINS0_5ChunkEEEEvEZNS0_8pipeline30SpillableHashJoinBuildOperator26_convert_hash_map_to_chunkEvEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x40b6a53  starrocks::pipeline::SpillProcessOperator::pull_chunk()
    @          0x38df98e  starrocks::pipeline::PipelineDriver::process()
    @          0x5f2e4b0  starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x62b8f9b  starrocks::ThreadPool::dispatch_thread()
    @          0x62b323a  starrocks::Thread::supervise_thread()
    @     0x7f644d32eb43  (unknown)
    @     0x7f644d3bfbb4  clone
    @              (nil)  (unknown)
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
