### PR TITLE
[Refactor] Move transaction methods to another file and more tests

### DIFF
--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "fs/fs.h"
+#include "testutil/sync_point.h"
 
 namespace starrocks::fs {
 
@@ -129,6 +130,7 @@ inline StatusOr<int64_t> copy(SequentialFile* src, WritableFile* dest, size_t bu
 
 // copy the file from src path to dest path, it will overwrite the existing files
 inline Status copy_file(const std::string& src_path, const std::string& dst_path) {
+    TEST_ERROR_POINT("fs::copy_file");
     WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     ASSIGN_OR_RETURN(auto src_fs, FileSystem::CreateSharedFromString(src_path));
     ASSIGN_OR_RETURN(auto dst_fs, FileSystem::CreateSharedFromString(dst_path));

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -18,19 +18,18 @@
 #include <bthread/condition_variable.h>
 #include <bthread/mutex.h>
 #include <butil/time.h> // NOLINT
-#include <bvar/bvar.h>
 
 #include "agent/agent_server.h"
 #include "common/config.h"
 #include "common/status.h"
 #include "fs/fs_util.h"
-#include "gutil/macros.h"
 #include "runtime/exec_env.h"
 #include "runtime/lake_snapshot_loader.h"
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/tablet.h"
+#include "storage/lake/transactions.h"
 #include "storage/lake/vacuum.h"
 #include "testutil/sync_point.h"
 #include "util/countdown_latch.h"
@@ -120,7 +119,7 @@ bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_n
 
 using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
 
-LakeServiceImpl::LakeServiceImpl(ExecEnv* env) : _env(env) {}
+LakeServiceImpl::LakeServiceImpl(ExecEnv* env, lake::TabletManager* tablet_mgr) : _env(env), _tablet_mgr(tablet_mgr) {}
 
 LakeServiceImpl::~LakeServiceImpl() = default;
 
@@ -179,14 +178,11 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             auto run_ts = butil::gettimeofday_us();
             auto base_version = request->base_version();
             auto new_version = request->new_version();
-            auto txns = request->txn_ids().data();
-            auto txns_size = request->txn_ids().size();
+            auto txns = std::span<const int64_t>(request->txn_ids().data(), request->txn_ids_size());
             auto commit_time = request->commit_time();
-            auto tablet_manager = _env->lake_tablet_manager();
             g_publish_tablet_version_queuing_latency << (run_ts - start_ts);
 
-            auto res =
-                    tablet_manager->publish_version(tablet_id, base_version, new_version, txns, txns_size, commit_time);
+            auto res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns, commit_time);
             if (res.ok()) {
                 auto metadata = std::move(res).value();
                 auto score = compaction_score(metadata);
@@ -255,8 +251,7 @@ void LakeServiceImpl::publish_log_version(::google::protobuf::RpcController* con
             DeferOp defer([&] { latch.count_down(); });
             auto txn_id = request->txn_id();
             auto version = request->version();
-
-            auto st = _env->lake_tablet_manager()->publish_log_version(tablet_id, txn_id, version);
+            auto st = lake::publish_log_version(_tablet_mgr, tablet_id, txn_id, version);
             if (!st.ok()) {
                 g_publish_version_failed_tasks << 1;
                 LOG(WARNING) << "Fail to rename txn log. tablet_id=" << tablet_id << " txn_id=" << txn_id << ": " << st;
@@ -289,9 +284,8 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
     for (auto tablet_id : request->tablet_ids()) {
         auto task = [&, tablet_id]() {
             DeferOp defer([&] { latch.count_down(); });
-            auto* txn_ids = request->txn_ids().data();
-            auto txn_ids_size = request->txn_ids_size();
-            _env->lake_tablet_manager()->abort_txn(tablet_id, txn_ids, txn_ids_size);
+            auto txn_ids = std::span<const int64_t>(request->txn_ids().data(), request->txn_ids_size());
+            lake::abort_txn(_tablet_mgr, tablet_id, txn_ids);
         };
         auto st = thread_pool->submit_func(task);
         if (!st.ok()) {
@@ -315,11 +309,6 @@ void LakeServiceImpl::delete_tablet(::google::protobuf::RpcController* controlle
         return;
     }
 
-    auto tablet_mgr = _env->lake_tablet_manager();
-    if (UNLIKELY(tablet_mgr == nullptr)) {
-        cntl->SetFailed("tablet manager is null");
-        return;
-    }
     auto thread_pool = delete_tablet_thread_pool(_env);
     if (UNLIKELY(thread_pool == nullptr)) {
         cntl->SetFailed("no thread pool to run task");
@@ -328,7 +317,7 @@ void LakeServiceImpl::delete_tablet(::google::protobuf::RpcController* controlle
     auto latch = BThreadCountDownLatch(1);
     auto st = thread_pool->submit_func([&]() {
         DeferOp defer([&] { latch.count_down(); });
-        lake::delete_tablets(tablet_mgr, *request, response);
+        lake::delete_tablets(_tablet_mgr, *request, response);
     });
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit delete tablet task: " << st;
@@ -363,7 +352,7 @@ void LakeServiceImpl::drop_table(::google::protobuf::RpcController* controller,
     auto latch = BThreadCountDownLatch(1);
     auto task = [&]() {
         DeferOp defer([&] { latch.count_down(); });
-        auto location = _env->lake_tablet_manager()->tablet_root_location(request->tablet_id());
+        auto location = _tablet_mgr->tablet_root_location(request->tablet_id());
         auto st = fs::remove_all(location);
         if (!st.ok() && !st.is_not_found()) {
             LOG(ERROR) << "Fail to remove " << location << ": " << st;
@@ -406,7 +395,7 @@ void LakeServiceImpl::delete_data(::google::protobuf::RpcController* controller,
     for (auto tablet_id : request->tablet_ids()) {
         auto task = [&, tablet_id]() {
             DeferOp defer([&] { latch.count_down(); });
-            auto tablet = _env->lake_tablet_manager()->get_tablet(tablet_id);
+            auto tablet = _tablet_mgr->get_tablet(tablet_id);
             if (!tablet.ok()) {
                 LOG(WARNING) << "Fail to get tablet " << tablet_id << ": " << tablet.status();
                 std::lock_guard l(response_mtx);
@@ -453,7 +442,7 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
         auto task = [&, tablet_info]() {
             DeferOp defer([&] { latch.count_down(); });
             int64_t tablet_id = tablet_info.tablet_id();
-            auto tablet = _env->lake_tablet_manager()->get_tablet(tablet_id);
+            auto tablet = _tablet_mgr->get_tablet(tablet_id);
             if (!tablet.ok()) {
                 LOG(WARNING) << "Fail to get tablet " << tablet_id << ": " << tablet.status();
                 return;
@@ -516,7 +505,7 @@ void LakeServiceImpl::lock_tablet_metadata(::google::protobuf::RpcController* co
     auto latch = BThreadCountDownLatch(1);
     auto task = [&]() {
         DeferOp defer([&] { latch.count_down(); });
-        auto tablet = _env->lake_tablet_manager()->get_tablet(request->tablet_id());
+        auto tablet = _tablet_mgr->get_tablet(request->tablet_id());
         if (!tablet.ok()) {
             LOG(ERROR) << "Fail to get tablet " << request->tablet_id();
             cntl->SetFailed("Fail to get tablet");
@@ -570,7 +559,7 @@ void LakeServiceImpl::unlock_tablet_metadata(::google::protobuf::RpcController* 
     auto latch = BThreadCountDownLatch(1);
     auto task = [&]() {
         DeferOp defer([&] { latch.count_down(); });
-        auto tablet = _env->lake_tablet_manager()->get_tablet(request->tablet_id());
+        auto tablet = _tablet_mgr->get_tablet(request->tablet_id());
         if (!tablet.ok()) {
             LOG(ERROR) << "Fail to get tablet " << request->tablet_id();
             cntl->SetFailed("Fail to get tablet");
@@ -673,7 +662,7 @@ void LakeServiceImpl::compact(::google::protobuf::RpcController* controller,
         return;
     }
 
-    _env->lake_tablet_manager()->compaction_scheduler()->compact(controller, request, response, guard.release());
+    _tablet_mgr->compaction_scheduler()->compact(controller, request, response, guard.release());
 }
 
 void LakeServiceImpl::abort_compaction(::google::protobuf::RpcController* controller,
@@ -690,7 +679,7 @@ void LakeServiceImpl::abort_compaction(::google::protobuf::RpcController* contro
         return;
     }
 
-    auto scheduler = _env->lake_tablet_manager()->compaction_scheduler();
+    auto scheduler = _tablet_mgr->compaction_scheduler();
     auto st = scheduler->abort(request->txn_id());
     TEST_SYNC_POINT("LakeServiceImpl::abort_compaction:aborted");
     st.to_protobuf(response->mutable_status());
@@ -732,7 +721,7 @@ void LakeServiceImpl::vacuum(::google::protobuf::RpcController* controller,
     auto latch = BThreadCountDownLatch(1);
     auto st = thread_pool->submit_func([&]() {
         DeferOp defer([&] { latch.count_down(); });
-        lake::vacuum(_env->lake_tablet_manager(), *request, response);
+        lake::vacuum(_tablet_mgr, *request, response);
     });
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;
@@ -756,7 +745,7 @@ void LakeServiceImpl::vacuum_full(::google::protobuf::RpcController* controller,
     auto latch = BThreadCountDownLatch(1);
     auto st = thread_pool->submit_func([&]() {
         DeferOp defer([&] { latch.count_down(); });
-        lake::vacuum_full(_env->lake_tablet_manager(), *request, response);
+        lake::vacuum_full(_tablet_mgr, *request, response);
     });
     if (!st.ok()) {
         LOG(WARNING) << "Fail to submit vacuum task: " << st;

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -254,7 +254,8 @@ void LakeServiceImpl::publish_log_version(::google::protobuf::RpcController* con
             auto st = lake::publish_log_version(_tablet_mgr, tablet_id, txn_id, version);
             if (!st.ok()) {
                 g_publish_version_failed_tasks << 1;
-                LOG(WARNING) << "Fail to rename txn log. tablet_id=" << tablet_id << " txn_id=" << txn_id << ": " << st;
+                LOG(WARNING) << "Fail to publish log version: " << st << " tablet_id=" << tablet_id
+                             << " txn_id=" << txn_id << " version=" << version;
                 std::lock_guard l(response_mtx);
                 response->add_failed_tablets(tablet_id);
             }

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -19,11 +19,14 @@
 namespace starrocks {
 
 class ExecEnv;
-class ThreadPool;
+
+namespace lake {
+class TabletManager;
+}
 
 class LakeServiceImpl : public ::starrocks::lake::LakeService {
 public:
-    explicit LakeServiceImpl(ExecEnv* env);
+    explicit LakeServiceImpl(ExecEnv* env, lake::TabletManager* tablet_mgr);
 
     ~LakeServiceImpl() override;
 
@@ -90,6 +93,7 @@ public:
 
 private:
     ExecEnv* _env;
+    lake::TabletManager* _tablet_mgr;
 };
 
 } // namespace starrocks

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -202,7 +202,7 @@ void start_be(const std::vector<StorePath>& paths, bool as_cn) {
 
     BackendInternalServiceImpl<PInternalService> internal_service(exec_env);
     BackendInternalServiceImpl<doris::PBackendService> backend_service(exec_env);
-    LakeServiceImpl lake_service(exec_env);
+    LakeServiceImpl lake_service(exec_env, exec_env->lake_tablet_manager());
 
     brpc_server->AddService(&internal_service, brpc::SERVER_DOESNT_OWN_SERVICE);
     brpc_server->AddService(&backend_service, brpc::SERVER_DOESNT_OWN_SERVICE);

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -187,6 +187,7 @@ add_library(Storage STATIC
     lake/tablet.cpp
     lake/tablet_manager.cpp
     lake/tablet_reader.cpp
+    lake/transactions.cpp
     lake/metadata_iterator.cpp
     lake/spark_load.cpp
     lake/update_manager.cpp

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -28,7 +28,6 @@
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "gutil/strings/util.h"
-#include "runtime/exec_env.h"
 #include "storage/lake/compaction_policy.h"
 #include "storage/lake/compaction_scheduler.h"
 #include "storage/lake/delta_writer.h"
@@ -123,10 +122,6 @@ static size_t get_metacache_usage(void*) {
 static bvar::PassiveStatus<size_t> g_metacache_capacity("lake", "metacache_capacity", get_metacache_capacity, nullptr);
 static bvar::PassiveStatus<size_t> g_metacache_usage("lake", "metacache_usage", get_metacache_usage, nullptr);
 #endif
-
-static StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, int64_t base_version,
-                                           int64_t new_version, const int64_t* txns, int txns_size,
-                                           int64_t commit_time);
 
 TabletManager::TabletManager(LocationProvider* location_provider, UpdateManager* update_mgr, int64_t cache_capacity)
         : _location_provider(location_provider),
@@ -557,18 +552,6 @@ Status TabletManager::delete_txn_vlog(int64_t tablet_id, int64_t version) {
     return st.is_not_found() ? Status::OK() : st;
 }
 
-Status TabletManager::delete_segment(int64_t tablet_id, std::string_view segment_name) {
-    erase_metacache(segment_name);
-    auto st = fs::delete_file(segment_location(tablet_id, segment_name));
-    return st.is_not_found() ? Status::OK() : st;
-}
-
-Status TabletManager::delete_del(int64_t tablet_id, std::string_view del_name) {
-    erase_metacache(del_name);
-    auto st = fs::delete_file(del_location(tablet_id, del_name));
-    return st.is_not_found() ? Status::OK() : st;
-}
-
 StatusOr<TxnLogIter> TabletManager::list_txn_log(int64_t tablet_id, bool filter_tablet) {
     std::vector<std::string> objects{};
     // TODO: construct prefix in LocationProvider
@@ -679,139 +662,6 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_index_id(int64_t t
     }
 }
 
-StatusOr<TabletMetadataPtr> TabletManager::publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version,
-                                                           const int64_t* txns, int txns_size, int64_t commit_time) {
-    ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id));
-    return publish(this, &tablet, base_version, new_version, txns, txns_size, commit_time);
-}
-
-StatusOr<TabletMetadataPtr> publish(TabletManager* tablet_mgr, Tablet* tablet, int64_t base_version,
-                                    int64_t new_version, const int64_t* txns, int txns_size, int64_t commit_time) {
-    if (txns_size != 1) {
-        return Status::NotSupported("does not support publish multiple txns yet");
-    }
-
-    auto new_version_metadata_or_error = [=](Status error) -> StatusOr<TabletMetadataPtr> {
-        auto res = tablet->get_metadata(new_version);
-        if (res.ok()) return res;
-        return error;
-    };
-
-    // Read base version metadata
-    auto res = tablet->get_metadata(base_version);
-    if (res.status().is_not_found()) {
-        return new_version_metadata_or_error(res.status());
-    }
-
-    if (!res.ok()) {
-        LOG(WARNING) << "Fail to get " << tablet->metadata_location(base_version) << ": " << res.status();
-        return res.status();
-    }
-
-    auto base_metadata = std::move(res).value();
-    auto new_metadata = std::make_shared<TabletMetadataPB>(*base_metadata);
-    auto log_applier = new_txn_log_applier(*tablet, new_metadata, new_version);
-
-    if (new_metadata->compaction_inputs_size() > 0) {
-        new_metadata->mutable_compaction_inputs()->Clear();
-    }
-
-    if (new_metadata->orphan_files_size() > 0) {
-        new_metadata->mutable_orphan_files()->Clear();
-    }
-
-    if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0) {
-        new_metadata->set_prev_garbage_version(base_metadata->version());
-    }
-
-    new_metadata->set_commit_time(commit_time);
-
-    auto init_st = log_applier->init();
-    if (!init_st.ok()) {
-        if (init_st.is_already_exist()) {
-            return new_version_metadata_or_error(init_st);
-        } else {
-            return init_st;
-        }
-    }
-
-    std::vector<std::string> files_to_delete;
-
-    // Apply txn logs
-    int64_t alter_version = -1;
-    for (int i = 0; i < txns_size; i++) {
-        auto txn_id = txns[i];
-        auto log_path = tablet_mgr->txn_log_location(tablet->id(), txn_id);
-        auto txn_log_st = tablet_mgr->get_txn_log(log_path, false);
-
-        if (txn_log_st.status().is_not_found()) {
-            return new_version_metadata_or_error(txn_log_st.status());
-        }
-
-        if (!txn_log_st.ok()) {
-            LOG(WARNING) << "Fail to get " << log_path << ": " << txn_log_st.status();
-            return txn_log_st.status();
-        }
-
-        auto& txn_log = txn_log_st.value();
-        if (txn_log->has_op_schema_change()) {
-            alter_version = txn_log->op_schema_change().alter_version();
-        }
-
-        auto st = log_applier->apply(*txn_log);
-        if (!st.ok()) {
-            LOG(WARNING) << "Fail to apply " << log_path << ": " << st;
-            return st;
-        }
-
-        files_to_delete.emplace_back(log_path);
-
-        tablet_mgr->metacache()->erase(CacheKey(log_path));
-    }
-
-    // Apply vtxn logs for schema change
-    // Should firstly apply schema change txn log, then apply txn version logs,
-    // because the rowsets in txn log are older.
-    if (alter_version != -1 && alter_version + 1 < new_version) {
-        DCHECK(base_version == 1 && txns_size == 1);
-        for (int64_t v = alter_version + 1; v < new_version; ++v) {
-            auto vlog_path = tablet_mgr->txn_vlog_location(tablet->id(), v);
-            auto txn_vlog = tablet_mgr->get_txn_vlog(vlog_path, false);
-            if (txn_vlog.status().is_not_found()) {
-                return new_version_metadata_or_error(txn_vlog.status());
-            }
-
-            if (!txn_vlog.ok()) {
-                LOG(WARNING) << "Fail to get " << vlog_path << ": " << txn_vlog.status();
-                return txn_vlog.status();
-            }
-
-            auto st = log_applier->apply(**txn_vlog);
-            if (!st.ok()) {
-                LOG(WARNING) << "Fail to apply " << vlog_path << ": " << st;
-                return st;
-            }
-
-            files_to_delete.emplace_back(vlog_path);
-
-            tablet_mgr->metacache()->erase(CacheKey(vlog_path));
-        }
-    }
-
-    // Save new metadata
-    RETURN_IF_ERROR(log_applier->finish());
-
-    // collect trash files, and remove them by background threads
-    auto trash_files = log_applier->trash_files();
-    if (trash_files != nullptr) {
-        files_to_delete.insert(files_to_delete.end(), trash_files->begin(), trash_files->end());
-    }
-
-    delete_files_async(std::move(files_to_delete));
-
-    return new_metadata;
-}
-
 StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t version, int64_t txn_id) {
     ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id));
     tablet.set_version_hint(version);
@@ -824,72 +674,6 @@ StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t ve
     } else {
         DCHECK(algorithm == HORIZONTAL_COMPACTION);
         return std::make_shared<HorizontalCompactionTask>(txn_id, version, std::move(tablet), std::move(input_rowsets));
-    }
-}
-
-void TabletManager::abort_txn(int64_t tablet_id, const int64_t* txns, int txns_size) {
-    std::vector<std::string> files_to_delete;
-    for (int i = 0; i < txns_size; i++) {
-        auto txn_id = txns[i];
-        auto log_path = txn_log_location(tablet_id, txn_id);
-        auto txn_log_or = get_txn_log(log_path, false);
-        if (!txn_log_or.ok()) {
-            LOG_IF(WARNING, !txn_log_or.status().is_not_found())
-                    << "Fail to get txn log " << log_path << ": " << txn_log_or.status();
-            continue;
-        }
-
-        TxnLogPtr txn_log = std::move(txn_log_or).value();
-        if (txn_log->has_op_write()) {
-            for (const auto& segment : txn_log->op_write().rowset().segments()) {
-                files_to_delete.emplace_back(segment_location(tablet_id, segment));
-            }
-            for (const auto& del_file : txn_log->op_write().dels()) {
-                files_to_delete.emplace_back(del_location(tablet_id, del_file));
-            }
-        }
-        if (txn_log->has_op_compaction()) {
-            for (const auto& segment : txn_log->op_compaction().output_rowset().segments()) {
-                files_to_delete.emplace_back(segment_location(tablet_id, segment));
-            }
-        }
-        if (txn_log->has_op_schema_change() && !txn_log->op_schema_change().linked_segment()) {
-            for (const auto& rowset : txn_log->op_schema_change().rowsets()) {
-                for (const auto& segment : rowset.segments()) {
-                    files_to_delete.emplace_back(segment_location(tablet_id, segment));
-                }
-            }
-        }
-
-        files_to_delete.emplace_back(log_path);
-
-        metacache()->erase(CacheKey(log_path));
-    }
-
-    delete_files_async(std::move(files_to_delete));
-}
-
-Status TabletManager::publish_log_version(int64_t tablet_id, int64_t txn_id, int64 log_version) {
-    auto txn_log_path = txn_log_location(tablet_id, txn_id);
-    auto txn_vlog_path = txn_vlog_location(tablet_id, log_version);
-    // TODO: use rename() API if supported by the underlying filesystem.
-    auto st = fs::copy_file(txn_log_path, txn_vlog_path);
-    if (st.is_not_found()) {
-        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(txn_vlog_path));
-        auto check_st = fs->path_exists(txn_vlog_path);
-        if (check_st.ok()) {
-            return Status::OK();
-        } else {
-            LOG_IF(WARNING, !check_st.is_not_found())
-                    << "Fail to check the existance of " << txn_vlog_path << ": " << check_st;
-            return st;
-        }
-    } else if (!st.ok()) {
-        return st;
-    } else {
-        delete_files_async({txn_log_path});
-        metacache()->erase(CacheKey(txn_log_path));
-        return Status::OK();
     }
 }
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -483,6 +483,11 @@ StatusOr<TxnLogPtr> TabletManager::load_txn_log(const std::string& txn_log_path,
     return std::move(meta);
 }
 
+StatusOr<TxnLogPtr> TabletManager::get_txn_vlog(const std::string& path, bool fill_cache) {
+    TEST_ERROR_POINT("TabletManager::get_txn_vlog");
+    return get_txn_log(path, fill_cache);
+}
+
 StatusOr<TxnLogPtr> TabletManager::get_txn_log(const std::string& path, bool fill_cache) {
     if (auto ptr = lookup_txn_log(path); ptr != nullptr) {
         TRACE("got cached txn log");

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -92,9 +92,7 @@ public:
 
     StatusOr<TxnLogPtr> get_txn_vlog(int64_t tablet_id, int64_t version);
 
-    StatusOr<TxnLogPtr> get_txn_vlog(const std::string& path, bool fill_cache = true) {
-        return get_txn_log(path, fill_cache);
-    }
+    StatusOr<TxnLogPtr> get_txn_vlog(const std::string& path, bool fill_cache = true);
 
     StatusOr<TxnLogIter> list_txn_log(int64_t tablet_id, bool filter_tablet);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -66,12 +66,6 @@ public:
 
     [[nodiscard]] Status delete_tablet(int64_t tablet_id);
 
-    // Returns the the newly created tablet metadata
-    StatusOr<TabletMetadataPtr> publish_version(int64_t tablet_id, int64_t base_version, int64_t new_version,
-                                                const int64_t* txns, int txns_size, int64_t commit_time);
-
-    void abort_txn(int64_t tablet_id, const int64_t* txns, int txns_size);
-
     StatusOr<CompactionTaskPtr> compact(int64_t tablet_id, int64_t version, int64_t txn_id);
 
     [[nodiscard]] Status put_tablet_metadata(const TabletMetadata& metadata);
@@ -107,13 +101,6 @@ public:
     [[nodiscard]] Status delete_txn_log(int64_t tablet_id, int64_t txn_id);
 
     [[nodiscard]] Status delete_txn_vlog(int64_t tablet_id, int64_t version);
-
-    [[nodiscard]] Status delete_segment(int64_t tablet_id, std::string_view segment_name);
-
-    [[nodiscard]] Status delete_del(int64_t tablet_id, std::string_view del_name);
-
-    // Transform a txn log into versioned txn log(i.e., rename `{tablet_id}_{txn_id}.log` to `{tablet_id}_{log_version}.vlog`)
-    [[nodiscard]] Status publish_log_version(int64_t tablet_id, int64_t txn_id, int64 log_version);
 
     [[nodiscard]] Status put_tablet_metadata_lock(int64_t tablet_id, int64_t version, int64_t expire_time);
 

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -20,7 +20,6 @@
 #include "storage/lake/txn_log.h"
 #include "storage/lake/txn_log_applier.h"
 #include "storage/lake/vacuum.h" // delete_files_async
-#include "testutil/sync_point.h"
 #include "util/lru_cache.h"
 
 namespace starrocks::lake {

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -152,7 +152,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
     return new_metadata;
 }
 
-Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id, int64 log_version) {
+Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id, int64_t log_version) {
     auto txn_log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
     auto txn_vlog_path = tablet_mgr->txn_vlog_location(tablet_id, log_version);
     // TODO: use rename() API if supported by the underlying filesystem.

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -1,0 +1,220 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/transactions.h"
+
+#include "fs/fs_util.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/txn_log.h"
+#include "storage/lake/txn_log_applier.h"
+#include "storage/lake/vacuum.h" // delete_files_async
+#include "util/lru_cache.h"
+
+namespace starrocks::lake {
+
+StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t base_version,
+                                            int64_t new_version, std::span<const int64_t> txn_ids,
+                                            int64_t commit_time) {
+    if (txn_ids.size() != 1) {
+        return Status::NotSupported("does not support publish multiple txns yet");
+    }
+
+    auto new_version_metadata_or_error = [=](Status error) -> StatusOr<TabletMetadataPtr> {
+        auto res = tablet_mgr->get_tablet_metadata(tablet_id, new_version);
+        if (res.ok()) return res;
+        return error;
+    };
+
+    // Read base version metadata
+    auto base_version_path = tablet_mgr->tablet_metadata_location(tablet_id, base_version);
+    auto base_metadata_or = tablet_mgr->get_tablet_metadata(base_version_path, false);
+    if (base_metadata_or.status().is_not_found()) {
+        return new_version_metadata_or_error(base_metadata_or.status());
+    }
+
+    if (!base_metadata_or.ok()) {
+        LOG(WARNING) << "Fail to get " << base_version_path << ": " << base_metadata_or.status();
+        return base_metadata_or.status();
+    }
+
+    auto base_metadata = std::move(base_metadata_or).value();
+    auto new_metadata = std::make_shared<TabletMetadataPB>(*base_metadata);
+    auto log_applier = new_txn_log_applier(Tablet(tablet_mgr, tablet_id), new_metadata, new_version);
+
+    if (new_metadata->compaction_inputs_size() > 0) {
+        new_metadata->mutable_compaction_inputs()->Clear();
+    }
+
+    if (new_metadata->orphan_files_size() > 0) {
+        new_metadata->mutable_orphan_files()->Clear();
+    }
+
+    if (base_metadata->compaction_inputs_size() > 0 || base_metadata->orphan_files_size() > 0) {
+        new_metadata->set_prev_garbage_version(base_metadata->version());
+    }
+
+    new_metadata->set_commit_time(commit_time);
+
+    auto init_st = log_applier->init();
+    if (!init_st.ok()) {
+        if (init_st.is_already_exist()) {
+            return new_version_metadata_or_error(init_st);
+        } else {
+            return init_st;
+        }
+    }
+
+    std::vector<std::string> files_to_delete;
+
+    // Apply txn logs
+    int64_t alter_version = -1;
+    for (auto txn_id : txn_ids) {
+        auto log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
+        auto txn_log_st = tablet_mgr->get_txn_log(log_path, false);
+
+        if (txn_log_st.status().is_not_found()) {
+            return new_version_metadata_or_error(txn_log_st.status());
+        }
+
+        if (!txn_log_st.ok()) {
+            LOG(WARNING) << "Fail to get " << log_path << ": " << txn_log_st.status();
+            return txn_log_st.status();
+        }
+
+        auto& txn_log = txn_log_st.value();
+        if (txn_log->has_op_schema_change()) {
+            alter_version = txn_log->op_schema_change().alter_version();
+        }
+
+        auto st = log_applier->apply(*txn_log);
+        if (!st.ok()) {
+            LOG(WARNING) << "Fail to apply " << log_path << ": " << st;
+            return st;
+        }
+
+        files_to_delete.emplace_back(log_path);
+
+        tablet_mgr->metacache()->erase(CacheKey(log_path));
+    }
+
+    // Apply vtxn logs for schema change
+    // Should firstly apply schema change txn log, then apply txn version logs,
+    // because the rowsets in txn log are older.
+    if (alter_version != -1 && alter_version + 1 < new_version) {
+        DCHECK(base_version == 1 && txn_ids.size() == 1);
+        for (int64_t v = alter_version + 1; v < new_version; ++v) {
+            auto vlog_path = tablet_mgr->txn_vlog_location(tablet_id, v);
+            auto txn_vlog = tablet_mgr->get_txn_vlog(vlog_path, false);
+            if (txn_vlog.status().is_not_found()) {
+                return new_version_metadata_or_error(txn_vlog.status());
+            }
+
+            if (!txn_vlog.ok()) {
+                LOG(WARNING) << "Fail to get " << vlog_path << ": " << txn_vlog.status();
+                return txn_vlog.status();
+            }
+
+            auto st = log_applier->apply(**txn_vlog);
+            if (!st.ok()) {
+                LOG(WARNING) << "Fail to apply " << vlog_path << ": " << st;
+                return st;
+            }
+
+            files_to_delete.emplace_back(vlog_path);
+
+            tablet_mgr->metacache()->erase(CacheKey(vlog_path));
+        }
+    }
+
+    // Save new metadata
+    RETURN_IF_ERROR(log_applier->finish());
+
+    // collect trash files, and remove them by background threads
+    auto trash_files = log_applier->trash_files();
+    if (trash_files != nullptr) {
+        files_to_delete.insert(files_to_delete.end(), trash_files->begin(), trash_files->end());
+    }
+
+    delete_files_async(std::move(files_to_delete));
+
+    return new_metadata;
+}
+
+Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id, int64 log_version) {
+    auto txn_log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
+    auto txn_vlog_path = tablet_mgr->txn_vlog_location(tablet_id, log_version);
+    // TODO: use rename() API if supported by the underlying filesystem.
+    auto st = fs::copy_file(txn_log_path, txn_vlog_path);
+    if (st.is_not_found()) {
+        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(txn_vlog_path));
+        auto check_st = fs->path_exists(txn_vlog_path);
+        if (check_st.ok()) {
+            return Status::OK();
+        } else {
+            LOG_IF(WARNING, !check_st.is_not_found())
+                    << "Fail to check the existance of " << txn_vlog_path << ": " << check_st;
+            return st;
+        }
+    } else if (!st.ok()) {
+        return st;
+    } else {
+        delete_files_async({txn_log_path});
+        tablet_mgr->metacache()->erase(CacheKey(txn_log_path));
+        return Status::OK();
+    }
+}
+
+void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const int64_t> txn_ids) {
+    std::vector<std::string> files_to_delete;
+    for (auto txn_id : txn_ids) {
+        auto log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
+        auto txn_log_or = tablet_mgr->get_txn_log(log_path, false);
+        if (!txn_log_or.ok()) {
+            LOG_IF(WARNING, !txn_log_or.status().is_not_found())
+                    << "Fail to get txn log " << log_path << ": " << txn_log_or.status();
+            continue;
+        }
+
+        TxnLogPtr txn_log = std::move(txn_log_or).value();
+        if (txn_log->has_op_write()) {
+            for (const auto& segment : txn_log->op_write().rowset().segments()) {
+                files_to_delete.emplace_back(tablet_mgr->segment_location(tablet_id, segment));
+            }
+            for (const auto& del_file : txn_log->op_write().dels()) {
+                files_to_delete.emplace_back(tablet_mgr->del_location(tablet_id, del_file));
+            }
+        }
+        if (txn_log->has_op_compaction()) {
+            for (const auto& segment : txn_log->op_compaction().output_rowset().segments()) {
+                files_to_delete.emplace_back(tablet_mgr->segment_location(tablet_id, segment));
+            }
+        }
+        if (txn_log->has_op_schema_change() && !txn_log->op_schema_change().linked_segment()) {
+            for (const auto& rowset : txn_log->op_schema_change().rowsets()) {
+                for (const auto& segment : rowset.segments()) {
+                    files_to_delete.emplace_back(tablet_mgr->segment_location(tablet_id, segment));
+                }
+            }
+        }
+
+        files_to_delete.emplace_back(log_path);
+
+        tablet_mgr->metacache()->erase(CacheKey(log_path));
+    }
+
+    delete_files_async(std::move(files_to_delete));
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -20,6 +20,7 @@
 #include "storage/lake/txn_log.h"
 #include "storage/lake/txn_log_applier.h"
 #include "storage/lake/vacuum.h" // delete_files_async
+#include "testutil/sync_point.h"
 #include "util/lru_cache.h"
 
 namespace starrocks::lake {

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -60,7 +60,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
 //
 // Return:
 // - Returns OK if the copy was successful, asynchronous deletion does not affect the return value.
-Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id, int64 log_version);
+Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id, int64_t log_version);
 
 // Aborts a transaction with the specified transaction IDs on the given tablet.
 //

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -23,12 +23,58 @@ namespace starrocks::lake {
 
 class TabletManager;
 
+// Publish a new version of tablet metadata by applying a set of transactions.
+//
+// This function does the following:
+//
+// 1. Load the base tablet metadata with id 'tablet_id' and version 'base_version'.
+// 2. Read the transaction logs for all 'txn_ids' sequentially and apply them to the base metadata.
+// 3. Save the result as a new tablet metadata with version 'new_version'.
+// 4. Update the metadata's commit timestamp to 'commit_time'.
+// 5. Persist the new metadata to the object storage.
+//
+// Parameters:
+// - tablet_mgr A pointer to the TabletManager object managing the tablet, cannot be nullptr
+// - tablet_id Id of the tablet
+// - base_version Version of the base metadata
+// - new_version The new version to be published
+// - txn_ids Transactions to apply in sequence
+// - commit_time New commit timestamp
+//
+// Return:
+// - StatusOr containing the new published TabletMetadataPtr on success.
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t base_version,
                                             int64_t new_version, std::span<const int64_t> txn_ids, int64_t commit_time);
 
-// Transform a txn log into versioned txn log(i.e., rename `{tablet_id}_{txn_id}.log` to `{tablet_id}_{log_version}.vlog`)
+// Publish a new version of a transaction log.
+//
+// This function does the following:
+// 1. copy the transaction log identified by 'txn_id' to a new file identified by 'log_version'
+// 2. Delete the transaction log identified by 'txn_id' in an asynchronous manner
+//
+// Parameters:
+// - tablet_mgr A pointer to the TabletManager object managing the tablet, cannot be nullptr
+// - tablet_id Id of the tablet
+// - txn_id ID of the transactions to abort
+// - log_version Version of the new file
+//
+// Return:
+// - Returns OK if the copy was successful, asynchronous deletion does not affect the return value.
 Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id, int64 log_version);
 
+// Aborts a transaction with the specified transaction IDs on the given tablet.
+//
+// This function does the following:
+//
+// 1. Read the transaction logs for all 'txn_ids' sequentially
+// 2. Collects the list of files logged in the transaction logs
+// 3. Delete all collected files and transaction logs
+//
+// Parameters:
+// - tablet_mgr A pointer to the TabletManager object managing the tablet, cannot be nullptr
+// - tablet_id The ID of the tablet where the transaction will be aborted.
+// - txn_ids A `std::span` of `int64_t` containing the transaction IDs to be aborted.
+//
 void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const int64_t> txn_ids);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <span>
+
+#include "common/statusor.h"
+#include "storage/lake/tablet_metadata.h"
+
+namespace starrocks::lake {
+
+class TabletManager;
+
+StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t base_version,
+                                            int64_t new_version, std::span<const int64_t> txn_ids, int64_t commit_time);
+
+// Transform a txn log into versioned txn log(i.e., rename `{tablet_id}_{txn_id}.log` to `{tablet_id}_{log_version}.vlog`)
+Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id, int64 log_version);
+
+void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, std::span<const int64_t> txn_ids);
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -23,6 +23,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/update_manager.h"
+#include "testutil/sync_point.h"
 #include "util/dynamic_cache.h"
 #include "util/phmap/phmap_fwd_decl.h"
 #include "util/trace.h"
@@ -219,6 +220,7 @@ public:
 
 private:
     Status apply_write_log(const TxnLogPB_OpWrite& op_write) {
+        TEST_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_write_log");
         if (op_write.has_rowset() && (op_write.rowset().num_rows() > 0 || op_write.rowset().has_delete_predicate())) {
             auto rowset = _metadata->add_rowsets();
             rowset->CopyFrom(op_write.rowset());
@@ -319,6 +321,7 @@ private:
     }
 
     Status apply_schema_change_log(const TxnLogPB_OpSchemaChange& op_schema_change) {
+        TEST_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_schema_change_log");
         DCHECK_EQ(0, _metadata->rowsets_size());
         for (const auto& rowset : op_schema_change.rowsets()) {
             DCHECK(rowset.has_id());

--- a/be/src/testutil/sync_point.h
+++ b/be/src/testutil/sync_point.h
@@ -176,7 +176,7 @@ private:
         if (!st.ok()) return st;                              \
     } while (0)
 #define TEST_ENABLE_ERROR_POINT(x, y) \
-    starrocks::SyncPoint::GetInstance()->SetCallBack(x, [](void* arg) { *(Status*)arg = y; })
+    starrocks::SyncPoint::GetInstance()->SetCallBack(x, [&](void* arg) { *(Status*)arg = y; })
 #define TEST_DISABLE_ERROR_POINT(x) starrocks::SyncPoint::GetInstance()->ClearCallBack(x)
 #endif // NDEBUG
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -19,7 +19,6 @@
 
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
-#include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/tablet.h"
@@ -36,9 +35,11 @@ namespace starrocks {
 
 class LakeServiceTest : public testing::Test {
 public:
-    LakeServiceTest() : _lake_service(ExecEnv::GetInstance()), _tablet_id(next_id()) {
-        _location_provider = new lake::FixedLocationProvider(kRootLocation);
-        _tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
+    LakeServiceTest()
+            : _tablet_id(next_id()),
+              _location_provider(new lake::FixedLocationProvider(kRootLocation)),
+              _tablet_mgr(ExecEnv::GetInstance()->lake_tablet_manager()),
+              _lake_service(ExecEnv::GetInstance(), ExecEnv::GetInstance()->lake_tablet_manager()) {
         _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName));
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName));
@@ -97,11 +98,11 @@ public:
 
 protected:
     constexpr static const char* const kRootLocation = "./lake_service_test";
-    LakeServiceImpl _lake_service;
     int64_t _tablet_id;
-    lake::TabletManager* _tablet_mgr;
     lake::LocationProvider* _location_provider;
+    lake::TabletManager* _tablet_mgr;
     lake::LocationProvider* _backup_location_provider;
+    LakeServiceImpl _lake_service;
 };
 
 // NOLINTNEXTLINE

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -690,7 +690,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_EQ("missing version", cntl.ErrorText());
     }
     for (auto inject_error : {Status::InternalError("injected"), Status::NotFound("injected")}) {
-        std::cerr << "Injected error: " << inject_error <<'\n';
+        std::cerr << "Injected error: " << inject_error << '\n';
         TEST_ENABLE_ERROR_POINT("fs::copy_file", inject_error);
         SyncPoint::GetInstance()->EnableProcessing();
         DeferOp defer([]() {

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -97,6 +97,30 @@ public:
     void TearDown() override { (void)_tablet_mgr->delete_tablet(_tablet_id); }
 
 protected:
+    // Return the new generated segment file name
+    std::string generate_segment_file(int64_t txn_id) {
+        auto seg_name = lake::gen_segment_filename(txn_id);
+        auto seg_path = _tablet_mgr->segment_location(_tablet_id, seg_name);
+        ASSIGN_OR_ABORT(auto f, fs::new_writable_file(seg_path));
+        CHECK_OK(f->append(seg_path));
+        CHECK_OK(f->close());
+        return seg_name;
+    }
+
+    lake::TxnLog generate_write_txn_log(int num_segments, int64_t num_rows, int64_t data_size) {
+        auto txn_id = next_id();
+        lake::TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        for (int i = 0; i < num_segments; i++) {
+            log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file(txn_id));
+        }
+        log.mutable_op_write()->mutable_rowset()->set_data_size(data_size);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(num_rows);
+        log.mutable_op_write()->mutable_rowset()->set_overlapped(num_segments > 1);
+        return log;
+    }
+
     constexpr static const char* const kRootLocation = "./lake_service_test";
     int64_t _tablet_id;
     lake::LocationProvider* _location_provider;
@@ -181,37 +205,23 @@ TEST_F(LakeServiceTest, test_publish_version_thread_pool_full) {
 
 // NOLINTNEXTLINE
 TEST_F(LakeServiceTest, test_publish_version_for_write) {
+    std::vector<lake::TxnLog> logs;
     // Empty TxnLog
-    {
-        lake::TxnLog txnlog;
-        txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(1000);
-        txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(0);
-        txnlog.mutable_op_write()->mutable_rowset()->set_data_size(0);
-        txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(false);
-        ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
-    }
-    // TxnLog with 2 segments
-    {
-        lake::TxnLog txnlog;
-        txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(1001);
-        txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
-        txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(101);
-        txnlog.mutable_op_write()->mutable_rowset()->set_data_size(4096);
-        txnlog.mutable_op_write()->mutable_rowset()->add_segments("1.dat");
-        txnlog.mutable_op_write()->mutable_rowset()->add_segments("2.dat");
-        ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
-    }
+    logs.emplace_back(generate_write_txn_log(0, 0, 0));
+    ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
 
-    // Publish version request for txn 1000
+    // TxnLog with 2 segments
+    logs.emplace_back(generate_write_txn_log(2, 101, 4096));
+    ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
+
+    // Publish version request for the first transaction
     lake::PublishVersionRequest publish_request_1000;
     publish_request_1000.set_base_version(1);
     publish_request_1000.set_new_version(2);
     publish_request_1000.add_tablet_ids(_tablet_id);
-    publish_request_1000.add_txn_ids(1000);
+    publish_request_1000.add_txn_ids(logs[0].txn_id());
 
-    // Publish txn 1000 failed: get base tablet metadata failed
+    // Publish txn failed: get base tablet metadata failed
     {
         _tablet_mgr->prune_metacache();
 
@@ -230,7 +240,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
     }
-    // Publish txn 1000 failed: get txn log failed
+    // Publish failed: get txn log failed
     {
         TEST_ENABLE_ERROR_POINT("TabletManager::load_txn_log", Status::IOError("injected get txn log error"));
 
@@ -246,22 +256,22 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
     }
-    // Publish txn 1000 success
+    // Publish txn success
     {
         lake::PublishVersionResponse response;
         _lake_service.publish_version(nullptr, &publish_request_1000, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
     }
 
-    // publish version request for txn 1001
-    lake::PublishVersionRequest publish_request_1001;
-    publish_request_1001.set_base_version(2);
-    publish_request_1001.set_new_version(3);
-    publish_request_1001.add_tablet_ids(_tablet_id);
-    publish_request_1001.add_txn_ids(1001);
-    publish_request_1001.set_commit_time(987654321);
+    // publish version request for the second transaction
+    lake::PublishVersionRequest publish_request_1;
+    publish_request_1.set_base_version(2);
+    publish_request_1.set_new_version(3);
+    publish_request_1.add_tablet_ids(_tablet_id);
+    publish_request_1.add_txn_ids(logs[1].txn_id());
+    publish_request_1.set_commit_time(987654321);
 
-    // Publish txn 1001 put tablet metadata failed
+    // Publish txn put tablet metadata failed
     {
         TEST_ENABLE_ERROR_POINT("TabletManager::put_tablet_metadata",
                                 Status::IOError("injected put tablet metadata error"));
@@ -274,15 +284,15 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         });
 
         lake::PublishVersionResponse response;
-        _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
+        _lake_service.publish_version(nullptr, &publish_request_1, &response, nullptr);
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(_tablet_id, response.failed_tablets(0));
     }
 
-    // Publish txn 1001
+    // Publish txn success
     {
         lake::PublishVersionResponse response;
-        _lake_service.publish_version(nullptr, &publish_request_1001, &response, nullptr);
+        _lake_service.publish_version(nullptr, &publish_request_1, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
     }
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
@@ -295,16 +305,16 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         ASSERT_EQ(1, metadata->rowsets(0).id());
         ASSERT_EQ(2, metadata->rowsets(0).segments_size());
         ASSERT_TRUE(metadata->rowsets(0).overlapped());
-        ASSERT_EQ(101, metadata->rowsets(0).num_rows());
-        ASSERT_EQ(4096, metadata->rowsets(0).data_size());
-        ASSERT_EQ("1.dat", metadata->rowsets(0).segments(0));
-        ASSERT_EQ("2.dat", metadata->rowsets(0).segments(1));
+        ASSERT_EQ(logs[1].op_write().rowset().num_rows(), metadata->rowsets(0).num_rows());
+        ASSERT_EQ(logs[1].op_write().rowset().data_size(), metadata->rowsets(0).data_size());
+        ASSERT_EQ(logs[1].op_write().rowset().segments(0), metadata->rowsets(0).segments(0));
+        ASSERT_EQ(logs[1].op_write().rowset().segments(1), metadata->rowsets(0).segments(1));
         EXPECT_EQ(987654321, metadata->commit_time());
     }
     ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
     // TxnLog`s should have been deleted
-    ASSERT_TRUE(tablet.get_txn_log(1000).status().is_not_found());
-    ASSERT_TRUE(tablet.get_txn_log(1001).status().is_not_found());
+    ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
+    ASSERT_TRUE(tablet.get_txn_log(logs[1].txn_id()).status().is_not_found());
 
     // Send publish version request again.
     {
@@ -313,7 +323,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         request.set_base_version(2);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1001);
+        request.add_txn_ids(logs[1].txn_id());
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
         ASSERT_EQ(1, response.compaction_scores_size());
@@ -326,7 +336,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
         request.add_tablet_ids(9999);
-        request.add_txn_ids(1001);
+        request.add_txn_ids(logs[1].txn_id());
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(1, response.failed_tablets_size());
         ASSERT_EQ(9999, response.failed_tablets(0));
@@ -355,7 +365,7 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
         request.set_base_version(2);
         request.set_new_version(3);
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1001);
+        request.add_txn_ids(logs[1].txn_id());
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
         ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
@@ -363,19 +373,17 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
 
     // Empty TxnLog
     {
-        lake::TxnLog txnlog;
-        txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(2000);
-        ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
+        logs.emplace_back(generate_write_txn_log(0, 0, 0));
+        ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
     }
-    // Publish txn 2000
+    // Publish txn
     {
         lake::PublishVersionRequest request;
         lake::PublishVersionResponse response;
         request.set_base_version(3);
         request.set_new_version(4);
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(2000);
+        request.add_txn_ids(logs[2].txn_id());
         request.set_commit_time(0);
         _lake_service.publish_version(nullptr, &request, &response, nullptr);
         ASSERT_EQ(0, response.failed_tablets_size());
@@ -387,54 +395,68 @@ TEST_F(LakeServiceTest, test_publish_version_for_write) {
 
 // NOLINTNEXTLINE
 TEST_F(LakeServiceTest, test_abort) {
+    std::vector<lake::TxnLog> logs;
+
     // Empty TxnLog
     {
-        lake::TxnLog txnlog;
-        txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(1000);
-        txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(0);
-        txnlog.mutable_op_write()->mutable_rowset()->set_data_size(0);
-        txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(false);
-        ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
-    }
-    // TxnLog with 2 segments
-    {
-        ASSIGN_OR_ABORT(auto seg1, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, "1.dat")));
-        ASSIGN_OR_ABORT(auto seg2, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, "2.dat")));
-        ASSERT_OK(seg1->append("xx"));
-        ASSERT_OK(seg2->append("yy"));
-        ASSERT_OK(seg1->close());
-        ASSERT_OK(seg2->close());
+        auto txn_id = next_id();
+        lake::TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
 
-        lake::TxnLog txnlog;
-        txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(1001);
-        txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
-        txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(101);
-        txnlog.mutable_op_write()->mutable_rowset()->set_data_size(4096);
-        txnlog.mutable_op_write()->mutable_rowset()->add_segments("1.dat");
-        txnlog.mutable_op_write()->mutable_rowset()->add_segments("2.dat");
-        ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
+        logs.emplace_back(log);
     }
-    // TxnLog with 2 segments generated by compaction task
-    {
-        ASSIGN_OR_ABORT(auto seg1, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, "3.dat")));
-        ASSIGN_OR_ABORT(auto seg2, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, "4.dat")));
-        ASSERT_OK(seg1->append("xx"));
-        ASSERT_OK(seg2->append("yy"));
-        ASSERT_OK(seg1->close());
-        ASSERT_OK(seg2->close());
 
-        lake::TxnLog txnlog;
-        txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(1002);
-        txnlog.mutable_op_compaction()->mutable_output_rowset()->set_overlapped(true);
-        txnlog.mutable_op_compaction()->mutable_output_rowset()->set_num_rows(101);
-        txnlog.mutable_op_compaction()->mutable_output_rowset()->set_data_size(4096);
-        txnlog.mutable_op_compaction()->mutable_output_rowset()->add_segments("3.dat");
-        txnlog.mutable_op_compaction()->mutable_output_rowset()->add_segments("4.dat");
-        ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
+    // Write txn log
+    {
+        auto txn_id = next_id();
+        lake::TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file(txn_id));
+        log.mutable_op_write()->mutable_rowset()->add_segments(generate_segment_file(txn_id));
+        log.mutable_op_write()->mutable_rowset()->set_data_size(4096);
+        log.mutable_op_write()->mutable_rowset()->set_num_rows(101);
+        log.mutable_op_write()->mutable_rowset()->set_overlapped(true);
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+        logs.emplace_back(log);
     }
+    // Compaction txn log
+    {
+        auto txn_id = next_id();
+        lake::TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_op_compaction()->mutable_output_rowset()->set_overlapped(false);
+        log.mutable_op_compaction()->mutable_output_rowset()->set_num_rows(101);
+        log.mutable_op_compaction()->mutable_output_rowset()->set_data_size(4096);
+        log.mutable_op_compaction()->mutable_output_rowset()->add_segments(generate_segment_file(txn_id));
+        log.mutable_op_compaction()->mutable_output_rowset()->add_segments(generate_segment_file(txn_id));
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+        logs.emplace_back(log);
+    }
+    // Schema change txn log
+    {
+        auto txn_id = next_id();
+        lake::TxnLog log;
+        log.set_tablet_id(_tablet_id);
+        log.set_txn_id(txn_id);
+        log.mutable_op_schema_change()->add_rowsets()->add_segments(generate_segment_file(txn_id));
+        log.mutable_op_schema_change()->add_rowsets()->add_segments(generate_segment_file(txn_id));
+        ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+        logs.emplace_back(log);
+    }
+
+    lake::AbortTxnRequest request;
+    request.add_tablet_ids(_tablet_id);
+    for (auto&& log : logs) {
+        request.add_txn_ids(log.txn_id());
+    }
+
     {
         TEST_ENABLE_ERROR_POINT("TabletManager::load_txn_log", Status::IOError("injected get txn log error"));
         SyncPoint::GetInstance()->EnableProcessing();
@@ -444,21 +466,11 @@ TEST_F(LakeServiceTest, test_abort) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::AbortTxnRequest request;
         lake::AbortTxnResponse response;
-        request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1000);
-        request.add_txn_ids(1001);
-        request.add_txn_ids(1002);
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
     {
-        lake::AbortTxnRequest request;
         lake::AbortTxnResponse response;
-        request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1000);
-        request.add_txn_ids(1001);
-        request.add_txn_ids(1002);
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
 
@@ -467,22 +479,24 @@ TEST_F(LakeServiceTest, test_abort) {
     ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
 
     // TxnLog`s and segments should have been deleted
-    ASSERT_TRUE(tablet.get_txn_log(1000).status().is_not_found());
-    ASSERT_TRUE(tablet.get_txn_log(1001).status().is_not_found());
-    ASSERT_TRUE(tablet.get_txn_log(1002).status().is_not_found());
-    ASSERT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, "1.dat")));
-    ASSERT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, "2.dat")));
-    ASSERT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, "3.dat")));
-    ASSERT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, "4.dat")));
+    for (auto&& log : logs) {
+        for (auto&& s : log.op_write().rowset().segments()) {
+            EXPECT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, s)));
+        }
+        for (auto&& s : log.op_compaction().output_rowset().segments()) {
+            EXPECT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, s)));
+        }
+        for (auto&& r : log.op_schema_change().rowsets()) {
+            for (auto&& s : r.segments()) {
+                EXPECT_FALSE(fs::path_exist(_tablet_mgr->segment_location(_tablet_id, s)));
+            }
+        }
+        EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, log.txn_id())));
+    }
 
     // Send AbortTxn request again
     {
-        lake::AbortTxnRequest request;
         lake::AbortTxnResponse response;
-        request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1000);
-        request.add_txn_ids(1001);
-        request.add_txn_ids(1002);
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
     // Thread pool is full
