### PR TITLE
[BugFix] Fix TopN RF plan error when SortNode without order by column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -145,7 +145,8 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
     public void buildRuntimeFilters(IdGenerator<RuntimeFilterId> generator, DescriptorTable descTbl) {
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
         // only support the runtime filter in TopN when limit > 0
-        if (limit < 0 || !sessionVariable.getEnableGlobalRuntimeFilter()) {
+        if (limit < 0 || !sessionVariable.getEnableGlobalRuntimeFilter() ||
+                getSortInfo().getOrderingExprs().isEmpty()) {
             return;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -519,6 +519,27 @@ public class OrderByTest extends PlanTestBase {
                 "  |  order by: [1, VARCHAR, false] ASC, [2, SMALLINT, false] ASC\n" +
                 "  |  build runtime filters:\n" +
                 "  |  - filter_id = 0, build_expr = (<slot 1> 1: t1a), remote = false");
+
+        // no order by column case
+        sql = "SELECT a, b FROM ( SELECT t1a AS a, t1b AS b, row_number() OVER() AS rn FROM" +
+                " test_all_type_not_null ) tb_rn WHERE rn>=10 and rn<19;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "runtime filters");
+
+        sql = "SELECT a, b FROM ( SELECT t1a AS a, t1b AS b, row_number() OVER( partition by t1a) AS rn FROM" +
+                " test_all_type_not_null ) tb_rn WHERE rn<19;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "runtime filters");
+
+        // no order by column pattern 2
+        sql = "select * from test_all_type_not_null limit 1000,200";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "runtime filters");
+
+        // order by null case
+        sql = "select * from test_all_type_not_null order by null + 1 limit 1";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "runtime filters");
     }
 
     @Test
@@ -530,6 +551,7 @@ public class OrderByTest extends PlanTestBase {
                 "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC");
     }
 
+    @Test
     public void testTopNFilterWithProject() throws Exception {
         String sql;
         String plan;


### PR DESCRIPTION
a possiable stack log in fe.warn.log
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
        at java.util.ArrayList.rangeCheck(ArrayList.java:657) ~[?:1.8.0_202]
        at java.util.ArrayList.get(ArrayList.java:433) ~[?:1.8.0_202]
        at com.starrocks.planner.SortNode.buildRuntimeFilters(SortNode.java:153) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.buildPartialTopNFragment(PlanFragmentBuilder.java:2133) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalTopN(PlanFragmentBuilder.java:2013) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalTopN(PlanFragmentBuilder.java:417) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.operator.physical.PhysicalTopNOperator.accept(PhysicalTopNOperator.java:141) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visit(PlanFragmentBuilder.java:434) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.plan.PlanFragmentBuilder$PhysicalPlanTranslator.visitPhysicalTopN(PlanFragmentBuilder.java:2009) ~[starrocks-fe.jar:?]
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
