### PR TITLE
[BugFix] avoid coroutine leaks in hash join probe

### DIFF
--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -428,6 +428,11 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         }
 
         *has_remain = _probe_state->has_remain;
+#ifdef BE_TEST
+        if (!_probe_state->has_remain && !_probe_state->handles.empty()) {
+            throw runtime_error(print_id(state->fragment_instance_id()) + " haven't remain tuples but have coroutines");
+        }
+#endif
     }
 
     if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN || _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN) {
@@ -820,20 +825,28 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
     _probe_state->count = match_count;
 }
 
-#define DO_PROBE(X, Y)                                                                  \
-    if (_probe_state->active_coroutines != 0) {                                         \
-        if constexpr (first_probe) {                                                    \
-            auto group_size = std::abs(state->query_options().interleaving_group_size); \
-            _probe_state->cur_probe_index = 0;                                          \
-            _probe_state->handles.clear();                                              \
-            for (int i = 0; i < group_size; ++i) {                                      \
-                _probe_state->handles.insert(X(state, build_data, data));               \
-            }                                                                           \
-            _probe_state->active_coroutines = group_size;                               \
-        }                                                                               \
-        _probe_coroutine<first_probe, Y>(state, build_data, data);                      \
-    } else {                                                                            \
-        X<first_probe>(state, build_data, data);                                        \
+#define DO_PROBE(X, Y)                                                                                          \
+    if (_probe_state->active_coroutines != 0) {                                                                 \
+        if constexpr (first_probe) {                                                                            \
+            auto group_size = std::abs(state->query_options().interleaving_group_size);                         \
+            _probe_state->cur_probe_index = 0;                                                                  \
+            if (!_probe_state->handles.empty()) {                                                               \
+                for (auto& h : _probe_state->handles) {                                                         \
+                    h.destroy();                                                                                \
+                }                                                                                               \
+                _probe_state->handles.clear();                                                                  \
+                std::string msg =                                                                               \
+                        "fragment = " + print_id(state->fragment_instance_id()) + " 's probe leaks coroutines"; \
+                throw std::runtime_error(msg + ", please set interleaving_group_size = 0 to disable it");       \
+            }                                                                                                   \
+            for (int i = 0; i < group_size; ++i) {                                                              \
+                _probe_state->handles.insert(X(state, build_data, data));                                       \
+            }                                                                                                   \
+            _probe_state->active_coroutines = group_size;                                                       \
+        }                                                                                                       \
+        _probe_coroutine<first_probe, Y>(state, build_data, data);                                              \
+    } else {                                                                                                    \
+        X<first_probe>(state, build_data, data);                                                                \
     }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
@@ -1011,6 +1024,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_coroutine(RuntimeState* state
     while (!_probe_state->handles.empty()) {
         for (auto it = _probe_state->handles.begin(); it != _probe_state->handles.end();) {
             if (it->promise().exception != nullptr) {
+                LOG(WARNING) << print_id(state->fragment_instance_id()) << " coroutine rethrow exceptions";
                 std::rethrow_exception(it->promise().exception);
             }
             if (it->done()) {
@@ -1020,7 +1034,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_coroutine(RuntimeState* state
                 it->resume();
                 it++;
             }
-            if (_probe_state->count == state->chunk_size()) {
+            if (_probe_state->count == state->chunk_size() && _probe_state->has_remain) {
                 return;
             }
         }

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -428,12 +428,14 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         }
 
         *has_remain = _probe_state->has_remain;
-#ifdef BE_TEST
-        if (!_probe_state->has_remain && !_probe_state->handles.empty()) {
-            throw std::runtime_error(print_id(state->fragment_instance_id()) +
-                                     " haven't remain tuples but have coroutines");
+
+        if (UNLIKELY(!_probe_state->has_remain && !_probe_state->handles.empty())) {
+            std::string msg =
+                    "HashJoin probe haven't remain tuples but have coroutines, likely leaking coroutines, please set "
+                    "global interleaving_group_size = 0 to disable coroutines, rerun this query and report to SR";
+            LOG(ERROR) << "fragment = " << print_id(state->fragment_instance_id()) << " " << msg;
+            throw std::runtime_error(msg);
         }
-#endif
     }
 
     if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN || _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN) {
@@ -826,30 +828,30 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_search_ht_remain(RuntimeState* stat
     _probe_state->count = match_count;
 }
 
-#define DO_PROBE(X, Y)                                                                               \
-    if (_probe_state->active_coroutines != 0) {                                                      \
-        if constexpr (first_probe) {                                                                 \
-            auto group_size = std::abs(state->query_options().interleaving_group_size);              \
-            _probe_state->cur_probe_index = 0;                                                       \
-            if (!_probe_state->handles.empty()) {                                                    \
-                for (auto& h : _probe_state->handles) {                                              \
-                    h.destroy();                                                                     \
-                }                                                                                    \
-                _probe_state->handles.clear();                                                       \
-                std::string msg = "HashJoin probe leaks coroutines, " +                              \
-                                  "please set global interleaving_group_size = 0 " +                 \
-                                  "to disable coroutines, rerun this query and report to SR";        \
-                LOG(ERROR) << "fragment = " + print_id(state->fragment_instance_id()) << " " << msg; \
-                throw std::runtime_error(msg);                                                       \
-            }                                                                                        \
-            for (int i = 0; i < group_size; ++i) {                                                   \
-                _probe_state->handles.insert(X(state, build_data, data));                            \
-            }                                                                                        \
-            _probe_state->active_coroutines = group_size;                                            \
-        }                                                                                            \
-        _probe_coroutine<first_probe, Y>(state, build_data, data);                                   \
-    } else {                                                                                         \
-        X<first_probe>(state, build_data, data);                                                     \
+#define DO_PROBE(X, Y)                                                                                               \
+    if (_probe_state->active_coroutines != 0) {                                                                      \
+        if constexpr (first_probe) {                                                                                 \
+            auto group_size = std::abs(state->query_options().interleaving_group_size);                              \
+            _probe_state->cur_probe_index = 0;                                                                       \
+            if (!_probe_state->handles.empty()) {                                                                    \
+                for (auto& h : _probe_state->handles) {                                                              \
+                    h.destroy();                                                                                     \
+                }                                                                                                    \
+                _probe_state->handles.clear();                                                                       \
+                std::string msg =                                                                                    \
+                        "HashJoin probe leaks coroutines, please set global interleaving_group_size = 0 to disable " \
+                        "coroutines, rerun this query and report to SR";                                             \
+                LOG(ERROR) << "fragment = " + print_id(state->fragment_instance_id()) << " " << msg;                 \
+                throw std::runtime_error(msg);                                                                       \
+            }                                                                                                        \
+            for (int i = 0; i < group_size; ++i) {                                                                   \
+                _probe_state->handles.insert(X(state, build_data, data));                                            \
+            }                                                                                                        \
+            _probe_state->active_coroutines = group_size;                                                            \
+        }                                                                                                            \
+        _probe_coroutine<first_probe, Y>(state, build_data, data);                                                   \
+    } else {                                                                                                         \
+        X<first_probe>(state, build_data, data);                                                                     \
     }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -430,7 +430,8 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         *has_remain = _probe_state->has_remain;
 #ifdef BE_TEST
         if (!_probe_state->has_remain && !_probe_state->handles.empty()) {
-            throw runtime_error(print_id(state->fragment_instance_id()) + " haven't remain tuples but have coroutines");
+            throw std::runtime_error(print_id(state->fragment_instance_id()) +
+                                     " haven't remain tuples but have coroutines");
         }
 #endif
     }


### PR DESCRIPTION
for a group of coroutines, when a part of them is done, and reach the condition that the result chunks is full, then the control functions (aka. `_probe_coroutine()`) returns, leaving some running coroutines. To avoid such cases, we change the return conditions of the control functions, additionally check the state of `has_remain`. 

In the control functions, when the result chunk is full, if `has_remain` is false, it will be true when there are new comming results and return, or waiting all coroutines finish to return.

Besides, we check if `has_remain` is false, there should not be coroutines after probing a chunk.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature ` manually tests on a cluster.`
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