@@ -495,12 +509,7 @@ TEST_F(LakeServiceTest, test_abort) {
             SyncPoint::GetInstance()->DisableProcessing();
         });
 
-        lake::AbortTxnRequest request;
         lake::AbortTxnResponse response;
-        request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1000);
-        request.add_txn_ids(1001);
-        request.add_txn_ids(1002);
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
 }
@@ -641,10 +650,11 @@ TEST_F(LakeServiceTest, test_drop_table) {
 
 // NOLINTNEXTLINE
 TEST_F(LakeServiceTest, test_publish_log_version) {
+    auto txn_id = next_id();
     {
         lake::TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(1001);
+        txnlog.set_txn_id(txn_id);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
         txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(101);
         txnlog.mutable_op_write()->mutable_rowset()->set_data_size(4096);
@@ -673,17 +683,41 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         lake::PublishLogVersionRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.set_txn_id(1001);
+        request.set_txn_id(txn_id);
         brpc::Controller cntl;
         _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
         ASSERT_EQ("missing version", cntl.ErrorText());
     }
+    for (auto inject_error : {Status::InternalError("injected"), Status::NotFound("injected")}) {
+        std::cerr << "Injected error: " << inject_error <<'\n';
+        TEST_ENABLE_ERROR_POINT("fs::copy_file", inject_error);
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("fs::copy_file");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        lake::PublishLogVersionRequest request;
+        lake::PublishLogVersionResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.set_txn_id(txn_id);
+        request.set_version(10);
+        brpc::Controller cntl;
+        _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id)));
+        EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
+    }
     {
         lake::PublishLogVersionRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.set_txn_id(1001);
+        request.set_txn_id(txn_id);
         request.set_version(10);
         brpc::Controller cntl;
         _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
@@ -691,21 +725,15 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_EQ(0, response.failed_tablets_size());
 
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
-        _tablet_mgr->prune_metacache();
-
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 1001).status();
-
-        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_vlog(_tablet_id, 10));
-        ASSERT_EQ(_tablet_id, txn_log->tablet_id());
-        ASSERT_EQ(1001, txn_log->txn_id());
+        EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, txn_id)));
+        EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
     }
     // duplicate request
     {
         lake::PublishLogVersionRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.set_txn_id(1001);
+        request.set_txn_id(txn_id);
         request.set_version(10);
         brpc::Controller cntl;
         _lake_service.publish_log_version(&cntl, &request, &response, nullptr);
@@ -713,14 +741,7 @@ TEST_F(LakeServiceTest, test_publish_log_version) {
         ASSERT_EQ(0, response.failed_tablets_size());
 
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
-        _tablet_mgr->prune_metacache();
-
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 1001).status();
-
-        ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_vlog(_tablet_id, 10));
-        ASSERT_EQ(_tablet_id, txn_log->tablet_id());
-        ASSERT_EQ(1001, txn_log->txn_id());
+        EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 10)));
     }
 }
 
