### PR TITLE
[Enhancement] use session variable to control cross join penalty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -543,6 +543,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String AUDIT_EXECUTE_STMT = "audit_execute_stmt";
 
+    public static final String CROSS_JOIN_COST_PENALTY = "cross_join_cost_penalty";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1381,6 +1383,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_PREDICATE_SUBFIELD_PATH, flag = VariableMgr.INVISIBLE)
     private boolean cboPredicateSubfieldPath = true;
+
+    @VarAttr(name = CROSS_JOIN_COST_PENALTY, flag = VariableMgr.INVISIBLE)
+    private long crossJoinCostPenalty = 1000000;
 
     public String getHiveTempStagingDir() {
         return hiveTempStagingDir;
@@ -2689,6 +2694,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public boolean getEnablePlanSerializeConcurrently() {
         return enablePlanSerializeConcurrently;
+    }
+
+    public long getCrossJoinCostPenalty() {
+        return crossJoinCostPenalty;
+    }
+
+    public void setCrossJoinCostPenalty(long crossJoinCostPenalty) {
+        this.crossJoinCostPenalty = crossJoinCostPenalty;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/cost/CostModel.java
@@ -63,6 +63,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.optimizer.statistics.StatisticsEstimateCoefficient.EXECUTE_COST_PENALTY;
+
 public class CostModel {
 
     private static final Logger LOG = LogManager.getLogger(CostModel.class);
@@ -443,7 +445,7 @@ public class CostModel {
                 return CostEstimate.of(leftStatistics.getOutputSize(context.getChildOutputColumns(0))
                                 + rightStatistics.getOutputSize(context.getChildOutputColumns(1)),
                         rightStatistics.getOutputSize(context.getChildOutputColumns(1))
-                                * StatisticsEstimateCoefficient.CROSS_JOIN_COST_PENALTY * 100D, 0);
+                                * EXECUTE_COST_PENALTY * 100D, 0);
             } else {
                 return CostEstimate.of((leftStatistics.getOutputSize(context.getChildOutputColumns(0))
                                 + rightStatistics.getOutputSize(context.getChildOutputColumns(1)) / 2),
@@ -459,18 +461,24 @@ public class CostModel {
 
             double leftSize = leftStatistics.getOutputSize(context.getChildOutputColumns(0));
             double rightSize = rightStatistics.getOutputSize(context.getChildOutputColumns(1));
-            double cpuCost = StatisticUtils.multiplyOutputSize(StatisticUtils.multiplyOutputSize(leftSize, rightSize),
-                    StatisticsEstimateCoefficient.CROSS_JOIN_COST_PENALTY);
-            double memCost = StatisticUtils.multiplyOutputSize(rightSize,
-                    StatisticsEstimateCoefficient.CROSS_JOIN_COST_PENALTY * 100D);
 
+            long crossJoinCostPenalty = ConnectContext.get().getSessionVariable().getCrossJoinCostPenalty();
+
+            double cpuCost = StatisticUtils.multiplyOutputSize(StatisticUtils.multiplyOutputSize(leftSize, rightSize),
+                    EXECUTE_COST_PENALTY);
+            double memCost = StatisticUtils.multiplyOutputSize(rightSize, EXECUTE_COST_PENALTY * 100D);
+
+
+            if (join.getJoinType().isCrossJoin()) {
+                cpuCost = StatisticUtils.multiplyOutputSize(cpuCost, crossJoinCostPenalty);
+            }
             // Right cross join could not be parallelized, so apply more punishment
             if (join.getJoinType().isRightJoin()) {
                 // Add more punishment when right size is 10x greater than left size.
                 if (rightSize > 10 * leftSize) {
-                    cpuCost *= StatisticsEstimateCoefficient.CROSS_JOIN_RIGHT_COST_PENALTY;
+                    cpuCost *= EXECUTE_COST_PENALTY;
                 } else {
-                    cpuCost += StatisticsEstimateCoefficient.CROSS_JOIN_RIGHT_COST_PENALTY;
+                    cpuCost += EXECUTE_COST_PENALTY;
                 }
                 memCost += rightSize;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/join/JoinOrder.java
@@ -17,7 +17,7 @@ package com.starrocks.sql.optimizer.rule.join;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.starrocks.analysis.JoinOperator;
-import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.Group;
 import com.starrocks.sql.optimizer.OptExpression;
@@ -287,10 +287,10 @@ public abstract class JoinOrder {
 
             LogicalJoinOperator joinOperator = (LogicalJoinOperator) exprInfo.expr.getOp();
             if (joinOperator.getJoinType().isCrossJoin()) {
-                cost = cost > (StatisticsEstimateCoefficient.MAXIMUM_COST /
-                        StatisticsEstimateCoefficient.CROSS_JOIN_COST_PENALTY) ?
+                long crossJoinCostPenalty = ConnectContext.get().getSessionVariable().getCrossJoinCostPenalty();
+                cost = cost > (StatisticsEstimateCoefficient.MAXIMUM_COST / crossJoinCostPenalty) ?
                         StatisticsEstimateCoefficient.MAXIMUM_COST :
-                        cost * StatisticsEstimateCoefficient.CROSS_JOIN_COST_PENALTY;
+                        cost * crossJoinCostPenalty;
             }
         }
         exprInfo.cost = cost;
@@ -299,31 +299,20 @@ public abstract class JoinOrder {
     protected Optional<ExpressionInfo> buildJoinExpr(GroupInfo leftGroup, GroupInfo rightGroup) {
         ExpressionInfo leftExprInfo = leftGroup.bestExprInfo;
         ExpressionInfo rightExprInfo = rightGroup.bestExprInfo;
-        Pair<ScalarOperator, ScalarOperator> predicates = buildInnerJoinPredicate(leftGroup.atoms, rightGroup.atoms);
-
-        ScalarOperator eqPredicate = predicates.first;
-        ScalarOperator otherPredicate = predicates.second;
+        ScalarOperator onPredicates = buildInnerJoinPredicate(leftGroup.atoms, rightGroup.atoms);
 
         LogicalJoinOperator newJoin;
-        if (eqPredicate != null) {
-            newJoin = new LogicalJoinOperator(JoinOperator.INNER_JOIN, eqPredicate);
+
+        if (onPredicates != null) {
+            newJoin = new LogicalJoinOperator(JoinOperator.INNER_JOIN, onPredicates);
         } else {
             newJoin = new LogicalJoinOperator(JoinOperator.CROSS_JOIN, null);
         }
-        newJoin.setPredicate(otherPredicate);
 
         Map<ColumnRefOperator, ScalarOperator> leftExpression = new HashMap<>();
         Map<ColumnRefOperator, ScalarOperator> rightExpression = new HashMap<>();
-        if (eqPredicate != null || otherPredicate != null) {
-            ColumnRefSet useColumns = new ColumnRefSet();
-
-            if (eqPredicate != null) {
-                useColumns.union(eqPredicate.getUsedColumns());
-            }
-
-            if (otherPredicate != null) {
-                useColumns.union(otherPredicate.getUsedColumns());
-            }
+        if (onPredicates != null) {
+            ColumnRefSet useColumns = onPredicates.getUsedColumns();
 
             for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : expressionMap.entrySet()) {
                 if (!useColumns.contains(entry.getKey())) {
@@ -348,8 +337,7 @@ public abstract class JoinOrder {
         pushRequiredColumns(leftExprInfo, leftExpression);
         pushRequiredColumns(rightExprInfo, rightExpression);
 
-        // In StarRocks, we only support hash join.
-        // So we always use small table as right child
+        // use small table as right child
         OptExpression joinExpr;
         if (leftExprInfo.rowCount < rightExprInfo.rowCount) {
             joinExpr = OptExpression.create(newJoin, rightExprInfo.expr,
@@ -402,12 +390,8 @@ public abstract class JoinOrder {
         exprInfo.expr.deriveLogicalPropertyItself();
     }
 
-    /*
-     * Pair<Equal-On-Predicate, Other-Predicate>
-     */
-    private Pair<ScalarOperator, ScalarOperator> buildInnerJoinPredicate(BitSet left, BitSet right) {
-        List<ScalarOperator> equalOnPredicates = Lists.newArrayList();
-        List<ScalarOperator> otherPredicates = Lists.newArrayList();
+    private ScalarOperator buildInnerJoinPredicate(BitSet left, BitSet right) {
+        List<ScalarOperator> onPredicates = Lists.newArrayList();
         BitSet joinBitSet = new BitSet();
         joinBitSet.or(left);
         joinBitSet.or(right);
@@ -416,14 +400,10 @@ public abstract class JoinOrder {
             if (contains(joinBitSet, edge.vertexes) &&
                     left.intersects(edge.vertexes) &&
                     right.intersects(edge.vertexes)) {
-                if (Utils.isEqualBinaryPredicate(edge.predicate)) {
-                    equalOnPredicates.add(edge.predicate);
-                } else {
-                    otherPredicates.add(edge.predicate);
-                }
+                onPredicates.add(edge.predicate);
             }
         }
-        return new Pair<>(Utils.compoundAnd(equalOnPredicates), Utils.compoundAnd(otherPredicates));
+        return Utils.compoundAnd(onPredicates);
     }
 
     public boolean canBuildInnerJoinPredicate(GroupInfo leftGroup, GroupInfo rightGroup) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsEstimateCoefficient.java
@@ -55,10 +55,8 @@ public class StatisticsEstimateCoefficient {
     // default or predicate limit
     public static final int DEFAULT_OR_OPERATOR_LIMIT = 16;
 
-    public static final double CROSS_JOIN_COST_PENALTY = 2;
 
-    public static final int CROSS_JOIN_RIGHT_COST_PENALTY = 2;
-
+    public static final double EXECUTE_COST_PENALTY = 2;
     public static final int BROADCAST_JOIN_MEM_EXCEED_PENALTY = 1000;
 
     public static final double MAXIMUM_COST = Double.MAX_VALUE / Math.pow(10, 50);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MultiJoinReorderTest.java
@@ -202,11 +202,9 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "  |----25:EXCHANGE"));
 
         // Right sub join tree (a)
-        assertContains(planFragment, "  22:NESTLOOP JOIN\n" +
+        assertContains(planFragment, "23:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  \n" +
-                "  |----21:EXCHANGE\n");
+                "  |  colocate: false, reason:");
     }
 
     @Test
@@ -219,15 +217,15 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "join (select * from t1 join t3 on t1.v4 = t3.v10 join t0 on t1.v4 = t0.v2 join t2 on t1.v5 = t2.v8) as a  " +
                 "on t1.v5 = a.v8 ";
         String planFragment = getCostExplain(sql);
-        Assert.assertTrue(planFragment, planFragment.contains("  23:HASH JOIN\n" +
+        Assert.assertTrue(planFragment, planFragment.contains("24:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  equal join conjunct: [1: v4, BIGINT, true] = [4: v10, BIGINT, true]\n" +
                 "  |  output columns: 7\n" +
-                "  |  cardinality: 900000000\n"));
+                "  |  cardinality: 900000000"));
 
-        Assert.assertTrue(planFragment, planFragment.contains("  18:HASH JOIN\n" +
+        Assert.assertTrue(planFragment, planFragment.contains("19:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  equal join conjunct: [13: v10, BIGINT, true] = [10: v4, BIGINT, true]\n"));
+                "  |  equal join conjunct: [13: v10, BIGINT, true] = [10: v4, BIGINT, true]"));
     }
 
     @Test
@@ -310,47 +308,35 @@ public class MultiJoinReorderTest extends PlanTestBase {
                 "     TABLE: t3\n");
 
         // Left sub join tree (b)
-        Assert.assertTrue(planFragment, planFragment.contains("  26:HASH JOIN\n" +
+        Assert.assertTrue(planFragment, planFragment.contains("26:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  equal join conjunct: 10: count = 12: v5\n" +
                 "  |  \n" +
                 "  |----25:EXCHANGE\n" +
                 "  |    \n" +
-                "  23:Project\n" +
+                "  18:Project\n" +
                 "  |  <slot 10> : 10: count\n" +
                 "  |  \n" +
-                "  22:NESTLOOP JOIN\n" +
-                "  |  join op: CROSS JOIN\n" +
-                "  |  colocate: false, reason: \n" +
-                "  |  \n" +
-                "  |----21:EXCHANGE\n" +
-                "  |    \n" +
-                "  2:Project\n" +
-                "  |  <slot 26> : 1\n" +
-                "  |  \n" +
-                "  1:OlapScanNode\n" +
-                "     TABLE: t2\n" +
-                "     PREAGGREGATION: ON\n" +
-                "     partitions=1/1\n" +
-                "     rollup: t2\n" +
-                "     tabletRatio=3/3\n"));
+                "  17:NESTLOOP JOIN"));
 
         // Right sub join tree (a)
-        assertContains(planFragment, "  STREAM DATA SINK\n" +
-                "    EXCHANGE ID: 21\n" +
+        assertContains(planFragment, "STREAM DATA SINK\n" +
+                "    EXCHANGE ID: 25\n" +
                 "    UNPARTITIONED\n" +
                 "\n" +
-                "  20:Project\n" +
-                "  |  <slot 10> : 10: count\n" +
+                "  24:Project\n" +
+                "  |  <slot 11> : 11: v4\n" +
+                "  |  <slot 12> : 12: v5\n" +
                 "  |  \n" +
-                "  19:NESTLOOP JOIN\n" +
+                "  23:NESTLOOP JOIN\n" +
                 "  |  join op: CROSS JOIN\n" +
                 "  |  colocate: false, reason: \n" +
                 "  |  \n" +
-                "  |----18:EXCHANGE\n" +
+                "  |----22:EXCHANGE\n" +
                 "  |    \n" +
-                "  15:AGGREGATE (merge finalize)");
+                "  19:OlapScanNode\n" +
+                "     TABLE: t1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -626,11 +626,11 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         FeConstants.isReplayFromQueryDump = true;
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/hive_tpch08_resource"), null, TExplainLevel.COSTS);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("21:HASH JOIN\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("5:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  equal join conjunct: [52: n_regionkey, INT, true] = [58: r_regionkey, INT, true]\n" +
                 "  |  build runtime filters:\n" +
-                "  |  - filter_id = 3, build_expr = (58: r_regionkey), remote = false\n" +
+                "  |  - filter_id = 0, build_expr = (58: r_regionkey), remote = false\n" +
                 "  |  output columns: 50\n" +
                 "  |  cardinality: 5"));
         FeConstants.isReplayFromQueryDump = false;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -464,7 +464,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/multi_view_cross_join"), null, TExplainLevel.NORMAL);
         // check without exception
-        Assert.assertTrue(replayPair.second, replayPair.second.contains(" 40:Project\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains(" 39:Project\n" +
                 "  |  <slot 1> : 1: c_0_0"));
     }
 

--- a/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q7.sql
+++ b/fe/fe-core/src/test/resources/sql/enumerate-plan/tpch-q7.sql
@@ -58,7 +58,7 @@ TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: ye
                                             INNER JOIN (join-predicate [4: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
                                                 SCAN (columns[1: S_SUPPKEY, 4: S_NATIONKEY] predicate[null])
                                                 EXCHANGE BROADCAST
-                                                    CROSS JOIN (join-predicate [null] post-join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA])
+                                                    INNER JOIN (join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA] post-join-predicate [null])
                                                         SCAN (columns[45: N_NATIONKEY, 46: N_NAME] predicate[46: N_NAME IN (CANADA, IRAN)])
                                                         EXCHANGE BROADCAST
                                                             SCAN (columns[50: N_NATIONKEY, 51: N_NAME] predicate[51: N_NAME IN (IRAN, CANADA)])
@@ -81,7 +81,7 @@ TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: ye
                                             INNER JOIN (join-predicate [4: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
                                                 SCAN (columns[1: S_SUPPKEY, 4: S_NATIONKEY] predicate[null])
                                                 EXCHANGE BROADCAST
-                                                    CROSS JOIN (join-predicate [null] post-join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA])
+                                                    INNER JOIN (join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA] post-join-predicate [null])
                                                         SCAN (columns[45: N_NATIONKEY, 46: N_NAME] predicate[46: N_NAME IN (CANADA, IRAN)])
                                                         EXCHANGE BROADCAST
                                                             SCAN (columns[50: N_NATIONKEY, 51: N_NAME] predicate[51: N_NAME IN (IRAN, CANADA)])
@@ -105,7 +105,31 @@ TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: ye
                                                 INNER JOIN (join-predicate [4: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
                                                     SCAN (columns[1: S_SUPPKEY, 4: S_NATIONKEY] predicate[null])
                                                     EXCHANGE BROADCAST
-                                                        CROSS JOIN (join-predicate [null] post-join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA])
+                                                        INNER JOIN (join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA] post-join-predicate [null])
+                                                            SCAN (columns[45: N_NATIONKEY, 46: N_NAME] predicate[46: N_NAME IN (CANADA, IRAN)])
+                                                            EXCHANGE BROADCAST
+                                                                SCAN (columns[50: N_NATIONKEY, 51: N_NAME] predicate[51: N_NAME IN (IRAN, CANADA)])
+[end]
+[plan-4]
+TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
+    TOP-N (order by [[46: N_NAME ASC NULLS FIRST, 51: N_NAME ASC NULLS FIRST, 55: year ASC NULLS FIRST]])
+        AGGREGATE ([GLOBAL] aggregate [{57: sum=sum(57: sum)}] group by [[46: N_NAME, 51: N_NAME, 55: year]] having [null]
+            EXCHANGE SHUFFLE[46, 51, 55]
+                AGGREGATE ([LOCAL] aggregate [{57: sum=sum(56: expr)}] group by [[46: N_NAME, 51: N_NAME, 55: year]] having [null]
+                    INNER JOIN (join-predicate [36: C_CUSTKEY = 27: O_CUSTKEY AND 39: C_NATIONKEY = 50: N_NATIONKEY] post-join-predicate [null])
+                        SCAN (columns[36: C_CUSTKEY, 39: C_NATIONKEY] predicate[null])
+                        EXCHANGE SHUFFLE[27]
+                            EXCHANGE SHUFFLE[27, 50]
+                                INNER JOIN (join-predicate [26: O_ORDERKEY = 9: L_ORDERKEY] post-join-predicate [null])
+                                    SCAN (columns[26: O_ORDERKEY, 27: O_CUSTKEY] predicate[null])
+                                    EXCHANGE SHUFFLE[9]
+                                        INNER JOIN (join-predicate [11: L_SUPPKEY = 1: S_SUPPKEY] post-join-predicate [null])
+                                            SCAN (columns[19: L_SHIPDATE, 9: L_ORDERKEY, 11: L_SUPPKEY, 14: L_EXTENDEDPRICE, 15: L_DISCOUNT] predicate[19: L_SHIPDATE >= 1995-01-01 AND 19: L_SHIPDATE <= 1996-12-31])
+                                            EXCHANGE BROADCAST
+                                                INNER JOIN (join-predicate [4: S_NATIONKEY = 45: N_NATIONKEY] post-join-predicate [null])
+                                                    SCAN (columns[1: S_SUPPKEY, 4: S_NATIONKEY] predicate[null])
+                                                    EXCHANGE BROADCAST
+                                                        INNER JOIN (join-predicate [46: N_NAME = CANADA AND 51: N_NAME = IRAN OR 46: N_NAME = IRAN AND 51: N_NAME = CANADA] post-join-predicate [null])
                                                             SCAN (columns[45: N_NATIONKEY, 46: N_NAME] predicate[46: N_NAME IN (CANADA, IRAN)])
                                                             EXCHANGE BROADCAST
                                                                 SCAN (columns[50: N_NATIONKEY, 51: N_NAME] predicate[51: N_NAME IN (IRAN, CANADA)])

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
@@ -37,34 +37,7 @@ group by
 order by
     o_year ;
 [fragment statistics]
-PLAN FRAGMENT 0(F20)
-Output Exprs:61: year | 66: expr
-Input Partition: UNPARTITIONED
-RESULT SINK
-
-38:MERGING-EXCHANGE
-distribution type: GATHER
-cardinality: 2
-column statistics:
-* year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-* sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
-* sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
-* expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
-
-PLAN FRAGMENT 1(F19)
-
-Input Partition: HASH_PARTITIONED: 61: year
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 38
-
-37:SORT
-|  order by: [61, SMALLINT, true] ASC
-|  offset: 0
-|  cardinality: 2
-|  column statistics:
-|  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
-|  * sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
-|  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATEPLAN FRAGMENT 0(F22)
+PLAN FRAGMENT 0(F22)
 Output Exprs:61: year | 66: expr
 Input Partition: UNPARTITIONED
 RESULT SINK

--- a/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/external/hive/tpch/q8.sql
@@ -64,10 +64,37 @@ OutPut Exchange Id: 38
 |  column statistics:
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+|  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATEPLAN FRAGMENT 0(F22)
+Output Exprs:61: year | 66: expr
+Input Partition: UNPARTITIONED
+RESULT SINK
+
+39:MERGING-EXCHANGE
+distribution type: GATHER
+cardinality: 2
+column statistics:
+* year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
+* sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+* sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
+* expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
+
+PLAN FRAGMENT 1(F21)
+
+Input Partition: HASH_PARTITIONED: 61: year
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 39
+
+38:SORT
+|  order by: [61, SMALLINT, true] ASC
+|  offset: 0
+|  cardinality: 2
+|  column statistics:
+|  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
+|  * sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 |  * expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
 |
-36:Project
+37:Project
 |  output columns:
 |  61 <-> [61: year, SMALLINT, true]
 |  66 <-> [64: sum, DECIMAL128(38,4), true] / [65: sum, DECIMAL128(38,4), true]
@@ -76,7 +103,7 @@ OutPut Exchange Id: 38
 |  * year-->[1995.0, 1996.0, 0.0, 2.0, 2.0] ESTIMATE
 |  * expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
 |
-35:AGGREGATE (merge finalize)
+36:AGGREGATE (merge finalize)
 |  aggregate: sum[([65: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([64: sum, DECIMAL128(38,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  group by: [61: year, SMALLINT, true]
 |  cardinality: 2
@@ -86,18 +113,18 @@ OutPut Exchange Id: 38
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 |  * expr-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
 |
-34:EXCHANGE
+35:EXCHANGE
 distribution type: SHUFFLE
 partition exprs: [61: year, SMALLINT, true]
 cardinality: 2
 
-PLAN FRAGMENT 2(F18)
+PLAN FRAGMENT 2(F20)
 
-Input Partition: HASH_PARTITIONED: 33: o_orderkey
+Input Partition: HASH_PARTITIONED: 19: l_suppkey
 OutPut Partition: HASH_PARTITIONED: 61: year
-OutPut Exchange Id: 34
+OutPut Exchange Id: 35
 
-33:AGGREGATE (update serialize)
+34:AGGREGATE (update serialize)
 |  STREAMING
 |  aggregate: sum[([62: expr, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true], sum[([63: case, DECIMAL128(33,4), true]); args: DECIMAL128; result: DECIMAL128(38,4); args nullable: true; result nullable: true]
 |  group by: [61: year, SMALLINT, true]
@@ -107,7 +134,7 @@ OutPut Exchange Id: 34
 |  * sum-->[-Infinity, Infinity, 0.0, 16.0, 2.0] ESTIMATE
 |  * sum-->[810.9, 104949.5, 0.0, 16.0, 2.0] ESTIMATE
 |
-32:Project
+33:Project
 |  output columns:
 |  61 <-> year[([37: o_orderdate, DATE, true]); args: DATE; result: SMALLINT; args nullable: true; result nullable: true]
 |  62 <-> [71: multiply, DECIMAL128(33,4), true]
@@ -124,11 +151,11 @@ OutPut Exchange Id: 34
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 242842.78223700623] ESTIMATE
 |  * case-->[-Infinity, Infinity, 0.0, 16.0, 242843.78223700623] ESTIMATE
 |
-31:HASH JOIN
+32:HASH JOIN
 |  join op: INNER JOIN (PARTITIONED)
-|  equal join conjunct: [33: o_orderkey, INT, true] = [17: l_orderkey, INT, true]
+|  equal join conjunct: [19: l_suppkey, INT, true] = [10: s_suppkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 6, build_expr = (17: l_orderkey), remote = true
+|  - filter_id = 6, build_expr = (10: s_suppkey), remote = true
 |  output columns: 22, 23, 37, 55
 |  cardinality: 242843
 |  column statistics:
@@ -142,67 +169,23 @@ OutPut Exchange Id: 34
 |  * expr-->[810.9, 104949.5, 0.0, 16.0, 242842.78223700623] ESTIMATE
 |  * case-->[-Infinity, Infinity, 0.0, 16.0, 242843.78223700623] ESTIMATE
 |
-|----30:EXCHANGE
-|       distribution type: SHUFFLE
-|       partition exprs: [17: l_orderkey, INT, true]
-|       cardinality: 4000253
-|
-14:EXCHANGE
-distribution type: SHUFFLE
-partition exprs: [33: o_orderkey, INT, true]
-cardinality: 13615647
-
-PLAN FRAGMENT 3(F16)
-
-Input Partition: HASH_PARTITIONED: 19: l_suppkey
-OutPut Partition: HASH_PARTITIONED: 17: l_orderkey
-OutPut Exchange Id: 30
-
-29:Project
-|  output columns:
-|  17 <-> [17: l_orderkey, INT, true]
-|  22 <-> [22: l_extendedprice, DECIMAL64(15,2), true]
-|  23 <-> [23: l_discount, DECIMAL64(15,2), true]
-|  55 <-> [55: n_name, VARCHAR, true]
-|  cardinality: 4000253
-|  column statistics:
-|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 4000252.6799999992] ESTIMATE
-|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-|
-28:HASH JOIN
-|  join op: INNER JOIN (PARTITIONED)
-|  equal join conjunct: [19: l_suppkey, INT, true] = [10: s_suppkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 5, build_expr = (10: s_suppkey), remote = true
-|  output columns: 17, 22, 23, 55
-|  cardinality: 4000253
-|  column statistics:
-|  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 4000252.6799999992] ESTIMATE
-|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
-|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
-|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
-|  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
-|
-|----27:EXCHANGE
+|----31:EXCHANGE
 |       distribution type: SHUFFLE
 |       partition exprs: [10: s_suppkey, INT, true]
 |       cardinality: 1000000
 |
-21:EXCHANGE
+25:EXCHANGE
 distribution type: SHUFFLE
 partition exprs: [19: l_suppkey, INT, true]
-cardinality: 4000253
+cardinality: 3000000
 
-PLAN FRAGMENT 4(F12)
+PLAN FRAGMENT 3(F16)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 10: s_suppkey
-OutPut Exchange Id: 27
+OutPut Exchange Id: 31
 
-26:Project
+30:Project
 |  output columns:
 |  10 <-> [10: s_suppkey, INT, true]
 |  55 <-> [55: n_name, VARCHAR, true]
@@ -211,11 +194,11 @@ OutPut Exchange Id: 27
 |  * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |
-25:HASH JOIN
+29:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [13: s_nationkey, INT, true] = [54: n_nationkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 4, build_expr = (54: n_nationkey), remote = false
+|  - filter_id = 5, build_expr = (54: n_nationkey), remote = false
 |  output columns: 10, 55
 |  cardinality: 1000000
 |  column statistics:
@@ -224,28 +207,28 @@ OutPut Exchange Id: 27
 |  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 |  * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 |
-|----24:EXCHANGE
+|----28:EXCHANGE
 |       distribution type: BROADCAST
 |       cardinality: 25
 |
-22:HdfsScanNode
+26:HdfsScanNode
 TABLE: supplier
 partitions=1/1
 avgRowSize=8.0
 cardinality: 1000000
 probe runtime filters:
-- filter_id = 4, probe_expr = (13: s_nationkey)
+- filter_id = 5, probe_expr = (13: s_nationkey)
 column statistics:
 * s_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
 * s_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 
-PLAN FRAGMENT 5(F13)
+PLAN FRAGMENT 4(F17)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 24
+OutPut Exchange Id: 28
 
-23:HdfsScanNode
+27:HdfsScanNode
 TABLE: nation
 NON-PARTITION PREDICATES: 54: n_nationkey IS NOT NULL
 partitions=1/1
@@ -255,13 +238,210 @@ column statistics:
 * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
 * n_name-->[-Infinity, Infinity, 0.0, 25.0, 25.0] ESTIMATE
 
+PLAN FRAGMENT 5(F14)
+
+Input Partition: HASH_PARTITIONED: 34: o_custkey
+OutPut Partition: HASH_PARTITIONED: 19: l_suppkey
+OutPut Exchange Id: 25
+
+24:Project
+|  output columns:
+|  19 <-> [19: l_suppkey, INT, true]
+|  22 <-> [22: l_extendedprice, DECIMAL64(15,2), true]
+|  23 <-> [23: l_discount, DECIMAL64(15,2), true]
+|  37 <-> [37: o_orderdate, DATE, true]
+|  cardinality: 3000000
+|  column statistics:
+|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3000000.0] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * o_orderdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2412.0] ESTIMATE
+|
+23:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
+|  equal join conjunct: [34: o_custkey, INT, true] = [42: c_custkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 4, build_expr = (42: c_custkey), remote = true
+|  output columns: 19, 22, 23, 37
+|  cardinality: 3000000
+|  column statistics:
+|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3000000.0] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * o_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|  * o_orderdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2412.0] ESTIMATE
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|
+|----22:EXCHANGE
+|       distribution type: SHUFFLE
+|       partition exprs: [42: c_custkey, INT, true]
+|       cardinality: 3000000
+|
+11:EXCHANGE
+distribution type: SHUFFLE
+partition exprs: [34: o_custkey, INT, true]
+cardinality: 4000253
+
 PLAN FRAGMENT 6(F08)
 
 Input Partition: RANDOM
-OutPut Partition: HASH_PARTITIONED: 19: l_suppkey
-OutPut Exchange Id: 21
+OutPut Partition: HASH_PARTITIONED: 42: c_custkey
+OutPut Exchange Id: 22
 
-20:Project
+21:Project
+|  output columns:
+|  42 <-> [42: c_custkey, INT, true]
+|  cardinality: 3000000
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|
+20:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [45: c_nationkey, INT, true] = [50: n_nationkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 3, build_expr = (50: n_nationkey), remote = false
+|  output columns: 42
+|  cardinality: 3000000
+|  column statistics:
+|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
+|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|
+|----19:EXCHANGE
+|       distribution type: BROADCAST
+|       cardinality: 5
+|
+12:HdfsScanNode
+TABLE: customer
+NON-PARTITION PREDICATES: 42: c_custkey IS NOT NULL
+partitions=1/1
+avgRowSize=12.0
+cardinality: 15000000
+probe runtime filters:
+- filter_id = 3, probe_expr = (45: c_nationkey)
+column statistics:
+* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
+* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+
+PLAN FRAGMENT 7(F09)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 19
+
+18:Project
+|  output columns:
+|  50 <-> [50: n_nationkey, INT, true]
+|  cardinality: 5
+|  column statistics:
+|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|
+17:HASH JOIN
+|  join op: INNER JOIN (BROADCAST)
+|  equal join conjunct: [52: n_regionkey, INT, true] = [58: r_regionkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 2, build_expr = (58: r_regionkey), remote = false
+|  output columns: 50
+|  cardinality: 5
+|  column statistics:
+|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
+|  * n_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+|----16:EXCHANGE
+|       distribution type: BROADCAST
+|       cardinality: 1
+|
+13:HdfsScanNode
+TABLE: nation
+NON-PARTITION PREDICATES: 50: n_nationkey IS NOT NULL
+partitions=1/1
+avgRowSize=8.0
+cardinality: 25
+probe runtime filters:
+- filter_id = 2, probe_expr = (52: n_regionkey)
+column statistics:
+* n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
+* n_regionkey-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
+
+PLAN FRAGMENT 8(F10)
+
+Input Partition: RANDOM
+OutPut Partition: UNPARTITIONED
+OutPut Exchange Id: 16
+
+15:Project
+|  output columns:
+|  58 <-> [58: r_regionkey, INT, true]
+|  cardinality: 1
+|  column statistics:
+|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+|
+14:HdfsScanNode
+TABLE: region
+NON-PARTITION PREDICATES: 59: r_name = 'MIDDLE EAST'
+MIN/MAX PREDICATES: 59: r_name <= 'MIDDLE EAST', 59: r_name >= 'MIDDLE EAST'
+partitions=1/1
+avgRowSize=10.8
+cardinality: 1
+column statistics:
+* r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
+* r_name-->[-Infinity, Infinity, 0.0, 6.8, 1.0] ESTIMATE
+
+PLAN FRAGMENT 9(F06)
+
+Input Partition: HASH_PARTITIONED: 33: o_orderkey
+OutPut Partition: HASH_PARTITIONED: 34: o_custkey
+OutPut Exchange Id: 11
+
+10:Project
+|  output columns:
+|  19 <-> [19: l_suppkey, INT, true]
+|  22 <-> [22: l_extendedprice, DECIMAL64(15,2), true]
+|  23 <-> [23: l_discount, DECIMAL64(15,2), true]
+|  34 <-> [34: o_custkey, INT, true]
+|  37 <-> [37: o_orderdate, DATE, true]
+|  cardinality: 4000253
+|  column statistics:
+|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 4000252.68] ESTIMATE
+|  * o_orderdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2412.0] ESTIMATE
+|
+9:HASH JOIN
+|  join op: INNER JOIN (PARTITIONED)
+|  equal join conjunct: [33: o_orderkey, INT, true] = [17: l_orderkey, INT, true]
+|  build runtime filters:
+|  - filter_id = 1, build_expr = (17: l_orderkey), remote = true
+|  output columns: 19, 22, 23, 34, 37
+|  cardinality: 4000253
+|  column statistics:
+|  * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 4000252.6799999997] ESTIMATE
+|  * l_suppkey-->[1.0, 1000000.0, 0.0, 4.0, 1000000.0] ESTIMATE
+|  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
+|  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
+|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 4000252.6799999997] ESTIMATE
+|  * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 4000252.68] ESTIMATE
+|  * o_orderdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2412.0] ESTIMATE
+|
+|----8:EXCHANGE
+|       distribution type: SHUFFLE
+|       partition exprs: [17: l_orderkey, INT, true]
+|       cardinality: 4000253
+|
+1:EXCHANGE
+distribution type: SHUFFLE
+partition exprs: [33: o_orderkey, INT, true]
+cardinality: 45530146
+
+PLAN FRAGMENT 10(F02)
+
+Input Partition: RANDOM
+OutPut Partition: HASH_PARTITIONED: 17: l_orderkey
+OutPut Exchange Id: 08
+
+7:Project
 |  output columns:
 |  17 <-> [17: l_orderkey, INT, true]
 |  19 <-> [19: l_suppkey, INT, true]
@@ -274,11 +454,11 @@ OutPut Exchange Id: 21
 |  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
-19:HASH JOIN
+6:HASH JOIN
 |  join op: INNER JOIN (BROADCAST)
 |  equal join conjunct: [18: l_partkey, INT, true] = [1: p_partkey, INT, true]
 |  build runtime filters:
-|  - filter_id = 3, build_expr = (1: p_partkey), remote = false
+|  - filter_id = 0, build_expr = (1: p_partkey), remote = false
 |  output columns: 17, 19, 22, 23
 |  cardinality: 4000253
 |  column statistics:
@@ -289,19 +469,19 @@ OutPut Exchange Id: 21
 |  * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 |  * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 |
-|----18:EXCHANGE
+|----5:EXCHANGE
 |       distribution type: BROADCAST
 |       cardinality: 133333
 |
-15:HdfsScanNode
+2:HdfsScanNode
 TABLE: lineitem
 NON-PARTITION PREDICATES: 18: l_partkey IS NOT NULL, 19: l_suppkey IS NOT NULL
 partitions=1/1
 avgRowSize=36.0
 cardinality: 600037902
 probe runtime filters:
-- filter_id = 3, probe_expr = (18: l_partkey)
-- filter_id = 5, probe_expr = (19: l_suppkey)
+- filter_id = 0, probe_expr = (18: l_partkey)
+- filter_id = 6, probe_expr = (19: l_suppkey)
 column statistics:
 * l_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.5E8] ESTIMATE
 * l_partkey-->[1.0, 2.0E7, 0.0, 8.0, 2.0E7] ESTIMATE
@@ -309,20 +489,20 @@ column statistics:
 * l_extendedprice-->[901.0, 104949.5, 0.0, 8.0, 3736520.0] ESTIMATE
 * l_discount-->[0.0, 0.1, 0.0, 8.0, 11.0] ESTIMATE
 
-PLAN FRAGMENT 7(F09)
+PLAN FRAGMENT 11(F03)
 
 Input Partition: RANDOM
 OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 18
+OutPut Exchange Id: 05
 
-17:Project
+4:Project
 |  output columns:
 |  1 <-> [1: p_partkey, INT, true]
 |  cardinality: 133333
 |  column statistics:
 |  * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 133333.33333333334] ESTIMATE
 |
-16:HdfsScanNode
+3:HdfsScanNode
 TABLE: part
 NON-PARTITION PREDICATES: 5: p_type = 'ECONOMY ANODIZED STEEL'
 MIN/MAX PREDICATES: 5: p_type <= 'ECONOMY ANODIZED STEEL', 5: p_type >= 'ECONOMY ANODIZED STEEL'
@@ -333,38 +513,12 @@ column statistics:
 * p_partkey-->[1.0, 2.0E7, 0.0, 8.0, 133333.33333333334] ESTIMATE
 * p_type-->[-Infinity, Infinity, 0.0, 25.0, 150.0] ESTIMATE
 
-PLAN FRAGMENT 8(F00)
+PLAN FRAGMENT 12(F00)
 
 Input Partition: RANDOM
 OutPut Partition: HASH_PARTITIONED: 33: o_orderkey
-OutPut Exchange Id: 14
+OutPut Exchange Id: 01
 
-13:Project
-|  output columns:
-|  33 <-> [33: o_orderkey, INT, true]
-|  37 <-> [37: o_orderdate, DATE, true]
-|  cardinality: 13615647
-|  column statistics:
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.3615646508925758E7] ESTIMATE
-|  * o_orderdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2412.0] ESTIMATE
-|
-12:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [34: o_custkey, INT, true] = [42: c_custkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 2, build_expr = (42: c_custkey), remote = false
-|  output columns: 33, 37
-|  cardinality: 13615647
-|  column statistics:
-|  * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 1.3615646508925758E7] ESTIMATE
-|  * o_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|  * o_orderdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2412.0] ESTIMATE
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|
-|----11:EXCHANGE
-|       distribution type: BROADCAST
-|       cardinality: 3000000
-|
 0:HdfsScanNode
 TABLE: orders
 NON-PARTITION PREDICATES: 37: o_orderdate >= '1995-01-01', 37: o_orderdate <= '1996-12-31'
@@ -373,117 +527,11 @@ partitions=1/1
 avgRowSize=20.0
 cardinality: 45530146
 probe runtime filters:
-- filter_id = 2, probe_expr = (34: o_custkey)
-- filter_id = 6, probe_expr = (33: o_orderkey)
+- filter_id = 1, probe_expr = (33: o_orderkey)
+- filter_id = 4, probe_expr = (34: o_custkey)
 column statistics:
 * o_orderkey-->[1.0, 6.0E8, 0.0, 8.0, 4.5530145530145526E7] ESTIMATE
 * o_custkey-->[1.0, 1.5E8, 0.0, 8.0, 1.0031873E7] ESTIMATE
 * o_orderdate-->[7.888896E8, 8.519616E8, 0.0, 4.0, 2412.0] ESTIMATE
-
-PLAN FRAGMENT 9(F01)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 11
-
-10:Project
-|  output columns:
-|  42 <-> [42: c_custkey, INT, true]
-|  cardinality: 3000000
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|
-9:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [45: c_nationkey, INT, true] = [50: n_nationkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 1, build_expr = (50: n_nationkey), remote = false
-|  output columns: 42
-|  cardinality: 3000000
-|  column statistics:
-|  * c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 3000000.0] ESTIMATE
-|  * c_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|
-|----8:EXCHANGE
-|       distribution type: BROADCAST
-|       cardinality: 5
-|
-1:HdfsScanNode
-TABLE: customer
-NON-PARTITION PREDICATES: 42: c_custkey IS NOT NULL
-partitions=1/1
-avgRowSize=12.0
-cardinality: 15000000
-probe runtime filters:
-- filter_id = 1, probe_expr = (45: c_nationkey)
-column statistics:
-* c_custkey-->[1.0, 1.5E7, 0.0, 8.0, 1.5E7] ESTIMATE
-* c_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-
-PLAN FRAGMENT 10(F02)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 08
-
-7:Project
-|  output columns:
-|  50 <-> [50: n_nationkey, INT, true]
-|  cardinality: 5
-|  column statistics:
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|
-6:HASH JOIN
-|  join op: INNER JOIN (BROADCAST)
-|  equal join conjunct: [52: n_regionkey, INT, true] = [58: r_regionkey, INT, true]
-|  build runtime filters:
-|  - filter_id = 0, build_expr = (58: r_regionkey), remote = false
-|  output columns: 50
-|  cardinality: 5
-|  column statistics:
-|  * n_nationkey-->[0.0, 24.0, 0.0, 4.0, 5.0] ESTIMATE
-|  * n_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-|----5:EXCHANGE
-|       distribution type: BROADCAST
-|       cardinality: 1
-|
-2:HdfsScanNode
-TABLE: nation
-NON-PARTITION PREDICATES: 50: n_nationkey IS NOT NULL
-partitions=1/1
-avgRowSize=8.0
-cardinality: 25
-probe runtime filters:
-- filter_id = 0, probe_expr = (52: n_regionkey)
-column statistics:
-* n_nationkey-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
-* n_regionkey-->[0.0, 4.0, 0.0, 4.0, 5.0] ESTIMATE
-
-PLAN FRAGMENT 11(F03)
-
-Input Partition: RANDOM
-OutPut Partition: UNPARTITIONED
-OutPut Exchange Id: 05
-
-4:Project
-|  output columns:
-|  58 <-> [58: r_regionkey, INT, true]
-|  cardinality: 1
-|  column statistics:
-|  * r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-|
-3:HdfsScanNode
-TABLE: region
-NON-PARTITION PREDICATES: 59: r_name = 'MIDDLE EAST'
-MIN/MAX PREDICATES: 59: r_name <= 'MIDDLE EAST', 59: r_name >= 'MIDDLE EAST'
-partitions=1/1
-avgRowSize=10.8
-cardinality: 1
-column statistics:
-* r_regionkey-->[0.0, 4.0, 0.0, 4.0, 1.0] ESTIMATE
-* r_name-->[-Infinity, Infinity, 0.0, 6.8, 1.0] ESTIMATE
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/scheduler/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/tpch/q7.sql
@@ -321,7 +321,7 @@ PLAN FRAGMENT 2
   |  join op: INNER JOIN (PARTITIONED)
   |  colocate: false, reason: 
   |  equal join conjunct: 10: L_SUPPKEY = 1: s_suppkey
-  |  other predicates: ((43: n_name = 'CANADA') AND (47: n_name = 'IRAN')) OR ((43: n_name = 'IRAN') AND (47: n_name = 'CANADA'))
+  |  other join predicates: ((43: n_name = 'CANADA') AND (47: n_name = 'IRAN')) OR ((43: n_name = 'IRAN') AND (47: n_name = 'CANADA'))
   |  
   |----21:EXCHANGE
   |    


### PR DESCRIPTION
Fixes #issue
- Setting a large penalty to cross join cost in reorder algorithm to avoid choosing a transfromed plan with it.
- Setting inner join type when there exists a  on predicate on matter whether it's a equal predicate.
- The `computeCost` logic in `JoinReorder` is realtive simple which actually just add the outputSize of all children. We will  improve it in the next pr.

 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
