### PR TITLE
[Enhancement] Add FE metric query_queue_queries to show pending reason (bacport #33030)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/ResourceGroupMetricMgr.java
@@ -20,6 +20,7 @@ import com.codahale.metrics.Snapshot;
 import com.starrocks.catalog.ResourceGroup;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.scheduler.slot.QueryQueueStatistics;
 import com.starrocks.thrift.TWorkGroup;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -40,6 +41,10 @@ public class ResourceGroupMetricMgr {
     private static final String RESOURCE_GROUP_QUERY_QUEUE_PENDING = "resource_group_query_queue_pending";
     private static final String RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT = "resource_group_query_queue_timeout";
 
+    private static final String QUERY_QUEUE_PENDING_REASON = "query_queue_pending_by";
+    private static final String QUERY_QUEUE_PENDING_REASON_DESC =
+            "the number of pending queries in the query queue with the specific reason";
+
     private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_COUNTER_MAP
             = new ConcurrentHashMap<>();
     private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_ERR_COUNTER_MAP
@@ -55,6 +60,42 @@ public class ResourceGroupMetricMgr {
 
     private static final ConcurrentHashMap<String, LongCounterMetric> RESOURCE_GROUP_QUERY_QUEUE_TIMEOUT_MAP
             = new ConcurrentHashMap<>();
+
+    private static final LongCounterMetric QUERY_QUEUE_PENDING_BY_GLOBAL_RESOURCE_QUERIES =
+            new LongCounterMetric(QUERY_QUEUE_PENDING_REASON,
+                    Metric.MetricUnit.REQUESTS, QUERY_QUEUE_PENDING_REASON_DESC);
+    private static final LongCounterMetric QUERY_QUEUE_PENDING_BY_GLOBAL_SLOT_QUERIES = new LongCounterMetric(
+            QUERY_QUEUE_PENDING_REASON,
+            Metric.MetricUnit.REQUESTS, QUERY_QUEUE_PENDING_REASON_DESC);
+    private static final LongCounterMetric QUERY_QUEUE_PENDING_BY_GROUP_RESOURCE_QUERIES =
+            new LongCounterMetric(QUERY_QUEUE_PENDING_REASON,
+                    Metric.MetricUnit.REQUESTS, QUERY_QUEUE_PENDING_REASON_DESC);
+    private static final LongCounterMetric QUERY_QUEUE_PENDING_BY_GROUP_SLOT_QUERIES = new LongCounterMetric(
+            QUERY_QUEUE_PENDING_REASON,
+            Metric.MetricUnit.REQUESTS, QUERY_QUEUE_PENDING_REASON_DESC);
+
+    static {
+        QUERY_QUEUE_PENDING_BY_GLOBAL_RESOURCE_QUERIES.addLabel(new MetricLabel("reason", "global_cpu_or_memory_limit"));
+        QUERY_QUEUE_PENDING_BY_GLOBAL_SLOT_QUERIES.addLabel(new MetricLabel("reason", "global_concurrency_limit"));
+        QUERY_QUEUE_PENDING_BY_GROUP_RESOURCE_QUERIES.addLabel(new MetricLabel("reason", "group_max_cpu_cores"));
+        QUERY_QUEUE_PENDING_BY_GROUP_SLOT_QUERIES.addLabel(new MetricLabel("reason", "group_concurrency_limit"));
+
+        MetricRepo.addMetric(QUERY_QUEUE_PENDING_BY_GLOBAL_RESOURCE_QUERIES);
+        MetricRepo.addMetric(QUERY_QUEUE_PENDING_BY_GLOBAL_SLOT_QUERIES);
+        MetricRepo.addMetric(QUERY_QUEUE_PENDING_BY_GROUP_RESOURCE_QUERIES);
+        MetricRepo.addMetric(QUERY_QUEUE_PENDING_BY_GROUP_SLOT_QUERIES);
+    }
+
+    public static void setQueryQueuePendingReason(QueryQueueStatistics stats) {
+        QUERY_QUEUE_PENDING_BY_GLOBAL_RESOURCE_QUERIES.increase(
+                -QUERY_QUEUE_PENDING_BY_GLOBAL_RESOURCE_QUERIES.getValue() + stats.getPendingByGlobalResourceQueries());
+        QUERY_QUEUE_PENDING_BY_GLOBAL_SLOT_QUERIES.increase(
+                -QUERY_QUEUE_PENDING_BY_GLOBAL_SLOT_QUERIES.getValue() + stats.getPendingByGlobalSlotQueries());
+        QUERY_QUEUE_PENDING_BY_GROUP_RESOURCE_QUERIES.increase(
+                -QUERY_QUEUE_PENDING_BY_GROUP_RESOURCE_QUERIES.getValue() + stats.getPendingByGroupResourceQueries());
+        QUERY_QUEUE_PENDING_BY_GROUP_SLOT_QUERIES.increase(
+                -QUERY_QUEUE_PENDING_BY_GROUP_SLOT_QUERIES.getValue() + stats.getPendingByGroupSlotQueries());
+    }
 
     /**
      * For the metric {@code starrocks_fe_query_resource_group}.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueStatistics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/QueryQueueStatistics.java
@@ -1,0 +1,83 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe.scheduler.slot;
+
+public class QueryQueueStatistics {
+    private int totalQueries = 0;
+    private int admittingQueries = 0;
+    private int pendingByGlobalResourceQueries = 0;
+    private int pendingByGlobalSlotQueries = 0;
+    private int pendingByGroupResourceQueries = 0;
+    private int pendingByGroupSlotQueries = 0;
+
+    public void reset(int totalQueries) {
+        this.totalQueries = totalQueries;
+        this.admittingQueries = 0;
+        this.pendingByGlobalResourceQueries = 0;
+        this.pendingByGlobalSlotQueries = 0;
+        this.pendingByGroupResourceQueries = 0;
+        this.pendingByGroupSlotQueries = 0;
+    }
+
+    public void finalizeStats() {
+        pendingByGlobalSlotQueries += totalQueries - admittingQueries -
+                pendingByGlobalResourceQueries - pendingByGlobalSlotQueries -
+                pendingByGroupResourceQueries - pendingByGroupSlotQueries;
+    }
+
+    public int getTotalQueries() {
+        return totalQueries;
+    }
+
+    public int getAdmittingQueries() {
+        return admittingQueries;
+    }
+
+    public int getPendingByGlobalResourceQueries() {
+        return pendingByGlobalResourceQueries;
+    }
+
+    public int getPendingByGlobalSlotQueries() {
+        return pendingByGlobalSlotQueries;
+    }
+
+    public int getPendingByGroupResourceQueries() {
+        return pendingByGroupResourceQueries;
+    }
+
+    public int getPendingByGroupSlotQueries() {
+        return pendingByGroupSlotQueries;
+    }
+
+    public void incrAdmittingQueries(int admittingQueries) {
+        this.admittingQueries += admittingQueries;
+    }
+
+    public void incrPendingByGlobalResourceQueries(int pendingByGlobalResourceQueries) {
+        this.pendingByGlobalResourceQueries += pendingByGlobalResourceQueries;
+    }
+
+    public void incrPendingByGlobalSlotQueries(int pendingByGlobalSlotQueries) {
+        this.pendingByGlobalSlotQueries += pendingByGlobalSlotQueries;
+    }
+
+    public void incrPendingByGroupResourceQueries(int pendingByGroupResourceQueries) {
+        this.pendingByGroupResourceQueries += pendingByGroupResourceQueries;
+    }
+
+    public void incrPendingByGroupSlotQueries(int pendingByGroupSlotQueries) {
+        this.pendingByGroupSlotQueries += pendingByGroupSlotQueries;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotRequestQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotRequestQueue.java
@@ -15,6 +15,7 @@
 package com.starrocks.qe.scheduler.slot;
 
 import com.starrocks.catalog.ResourceGroup;
+import com.starrocks.metric.ResourceGroupMetricMgr;
 import com.starrocks.qe.GlobalVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.BackendCoreStat;
@@ -47,6 +48,8 @@ public class SlotRequestQueue {
 
     private final BooleanSupplier isGlobalResourceOverloaded;
     private final Function<Long, Boolean> isGroupResourceOverloaded;
+
+    private final QueryQueueStatistics stats = new QueryQueueStatistics();
 
     public SlotRequestQueue(BooleanSupplier isGlobalResourceOverloaded, Function<Long, Boolean> isGroupResourceOverloaded) {
         this.isGlobalResourceOverloaded = isGlobalResourceOverloaded;
@@ -99,47 +102,65 @@ public class SlotRequestQueue {
             return slotsToAllocate;
         }
 
-        int numAllocatedSlots = allocatedSlots.getNumSlots();
-        int numAllocatedDrivers = allocatedSlots.getNumDrivers();
-        if (!isGlobalSlotAvailable(numAllocatedSlots) || isGlobalResourceOverloaded.getAsBoolean()) {
-            return slotsToAllocate;
-        }
+        stats.reset(slots.size());
+        try {
+            if (isGlobalResourceOverloaded.getAsBoolean()) {
+                stats.incrPendingByGlobalResourceQueries(stats.getTotalQueries());
+                return slotsToAllocate;
+            }
 
-        // Traverse groups round-robin from nextGroupIndex.
-        int localNextGroupIndex = nextGroupIndex;
-        Iterator<Map.Entry<Long, LinkedHashMap<TUniqueId, LogicalSlot>>> groupIterator = groupIdToSubQueue.entrySet().iterator();
-        for (int i = 0; i < localNextGroupIndex && groupIterator.hasNext(); i++) {
-            groupIterator.next();
-        }
-
-        for (int i = 0; i < groupIdToSubQueue.size(); i++) {
+            int numAllocatedSlots = allocatedSlots.getNumSlots();
+            int numAllocatedDrivers = allocatedSlots.getNumDrivers();
             if (!isGlobalSlotAvailable(numAllocatedSlots)) {
-                break;
+                stats.incrPendingByGlobalSlotQueries(stats.getTotalQueries());
+                return slotsToAllocate;
             }
 
-            localNextGroupIndex = (localNextGroupIndex + 1) % groupIdToSubQueue.size();
-            if (!groupIterator.hasNext()) {
-                groupIterator = groupIdToSubQueue.entrySet().iterator();
+            // Traverse groups round-robin from nextGroupIndex.
+            int localNextGroupIndex = nextGroupIndex;
+            Iterator<Map.Entry<Long, LinkedHashMap<TUniqueId, LogicalSlot>>> groupIterator =
+                    groupIdToSubQueue.entrySet().iterator();
+            for (int i = 0; i < localNextGroupIndex && groupIterator.hasNext(); i++) {
+                groupIterator.next();
             }
-            Map.Entry<Long, LinkedHashMap<TUniqueId, LogicalSlot>> entry = groupIterator.next();
-            Long groupId = entry.getKey();
-            LinkedHashMap<TUniqueId, LogicalSlot> subQueue = entry.getValue();
 
-            ResourceGroup group = GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup(groupId);
-            int numAllocatedSlotsOfGroup = allocatedSlots.getNumSlotsOfGroup(groupId);
-            AllocatedResource allocatedResource = peakSlotsToAllocateFromSubQueue(
-                    subQueue, group, numAllocatedSlots, numAllocatedSlotsOfGroup, numAllocatedDrivers, slotsToAllocate);
-            numAllocatedSlots += allocatedResource.numSlots;
-            numAllocatedDrivers += allocatedResource.numDrivers;
+            for (int i = 0; i < groupIdToSubQueue.size(); i++) {
+                if (!isGlobalSlotAvailable(numAllocatedSlots)) {
+                    break;
+                }
 
-            // If the group of the current index peaks slots to allocate, update nextGroupIndex to make the next turn starts
-            // from the next group index.
-            if (allocatedResource.numSlots > 0) {
-                nextGroupIndex = localNextGroupIndex;
+                localNextGroupIndex = (localNextGroupIndex + 1) % groupIdToSubQueue.size();
+                if (!groupIterator.hasNext()) {
+                    groupIterator = groupIdToSubQueue.entrySet().iterator();
+                }
+                Map.Entry<Long, LinkedHashMap<TUniqueId, LogicalSlot>> entry = groupIterator.next();
+                Long groupId = entry.getKey();
+                LinkedHashMap<TUniqueId, LogicalSlot> subQueue = entry.getValue();
+
+                if (subQueue.isEmpty()) {
+                    continue;
+                }
+
+                ResourceGroup group = GlobalStateMgr.getCurrentState().getResourceGroupMgr().getResourceGroup(groupId);
+                int numAllocatedSlotsOfGroup = allocatedSlots.getNumSlotsOfGroup(groupId);
+                AllocatedResource allocatedResource = peakSlotsToAllocateFromSubQueue(
+                        subQueue, group, numAllocatedSlots, numAllocatedSlotsOfGroup, numAllocatedDrivers, slotsToAllocate);
+                numAllocatedSlots += allocatedResource.numSlots;
+                numAllocatedDrivers += allocatedResource.numDrivers;
+                stats.incrAdmittingQueries(allocatedResource.numSlots);
+
+                // If the group of the current index peaks slots to allocate, update nextGroupIndex to make the next turn starts
+                // from the next group index.
+                if (allocatedResource.numSlots > 0) {
+                    nextGroupIndex = localNextGroupIndex;
+                }
             }
+
+            return slotsToAllocate;
+        } finally {
+            stats.finalizeStats();
+            ResourceGroupMetricMgr.setQueryQueuePendingReason(stats);
         }
-
-        return slotsToAllocate;
     }
 
     private boolean isGlobalSlotAvailable(int numAllocatedSlots) {
@@ -151,12 +172,14 @@ public class SlotRequestQueue {
         if (group == null) {
             return true;
         }
+        return !group.isConcurrencyLimitEffective() || numAllocatedSlotsOfGroup < group.getConcurrencyLimit();
+    }
 
-        if (group.isConcurrencyLimitEffective() && numAllocatedSlotsOfGroup >= group.getConcurrencyLimit()) {
+    private boolean isGroupResourceOverloaded(ResourceGroup group) {
+        if (group == null) {
             return false;
         }
-
-        return !isGroupResourceOverloaded.apply(group.getId());
+        return isGroupResourceOverloaded.apply(group.getId());
     }
 
     private int calculateSlotPipelineDop(final int numAllocatedDrivers, final int numFragmentsToAllocate) {
@@ -200,10 +223,17 @@ public class SlotRequestQueue {
         int numDriversToAllocate = 0;
         for (LogicalSlot slot : subQueue.values()) {
             if (!isGlobalSlotAvailable(numAllocatedSlots + numSlotsToAllocate)) {
+                stats.incrPendingByGlobalSlotQueries(subQueue.size() - numSlotsToAllocate);
                 break;
             }
 
             if (!isGroupSlotAvailable(group, numAllocatedSlotsOfGroup + numSlotsToAllocate)) {
+                stats.incrPendingByGroupSlotQueries(subQueue.size() - numSlotsToAllocate);
+                break;
+            }
+
+            if (isGroupResourceOverloaded(group)) {
+                stats.incrPendingByGroupResourceQueries(subQueue.size() - numSlotsToAllocate);
                 break;
             }
 
@@ -238,4 +268,5 @@ public class SlotRequestQueue {
             this.numDrivers = numDrivers;
         }
     }
+
 }


### PR DESCRIPTION
This is cherry-picked from #33030.

Add a FE metric `starrocks_fe_query_queue_pending_by` labeled by `reason` to show the number of queries pending by the specific reason.
Note that, this metric can be only retrieved from the leader FE.
```
starrocks_fe_query_queue_pending_by{reason="global_cpu_or_memory_limit"} 0
starrocks_fe_query_queue_pending_by{reason="global_concurrency_limit"} 0
starrocks_fe_query_queue_pending_by{reason="group_max_cpu_cores"} 0
starrocks_fe_query_queue_pending_by{reason="group_concurrency_limit"} 4
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
