### PR TITLE
[Enhancement] active mv automatically

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -144,6 +144,7 @@ import java.util.stream.Collectors;
 
 public class AlterJobMgr {
     private static final Logger LOG = LogManager.getLogger(AlterJobMgr.class);
+    public static final String MANUAL_INACTIVE_MV_REASON = "user use alter materialized view set status to inactive";
 
     private final SchemaChangeHandler schemaChangeHandler;
     private final MaterializedViewHandler materializedViewHandler;
@@ -300,7 +301,7 @@ public class AlterJobMgr {
                     materializedView, baseTableInfos);
             materializedView.setActive();
         } else if (AlterMaterializedViewStatusClause.INACTIVE.equalsIgnoreCase(status)) {
-            materializedView.setInactiveAndReason("user use alter materialized view set status to inactive");
+            materializedView.setInactiveAndReason(MANUAL_INACTIVE_MV_REASON);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2519,6 +2519,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = false)
     public static int pipe_scheduler_interval_millis = 1000;
 
+    @ConfField(mutable = true)
+    public static long mv_active_checker_interval_seconds = 60;
+
     /**
      * To prevent the external catalog from displaying too many entries in the grantsTo system table,
      * you can use this variable to ignore the entries in the external catalog

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -74,7 +74,7 @@ public class MVActiveChecker extends FrontendDaemon {
         }
     }
 
-    private void tryToActivate(MaterializedView mv) {
+    public static void tryToActivate(MaterializedView mv) {
         // if the mv is set to inactive manually, we don't activate it
         String reason = mv.getInactiveReason();
         if (mv.isActive() || AlterJobMgr.MANUAL_INACTIVE_MV_REASON.equalsIgnoreCase(reason)) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -1,0 +1,111 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.starrocks.alter.AlterJobMgr;
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.statistic.StatisticUtils;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Collection;
+import java.util.Optional;
+
+/**
+ * A daemon thread that check the MV active status, try to activate the MV it's inactive.
+ */
+public class MVActiveChecker extends FrontendDaemon {
+
+    private static final Logger LOG = LogManager.getLogger(MVActiveChecker.class);
+
+    public MVActiveChecker() {
+        super("MVActiveChecker", Config.mv_active_checker_interval_seconds * 1000);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        // reset if the interval has been changed
+        setInterval(Config.mv_active_checker_interval_seconds * 1000L);
+
+        try {
+            process();
+        } catch (Throwable e) {
+            LOG.warn("Failed to process one round of MVActiveChecker", e);
+        }
+    }
+
+    @VisibleForTesting
+    public void runForTest() {
+        process();
+    }
+
+    private void process() {
+        Collection<Database> dbs = GlobalStateMgr.getCurrentState().getIdToDb().values();
+        for (Database db : CollectionUtils.emptyIfNull(dbs)) {
+            for (Table table : CollectionUtils.emptyIfNull(db.getTables())) {
+                if (table.isMaterializedView()) {
+                    MaterializedView mv = (MaterializedView) table;
+                    if (!mv.isActive()) {
+                        tryToActivate(mv);
+                    }
+                }
+            }
+        }
+    }
+
+    private void tryToActivate(MaterializedView mv) {
+        // if the mv is set to inactive manually, we don't activate it
+        String reason = mv.getInactiveReason();
+        if (mv.isActive() || AlterJobMgr.MANUAL_INACTIVE_MV_REASON.equalsIgnoreCase(reason)) {
+            return;
+        }
+
+        long dbId = mv.getDbId();
+        Optional<String> dbName = GlobalStateMgr.getCurrentState().mayGetDb(dbId).map(Database::getFullName);
+        if (!dbName.isPresent()) {
+            LOG.warn("[MVActiveChecker] cannot activate MV {} since database {} not found", mv.getName(), dbId);
+            return;
+        }
+
+        String mvFullName = new TableName(dbName.get(), mv.getName()).toString();
+        String sql = String.format("ALTER MATERIALIZED VIEW %s active", mvFullName);
+        try {
+            ConnectContext connect = StatisticUtils.buildConnectContext();
+            connect.setStatisticsContext(false);
+            connect.setDatabase(dbName.get());
+
+            connect.executeSql(sql);
+            if (mv.isActive()) {
+                LOG.info("[MVActiveChecker] activate MV {} successfully", mvFullName);
+            } else {
+                LOG.warn("[MVActiveChecker] activate MV {} failed", mvFullName);
+            }
+        } catch (Exception e) {
+            LOG.warn("[MVActiveChecker] activate MV {} failed", mvFullName, e);
+            throw new RuntimeException(e);
+        } finally {
+            ConnectContext.remove();
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -610,6 +610,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     mvId, context.ctx.getDatabase()));
         }
         materializedView = (MaterializedView) table;