@@ -771,21 +792,99 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
         rowset1->set_data_size(13);
         rowset1->add_segments("3.dat");
         ASSERT_OK(_tablet_mgr->put_txn_log(txnlog));
+    }
 
-        lake::PublishVersionRequest request;
+    lake::PublishVersionRequest request;
+    request.set_base_version(1);
+    request.set_new_version(5);
+    request.add_tablet_ids(_tablet_id);
+    request.add_txn_ids(1001);
+
+    // fail to get txn vlog
+    {
+        TEST_ENABLE_ERROR_POINT("TabletManager::get_txn_vlog", Status::InternalError("injected internal error"));
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::get_txn_vlog");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
         lake::PublishVersionResponse response;
-        request.set_base_version(1);
-        request.set_new_version(5);
-        request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1001);
+        brpc::Controller cntl;
+        _lake_service.publish_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+    // txn vlog does not exit
+    {
+        TEST_ENABLE_ERROR_POINT("TabletManager::get_txn_vlog", Status::NotFound("injected not found"));
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("TabletManager::get_txn_vlog");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        lake::PublishVersionResponse response;
+        brpc::Controller cntl;
+        _lake_service.publish_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+    // apply schema change log failed
+    {
+        TEST_ENABLE_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_schema_change_log",
+                                Status::InternalError("injected apply error"));
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_schema_change_log");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        lake::PublishVersionResponse response;
+        brpc::Controller cntl;
+        _lake_service.publish_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+    // apply write log failed
+    {
+        TEST_ENABLE_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_write_log",
+                                Status::InternalError("injected apply error"));
+        SyncPoint::GetInstance()->EnableProcessing();
+        DeferOp defer([]() {
+            TEST_DISABLE_ERROR_POINT("NonPrimaryKeyTxnLogApplier::apply_write_log");
+            SyncPoint::GetInstance()->DisableProcessing();
+        });
+
+        lake::PublishVersionResponse response;
+        brpc::Controller cntl;
+        _lake_service.publish_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(1, response.failed_tablets_size());
+        ASSERT_EQ(_tablet_id, response.failed_tablets(0));
+    }
+    // apply success
+    {
+        lake::PublishVersionResponse response;
         brpc::Controller cntl;
         _lake_service.publish_version(&cntl, &request, &response, nullptr);
         ASSERT_FALSE(cntl.Failed());
         ASSERT_EQ(0, response.failed_tablets_size());
         ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
     }
