### PR TITLE
[BugFix] Fix 'remove_unused_buffer_values' of window function

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -714,6 +714,8 @@ CONF_Int64(pipeline_scan_queue_mode, "0");
 CONF_Int64(pipeline_scan_queue_level_time_slice_base_ns, "100000000");
 CONF_Double(pipeline_scan_queue_ratio_of_adjacent_queue, "1.5");
 
+CONF_Int32(pipeline_analytic_max_buffer_size, "128");
+
 /// For parallel scan on the single tablet.
 // These three configs are used to calculate the minimum number of rows picked up from a segment at one time.
 // It is `splitted_scan_bytes/scan_row_bytes` and restricted in the range [min_splitted_scan_rows, max_splitted_scan_rows].

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -378,6 +378,10 @@ bool Analytor::is_chunk_buffer_empty() {
     return _buffer.empty();
 }
 
+bool Analytor::is_chunk_buffer_full() {
+    return _buffer.size() >= config::pipeline_analytic_max_buffer_size;
+}
+
 ChunkPtr Analytor::poll_chunk_buffer() {
     std::lock_guard<std::mutex> l(_buffer_mutex);
     if (_buffer.empty()) {

--- a/be/src/exec/analytor.cpp
+++ b/be/src/exec/analytor.cpp
@@ -560,7 +560,7 @@ bool Analytor::is_new_partition() {
             ((_partition_end == 0) | (_partition_end != _found_partition_end.second)));
 }
 
-int64_t Analytor::get_total_position(int64_t local_position) {
+int64_t Analytor::get_total_position(int64_t local_position) const {
     return _removed_from_buffer_rows + local_position;
 }
 
@@ -721,6 +721,10 @@ void Analytor::remove_unused_buffer_values(RuntimeState* state) {
         for (size_t i = 0; i < _order_ctxs.size(); i++) {
             _order_columns[i]->remove_first_n_values(remove_count);
         }
+        for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
+            _agg_functions[i]->reset_state_for_contraction(
+                    _agg_fn_ctxs[i], _managed_fn_states[0]->mutable_data() + _agg_states_offsets[i], remove_count);
+        }
     }
 
     _removed_from_buffer_rows += remove_count;
@@ -753,10 +757,15 @@ std::string Analytor::debug_string() const {
     std::stringstream ss;
     ss << std::boolalpha;
 
-    ss << "current_row_position=" << _current_row_position << ", partition=(" << _partition_start << ", "
-       << _partition_end << ", " << _found_partition_end.second << "/" << _found_partition_end.first
-       << "), peer_group=(" << _peer_group_start << ", " << _peer_group_end << ")"
-       << ", frame=(" << _rows_start_offset << ", " << _rows_end_offset << ")";
+    ss << "current_row_position=" << get_total_position(_current_row_position) << ", partition=("
+       << get_total_position(_partition_start) << ", " << get_total_position(_partition_end) << ", "
+       << get_total_position(_found_partition_end.second) << "/" << _found_partition_end.first << "), peer_group=("
+       << get_total_position(_peer_group_start) << ", " << get_total_position(_peer_group_end) << ", "
+       << get_total_position(_found_peer_group_end.second) << "/" << _found_peer_group_end.first << ")"
+       << ", frame=(" << _rows_start_offset << ", " << _rows_end_offset << ")"
+       << ", input_chunks_size=" << _input_chunks.size() << ", output_chunk_index=" << _output_chunk_index
+       << ", removed_from_buffer_rows=" << _removed_from_buffer_rows
+       << ", removed_chunk_index=" << _removed_chunk_index;
 
     return ss.str();
 }

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -98,6 +98,7 @@ public:
     bool is_sink_complete() { return _is_sink_complete.load(std::memory_order_acquire); }
     void sink_complete() { _is_sink_complete.store(true, std::memory_order_release); }
     bool is_chunk_buffer_empty();
+    bool is_chunk_buffer_full();
     ChunkPtr poll_chunk_buffer();
     void offer_chunk_to_buffer(const ChunkPtr& chunk);
 
@@ -176,7 +177,11 @@ public:
 
     Status check_has_error();
 
+#ifdef NDEBUG
+    static constexpr int32_t BUFFER_CHUNK_NUMBER = 128;
+#else
     static constexpr int32_t BUFFER_CHUNK_NUMBER = 1;
+#endif
 
 private:
     RuntimeState* _state = nullptr;

--- a/be/src/exec/analytor.h
+++ b/be/src/exec/analytor.h
@@ -152,7 +152,7 @@ public:
     void create_agg_result_columns(int64_t chunk_size);
 
     bool is_new_partition();
-    int64_t get_total_position(int64_t local_position);
+    int64_t get_total_position(int64_t local_position) const;
     void find_partition_end();
     void find_peer_group_end();
     void reset_state_for_cur_partition();
@@ -176,11 +176,7 @@ public:
 
     Status check_has_error();
 
-#ifdef NDEBUG
-    static constexpr int32_t BUFFER_CHUNK_NUMBER = 1000;
-#else
     static constexpr int32_t BUFFER_CHUNK_NUMBER = 1;
-#endif
 
 private:
     RuntimeState* _state = nullptr;

--- a/be/src/exec/pipeline/analysis/analytic_sink_operator.h
+++ b/be/src/exec/pipeline/analysis/analytic_sink_operator.h
@@ -32,7 +32,7 @@ public:
     ~AnalyticSinkOperator() override = default;
 
     bool has_output() const override { return false; }
-    bool need_input() const override { return !is_finished(); }
+    bool need_input() const override { return !is_finished() && !_analytor->is_chunk_buffer_full(); }
     bool is_finished() const override { return _is_finished || _analytor->reached_limit() || _analytor->is_finished(); }
     Status set_finishing(RuntimeState* state) override;
 

--- a/be/src/exprs/agg/aggregate.h
+++ b/be/src/exprs/agg/aggregate.h
@@ -100,6 +100,13 @@ public:
     virtual void get_values(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* dst, size_t start,
                             size_t end) const {}
 
+    // For aggregation window functions
+    // For certain window functions, such as "rank," the process will be executed in streaming mode,
+    // and the columns that were previously buffered but are no longer needed will be contracted.
+    // And if the implementation of the window function record some certain information, such as partition boundary,
+    // this information should be updated as well.
+    virtual void reset_state_for_contraction(FunctionContext* ctx, AggDataPtr __restrict state, size_t count) const {}
+
     virtual std::string get_name() const = 0;
 
     // State management methods:

--- a/be/src/exprs/agg/window.h
+++ b/be/src/exprs/agg/window.h
@@ -180,6 +180,10 @@ class RankWindowFunction final : public WindowFunction<RankState> {
         this->data(state).peer_group_start = -1;
     }
 
+    void reset_state_for_contraction(FunctionContext* ctx, AggDataPtr __restrict state, size_t count) const override {
+        this->data(state).peer_group_start -= count;
+    }
+
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
@@ -214,6 +218,10 @@ class DenseRankWindowFunction final : public WindowFunction<DenseRankState> {
         this->data(state).peer_group_start = -1;
     }
 
+    void reset_state_for_contraction(FunctionContext* ctx, AggDataPtr __restrict state, size_t count) const override {
+        this->data(state).peer_group_start -= count;
+    }
+
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
@@ -237,7 +245,7 @@ class DenseRankWindowFunction final : public WindowFunction<DenseRankState> {
 
 struct CumeDistState {
     int64_t rank;
-    int64_t frame_start;
+    int64_t peer_group_start;
     int64_t count;
 };
 
@@ -245,16 +253,20 @@ class CumeDistWindowFunction final : public WindowFunction<CumeDistState> {
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         auto& s = this->data(state);
         s.rank = 0;
-        s.frame_start = -1;
+        s.peer_group_start = -1;
         s.count = 1;
+    }
+
+    void reset_state_for_contraction(FunctionContext* ctx, AggDataPtr __restrict state, size_t count) const override {
+        this->data(state).peer_group_start -= count;
     }
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                               int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                               int64_t frame_end) const override {
         auto& s = this->data(state);
-        if (s.frame_start != peer_group_start) {
-            s.frame_start = peer_group_start;
+        if (s.peer_group_start != peer_group_start) {
+            s.peer_group_start = peer_group_start;
             int64_t peer_group_count = peer_group_end - peer_group_start;
             s.rank += peer_group_count;
         }
@@ -281,9 +293,13 @@ class PercentRankWindowFunction final : public WindowFunction<PercentRankState> 
     void reset(FunctionContext* ctx, const Columns& args, AggDataPtr __restrict state) const override {
         auto& s = this->data(state);
         s.rank = 0;
-        s.frame_start = -1;
+        s.peer_group_start = -1;
         s.peer_group_count = 1;
         s.count = 1;
+    }
+
+    void reset_state_for_contraction(FunctionContext* ctx, AggDataPtr __restrict state, size_t count) const override {
+        this->data(state).peer_group_start -= count;
     }
 
     void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
@@ -291,8 +307,8 @@ class PercentRankWindowFunction final : public WindowFunction<PercentRankState> 
                                               int64_t frame_end) const override {
         int64_t peer_group_count = peer_group_end - peer_group_start;
         auto& s = this->data(state);
-        if (s.frame_start != peer_group_start) {
-            s.frame_start = peer_group_start;
+        if (s.peer_group_start != peer_group_start) {
+            s.peer_group_start = peer_group_start;
             s.rank += s.peer_group_count;
         }
         s.peer_group_count = peer_group_count;

--- a/test/sql/test_window_function/R/test_window_function_streaming
+++ b/test/sql/test_window_function/R/test_window_function_streaming
@@ -1,0 +1,165 @@
+-- name: test_window_function_streaming
+CREATE TABLE `t1` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NOT NULL,
+  `v4` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (1, 1, 1, NULL),
+    (1, 1, 2, NULL),
+    (1, NULL, 3, NULL),
+    (1, NULL, 4, NULL),
+    (1, 2, 5, NULL),
+    (1, 2, 6, NULL),
+    (1, NULL, 7, NULL),
+    (1, NULL, 8, NULL),
+    (2, 3, 9, NULL),
+    (2, 3, 10, NULL),
+    (2, NULL, 11, NULL),
+    (2, NULL, 12, NULL),
+    (2, 4, 13, NULL),
+    (2, 4, 14, NULL),
+    (2, NULL, 15, NULL),
+    (2, NULL, 16, NULL),
+    (NULL, 3, 17, NULL),
+    (NULL, 3, 18, NULL),
+    (NULL, NULL, 19, NULL),
+    (NULL, NULL, 20, NULL),
+    (NULL, 4, 21, NULL),
+    (NULL, 4, 22, NULL),
+    (NULL, NULL, 23, NULL),
+    (NULL, NULL, 24, NULL);
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (101, 101, 101, NULL),
+    (101, 101, 102, NULL),
+    (101, NULL, 103, NULL),
+    (101, NULL, 104, NULL),
+    (101, 102, 105, NULL),
+    (101, 102, 106, NULL),
+    (101, NULL, 107, NULL),
+    (101, NULL, 108, NULL),
+    (102, 103, 109, NULL),
+    (102, 103, 110, NULL),
+    (102, NULL, 111, NULL),
+    (102, NULL, 112, NULL),
+    (102, 104, 113, NULL),
+    (102, 104, 114, NULL),
+    (102, NULL, 115, NULL),
+    (102, NULL, 116, NULL),
+    (NULL, 103, 117, NULL),
+    (NULL, 103, 118, NULL),
+    (NULL, NULL, 119, NULL),
+    (NULL, NULL, 120, NULL),
+    (NULL, 104, 121, NULL),
+    (NULL, 104, 122, NULL),
+    (NULL, NULL, 123, NULL),
+    (NULL, NULL, 124, NULL);
+-- result:
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT row_number() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk <= 1;
+-- result:
+9	9	1	1
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT row_number() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk > 1;
+-- result:
+49167	386195551	2	24588
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT row_number() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a;
+-- result:
+49176	386195560	1	24588
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk <= 1;
+-- result:
+24588	24588	1	1
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk > 1;
+-- result:
+24588	235167812	3	24585
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a;
+-- result:
+49176	235192400	1	24585
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT dense_rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk <= 1;
+-- result:
+24588	24588	1	1
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT dense_rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk > 1;
+-- result:
+24588	57388	2	5
+-- !result
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT dense_rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a;
+-- result:
+49176	81976	1	5
+-- !result
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT count(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+-- result:
+49176	537198720	2	24588
+-- !result
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT min(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+-- result:
+49176	476568	1	121
+-- !result
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT max(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+-- result:
+49176	3410736	2	124
+-- !result
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT sum(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+-- result:
+49176	7799945536	203	333138
+-- !result
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT avg(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+-- result:
+49176	715012.2492279809	1.5	121.5
+-- !result
+SELECT /*+ SET_VAR(pipeline_dop='1')*/ COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT cume_dist() OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+-- result:
+49176	36879.33463478241	0.3333333333333333	1.0
+-- !result
+SELECT /*+ SET_VAR(pipeline_dop='1')*/ COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT percent_rank() OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+-- result:
+49176	12298.165548229932	0.0	0.9998779843006467
+-- !result

--- a/test/sql/test_window_function/T/test_window_function_streaming
+++ b/test/sql/test_window_function/T/test_window_function_streaming
@@ -1,0 +1,97 @@
+-- name: test_window_function_streaming
+CREATE TABLE `t1` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NOT NULL,
+  `v4` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (1, 1, 1, NULL),
+    (1, 1, 2, NULL),
+    (1, NULL, 3, NULL),
+    (1, NULL, 4, NULL),
+    (1, 2, 5, NULL),
+    (1, 2, 6, NULL),
+    (1, NULL, 7, NULL),
+    (1, NULL, 8, NULL),
+    (2, 3, 9, NULL),
+    (2, 3, 10, NULL),
+    (2, NULL, 11, NULL),
+    (2, NULL, 12, NULL),
+    (2, 4, 13, NULL),
+    (2, 4, 14, NULL),
+    (2, NULL, 15, NULL),
+    (2, NULL, 16, NULL),
+    (NULL, 3, 17, NULL),
+    (NULL, 3, 18, NULL),
+    (NULL, NULL, 19, NULL),
+    (NULL, NULL, 20, NULL),
+    (NULL, 4, 21, NULL),
+    (NULL, 4, 22, NULL),
+    (NULL, NULL, 23, NULL),
+    (NULL, NULL, 24, NULL);
+
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (101, 101, 101, NULL),
+    (101, 101, 102, NULL),
+    (101, NULL, 103, NULL),
+    (101, NULL, 104, NULL),
+    (101, 102, 105, NULL),
+    (101, 102, 106, NULL),
+    (101, NULL, 107, NULL),
+    (101, NULL, 108, NULL),
+    (102, 103, 109, NULL),
+    (102, 103, 110, NULL),
+    (102, NULL, 111, NULL),
+    (102, NULL, 112, NULL),
+    (102, 104, 113, NULL),
+    (102, 104, 114, NULL),
+    (102, NULL, 115, NULL),
+    (102, NULL, 116, NULL),
+    (NULL, 103, 117, NULL),
+    (NULL, 103, 118, NULL),
+    (NULL, NULL, 119, NULL),
+    (NULL, NULL, 120, NULL),
+    (NULL, 104, 121, NULL),
+    (NULL, 104, 122, NULL),
+    (NULL, NULL, 123, NULL),
+    (NULL, NULL, 124, NULL);
+
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT row_number() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk <= 1;
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT row_number() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk > 1;
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT row_number() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a;
+
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk <= 1;
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk > 1;
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a;
+
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT dense_rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk <= 1;
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT dense_rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a WHERE rk > 1;
+SELECT COUNT(*), SUM(rk), MIN(rk), MAX(rk) FROM (SELECT dense_rank() OVER (PARTITION BY v2 ORDER BY v1) AS rk FROM t1)a;
+
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT count(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT min(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT max(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT sum(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+SELECT COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT avg(v3) OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+
+SELECT /*+ SET_VAR(pipeline_dop='1')*/ COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT cume_dist() OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;
+SELECT /*+ SET_VAR(pipeline_dop='1')*/ COUNT(*), SUM(wv), MIN(wv), MAX(wv) FROM (SELECT percent_rank() OVER (PARTITION BY v2 ORDER BY v1) AS wv FROM t1)a;


### PR DESCRIPTION
## Main works of this pr

1. `Analytor::BUFFER_CHUNK_NUMBER` is set to 1000, which is too large that may lead to significant memory usage for buffering 1000 chunks.
2. Fix the bug in the function `remove_unused_buffer_values`, if previous parts are discarded, all the related field will be updated, like the partition boundary, peer group boundary. But some window function will record the previous boundary, and these information need to be udpated as well. So I introduced a method named `reset_state_for_contraction`, which will be invoded within `remove_unused_buffer_values` to update previously recorded partition boundary.

```cpp
    void update_batch_single_state_with_frame(FunctionContext* ctx, AggDataPtr __restrict state, const Column** columns,
                                              int64_t peer_group_start, int64_t peer_group_end, int64_t frame_start,
                                              int64_t frame_end) const override {
        int64_t peer_group_count = peer_group_end - peer_group_start;
        if (this->data(state).peer_group_start != peer_group_start) {
            // !!! HERE, this state record the peer group boundary
            this->data(state).peer_group_start = peer_group_start;
            this->data(state).rank += this->data(state).count;
        }
        this->data(state).count = peer_group_count;
    }
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
