### PR TITLE
[BugFix] Append null to nullable numeric column

### DIFF
--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -72,14 +72,13 @@ static Status add_nullable_numeric_column(Column* column, const TypeDescriptor& 
                                           simdjson::ondemand::value* value) {
     auto nullable_column = down_cast<NullableColumn*>(column);
     try {
-        auto& null_column = nullable_column->null_column();
-        auto& data_column = nullable_column->data_column();
-
         if (value->is_null()) {
-            data_column->append_default(1);
-            null_column->append(1);
+            nullable_column->append_default();
             return Status::OK();
         }
+
+        auto& null_column = nullable_column->null_column();
+        auto& data_column = nullable_column->data_column();
 
         RETURN_IF_ERROR(add_numeric_column<T>(data_column.get(), type_desc, name, value));
 

--- a/be/src/formats/json/nullable_column.cpp
+++ b/be/src/formats/json/nullable_column.cpp
@@ -73,7 +73,7 @@ static Status add_nullable_numeric_column(Column* column, const TypeDescriptor& 
     auto nullable_column = down_cast<NullableColumn*>(column);
     try {
         if (value->is_null()) {
-            nullable_column->append_default();
+            nullable_column->append_nulls(1);
             return Status::OK();
         }
 

--- a/be/test/formats/json/nullable_column_test.cpp
+++ b/be/test/formats/json/nullable_column_test.cpp
@@ -97,4 +97,18 @@ TEST_F(AddNullableColumnTest, test_add_invalid) {
     ASSERT_TRUE(st.is_invalid_argument());
 }
 
+TEST_F(AddNullableColumnTest, add_null_numeric_array) {
+    auto desc = TypeDescriptor::create_array_type(TypeDescriptor::from_logical_type(TYPE_INT));
+    auto column = ColumnHelper::create_column(desc, true);
+
+    simdjson::ondemand::parser parser;
+    auto json = R"(  { "f_array": [null]}  )"_padded;
+    auto doc = parser.iterate(json);
+    simdjson::ondemand::value val = doc.find_field("f_array");
+
+    auto st = add_nullable_column(column.get(), desc, "f_array", &val, false);
+    ASSERT_TRUE(st.ok());
+    column->check_or_die();
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Fixes  https://github.com/StarRocks/starrocks/issues/32656
The  `add_nullable_numeric_column` dose not set `_has_null` of nullable column when a null value is appended.
This PR fixes this issue.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
