### PR TITLE
[BugFix] db lock deadlock cause by isRestoreReplica function in tabletReport(#32789)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletInvertedIndex.java
@@ -538,14 +538,8 @@ public class TabletInvertedIndex {
 
             Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
             if (db != null) {
-                com.starrocks.catalog.Table tbl = null;
-                db.readLock();
-                try {
-                    tbl = db.getTable(tableId);
-                } finally {
-                    db.readUnlock();
-                }
-
+                // getTable is thread-safe for caller, lock free
+                com.starrocks.catalog.Table tbl = db.getTable(tableId);
                 if (tbl != null && tbl instanceof OlapTable) {
                     OlapTable olapTable = (OlapTable) tbl;
                     if (olapTable.getState() == OlapTable.OlapTableState.RESTORE) {


### PR DESCRIPTION
tabletInvertedIndex lock and db lock must lock and unlock in the following order： lock: db->tabletInvertedIndex
unlock:tabletInvertedIndex -> db

The problem here is that tabletInvertedIndex has been locked so it must under the db lock. isRestoreReplica lock db lock again the cause the deadlock

Fixes #32789

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
