### PR TITLE
[Enhancement]Support using multi disks with local lake persistent index

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -97,6 +97,7 @@ Status DataDir::init(bool read_only) {
     RETURN_IF_ERROR_WITH_WARN(_init_data_dir(), "_init_data_dir failed");
     RETURN_IF_ERROR_WITH_WARN(_init_tmp_dir(), "_init_tmp_dir failed");
     RETURN_IF_ERROR_WITH_WARN(_init_meta(read_only), "_init_meta failed");
+    RETURN_IF_ERROR_WITH_WARN(init_persistent_index_dir(), "_init_persistent_index_dir failed");
 
     _is_used = true;
     return Status::OK();

--- a/be/src/storage/lake/lake_local_persistent_index.cpp
+++ b/be/src/storage/lake/lake_local_persistent_index.cpp
@@ -42,7 +42,7 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
 
     // persistent_index_dir has been checked
     Status status = TabletMetaManager::get_persistent_index_meta(
-            StorageEngine::instance()->get_persistent_index_store(), tablet->id(), &index_meta);
+            StorageEngine::instance()->get_persistent_index_store(tablet->id()), tablet->id(), &index_meta);
     if (!status.ok() && !status.is_not_found()) {
         LOG(ERROR) << "get tablet persistent index meta failed, tablet: " << tablet->id()
                    << "version: " << base_version;
@@ -287,8 +287,8 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
         return status;
     }
     // write pesistent index meta