-
     _tablet_mgr->prune_metacache();
+    // publish again
+    {
+        lake::PublishVersionResponse response;
+        brpc::Controller cntl;
+        _lake_service.publish_version(&cntl, &request, &response, nullptr);
+        ASSERT_FALSE(cntl.Failed());
+        ASSERT_EQ(0, response.failed_tablets_size());
+        ASSERT_TRUE(response.compaction_scores().contains(_tablet_id));
+    }
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
     ASSIGN_OR_ABORT(auto metadata, tablet.get_metadata(5));
     ASSERT_EQ(5, metadata->version());
@@ -805,6 +904,11 @@ TEST_F(LakeServiceTest, test_publish_version_for_schema_change) {
     ASSERT_EQ(4, rowset2.num_rows());
     ASSERT_EQ(14, rowset2.data_size());
     ASSERT_EQ(3, rowset2.segments_size());
+
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, 1000)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, 1001)));
+    EXPECT_FALSE(fs::path_exist(_tablet_mgr->txn_vlog_location(_tablet_id, 4)));
 }
 
 // NOLINTNEXTLINE

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -82,7 +82,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
 
-    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1, time(NULL));
+    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
 
@@ -98,7 +98,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
 
-    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1, time(NULL));
+    auto new_tablet_meta2 = publish_single_version(tablet_id, 3, txn_id2);
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(false, new_tablet_meta2.value()->enable_persistent_index());
 }
