### PR TITLE
[BugFix] fix lambdaFunctionExpr's clone bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
@@ -54,6 +54,7 @@ public class LambdaFunctionExpr extends Expr {
     public LambdaFunctionExpr(LambdaFunctionExpr rhs) {
         super(rhs);
         this.commonSubOperatorNum = rhs.commonSubOperatorNum;
+        this.checkValid();
     }
 
     @Override
@@ -109,6 +110,17 @@ public class LambdaFunctionExpr extends Expr {
             commonSubOp.append("\n        ");
         }
         return String.format("%s -> %s%s", names, getChild(0).explain(), commonSubOp);
+    }
+
+    public void checkValid() {
+        // 1 lambda expr, at least 1 lambda argument and common sub op's slotref + expr
+        Preconditions.checkState(children.size() >= 2 + 2 * commonSubOperatorNum,
+                "lambda expr's children num " + children.size() + " should >= " + (2 + 2 * commonSubOperatorNum));
+        int realChildrenNum = getChildren().size() - 2 * commonSubOperatorNum;
+        for (int i = 1; i < realChildrenNum; i++) {
+            Preconditions.checkState(getChild(i) instanceof SlotRef,
+                    i + "-th lambda argument should be type of SlotRef, but actually " + getChild(i).toSql());
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
@@ -53,6 +53,7 @@ public class LambdaFunctionExpr extends Expr {
 
     public LambdaFunctionExpr(LambdaFunctionExpr rhs) {
         super(rhs);
+        this.commonSubOperatorNum = rhs.commonSubOperatorNum;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -556,8 +556,9 @@ public class ScalarOperatorToExpr {
             newArguments.add(lambdaExpr);
             newArguments.addAll(arguments);
 
-            Expr result = new LambdaFunctionExpr(newArguments, commonSubOperatorMap);
+            LambdaFunctionExpr result = new LambdaFunctionExpr(newArguments, commonSubOperatorMap);
             result.setType(Type.FUNCTION);
+            result.checkValid();
             return result;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -611,6 +611,11 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("lambda common expressions:{<slot 8> <-> CAST(<slot 4> AS BIGINT)}{<slot 9> " +
                 "<-> <slot 8> * 2}{<slot 10> <-> <slot 9> + 6: abs}"));
+
+        sql = "SELECT max(g) FROM(SELECT array_sum(array_map(x -> ((x * x) + (x * b)), a)) AS g FROM " +
+                "(SELECT [1,2] a, 1 AS b) AS A) AS B";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("lambda common expressions:{<slot 8> <-> CAST(<slot 4> AS SMALLINT)}"));
     }
 
     @Test


### PR DESCRIPTION
Cloning agg's sub expressions expose this bug.
```
mysql>  explain SELECT max(g) FROM(SELECT array_sum(array_map(x -> ((x * x) + (x * b)), a)) AS g FROM (SELECT [1,2] a, 1 AS b) AS A) AS B;
+---------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                  |
+---------------------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                                 |
|  OUTPUT EXPRS:6: max                                                                                                            |
|   PARTITION: UNPARTITIONED                                                                                                      |
|                                                                                                                                 |
|   RESULT SINK                                                                                                                   |
|                                                                                                                                 |
|   1:AGGREGATE (update finalize)                                                                                                 |
|   |  output: max(array_sum(array_map(<slot 4> -> CAST(<slot 8> * <slot 8> AS INT) + CAST(<slot 8> * CAST(1 AS SMALLINT) AS INT) |
|         lambda common expressions:{<slot 8> <-> CAST(<slot 4> AS SMALLINT)}                                                     |
|         , [1,2])))                                                                                                              |
|   |  group by:                                                                                                                  |
|   |                                                                                                                             |
|   0:UNION                                                                                                                       |
|      constant exprs:                                                                                                            |
|          NULL                                                                                                                   |
+---------------------------------------------------------------------------------------------------------------------------------+
```
wrong cases
```
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                                                    |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| PLAN FRAGMENT 0                                                                                                                                                                   |
|  OUTPUT EXPRS:6: max                                                                                                                                                              |
|   PARTITION: UNPARTITIONED                                                                                                                                                        |
|                                                                                                                                                                                   |
|   RESULT SINK                                                                                                                                                                     |
|                                                                                                                                                                                   |
|   1:AGGREGATE (update finalize)                                                                                                                                                   |
|   |  output: max(array_sum(array_map((<slot 4>, <slot 8>, CAST(<slot 4> AS SMALLINT)) -> CAST(<slot 8> * <slot 8> AS INT) + CAST(<slot 8> * CAST(1 AS SMALLINT) AS INT), [1,2]))) |
|   |  group by:                                                                                                                                                                    |
|   |                                                                                                                                                                               |
|   0:UNION                                                                                                                                                                         |
|      constant exprs:                                                                                                                                                              |
|          NULL                                                                                                                                                                     |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
