### PR TITLE
[Enhancement] add ignore folders and files to development environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,10 @@ fe/*/target
 fe/fe-core/gen
 fe/fe-common/.classpath
 fe/fe-core/src/main/java/com/starrocks/sql/parser/gen
+fe/fe-core/src/main/java/com/starrocks/builtins
+fe/fe-core/src/main/java/com/starrocks/common/Version.java
+fe/fe-core/src/main/java/com/starrocks/proto
+fe/fe-core/src/main/java/com/starrocks/thrift
 fs_brokers/apache_hdfs_broker/src/main/resources/
 fs_brokers/apache_hdfs_broker/src/main/thrift/
 fs_brokers/apache_hdfs_broker/jindosdk-4.6.2


### PR DESCRIPTION
Fixes #issue
When FE builds a local development environment, such as IntelliJ IDEA, some classes do not exist and the local development environment will report a red error. These classes are generated by gensrc during compilation, and we need to manually copy them to the fe core directory, but we need to block these files.
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