@@ -118,7 +118,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
     update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
 
-    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1, time(NULL));
+    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
 
@@ -135,7 +135,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
     update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
 
-    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1, time(NULL));
+    auto new_tablet_meta2 = publish_single_version(tablet_id, 3, txn_id2);
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(true, new_tablet_meta2.value()->enable_persistent_index());
 }

--- a/be/test/storage/lake/auto_increment_partial_update_test.cpp
+++ b/be/test/storage/lake/auto_increment_partial_update_test.cpp
@@ -206,7 +206,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
@@ -239,7 +239,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_write) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
@@ -276,7 +276,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_resolve_conflict) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));
@@ -313,7 +313,7 @@ TEST_F(LakeAutoIncrementPartialUpdateTest, test_resolve_conflict) {
     }
     // publish in order
     for (auto txn_id : txn_ids) {
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c1 - 1 == c0) && (c1 - 1 == c2); }));

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -175,7 +175,7 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -189,8 +189,7 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                      .status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
 
@@ -216,8 +215,7 @@ TEST_F(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                      .status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(0, read(version));
 }
@@ -344,7 +342,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 6, read(version));
@@ -367,8 +365,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
         CompactionTask::Progress progress;
         ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, progress.value());
-        ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                          .status());
+        ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
         version++;
         ASSERT_EQ(kChunkSize * 6, read(version));
     }
