### PR TITLE
[BugFix] Fix bugs when materialized view with sort keys

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -386,6 +386,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @SerializedName(value = "maxMVRewriteStaleness")
     private int maxMVRewriteStaleness = 0;
 
+
+    // Materialized view's output columns may be different from defined query's output columns.
+    // Record the indexes based on materialized view's column output.
+    // eg: create materialized view mv as select col1, col2, col3 from tbl
+    //  desc mv             :  col2, col1, col3
+    //  queryOutputIndexes  :  1, 0, 2
+    // which means 0th of query output column is in 1th mv's output columns, and 1th -> 0th, 2th -> 2th.
+    @SerializedName(value = "queryOutputIndexes")
+    protected List<Integer> queryOutputIndexes = Lists.newArrayList();
+
+
     // it is a property in momery, do not serialize it
     private PlanMode planMode = PlanMode.UNKNOWN;
 
@@ -539,6 +550,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public void setMaxMVRewriteStaleness(int maxMVRewriteStaleness) {
         this.maxMVRewriteStaleness = maxMVRewriteStaleness;
+    }
+
+    public List<Integer> getQueryOutputIndexes() {
+        return queryOutputIndexes;
+    }
+
+    public void setQueryOutputIndexes(List<Integer> queryOutputIndexes) {
+        this.queryOutputIndexes = queryOutputIndexes;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -393,8 +393,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     //  desc mv             :  col2, col1, col3
     //  queryOutputIndexes  :  1, 0, 2
     // which means 0th of query output column is in 1th mv's output columns, and 1th -> 0th, 2th -> 2th.
-    @SerializedName(value = "queryOutputIndexes")
-    protected List<Integer> queryOutputIndexes = Lists.newArrayList();
+    @SerializedName(value = "queryOutputIndices")
+    protected List<Integer> queryOutputIndices = Lists.newArrayList();
 
 
     // it is a property in momery, do not serialize it
@@ -552,12 +552,12 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.maxMVRewriteStaleness = maxMVRewriteStaleness;
     }
 
