### PR TITLE
[Enhancement] Add unkown file format in scan range

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
@@ -60,8 +60,7 @@ public enum RemoteFileInputFormat {
             case TEXT:
                 return THdfsFileFormat.TEXT;
             default:
-                break;
+                return THdfsFileFormat.UNKNOWN;
         }
-        return null;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/RemoteFileInputFormatTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/RemoteFileInputFormatTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.hive;
 
+import com.starrocks.thrift.THdfsFileFormat;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -24,5 +25,11 @@ public class RemoteFileInputFormatTest {
                 .fromHdfsInputFormatClass("org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"));
         Assert.assertSame(RemoteFileInputFormat.ORC,
                 RemoteFileInputFormat.fromHdfsInputFormatClass("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat"));
+    }
+
+    @Test
+    public void testUnknownFormat() {
+        RemoteFileInputFormat format = RemoteFileInputFormat.UNKNOWN;
+        Assert.assertEquals(THdfsFileFormat.UNKNOWN, format.toThrift());
     }
 }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -63,13 +63,15 @@ struct TTupleDescriptor {
 }
 
 enum THdfsFileFormat {
-  TEXT,
-  LZO_TEXT,
-  RC_FILE,
-  SEQUENCE_FILE,
-  AVRO,
-  PARQUET,
-  ORC,
+  TEXT = 0,
+  LZO_TEXT = 1,
+  RC_FILE = 2,
+  SEQUENCE_FILE = 3,
+  AVRO = 4,
+  PARQUET = 5,
+  ORC = 6,
+
+  UNKNOWN = 100
 }
 
 


### PR DESCRIPTION
In the past, if we recognized an unknown file format, we would return null directly.
In thrift, null means `0` in the enum type, and we will handle this scan range as a TextFile in be, this is not as expected.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
