### PR TITLE
[Enhancement] Support asynchronous profile processes

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -517,6 +517,18 @@ public class Config extends ConfigBase {
     public static int heartbeat_mgr_blocking_queue_size = 1024;
 
     /**
+     * num of thread to handle heartbeat events in heartbeat_mgr.
+     */
+    @ConfField
+    public static int profile_process_threads_num = 2;
+
+    /**
+     * blocking queue size to store heartbeat task in heartbeat_mgr.
+     */
+    @ConfField
+    public static int profile_process_blocking_queue_size = 1024;
+
+    /**
      * max num of thread to handle agent task in agent task thread-pool.
      */
     @ConfField

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -517,16 +517,16 @@ public class Config extends ConfigBase {
     public static int heartbeat_mgr_blocking_queue_size = 1024;
 
     /**
-     * num of thread to handle heartbeat events in heartbeat_mgr.
+     * num of thread to handle profile processing
      */
     @ConfField
     public static int profile_process_threads_num = 2;
 
     /**
-     * blocking queue size to store heartbeat task in heartbeat_mgr.
+     * blocking queue size to store profile process task
      */
     @ConfField
-    public static int profile_process_blocking_queue_size = 1024;
+    public static int profile_process_blocking_queue_size = profile_process_threads_num * 128;
 
     /**
      * max num of thread to handle agent task in agent task thread-pool.

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -73,7 +73,7 @@ public class ProfileManager {
     public static final String USER = "User";
     public static final String DEFAULT_DB = "Default Db";
     public static final String VARIABLES = "Variables";
-    public static final String PROFILE_TIME = "Collect Profile Time";
+    public static final String PROFILE_COLLECT_TIME = "Collect Profile Time";
 
     public static final ArrayList<String> PROFILE_HEADERS = new ArrayList<>(
             Arrays.asList(QUERY_ID, USER, DEFAULT_DB, SQL_STATEMENT, QUERY_TYPE,

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -216,7 +216,7 @@ public class LoadLoadingTask extends LoadTask {
 
                 curCoordinator.getQueryProfile().getCounterTotalTime()
                         .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
-                curCoordinator.endProfile();
+                curCoordinator.collectProfileSync();
                 profile.addChild(curCoordinator.buildMergedQueryProfile());
 
                 StringBuilder builder = new StringBuilder();

--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadTask.java
@@ -1057,7 +1057,7 @@ public class StreamLoadTask extends AbstractTxnStateChangeCallback
         profile.addChild(summaryProfile);
         if (coord.getQueryProfile() != null) {
             if (!isSyncStreamLoad()) {
-                coord.endProfile();
+                coord.collectProfileSync();
                 profile.addChild(coord.buildMergedQueryProfile());
             } else {
                 profile.addChild(coord.getQueryProfile());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -963,7 +963,9 @@ public class DefaultCoordinator extends Coordinator {
         }
 
         if (!enableAsyncProfile || !queryProfile.addListener(task)) {
-            LOG.warn("Profile task is full, execute in sync mode, query id = {}", DebugUtil.printId(queryId));
+            if (enableAsyncProfile) {
+                LOG.info("Profile task is full, execute in sync mode, query id = {}", DebugUtil.printId(queryId));
+            }
             collectProfileSync();
             task.accept(false);
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -103,6 +103,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -153,7 +154,8 @@ public class DefaultCoordinator extends Coordinator {
         public DefaultCoordinator createQueryScheduler(ConnectContext context, List<PlanFragment> fragments,
                                                        List<ScanNode> scanNodes,
                                                        TDescriptorTable descTable) {
-            JobSpec jobSpec = JobSpec.Factory.fromQuerySpec(context, fragments, scanNodes, descTable, TQueryType.SELECT);
+            JobSpec jobSpec =
+                    JobSpec.Factory.fromQuerySpec(context, fragments, scanNodes, descTable, TQueryType.SELECT);
             return new DefaultCoordinator(context, jobSpec);
         }
 
@@ -254,7 +256,8 @@ public class DefaultCoordinator extends Coordinator {
         this.coordinatorPreprocessor = new CoordinatorPreprocessor(context, jobSpec);
         this.executionDAG = coordinatorPreprocessor.getExecutionDAG();
 
-        this.queryProfile = new QueryRuntimeProfile(connectContext, jobSpec, executionDAG.getFragmentsInCreatedOrder().size());
+        this.queryProfile =
+                new QueryRuntimeProfile(connectContext, jobSpec, executionDAG.getFragmentsInCreatedOrder().size());
     }
 
     @Override
@@ -415,7 +418,8 @@ public class DefaultCoordinator extends Coordinator {
                     DebugUtil.printId(jobSpec.getQueryId()), jobSpec.getDescTable());
         }
 
-        if (slot != null && slot.getPipelineDop() > 0 && slot.getPipelineDop() != jobSpec.getQueryOptions().getPipeline_dop()) {
+        if (slot != null && slot.getPipelineDop() > 0 &&
+                slot.getPipelineDop() != jobSpec.getQueryOptions().getPipeline_dop()) {
             jobSpec.getFragments().forEach(fragment -> fragment.limitMaxPipelineDop(slot.getPipelineDop()));
         }
 
@@ -914,7 +918,7 @@ public class DefaultCoordinator extends Coordinator {
         }
     }
 
-    public void endProfile() {
+    public void collectProfileSync() {
         if (executionDAG.getExecutions().isEmpty()) {
             return;
         }
@@ -940,6 +944,31 @@ public class DefaultCoordinator extends Coordinator {
         } finally {
             unlock();
         }
+    }
+
+    public boolean tryProcessProfileAsync(Consumer<Boolean> task) {
+        if (executionDAG.getExecutions().isEmpty()) {
+            return false;
+        }
+        if (!jobSpec.isNeedReport()) {
+            return false;
+        }
+        boolean enableAsyncProfile = true;
+        if (connectContext != null && connectContext.getSessionVariable() != null) {
+            enableAsyncProfile = connectContext.getSessionVariable().isEnableAsyncProfile();
+        }
+        TUniqueId queryId = null;
+        if (connectContext != null) {
+            queryId = connectContext.getExecutionId();
+        }
+
+        if (!enableAsyncProfile || !queryProfile.addListener(task)) {
+            LOG.warn("Profile task is full, execute in sync mode, query id = {}", DebugUtil.printId(queryId));
+            collectProfileSync();
+            task.accept(false);
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessor.java
@@ -45,6 +45,10 @@ public interface QeProcessor {
 
     void unregisterQuery(TUniqueId queryId);
 
+    void monitorQuery(TUniqueId queryId, long expireTime);
+
+    void unMonitorQuery(TUniqueId queryId);
+
     Map<String, QueryStatisticsItem> getQueryStatistics();
 
     Coordinator getCoordinator(TUniqueId queryId);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -233,6 +233,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String RUNTIME_PROFILE_REPORT_INTERVAL = "runtime_profile_report_interval";
     public static final String PROFILE_LIMIT_FOLD = "profile_limit_fold";
     public static final String PIPELINE_PROFILE_LEVEL = "pipeline_profile_level";
+    public static final String ENABLE_ASYNC_PROFILE = "enable_async_profile";
 
     public static final String RESOURCE_GROUP_ID = "workgroup_id";
     public static final String RESOURCE_GROUP_ID_V2 = "resource_group_id";
@@ -831,6 +832,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = PIPELINE_PROFILE_LEVEL)
     private int pipelineProfileLevel = 1;
+
+    @VariableMgr.VarAttr(name = ENABLE_ASYNC_PROFILE, flag = VariableMgr.INVISIBLE)
+    private boolean enableAsyncProfile = true;
 
     @VariableMgr.VarAttr(name = RESOURCE_GROUP_ID, alias = RESOURCE_GROUP_ID_V2,
             show = RESOURCE_GROUP_ID_V2, flag = VariableMgr.INVISIBLE)
@@ -2133,6 +2137,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public int getPipelineProfileLevel() {
         return pipelineProfileLevel;
+    }
+
+    public boolean isEnableAsyncProfile() {
+        return enableAsyncProfile;
+    }
+
+    public void setEnableAsyncProfile(boolean enableAsyncProfile) {
+        this.enableAsyncProfile = enableAsyncProfile;
     }
 
     public boolean isEnableReplicationJoin() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -215,6 +215,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
@@ -332,23 +333,6 @@ public class StmtExecutor {
         profile.addChild(plannerProfile);
         Tracers.toRuntimeProfile(plannerProfile);
         return profile;
-    }
-
-    // At the end of query execution, we begin to add up profile
-    private void initProfile(long beginTimeInNanoSecond) {
-        profile = buildTopLevelProfile();
-        if (coord != null) {
-            if (coord.getQueryProfile() != null) {
-                coord.getQueryProfile().getCounterTotalTime()
-                        .setValue(TimeUtils.getEstimatedTime(beginTimeInNanoSecond));
-                long profileCollectStartTime = System.currentTimeMillis();
-                coord.endProfile();
-                profile.getChild("Summary").addInfoString(ProfileManager.PROFILE_TIME,
-                        DebugUtil.getPrettyStringMs(System.currentTimeMillis() - profileCollectStartTime));
-                profile.addChild(coord.buildMergedQueryProfile());
-            }
-        }
-        profile.computeTimeInChildProfile();
     }
 
     public boolean isForwardToLeader() {
@@ -627,15 +611,21 @@ public class StmtExecutor {
                             throw e;
                         }
                     } finally {
+                        boolean isAsync = false;
                         if (!needRetry && context.getSessionVariable().isEnableProfile()) {
-                            writeProfile(execPlan, beginTimeInNanoSecond);
+                            isAsync = tryProcessProfileAsync(execPlan);
                             if (parsedStmt.isExplain() &&
                                     StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
                                 handleExplainStmt(ExplainAnalyzer.analyze(
                                         ProfilingExecPlan.buildFrom(execPlan), profile, null));
                             }
                         }
-                        QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
+                        if (isAsync) {
+                            QeProcessorImpl.INSTANCE.monitorQuery(context.getExecutionId(), System.currentTimeMillis() +
+                                    context.getSessionVariable().getProfileTimeout() * 1000L);
+                        } else {
+                            QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
+                        }
                     }
                 }
             } else if (parsedStmt instanceof SetStmt) {
@@ -653,7 +643,7 @@ public class StmtExecutor {
                     throw new AnalysisException("old planner does not support CTAS statement");
                 }
             } else if (parsedStmt instanceof DmlStmt) {
-                handleDMLStmtWithProfile(execPlan, (DmlStmt) parsedStmt, beginTimeInNanoSecond);
+                handleDMLStmtWithProfile(execPlan, (DmlStmt) parsedStmt);
             } else if (parsedStmt instanceof DdlStmt) {
                 handleDdlStmt();
             } else if (parsedStmt instanceof ShowStmt) {
@@ -749,8 +739,7 @@ public class StmtExecutor {
         try {
             InsertStmt insertStmt = createTableAsSelectStmt.getInsertStmt();
             ExecPlan execPlan = new StatementPlanner().plan(insertStmt, context);
-            handleDMLStmtWithProfile(execPlan, ((CreateTableAsSelectStmt) parsedStmt).getInsertStmt(),
-                    beginTimeInNanoSecond);
+            handleDMLStmtWithProfile(execPlan, ((CreateTableAsSelectStmt) parsedStmt).getInsertStmt());
             if (context.getState().getStateType() == MysqlStateType.ERR) {
                 ((CreateTableAsSelectStmt) parsedStmt).dropTable(context);
             }
@@ -789,13 +778,43 @@ public class StmtExecutor {
         leaderOpExecutor.execute();
     }
 
-    private void writeProfile(ExecPlan plan, long beginTimeInNanoSecond) {
-        initProfile(beginTimeInNanoSecond);
-        ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
-        String profileContent = ProfileManager.getInstance().pushProfile(profilingPlan, profile);
-        if (context.getQueryDetail() != null) {
-            context.getQueryDetail().setProfile(profileContent);
+    private boolean tryProcessProfileAsync(ExecPlan plan) {
+        if (coord == null || coord.getQueryProfile() == null) {
+            return false;
         }
+        // This process will get information from the context, so it must be executed synchronously.
+        // Otherwise, the context may be changed, for example, containing the wrong query id.
+        profile = buildTopLevelProfile();
+
+        long profileCollectStartTime = System.currentTimeMillis();
+        long startTime = context.getStartTime();
+        TUniqueId executionId = context.getExecutionId();
+        QueryDetail queryDetail = context.getQueryDetail();
+
+        // DO NOT use context int the async task, because the context is shared among consecutive queries.
+        // profile of query1 maybe executed when query2 is under execution.
+        Consumer<Boolean> task = (Boolean isAsync) -> {
+            RuntimeProfile summaryProfile = profile.getChild("Summary");
+            summaryProfile.addInfoString(ProfileManager.PROFILE_COLLECT_TIME,
+                    DebugUtil.getPrettyStringMs(System.currentTimeMillis() - profileCollectStartTime));
+            summaryProfile.addInfoString("IsProfileAsync", String.valueOf(isAsync));
+            profile.addChild(coord.buildMergedQueryProfile());
+
+            // Update TotalTime to include the Profile Collect Time and the time to build the profile.
+            long now = System.currentTimeMillis();
+            long totalTimeMs = now - startTime;
+            summaryProfile.addInfoString(ProfileManager.END_TIME, TimeUtils.longToTimeString(now));
+            summaryProfile.addInfoString(ProfileManager.TOTAL_TIME, DebugUtil.getPrettyStringMs(totalTimeMs));
+
+            ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
+            String profileContent = ProfileManager.getInstance().pushProfile(profilingPlan, profile);
+            if (queryDetail != null) {
+                queryDetail.setProfile(profileContent);
+            }
+            QeProcessorImpl.INSTANCE.unMonitorQuery(executionId);
+            QeProcessorImpl.INSTANCE.unregisterQuery(executionId);
+        };
+        return coord.tryProcessProfileAsync(task);
     }
 
     // Analyze one statement to structure in memory.
@@ -918,6 +937,7 @@ public class StmtExecutor {
 
         if (isExplainAnalyze) {
             context.getSessionVariable().setEnableProfile(true);
+            context.getSessionVariable().setEnableAsyncProfile(false);
             context.getSessionVariable().setPipelineProfileLevel(1);
             context.getSessionVariable().setProfileLimitFold(false);
         } else if (isSchedulerExplain) {
@@ -1665,23 +1685,27 @@ public class StmtExecutor {
      * `handleDMLStmtWithProfile` executes DML statement and write profile at the end.
      * NOTE: `writeProfile` can only be called once, otherwise the profile detail will be lost.
      */
-    public void handleDMLStmtWithProfile(ExecPlan execPlan,
-                                         DmlStmt stmt,
-                                         long beginTimeInNanoSecond) throws Exception {
+    public void handleDMLStmtWithProfile(ExecPlan execPlan, DmlStmt stmt) throws Exception {
         try {
             handleDMLStmt(execPlan, stmt);
         } catch (Throwable t) {
             LOG.warn("DML statement(" + originStmt.originStmt + ") process failed.", t);
             throw t;
         } finally {
+            boolean isAsync = false;
             if (context.getSessionVariable().isEnableProfile()) {
-                writeProfile(execPlan, beginTimeInNanoSecond);
+                isAsync = tryProcessProfileAsync(execPlan);
                 if (parsedStmt.isExplain() &&
                         StatementBase.ExplainLevel.ANALYZE.equals(parsedStmt.getExplainLevel())) {
                     handleExplainStmt(ExplainAnalyzer.analyze(ProfilingExecPlan.buildFrom(execPlan), profile, null));
                 }
             }
-            QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
+            if (isAsync) {
+                QeProcessorImpl.INSTANCE.monitorQuery(context.getExecutionId(), System.currentTimeMillis() +
+                        context.getSessionVariable().getProfileTimeout() * 1000L);
+            } else {
+                QeProcessorImpl.INSTANCE.unregisterQuery(context.getExecutionId());
+            }
         }
     }
 
@@ -1696,6 +1720,7 @@ public class StmtExecutor {
 
         if (isExplainAnalyze) {
             context.getSessionVariable().setEnableProfile(true);
+            context.getSessionVariable().setEnableAsyncProfile(false);
             context.getSessionVariable().setPipelineProfileLevel(1);
             context.getSessionVariable().setProfileLimitFold(false);
         } else if (isSchedulerExplain) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/Coordinator.java
@@ -40,6 +40,7 @@ import com.starrocks.thrift.TUniqueId;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 public abstract class Coordinator {
@@ -152,7 +153,9 @@ public abstract class Coordinator {
     // Methods for profile.
     // ------------------------------------------------------------------------------------
 
-    public abstract void endProfile();
+    public abstract void collectProfileSync();
+
+    public abstract boolean tryProcessProfileAsync(Consumer<Boolean> task);
 
     public abstract void setTopProfileSupplier(Supplier<RuntimeProfile> topProfileSupplier);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1372,7 +1372,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     @VisibleForTesting
     public void refreshMaterializedView(MvTaskRunContext mvContext, ExecPlan execPlan, InsertStmt insertStmt)
             throws Exception {
-        long beginTimeInNanoSecond = TimeUtils.getStartTime();
         Preconditions.checkNotNull(execPlan);
         Preconditions.checkNotNull(insertStmt);
         ConnectContext ctx = mvContext.getCtx();
@@ -1385,7 +1384,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         try {
-            executor.handleDMLStmtWithProfile(execPlan, insertStmt, beginTimeInNanoSecond);
+            executor.handleDMLStmtWithProfile(execPlan, insertStmt);
         } catch (Exception e) {
             LOG.warn("refresh materialized view {} failed: {}", materializedView.getName(), e);
             throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -362,10 +362,12 @@ public class ExplainAnalyzer {
                     "]");
         }
         if (!isRuntimeProfile) {
-            appendSummaryLine("CollectProfileTime: ", summaryProfile.containsInfoString(ProfileManager.PROFILE_TIME) ?
-                    summaryProfile.getInfoString(ProfileManager.PROFILE_TIME) :
-                    summaryProfile.getCounter(ProfileManager.PROFILE_TIME));
+            appendSummaryLine("CollectProfileTime: ",
+                    summaryProfile.containsInfoString(ProfileManager.PROFILE_COLLECT_TIME) ?
+                            summaryProfile.getInfoString(ProfileManager.PROFILE_COLLECT_TIME) :
+                            summaryProfile.getCounter(ProfileManager.PROFILE_COLLECT_TIME));
         }
+        appendSummaryLine("FrontendProfileMergeTime: ", executionProfile.getCounter("FrontendProfileMergeTime"));
         popIndent(); // metric indent
 
         // 3. Memory Usage

--- a/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ExportExportingTask.java
@@ -373,7 +373,7 @@ public class ExportExportingTask extends PriorityLeaderTask {
             }
 
             coord.getQueryProfile().getCounterTotalTime().setValue(TimeUtils.getEstimatedTime(job.getStartTimeMs()));
-            coord.endProfile();
+            coord.collectProfileSync();
             synchronized (fragmentProfiles) {
                 fragmentProfiles.add(coord.getQueryProfile());
             }

--- a/test/sql/test_metrics/R/test_memory_metrics
+++ b/test/sql/test_metrics/R/test_memory_metrics
@@ -87,6 +87,9 @@ PROPERTIES (
 set enable_profile=true;
 -- result:
 -- !result
+set enable_async_profile=false;
+-- result:
+-- !result
 select count(*) from t1;
 -- result:
 0

--- a/test/sql/test_metrics/T/test_memory_metrics
+++ b/test/sql/test_metrics/T/test_memory_metrics
@@ -125,6 +125,7 @@ PROPERTIES (
 "replication_num" = "1"
 );
 set enable_profile=true;
+set enable_async_profile=false;
 select count(*) from t1;
 shell: curl '${url}/metrics' | grep starrocks_fe_memory | grep \"query_profile_count\" | awk '{if ($NF >= 1) print "true"; else print "false";}'
 


### PR DESCRIPTION
## Background

The total query time comprises of the following parts:
1. plan
1. execution
1. profile collection
1. profile process

In some scenerios, some operators fail to quickly response to short circuit, the time difference between fragment instances may vary significantly, which thereby lead to long profile collection.

And in some other scenerios where the query is super complex, the profile will also become super large, and the profile process time may raise to nearly 500ms.

But the client needn't to wait the process to be finished(part 3 and part 4), because the result has been already generated and transmitted. So we can async profile process to reduce the client waiting time.

## Main work of this pr

Async the profile collect and profile process steps, and decouple these to steps from the query execution process.
1. Add listener mechanism to `MarkedCountDownLatch`
2. Setup a separate thread pool, with 2 threads by default, to handle the profile process.
3. Introduce a monitor mechanism of `QeProcessorImpl` to gracefully maintain the context of query.

And the process will be executed like this:

```
generate_plan();
execution();
wait_result();

if(size(profile_thread_queue) > Config.profile_process_blocking_queue_size) {
      collect_profile_sync();
      process_profile();
} else {
      Task profile_process_task = { process_profile(); }
      add_listener_to_profile_collect(profile_process_task);
}
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
