### PR TITLE
[BugFix] Fix unimplements method in spillable AGG reset_state

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
@@ -22,7 +22,6 @@
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
-// TODO: implements reset_state
 class SpillableAggregateBlockingSinkOperator : public AggregateBlockingSinkOperator {
 public:
     template <class... Args>

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -102,6 +102,8 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::pull_chunk(RuntimeS
 
 Status SpillableAggregateBlockingSourceOperator::reset_state(RuntimeState* state,
                                                              const std::vector<ChunkPtr>& refill_chunks) {
+    _is_finished = false;
+    _has_last_chunk = true;
     _accumulator.reset_state();
     return Status::OK();
 }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
@@ -58,6 +58,8 @@ public:
         return 0;
     }
 
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+
 private:
     [[nodiscard]] Status _spill_all_inputs(RuntimeState* state, const ChunkPtr& chunk);
     [[nodiscard]] Status _spill_aggregated_data(RuntimeState* state);
@@ -116,7 +118,7 @@ public:
     void close(RuntimeState* state) override;
 
     [[nodiscard]] StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
-    bool pending_finish() const override { return _aggregator->has_pending_restore(); }
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 private:
     [[nodiscard]] StatusOr<ChunkPtr> _pull_spilled_chunk(RuntimeState* state);

--- a/be/src/exec/pipeline/bucket_process_operator.cpp
+++ b/be/src/exec/pipeline/bucket_process_operator.cpp
@@ -31,7 +31,7 @@ bool BucketProcessSinkOperator::need_input() const {
 }
 
 bool BucketProcessSinkOperator::is_finished() const {
-    return _ctx->all_input_finishing && _ctx->sink->is_finished();
+    return _ctx->finished || (_ctx->all_input_finishing && _ctx->sink->is_finished());
 }
 
 Status BucketProcessSinkOperator::set_finishing(RuntimeState* state) {
@@ -71,7 +71,7 @@ bool BucketProcessSourceOperator::has_output() const {
     return _ctx->current_bucket_sink_finished && (_ctx->source->has_output() || _ctx->source->is_finished());
 }
 bool BucketProcessSourceOperator::is_finished() const {
-    return _ctx->all_input_finishing && _ctx->source->is_finished();
+    return _ctx->finished || (_ctx->all_input_finishing && _ctx->source->is_finished());
 }
 Status BucketProcessSourceOperator::set_finished(RuntimeState* state) {
     _ctx->finished = true;

--- a/test/sql/test_spill/R/test_spill_aggregate
+++ b/test/sql/test_spill/R/test_spill_aggregate
@@ -63,3 +63,108 @@ select count(sl) from (select count(c1) sl from t0 group by c0) tb;
 -- result:
 4096
 -- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+create table t3 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t3 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into t3 values (null,null);
+-- result:
+-- !result
+insert into t3 select * from t3;
+-- result:
+-- !result
+insert into t3 select * from t3;
+-- result:
+-- !result
+select count(*) from t3;
+-- result:
+163844
+-- !result
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+-- result:
+None	None
+1	40959
+-- !result
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+-- result:
+40961	40960	0
+-- !result
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+-- result:
+100
+-- !result
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+-- result:
+40961	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+-- result:
+40860	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+-- result:
+10	110	163400
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+-- result:
+100	100	163440
+-- !result
+select count(*) from (select array_agg(c0) from t3 group by c0) tb;
+-- result:
+40961
+-- !result
+with agged as ( select c0 as lk, c1 from t3 group by 1,2 ) select count(*),count(l.lk),count(l.c1),count(r.lk),count(r.c1) from agged l join agged r on l.lk = r.lk;
+-- result:
+40960	40960	40960	40960	40960
+-- !result
+create table tempty like t3;
+-- result:
+-- !result
+select count(*) from (select distinct c0, c1 from t3 l left semi join tempty r on l.c0 = r.c0) tb; 
+
+CREATE TABLE `t4` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c0`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"colocate_with" = "spill_agg_colocate_1",
+"compression" = "LZ4"
+);
+-- result:
+0
+-- !result
+insert into t2 select * from t1;
+-- result:
+-- !result
+select distinct c0, c1 from t4 order by 1, 2 limit 2;
+-- result:
+-- !result
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t4) tb;
+-- result:
+0	None	None
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t4 group by c0 having c0 > 100) tb;
+-- result:
+0	None	None
+-- !result

--- a/test/sql/test_spill/T/test_spill_aggregate
+++ b/test/sql/test_spill/T/test_spill_aggregate
@@ -31,3 +31,55 @@ select max(sl) from (select sum(c1) sl from t0 group by c0) tb;
 select avg(sl) from (select sum(c1) sl from t0 group by c0) tb;
 select count(sl) from (select sum(c1) sl from t0 group by c0) tb;
 select count(sl) from (select count(c1) sl from t0 group by c0) tb;
+
+set pipeline_dop = 1;
+create table t3 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+
+insert into t3 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  40960));
+insert into t3 values (null,null);
+insert into t3 select * from t3;
+insert into t3 select * from t3;
+
+select count(*) from t3;
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+select count(*) from (select array_agg(c0) from t3 group by c0) tb;
+with agged as ( select c0 as lk, c1 from t3 group by 1,2 ) select count(*),count(l.lk),count(l.c1),count(r.lk),count(r.c1) from agged l join agged r on l.lk = r.lk;
+-- short_circuit case
+create table tempty like t3;
+select count(*) from (select distinct c0, c1 from t3 l left semi join tempty r on l.c0 = r.c0) tb; 
+
+CREATE TABLE `t4` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c0`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"colocate_with" = "spill_agg_colocate_1",
+"compression" = "LZ4"
+);
+insert into t2 select * from t1;
+
+select distinct c0, c1 from t4 order by 1, 2 limit 2;
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t4) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t4 group by c0 having c0 > 100) tb;


### PR DESCRIPTION
Fix unimplements method in spillable AGG reset_state. which will cause wrong result when enable per bucket optimize

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
