### PR TITLE
[BugFix] Fix spill use-after-free when enable per bucket compute

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -65,7 +65,7 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
 
     auto flush_function = [this](RuntimeState* state, auto io_executor) {
         auto& spiller = _aggregator->spiller();
-        return spiller->flush(state, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, spiller));
+        return spiller->flush(state, *io_executor, TRACKER_WITH_SPILLER_READER_GUARD(state, spiller));
     };
 
     _aggregator->ref();
@@ -76,7 +76,7 @@ Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state
                     RETURN_IF_ERROR(AggregateBlockingSinkOperator::set_finishing(state));
                     return Status::OK();
                 },
-                state, *io_executor, TRACKER_WITH_SPILLER_GUARD(state, _aggregator->spiller()));
+                state, *io_executor, TRACKER_WITH_SPILLER_READER_GUARD(state, _aggregator->spiller()));
     };
 
     SpillProcessTasksBuilder task_builder(state, io_executor);

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -118,7 +118,8 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
 
     if (!_aggregator->is_spilled_eos()) {
         auto executor = _aggregator->spill_channel()->io_executor();
-        ASSIGN_OR_RETURN(auto chunk, spiller->restore(state, *executor, TRACKER_WITH_SPILLER_GUARD(state, spiller)));
+        ASSIGN_OR_RETURN(auto chunk,
+                         spiller->restore(state, *executor, TRACKER_WITH_SPILLER_READER_GUARD(state, spiller)));
         if (chunk->is_empty()) {
             return chunk;
         }

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -119,4 +119,7 @@ struct SyncTaskExecutor {
 
 #define TRACKER_WITH_SPILLER_GUARD(state, spiller) RESOURCE_TLS_MEMTRACER_GUARD(state, spiller->weak_from_this())
 
+#define TRACKER_WITH_SPILLER_READER_GUARD(state, spiller) \
+    RESOURCE_TLS_MEMTRACER_GUARD(state, spiller->weak_from_this(), std::weak_ptr((spiller)->reader()))
+
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -198,6 +198,7 @@ public:
             const std::vector<const SpillPartitionInfo*>& parititons);
 
     const std::unique_ptr<SpillerWriter>& writer() { return _writer; }
+    const std::shared_ptr<SpillerReader>& reader() { return _reader; }
 
     const std::shared_ptr<spill::Serde>& serde() { return _serde; }
     BlockManager* block_manager() { return _block_manager; }
@@ -216,7 +217,7 @@ private:
     std::weak_ptr<SpillerFactory> _parent;
 
     std::unique_ptr<SpillerWriter> _writer;
-    std::unique_ptr<SpillerReader> _reader;
+    std::shared_ptr<SpillerReader> _reader;
 
     std::mutex _mutex;
 

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -203,8 +203,8 @@ Status SpillerReader::trigger_restore(RuntimeState* state, TaskExecutor&& execut
         auto restore_task = [this, guard, trace = TraceInfo(state)]() {
             SCOPED_SET_TRACE_INFO({}, trace.query_id, trace.fragment_id);
             RETURN_IF(!guard.scoped_begin(), Status::OK());
-            auto defer = DeferOp([&]() { _running_restore_tasks--; });
             {
+                auto defer = DeferOp([&]() { _running_restore_tasks--; });
                 Status res;
                 SerdeContext ctx;
                 res = _stream->prefetch(ctx);


### PR DESCRIPTION
when enable per bucket compute optimize. reset_state will be called.

thread 1
```
source->reset_state()
    spiller->reset_state()
        reader->reset()
```

But the background thread has not ended yet. Releasing the reader at this time may lead to use-after-free. Therefore, one solution is to add the reader to the resource guard.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