-    public List<Integer> getQueryOutputIndexes() {
-        return queryOutputIndexes;
+    public List<Integer> getQueryOutputIndices() {
+        return queryOutputIndices;
     }
 
-    public void setQueryOutputIndexes(List<Integer> queryOutputIndexes) {
-        this.queryOutputIndexes = queryOutputIndexes;
+    public void setQueryOutputIndices(List<Integer> queryOutputIndices) {
+        this.queryOutputIndices = queryOutputIndices;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1032,6 +1032,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 .setUser(ctx.getQualifiedUser())
                 .setDb(ctx.getDatabase());
         ctx.setThreadLocalInfo();
+
+        // TODO: Support use mv when refreshing mv.
         ctx.getSessionVariable().setEnableMaterializedViewRewrite(false);
         String definition = mvContext.getDefinition();
         InsertStmt insertStmt =
@@ -1039,7 +1041,21 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         insertStmt.setTargetPartitionNames(new PartitionNames(false, new ArrayList<>(materializedViewPartitions)));
         // insert overwrite mv must set system = true
         insertStmt.setSystem(true);
+
+        // if materialized view has set sort keys, materialized view's output columns
+        // may be different from the defined query's output.
+        // so set materialized view's defined outputs as target columns.
+        List<Integer> queryOutputIndexes = materializedView.getQueryOutputIndexes();
+        List<Column> baseSchema = materializedView.getBaseSchema();
+        if (queryOutputIndexes != null && baseSchema.size() == queryOutputIndexes.size()) {
+            List<String> targetColumnNames = queryOutputIndexes.stream()
+                    .map(i -> baseSchema.get(i))
+                    .map(Column::getName).collect(Collectors.toList());
+            insertStmt.setTargetColumnNames(targetColumnNames);
+        }
+
         Analyzer.analyze(insertStmt, ctx);
+
         // after analyze, we could get the table meta info of the tableRelation.
         QueryStatement queryStatement = insertStmt.getQueryStatement();
         Multimap<String, TableRelation> tableRelations =

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1045,7 +1045,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         // if materialized view has set sort keys, materialized view's output columns
         // may be different from the defined query's output.
         // so set materialized view's defined outputs as target columns.
-        List<Integer> queryOutputIndexes = materializedView.getQueryOutputIndexes();
+        List<Integer> queryOutputIndexes = materializedView.getQueryOutputIndices();
         List<Column> baseSchema = materializedView.getBaseSchema();
         if (queryOutputIndexes != null && baseSchema.size() == queryOutputIndexes.size()) {
             List<String> targetColumnNames = queryOutputIndexes.stream()

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3076,6 +3076,8 @@ public class LocalMetastore implements ConnectorMetadata {
         // set base index id
         long baseIndexId = getNextId();
         materializedView.setBaseIndexId(baseIndexId);
+        // set query output indexes
+        materializedView.setQueryOutputIndexes(stmt.getQueryOutputIndexes());
         // set base index meta
         int schemaVersion = 0;
         int schemaHash = Util.schemaHash(schemaVersion, baseSchema, null, 0d);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3077,7 +3077,7 @@ public class LocalMetastore implements ConnectorMetadata {
         long baseIndexId = getNextId();
         materializedView.setBaseIndexId(baseIndexId);
         // set query output indexes
-        materializedView.setQueryOutputIndexes(stmt.getQueryOutputIndexes());
+        materializedView.setQueryOutputIndices(stmt.getQueryOutputIndices());
         // set base index meta
         int schemaVersion = 0;
         int schemaHash = Util.schemaHash(schemaVersion, baseSchema, null, 0d);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -213,6 +213,16 @@ public class MaterializedViewAnalyzer {
         }
     }
 
+    @VisibleForTesting
+    protected static List<Integer> getQueryOutputIndices(List<Pair<Column, Integer>> mvColumnPairs) {
+        return Streams
+                .mapWithIndex(mvColumnPairs.stream(), (pair, idx) -> Pair.create(pair.second, (int) idx))
+                .sorted(Comparator.comparingInt(x -> x.first))
+                .map(x -> x.second)
+                .collect(Collectors.toList());
+    }
+
+
     static class MaterializedViewAnalyzerVisitor extends AstVisitor<Void, ConnectContext> {
 
         public enum RefreshTimeUnit {
@@ -265,11 +275,7 @@ public class MaterializedViewAnalyzer {
             statement.setMvColumnItems(mvColumns);
 
             // record query output indices
-            List<Integer> queryOutputIndices = Streams
-                    .mapWithIndex(mvColumnPairs.stream(), (pair, idx) -> Pair.create(pair.second, (int)idx))
-                    .sorted(Comparator.comparingInt(x -> x.first))
-                    .map(x -> x.second)
-                    .collect(Collectors.toList());
+            List<Integer> queryOutputIndices = getQueryOutputIndices(mvColumnPairs);
             statement.setQueryOutputIndices(queryOutputIndices);
 
             // set the Indexes into createMaterializedViewStatement

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -222,7 +222,6 @@ public class MaterializedViewAnalyzer {
                 .collect(Collectors.toList());
     }
 
-
     static class MaterializedViewAnalyzerVisitor extends AstVisitor<Void, ConnectContext> {
 
         public enum RefreshTimeUnit {
@@ -288,8 +287,7 @@ public class MaterializedViewAnalyzer {
             // columns' order may be changed for sort keys' reorder, need to
             // change `queryStatement.getQueryRelation`'s outputs at the same time.
             List<Expr> outputExpressions = queryStatement.getQueryRelation().getOutputExpression();
-            for (int i = 0; i < mvColumnPairs.size(); i++) {
-                Pair<Column, Integer> pair = mvColumnPairs.get(i);
+            for (Pair<Column, Integer> pair : mvColumnPairs) {
                 Preconditions.checkState(pair.second < outputExpressions.size());
                 columnExprMap.put(pair.first, outputExpressions.get(pair.second));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
 import com.starrocks.analysis.AnalyticExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
@@ -101,6 +102,7 @@ import org.apache.logging.log4j.util.Strings;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -261,17 +263,14 @@ public class MaterializedViewAnalyzer {
             List<Pair<Column, Integer>> mvColumnPairs = genMaterializedViewColumns(statement);
             List<Column> mvColumns = mvColumnPairs.stream().map(pair -> pair.first).collect(Collectors.toList());
             statement.setMvColumnItems(mvColumns);
-            Map<Integer, Integer> queryToMVOutputIndexMap = Maps.newHashMap();
-            for (int i = 0; i < mvColumnPairs.size(); i++) {
-                Pair<Column, Integer> pair = mvColumnPairs.get(i);
-                queryToMVOutputIndexMap.put(pair.second, i);
-            }
-            List<Integer> queryOutputIndexes = Lists.newArrayList();
-            for (int i = 0; i < mvColumnPairs.size(); i++) {
-                Preconditions.checkState(queryToMVOutputIndexMap.containsKey(i));
-                queryOutputIndexes.add(queryToMVOutputIndexMap.get(i));
-            }
-            statement.setQueryOutputIndexes(queryOutputIndexes);
+
+            // record query output indices
+            List<Integer> queryOutputIndices = Streams
+                    .mapWithIndex(mvColumnPairs.stream(), (pair, idx) -> Pair.create(pair.second, (int)idx))
+                    .sorted(Comparator.comparingInt(x -> x.first))
+                    .map(x -> x.second)
+                    .collect(Collectors.toList());
+            statement.setQueryOutputIndices(queryOutputIndices);
 
             // set the Indexes into createMaterializedViewStatement
             List<Index> mvIndexes = genMaterializedViewIndexes(statement);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -261,6 +261,17 @@ public class MaterializedViewAnalyzer {
             List<Pair<Column, Integer>> mvColumnPairs = genMaterializedViewColumns(statement);
             List<Column> mvColumns = mvColumnPairs.stream().map(pair -> pair.first).collect(Collectors.toList());
             statement.setMvColumnItems(mvColumns);
+            Map<Integer, Integer> queryToMVOutputIndexMap = Maps.newHashMap();
+            for (int i = 0; i < mvColumnPairs.size(); i++) {
+                Pair<Column, Integer> pair = mvColumnPairs.get(i);
+                queryToMVOutputIndexMap.put(pair.second, i);
+            }
+            List<Integer> queryOutputIndexes = Lists.newArrayList();
+            for (int i = 0; i < mvColumnPairs.size(); i++) {
+                Preconditions.checkState(queryToMVOutputIndexMap.containsKey(i));
+                queryOutputIndexes.add(queryToMVOutputIndexMap.get(i));
+            }
+            statement.setQueryOutputIndexes(queryOutputIndexes);
 
             // set the Indexes into createMaterializedViewStatement
             List<Index> mvIndexes = genMaterializedViewIndexes(statement);
@@ -272,7 +283,8 @@ public class MaterializedViewAnalyzer {
             // columns' order may be changed for sort keys' reorder, need to
             // change `queryStatement.getQueryRelation`'s outputs at the same time.
             List<Expr> outputExpressions = queryStatement.getQueryRelation().getOutputExpression();
-            for (Pair<Column, Integer> pair : mvColumnPairs) {
+            for (int i = 0; i < mvColumnPairs.size(); i++) {
+                Pair<Column, Integer> pair = mvColumnPairs.get(i);
                 Preconditions.checkState(pair.second < outputExpressions.size());
                 columnExprMap.put(pair.first, outputExpressions.get(pair.second));
             }
@@ -431,8 +443,8 @@ public class MaterializedViewAnalyzer {
                 keyCols.add(column.getName());
             }
             if (theBeginIndexOfValue == skip) {
-                throw new SemanticException("Data type of first column cannot be " +
-                        mvColumns.get(theBeginIndexOfValue).getType());
+                throw new SemanticException("Data type of {}th column cannot be " +
+                        mvColumns.get(theBeginIndexOfValue).getType(), theBeginIndexOfValue);
             }
             return keyCols;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -78,7 +78,7 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     //  desc mv             :  col2, col1, col3
     //  queryOutputIndexes  :  1, 0, 2
     // which means 0th of query output column is in 1th mv's output columns, and 1th -> 0th, 2th -> 2th.
-    private List<Integer> queryOutputIndexes = Lists.newArrayList();
+    private List<Integer> queryOutputIndices = Lists.newArrayList();
 
     public CreateMaterializedViewStatement(TableName tableName, boolean ifNotExists,
                                            List<ColWithComment> colWithComments,
@@ -251,12 +251,12 @@ public class CreateMaterializedViewStatement extends DdlStmt {
         return columnRefFactory;
     }
 
-    public List<Integer> getQueryOutputIndexes() {
-        return queryOutputIndexes;
+    public List<Integer> getQueryOutputIndices() {
+        return queryOutputIndices;
     }
 
-    public void setQueryOutputIndexes(List<Integer> queryOutputIndexes) {
-        this.queryOutputIndexes = queryOutputIndexes;
+    public void setQueryOutputIndices(List<Integer> queryOutputIndices) {
+        this.queryOutputIndices = queryOutputIndices;
     }
 
     public void setMaintenancePlan(ExecPlan maintenancePlan, ColumnRefFactory columnRefFactory) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateMaterializedViewStatement.java
@@ -72,6 +72,14 @@ public class CreateMaterializedViewStatement extends DdlStmt {
     // record expression which related with partition by clause
     private Expr partitionRefTableExpr;
 
+    // Materialized view's output columns may be different from defined query's output columns.
+    // Record the indexes based on materialized view's column output.
+    // eg: create materialized view mv as select col1, col2, col3 from tbl
+    //  desc mv             :  col2, col1, col3
+    //  queryOutputIndexes  :  1, 0, 2
+    // which means 0th of query output column is in 1th mv's output columns, and 1th -> 0th, 2th -> 2th.
+    private List<Integer> queryOutputIndexes = Lists.newArrayList();
+
     public CreateMaterializedViewStatement(TableName tableName, boolean ifNotExists,
                                            List<ColWithComment> colWithComments,
                                            List<IndexDef> indexDefs,
@@ -241,6 +249,14 @@ public class CreateMaterializedViewStatement extends DdlStmt {
 
     public ColumnRefFactory getColumnRefFactory() {
         return columnRefFactory;
+    }
+
+    public List<Integer> getQueryOutputIndexes() {
+        return queryOutputIndexes;
+    }
+
+    public void setQueryOutputIndexes(List<Integer> queryOutputIndexes) {
+        this.queryOutputIndexes = queryOutputIndexes;
     }
 
     public void setMaintenancePlan(ExecPlan maintenancePlan, ColumnRefFactory columnRefFactory) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -61,7 +61,7 @@ public class InsertStmt extends DmlStmt {
     // parsed from targetPartitionNames.
     // if targetPartitionNames is not set, add all formal partitions' id of the table into it
     private List<Long> targetPartitionIds = Lists.newArrayList();
-    private final List<String> targetColumnNames;
+    private List<String> targetColumnNames;
     private QueryStatement queryStatement;
     private String label = null;
 
@@ -205,6 +205,10 @@ public class InsertStmt extends DmlStmt {
 
     public boolean isSpecifyPartitionNames() {
         return targetPartitionNames != null && !targetPartitionNames.isStaticKeyPartitionInsert();
+    }
+
+    public void setTargetColumnNames(List<String> targetColumnNames) {
+        this.targetColumnNames = targetColumnNames;
     }
 
     public List<String> getTargetColumnNames() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Joiner;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
@@ -25,6 +26,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.Pair;
 import com.starrocks.qe.ShowExecutor;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.sql.ast.ShowStmt;
@@ -35,6 +37,8 @@ import org.apache.hadoop.util.Lists;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.util.List;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeFail;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
@@ -279,5 +283,18 @@ public class MaterializedViewAnalyzerTest {
             analyzeFail(mvSql, "Detail message: window function row_number ’s partition expressions" +
                     " should contain the partition column k1 of materialized view");
         }
+    }
+
+    @Test
+    public void testGetQueryOutputIndices() {
+        List<Pair<Column, Integer>> mvColumnPairs = Lists.newArrayList();
+        mvColumnPairs.add(Pair.create(new Column(), 1));
+        mvColumnPairs.add(Pair.create(new Column(), 2));
+        mvColumnPairs.add(Pair.create(new Column(), 0));
+        mvColumnPairs.add(Pair.create(new Column(), 3));
+
+        List<Integer> queryOutputIndices = MaterializedViewAnalyzer.getQueryOutputIndices(mvColumnPairs);
+        Assert.assertTrue(queryOutputIndices.size() == mvColumnPairs.size());
+        Assert.assertEquals(Joiner.on(",").join(queryOutputIndices), "2,0,1,3");
     }
 }

--- a/test/sql/test_materialized_view/R/test_materialized_view_sort_key
+++ b/test/sql/test_materialized_view/R/test_materialized_view_sort_key
@@ -1,0 +1,71 @@
+-- name: test_materialized_view_sort_key
+CREATE TABLE `test_sort_key_tbl1` (
+  `order_number` bigint(20) NULL COMMENT "",
+  `date` datetime NULL COMMENT "",
+  `sku_number` varchar(65533) NULL COMMENT "",
+  `cost` decimal64(18, 0) NULL COMMENT "",
+  `price` double NULL COMMENT "",
+  `pt` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`order_number`, `date`, `sku_number`)
+DISTRIBUTED BY HASH(`order_number`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into test_sort_key_tbl1 values (1, '2023-10-01', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-02', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-01', 'a1', 2.0, 1010.00, '20231001');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_sort_key_tbl_mv1
+DISTRIBUTED BY RANDOM
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select sum(price), sum(price + 1), sum(cost), `date` from test_sort_key_tbl1 group by `date`;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_sort_key_tbl_mv2
+DISTRIBUTED BY RANDOM
+ORDER BY (`date`, sum_cost)
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select sum(price), max(price), sum(cost) as sum_cost, `date` from test_sort_key_tbl1 group by `date`;
+-- result:
+-- !result
+refresh materialized view test_sort_key_tbl_mv1 with sync mode;
+refresh materialized view test_sort_key_tbl_mv2 with sync mode;
+select * from test_sort_key_tbl_mv1 order by 1, 2;
+-- result:
+1	2023-10-02 00:00:00	100.0	101.0
+3	2023-10-01 00:00:00	1110.0	1112.0
+-- !result
+select * from test_sort_key_tbl_mv2 order by 1, 2;
+-- result:
+2023-10-01 00:00:00	3	1110.0	1010.0
+2023-10-02 00:00:00	1	100.0	100.0
+-- !result
+insert into test_sort_key_tbl1 values (1, '2023-10-01', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-02', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-01', 'a1', 2.0, 1010.00, '20231001');
+-- result:
+-- !result
+refresh materialized view test_sort_key_tbl_mv1 with sync mode;
+refresh materialized view test_sort_key_tbl_mv2 with sync mode;
+select * from test_sort_key_tbl_mv1 order by 1, 2;
+-- result:
+2	2023-10-02 00:00:00	200.0	202.0
+6	2023-10-01 00:00:00	2220.0	2224.0
+-- !result
+select * from test_sort_key_tbl_mv2 order by 1, 2;
+-- result:
+2023-10-01 00:00:00	6	2220.0	1010.0
+2023-10-02 00:00:00	2	200.0	100.0
+-- !result
+drop materialized view test_sort_key_tbl_mv1;
+-- result:
+-- !result
+drop materialized view test_sort_key_tbl_mv2;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_sort_key
+++ b/test/sql/test_materialized_view/T/test_materialized_view_sort_key
@@ -1,0 +1,49 @@
+-- name: test_materialized_view_sort_key
+CREATE TABLE `test_sort_key_tbl1` (
+  `order_number` bigint(20) NULL COMMENT "",
+  `date` datetime NULL COMMENT "",
+  `sku_number` varchar(65533) NULL COMMENT "",
+  `cost` decimal64(18, 0) NULL COMMENT "",
+  `price` double NULL COMMENT "",
+  `pt` varchar(255) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`order_number`, `date`, `sku_number`)
+DISTRIBUTED BY HASH(`order_number`)
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into test_sort_key_tbl1 values (1, '2023-10-01', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-02', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-01', 'a1', 2.0, 1010.00, '20231001');
+
+CREATE MATERIALIZED VIEW test_sort_key_tbl_mv1
+DISTRIBUTED BY RANDOM
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select sum(price), sum(price + 1), sum(cost), `date` from test_sort_key_tbl1 group by `date`;
+
+
+CREATE MATERIALIZED VIEW test_sort_key_tbl_mv2
+DISTRIBUTED BY RANDOM
+ORDER BY (`date`, sum_cost)
+REFRESH MANUAL
+PROPERTIES (
+"replication_num" = "1"
+)
+AS select sum(price), max(price), sum(cost) as sum_cost, `date` from test_sort_key_tbl1 group by `date`;
+
+refresh materialized view test_sort_key_tbl_mv1 with sync mode;
+refresh materialized view test_sort_key_tbl_mv2 with sync mode;
+select * from test_sort_key_tbl_mv1 order by 1, 2;
+select * from test_sort_key_tbl_mv2 order by 1, 2;
+
+
+insert into test_sort_key_tbl1 values (1, '2023-10-01', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-02', 'a1', 1.0, 100.00, '20231001'), (1, '2023-10-01', 'a1', 2.0, 1010.00, '20231001');
+
+refresh materialized view test_sort_key_tbl_mv1 with sync mode;
+refresh materialized view test_sort_key_tbl_mv2 with sync mode;
+select * from test_sort_key_tbl_mv1 order by 1, 2;
+select * from test_sort_key_tbl_mv2 order by 1, 2;
+drop materialized view test_sort_key_tbl_mv1;
+drop materialized view test_sort_key_tbl_mv2;


### PR DESCRIPTION
When the materialized view has set sort keys,  or adjust output column orders by the default sort key policy, need to set target names by the query's output columns' order in refreshing materialized view.



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
