### PR TITLE
[BugFix] fix non-partitioned mv for iceberg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -266,8 +266,8 @@ public class PartitionUtil {
             partitionNames = GlobalStateMgr.getCurrentState().getMetadataMgr().listPartitionNames(
                     paimonTable.getCatalogName(), paimonTable.getDbName(), paimonTable.getTableName());
         } else {
-            Preconditions.checkState(false, "Do not support get partition names and columns for" +
-                    "table type %s", table.getType());
+            Preconditions.checkState(false, "Not support getPartitionNames for table type %s",
+                    table.getType());
         }
         return partitionNames;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1617,6 +1617,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 if (table.isNativeTableOrMaterializedView()) {
                     tableNamePartitionNames.put(table, ((OlapTable) table).getVisiblePartitionNames());
                 } else if (table.isView()) {
+                    // do nothing
                 } else {
                     tableNamePartitionNames.put(table, Sets.newHashSet(PartitionUtil.getPartitionNames(table)));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1611,18 +1611,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         Map<Table, Set<String>> tableNamePartitionNames = Maps.newHashMap();
         for (Pair<BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
             Table table = tablePair.second;
-            if (partitionTable != null && partitionTable == table) {
-                // do nothing.
+            if (partitionTable != null && partitionTable.equals(table)) {
+                // do nothing
             } else {
                 if (table.isNativeTableOrMaterializedView()) {
                     tableNamePartitionNames.put(table, ((OlapTable) table).getVisiblePartitionNames());
-                } else if (table.isHiveTable()) {
-                    tableNamePartitionNames.put(table, Sets.newHashSet(PartitionUtil.getPartitionNames(table)));
                 } else if (table.isView()) {
-                    continue;
                 } else {
-                    LOG.warn("Do not support get partition names and columns for" +
-                            " table type {}", table.getType());
+                    tableNamePartitionNames.put(table, Sets.newHashSet(PartitionUtil.getPartitionNames(table)));
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -15,7 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.TableName;
@@ -334,7 +334,6 @@ public class PartitionBasedMvRefreshProcessorTest {
                         "\"partition_refresh_number\" = \"1\"" +
                         ") " +
                         "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
-
 
         new MockUp<StmtExecutor>() {
             @Mock
@@ -714,9 +713,22 @@ public class PartitionBasedMvRefreshProcessorTest {
     }
 
     @Test
-    public void testCreateUnPartitionedIcebergMaterializedView() throws Exception {
+    public void testRewriteNonPartitionedMVForOlapTable() throws Exception {
         starRocksAssert.useDatabase("test")
-                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv1`\n" +
+                .withMaterializedView("create materialized view mv_single_for_olap " +
+                        "refresh async " +
+                        "as select * from tbl1");
+        String mvName = "mv_single_for_olap";
+        refreshMVRange(mvName, false);
+        String querySql = "select * from tbl1";
+        starRocksAssert.query(querySql).explainContains(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreateNonPartitionedMVForIceberg() throws Exception {
+        starRocksAssert.useDatabase("test")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv1` " +
                         "COMMENT \"MATERIALIZED_VIEW\"\n" +
                         "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                         "REFRESH DEFERRED MANUAL\n" +
@@ -724,18 +736,51 @@ public class PartitionBasedMvRefreshProcessorTest {
                         "\"replication_num\" = \"1\",\n" +
                         "\"storage_medium\" = \"HDD\"\n" +
                         ")\n" +
-                        "AS SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_mv1"));
-        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+                        "AS SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;")
+                .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv2` " +
+                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                        "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                        "REFRESH DEFERRED MANUAL\n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\" = \"1\",\n" +
+                        "\"storage_medium\" = \"HDD\"\n" +
+                        ")\n" +
+                        "AS SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` as a;");
 
-        Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
-        Assert.assertEquals(1, partitions.size());
-        Assert.assertEquals(Lists.newArrayList(partitions).get(0).getName(), "iceberg_mv1");
+        // Partitioned base table
+        {
+            String mvName = "iceberg_mv2";
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
+            refreshMVRange(mvName, true);
+            List<String> partitionNames = mv.getPartitions().stream().map(Partition::getName)
+                    .sorted().collect(Collectors.toList());
+            Assert.assertEquals(ImmutableList.of(mvName), partitionNames);
+            String querySql = "SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1`";
+            starRocksAssert.query(querySql).explainContains(mvName);
+            starRocksAssert.dropMaterializedView(mvName);
+        }
+
+        // Non-Partitioned base table
+        {
+            String mvName = "iceberg_mv1";
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView mv = ((MaterializedView) testDb.getTable(mvName));
+            refreshMVRange(mvName, true);
+            List<String> partitionNames = mv.getPartitions().stream().map(Partition::getName)
+                    .sorted().collect(Collectors.toList());
+            Assert.assertEquals(ImmutableList.of(mvName), partitionNames);
+
+            // test rewrite
+            String querySql = "SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0`";
+            starRocksAssert.query(querySql).explainContains(mvName);
+            starRocksAssert.dropMaterializedView(mvName);
+        }
     }
 
     @Test
-    public void testCreatePartitionedIcebergMaterializeView() throws Exception {
+    public void testCreatePartitionedMVForIceberg() throws Exception {
+        String mvName = "iceberg_parttbl_mv1";
         starRocksAssert.useDatabase("test")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv1`\n" +
                         "COMMENT \"MATERIALIZED_VIEW\"\n" +
@@ -755,8 +800,9 @@ public class PartitionBasedMvRefreshProcessorTest {
         Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
         Assert.assertEquals(4, partitions.size());
 
-        MockIcebergMetadata mockIcebergMetadata = (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
-                getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+        MockIcebergMetadata mockIcebergMetadata =
+                (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                        getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
         mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-02");
         // refresh only one partition
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
@@ -770,16 +816,14 @@ public class PartitionBasedMvRefreshProcessorTest {
         ExecPlan execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "CAST(3: date AS DATE) >= '2020-01-02', CAST(3: date AS DATE) < '2020-01-03'");
 
-        partitions = partitionedMaterializedView.getPartitions();
-        Assert.assertEquals(4, partitions.size());
-        Assert.assertEquals(2,
-                partitionedMaterializedView.getPartition("p20200101_20200102").getVisibleVersion());
-        Assert.assertEquals(3,
-                partitionedMaterializedView.getPartition("p20200102_20200103").getVisibleVersion());
-        Assert.assertEquals(2,
-                partitionedMaterializedView.getPartition("p20200103_20200104").getVisibleVersion());
-        Assert.assertEquals(2,
-                partitionedMaterializedView.getPartition("p20200104_20200105").getVisibleVersion());
+        Map<String, Long> partitionVersionMap = partitionedMaterializedView.getPartitions().stream()
+                .collect(Collectors.toMap(Partition::getName, Partition::getVisibleVersion));
+        Assert.assertEquals(
+                ImmutableMap.of("p20200104_20200105", 2L,
+                        "p20200101_20200102", 2L,
+                        "p20200103_20200104", 2L,
+                        "p20200102_20200103", 3L),
+                ImmutableMap.copyOf(partitionVersionMap));
 
         // add new row and refresh again
         mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-01");
@@ -792,6 +836,13 @@ public class PartitionBasedMvRefreshProcessorTest {
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
         assertPlanContains(execPlan, "CAST(3: date AS DATE) >= '2020-01-01', CAST(3: date AS DATE) < '2020-01-02'");
+
+        // test rewrite
+        starRocksAssert.query("SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1`")
+                .explainContains(mvName);
+        starRocksAssert.query("SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` where date = '2020-01-01'")
+                .explainContains(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q15.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q15.sql
@@ -40,7 +40,7 @@ order by
 TOP-N (order by [[1: s_suppkey ASC NULLS FIRST]])
     TOP-N (order by [[1: s_suppkey ASC NULLS FIRST]])
         INNER JOIN (join-predicate [1: s_suppkey = 10: l_suppkey] post-join-predicate [null])
-            SCAN (columns{1,2,3,5} predicate[1: s_suppkey IS NOT NULL])
+            HIVE SCAN (columns{1,2,3,5} predicate[1: s_suppkey IS NOT NULL])
             EXCHANGE BROADCAST
                 INNER JOIN (join-predicate [25: sum = 44: max] post-join-predicate [null])
                     AGGREGATE ([GLOBAL] aggregate [{148: sum=sum(148: sum)}] group by [[129: l_suppkey]] having [148: sum IS NOT NULL]

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q22.sql
@@ -44,10 +44,10 @@ TOP-N (order by [[29: substring ASC NULLS FIRST]])
                 AGGREGATE ([LOCAL] aggregate [{30: count=count(), 31: sum=sum(6: c_acctbal)}] group by [[29: substring]] having [null]
                     RIGHT ANTI JOIN (join-predicate [20: o_custkey = 1: c_custkey] post-join-predicate [null])
                         EXCHANGE SHUFFLE[20]
-                            SCAN (columns{20} predicate[null])
+                            HIVE SCAN (columns{20} predicate[null])
                         EXCHANGE SHUFFLE[1]
                             INNER JOIN (join-predicate [cast(6: c_acctbal as decimal128(38, 8)) > 17: avg] post-join-predicate [null])
-                                SCAN (columns{1,5,6} predicate[substring(5: c_phone, 1, 2) IN (21, 28, 24, 32, 35, 34, 37)])
+                                HIVE SCAN (columns{1,5,6} predicate[substring(5: c_phone, 1, 2) IN (21, 28, 24, 32, 35, 34, 37)])
                                 EXCHANGE BROADCAST
                                     ASSERT LE 1
                                         AGGREGATE ([GLOBAL] aggregate [{95: sum=sum(95: sum), 96: count=sum(96: count)}] group by [[]] having [null]


### PR DESCRIPTION
Fixes #issue


- Issue: non-partitioned mv cannot be used for query rewrite, it always report `outdated partitioned` exception
- Root cause: function `PartitionBasedMvRefreshProcessor#getNonRefTableRefreshPartitions` does not handle the Iceberg table type.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
