### PR TITLE
[BugFix] use unique column id in partial update by column

### DIFF
--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -629,7 +629,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             return Status::InternalError(msg);
         }
         if (!tschema->column(cid).is_key()) {
-            unique_update_column_ids.push_back(cid);
+            unique_update_column_ids.push_back(uid);
         }
     }
     auto partial_tschema = TabletSchema::create(tschema, update_column_ids);

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update_drop_column
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update_drop_column
@@ -1,0 +1,63 @@
+-- name: test_partial_update_drop_column
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100);
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200);
+-- result:
+-- !result
+insert into tab1 values (300, "k3_300", 300, 300, 300);
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100
+200	k2_200	200	200	200
+300	k3_300	300	300	300
+-- !result
+update tab1 set v2 = 5000;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	5000	100
+200	k2_200	200	5000	200
+300	k3_300	300	5000	300
+-- !result
+alter table tab1 drop column v2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100
+200	k2_200	200	200
+300	k3_300	300	300
+-- !result
+update tab1 set v3 = 5000;
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	5000
+200	k2_200	200	5000
+300	k3_300	300	5000
+-- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update_drop_column
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update_drop_column
@@ -1,0 +1,26 @@
+-- name: test_partial_update_drop_column
+show backends;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab1 values (100, "k2_100", 100, 100, 100);
+insert into tab1 values (200, "k2_200", 200, 200, 200);
+insert into tab1 values (300, "k3_300", 300, 300, 300);
+select * from tab1;
+update tab1 set v2 = 5000;
+select * from tab1;
+alter table tab1 drop column v2;
+function: wait_alter_table_finish()
+select * from tab1;
+update tab1 set v3 = 5000;
+select * from tab1;


### PR DESCRIPTION
Must use unique column id in delta column group, but we record incorrect column id right now. It may cause issue when drop column.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