@@ -523,7 +520,7 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -537,8 +534,7 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                      .status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
 
@@ -672,7 +668,7 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -710,8 +706,7 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                      .status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize - 4, read(version));
 

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -192,7 +192,7 @@ TEST_P(ConditionUpdateTest, test_condition_update) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -226,7 +226,7 @@ TEST_P(ConditionUpdateTest, test_condition_update) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
         ASSERT_EQ(kChunkSize, check(version, [&](int c0, int c1, int c2) {
                       return (c0 * result[i].first == c1) && (c0 * result[i].second == c2);
@@ -264,7 +264,7 @@ TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -292,7 +292,7 @@ TEST_P(ConditionUpdateTest, test_condition_update_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -334,7 +334,7 @@ TEST_P(ConditionUpdateTest, test_condition_update_in_memtable) {
     ASSERT_OK(delta_writer->finish());
     delta_writer->close();
     // Publish version
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize, check(version, [&](int c0, int c1, int c2) {
                   return (c0 * result.first == c1) && (c0 * result.second == c2);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -223,7 +223,7 @@ TEST_P(LakePartialUpdateTest, test_write) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -248,7 +248,7 @@ TEST_P(LakePartialUpdateTest, test_write) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -285,7 +285,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -313,7 +313,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -354,7 +354,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -382,7 +382,7 @@ TEST_P(LakePartialUpdateTest, test_write_multi_segment_by_diff_val) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -422,7 +422,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -452,7 +452,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict) {
     // publish in order
     for (auto txn_id : txn_ids) {
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -490,7 +490,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -523,7 +523,7 @@ TEST_P(LakePartialUpdateTest, test_resolve_conflict_multi_segment) {
     // publish in order
     for (auto txn_id : txn_ids) {
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -563,7 +563,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -591,7 +591,7 @@ TEST_P(LakePartialUpdateTest, test_write_with_index_reload) {
         delta_writer->close();
         add_trash_files(tablet_id, txn_id);
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -629,7 +629,7 @@ TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
@@ -655,12 +655,12 @@ TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
 
         SyncPoint::GetInstance()->SetCallBack("ProtobufFile::save:serialize", [](void* arg) { *(bool*)arg = false; });
         SyncPoint::GetInstance()->EnableProcessing();
-        ASSERT_ERROR(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_ERROR(publish_single_version(tablet_id, version + 1, txn_id).status());
         SyncPoint::GetInstance()->ClearCallBack("ProtobufFile::save:serialize");
         SyncPoint::GetInstance()->DisableProcessing();
     }
     // retry publish again
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
     _tablet_mgr->prune_metacache();
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
 }

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -224,7 +224,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read(version));
@@ -248,7 +248,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+    ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
     if (GetParam().enable_persistent_index) {
@@ -290,7 +290,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -303,8 +303,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                      .status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
     if (GetParam().enable_persistent_index) {
@@ -355,7 +354,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 2, read(version));
@@ -368,8 +367,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     CompactionTask::Progress progress;
     ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, progress.value());
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                      .status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
@@ -410,7 +408,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -459,7 +457,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     {
@@ -477,7 +475,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy2) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 6, read(version));
@@ -534,7 +532,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     {
@@ -552,7 +550,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_policy3) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     config::write_buffer_size = old_size;
@@ -605,7 +603,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_score_by_policy) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -660,7 +658,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -686,8 +684,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
         EXPECT_EQ(_update_mgr->compaction_state_mem_tracker()->consumption(), 0);
     }
     // publish version
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), version, version + 1, &txn_id, 1, time(NULL))
-                      .status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
 

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -184,8 +184,6 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success) {
     ASSERT_OK(writer->finish());
 
     // write txnlog
-    int64_t logs[1];
-    logs[0] = txn_id;
     auto txn_log = std::make_shared<TxnLog>();
     txn_log->set_tablet_id(_tablet_metadata->id());
     txn_log->set_txn_id(txn_id);
@@ -201,7 +199,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success) {
 
     writer->close();
 
-    ASSERT_OK(_tablet_mgr->publish_version(_tablet_metadata->id(), 1, 2, logs, 1, time(NULL)).status());
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(_tablet_metadata->id(), txn_id));
 
     // read at version 2
@@ -239,7 +237,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
         version++;
     }
@@ -279,7 +277,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
         version++;
     }
@@ -331,7 +329,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
         version++;
     }