+
+        // try to activate the mv before refresh
+        if (!materializedView.isActive()) {
+            MVActiveChecker.tryToActivate(materializedView);
+            LOG.info("Activated the MV before refreshing: {}", materializedView.getName());
+        }
         if (!materializedView.isActive()) {
             String errorMsg = String.format("Materialized view: %s, id: %d is not active, " +
                     "skip sync partition and data with base tables", materializedView.getName(), mvId);

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -234,6 +234,7 @@ import com.starrocks.qe.scheduler.slot.ResourceUsageMonitor;
 import com.starrocks.qe.scheduler.slot.SlotManager;
 import com.starrocks.qe.scheduler.slot.SlotProvider;
 import com.starrocks.rpc.FrontendServiceProxy;
+import com.starrocks.scheduler.MVActiveChecker;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.mv.MVJobExecutor;
 import com.starrocks.scheduler.mv.MaterializedViewMgr;
@@ -545,6 +546,7 @@ public class GlobalStateMgr {
     private PipeManager pipeManager;
     private PipeListener pipeListener;
     private PipeScheduler pipeScheduler;
+    private MVActiveChecker mvActiveChecker;
 
     private final ResourceUsageMonitor resourceUsageMonitor = new ResourceUsageMonitor();
     private final SlotManager slotManager = new SlotManager(resourceUsageMonitor);
@@ -766,6 +768,7 @@ public class GlobalStateMgr {
         this.pipeManager = new PipeManager();
         this.pipeListener = new PipeListener(this.pipeManager);
         this.pipeScheduler = new PipeScheduler(this.pipeManager);
+        this.mvActiveChecker = new MVActiveChecker();
 
         if (RunMode.getCurrentRunMode().isAllowCreateLakeTable()) {
             this.storageVolumeMgr = new SharedDataStorageVolumeMgr();
@@ -1021,6 +1024,10 @@ public class GlobalStateMgr {
 
     public PipeListener getPipeListener() {
         return pipeListener;
+    }
+
+    public MVActiveChecker getMvActiveChecker() {
+        return mvActiveChecker;
     }
 
     public ConnectorTblMetaInfoMgr getConnectorTblMetaInfoMgr() {
@@ -1389,6 +1396,7 @@ public class GlobalStateMgr {
         mvMVJobExecutor.start();
         pipeListener.start();
         pipeScheduler.start();
+        mvActiveChecker.start();
 
         // start daemon thread to report the progress of RunningTaskRun to the follower by editlog
         taskRunStateSynchronizer = new TaskRunStateSynchronizer();

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.analysis;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
@@ -258,6 +259,13 @@ public class AlterMaterializedViewTest {
         starRocksAssert.withTable(createTableSql);
         checker.runForTest();
         Assert.assertTrue(mv.isActive());
+
+        // manually set to inactive
+        mv.setInactiveAndReason(AlterJobMgr.MANUAL_INACTIVE_MV_REASON);
+        Assert.assertFalse(mv.isActive());
+        checker.runForTest();
+        Assert.assertFalse(mv.isActive());
+        Assert.assertEquals(AlterJobMgr.MANUAL_INACTIVE_MV_REASON, mv.getInactiveReason());
 
         checker.start();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.scheduler.MVActiveChecker;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -30,6 +31,7 @@ import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -59,6 +61,11 @@ public class AlterMaterializedViewTest {
                 "                )\n" +
                 "                as  select v1, count(v2) as count_c2, sum(v3) as sum_c3\n" +
                 "                from t0 group by v1;\n");
+    }
+
+    @Before
+    public void before() {
+        connectContext.setThreadLocalInfo();
     }
 
     @Test
@@ -222,5 +229,36 @@ public class AlterMaterializedViewTest {
         connectContext.executeSql(String.format("alter materialized view %s active", mvName));
         Assert.assertTrue(mv.isActive());
         Assert.assertNull(mv.getInactiveReason());
+    }
+
+    @Test
+    public void testActiveChecker() throws Exception {
+        MVActiveChecker checker = GlobalStateMgr.getCurrentState().getMvActiveChecker();
+        checker.setStop();
+
+        String baseTableName = "base_tbl_active";
+        String createTableSql =
+                "create table " + baseTableName + " ( k1 int, k2 int) properties('replication_num'='1')";
+        starRocksAssert.withTable(createTableSql);
+        starRocksAssert.withMaterializedView("create materialized view mv_active " +
+                " refresh async as select * from base_tbl_active");
+        MaterializedView mv = (MaterializedView) starRocksAssert.getTable(connectContext.getDatabase(), "mv_active");
+        Assert.assertTrue(mv.isActive());
+
+        // drop the base table and try to activate it
+        starRocksAssert.dropTable(baseTableName);
+        Assert.assertFalse(mv.isActive());
+        Assert.assertEquals("base-table dropped: base_tbl_active", mv.getInactiveReason());
+        checker.runForTest();
+        Assert.assertFalse(mv.isActive());
+        Assert.assertEquals("base-table dropped: base_tbl_active", mv.getInactiveReason());
+
+        // create the table again, and activate it
+        connectContext.setThreadLocalInfo();
+        starRocksAssert.withTable(createTableSql);
+        checker.runForTest();
+        Assert.assertTrue(mv.isActive());
+
+        checker.start();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -463,23 +463,6 @@ public class PartitionBasedMvRefreshProcessorTest {
     }
 
     @Test
-    public void testInactive() {
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_inactive"));
-        materializedView.setInactiveAndReason("");
-        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
-        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        try {
-            taskRun.executeTaskRun();
-            Assert.fail("should not be here. executeTaskRun will throw exception");
-        } catch (Exception e) {
-            Assert.assertTrue(e.getMessage().contains("is not active, skip sync partition and data with base tables"));
-        }
-    }
-
-    @Test
     public void testMvWithoutPartition() {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_without_partition"));


### PR DESCRIPTION
Fixes #issue


Introduce a daemon thread `MVActiveChecker`:
1. Try to activate MV, if it's not set to inactive manually
2. The default check interval is 1 minute, user could modify it through `admin set frontend config('mv_active_checker_interval_seconds'='300')`

Use case:
1. The base table of MV could be dropped and created everyday, for Hive external table
2. Without this mechanism, user need to activate it in the workflow, which is tedious

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
