### PR TITLE
[Enhancement] Support parquet footer cache.

### DIFF
--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -83,8 +83,8 @@ Status BlockCache::init(const CacheOptions& options) {
     return _kv_cache->init(options);
 }
 
-Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer,
-                               WriteCacheOptions* options) {
+Status BlockCache::write_buffer(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer,
+                                WriteCacheOptions* options) {
     if (offset % _block_size != 0) {
         LOG(WARNING) << "write block key: " << cache_key << " with invalid args, offset: " << offset;
         return Status::InvalidArgument(strings::Substitute("offset must be aligned by block size $0", _block_size));
@@ -95,42 +95,54 @@ Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, const IO
 
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->write_cache(block_key, buffer, options);
+    return _kv_cache->write_buffer(block_key, buffer, options);
 }
 
 static void empty_deleter(void*) {}
 
-Status BlockCache::write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
-                               WriteCacheOptions* options) {
+Status BlockCache::write_buffer(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
+                                WriteCacheOptions* options) {
     if (!data) {
         return Status::InvalidArgument("invalid data buffer");
     }
 
     IOBuffer buffer;
     buffer.append_user_data((void*)data, size, empty_deleter);
-    return write_cache(cache_key, offset, buffer, options);
+    return write_buffer(cache_key, offset, buffer, options);
 }
 
-Status BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
-                              ReadCacheOptions* options) {
+Status BlockCache::write_object(const CacheKey& cache_key, const void* ptr, size_t size, DeleterFunc deleter,
+                                CacheHandle* handle, WriteCacheOptions* options) {
+    if (!ptr) {
+        return Status::InvalidArgument("invalid object pointer");
+    }
+    return _kv_cache->write_object(cache_key, ptr, size, std::move(deleter), handle, options);
+}
+
+Status BlockCache::read_buffer(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
+                               ReadCacheOptions* options) {
     if (size == 0) {
         return Status::OK();
     }
 
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->read_cache(block_key, offset - index * _block_size, size, buffer, options);
+    return _kv_cache->read_buffer(block_key, offset - index * _block_size, size, buffer, options);
 }
 
-StatusOr<size_t> BlockCache::read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data,
-                                        ReadCacheOptions* options) {
+StatusOr<size_t> BlockCache::read_buffer(const CacheKey& cache_key, off_t offset, size_t size, char* data,
+                                         ReadCacheOptions* options) {
     IOBuffer buffer;
-    RETURN_IF_ERROR(read_cache(cache_key, offset, size, &buffer, options));
+    RETURN_IF_ERROR(read_buffer(cache_key, offset, size, &buffer, options));
     buffer.copy_to(data);
     return buffer.size();
 }
 
-Status BlockCache::remove_cache(const CacheKey& cache_key, off_t offset, size_t size) {
+Status BlockCache::read_object(const CacheKey& cache_key, CacheHandle* handle, ReadCacheOptions* options) {
+    return _kv_cache->read_object(cache_key, handle, options);
+}
+
+Status BlockCache::remove(const CacheKey& cache_key, off_t offset, size_t size) {
     if (offset % _block_size != 0) {
         LOG(WARNING) << "remove block key: " << cache_key << " with invalid args, offset: " << offset
                      << ", size: " << size;
@@ -143,7 +155,7 @@ Status BlockCache::remove_cache(const CacheKey& cache_key, off_t offset, size_t 
 
     size_t index = offset / _block_size;
     std::string block_key = fmt::format("{}/{}", cache_key, index);
-    return _kv_cache->remove_cache(block_key);
+    return _kv_cache->remove(block_key);
 }
 
 void BlockCache::record_read_remote(size_t size, int64_t lateny_us) {

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -21,7 +21,8 @@ namespace starrocks {
 
 class BlockCache {
 public:
-    typedef std::string CacheKey;
+    using CacheKey = std::string;
+    using DeleterFunc = std::function<void()>;
 
     // Return a singleton block cache instance
     static BlockCache* instance();
@@ -29,23 +30,32 @@ public:
     // Init the block cache instance
     Status init(const CacheOptions& options);
 
-    // Write data to cache, the offset must be aligned by block size
-    Status write_cache(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer,
-                       WriteCacheOptions* options = nullptr);
+    // Write data buffer to cache, the `offset` must be aligned by block size
+    Status write_buffer(const CacheKey& cache_key, off_t offset, const IOBuffer& buffer,
+                        WriteCacheOptions* options = nullptr);
 
-    Status write_cache(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
-                       WriteCacheOptions* options = nullptr);
+    Status write_buffer(const CacheKey& cache_key, off_t offset, size_t size, const char* data,
+                        WriteCacheOptions* options = nullptr);
+
+    // Write object to cache, the `ptr` is the object pointer.
+    Status write_object(const CacheKey& cache_key, const void* ptr, size_t size, DeleterFunc deleter,
+                        CacheHandle* handle, WriteCacheOptions* options = nullptr);
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned. The offset and size must be aligned by block size.
-    Status read_cache(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
-                      ReadCacheOptions* options = nullptr);
+    Status read_buffer(const CacheKey& cache_key, off_t offset, size_t size, IOBuffer* buffer,
+                       ReadCacheOptions* options = nullptr);
 
-    StatusOr<size_t> read_cache(const CacheKey& cache_key, off_t offset, size_t size, char* data,
-                                ReadCacheOptions* options = nullptr);
+    StatusOr<size_t> read_buffer(const CacheKey& cache_key, off_t offset, size_t size, char* data,
+                                 ReadCacheOptions* options = nullptr);
+
+    // Read object from cache, the `handle` wraps the object pointer.
+    // As long as the handle object is not destroyed and the user does not manully call the `handle->release()`
+    // function, the corresponding pointer will never be freed by the cache system.
+    Status read_object(const CacheKey& cache_key, CacheHandle* handle, ReadCacheOptions* options = nullptr);
 
     // Remove data from cache. The offset and size must be aligned by block size
-    Status remove_cache(const CacheKey& cache_key, off_t offset, size_t size);
+    Status remove(const CacheKey& cache_key, off_t offset, size_t size);
 
     void record_read_remote(size_t size, int64_t lateny_us);
 

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -55,7 +55,7 @@ Status CacheLibWrapper::init(const CacheOptions& options) {
     return Status::OK();
 }
 
-Status CacheLibWrapper::write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
+Status CacheLibWrapper::write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
     //  Simulate the behavior of skipping if exists
     if (options && !options->overwrite && _cache->find(key)) {
         return Status::AlreadyExist("the cache item already exists");
@@ -70,8 +70,8 @@ Status CacheLibWrapper::write_cache(const std::string& key, const IOBuffer& buff
     return Status::OK();
 }
 
-Status CacheLibWrapper::read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                                   ReadCacheOptions* options) {
+Status CacheLibWrapper::read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                                    ReadCacheOptions* options) {
     // TODO:
     // 1. check chain item
     // 2. replace with async methods
@@ -87,7 +87,7 @@ Status CacheLibWrapper::read_cache(const std::string& key, size_t off, size_t si
     return Status::OK();
 }
 
-Status CacheLibWrapper::remove_cache(const std::string& key) {
+Status CacheLibWrapper::remove(const std::string& key) {
     _cache->remove(key);
     return Status::OK();
 }
@@ -95,6 +95,15 @@ Status CacheLibWrapper::remove_cache(const std::string& key) {
 std::unordered_map<std::string, double> CacheLibWrapper::cache_stats() {
     const auto navy_stats = _cache->getNvmCacheStatsMap().toMap();
     return navy_stats;
+}
+
+Status CacheLibWrapper::write_object(const std::string& key, const void* ptr, size_t size,
+                                     std::function<void()> deleter, CacheHandle* handle, WriteCacheOptions* options) {
+    return Status::NotSupported("not supported write object in cachelib");
+}
+
+Status CacheLibWrapper::read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) {
+    return Status::NotSupported("not supported read object in cachelib");
 }
 
 void CacheLibWrapper::record_read_remote(size_t size, int64_t lateny_us) {}

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -44,12 +44,17 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
+    Status write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
 
-    Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                      ReadCacheOptions* options) override;
+    Status write_object(const std::string& key, const void* ptr, size_t size, std::function<void()> deleter,
+                        CacheHandle* handle, WriteCacheOptions* options) override;
 
-    Status remove_cache(const std::string& key) override;
+    Status read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                       ReadCacheOptions* options) override;
+
+    Status read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) override;
+
+    Status remove(const std::string& key) override;
 
     std::unordered_map<std::string, double> cache_stats() override;
 

--- a/be/src/block_cache/io_buffer.h
+++ b/be/src/block_cache/io_buffer.h
@@ -16,6 +16,8 @@
 
 #include <butil/iobuf.h>
 
+#include "starcache/obj_handle.h"
+
 namespace starrocks {
 
 class IOBuffer {
@@ -46,5 +48,11 @@ public:
 private:
     butil::IOBuf _buf;
 };
+
+// We use the `starcache::ObjectHandle` directly because implementing a new one seems unnecessary.
+// Importing the starcache headers here is not graceful, but the `cachelib` doesn't support
+// object cache and we'll deprecate it for some performance reasons. Now there is no need to
+// pay too much attention to the compatibility and upper-level abstraction of the cachelib interface.
+using CacheHandle = starcache::ObjectHandle;
 
 } // namespace starrocks

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -28,15 +28,20 @@ public:
     virtual Status init(const CacheOptions& options) = 0;
 
     // Write data to cache
-    virtual Status write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) = 0;
+    virtual Status write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) = 0;
+
+    virtual Status write_object(const std::string& key, const void* ptr, size_t size, std::function<void()> deleter,
+                                CacheHandle* handle, WriteCacheOptions* options) = 0;
 
     // Read data from cache, it returns the data size if successful; otherwise the error status
     // will be returned.
-    virtual Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                              ReadCacheOptions* options) = 0;
+    virtual Status read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                               ReadCacheOptions* options) = 0;
+
+    virtual Status read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) = 0;
 
     // Remove data from cache. The offset must be aligned by block size
-    virtual Status remove_cache(const std::string& key) = 0;
+    virtual Status remove(const std::string& key) = 0;
 
     virtual std::unordered_map<std::string, double> cache_stats() = 0;
 

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -41,7 +41,7 @@ Status StarCacheWrapper::init(const CacheOptions& options) {
     return to_status(_cache->init(opt));
 }
 
-Status StarCacheWrapper::write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
+Status StarCacheWrapper::write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) {
     if (!options) {
         return to_status(_cache->set(key, buffer.const_raw_buf(), nullptr));
     }
@@ -56,8 +56,23 @@ Status StarCacheWrapper::write_cache(const std::string& key, const IOBuffer& buf
     return st;
 }
 
-Status StarCacheWrapper::read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                                    ReadCacheOptions* options) {
+Status StarCacheWrapper::write_object(const std::string& key, const void* ptr, size_t size,
+                                      std::function<void()> deleter, CacheHandle* handle, WriteCacheOptions* options) {
+    if (!options) {
+        return to_status(_cache->set_object(key, ptr, size, deleter, handle, nullptr));
+    }
+    starcache::WriteOptions opts;
+    opts.ttl_seconds = options->ttl_seconds;
+    opts.overwrite = options->overwrite;
+    auto st = to_status(_cache->set_object(key, ptr, size, deleter, handle, &opts));
+    if (st.ok()) {
+        options->stats.write_mem_bytes = size;
+    }
+    return st;
+}
+
+Status StarCacheWrapper::read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                                     ReadCacheOptions* options) {
     if (!options) {
         return to_status(_cache->read(key, off, size, &buffer->raw_buf(), nullptr));
     }
@@ -70,7 +85,19 @@ Status StarCacheWrapper::read_cache(const std::string& key, size_t off, size_t s
     return st;
 }
 
-Status StarCacheWrapper::remove_cache(const std::string& key) {
+Status StarCacheWrapper::read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) {
+    if (!options) {
+        return to_status(_cache->get_object(key, handle, nullptr));
+    }
+    starcache::ReadOptions opts;
+    auto st = to_status(_cache->get_object(key, handle, &opts));
+    if (st.ok()) {
+        options->stats.read_mem_bytes = opts.stats.read_mem_bytes;
+    }
+    return st;
+}
+
+Status StarCacheWrapper::remove(const std::string& key) {
     _cache->remove(key);
     return Status::OK();
 }

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -28,12 +28,17 @@ public:
 
     Status init(const CacheOptions& options) override;
 
-    Status write_cache(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
+    Status write_buffer(const std::string& key, const IOBuffer& buffer, WriteCacheOptions* options) override;
 
-    Status read_cache(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
-                      ReadCacheOptions* options) override;
+    Status write_object(const std::string& key, const void* ptr, size_t size, std::function<void()> deleter,
+                        CacheHandle* handle, WriteCacheOptions* options) override;
 
-    Status remove_cache(const std::string& key) override;
+    Status read_buffer(const std::string& key, size_t off, size_t size, IOBuffer* buffer,
+                       ReadCacheOptions* options) override;
+
+    Status read_object(const std::string& key, CacheHandle* handle, ReadCacheOptions* options) override;
+
+    Status remove(const std::string& key) override;
 
     std::unordered_map<std::string, double> cache_stats() override;
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -106,6 +106,9 @@ Status HiveDataSource::open(RuntimeState* state) {
         _scan_range.datacache_options.priority == -1) {
         _use_datacache = false;
     }
+    if (state->query_options().__isset.enable_file_metacache) {
+        _use_file_metacache = state->query_options().enable_file_metacache;
+    }
 
     RETURN_IF_ERROR(_init_conjunct_ctxs(state));
     _init_tuples_and_slots(state);
@@ -733,6 +736,7 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.enable_populate_datacache = _enable_populate_datacache;
     scanner_params.can_use_any_column = _can_use_any_column;
     scanner_params.can_use_min_max_count_opt = _can_use_min_max_count_opt;
+    scanner_params.use_file_metacache = _use_file_metacache;
 
     HdfsScanner* scanner = nullptr;
     auto format = scan_range.file_format;

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -96,6 +96,7 @@ private:
     bool _use_datacache = false;
     bool _enable_populate_datacache = false;
     bool _enable_dynamic_prune_scan_range = true;
+    bool _use_file_metacache = false;
 
     // ============ conjuncts =================
     std::vector<ExprContext*> _min_max_conjunct_ctxs;

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -137,6 +137,7 @@ Status HdfsScanner::_build_scanner_context() {
     ctx.case_sensitive = _scanner_params.case_sensitive;
     ctx.can_use_any_column = _scanner_params.can_use_any_column;
     ctx.can_use_min_max_count_opt = _scanner_params.can_use_min_max_count_opt;
+    ctx.use_file_metacache = _scanner_params.use_file_metacache;
     ctx.timezone = _runtime_state->timezone();
     ctx.iceberg_schema = _scanner_params.iceberg_schema;
     ctx.stats = &_app_stats;

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -56,6 +56,10 @@ struct HdfsScanStats {
     int64_t page_read_ns = 0;
     // reader init
     int64_t footer_read_ns = 0;
+    int64_t footer_cache_read_ns = 0;
+    int64_t footer_cache_read_count = 0;
+    int64_t footer_cache_write_count = 0;
+    int64_t footer_cache_write_bytes = 0;
     int64_t column_reader_init_ns = 0;
     // dict filter
     int64_t group_chunk_read_ns = 0;
@@ -148,6 +152,7 @@ struct HdfsScannerParams {
     // The file size. -1 means unknown.
     int64_t file_size = -1;
 
+    // The file last modification time
     int64_t modification_time = 0;
 
     const TupleDescriptor* tuple_desc = nullptr;
@@ -191,6 +196,7 @@ struct HdfsScannerParams {
     std::atomic<int32_t>* lazy_column_coalesce_counter;
     bool can_use_any_column = false;
     bool can_use_min_max_count_opt = false;
+    bool use_file_metacache = false;
 };
 
 struct HdfsScannerContext {
@@ -238,6 +244,8 @@ struct HdfsScannerContext {
     bool can_use_any_column = false;
 
     bool can_use_min_max_count_opt = false;
+
+    bool use_file_metacache = false;
 
     std::string timezone;
 

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -25,6 +25,7 @@
 #include "formats/parquet/metadata.h"
 #include "fs/fs.h"
 #include "gutil/strings/substitute.h"
+#include "runtime/current_thread.h"
 #include "storage/chunk_helper.h"
 #include "util/coding.h"
 #include "util/defer_op.h"
@@ -33,19 +34,49 @@
 
 namespace starrocks::parquet {
 
-FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
+FileReader::FileReader(int chunk_size, RandomAccessFile* file, size_t file_size, int64_t file_mtime,
                        io::SharedBufferedInputStream* sb_stream, const std::set<int64_t>* _need_skip_rowids)
         : _chunk_size(chunk_size),
           _file(file),
           _file_size(file_size),
+          _file_mtime(file_mtime),
           _sb_stream(sb_stream),
           _need_skip_rowids(_need_skip_rowids) {}
 
-FileReader::~FileReader() = default;
+FileReader::~FileReader() {
+    if (!_is_metadata_cached && _file_metadata) {
+        delete _file_metadata;
+    }
+}
+
+void FileReader::_build_metacache_key() {
+    auto& filename = _file->filename();
+    _metacache_key.resize(14);
+    char* data = _metacache_key.data();
+    const std::string footer_suffix = "ft";
+    uint64_t hash_value = HashUtil::hash64(filename.data(), filename.size(), 0);
+    memcpy(data, &hash_value, sizeof(hash_value));
+    memcpy(data + 8, footer_suffix.data(), footer_suffix.length());
+    // The modification time is more appropriate to indicate the different file versions.
+    // While some data source, such as Hudi, have no modification time because their files
+    // cannot be overwritten. So, if the modification time is unsupported, we use file size instead.
+    // Also, to reduce memory usage, we only use the high four bytes to represent the second timestamp.
+    if (_file_mtime > 0) {
+        uint32_t mtime_s = (_file_mtime >> 9) & 0x00000000FFFFFFFF;
+        memcpy(data + 10, &mtime_s, sizeof(mtime_s));
+    } else {
+        uint32_t size = _file_size;
+        memcpy(data + 10, &size, sizeof(size));
+    }
+}
 
 Status FileReader::init(HdfsScannerContext* ctx) {
     _scanner_ctx = ctx;
-    RETURN_IF_ERROR(_parse_footer());
+    if (ctx->use_file_metacache && config::datacache_enable) {
+        _build_metacache_key();
+        _cache = BlockCache::instance();
+    }
+    RETURN_IF_ERROR(_get_footer());
 
     if (_scanner_ctx->iceberg_schema != nullptr && _file_metadata->schema().exist_filed_id()) {
         // If we want read this parquet file with iceberg schema,
@@ -70,11 +101,11 @@ Status FileReader::init(HdfsScannerContext* ctx) {
     return Status::OK();
 }
 
-std::shared_ptr<FileMetaData> FileReader::get_file_metadata() {
+FileMetaData* FileReader::get_file_metadata() {
     return _file_metadata;
 }
 
-Status FileReader::_parse_footer() {
+Status FileReader::_parse_footer(FileMetaData** file_metadata, int64_t* file_metadata_size) {
     std::vector<char> footer_buffer;
     ASSIGN_OR_RETURN(uint32_t footer_read_size, _get_footer_read_size());
     footer_buffer.resize(footer_read_size);
@@ -104,8 +135,51 @@ Status FileReader::_parse_footer() {
     RETURN_IF_ERROR(deserialize_thrift_msg(reinterpret_cast<const uint8*>(footer_buffer.data()) + footer_buffer.size() -
                                                    PARQUET_FOOTER_SIZE - metadata_length,
                                            &metadata_length, TProtocolType::COMPACT, &t_metadata));
-    _file_metadata.reset(new FileMetaData());
-    RETURN_IF_ERROR(_file_metadata->init(t_metadata, _scanner_ctx->case_sensitive));
+    int64_t before_bytes = CurrentThread::current().get_consumed_bytes();
+    *file_metadata = new FileMetaData();
+    RETURN_IF_ERROR((*file_metadata)->init(t_metadata, _scanner_ctx->case_sensitive));
+    *file_metadata_size = CurrentThread::current().get_consumed_bytes() - before_bytes;
+#ifdef BE_TEST
+    *file_metadata_size = sizeof(FileMetaData);
+#endif
+
+    return Status::OK();
+}
+
+Status FileReader::_get_footer() {
+    _is_metadata_cached = false;
+    if (!_cache) {
+        int64_t file_metadata_size = 0;
+        return _parse_footer(&_file_metadata, &file_metadata_size);
+    }
+
+    {
+        SCOPED_RAW_TIMER(&_scanner_ctx->stats->footer_cache_read_ns);
+        Status st = _cache->read_object(_metacache_key, &_cache_handle);
+        if (st.ok()) {
+            _file_metadata = (FileMetaData*)_cache_handle.ptr();
+            _scanner_ctx->stats->footer_cache_read_count += 1;
+            _is_metadata_cached = true;
+            return st;
+        }
+    }
+
+    int64_t file_metadata_size = 0;
+    FileMetaData* file_metadata = nullptr;
+    RETURN_IF_ERROR(_parse_footer(&file_metadata, &file_metadata_size));
+    if (file_metadata_size > 0) {
+        auto deleter = [file_metadata]() { delete file_metadata; };
+        Status st = _cache->write_object(_metacache_key, file_metadata, file_metadata_size, deleter, &_cache_handle);
+        if (st.ok()) {
+            _scanner_ctx->stats->footer_cache_write_bytes += file_metadata_size;
+            _scanner_ctx->stats->footer_cache_write_count += 1;
+            _is_metadata_cached = true;
+        }
+    } else {
+        LOG(ERROR) << "Parsing unexpected parquet file metadata size";
+    }
+
+    _file_metadata = file_metadata;
     return Status::OK();
 }
 
@@ -427,7 +501,7 @@ Status FileReader::_init_group_readers() {
     _group_reader_param.sb_stream = nullptr;
     _group_reader_param.chunk_size = _chunk_size;
     _group_reader_param.file = _file;
-    _group_reader_param.file_metadata = _file_metadata.get();
+    _group_reader_param.file_metadata = _file_metadata;
     _group_reader_param.case_sensitive = fd_scanner_ctx.case_sensitive;
     _group_reader_param.lazy_column_coalesce_counter = fd_scanner_ctx.lazy_column_coalesce_counter;
 

--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -17,6 +17,7 @@
 #include <cstdint>
 #include <memory>
 
+#include "block_cache/block_cache.h"
 #include "column/chunk.h"
 #include "common/status.h"
 #include "formats/parquet/group_reader.h"
@@ -45,7 +46,7 @@ class FileMetaData;
 
 class FileReader {
 public:
-    FileReader(int chunk_size, RandomAccessFile* file, size_t file_size,
+    FileReader(int chunk_size, RandomAccessFile* file, size_t file_size, int64_t file_mtime,
                io::SharedBufferedInputStream* sb_stream = nullptr,
                const std::set<int64_t>* _need_skip_rowids = nullptr);
     ~FileReader();
@@ -54,13 +55,18 @@ public:
 
     Status get_next(ChunkPtr* chunk);
 
-    std::shared_ptr<FileMetaData> get_file_metadata();
+    FileMetaData* get_file_metadata();
 
 private:
     int _chunk_size;
 
+    // get footer of parquet file from cache or parquet file
+    Status _get_footer();
+
+    void _build_metacache_key();
+
     // parse footer of parquet file
-    Status _parse_footer();
+    Status _parse_footer(FileMetaData** file_metadata, int64_t* file_metadata_size);
 
     void _prepare_read_columns();
 
@@ -107,8 +113,8 @@ private:
 
     RandomAccessFile* _file = nullptr;
     uint64_t _file_size = 0;
+    int64_t _file_mtime = 0;
 
-    std::shared_ptr<FileMetaData> _file_metadata;
     std::vector<std::shared_ptr<GroupReader>> _row_group_readers;
     size_t _cur_row_group_idx = 0;
     size_t _row_group_size = 0;
@@ -116,6 +122,12 @@ private:
     size_t _total_row_count = 0;
     size_t _scan_row_count = 0;
     bool _no_materialized_column_scan = false;
+
+    BlockCache* _cache = nullptr;
+    FileMetaData* _file_metadata = nullptr;
+    bool _is_metadata_cached = false;
+    std::string _metacache_key;
+    CacheHandle _cache_handle;
 
     // not exist column conjuncts eval false, file can be skipped
     bool _is_file_filtered = false;

--- a/be/src/formats/parquet/meta_helper.h
+++ b/be/src/formats/parquet/meta_helper.h
@@ -77,13 +77,13 @@ protected:
     }
 
     bool _case_sensitive = false;
-    std::shared_ptr<FileMetaData> _file_metadata;
+    FileMetaData* _file_metadata;
 };
 
 class ParquetMetaHelper : public MetaHelper {
 public:
-    ParquetMetaHelper(std::shared_ptr<FileMetaData> file_metadata, bool case_sensitive) {
-        _file_metadata = std::move(file_metadata);
+    ParquetMetaHelper(FileMetaData* file_metadata, bool case_sensitive) {
+        _file_metadata = file_metadata;
         _case_sensitive = case_sensitive;
     }
     ~ParquetMetaHelper() override = default;
@@ -100,9 +100,8 @@ public:
 
 class IcebergMetaHelper : public MetaHelper {
 public:
-    IcebergMetaHelper(std::shared_ptr<FileMetaData> file_metadata, bool case_sensitive,
-                      const TIcebergSchema* t_iceberg_schema) {
-        _file_metadata = std::move(file_metadata);
+    IcebergMetaHelper(FileMetaData* file_metadata, bool case_sensitive, const TIcebergSchema* t_iceberg_schema) {
+        _file_metadata = file_metadata;
         _case_sensitive = case_sensitive;
         _t_iceberg_schema = t_iceberg_schema;
         DCHECK(_t_iceberg_schema != nullptr);

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -20,17 +20,16 @@
 
 namespace starrocks::parquet {
 
-Status FileMetaData::init(const tparquet::FileMetaData& t_metadata, bool case_sensitive) {
+Status FileMetaData::init(tparquet::FileMetaData& t_metadata, bool case_sensitive) {
     // construct schema from thrift
     RETURN_IF_ERROR(_schema.from_thrift(t_metadata.schema, case_sensitive));
     _num_rows = t_metadata.num_rows;
-    _t_metadata = t_metadata;
+    _t_metadata = std::move(t_metadata);
     if (_t_metadata.__isset.created_by) {
         _writer_version = ApplicationVersion(_t_metadata.created_by);
     } else {
         _writer_version = ApplicationVersion("unknown 0.0.0");
     }
-
     return Status::OK();
 }
 

--- a/be/src/formats/parquet/metadata.h
+++ b/be/src/formats/parquet/metadata.h
@@ -75,7 +75,7 @@ public:
     FileMetaData() = default;
     ~FileMetaData() = default;
 
-    Status init(const tparquet::FileMetaData& t_metadata, bool case_sensitive);
+    Status init(tparquet::FileMetaData& t_metadata, bool case_sensitive);
 
     uint64_t num_rows() const { return _num_rows; }
 

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -37,12 +37,11 @@ CacheInputStream::CacheInputStream(const std::shared_ptr<SharedBufferedInputStre
           _sb_stream(stream),
           _offset(0),
           _size(size) {
-    // _cache_key = _filename;
-    // use hash(filename) as cache key.
     _cache = BlockCache::instance();
     _block_size = _cache->block_size();
 
     _cache_key.resize(12);
+
     char* data = _cache_key.data();
     uint64_t hash_value = HashUtil::hash64(filename.data(), filename.size(), 0);
     memcpy(data, &hash_value, sizeof(hash_value));
@@ -111,10 +110,10 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
     {
         SCOPED_RAW_TIMER(&read_cache_ns);
         if (_enable_block_buffer) {
-            res = _cache->read_cache(_cache_key, block_offset, load_size, &block.buffer);
+            res = _cache->read_buffer(_cache_key, block_offset, load_size, &block.buffer, &options);
             read_size = load_size;
         } else {
-            StatusOr<size_t> r = _cache->read_cache(_cache_key, offset, size, out);
+            StatusOr<size_t> r = _cache->read_buffer(_cache_key, offset, size, out, &options);
             res = r.status();
             read_size = size;
         }
@@ -165,7 +164,7 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
     if (_enable_populate_cache && res.is_not_found()) {
         SCOPED_RAW_TIMER(&_stats.write_cache_ns);
         WriteCacheOptions options;
-        Status r = _cache->write_cache(_cache_key, block_offset, load_size, src, &options);
+        Status r = _cache->write_buffer(_cache_key, block_offset, load_size, src, &options);
         if (r.ok()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += load_size;
@@ -282,7 +281,7 @@ void CacheInputStream::_populate_cache_from_zero_copy_buffer(const char* p, int6
         SCOPED_RAW_TIMER(&_stats.write_cache_ns);
         WriteCacheOptions options;
         options.overwrite = false;
-        Status r = cache->write_cache(_cache_key, offset, size, buf, &options);
+        Status r = cache->write_buffer(_cache_key, offset, size, buf, &options);
         if (r.ok()) {
             _stats.write_cache_count += 1;
             _stats.write_cache_bytes += size;

--- a/be/test/block_cache/block_cache_test.cpp
+++ b/be/test/block_cache/block_cache_test.cpp
@@ -62,7 +62,7 @@ TEST_F(BlockCacheTest, auto_create_disk_cache_path) {
     for (size_t i = 0; i < rounds; ++i) {
         char ch = 'a' + i % 26;
         std::string value(batch_size, ch);
-        Status st = cache->write_cache(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
         ASSERT_TRUE(st.ok());
     }
 
@@ -71,7 +71,7 @@ TEST_F(BlockCacheTest, auto_create_disk_cache_path) {
         char ch = 'a' + i % 26;
         std::string expect_value(batch_size, ch);
         char value[batch_size] = {0};
-        auto res = cache->read_cache(cache_key + std::to_string(i), 0, batch_size, value);
+        auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value);
         ASSERT_TRUE(res.status().ok());
         ASSERT_EQ(memcmp(value, expect_value.c_str(), batch_size), 0);
     }
@@ -161,7 +161,7 @@ TEST_F(BlockCacheTest, hybrid_cache) {
     for (size_t i = 0; i < rounds; ++i) {
         char ch = 'a' + i % 26;
         std::string value(batch_size, ch);
-        Status st = cache->write_cache(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
         ASSERT_TRUE(st.ok());
     }
 
@@ -170,21 +170,21 @@ TEST_F(BlockCacheTest, hybrid_cache) {
         char ch = 'a' + i % 26;
         std::string expect_value(batch_size, ch);
         char value[batch_size] = {0};
-        auto res = cache->read_cache(cache_key + std::to_string(i), 0, batch_size, value);
+        auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value);
         ASSERT_TRUE(res.status().ok());
         ASSERT_EQ(memcmp(value, expect_value.c_str(), batch_size), 0);
     }
 
     // remove cache
     char value[1024] = {0};
-    status = cache->remove_cache(cache_key, 0, batch_size);
+    status = cache->remove(cache_key, 0, batch_size);
     ASSERT_TRUE(status.ok());
 
-    auto res = cache->read_cache(cache_key, 0, batch_size, value);
+    auto res = cache->read_buffer(cache_key, 0, batch_size, value);
     ASSERT_TRUE(res.status().is_not_found());
 
     // not found
-    res = cache->read_cache(cache_key, block_size * 1000, batch_size, value);
+    res = cache->read_buffer(cache_key, block_size * 1000, batch_size, value);
     ASSERT_TRUE(res.status().is_not_found());
 
     cache->shutdown();
@@ -206,23 +206,23 @@ TEST_F(BlockCacheTest, write_with_overwrite_option) {
     const std::string cache_key = "test_file";
 
     std::string value(cache_size, 'a');
-    Status st = cache->write_cache(cache_key, 0, cache_size, value.c_str());
+    Status st = cache->write_buffer(cache_key, 0, cache_size, value.c_str());
     ASSERT_TRUE(st.ok());
 
     WriteCacheOptions write_options;
     std::string value2(cache_size, 'b');
-    st = cache->write_cache(cache_key, 0, cache_size, value2.c_str(), &write_options);
+    st = cache->write_buffer(cache_key, 0, cache_size, value2.c_str(), &write_options);
     ASSERT_TRUE(st.ok());
 
     char rvalue[cache_size] = {0};
-    auto res = cache->read_cache(cache_key, 0, cache_size, rvalue);
+    auto res = cache->read_buffer(cache_key, 0, cache_size, rvalue);
     ASSERT_TRUE(res.status().ok());
     std::string expect_value(cache_size, 'b');
     ASSERT_EQ(memcmp(rvalue, expect_value.c_str(), cache_size), 0);
 
     write_options.overwrite = false;
     std::string value3(cache_size, 'c');
-    st = cache->write_cache(cache_key, 0, cache_size, value3.c_str(), &write_options);
+    st = cache->write_buffer(cache_key, 0, cache_size, value3.c_str(), &write_options);
     ASSERT_TRUE(st.is_already_exist());
 
     cache->shutdown();
@@ -252,7 +252,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
     for (size_t i = 0; i < rounds; ++i) {
         char ch = 'a' + i % 26;
         std::string value(batch_size, ch);
-        Status st = cache->write_cache(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
         ASSERT_TRUE(st.ok());
     }
 
@@ -270,7 +270,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
         std::string expect_value(batch_size, ch);
         char value[batch_size] = {0};
         ReadCacheOptions opts;
-        auto res = cache->read_cache(cache_key + std::to_string(i), 0, batch_size, value, &opts);
+        auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value, &opts);
         ASSERT_TRUE(res.status().is_resource_busy());
     }
 
@@ -286,7 +286,7 @@ TEST_F(BlockCacheTest, read_cache_with_adaptor) {
         std::string expect_value(batch_size, ch);
         char value[batch_size] = {0};
         ReadCacheOptions opts;
-        auto res = cache->read_cache(cache_key + std::to_string(i), 0, batch_size, value, &opts);
+        auto res = cache->read_buffer(cache_key + std::to_string(i), 0, batch_size, value, &opts);
         ASSERT_TRUE(res.status().ok());
     }
 
@@ -316,14 +316,14 @@ TEST_F(BlockCacheTest, custom_lru_insertion_point) {
     for (size_t i = 0; i < rounds; ++i) {
         char ch = 'a' + i % 26;
         std::string value(batch_size, ch);
-        Status st = cache->write_cache(cache_key + std::to_string(i), 0, batch_size, value.c_str());
+        Status st = cache->write_buffer(cache_key + std::to_string(i), 0, batch_size, value.c_str());
         ASSERT_TRUE(st.ok());
     }
 
     // read cache
     // with the 1/2 lru insertion point, the test_file1 items will not be evicted
     char value[batch_size] = {0};
-    auto res = cache->read_cache(cache_key + std::to_string(1), 0, batch_size, value);
+    auto res = cache->read_buffer(cache_key + std::to_string(1), 0, batch_size, value);
     ASSERT_TRUE(res.status().ok());
 
     cache->shutdown();

--- a/be/test/formats/parquet/column_converter_test.cpp
+++ b/be/test/formats/parquet/column_converter_test.cpp
@@ -76,7 +76,7 @@ protected:
                const std::string& expected_value, const size_t expected_rows, bool is_failed = false) {
         auto file = _create_file(filepath);
         auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                        std::filesystem::file_size(filepath));
+                                                        std::filesystem::file_size(filepath), 0);
 
         // --------------init context---------------
         auto ctx = _create_scan_context();

--- a/be/test/formats/parquet/file_writer_test.cpp
+++ b/be/test/formats/parquet/file_writer_test.cpp
@@ -114,7 +114,7 @@ protected:
         auto ctx = _create_scan_context(type_descs);
         ASSIGN_OR_ABORT(auto file, _fs.new_random_access_file(_file_path));
         ASSIGN_OR_ABORT(auto file_size, _fs.get_file_size(_file_path));
-        auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), file_size);
+        auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(), file_size, 0);
 
         auto st = file_reader->init(ctx);
         if (!st.ok()) {

--- a/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
+++ b/be/test/formats/parquet/iceberg_schema_evolution_file_reader_test.cpp
@@ -93,7 +93,7 @@ protected:
 TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -175,7 +175,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructAddSubfield) {
 TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -243,7 +243,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructDropSubfield) {
 TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -311,7 +311,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructReorderSubfield) {
 TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -393,7 +393,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestStructRenameSubfield) {
 TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -444,8 +444,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestAddColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
-
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
     // --------------init context---------------
     auto ctx = _create_scan_context();
     TIcebergSchema schema = TIcebergSchema{};
@@ -488,7 +487,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestDropColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -532,7 +531,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestRenameColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -593,7 +592,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestReorderColumn) {
 TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
     auto file = _create_file(add_struct_subfield_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(add_struct_subfield_file_path));
+                                                    std::filesystem::file_size(add_struct_subfield_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();
@@ -648,7 +647,7 @@ TEST_F(IcebergSchemaEvolutionTest, TestWidenColumnType) {
 TEST_F(IcebergSchemaEvolutionTest, TestWithoutFieldId) {
     auto file = _create_file(no_field_id_file_path);
     auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
-                                                    std::filesystem::file_size(no_field_id_file_path));
+                                                    std::filesystem::file_size(no_field_id_file_path), 0);
 
     // --------------init context---------------
     auto ctx = _create_scan_context();

--- a/be/test/formats/parquet/parquet_footer_test.cpp
+++ b/be/test/formats/parquet/parquet_footer_test.cpp
@@ -38,8 +38,8 @@ protected:
 TEST_F(ParquetFooterTest, TestEmptyParquetFile) {
     const std::string file_path = "./be/test/formats/parquet/test_data/empty.parquet";
     auto file = open_file(file_path);
-    auto file_reader =
-            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                                    std::filesystem::file_size(file_path), 0);
     Status status = file_reader->init(&ctx);
     EXPECT_TRUE(status.is_corruption());
 }
@@ -47,8 +47,8 @@ TEST_F(ParquetFooterTest, TestEmptyParquetFile) {
 TEST_F(ParquetFooterTest, TestEncryptedParquetFile) {
     const std::string file_path = "./be/test/formats/parquet/test_data/encrypt_columns_and_footer.parquet.encrypted";
     auto file = open_file(file_path);
-    auto file_reader =
-            std::make_shared<FileReader>(config::vector_chunk_size, file.get(), std::filesystem::file_size(file_path));
+    auto file_reader = std::make_shared<FileReader>(config::vector_chunk_size, file.get(),
+                                                    std::filesystem::file_size(file_path), 0);
     Status status = file_reader->init(&ctx);
     EXPECT_TRUE(status.is_not_supported());
 }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -389,6 +389,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_SCAN_BLOCK_CACHE = "enable_scan_block_cache";
     public static final String ENABLE_POPULATE_BLOCK_CACHE = "enable_populate_block_cache";
 
+    public static final String ENABLE_FILE_METACACHE = "enable_file_metacache";
     public static final String HUDI_MOR_FORCE_JNI_READER = "hudi_mor_force_jni_reader";
     public static final String ENABLE_DYNAMIC_PRUNE_SCAN_RANGE = "enable_dynamic_prune_scan_range";
     public static final String IO_TASKS_PER_SCAN_OPERATOR = "io_tasks_per_scan_operator";
@@ -1237,6 +1238,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = CONNECTOR_SCAN_USE_QUERY_MEM_RATIO)
     private double connectorScanUseQueryMemRatio = 0.3;
+
+    @VariableMgr.VarAttr(name = ENABLE_FILE_METACACHE)
+    private boolean enableFileMetaCache = true;
 
     @VariableMgr.VarAttr(name = HUDI_MOR_FORCE_JNI_READER)
     private boolean hudiMORForceJNIReader = false;
@@ -2866,6 +2870,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
         tResult.setEnable_scan_datacache(enableScanDataCache);
         tResult.setEnable_populate_datacache(enablePopulateDataCache);
+        tResult.setEnable_file_metacache(enableFileMetaCache);
         tResult.setHudi_mor_force_jni_reader(hudiMORForceJNIReader);
         tResult.setIo_tasks_per_scan_operator(ioTasksPerScanOperator);
         tResult.setConnector_io_tasks_per_scan_operator(connectorIoTasksPerScanOperator);

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -241,6 +241,8 @@ struct TQueryOptions {
   109: optional i64 big_query_profile_second_threshold;
 
   110: optional TQueryQueueOptions query_queue_options;
+
+  111: optional bool enable_file_metacache;
 }
 
 
@@ -290,7 +292,7 @@ struct TPlanFragmentExecParams {
   // To enable pass through chunks between sink/exchange if they are in the same process.
   52: optional bool enable_exchange_pass_through
 
-  53: optional map<Types.TPlanNodeId, map<i32, list<TScanRangeParams>>> node_to_per_driver_seq_scan_ranges
+  53: optional map<Types.TPlanNodeId, map<i32, list<TScanRangeParams>>> node_to_per_driver_seq_scan_ranges 
 
   54: optional bool enable_exchange_perf
 

--- a/thirdparty/vars-aarch64.sh
+++ b/thirdparty/vars-aarch64.sh
@@ -52,7 +52,7 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-el7-aarch64"
 JINDOSDK_MD5SUM="27a4e2cd9a403c6e21079a866287d88b"
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.1/starcache-centos7_arm64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.2/starcache-centos7_arm64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="0a3cb9711fe35f0b08c140a7d4cf3da9"
+STARCACHE_MD5SUM="e76dfea7046424db19d18c71fae6a061"

--- a/thirdparty/vars-ubuntu22-aarch64.sh
+++ b/thirdparty/vars-ubuntu22-aarch64.sh
@@ -22,7 +22,7 @@
 #####################################################
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.1/starcache-ubuntu22_arm64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.2/starcache-ubuntu22_arm64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="59a6b919442d6bab3577e3753d704e8f"
+STARCACHE_MD5SUM="02a6f6df641e203755368f2ae582b329"

--- a/thirdparty/vars-ubuntu22-x86_64.sh
+++ b/thirdparty/vars-ubuntu22-x86_64.sh
@@ -28,7 +28,7 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux-ubuntu22-x86_64"
 JINDOSDK_MD5SUM="52236053391091591c2d09684791e810"
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.1/starcache-ubuntu22_amd64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.2/starcache-ubuntu22_amd64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="ae0ace22c981c96b1801589511a9e2b1"
+STARCACHE_MD5SUM="d0439870aba4f5dba05db6d376fc591a"

--- a/thirdparty/vars-x86_64.sh
+++ b/thirdparty/vars-x86_64.sh
@@ -52,7 +52,7 @@ JINDOSDK_SOURCE="jindosdk-4.6.8-linux"
 JINDOSDK_MD5SUM="5436e4fe39c4dfdc942e41821f1dd8a9"
 
 # starcache
-STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.1/starcache-centos7_amd64.tar.gz"
+STARCACHE_DOWNLOAD="https://cdn-thirdparty.starrocks.com/starcache/v2.0.2/starcache-centos7_amd64.tar.gz"
 STARCACHE_NAME="starcache.tar.gz"
 STARCACHE_SOURCE="starcache"
-STARCACHE_MD5SUM="eb125fd1df48d61ced6ac6357b87f512"
+STARCACHE_MD5SUM="05d44dc8803fc398e6d4fa4ca95b7634"


### PR DESCRIPTION
Parsing parquet footer usually bring lots of CPU overhead when the parquet file has a large footer.
So, we support parquet footer cache based on object cache functions in starcache library. It can store a parsed `FileMetaData` object in the cache, and we can reuse it directly later avoid parsing the footer data repeatedlly.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
