### PR TITLE
[BugFix] Add dicts of offspring fragments of cached fragments into digest computation (backport #32673)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -42,6 +42,8 @@ import com.starrocks.common.Pair;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TCacheParam;
+import com.starrocks.thrift.TExpr;
+import com.starrocks.thrift.TGlobalDict;
 import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TExpr;
 import org.apache.thrift.TException;
@@ -55,6 +57,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -103,6 +106,7 @@ public class FragmentNormalizer {
 
     private Set<Integer> cachedPlanNodeIds = Sets.newHashSet();
     private boolean assignScanRangesAcrossDrivers = false;
+
     public FragmentNormalizer(ExecPlan execPlan, PlanFragment fragment) {
         this.execPlan = execPlan;
         this.fragment = fragment;
@@ -306,9 +310,13 @@ public class FragmentNormalizer {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
 
             for (TNormalPlanNode node : normalizedPlanNodes) {
-                byte[] data = serializer.serialize(node);
-                digest.update(data);
+                digest.update(serializer.serialize(node));
             }
+            List<TGlobalDict> dicts = normalizeDicts(getAllOffspringFragments(fragment));
+            for (TGlobalDict dict : dicts) {
+                digest.update(serializer.serialize(dict));
+            }
+
             List<SlotId> slotIds = cachePointNode.getOutputSlotIds(execPlan.getDescTbl());
             List<Integer> remappedSlotIds = remapSlotIds(slotIds);
             Map<Integer, Integer> outputSlotIdRemapping = Maps.newHashMap();
@@ -705,7 +713,7 @@ public class FragmentNormalizer {
         // Get leftmost path
         List<PlanNode> leftNodesTopDown = Lists.newArrayList();
         for (PlanNode currNode = root; currNode != null && currNode.getFragment() == fragment;
-                currNode = currNode.getChild(0)) {
+             currNode = currNode.getChild(0)) {
             leftNodesTopDown.add(currNode);
         }
 
@@ -794,8 +802,35 @@ public class FragmentNormalizer {
         normalizeSubTree(leftNodeIds, topMostDigestNode, Sets.newHashSet());
         List<PlanNode> cachedPlanNodes = leftNodesTopDown.stream().skip(firstAggNodeIdx).collect(Collectors.toList());
         fragment.setAssignScanRangesPerDriverSeq(canAssignScanRangesAcrossDrivers(cachedPlanNodes));
-        cachedPlanNodeIds = cachedPlanNodes.stream().map(node->node.getId().asInt()).collect(Collectors.toSet());
+        cachedPlanNodeIds = cachedPlanNodes.stream().map(node -> node.getId().asInt()).collect(Collectors.toSet());
         return computeDigest(firstAggNode);
+    }
+
+    // get All of offspring fragments of the current fragment, the current fragment
+    // is also included. fragments containing MulticastSink are counted once.
+    private List<PlanFragment> getAllOffspringFragments(PlanFragment fragment) {
+        List<ExchangeNode> exchangeNodes = Lists.newArrayList();
+        fragment.getPlanRoot().collect(ExchangeNode.class, exchangeNodes);
+        List<PlanFragment> fragments = exchangeNodes.stream()
+                .flatMap(ex -> ex.getChildren().stream().map(PlanNode::getFragment))
+                .sorted(Comparator.comparingInt(frag -> frag.getFragmentId().asInt()))
+                .distinct().collect(Collectors.toList());
+        fragments.add(fragment);
+        return fragments;
+    }
+
+    // Normalize global dicts of the given fragments
+    private List<TGlobalDict> normalizeDicts(List<PlanFragment> fragments) {
+        List<TGlobalDict> dicts = Lists.newArrayList();
+        for (PlanFragment fragment : fragments) {
+            if (fragment.getQueryGlobalDicts() != null) {
+                dicts.addAll(fragment.normalizeDicts(fragment.getQueryGlobalDicts(), this));
+            }
+            if (fragment.getLoadGlobalDicts() != null) {
+                dicts.addAll(fragment.normalizeDicts(fragment.getLoadGlobalDicts(), this));
+            }
+        }
+        return dicts;
     }
 
     public static class SlotEquivRelation {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -56,6 +56,7 @@ import org.apache.commons.collections.CollectionUtils;
 
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -417,7 +418,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         return result;
     }
 
-    private List<TGlobalDict> dictToThrift(List<Pair<Integer, ColumnDict>> dicts) {
+    public List<TGlobalDict> dictToThrift(List<Pair<Integer, ColumnDict>> dicts) {
         List<TGlobalDict> result = Lists.newArrayList();
         for (Pair<Integer, ColumnDict> dictPair : dicts) {
             TGlobalDict globalDict = new TGlobalDict();
@@ -431,6 +432,25 @@ public class PlanFragment extends TreeNode<PlanFragment> {
             globalDict.setVersion(dictPair.second.getCollectedVersionTime());
             globalDict.setStrings(strings);
             globalDict.setIds(integers);
+            result.add(globalDict);
+        }
+        return result;
+    }
+
+    // normalize dicts of the fragment, it is different from dictToThrift in three points:
+    // 1. SlotIds must be replaced by remapped SlotIds;
+    // 2. dict should be sorted according to its corresponding remapped SlotIds;
+    public List<TGlobalDict> normalizeDicts(List<Pair<Integer, ColumnDict>> dicts, FragmentNormalizer normalizer) {
+        List<TGlobalDict> result = Lists.newArrayList();
+        // replace slot id with the remapped slot id, sort dicts according to remapped slot ids.
+        List<Pair<Integer, ColumnDict>> sortedDicts =
+                dicts.stream().map(p -> Pair.create(normalizer.remapSlotId(p.first), p.second))
+                        .sorted(Comparator.comparingInt(p -> p.first)).collect(Collectors.toList());
+
+        for (Pair<Integer, ColumnDict> dictPair : sortedDicts) {
+            TGlobalDict globalDict = new TGlobalDict();
+            globalDict.setColumnId(dictPair.first);
+            globalDict.setVersion(dictPair.second.getCollectedVersionTime());
             result.add(globalDict);
         }
         return result;

--- a/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
@@ -1,0 +1,145 @@
+-- name: test_query_cache_use_fresh_global_dict
+DROP TABLE IF EXISTS `t0`;
+-- result:
+-- !result
+CREATE TABLE `t0` (
+  `dt` date NOT NULL COMMENT "",
+  `k1` varchar(100) NOT NULL COMMENT "",
+  `k2` varchar(100) NOT NULL COMMENT "",
+  `v1` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`dt`, `k1`, `k2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`dt`)
+(PARTITION p20230101 VALUES [("2023-01-01"), ("2023-01-02")),
+PARTITION p20230102 VALUES [("2023-01-02"), ("2023-01-03")),
+PARTITION p20230103 VALUES [("2023-01-03"), ("2023-01-04")),
+PARTITION p20230104 VALUES [("2023-01-04"), ("2023-01-05")),
+PARTITION p20230105 VALUES [("2023-01-05"), ("2023-01-06")),
+PARTITION p20230106 VALUES [("2023-01-06"), ("2023-01-07")),
+PARTITION p20230107 VALUES [("2023-01-07"), ("2023-01-08")),
+PARTITION p20230108 VALUES [("2023-01-08"), ("2023-01-09")),
+PARTITION p20230109 VALUES [("2023-01-09"), ("2023-01-10")))
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 4 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into t0 values('2023-01-01', 'foo_0001', 'bar_0010', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-02', 'foo_0001', 'bar_0011', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-03', 'foo_0001', 'bar_0012', 1);
+-- result:
+-- !result
+[UC]analyze full table t0;
+-- result:
+-- !result
+select sleep(10);
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+insert into t0 values('2023-01-04', 'foo_0002', 'bar_0001', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-05', 'foo_0002', 'bar_0002', 1);
+-- result:
+-- !result
+insert into t0 values('2023-01-06', 'foo_0002', 'bar_0003', 1);
+-- result:
+-- !result
+[UC]analyze full table t0;
+-- result:
+-- !result
+select sleep(10);
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+-- result:
+1
+-- !result

--- a/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
@@ -1,0 +1,59 @@
+-- name: test_query_cache_use_fresh_global_dict
+DROP TABLE IF EXISTS `t0`;
+CREATE TABLE `t0` (
+  `dt` date NOT NULL COMMENT "",
+  `k1` varchar(100) NOT NULL COMMENT "",
+  `k2` varchar(100) NOT NULL COMMENT "",
+  `v1` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`dt`, `k1`, `k2`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`dt`)
+(PARTITION p20230101 VALUES [("2023-01-01"), ("2023-01-02")),
+PARTITION p20230102 VALUES [("2023-01-02"), ("2023-01-03")),
+PARTITION p20230103 VALUES [("2023-01-03"), ("2023-01-04")),
+PARTITION p20230104 VALUES [("2023-01-04"), ("2023-01-05")),
+PARTITION p20230105 VALUES [("2023-01-05"), ("2023-01-06")),
+PARTITION p20230106 VALUES [("2023-01-06"), ("2023-01-07")),
+PARTITION p20230107 VALUES [("2023-01-07"), ("2023-01-08")),
+PARTITION p20230108 VALUES [("2023-01-08"), ("2023-01-09")),
+PARTITION p20230109 VALUES [("2023-01-09"), ("2023-01-10")))
+DISTRIBUTED BY HASH(`k1`, `k2`) BUCKETS 4 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+insert into t0 values('2023-01-01', 'foo_0001', 'bar_0010', 1);
+insert into t0 values('2023-01-02', 'foo_0001', 'bar_0011', 1);
+insert into t0 values('2023-01-03', 'foo_0001', 'bar_0012', 1);
+[UC]analyze full table t0;
+select sleep(10);
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+insert into t0 values('2023-01-04', 'foo_0002', 'bar_0001', 1);
+insert into t0 values('2023-01-05', 'foo_0002', 'bar_0002', 1);
+insert into t0 values('2023-01-06', 'foo_0002', 'bar_0003', 1);
+[UC]analyze full table t0;
+select sleep(10);
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;
+select  /*+SET_VAR(enable_query_cache=true,new_planner_agg_stage=2) */ assert_true(k2='bar_0010') from (select distinct k2  from t0 where k1 = 'foo_0001' order by k2 limit 1) t;


### PR DESCRIPTION
cp #32673 
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