@@ -363,7 +361,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
         version++;
         txns.push_back(txn_id);
@@ -372,12 +370,11 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
     // duplicate publish
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version - 1, version, &txns.back(), 1, time(NULL)).status());
+    ASSERT_OK(publish_single_version(tablet_id, version, txns.back()).status());
     // publish using old version
-    ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version - 2, version - 1, &txns.back(), 1, time(NULL)).status());
+    ASSERT_OK(publish_single_version(tablet_id, version - 1, txns.back()).status());
     // advince publish should fail, because version + 1 don't exist
-    ASSERT_ERROR(
-            _tablet_mgr->publish_version(tablet_id, version + 1, version + 2, &txns.back(), 1, time(NULL)).status());
+    ASSERT_ERROR(publish_single_version(tablet_id, version + 2, txns.back()).status());
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
@@ -405,9 +402,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
         // start to publish using multi thread
         std::vector<std::thread> workers;
         for (int j = 0; j < 5; j++) {
-            workers.emplace_back([&]() {
-                (void)_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL));
-            });
+            workers.emplace_back([&]() { (void)publish_single_version(tablet_id, version + 1, txn_id); });
         }
         for (auto& t : workers) {
             t.join();
@@ -441,7 +436,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         version++;
     }
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
@@ -469,7 +464,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
     }
     // publish in order
     for (int64_t txn_id : txn_ids) {
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
         version++;
     }
@@ -513,7 +508,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success_multiple_tablet) {
             ASSERT_OK(w->finish());
             w->close();
             // Publish version
-            ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+            ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
             EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
         }
         version++;
@@ -550,7 +545,7 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
         // Publish version
