### PR TITLE
[Enhancement] optimize thread pool usage in shared data mode

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -174,7 +174,7 @@ void AgentServer::Impl::init_or_die() {
                                         [this]() { return _thread_pool_publish_version->num_queued_tasks(); });
 #endif
 
-        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", config::drop_tablet_worker_count, config::drop_tablet_worker_count,
+        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, config::drop_tablet_worker_count,
                                        std::numeric_limits<int>::max(), _thread_pool_drop);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", config::create_tablet_worker_count,

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -174,8 +174,8 @@ void AgentServer::Impl::init_or_die() {
                                         [this]() { return _thread_pool_publish_version->num_queued_tasks(); });
 #endif
 
-        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, config::drop_tablet_worker_count,
-                                       std::numeric_limits<int>::max(), _thread_pool_drop);
+        BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, config::drop_tablet_worker_count, std::numeric_limits<int>::max(),
+                                       _thread_pool_drop);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", config::create_tablet_worker_count,
                                        config::create_tablet_worker_count, std::numeric_limits<int>::max(),

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1088,6 +1088,6 @@ CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
 // 0 means no limit
 CONF_Int32(lake_service_max_concurrency, "0");
 
-CONF_mInt64(lake_vacuum_max_batch_delete_size, "10000");
+CONF_mInt64(lake_vacuum_min_batch_delete_size, "10000");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1088,6 +1088,6 @@ CONF_mBool(enable_drop_tablet_if_unfinished_txn, "true");
 // 0 means no limit
 CONF_Int32(lake_service_max_concurrency, "0");
 
-CONF_mInt64(lake_vacuum_min_batch_delete_size, "10000");
+CONF_mInt64(lake_vacuum_min_batch_delete_size, "1000");
 
 } // namespace starrocks::config

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -86,7 +86,7 @@ CONF_Int32(heartbeat_service_thread_count, "1");
 // The count of thread to create table.
 CONF_Int32(create_tablet_worker_count, "3");
 // The count of thread to drop table.
-CONF_Int32(drop_tablet_worker_count, "3");
+CONF_mInt32(drop_tablet_worker_count, "3");
 // The count of thread to batch load.
 CONF_Int32(push_worker_count_normal_priority, "3");
 // The count of thread to high priority batch load.
@@ -121,7 +121,7 @@ CONF_Int32(upload_worker_count, "1");
 // The count of thread to download.
 CONF_Int32(download_worker_count, "1");
 // The count of thread to make snapshot.
-CONF_Int32(make_snapshot_worker_count, "5");
+CONF_mInt32(make_snapshot_worker_count, "5");
 // The count of thread to release snapshot.
 CONF_Int32(release_snapshot_worker_count, "5");
 // The interval time(seconds) for agent report tasks signatrue to FE.

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -151,6 +151,18 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             (void)StorageEngine::instance()->update_manager()->get_pindex_thread_pool()->update_max_threads(
                     max_thread_cnt);
         });
+        _config_callback.emplace("drop_tablet_worker_count", [&]() {
+            auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::DROP);
+            (void)thread_pool->update_max_threads(config::drop_tablet_worker_count);
+        });
+        _config_callback.emplace("make_snapshot_worker_count", [&]() {
+            auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::MAKE_SNAPSHOT);
+            (void)thread_pool->update_max_threads(config::make_snapshot_worker_count);
+        });
+        _config_callback.emplace("release_snapshot_worker_count", [&]() {
+            auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::RELEASE_SNAPSHOT);
+            (void)thread_pool->update_max_threads(config::release_snapshot_worker_count);
+        });
     });
 
     Status s = config::set_config(name, value);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -654,7 +654,7 @@ int32_t ExecEnv::calc_pipeline_dop(int32_t pipeline_dop) const {
     return std::max<int32_t>(1, _max_executor_threads / 2);
 }
 
-ThreadPool* ExecEnv::vacuum_thread_pool() {
+ThreadPool* ExecEnv::delete_file_thread_pool() {
     return _agent_server ? _agent_server->get_thread_pool(TTaskType::DROP) : nullptr;
 }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -309,7 +309,7 @@ public:
 
     spill::DirManager* spill_dir_mgr() const { return _spill_dir_mgr.get(); }
 
-    ThreadPool* vacuum_thread_pool();
+    ThreadPool* delete_file_thread_pool();
 
 private:
     void _wait_for_fragments_finish();

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -393,11 +393,7 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
         return;
     }
 
