### PR TITLE
[Enhancement] delay metascan init

### DIFF
--- a/be/src/exec/lake_meta_scanner.h
+++ b/be/src/exec/lake_meta_scanner.h
@@ -21,14 +21,22 @@
 #include "exec/olap_utils.h"
 #include "runtime/runtime_state.h"
 #include "storage/lake_meta_reader.h"
+
+#ifdef BE_TEST
+// remove final declaration for UT
+#define DECL_FINAL
+#else
+#define DECL_FINAL final
+#endif
+
 namespace starrocks {
 
 class LakeMetaScanNode;
 
-class LakeMetaScanner final : public MetaScanner {
+class LakeMetaScanner DECL_FINAL : public MetaScanner {
 public:
     LakeMetaScanner(LakeMetaScanNode* parent);
-    ~LakeMetaScanner() final = default;
+    ~LakeMetaScanner() DECL_FINAL = default;
 
     LakeMetaScanner(const LakeMetaScanner&) = delete;
     LakeMetaScanner(LakeMetaScanner&) = delete;
@@ -45,16 +53,22 @@ public:
 
     bool has_more() override;
 
-private:
+protected:
+    Status _lazy_init(RuntimeState* runtime_state, const MetaScannerParams& params);
+    Status _real_init();
+
     Status _get_tablet(const TInternalScanRange* scan_range) override;
     Status _init_meta_reader_params() override;
 
     LakeMetaScanNode* _parent;
-    StatusOr<lake::Tablet> _tablet;
+    lake::Tablet _tablet;
     std::shared_ptr<const TabletSchema> _tablet_schema;
 
     LakeMetaReaderParams _reader_params;
     std::shared_ptr<LakeMetaReader> _reader;
+    int64_t _tablet_id;
 };
 
 } // namespace starrocks
+
+#undef DECL_FINAL

--- a/be/src/storage/lake_meta_reader.h
+++ b/be/src/storage/lake_meta_reader.h
@@ -26,6 +26,12 @@
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/segment.h"
 
+#ifdef BE_TEST
+#define DECL_FINAL
+#else
+#define DECL_FINAL final
+#endif
+
 namespace starrocks {
 // Params for MetaReader
 // mainly include tablet
@@ -38,12 +44,12 @@ struct LakeMetaReaderParams : MetaReaderParams {
 // MetaReader will implements
 // 1. read meta info from segment footer
 // 2. read dict info from dict page if column is dict encoding type
-class LakeMetaReader final : public MetaReader {
+class LakeMetaReader DECL_FINAL : public MetaReader {
 public:
     LakeMetaReader();
     ~LakeMetaReader() override = default;
 
-    Status init(const LakeMetaReaderParams& read_params);
+    virtual Status init(const LakeMetaReaderParams& read_params);
 
     lake::Tablet tablet() { return _tablet.value(); }
 
@@ -64,3 +70,5 @@ private:
 };
 
 } // namespace starrocks
+
+#undef DECL_FINAL

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -64,6 +64,7 @@ set(EXEC_FILES
         ./exec/join_hash_map_test.cpp
         ./exec/json_parser_test.cpp
         ./exec/json_scanner_test.cpp
+        ./exec/lake_meta_scanner_test.cpp
         ./exec/avro_scanner_test.cpp
         ./exec/parquet_scanner_test.cpp
         ./exec/repeat_node_test.cpp

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -1,0 +1,167 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/lake_meta_scanner.h"
+
+#include <gtest/gtest.h>
+
+#include "exec/lake_meta_scan_node.h"
+#include "fs/fs_util.h"
+#include "runtime/descriptor_helper.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake_meta_reader.h"
+#include "testutil/id_generator.h"
+#include "testutil/sync_point.h"
+
+namespace starrocks {
+
+// provides an empty implementation of the reader
+struct MockLakeMetaReader : public LakeMetaReader {
+public:
+    Status init(const LakeMetaReaderParams& read_params) override { return Status::OK(); }
+};
+
+// access the protected members of LakeMetaScanner
+struct MockLakeMetaScanner : public LakeMetaScanner {
+public:
+    MockLakeMetaScanner(LakeMetaScanNode* parent) : LakeMetaScanner(parent) {}
+
+    std::shared_ptr<LakeMetaReader> reader() { return _reader; }
+    int64_t tablet_id() const { return _tablet_id; }
+    bool is_opened() const { return _is_open; }
+};
+
+class LakeMetaScannerTest : public ::testing::Test {
+public:
+    LakeMetaScannerTest() : _tablet_id(next_id()) {
+        // setup TabletManager
+        _location_provider = std::make_unique<lake::FixedLocationProvider>(kRootLocation);
+        _tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
+        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider.get());
+        FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName));
+        FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName));
+        FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName));
+
+        auto st = _tablet_mgr->delete_tablet(_tablet_id);
+        EXPECT_TRUE(st.ok());
+
+        {
+            // create the tablet with its schema prepared
+            lake::TabletMetadata metadata;
+            metadata.set_id(_tablet_id);
+            metadata.set_version(2);
+
+            auto schema = metadata.mutable_schema();
+            schema->set_id(10);
+            schema->set_num_short_key_columns(1);
+            schema->set_keys_type(DUP_KEYS);
+            schema->set_num_rows_per_row_block(65535);
+            auto c0 = schema->add_column();
+            c0->set_unique_id(0);
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+            auto st = _tablet_mgr->put_tablet_metadata(metadata);
+            EXPECT_TRUE(st.ok());
+
+            auto tablet_or = _tablet_mgr->get_tablet(_tablet_id);
+            EXPECT_TRUE(tablet_or.ok());
+            auto st2 = tablet_or->get_schema();
+            EXPECT_TRUE(st2.ok());
+        }
+
+        _state = _pool.add(new RuntimeState(TQueryGlobals()));
+
+        std::vector<::starrocks::TTupleId> tuple_ids{0};
+        std::vector<bool> nullable_tuples{true};
+        _tnode = std::make_unique<TPlanNode>();
+        _tnode->__set_node_id(1);
+        _tnode->__set_node_type(TPlanNodeType::LAKE_SCAN_NODE);
+        _tnode->__set_row_tuples(tuple_ids);
+        _tnode->__set_nullable_tuples(nullable_tuples);
+        _tnode->__set_limit(-1);
+
+        TDescriptorTableBuilder table_desc_builder;
+        TSlotDescriptorBuilder slot_desc_builder;
+        auto slot =
+                slot_desc_builder.type(LogicalType::TYPE_INT).column_name("col1").column_pos(0).nullable(true).build();
+        TTupleDescriptorBuilder tuple_desc_builder;
+        tuple_desc_builder.add_slot(slot);
+        tuple_desc_builder.build(&table_desc_builder);
+
+        CHECK(DescriptorTbl::create(_state, &_pool, table_desc_builder.desc_tbl(), &_tbl, config::vector_chunk_size)
+                      .ok());
+
+        _parent = std::make_unique<LakeMetaScanNode>(&_pool, *_tnode, *_tbl);
+    }
+
+    ~LakeMetaScannerTest() {
+        auto st = fs::remove_all(kRootLocation);
+        EXPECT_TRUE(st.ok());
+        (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
+    }
+
+    void TearDown() override { (void)_tablet_mgr->delete_tablet(_tablet_id); }
+
+public:
+    constexpr static const char* const kRootLocation = "./LakeMetaScannerTest";
+    lake::TabletManager* _tablet_mgr;
+    std::unique_ptr<lake::LocationProvider> _location_provider;
+    lake::LocationProvider* _backup_location_provider;
+    int64_t _tablet_id;
+
+    ObjectPool _pool;
+    RuntimeState* _state = nullptr;
+    std::unique_ptr<TPlanNode> _tnode;
+    DescriptorTbl* _tbl;
+    std::unique_ptr<LakeMetaScanNode> _parent;
+};
+
+TEST_F(LakeMetaScannerTest, test_init_lazy_and_real) {
+    auto range = _pool.add(new TInternalScanRange());
+    range->tablet_id = _tablet_id;
+    range->version = 2;
+    MetaScannerParams params{.scan_range = range};
+
+    MockLakeMetaScanner scanner(_parent.get());
+    auto st = scanner.init(_state, params);
+    // after init() called, reader is not created at all
+    EXPECT_TRUE(st.ok());
+    EXPECT_TRUE(scanner.reader().get() == nullptr);
+    EXPECT_EQ(range->tablet_id, scanner.tablet_id());
+
+    std::shared_ptr<LakeMetaReader> mock_reader(new MockLakeMetaReader);
+    SyncPoint::GetInstance()->SetCallBack("lake_meta_scanner:open_mock_reader", [=](void* arg) {
+        std::shared_ptr<LakeMetaReader>* reader = static_cast<std::shared_ptr<LakeMetaReader>*>(arg);
+        // non-empty reader
+        EXPECT_TRUE((*reader).get() != nullptr);
+        *reader = mock_reader;
+    });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    auto st2 = scanner.open(nullptr);
+    // after open() called, reader is created
+    EXPECT_TRUE(st2.ok()) << st2;
+    EXPECT_EQ(mock_reader.get(), scanner.reader().get());
+    EXPECT_TRUE(scanner.is_opened());
+
+    SyncPoint::GetInstance()->ClearCallBack("lake_meta_scanner:open_mock_reader");
+    SyncPoint::GetInstance()->DisableProcessing();
+}
+
+} // namespace starrocks


### PR DESCRIPTION
* init metascanner during the open due to possible heavy io ops
* unblock pipeline prepare thread pool


**test result data**

shared-data mode, 1 FE 1BE, ssb lineorder_flat 10g, disable local cache, cold query (BE restarted without any cache)
SQL: `select dict_merge(S_CITY) from lineorder_flat [_META_] ;`

**WITHOUT the fix**
```
  Planner:
     ...
     - -- Deploy[1] 38s798ms
```
**WITH the fix**
```
  Planner:
     ...
     - -- Deploy[1] 15ms
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