-        ASSERT_OK(_tablet_mgr->publish_version(tablet_id, version, version + 1, &txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
         EXPECT_TRUE(_update_mgr->TEST_check_update_state_cache_noexist(tablet_id, txn_id));
         version++;
     }

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -30,6 +30,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/tablet_reader.h"
+#include "storage/lake/test_util.h"
 #include "storage/lake/update_manager.h"
 #include "testutil/assert.h"
 #include "testutil/id_generator.h"
@@ -90,6 +91,12 @@ protected:
             }
         }
         return chunk;
+    }
+
+    Status publish_version_for_schema_change(int64_t tablet_id, int64_t new_version, int64_t txn_id) {
+        return publish_version(_tablet_manager.get(), tablet_id, 1, new_version, std::span<const int64_t>(&txn_id, 1),
+                               time(nullptr))
+                .status();
     }
 
     std::unique_ptr<MemTracker> _mem_tracker;
@@ -248,8 +255,7 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
         ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
-                          .status());
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
         version++;
         txn_id++;
     }
@@ -294,7 +300,7 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
         ASSERT_OK(delta_writer->write(chunk1, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_log_version(new_tablet_id, txn_id, version + 1));
+        ASSERT_OK(TEST_publish_single_log_version(_tablet_manager.get(), new_tablet_id, txn_id, version + 1));
         version++;
         txn_id++;
     }
@@ -302,14 +308,12 @@ TEST_P(SchemaChangeAddColumnTest, test_add_column) {
     // publish schema change
     int concurrency = GetParam().concurrency;
     if (concurrency == 1) {
-        ASSERT_OK(
-                _tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
     } else {
         std::vector<std::thread> threads;
         for (int i = 0; i < concurrency; i++) {
-            threads.emplace_back([&]() {
-                (void)_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL));
-            });
+            threads.emplace_back(
+                    [&]() { (void)publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id); });
         }
         for (auto& t : threads) {
             t.join();
@@ -506,8 +510,7 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
         ASSERT_OK(delta_writer->write(chunk0, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
-                          .status());
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
         version++;
         txn_id++;
     }
@@ -551,21 +554,19 @@ TEST_P(SchemaChangeModifyColumnTypeTest, test_alter_column_type) {
         ASSERT_OK(delta_writer->write(chunk1, indexes, sizeof(indexes) / sizeof(indexes[0])));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_log_version(new_tablet_id, txn_id, version + 1));
+        ASSERT_OK(TEST_publish_single_log_version(_tablet_manager.get(), new_tablet_id, txn_id, version + 1));
         version++;
         txn_id++;
     }
 
     int concurrency = GetParam().concurrency;
     if (concurrency == 1) {
-        ASSERT_OK(
-                _tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
+        ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
     } else {
         std::vector<std::thread> threads;
         for (int i = 0; i < concurrency; i++) {
-            threads.emplace_back([&]() {
-                (void)_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL));
-            });
+            threads.emplace_back(
+                    [&]() { (void)publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id); });
         }
         for (auto& t : threads) {
             t.join();
@@ -788,8 +789,7 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
-                          .status());
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
         version++;
         txn_id++;
     }
@@ -823,12 +823,12 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_log_version(new_tablet_id, txn_id, version + 1));
+        ASSERT_OK(TEST_publish_single_log_version(_tablet_manager.get(), new_tablet_id, txn_id, version + 1));
         version++;
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
+    ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
     version++;
     txn_id++;
 
@@ -1050,8 +1050,7 @@ TEST_P(SchemaChangeSortKeyReorderTest1, test_alter_sortkey_reorder_1) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
-                          .status());
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
         version++;
         txn_id++;
     }
@@ -1085,12 +1084,12 @@ TEST_P(SchemaChangeSortKeyReorderTest1, test_alter_sortkey_reorder_1) {
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_log_version(new_tablet_id, txn_id, version + 1));
+        ASSERT_OK(TEST_publish_single_log_version(_tablet_manager.get(), new_tablet_id, txn_id, version + 1));
         version++;
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
+    ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
     version++;
     txn_id++;
 
@@ -1289,8 +1288,7 @@ TEST_P(SchemaChangeSortKeyReorderTest2, test_alter_sortkey_reorder2) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
-                          .status());
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
         version++;
         txn_id++;
     }
@@ -1324,12 +1322,12 @@ TEST_P(SchemaChangeSortKeyReorderTest2, test_alter_sortkey_reorder2) {
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_log_version(new_tablet_id, txn_id, version + 1));
+        ASSERT_OK(TEST_publish_single_log_version(_tablet_manager.get(), new_tablet_id, txn_id, version + 1));
         version++;
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
+    ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
     version++;
     txn_id++;
 
@@ -1526,8 +1524,7 @@ TEST_P(SchemaChangeSortKeyReorderTest3, test_alter_sortkey_reorder3) {
         ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_version(base_tablet_id, version, version + 1, &txn_id, 1, time(NULL))
-                          .status());
+        ASSERT_OK(TEST_publish_single_version(_tablet_manager.get(), base_tablet_id, version + 1, txn_id).status());
         version++;
         txn_id++;
     }
@@ -1561,12 +1558,12 @@ TEST_P(SchemaChangeSortKeyReorderTest3, test_alter_sortkey_reorder3) {
         ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
         ASSERT_OK(delta_writer->finish());
         delta_writer->close();
-        ASSERT_OK(_tablet_manager->publish_log_version(new_tablet_id, txn_id, version + 1));
+        ASSERT_OK(TEST_publish_single_log_version(_tablet_manager.get(), new_tablet_id, txn_id, version + 1));
         version++;
         txn_id++;
     }
 
-    ASSERT_OK(_tablet_manager->publish_version(new_tablet_id, 1, version + 1, &alter_txn_id, 1, time(NULL)).status());
+    ASSERT_OK(publish_version_for_schema_change(new_tablet_id, version + 1, alter_txn_id));
     version++;
     txn_id++;
 

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -20,15 +20,23 @@
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
+#include "service/service_be/lake_service.h"
 #include "storage/lake/filenames.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/lake/transactions.h"
 #include "storage/lake/update_manager.h"
 #include "storage/tablet_meta_manager.h"
 #include "testutil/assert.h"
 
 namespace starrocks::lake {
+
+StatusOr<TabletMetadataPtr> TEST_publish_single_version(TabletManager* tablet_mgr, int64_t tablet_id,
+                                                        int64_t new_version, int64_t txn_id);
+
+Status TEST_publish_single_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id,
+                                       int64_t log_version);
 
 class TestBase : public ::testing::Test {
 public:
@@ -66,6 +74,10 @@ protected:
         ASSERT_TRUE(index_meta.version().major_number() == expected_version);
     }
 
+    StatusOr<TabletMetadataPtr> publish_single_version(int64_t tablet_id, int64_t new_version, int64_t txn_id);
+
+    Status publish_single_log_version(int64_t tablet_id, int64_t txn_id, int64_t log_version);
+
     std::string _test_dir;
     std::unique_ptr<MemTracker> _parent_tracker;
     std::unique_ptr<MemTracker> _mem_tracker;
@@ -77,5 +89,56 @@ protected:
 struct PrimaryKeyParam {
     bool enable_persistent_index = false;
 };
+
+inline StatusOr<TabletMetadataPtr> TEST_publish_single_version(TabletManager* tablet_mgr, int64_t tablet_id,
+                                                               int64_t new_version, int64_t txn_id) {
+    lake::PublishVersionRequest request;
+    lake::PublishVersionResponse response;
+
+    request.add_tablet_ids(tablet_id);
+    request.add_txn_ids(txn_id);
+    request.set_base_version(new_version - 1);
+    request.set_new_version(new_version);
+    request.set_commit_time(time(nullptr));
+
+    auto lake_service = LakeServiceImpl(ExecEnv::GetInstance(), tablet_mgr);
+    lake_service.publish_version(nullptr, &request, &response, nullptr);
+
+    if (response.failed_tablets_size() == 0) {
+        return tablet_mgr->get_tablet_metadata(tablet_id, new_version);
+    } else {
+        return Status::InternalError(fmt::format("failed to publish version. tablet_id={} txn_id={} new_version={}",
+                                                 tablet_id, txn_id, new_version));
+    }
+}
+
+inline Status TEST_publish_single_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id,
+                                              int64_t log_version) {
+    lake::PublishLogVersionRequest request;
+    lake::PublishLogVersionResponse response;
+
+    request.add_tablet_ids(tablet_id);
+    request.set_txn_id(txn_id);
+    request.set_version(log_version);
+
+    auto lake_service = LakeServiceImpl(ExecEnv::GetInstance(), tablet_mgr);
+    lake_service.publish_log_version(nullptr, &request, &response, nullptr);
+
+    if (response.failed_tablets_size() == 0) {
+        return Status::OK();
+    } else {
+        return Status::InternalError(fmt::format("failed to publish log version. tablet_id={} txn_id={} version={}",
+                                                 tablet_id, txn_id, log_version));
+    }
+}
+
+inline StatusOr<TabletMetadataPtr> TestBase::publish_single_version(int64_t tablet_id, int64_t new_version,
+                                                                    int64_t txn_id) {
+    return TEST_publish_single_version(_tablet_mgr.get(), tablet_id, new_version, txn_id);
+}
+
+inline Status TestBase::publish_single_log_version(int64_t tablet_id, int64_t txn_id, int64_t log_version) {
+    return TEST_publish_single_log_version(_tablet_mgr.get(), tablet_id, txn_id, log_version);
+}
 
 } // namespace starrocks::lake


### PR DESCRIPTION
- Move lake::TabletManager::{publish_version(), abort_txn(), publish_log_version()} to another file.
- Add some unit tests to cover more cases.
- Use the higher-level LakeService module's publish_version/abort_txn/publish_log_version interface in unit tests.
- Reducing Duplicate Code in Unit Tests.
- Remove two unused methods: lake::TabletManager::{delete_segment(), delete_del()}

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
