### PR TITLE
[Tool] Support ddprof integration

### DIFF
--- a/bin/start_backend.sh
+++ b/bin/start_backend.sh
@@ -189,6 +189,11 @@ if [ ${RUN_CN} -eq 1 ]; then
     LOG_FILE=${LOG_DIR}/cn.out
 fi
 
+if [ ${ENABLE_DD_PROFILE} == "true" ]; then
+    chmod 755 ${STARROCKS_HOME}/lib/ddprof
+    START_BE_CMD="${STARROCKS_HOME}/lib/ddprof ${START_BE_CMD}"
+fi
+
 if [ ${RUN_LOG_CONSOLE} -eq 1 ] ; then
     # force glog output to console (stderr)
     export GLOG_logtostderr=1

--- a/docker/dockerfiles/artifacts/artifact.Dockerfile
+++ b/docker/dockerfiles/artifacts/artifact.Dockerfile
@@ -51,4 +51,10 @@ COPY --from=fe-builder /build/starrocks/output /release/fe_artifacts
 COPY --from=be-builder /build/starrocks/output /release/be_artifacts
 COPY --from=broker-builder /build/starrocks/fs_brokers/apache_hdfs_broker/output /release/broker_artifacts
 
+
+# Get ddprof
+RUN wget https://github.com/DataDog/ddprof/releases/download/v0.14.1/ddprof-0.14.1-amd64-linux.tar.xz -O ddprof-amd64-linux.tar.xz && \
+    tar xvf ddprof-amd64-linux.tar.xz && \
+    mv ddprof/bin/ddprof /release/be_artifacts/be/lib/
+
 WORKDIR /release


### PR DESCRIPTION
## What type of PR is this:

- [x] Tool
With this PR, the starrocks be can be started with ddprof with this env variable `ENABLE_DD_PROFILE = true`

Does this PR entail a change in behavior?

- [x] No, this PR will not result in a change in behavior.

## Checklist:
I have tested the correctness of integration test with Datadog
![image](https://github.com/StarRocks/starrocks/assets/5108773/d725383b-5e1f-4569-a488-b99dad3eaf81)


## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5