### PR TITLE
[Cherry-pick][Branch-3.1][BugFix] Fix iceberg mv refresh failed when iceberg table is unpartitioned (#32859)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -746,8 +746,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             if (!baseTableInfo.getTableIdentifier().equalsIgnoreCase(baseTable.getTableIdentifier())) {
                 continue;
             }
-            List<String> partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
-                    baseTableInfo.getCatalogName(), baseTableInfo.getDbName(), baseTableInfo.getTableName());
+            List<String> partitionNames = PartitionUtil.getPartitionNames(baseTable);
             Snapshot snapshot = baseTable.getNativeTable().currentSnapshot();
             long currentVersion = snapshot != null ? snapshot.timestampMillis() : -1;
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -1,0 +1,239 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Type;
+import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+public class MockIcebergMetadata implements ConnectorMetadata {
+    private static final Map<String, Map<String, IcebergTableInfo>> MOCK_TABLE_MAP = new CaseInsensitiveMap<>();
+    private final AtomicLong idGen = new AtomicLong(0L);
+    public static final String MOCKED_ICEBERG_CATALOG_NAME = "iceberg0";
+    public static final String MOCKED_UNPARTITIONED_DB_NAME = "unpartitioned_db";
+    public static final String MOCKED_PARTITIONED_DB_NAME = "partitioned_db";
+
+    public static String getStarRocksHome() throws IOException {
+        String starRocksHome = System.getenv("STARROCKS_HOME");
+        if (Strings.isNullOrEmpty(starRocksHome)) {
+            starRocksHome = Files.createTempDirectory("STARROCKS_HOME").toAbsolutePath().toString();
+        }
+        return starRocksHome;
+    }
+
+    private static ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
+    static {
+        try {
+            mockUnPartitionedTable();
+            mockPartitionedTable();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void mockUnPartitionedTable() throws IOException {
+        MOCK_TABLE_MAP.putIfAbsent(MOCKED_UNPARTITIONED_DB_NAME, new CaseInsensitiveMap<>());
+        Map<String, IcebergTableInfo> icebergTableInfoMap = MOCK_TABLE_MAP.get(MOCKED_UNPARTITIONED_DB_NAME);
+
+        List<Column> schemas = ImmutableList.of(new Column("id", Type.INT, true),
+                new Column("data", Type.STRING, true),
+                new Column("date", Type.STRING, true));
+
+        Schema schema =
+                new Schema(required(3, "id", Types.IntegerType.get()),
+                        required(4, "data", Types.StringType.get()),
+                        required(5, "date", Types.StringType.get()));
+        PartitionSpec spec =
+                PartitionSpec.builderFor(schema).build();
+        TestTables.TestTable baseTable = TestTables.create(
+                new File(getStarRocksHome() + "/" + MOCKED_UNPARTITIONED_DB_NAME + "/" + "t0"), "t0",
+                schema, spec, 1);
+
+        String tableIdentifier = Joiner.on(":").join("t0", UUID.randomUUID());
+        MockIcebergTable mockIcebergTable = new MockIcebergTable(1, "t0", MOCKED_ICEBERG_CATALOG_NAME,
+                null, MOCKED_UNPARTITIONED_DB_NAME, "t0", schemas, baseTable, null,
+                tableIdentifier);
+
+        Map<String, ColumnStatistic> columnStatisticMap;
+        List<String> colNames = schemas.stream().map(Column::getName).collect(Collectors.toList());
+        columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
+                col -> ColumnStatistic.unknown()));
+
+        icebergTableInfoMap.put("t0", new IcebergTableInfo(mockIcebergTable, Lists.newArrayList(), 100,
+                columnStatisticMap));
+    }
+
+    public static void mockPartitionedTable() throws IOException {
+        MOCK_TABLE_MAP.putIfAbsent(MOCKED_PARTITIONED_DB_NAME, new CaseInsensitiveMap<>());
+        Map<String, IcebergTableInfo> icebergTableInfoMap = MOCK_TABLE_MAP.get(MOCKED_PARTITIONED_DB_NAME);
+
+        List<Column> schemas = ImmutableList.of(new Column("id", Type.INT, true),
+                new Column("data", Type.STRING, true),
+                new Column("date", Type.STRING, true));
+
+        Schema schema =
+                new Schema(required(3, "id", Types.IntegerType.get()),
+                        required(4, "data", Types.StringType.get()),
+                        required(5, "date", Types.StringType.get()));
+        PartitionSpec spec =
+                PartitionSpec.builderFor(schema).identity("date").build();
+        TestTables.TestTable baseTable = TestTables.create(
+                new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_DB_NAME + "/" + "t1"), "t1",
+                schema, spec, 1);
+
+        String tableIdentifier = Joiner.on(":").join("t1", UUID.randomUUID());
+        MockIcebergTable mockIcebergTable = new MockIcebergTable(1, "t1", MOCKED_ICEBERG_CATALOG_NAME,
+                null, MOCKED_PARTITIONED_DB_NAME, "t1", schemas, baseTable, null,
+                tableIdentifier);
+
+        List<String> partitionNames = Lists.newArrayList("date=2020-01-01",
+                "date=2020-01-02",
+                "date=2020-01-03",
+                "date=2020-01-04");
+        Map<String, ColumnStatistic> columnStatisticMap;
+        List<String> colNames = schemas.stream().map(Column::getName).collect(Collectors.toList());
+        columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
+                col -> ColumnStatistic.unknown()));
+
+        icebergTableInfoMap.put("t1", new IcebergTableInfo(mockIcebergTable, partitionNames, 100,
+                columnStatisticMap));
+    }
+
+    @Override
+    public Database getDb(String dbName) {
+        return new Database(idGen.getAndIncrement(), dbName);
+    }
+
+    @Override
+    public com.starrocks.catalog.Table getTable(String dbName, String tblName) {
+        readLock();
+        try {
+            return MOCK_TABLE_MAP.get(dbName).get(tblName).icebergTable;
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @Override
+    public List<String> listPartitionNames(String dbName, String tableName) {
+        readLock();
+        try {
+            return MOCK_TABLE_MAP.get(dbName).get(tableName).partitionNames;
+        } finally {
+            readUnlock();
+        }
+    }
+
+    @Override
+    public Statistics getTableStatistics(OptimizerContext session, com.starrocks.catalog.Table table,
+                                         Map<ColumnRefOperator, Column> columns, List<PartitionKey> partitionKeys,
+                                         ScalarOperator predicate) {
+        MockIcebergTable icebergTable = (MockIcebergTable) table;
+        String hiveDb = icebergTable.getRemoteDbName();
+        String tblName = icebergTable.getName();
+
+        readLock();
+        try {
+            IcebergTableInfo info = MOCK_TABLE_MAP.get(hiveDb).get(tblName);
+            Statistics.Builder builder = Statistics.builder();
+            builder.setOutputRowCount(info.rowCount);
+            for (ColumnRefOperator columnRefOperator : columns.keySet()) {
+                ColumnStatistic columnStatistic = info.columnStatsMap.get(columnRefOperator.getName());
+                builder.addColumnStatistic(columnRefOperator, columnStatistic);
+            }
+            return builder.build();
+        } finally {
+            readUnlock();
+        }
+    }
+
+    public void addRowsToPartition(String dbName, String tableName, int rowCount, String partitionName) {
+        IcebergTable icebergTable = MOCK_TABLE_MAP.get(dbName).get(tableName).icebergTable;
+        Table nativeTable = icebergTable.getNativeTable();
+        DataFile file = DataFiles.builder(nativeTable.spec())
+                .withPath("/path/to/data-a.parquet")
+                .withFileSizeInBytes(10)
+                .withPartitionPath(partitionName) // easy way to set partition data for now
+                .withRecordCount(rowCount)
+                .build();
+        writeLock();
+        try {
+            nativeTable.newAppend().appendFile(file).commit();
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    private static class IcebergTableInfo {
+        private MockIcebergTable icebergTable;
+        private List<String> partitionNames;
+        private long rowCount;
+        private Map<String, ColumnStatistic> columnStatsMap;
+
+        public IcebergTableInfo(MockIcebergTable icebergTable, List<String> partitionNames, long rowCount,
+                                Map<String, ColumnStatistic> columnStatsMap) {
+            this.icebergTable = icebergTable;
+            this.partitionNames = partitionNames;
+            this.rowCount = rowCount;
+            this.columnStatsMap = columnStatsMap;
+        }
+    }
+
+    private void writeLock() {
+        lock.writeLock().lock();
+    }
+    private void writeUnlock() {
+        lock.writeLock().unlock();
+    }
+    private void readLock() {
+        lock.readLock().lock();
+    }
+    private void readUnlock() {
+        lock.readLock().unlock();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergTable.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergTable.java
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+
+import java.util.List;
+import java.util.Map;
+
+public class MockIcebergTable extends IcebergTable {
+    private final String tableIdentifier;
+
+    public MockIcebergTable(long id, String srTableName, String catalogName, String resourceName, String remoteDbName,
+                            String remoteTableName, List<Column> schema, org.apache.iceberg.Table nativeTable,
+                            Map<String, String> icebergProperties, String tableIdentifier) {
+        super(id, srTableName, catalogName, resourceName, remoteDbName, remoteTableName, schema,
+                nativeTable, icebergProperties);
+        this.tableIdentifier = tableIdentifier;
+    }
+
+    @Override
+    public String getTableIdentifier() {
+        return this.tableIdentifier;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TestTables.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TestTables.java
@@ -326,5 +326,10 @@ public class TestTables {
                 throw new RuntimeIOException("Failed to delete file: " + path);
             }
         }
+
+        @Override
+        public Map<String, String> properties() {
+            return Maps.newHashMap();
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -16,6 +16,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.TableName;
@@ -40,6 +41,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.hive.MockedHiveMetadata;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.Coordinator;
@@ -670,6 +672,95 @@ public class PartitionBasedMvRefreshProcessorTest {
         ExecPlan execPlan = mvContext.getExecPlan();
         String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
         Assert.assertTrue(plan.contains("4:HASH JOIN"));
+    }
+
+    private static void trigerRefreshPaimonMv(Database testDb, MaterializedView partitionedMaterializedView)
+            throws Exception {
+        Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+    }
+
+    @Test
+    public void testCreateUnPartitionedIcebergMaterializedView() throws Exception {
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv1`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_mv1"));
+        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(1, partitions.size());
+        Assert.assertEquals(Lists.newArrayList(partitions).get(0).getName(), "iceberg_mv1");
+    }
+
+    @Test
+    public void testCreatePartitionedIcebergMaterializeView() throws Exception {
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv1`\n" +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
+
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_parttbl_mv1"));
+        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+
+        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(4, partitions.size());
+
+        MockIcebergMetadata mockIcebergMetadata = (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-02");
+        // refresh only one partition
+        Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                taskRun.getProcessor();
+
+        MvTaskRunContext mvContext = processor.getMvContext();
+        ExecPlan execPlan = mvContext.getExecPlan();
+        assertPlanContains(execPlan, "CAST(3: date AS DATE) >= '2020-01-02', CAST(3: date AS DATE) < '2020-01-03'");
+
+        partitions = partitionedMaterializedView.getPartitions();
+        Assert.assertEquals(4, partitions.size());
+        Assert.assertEquals(2,
+                partitionedMaterializedView.getPartition("p20200101_20200102").getVisibleVersion());
+        Assert.assertEquals(3,
+                partitionedMaterializedView.getPartition("p20200102_20200103").getVisibleVersion());
+        Assert.assertEquals(2,
+                partitionedMaterializedView.getPartition("p20200103_20200104").getVisibleVersion());
+        Assert.assertEquals(2,
+                partitionedMaterializedView.getPartition("p20200104_20200105").getVisibleVersion());
+
+        // add new row and refresh again
+        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-01");
+        taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMvRefreshProcessor)
+                taskRun.getProcessor();
+
+        mvContext = processor.getMvContext();
+        execPlan = mvContext.getExecPlan();
+        assertPlanContains(execPlan, "CAST(3: date AS DATE) >= '2020-01-01', CAST(3: date AS DATE) < '2020-01-02'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ConnectorPlanTestBase.java
@@ -22,6 +22,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.hive.MockedHiveMetadata;
+import com.starrocks.connector.iceberg.MockIcebergMetadata;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -48,6 +49,7 @@ public class ConnectorPlanTestBase extends PlanTestBase {
         gsmMgr.setMetadataMgr(metadataMgr);
         mockHiveCatalogImpl(metadataMgr);
         mockJDBCCatalogImpl(metadataMgr);
+        mockIcebergCatalogImpl(metadataMgr);
     }
 
     public static void mockHiveCatalog(ConnectContext ctx) throws DdlException {
@@ -97,5 +99,18 @@ public class ConnectorPlanTestBase extends PlanTestBase {
                 createCatalog("jdbc", MockedJDBCMetadata.MOCKED_JDBC_PG_CATALOG_NAME, "", pgProperties);
         metadataMgr.registerMockedMetadata(MockedJDBCMetadata.MOCKED_JDBC_PG_CATALOG_NAME,
                 new MockedJDBCMetadata(pgProperties));
+    }
+
+    private static void mockIcebergCatalogImpl(MockedMetadataMgr metadataMgr) throws DdlException {
+        Map<String, String> properties = Maps.newHashMap();
+
+        properties.put("type", "iceberg");
+        properties.put("iceberg.catalog.type", "hive");
+        properties.put("hive.metastore.uris", "thrift://127.0.0.1:9083");
+
+        GlobalStateMgr.getCurrentState().getCatalogMgr().createCatalog("iceberg", "iceberg0", "", properties);
+
+        MockIcebergMetadata mockIcebergMetadata = new MockIcebergMetadata();
+        metadataMgr.registerMockedMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME, mockIcebergMetadata);
     }
 }


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
