### PR TITLE
[BugFix] Fix dead lock in add_workgroup

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -259,7 +259,7 @@ WorkGroupPtr WorkGroupManager::add_workgroup(const WorkGroupPtr& wg) {
     if (_workgroup_versions.count(wg->id()) && _workgroup_versions[wg->id()] == wg->version()) {
         return _workgroups[unique_id];
     } else {
-        return get_default_workgroup();
+        return get_default_workgroup_unlocked();
     }
 }
 
@@ -442,6 +442,10 @@ void WorkGroupManager::update_metrics() {
 
 WorkGroupPtr WorkGroupManager::get_default_workgroup() {
     std::shared_lock read_lock(_mutex);
+    return get_default_workgroup_unlocked();
+}
+
+WorkGroupPtr WorkGroupManager::get_default_workgroup_unlocked() {
     auto unique_id = WorkGroup::create_unique_id(WorkGroup::DEFAULT_VERSION, WorkGroup::DEFAULT_WG_ID);
     DCHECK(_workgroups.count(unique_id));
     return _workgroups[unique_id];

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -287,6 +287,7 @@ private:
     void delete_workgroup_unlocked(const WorkGroupPtr& wg);
     void add_metrics_unlocked(const WorkGroupPtr& wg, UniqueLockType& unique_lock);
     void update_metrics_unlocked();
+    WorkGroupPtr get_default_workgroup_unlocked();
 
 private:
     mutable std::shared_mutex _mutex;


### PR DESCRIPTION

If the resource group is modified and generates a new version, but the query delivered to BE with the old version resource group, then `add_workgroup` -> `get_default_workgroup` will be called， where `add_workgroup` locks exclusively, and `get_default_workgroup` locks sharedly.

According to the [document for std::shared_mutex::lock_shared](https://en.cppreference.com/w/cpp/thread/shared_mutex/lock_shared), If lock_shared is called by a thread that already owns the mutex in any mode (exclusive or shared), the behavior is undefined.


BE crashed, and the stack is as follows:
```
terminate called after throwing an instance of 'std::system_error'
  what():  已避免资源死锁

*** Aborted at 1697618544 (unix time) try "date -d @1697618544" if you are using GNU date ***
PC: @     0x7f841d1a5387 __GI_raise
*** SIGABRT (@0x3e800004b61) received by PID 19297 (TID 0x7f83a2f2c700) from PID 19297; stack trace: ***
    @          0x633c8a2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f841dc5a630 (unknown)
    @     0x7f841d1a5387 __GI_raise
    @     0x7f841d1a6a78 __GI_abort
    @          0x2803236 _ZN9__gnu_cxx27__verbose_terminate_handlerEv.cold
    @          0x8608fc6 __cxxabiv1::__terminate()
    @          0x8609031 std::terminate()
    @          0x8609184 __cxa_throw
    @          0x28051ae std::__throw_system_error()
    @          0x36516f4 starrocks::workgroup::WorkGroupManager::add_workgroup()
    @          0x350fc9a starrocks::pipeline::FragmentExecutor::_prepare_workgroup()
    @          0x3516fa8 starrocks::pipeline::FragmentExecutor::prepare()
    @          0x54d856b starrocks::PInternalServiceImplBase<>::_exec_plan_fragment_by_pipeline()
    @          0x54dd4c1 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @          0x54e6f15 starrocks::PInternalServiceImplBase<>::_exec_plan_fragment()
    @          0x2a9de9d starrocks::PriorityThreadPool::work_thread()
    @          0x62fc267 thread_proxy
    @     0x7f841dc52ea5 start_thread
    @     0x7f841d26db0d __clone
    @                0x0 (unknown)
```

gdb:
```
#0  0x00007f841d1a5387 in raise () from /lib64/libc.so.6
#1  0x00007f841d1a6a78 in abort () from /lib64/libc.so.6
#2  0x0000000002803236 in __gnu_cxx::__verbose_terminate_handler () at ../../.././libstdc++-v3/libsupc++/vterminate.cc:95
#3  0x00007f80942fa9c0 in ?? ()
#4  0x0000000095ccd320 in ?? ()
#5  0x0000000000000023 in ?? ()
#6  0x00007f8295ccd380 in ?? ()
#7  0x000000000a29bff0 in typeinfo for std::_V2::error_category ()
#8  0x0000000008608fc6 in __cxxabiv1::__terminate (handler=<optimized out>) at ../../.././libstdc++-v3/libsupc++/eh_terminate.cc:48
#9  0x00007f83a2f24bd0 in ?? ()
#10 0x0000000008609031 in std::terminate () at ../../.././libstdc++-v3/libsupc++/eh_terminate.cc:58
#11 0x0000000000000023 in ?? ()
#12 0x0000000008609184 in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7f822f0e72c0, dest=0x8682200 <std::system_error::~system_error()>) at ../../.././libstdc++-v3/libsupc++/eh_throw.cc:95
#13 0x000000000a2ead38 in (anonymous namespace)::system_category_instance ()
#14 0x00007f8295ccd3a0 in ?? ()
#15 0x00007f83a2f24be0 in ?? ()
#16 0x00000000028051ae in std::__throw_system_error (__i=170831504) at /workspace/gcc/x86_64-pc-linux-gnu/libstdc++-v3/include/system_error:223
#17 0x00007f808e1eaf80 in ?? ()
#18 0x0000000000000015 in ?? ()
#19 0x0000000000000015 in ?? ()
#20 0x00000000024abe50 in ?? ()
#21 0x00000000024abe50 in ?? ()
#22 0x00007f83a2f24c70 in ?? ()
#23 0x000000000a2f1ac0 in ?? ()
#24 0x00007f83a2f24cb0 in ?? ()
#25 0x00007f83a2f24c80 in ?? ()
#26 0x00000000036516f4 in std::__shared_mutex_pthread::lock_shared (this=0x7f822f0e72c0) at /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/shared_mutex:227
#27 std::shared_mutex::lock_shared (this=0x7f822f0e72c0) at /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/shared_mutex:421
#28 std::shared_lock<std::shared_mutex>::shared_lock (__m=..., this=<synthetic pointer>) at /opt/rh/gcc-toolset-10/root/usr/include/c++/10.3.0/shared_mutex:722
#29 starrocks::workgroup::WorkGroupManager::get_default_workgroup (this=0x7f822f0e72c0) at /root/starrocks/be/src/exec/workgroup/work_group.cpp:444
#30 starrocks::workgroup::WorkGroupManager::add_workgroup (this=0x7f822f0e72c0, wg=...) at /root/starrocks/be/src/exec/workgroup/work_group.cpp:262
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
