### PR TITLE
[BugFix] compaction crash cause by non-atomic schema replacement by restore(#32893)

### DIFF
--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -564,13 +564,15 @@ void TabletMeta::create_inital_updates_meta() {
 }
 
 void TabletMeta::reset_tablet_schema_for_restore(const TabletSchemaPB& schema_pb) {
-    _schema.reset();
+    TabletSchemaCSPtr new_schema_ptr = nullptr;
     if (schema_pb.has_id() && schema_pb.id() != TabletSchema::invalid_id()) {
         // Does not collect the memory usage of |_schema|.
-        _schema = GlobalTabletSchemaMap::Instance()->emplace(schema_pb).first;
+        new_schema_ptr = GlobalTabletSchemaMap::Instance()->emplace(schema_pb).first;
     } else {
-        _schema = std::make_shared<const TabletSchema>(schema_pb);
+        new_schema_ptr = std::make_shared<const TabletSchema>(schema_pb);
     }
+    // atomic swap
+    _schema.swap(new_schema_ptr);
 }
 
 bool operator==(const TabletMeta& a, const TabletMeta& b) {


### PR DESCRIPTION
Problem:
schema in tablet_meta is not replaced in restore atomicly, it cause the BE crash if compaction execute at the same time

Solution:
atomic replace the schema

Fixes #32893

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