-    status = TabletMetaManager::write_persistent_index_meta(StorageEngine::instance()->get_persistent_index_store(),
-                                                            tablet->id(), index_meta);
+    status = TabletMetaManager::write_persistent_index_meta(
+            StorageEngine::instance()->get_persistent_index_store(tablet->id()), tablet->id(), index_meta);
     if (!status.ok()) {
         LOG(WARNING) << "build persistent index failed because write persistent index meta failed: "
                      << status.to_string();

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -71,35 +71,36 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
     if (tablet->get_enable_persistent_index(base_version) && (fix_size <= 128)) {
         DCHECK(_persistent_index == nullptr);
 
-        // Even if `enable_persistent_index` is enabled,
-        // it may not take effect because `storage_root_path` is not set
-        if (StorageEngine::instance()->is_lake_persistent_index_dir_inited()) {
-            auto persistent_index_type = tablet->get_persistent_index_type(base_version);
-            if (persistent_index_type.ok()) {
-                switch (persistent_index_type.value()) {
-                case PersistentIndexTypePB::LOCAL: {
-                    std::string path = strings::Substitute(
-                            "$0/$1/",
-                            StorageEngine::instance()->get_persistent_index_store()->get_persistent_index_path(),
-                            tablet->id());
+        auto persistent_index_type = tablet->get_persistent_index_type(base_version);
+        if (persistent_index_type.ok()) {
+            switch (persistent_index_type.value()) {
+            case PersistentIndexTypePB::LOCAL: {
+                // Even if `enable_persistent_index` is enabled,
+                // it may not take effect if is as compute node without any storage path.
+                if (StorageEngine::instance()->get_persistent_index_store(tablet->id()) == nullptr) {
+                    LOG(WARNING) << "lake_persistent_index_type of LOCAL will not take effect when as cn without any "
+                                    "storage path";
+                    return Status::InternalError(
+                            "lake_persistent_index_type of LOCAL will not take effect when as cn without any storage "
+                            "path");
+                }
+                std::string path = strings::Substitute("$0/$1/",
+                                                       StorageEngine::instance()
+                                                               ->get_persistent_index_store(tablet->id())
+                                                               ->get_persistent_index_path(),
+                                                       tablet->id());
 
-                    RETURN_IF_ERROR(
-                            StorageEngine::instance()->get_persistent_index_store()->create_dir_if_path_not_exists(
-                                    path));
-                    _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path);
-                    return ((LakeLocalPersistentIndex*)_persistent_index.get())
-                            ->load_from_lake_tablet(tablet, metadata, base_version, builder);
-                }
-                default:
-                    LOG(WARNING) << "only support LOCAL lake_persistend_index_type for now";
-                    return Status::InternalError("only support LOCAL lake_persistend_index_type for now");
-                }
+                RETURN_IF_ERROR(StorageEngine::instance()
+                                        ->get_persistent_index_store(tablet->id())
+                                        ->create_dir_if_path_not_exists(path));
+                _persistent_index = std::make_unique<LakeLocalPersistentIndex>(path);
+                return ((LakeLocalPersistentIndex*)_persistent_index.get())
+                        ->load_from_lake_tablet(tablet, metadata, base_version, builder);
             }
-
-        } else {
-            LOG(WARNING) << "lake tablet persistent_index will not take effect, for storage_root_path is not set";
-            return Status::InternalError(
-                    "lake tablet persistent_index will not take effect, for storage_root_path is not set");
+            default:
+                LOG(WARNING) << "only support LOCAL lake_persistent_index_type for now";
+                return Status::InternalError("only support LOCAL lake_persistent_index_type for now");
+            }
         }
     }
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -83,7 +83,7 @@ Status UpdateManager::commit_primary_index(IndexEntry* index_entry, Tablet* tabl
         if (index.enable_persistent_index()) {
             // only take affect in local persistent index
             PersistentIndexMetaPB index_meta;
-            DataDir* data_dir = StorageEngine::instance()->get_persistent_index_store();
+            DataDir* data_dir = StorageEngine::instance()->get_persistent_index_store(tablet->id());
             RETURN_IF_ERROR(TabletMetaManager::get_persistent_index_meta(data_dir, tablet->id(), &index_meta));
             RETURN_IF_ERROR(index.commit(&index_meta));
             RETURN_IF_ERROR(TabletMetaManager::write_persistent_index_meta(data_dir, tablet->id(), index_meta));

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -278,14 +278,6 @@ Status StorageEngine::_init_store_map() {
     for (auto& store : tmp_stores) {
         _store_map.emplace(store.second->path(), store.second);
         store.first = false;
-        if (!_lake_persistent_index_dir_inited) {
-            auto status = store.second->init_persistent_index_dir();
-            if (!status.ok()) {
-                return Status::InternalError(strings::Substitute("init persistIndex dir failed, error=$0", error_msg));
-            }
-            _lake_persistent_index_dir_inited = true;
-            _persistent_index_data_dir = store.second;
-        }
     }
 
     release_guard.cancel();
@@ -533,13 +525,14 @@ DataDir* StorageEngine::get_store(int64_t path_hash) {
     return nullptr;
 }
 
-bool StorageEngine::is_lake_persistent_index_dir_inited() {
-    return _lake_persistent_index_dir_inited;
-}
-
-// maybe nullptr if storage_root_path is not set
-DataDir* StorageEngine::get_persistent_index_store() {
-    return _persistent_index_data_dir;
+// maybe nullptr if as cn
+DataDir* StorageEngine::get_persistent_index_store(int64_t tablet_id) {
+    auto stores = get_stores<false>();
+    if (stores.empty()) {
+        return nullptr;
+    } else {
+        return stores[tablet_id % stores.size()];
+    }
 }
 
 static bool too_many_disks_are_failed(uint32_t unused_num, uint32_t total_num) {

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -156,8 +156,7 @@ public:
     DataDir* get_store(const std::string& path);
     DataDir* get_store(int64_t path_hash);
 
-    bool is_lake_persistent_index_dir_inited();
-    DataDir* get_persistent_index_store();
+    DataDir* get_persistent_index_store(int64_t tablet_id);
 
     uint32_t available_storage_medium_type_count() { return _available_storage_medium_type_count; }
 
@@ -284,6 +283,8 @@ public:
         _finish_publish_version_cv.notify_one();
     }
 
+    bool is_as_cn() { return !_options.need_write_cluster_id; }
+
 protected:
     static StorageEngine* _s_instance;
 
@@ -374,11 +375,7 @@ private:
     EngineOptions _options;
     std::mutex _store_lock;
     std::map<std::string, DataDir*> _store_map;
-    DataDir* _persistent_index_data_dir = nullptr;
     uint32_t _available_storage_medium_type_count;
-
-    std::atomic<bool> _lake_persistent_index_dir_inited{false};
-
     bool _is_all_cluster_id_exist;
 
     std::mutex _gc_mutex;

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -61,7 +61,7 @@ protected:
 
     void check_local_persistent_index_meta(int64_t tablet_id, int64_t expected_version) {
         PersistentIndexMetaPB index_meta;
-        DataDir* data_dir = StorageEngine::instance()->get_persistent_index_store();
+        DataDir* data_dir = StorageEngine::instance()->get_persistent_index_store(tablet_id);
         CHECK_OK(TabletMetaManager::get_persistent_index_meta(data_dir, tablet_id, &index_meta));
         ASSERT_TRUE(index_meta.version().major_number() == expected_version);
     }


### PR DESCRIPTION
Fixes #issue
Local persistent index in shard_data only uses one disk even if multiple disks are configured currently, it will cause disk waste. This PR will select different paths for different tablet through hashing when building persistent index. And if `stoage_path` changed, gc will clean the persistent index meta and dir which implemented in #32184
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
