### PR TITLE
[BugFix] Fix prune empty outer join lose predicate

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/EmptyValueTest.java
@@ -194,4 +194,46 @@ public class EmptyValueTest extends PlanTestBase {
                 "  |      [4: L_ORDERKEY, INT, true]\n" +
                 "  |      [24: L_ORDERKEY, INT, true]");
     }
+
+    @Test
+    public void testOuterPredicate() throws Exception {
+        String sql = "select t0.v2 from t0 full outer join " +
+                "(select * from lineitem_partition p where L_SHIPDATE = '2000-01-01') x on x.L_ORDERKEY = t0.v2" +
+                " where (t0.v3 + 1) is NULL";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:SELECT\n" +
+                "  |  predicates: 3: v3 + 1 IS NULL");
+
+        sql = "select t0.v2 from t0 left outer join " +
+                "(select * from lineitem_partition p where L_SHIPDATE = '2000-01-01') x on x.L_ORDERKEY = t0.v2" +
+                " where (x.L_SUPPKEY + 1) is NULL";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:SELECT\n" +
+                "  |  predicates: CAST(6: L_SUPPKEY AS BIGINT) + 1 IS NULL\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 6> : NULL\n" +
+                "  |  <slot 21> : NULL");
+
+        sql = "select t0.v2 from t0 right outer join " +
+                "(select * from lineitem_partition p where L_SHIPDATE = '2000-01-01') x on x.L_ORDERKEY = t0.v2" +
+                " where (x.L_SUPPKEY + 1) is NULL";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  RESULT SINK\n" +
+                "\n" +
+                "  0:EMPTYSET");
+
+        sql = "select t0.v2 from (select * from lineitem_partition p where L_SHIPDATE = '2000-01-01') x " +
+                " right outer join t0 on x.L_ORDERKEY = t0.v2" +
+                " where (x.L_SUPPKEY + 1) is NULL";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "  2:SELECT\n" +
+                "  |  predicates: CAST(3: L_SUPPKEY AS BIGINT) + 1 IS NULL\n" +
+                "  |  \n" +
+                "  1:Project\n" +
+                "  |  <slot 3> : NULL\n" +
+                "  |  <slot 19> : 19: v2\n" +
+                "  |  <slot 21> : NULL");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/StarRocksTest/issues/4181

![image](https://github.com/StarRocks/starrocks/assets/5609319/ebad3119-807c-4a38-b9e2-efeca9c65f1d)

x1.v2 is null lose when prune empty full outer join


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