-    auto thread_pool = vacuum_thread_pool(_env);
-    if (UNLIKELY(thread_pool == nullptr)) {
-        cntl->SetFailed("no vacuum thread pool");
-        return;
-    }
+    auto thread_pool = publish_version_thread_pool(_env);
     auto latch = BThreadCountDownLatch(request->tablet_ids_size());
     bthread::Mutex response_mtx;
     for (auto tablet_id : request->tablet_ids()) {

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -42,27 +42,33 @@
 namespace starrocks {
 
 ThreadPool* publish_version_thread_pool(ExecEnv* env) {
-    return env->agent_server()->get_thread_pool(TTaskType::PUBLISH_VERSION);
+    auto agent = env ? env->agent_server() : nullptr;
+    return agent->get_thread_pool(TTaskType::PUBLISH_VERSION);
 }
 
 ThreadPool* abort_txn_thread_pool(ExecEnv* env) {
-    return env->agent_server()->get_thread_pool(TTaskType::MAKE_SNAPSHOT);
+    auto agent = env ? env->agent_server() : nullptr;
+    return agent->get_thread_pool(TTaskType::MAKE_SNAPSHOT);
 }
 
 ThreadPool* delete_tablet_thread_pool(ExecEnv* env) {
-    return env->agent_server()->get_thread_pool(TTaskType::CLONE);
+    auto agent = env ? env->agent_server() : nullptr;
+    return agent->get_thread_pool(TTaskType::CLONE);
 }
 
 ThreadPool* drop_table_thread_pool(ExecEnv* env) {
-    return env->agent_server()->get_thread_pool(TTaskType::CLONE);
+    auto agent = env ? env->agent_server() : nullptr;
+    return agent->get_thread_pool(TTaskType::CLONE);
 }
 
 ThreadPool* vacuum_thread_pool(ExecEnv* env) {
-    return env->agent_server()->get_thread_pool(TTaskType::RELEASE_SNAPSHOT);
+    auto agent = env ? env->agent_server() : nullptr;
+    return agent->get_thread_pool(TTaskType::RELEASE_SNAPSHOT);
 }
 
 ThreadPool* get_tablet_stats_thread_pool(ExecEnv* env) {
-    return env->agent_server()->get_thread_pool(TTaskType::UPDATE_TABLET_META_INFO);
+    auto agent = env ? env->agent_server() : nullptr;
+    return agent->get_thread_pool(TTaskType::UPDATE_TABLET_META_INFO);
 }
 
 static int get_num_publish_queued_tasks(void*) {

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -77,7 +77,7 @@ static int get_num_publish_queued_tasks(void*) {
 static int get_num_publish_active_tasks(void*) {
 #ifndef BE_TEST
     auto tp = publish_version_thread_pool(ExecEnv::GetInstance());
-    return tp ? tp->num_queued_tasks() : 0;
+    return tp ? tp->active_threads() : 0;
 #else
     return 0;
 #endif
@@ -85,7 +85,7 @@ static int get_num_publish_active_tasks(void*) {
 
 static int get_num_vacuum_queued_tasks(void*) {
 #ifndef BE_TEST
-    auto tp = publish_version_thread_pool(ExecEnv::GetInstance());
+    auto tp = vacuum_thread_pool(ExecEnv::GetInstance());
     return tp ? tp->num_queued_tasks() : 0;
 #else
     return 0;
@@ -94,8 +94,8 @@ static int get_num_vacuum_queued_tasks(void*) {
 
 static int get_num_vacuum_active_tasks(void*) {
 #ifndef BE_TEST
-    auto tp = publish_version_thread_pool(ExecEnv::GetInstance());
-    return tp ? tp->num_queued_tasks() : 0;
+    auto tp = vacuum_thread_pool(ExecEnv::GetInstance());
+    return tp ? tp->active_threads() : 0;
 #else
     return 0;
 #endif

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -113,9 +113,7 @@ static bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks"
 
 using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
 
-LakeServiceImpl::LakeServiceImpl(ExecEnv* env) : _env(env) {
-
-}
+LakeServiceImpl::LakeServiceImpl(ExecEnv* env) : _env(env) {}
 
 LakeServiceImpl::~LakeServiceImpl() = default;
 

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -720,7 +720,7 @@ void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller,
         }
     }
 
-    DeferOp defer([]() {
+    DeferOp defer([&]() {
         if (request->partition_id() > 0) {
             std::lock_guard l(s_mtx);
             s_vacuuming_partitions.erase(request->partition_id());

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+
 #include "gen_cpp/lake_service.pb.h"
 
 namespace starrocks {

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <memory>
 #include "gen_cpp/lake_service.pb.h"
 
 namespace starrocks {

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -14,8 +14,6 @@
 
 #pragma once
 
-#include <memory>
-
 #include "gen_cpp/lake_service.pb.h"
 
 namespace starrocks {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -66,7 +66,7 @@ void HorizontalGeneralTabletWriter::close() {
         for (const auto& f : _files) {
             full_paths_to_delete.emplace_back(_tablet.segment_location(f));
         }
-        delete_files_async(full_paths_to_delete);
+        delete_files_async(std::move(full_paths_to_delete));
     }
     _files.clear();
 }
@@ -213,7 +213,7 @@ void VerticalGeneralTabletWriter::close() {
         for (const auto& f : _files) {
             full_paths_to_delete.emplace_back(_tablet.segment_location(f));
         }
-        delete_files_async(full_paths_to_delete);
+        delete_files_async(std::move(full_paths_to_delete));
     }
     _files.clear();
 }

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -210,7 +210,7 @@ void VerticalGeneralTabletWriter::close() {
     if (!_finished && !_files.empty()) {
         std::vector<std::string> full_paths_to_delete;
         full_paths_to_delete.reserve(_files.size());
-        for (auto& f : _files) {
+        for (const auto& f : _files) {
             full_paths_to_delete.emplace_back(_tablet.segment_location(f));
         }
         delete_files_async(full_paths_to_delete);

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -21,6 +21,7 @@
 #include "fs/fs_util.h"
 #include "serde/column_array_serde.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/vacuum.h"
 #include "storage/rowset/segment_writer.h"
 
 namespace starrocks::lake {
@@ -60,17 +61,12 @@ Status HorizontalGeneralTabletWriter::finish() {
 
 void HorizontalGeneralTabletWriter::close() {
     if (!_finished && !_files.empty()) {
-        // Delete files
-        auto maybe_fs = FileSystem::CreateSharedFromString(_tablet.root_location());
-        if (maybe_fs.ok()) {
-            auto fs = std::move(maybe_fs).value();
-            // TODO: batch delete
-            for (const auto& name : _files) {
-                auto path = _tablet.segment_location(name);
-                auto st = fs->delete_file(path);
-                LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << path;
-            }
+        std::vector<std::string> full_paths_to_delete;
+        full_paths_to_delete.reserve(_files.size());
+        for (const auto& f : _files) {
+            full_paths_to_delete.emplace_back(_tablet.segment_location(f));
         }
+        delete_files_async(full_paths_to_delete);
     }
     _files.clear();
 }
@@ -212,15 +208,12 @@ Status VerticalGeneralTabletWriter::finish() {
 
 void VerticalGeneralTabletWriter::close() {
     if (!_finished && !_files.empty()) {
-        // Delete files
-        auto maybe_fs = FileSystem::CreateSharedFromString(_tablet.root_location());
-        if (maybe_fs.ok()) {
-            auto fs = std::move(maybe_fs).value();
-            for (const auto& name : _files) {
-                auto path = _tablet.segment_location(name);
-                (void)fs->delete_file(path);
-            }
+        std::vector<std::string> full_paths_to_delete;
+        full_paths_to_delete.reserve(_files.size());
+        for (auto& f : _files) {
+            full_paths_to_delete.emplace_back(_tablet.segment_location(f));
         }
+        delete_files_async(full_paths_to_delete);
     }
     _files.clear();
 }

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -68,10 +68,11 @@ void MetaFileBuilder::apply_opwrite(const TxnLogPB_OpWrite& op_write,
     _tablet_meta->set_next_rowset_id(_tablet_meta->next_rowset_id() + std::max(1, rowset->segments_size()));
     // collect trash files
     for (const auto& orphan_file : orphan_files) {
-        _trash_files->push_back(orphan_file);
+        DCHECK(is_segment(orphan_file));
+        _trash_files->push_back(_tablet.segment_location(orphan_file));
     }
     for (const auto& del_file : op_write.dels()) {
-        _trash_files->push_back(del_file);
+        _trash_files->push_back(_tablet.del_location(del_file));
     }
 }
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -41,6 +41,7 @@
 #include "storage/lake/txn_log.h"
 #include "storage/lake/txn_log_applier.h"
 #include "storage/lake/update_manager.h"
+#include "storage/lake/vacuum.h"
 #include "storage/lake/vertical_compaction_task.h"
 #include "storage/metadata_util.h"
 #include "storage/protobuf_file.h"
@@ -731,18 +732,21 @@ StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, i
         }
     }
 
+    std::vector<std::string> files_to_delete;
+
     // Apply txn logs
     int64_t alter_version = -1;
     for (int i = 0; i < txns_size; i++) {
         auto txn_id = txns[i];
-        auto txn_log_st = tablet->get_txn_log(txn_id);
+        auto log_path = tablet_mgr->txn_log_location(tablet->id(), txn_id);
+        auto txn_log_st = tablet_mgr->get_txn_log(log_path, false);
 
         if (txn_log_st.status().is_not_found()) {
             return new_version_metadata_or_error(txn_log_st.status());
         }
 
         if (!txn_log_st.ok()) {
-            LOG(WARNING) << "Fail to get " << tablet->txn_log_location(txn_id) << ": " << txn_log_st.status();
+            LOG(WARNING) << "Fail to get " << log_path << ": " << txn_log_st.status();
             return txn_log_st.status();
         }
 
@@ -753,9 +757,13 @@ StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, i
 
         auto st = log_applier->apply(*txn_log);
         if (!st.ok()) {
-            LOG(WARNING) << "Fail to apply " << tablet->txn_log_location(txn_id) << ": " << st;
+            LOG(WARNING) << "Fail to apply " << log_path << ": " << st;
             return st;
         }
+
+        files_to_delete.emplace_back(log_path);
+
+        tablet_mgr->metacache()->erase(CacheKey(log_path));
     }
 
     // Apply vtxn logs for schema change
@@ -764,21 +772,24 @@ StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, i
     if (alter_version != -1 && alter_version + 1 < new_version) {
         DCHECK(base_version == 1 && txns_size == 1);
         for (int64_t v = alter_version + 1; v < new_version; ++v) {
-            auto txn_vlog = tablet->get_txn_vlog(v);
+            auto vlog_path = tablet_mgr->txn_vlog_location(tablet->id(), v);
+            auto txn_vlog = tablet_mgr->get_txn_vlog(vlog_path, false);
             if (txn_vlog.status().is_not_found()) {
                 return new_version_metadata_or_error(txn_vlog.status());
             }
 
             if (!txn_vlog.ok()) {
-                LOG(WARNING) << "Fail to get " << tablet->txn_vlog_location(v) << ": " << txn_vlog.status();
+                LOG(WARNING) << "Fail to get " << vlog_path << ": " << txn_vlog.status();
                 return txn_vlog.status();
             }
 
             auto st = log_applier->apply(**txn_vlog);
             if (!st.ok()) {
-                LOG(WARNING) << "Fail to apply " << tablet->txn_vlog_location(v) << ": " << st;
+                LOG(WARNING) << "Fail to apply " << vlog_path << ": " << st;
                 return st;
             }
+
+            tablet_mgr->metacache()->erase(CacheKey(vlog_path));
         }
     }
 
@@ -787,48 +798,12 @@ StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, i
 
     // collect trash files, and remove them by background threads
     auto trash_files = log_applier->trash_files();
-
-    CHECK_EQ(1, txns_size);
-    auto tablet_id = tablet->id();
-    auto txn_id = txns[0];
-    auto clear_task = [=]() {
-        // Delete txn logs
-        auto st = tablet_mgr->delete_txn_log(tablet_id, txn_id);
-        TEST_SYNC_POINT_CALLBACK("publish_version:delete_txn_log", &st);
-        LOG_IF(WARNING, !st.ok()) << "Fail to delete " << tablet_mgr->txn_log_location(tablet_id, txn_id) << ": " << st;
-        // Delete vtxn logs
-        if (alter_version != -1 && alter_version + 1 < new_version) {
-            for (int64_t v = alter_version + 1; v < new_version; ++v) {
-                auto r = tablet_mgr->delete_txn_vlog(tablet_id, v);
-                LOG_IF(WARNING, !r.ok()) << "Fail to delete " << tablet_mgr->txn_vlog_location(tablet_id, v) << ": "
-                                         << r;
-            }
-        }
-        // Delete trash_file files
-        if (nullptr != trash_files) {
-            for (const auto& trash_file : *trash_files) {
-                if (is_del(trash_file)) {
-                    auto r = tablet_mgr->delete_del(tablet_id, trash_file);
-                    LOG_IF(WARNING, !r.ok())
-                            << "Fail to delete " << tablet_mgr->del_location(tablet_id, trash_file) << ": " << r;
-                } else if (is_segment(trash_file)) {
-                    auto r = tablet_mgr->delete_segment(tablet_id, trash_file);
-                    LOG_IF(WARNING, !r.ok())
-                            << "Fail to delete " << tablet_mgr->segment_location(tablet_id, trash_file) << ": " << r;
-                } else {
-                    LOG(ERROR) << "Unknown file: " << trash_file << " tablet_id: " << tablet_id;
-                }
-            }
-        }
-    };
-
-    auto tp = ExecEnv::GetInstance()->vacuum_thread_pool();
-    if (LIKELY(tp != nullptr)) {
-        auto st = tp->submit_func(std::move(clear_task));
-        LOG_IF(INFO, !st.ok()) << "Fail to submit clear task of txn " << txn_id << ", ignore this error";
-    } else {
-        clear_task();
+    if (trash_files != nullptr) {
+        files_to_delete.insert(files_to_delete.end(), trash_files->begin(), trash_files->end());
     }
+
+    delete_files_async(std::move(files_to_delete));
+
     return new_metadata;
 }
 
@@ -848,45 +823,45 @@ StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t ve
 }
 
 void TabletManager::abort_txn(int64_t tablet_id, const int64_t* txns, int txns_size) {
-    // TODO: batch deletion
+    std::vector<std::string> files_to_delete;
     for (int i = 0; i < txns_size; i++) {
         auto txn_id = txns[i];
-        auto txn_log_or = get_txn_log(tablet_id, txn_id);
+        auto log_path = txn_log_location(tablet_id, txn_id);
+        auto txn_log_or = get_txn_log(log_path, false);
         if (!txn_log_or.ok()) {
             LOG_IF(WARNING, !txn_log_or.status().is_not_found())
-                    << "Fail to get txn log " << txn_log_location(tablet_id, txn_id) << ": " << txn_log_or.status();
+                    << "Fail to get txn log " << log_path << ": " << txn_log_or.status();
             continue;
         }
 
         TxnLogPtr txn_log = std::move(txn_log_or).value();
         if (txn_log->has_op_write()) {
             for (const auto& segment : txn_log->op_write().rowset().segments()) {
-                auto st = delete_segment(tablet_id, segment);
-                LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << segment << ": " << st;
+                files_to_delete.emplace_back(segment_location(tablet_id, segment));
             }
             for (const auto& del_file : txn_log->op_write().dels()) {
-                auto st = delete_del(tablet_id, del_file);
-                LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << del_file << ": " << st;
+                files_to_delete.emplace_back(del_location(tablet_id, del_file));
             }
         }
         if (txn_log->has_op_compaction()) {
             for (const auto& segment : txn_log->op_compaction().output_rowset().segments()) {
-                auto st = delete_segment(tablet_id, segment);
-                LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << segment << ": " << st;
+                files_to_delete.emplace_back(segment_location(tablet_id, segment));
             }
         }
         if (txn_log->has_op_schema_change() && !txn_log->op_schema_change().linked_segment()) {
             for (const auto& rowset : txn_log->op_schema_change().rowsets()) {
                 for (const auto& segment : rowset.segments()) {
-                    auto st = delete_segment(tablet_id, segment);
-                    LOG_IF(WARNING, !st.ok() && !st.is_not_found()) << "Fail to delete " << segment << ": " << st;
+                    files_to_delete.emplace_back(segment_location(tablet_id, segment));
                 }
             }
         }
-        auto st = delete_txn_log(tablet_id, txn_id);
-        LOG_IF(WARNING, !st.ok() && !st.is_not_found())
-                << "Fail to delete " << txn_log_location(tablet_id, txn_id) << ": " << st;
+
+        files_to_delete.emplace_back(log_path);
+
+        metacache()->erase(CacheKey(log_path));
     }
+
+    delete_files_async(files_to_delete);
 }
 
 Status TabletManager::publish_log_version(int64_t tablet_id, int64_t txn_id, int64 log_version) {
@@ -907,8 +882,8 @@ Status TabletManager::publish_log_version(int64_t tablet_id, int64_t txn_id, int
     } else if (!st.ok()) {
         return st;
     } else {
-        st = fs::delete_file(txn_log_path);
-        st.permit_unchecked_error();
+        delete_files_async({txn_log_path});
+        metacache()->erase(CacheKey(txn_log_path));
         return Status::OK();
     }
 }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -792,6 +792,8 @@ StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, i
                 return st;
             }
 
+            files_to_delete.emplace_back(vlog_path);
+
             tablet_mgr->metacache()->erase(CacheKey(vlog_path));
         }
     }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -866,7 +866,7 @@ void TabletManager::abort_txn(int64_t tablet_id, const int64_t* txns, int txns_s
         metacache()->erase(CacheKey(log_path));
     }
 
-    delete_files_async(files_to_delete);
+    delete_files_async(std::move(files_to_delete));
 }
 
 Status TabletManager::publish_log_version(int64_t tablet_id, int64_t txn_id, int64 log_version) {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -395,6 +395,7 @@ Status TabletManager::delete_tablet(int64_t tablet_id) {
 }
 
 Status TabletManager::put_tablet_metadata(TabletMetadataPtr metadata) {
+    TEST_ERROR_POINT("TabletManager::put_tablet_metadata");
     // write metadata file
     auto t0 = butil::gettimeofday_us();
     auto filepath = tablet_metadata_location(metadata->id(), metadata->version());
@@ -418,6 +419,7 @@ Status TabletManager::put_tablet_metadata(const TabletMetadata& metadata) {
 }
 
 StatusOr<TabletMetadataPtr> TabletManager::load_tablet_metadata(const string& metadata_location, bool fill_cache) {
+    TEST_ERROR_POINT("TabletManager::load_tablet_metadata");
     auto t0 = butil::gettimeofday_us();
     auto metadata = std::make_shared<TabletMetadataPB>();
     ProtobufFile file(metadata_location);
@@ -476,6 +478,7 @@ StatusOr<TabletMetadataIter> TabletManager::list_tablet_metadata(int64_t tablet_
 }
 
 StatusOr<TxnLogPtr> TabletManager::load_txn_log(const std::string& txn_log_path, bool fill_cache) {
+    TEST_ERROR_POINT("TabletManager::load_txn_log");
     auto t0 = butil::gettimeofday_us();
     auto meta = std::make_shared<TxnLog>();
     ProtobufFile file(txn_log_path);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -94,9 +94,13 @@ public:
 
     StatusOr<TxnLogPtr> get_txn_log(int64_t tablet_id, int64_t txn_id);
 
+    StatusOr<TxnLogPtr> get_txn_log(const std::string& path, bool fill_cache = true);
+
     StatusOr<TxnLogPtr> get_txn_vlog(int64_t tablet_id, int64_t version);
 
-    StatusOr<TxnLogPtr> get_txn_log(const std::string& path, bool fill_cache = true);
+    StatusOr<TxnLogPtr> get_txn_vlog(const std::string& path, bool fill_cache = true) {
+        return get_txn_log(path, fill_cache);
+    }
 
     StatusOr<TxnLogIter> list_txn_log(int64_t tablet_id, bool filter_tablet);
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -301,14 +301,14 @@ static Status vacuum_tablet_metadata(TabletManager* tablet_mgr, std::string_view
     DCHECK(vacuumed_file_size != nullptr);
 
     AsyncFileDeleter async_deleter;
-    int64_t max_batch_delete_size = config::lake_vacuum_min_batch_delete_size;
+    int64_t min_batch_delete_size = config::lake_vacuum_min_batch_delete_size;
     std::vector<std::string> datafiles_to_vacuum;
     std::vector<std::string> metafiles_to_vacuum;
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(root_dir));
     for (auto tablet_id : tablet_ids) {
         RETURN_IF_ERROR(collect_files_to_vacuum(tablet_mgr, root_dir, tablet_id, grace_timestamp, min_retain_version,
                                                 &datafiles_to_vacuum, &metafiles_to_vacuum, vacuumed_file_size));
-        if (datafiles_to_vacuum.size() < max_batch_delete_size && metafiles_to_vacuum.size() < max_batch_delete_size) {
+        if (datafiles_to_vacuum.size() < min_batch_delete_size && metafiles_to_vacuum.size() < min_batch_delete_size) {
             continue;
         }
         (*vacuumed_files) += (datafiles_to_vacuum.size() + metafiles_to_vacuum.size());

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -466,7 +466,8 @@ void delete_files_async(std::vector<std::string> files_to_delete) {
         }
     };
 
-    auto st = delete_file_thread_pool()->submit_func(std::move(task));
+    auto tp = ExecEnv::GetInstance()->delete_file_thread_pool();
+    auto st = tp->submit_func(std::move(task));
     LOG_IF(ERROR, !st.ok()) << st;
 }
 

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -14,7 +14,15 @@
 
 #pragma once
 
+#include <future>
+#include <string>
+#include <vector>
+
 #include "gen_cpp/lake_service.pb.h"
+
+namespace starrocks {
+class Status;
+}
 
 namespace starrocks::lake {
 
@@ -29,5 +37,7 @@ void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, Va
 //  - request.tablet_ids_size() > 0
 //  - response != NULL
 void delete_tablets(TabletManager* tablet_mgr, const DeleteTabletRequest& request, DeleteTabletResponse* response);
+
+void delete_files_async(std::vector<std::string> files_to_delete);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -38,8 +38,15 @@ void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, Va
 //  - response != NULL
 void delete_tablets(TabletManager* tablet_mgr, const DeleteTabletRequest& request, DeleteTabletResponse* response);
 
+// Batch delete files.
+// REQUIRE: All files in |paths| have the same file system scheme.
+Status delete_files(const std::vector<std::string>& paths);
+
+// An Async wrapper for delete_files that queues the request into a thread executor.
 void delete_files_async(std::vector<std::string> files_to_delete);
 
+// A Callable wrapper for delete_files that returns a future to the operation so that
+// it can be executed in parallel to other requests
 std::future<Status> delete_files_callable(std::vector<std::string> files_to_delete);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -40,4 +40,6 @@ void delete_tablets(TabletManager* tablet_mgr, const DeleteTabletRequest& reques
 
 void delete_files_async(std::vector<std::string> files_to_delete);
 
+std::future<Status> delete_files_callable(std::vector<std::string> files_to_delete);
+
 } // namespace starrocks::lake

--- a/be/src/testutil/sync_point.h
+++ b/be/src/testutil/sync_point.h
@@ -71,6 +71,9 @@ public:
 #define TEST_IDX_SYNC_POINT(x, index)
 #define TEST_SYNC_POINT_CALLBACK(x, y)
 #define INIT_SYNC_POINT_SINGLETONS()
+#define TEST_ERROR_POINT(x)
+#define TEST_ENABLE_ERROR_POINT(x, y)
+#define TEST_DISABLE_ERROR_POINT(x)
 #else
 
 namespace starrocks {
@@ -166,6 +169,15 @@ private:
 #define TEST_IDX_SYNC_POINT(x, index) starrocks::SyncPoint::GetInstance()->Process(x + std::to_string(index))
 #define TEST_SYNC_POINT_CALLBACK(x, y) starrocks::SyncPoint::GetInstance()->Process(x, y)
 #define INIT_SYNC_POINT_SINGLETONS() (void)starrocks::SyncPoint::GetInstance();
+#define TEST_ERROR_POINT(x)                                   \
+    do {                                                      \
+        Status st;                                            \
+        starrocks::SyncPoint::GetInstance()->Process(x, &st); \
+        if (!st.ok()) return st;                              \
+    } while (0)
+#define TEST_ENABLE_ERROR_POINT(x, y) \
+    starrocks::SyncPoint::GetInstance()->SetCallBack(x, [](void* arg) { *(Status*)arg = y; })
+#define TEST_DISABLE_ERROR_POINT(x) starrocks::SyncPoint::GetInstance()->ClearCallBack(x)
 #endif // NDEBUG
 
 // Callback sync point for any read IO errors that should be ignored by

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -42,6 +42,7 @@
 #include "gutil/map_util.h"
 #include "gutil/strings/substitute.h"
 #include "gutil/sysinfo.h"
+#include "testutil/sync_point.h"
 #include "util/cpu_info.h"
 #include "util/scoped_cleanup.h"
 #include "util/thread.h"
@@ -379,7 +380,7 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
         // dynamic decrease _max_threads
         capacity_remaining = static_cast<int64_t>(_max_queue_size) - _total_queued_tasks;
     }
-
+    TEST_SYNC_POINT_CALLBACK("ThreadPool::do_submit:1", &capacity_remaining);
     if (capacity_remaining < 1) {
         return Status::ServiceUnavailable(strings::Substitute(
                 "Thread pool is at capacity ($0/$1 tasks running, $2/$3 tasks queued)",

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -30,6 +30,7 @@
 #include "testutil/id_generator.h"
 #include "testutil/sync_point.h"
 #include "util/countdown_latch.h"
+#include "util/defer_op.h"
 
 namespace starrocks {
 
@@ -156,6 +157,28 @@ TEST_F(LakeServiceTest, test_publish_version_missing_new_version) {
 }
 
 // NOLINTNEXTLINE
+TEST_F(LakeServiceTest, test_publish_version_thread_pool_full) {
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    brpc::Controller cntl;
+    lake::PublishVersionRequest request;
+    lake::PublishVersionResponse response;
+    request.set_base_version(1);
+    request.set_new_version(2);
+    request.add_tablet_ids(_tablet_id);
+    request.add_txn_ids(1000);
+    _lake_service.publish_version(&cntl, &request, &response, nullptr);
+    ASSERT_FALSE(cntl.Failed()) << cntl.ErrorText();
+    ASSERT_EQ(1, response.failed_tablets_size());
+    ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+}
+
+// NOLINTNEXTLINE
 TEST_F(LakeServiceTest, test_publish_version_for_write) {
     // Empty TxnLog
     {
@@ -180,27 +203,85 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
     }
 
-    // Publish txn 1000
+    // Publish version request for txn 1000
+    lake::PublishVersionRequest publish_request_1000;
+    publish_request_1000.set_base_version(1);
+    publish_request_1000.set_new_version(2);
+    publish_request_1000.add_tablet_ids(_tablet_id);
+    publish_request_1000.add_txn_ids(1000);
+
+    // Publish txn 1000 failed: get base tablet metadata failed
     {
-        lake::PublishVersionRequest request;
+        _tablet_mgr->prune_metacache();
+
+        TEST_ENABLE_ERROR_POINT("TabletManager::load_tablet_metadata",
+                                Status::IOError("injected get tablet metadata error"));
+
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::load_tablet_metadata");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
         lake::PublishVersionResponse response;
-        request.set_base_version(1);
-        request.set_new_version(2);
-        request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1000);
-        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+    // Publish txn 1000 failed: get txn log failed
+    {
+        TEST_ENABLE_ERROR_POINT("TabletManager::load_txn_log", Status::IOError("injected get txn log error"));
+
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::load_txn_log");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        lake::PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+    // Publish txn 1000 success
+    {
+        lake::PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
     }
+
+    // publish version request for txn 1001
+    lake::PublishVersionRequest publish_request_1001;
+    publish_request_1001.set_base_version(2);
+    publish_request_1001.set_new_version(3);
+    publish_request_1001.add_tablet_ids(_tablet_id);
+    publish_request_1001.add_txn_ids(1001);
+    publish_request_1001.set_commit_time(987654321);
+
+    // Publish txn 1001 put tablet metadata failed
+    {
+        TEST_ENABLE_ERROR_POINT("TabletManager::put_tablet_metadata",
+                                Status::IOError("injected put tablet metadata error"));
+
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::put_tablet_metadata");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        lake::PublishVersionResponse response;
+        _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+
     // Publish txn 1001
     {
-        lake::PublishVersionRequest request;
         lake::PublishVersionResponse response;
-        request.set_base_version(2);
-        request.set_new_version(3);
-        request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1001);
-        request.set_commit_time(987654321);
-        _lake_service.publish_version(nullptr, &request, &response, nullptr);
+        _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
     }
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
@@ -353,7 +434,23 @@ TEST_F(LakeServiceTest, test_abort) {
         txnlog.mutable_op_compaction()->mutable_output_rowset()->add_segments("4.dat");
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
     }
-    // Send AbortTxn request
+    {
+        TEST_ENABLE_ERROR_POINT("TabletManager::load_txn_log", Status::IOError("injected get txn log error"));
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::load_txn_log");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        lake::AbortTxnRequest request;
+        lake::AbortTxnResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(1000);
+        request.add_txn_ids(1001);
+        request.add_txn_ids(1002);
+        _lake_service.abort_txn(nullptr, &request, &response, nullptr);
+    }
     {
         lake::AbortTxnRequest request;
         lake::AbortTxnResponse response;
@@ -379,6 +476,24 @@ TEST_F(LakeServiceTest, test_abort) {
 
     // Send AbortTxn request again
     {
+        lake::AbortTxnRequest request;
+        lake::AbortTxnResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(1000);
+        request.add_txn_ids(1001);
+        request.add_txn_ids(1002);
+        _lake_service.abort_txn(nullptr, &request, &response, nullptr);
+    }
+    // Thread pool is full
+    {
+        SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+        SyncPoint::GetInstance()->EnableProcessing();
+
+        DeferOp defer([]() {
+            SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
         lake::AbortTxnRequest request;
         lake::AbortTxnResponse response;
         request.add_tablet_ids(_tablet_id);
@@ -734,6 +849,8 @@ TEST_F(LakeServiceTest, test_abort_compaction) {
             {{"CompactionScheduler::compact:return", "LakeServiceImpl::abort_compaction:enter"},
              {"LakeServiceImpl::abort_compaction:aborted", "CompactionScheduler::do_compaction:before_execute_task"}});
 
+    DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
+
     auto txn_id = next_id();
 
     auto compaction_thread = std::thread([&]() {
@@ -771,9 +888,6 @@ TEST_F(LakeServiceTest, test_abort_compaction) {
         _lake_service.abort_compaction(&cntl, &request, &response, nullptr);
         ASSERT_EQ(TStatusCode::NOT_FOUND, response.status().status_code());
     }
-
-    SyncPoint::GetInstance()->ClearCallBack("publish_version:delete_txn_log");
-    SyncPoint::GetInstance()->DisableProcessing();
 }
 
 // https://github.com/StarRocks/starrocks/issues/28244
@@ -796,6 +910,11 @@ TEST_F(LakeServiceTest, test_publish_version_issue28244) {
             {{"LakeServiceImpl::publish_version:return", "publish_version:delete_txn_log"}});
     SyncPoint::GetInstance()->EnableProcessing();
 
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("publish_version:delete_txn_log");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
     {
         lake::PublishVersionRequest request;
         lake::PublishVersionResponse response;
@@ -809,9 +928,6 @@ TEST_F(LakeServiceTest, test_publish_version_issue28244) {
 
     ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
     ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 102301).status().is_not_found());
-
-    SyncPoint::GetInstance()->ClearCallBack("publish_version:delete_txn_log");
-    SyncPoint::GetInstance()->DisableProcessing();
 }
 
 TEST_F(LakeServiceTest, test_get_tablet_stats) {
@@ -834,6 +950,10 @@ TEST_F(LakeServiceTest, test_drop_table_no_thread_pool) {
     SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",
                                           [](void* arg) { *(ThreadPool**)arg = nullptr; });
     SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
 
     lake::DropTableRequest request;
     lake::DropTableResponse response;
@@ -842,9 +962,6 @@ TEST_F(LakeServiceTest, test_drop_table_no_thread_pool) {
     _lake_service.drop_table(&cntl, &request, &response, nullptr);
     ASSERT_TRUE(cntl.Failed());
     ASSERT_EQ("no thread pool to run task", cntl.ErrorText());
-
-    SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
-    SyncPoint::GetInstance()->DisableProcessing();
 }
 
 // NOLINTNEXTLINE
@@ -852,6 +969,11 @@ TEST_F(LakeServiceTest, test_delete_tablet_no_thread_pool) {
     SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",
                                           [](void* arg) { *(ThreadPool**)arg = nullptr; });
     SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
     brpc::Controller cntl;
     lake::DeleteTabletRequest request;
     lake::DeleteTabletResponse response;
@@ -859,15 +981,87 @@ TEST_F(LakeServiceTest, test_delete_tablet_no_thread_pool) {
     _lake_service.delete_tablet(&cntl, &request, &response, nullptr);
     ASSERT_TRUE(cntl.Failed());
     ASSERT_EQ("no thread pool to run task", cntl.ErrorText());
+}
 
-    SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
-    SyncPoint::GetInstance()->DisableProcessing();
+// NOLINTNEXTLINE
+TEST_F(LakeServiceTest, test_vacuum_null_thread_pool) {
+    SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",
+                                          [](void* arg) { *(ThreadPool**)arg = nullptr; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    brpc::Controller cntl;
+    lake::VacuumRequest request;
+    lake::VacuumResponse response;
+    request.add_tablet_ids(_tablet_id);
+    request.set_partition_id(next_id());
+    _lake_service.vacuum(&cntl, &request, &response, nullptr);
+    ASSERT_EQ("vacuum thread pool is null", cntl.ErrorText());
+}
+
+// NOLINTNEXTLINE
+TEST_F(LakeServiceTest, test_vacuum_thread_pool_full) {
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    brpc::Controller cntl;
+    lake::VacuumRequest request;
+    lake::VacuumResponse response;
+    request.add_tablet_ids(_tablet_id);
+    request.set_partition_id(next_id());
+    _lake_service.vacuum(&cntl, &request, &response, nullptr);
+    EXPECT_FALSE(cntl.Failed());
+    EXPECT_EQ(TStatusCode::SERVICE_UNAVAILABLE, response.status().status_code()) << response.status().status_code();
+}
+
+// NOLINTNEXTLINE
+TEST_F(LakeServiceTest, test_vacuum_full_null_thread_pool) {
+    SyncPoint::GetInstance()->SetCallBack("AgentServer::Impl::get_thread_pool:1",
+                                          [](void* arg) { *(ThreadPool**)arg = nullptr; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("AgentServer::Impl::get_thread_pool:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    brpc::Controller cntl;
+    lake::VacuumFullRequest request;
+    lake::VacuumFullResponse response;
+    request.add_tablet_ids(_tablet_id);
+    _lake_service.vacuum_full(&cntl, &request, &response, nullptr);
+    ASSERT_EQ("full vacuum thread pool is null", cntl.ErrorText());
+}
+
+// NOLINTNEXTLINE
+TEST_F(LakeServiceTest, test_vacuum_full_thread_pool_full) {
+    SyncPoint::GetInstance()->SetCallBack("ThreadPool::do_submit:1", [](void* arg) { *(int64_t*)arg = 0; });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("ThreadPool::do_submit:1");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    brpc::Controller cntl;
+    lake::VacuumFullRequest request;
+    lake::VacuumFullResponse response;
+    request.add_tablet_ids(_tablet_id);
+    _lake_service.vacuum_full(&cntl, &request, &response, nullptr);
+    EXPECT_FALSE(cntl.Failed()) << cntl.ErrorText();
+    EXPECT_EQ(TStatusCode::SERVICE_UNAVAILABLE, response.status().status_code()) << response.status().status_code();
 }
 
 // NOLINTNEXTLINE
 TEST_F(LakeServiceTest, test_duplicated_vacuum_request) {
     SyncPoint::GetInstance()->LoadDependency({{"LakeServiceImpl::vacuum:1", "LakeServiceImpl::vacuum:2"}});
     SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([]() { SyncPoint::GetInstance()->DisableProcessing(); });
 
     auto duplicate = false;
     auto partition_id = next_id();
@@ -897,8 +1091,6 @@ TEST_F(LakeServiceTest, test_duplicated_vacuum_request) {
     }
 
     t.join();
-
-    SyncPoint::GetInstance()->DisableProcessing();
 
     ASSERT_TRUE(duplicate);
 }

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -107,7 +107,7 @@ public:
     void TearDown() override {
         // check primary index cache's ref
         EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
-        ExecEnv::GetInstance()->vacuum_thread_pool()->wait();
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
         // check trash files already removed
         for (const auto& file : _trash_files) {
             EXPECT_FALSE(fs::path_exist(file));
@@ -738,7 +738,7 @@ public:
     void TearDown() override {
         // check primary index cache's ref
         EXPECT_TRUE(_update_mgr->TEST_check_primary_index_cache_ref(_tablet_metadata->id(), 1));
-        ExecEnv::GetInstance()->vacuum_thread_pool()->wait();
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
         remove_test_dir_or_die();
     }
 

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -231,7 +231,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata1, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata1->rowsets_size(), 3);
 
-    ExecEnv::GetInstance()->vacuum_thread_pool()->wait();
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
     // make sure delvecs have been generated
     for (int i = 0; i < 2; i++) {
         auto itr = new_tablet_metadata1->delvec_meta().version_to_file().find(version - i);

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -304,6 +304,67 @@ TEST_P(LakeTabletWriterTest, test_close_without_finish) {
     ASSERT_TRUE(fs->path_exists(seg_path).is_not_found());
 }
 
+TEST_P(LakeTabletWriterTest, test_vertical_write_close_without_finish) {
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
+
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+    auto schema0 = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema, {0}));
+    auto schema1 = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema, {1}));
+
+    Chunk c0_chunk({c0}, schema0);
+    Chunk c1_chunk({c1}, schema1);
+    Chunk c2_chunk({c2}, schema0);
+    Chunk c3_chunk({c3}, schema1);
+
+    const int segment_rows = c0_chunk.num_rows() + c2_chunk.num_rows();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kVertical, next_id(), segment_rows + 1));
+
+    ASSERT_OK(writer->open());
+    ASSERT_OK(writer->write_columns(c0_chunk, {0}, true));
+    ASSERT_OK(writer->write_columns(c2_chunk, {0}, true));
+    ASSERT_OK(writer->write_columns(c0_chunk, {0}, true));
+    ASSERT_OK(writer->write_columns(c2_chunk, {0}, true));
+    ASSERT_OK(writer->flush_columns());
+    ASSERT_OK(writer->write_columns(c1_chunk, {1}, false));
+    ASSERT_OK(writer->write_columns(c3_chunk, {1}, false));
+    ASSERT_OK(writer->write_columns(c1_chunk, {1}, false));
+    ASSERT_OK(writer->write_columns(c3_chunk, {1}, false));
+    ASSERT_OK(writer->flush_columns());
+
+    auto files = writer->files();
+    ASSERT_EQ(2, files.size());
+    ASSERT_NE(files[0], files[1]);
+    for (const auto& f : files) {
+        ASSERT_TRUE(fs->path_exists(_tablet_mgr->segment_location(_tablet_metadata->id(), f)).ok());
+    }
+
+    // `close()` directly without calling `finish()`
+    writer->close();
+
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+    // segment file should be deleted
+    for (const auto& f : files) {
+        ASSERT_TRUE(fs->path_exists(_tablet_mgr->segment_location(_tablet_metadata->id(), f)).is_not_found());
+    }
+}
+
 INSTANTIATE_TEST_SUITE_P(LakeTabletWriterTest, LakeTabletWriterTest,
                          ::testing::Values(DUP_KEYS, AGG_KEYS, UNIQUE_KEYS, PRIMARY_KEYS));
 

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -298,6 +298,8 @@ TEST_P(LakeTabletWriterTest, test_close_without_finish) {
     // `close()` directly without calling `finish()`
     writer->close();
 
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
     // segment file should be deleted
     ASSERT_TRUE(fs->path_exists(seg_path).is_not_found());
 }

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -35,7 +35,7 @@ public:
     ~TestBase() override {
         // Wait for all vacuum tasks finished processing before destroying
         // _tablet_mgr.
-        ExecEnv::GetInstance()->vacuum_thread_pool()->wait();
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
         (void)fs::remove_all(_test_dir);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Partition.java
@@ -127,7 +127,7 @@ public class Partition extends MetaObject implements PhysicalPartition, Writable
     @SerializedName(value = "nextVersion")
     private long nextVersion;
 
-    private volatile long nextVacuumTime = 0;
+    private volatile long lastVacuumTime = 0;
 
     private volatile long minRetainVersion = 0;
 
@@ -617,12 +617,12 @@ public class Partition extends MetaObject implements PhysicalPartition, Writable
         return hasChanged;
     }
 
-    public long getNextVacuumTime() {
-        return nextVacuumTime;
+    public long getLastVacuumTime() {
+        return lastVacuumTime;
     }
 
-    public void setNextVacuumTime(long nextVacuumTime) {
-        this.nextVacuumTime = nextVacuumTime;
+    public void setLastVacuumTime(long lastVacuumTime) {
+        this.lastVacuumTime = lastVacuumTime;
     }
 
     public long getMinRetainVersion() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/vacuum/AutovacuumDaemon.java
@@ -53,7 +53,7 @@ public class AutovacuumDaemon extends FrontendDaemon {
     private static final long SECONDS_PER_MINUTE = 60;
     private static final long MINUTES_PER_HOUR = 60;
     private static final long MILLISECONDS_PER_HOUR = MINUTES_PER_HOUR * SECONDS_PER_MINUTE * MILLISECONDS_PER_SECOND;
- 
+
     private final Set<Long> vacuumingPartitions = Sets.newConcurrentHashSet();
     private final BlockingThreadPoolExecutorService executorService = BlockingThreadPoolExecutorService.newInstance(
             Config.lake_autovacuum_parallel_partitions, 0, 1, TimeUnit.HOURS, "autovacuum");
@@ -74,7 +74,8 @@ public class AutovacuumDaemon extends FrontendDaemon {
             List<Table> tables;
             db.readLock();
             try {
-                tables = db.getTables().stream().filter(Table::isCloudNativeTableOrMaterializedView).collect(Collectors.toList());
+                tables = db.getTables().stream().filter(Table::isCloudNativeTableOrMaterializedView)
+                        .collect(Collectors.toList());
             } finally {
                 db.readUnlock();
             }
@@ -155,8 +156,10 @@ public class AutovacuumDaemon extends FrontendDaemon {
             VacuumRequest vacuumRequest = new VacuumRequest();
             vacuumRequest.tabletIds = entry.getValue();
             vacuumRequest.minRetainVersion = minRetainVersion;
-            vacuumRequest.graceTimestamp = startTime / MILLISECONDS_PER_SECOND - Config.lake_autovacuum_grace_period_minutes * 60;
+            vacuumRequest.graceTimestamp =
+                    startTime / MILLISECONDS_PER_SECOND - Config.lake_autovacuum_grace_period_minutes * 60;
             vacuumRequest.minActiveTxnId = minActiveTxnId;
+            vacuumRequest.partitionId = partition.getId();
             vacuumRequest.deleteTxnLog = needDeleteTxnLog;
             // Perform deletion of txn log on the first node only.
             needDeleteTxnLog = false;
@@ -164,7 +167,8 @@ public class AutovacuumDaemon extends FrontendDaemon {
                 LakeService service = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
                 responseFutures.add(service.vacuum(vacuumRequest));
             } catch (RpcException e) {
-                LOG.error("failed to send vacuum request", e);
+                LOG.error("failed to send vacuum request for partition {}.{}.{}", db.getFullName(), table.getName(),
+                        partition.getName(), e);
                 hasError = true;
                 break;
             }
@@ -175,7 +179,8 @@ public class AutovacuumDaemon extends FrontendDaemon {
                 VacuumResponse response = responseFuture.get();
                 if (response.status.statusCode != 0) {
                     hasError = true;
-                    LOG.warn(response.status.errorMsgs.get(0));
+                    LOG.warn("Vacuumed {}.{}.{} with error: {}", db.getFullName(), table.getName(), partition.getName(),
+                            response.status.errorMsgs.get(0));
                 } else {
                     vacuumedFiles += response.vacuumedFiles;
                     vacuumedFileSize += response.vacuumedFileSize;
@@ -185,7 +190,8 @@ public class AutovacuumDaemon extends FrontendDaemon {
                 Thread.currentThread().interrupt();
                 hasError = true;
             } catch (ExecutionException e) {
-                LOG.warn(e.getMessage());
+                LOG.error("failed to vacuum {}.{}.{}: {}", db.getFullName(), table.getName(), partition.getName(),
+                        e.getMessage());
                 hasError = true;
             }
         }
@@ -199,7 +205,8 @@ public class AutovacuumDaemon extends FrontendDaemon {
 
     private static long computeMinActiveTxnId(Database db, Table table) {
         long a = GlobalStateMgr.getCurrentGlobalTransactionMgr().getMinActiveTxnIdOfDatabase(db.getId());
-        Optional<Long> b = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getActiveTxnIdOfTable(table.getId());
+        Optional<Long> b =
+                GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getActiveTxnIdOfTable(table.getId());
         return Math.min(a, b.orElse(Long.MAX_VALUE));
     }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -51,6 +51,7 @@ message AbortTxnResponse {
 }
 
 message DeleteTabletRequest {
+    // All tablets must be in the same partition.
     repeated int64 tablet_ids = 1;
 }
 
@@ -188,6 +189,7 @@ message AbortCompactionResponse {
 }
 
 message VacuumRequest {
+    // All tablets must be in the same partition.
     repeated int64 tablet_ids = 1;
     // Tablet metadata files with version numbers greater than or equals to min_retain_version
     // will NOT be vacuumed. For tablet metadata files with version numbers less than
@@ -203,6 +205,8 @@ message VacuumRequest {
     optional int64 min_active_txn_id = 4;
     // Whether need to delete committed txn logs or not.
     optional bool delete_txn_log = 5;
+    // ID of the partition the tablet belongs to.
+    optional int64 partition_id = 6;
 }
 
 message VacuumResponse {


### PR DESCRIPTION
This patch contains the following changes:
- Run abort txn and publish version tasks in different thread pools
- Make file deletion and vacuum tasks run in different threads to
avoid vacuum tasks blocking other deletion tasks.
- Vacuum task de-duplication
- Allows dynamic modification of the maximum number of threads for
some thread pools

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
