### PR TITLE
[Enhancement] FE and BE add hdfs-site.xml and core-site.xml configuration files for distribution

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -1060,6 +1060,11 @@ install(FILES
     ${BASE_DIR}/../conf/udf_security.policy
     DESTINATION ${OUTPUT_DIR}/conf)
 
+install(FILES
+        ${BASE_DIR}/../conf/hdfs-site.xml
+        ${BASE_DIR}/../conf/core-site.xml
+        DESTINATION ${OUTPUT_DIR}/conf OPTIONAL)
+
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "ASAN" OR "${CMAKE_BUILD_TYPE}" STREQUAL "LSAN")
 install(FILES
     ${BASE_DIR}/../conf/asan_suppressions.conf

--- a/build.sh
+++ b/build.sh
@@ -422,6 +422,8 @@ if [ ${BUILD_FE} -eq 1 -o ${BUILD_SPARK_DPP} -eq 1 ]; then
         cp -r -p ${STARROCKS_HOME}/conf/fe.conf ${STARROCKS_OUTPUT}/fe/conf/
         cp -r -p ${STARROCKS_HOME}/conf/udf_security.policy ${STARROCKS_OUTPUT}/fe/conf/
         cp -r -p ${STARROCKS_HOME}/conf/hadoop_env.sh ${STARROCKS_OUTPUT}/fe/conf/
+	cp -r -p ${STARROCKS_HOME}/conf/hdfs-site.xml ${STARROCKS_OUTPUT}/fe/conf/ 2>/dev/null
+        cp -r -p ${STARROCKS_HOME}/conf/core-site.xml ${STARROCKS_OUTPUT}/fe/conf/ 2>/dev/null
         rm -rf ${STARROCKS_OUTPUT}/fe/lib/*
         cp -r -p ${STARROCKS_HOME}/fe/fe-core/target/lib/* ${STARROCKS_OUTPUT}/fe/lib/
         cp -r -p ${STARROCKS_HOME}/fe/fe-core/target/starrocks-fe.jar ${STARROCKS_OUTPUT}/fe/lib/
@@ -455,6 +457,8 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_HOME}/be/output/conf/cn.conf ${STARROCKS_OUTPUT}/be/conf/
     cp -r -p ${STARROCKS_HOME}/be/output/conf/hadoop_env.sh ${STARROCKS_OUTPUT}/be/conf/
     cp -r -p ${STARROCKS_HOME}/be/output/conf/log4j2.properties ${STARROCKS_OUTPUT}/be/conf/
+    cp -r -p ${STARROCKS_HOME}/be/output/conf/hdfs-site.xml ${STARROCKS_OUTPUT}/be/conf/ 2>/dev/null
+    cp -r -p ${STARROCKS_HOME}/be/output/conf/core-site.xml ${STARROCKS_OUTPUT}/be/conf/ 2>/dev/null
     if [ "${BUILD_TYPE}" == "ASAN" ]; then
         cp -r -p ${STARROCKS_HOME}/be/output/conf/asan_suppressions.conf ${STARROCKS_OUTPUT}/be/conf/
     fi


### PR DESCRIPTION
Fixes #issue
FE and BE add hdfs-site.xml and core-site.xml configuration files for distribution. 
Our project requires hdfs related configuration when using hdfs catalog or hive catalog, so we plan to include hdfs-site.xml and core-site.xml in the project project. When packaging and deploying production environments, we do not need to upload hdfs-site.xml and core-site.xml again, and can directly maintain the hdfs-site.xml and core-site.xml configuration files in the project project. Therefore, we hope to place hdfs-site.xml and core-site.xml in the conf directory. 
Of course, if hdfs-site.xml and core-site.xml are not configured, there will be no issues with compilation.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
