### PR TITLE
[Enhancement] Optimize segment open for cloud native tablet

### DIFF
--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -99,7 +99,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
     }
 
     template <LogicalType type, EncodingTypePB encoding, uint32_t version>

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -48,7 +48,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
     }
 
     void test_int_map() {

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -50,7 +50,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(Segment::private_type(0), fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
     }
 
     void test_int_struct() {


### PR DESCRIPTION
segment->open will read the footer, and it is time-consuming. 
separate it from static Segment::open is to prevent a large number of cache misses, 
and many temporary segment objects generation when loading the same segment concurrently.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
