### PR TITLE
[BugFix] Push down runtime filter across DecodeNode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DecodeNode.java
@@ -15,8 +15,11 @@
 
 package com.starrocks.planner;
 
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotId;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.common.Pair;
 import com.starrocks.thrift.TDecodeNode;
@@ -30,6 +33,8 @@ import java.nio.ByteBuffer;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 public class DecodeNode extends PlanNode {
@@ -38,15 +43,22 @@ public class DecodeNode extends PlanNode {
     // The string functions have applied global dict optimization
     private final Map<SlotId, Expr> stringFunctions;
 
+    // TupleId is changed when DecodeNode is interpolated, so pushing down runtime filters
+    // across DecodeNode requires that replace the output SlotRef with the input SlotRef.
+    private final Map<SlotRef, SlotRef> slotRefMap;
+
     public DecodeNode(PlanNodeId id,
                       TupleDescriptor tupleDescriptor,
                       PlanNode child,
                       Map<Integer, Integer> dictIdToStringIds,
-                      Map<SlotId, Expr> stringFunctions) {
+                      Map<SlotId, Expr> stringFunctions,
+                      Map<SlotRef, SlotRef> slotRefMap
+                      ) {
         super(id, tupleDescriptor.getId().asList(), "Decode");
         addChild(child);
         this.dictIdToStringIds = dictIdToStringIds;
         this.stringFunctions = stringFunctions;
+        this.slotRefMap = slotRefMap;
     }
 
     @Override
@@ -87,6 +99,33 @@ public class DecodeNode extends PlanNode {
             }
         }
         return output.toString();
+    }
+
+    @Override
+    public Optional<List<Expr>> candidatesOfSlotExpr(Expr expr, Function<Expr, Boolean> couldBound) {
+        if (!(expr instanceof SlotRef)) {
+            return Optional.empty();
+        }
+        if (!couldBound.apply(expr)) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(slotRefMap.get(expr)).map(Lists::newArrayList);
+    }
+
+    @Override
+    public boolean pushDownRuntimeFilters(DescriptorTable descTbl, RuntimeFilterDescription description,
+                                          Expr probeExpr,
+                                          List<Expr> partitionByExprs) {
+        if (!canPushDownRuntimeFilter()) {
+            return false;
+        }
+
+        if (!couldBound(probeExpr, description, descTbl)) {
+            return false;
+        }
+
+        return pushdownRuntimeFilterForChildOrAccept(descTbl, description, probeExpr, candidatesOfSlotExpr(probeExpr, couldBound(description, descTbl)),
+                partitionByExprs, candidatesOfSlotExprs(partitionByExprs, couldBoundForPartitionExpr()), 0, true);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -36,6 +36,7 @@ package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Analyzer;
@@ -59,6 +60,7 @@ import com.starrocks.thrift.TPlan;
 import com.starrocks.thrift.TPlanNode;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
+import org.roaringbitmap.RoaringBitmap;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -748,7 +750,9 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
 
     public Optional<List<List<Expr>>> candidatesOfSlotExprs(List<Expr> exprs, Function<Expr, Boolean> couldBound) {
         if (!exprs.stream().allMatch(expr -> candidatesOfSlotExpr(expr, couldBound).isPresent())) {
-            return Optional.empty();
+            // NOTE: This is necessary, when expr is partition_by_epxr because
+            // partition_by_exprs may exist in JoinNode below the ProjectNode.
+            return Optional.of(ImmutableList.of(exprs));
         }
         List<List<Expr>> candidatesOfSlotExprs =
                 exprs.stream().map(expr -> candidatesOfSlotExpr(expr, couldBound).get()).collect(Collectors.toList());
@@ -835,6 +839,18 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         return (Expr expr) -> expr.isBoundByTupleIds(getTupleIds());
     }
 
+    private RoaringBitmap cachedSlotIds = null;
+
+    public RoaringBitmap getSlotIds(DescriptorTable descTbl) {
+        if (cachedSlotIds == null) {
+            cachedSlotIds = new RoaringBitmap();
+            getTupleIds().stream().map(descTbl::getTupleDesc)
+                    .flatMap(tupleDesc -> tupleDesc.getSlots().stream().map(SlotDescriptor::getId))
+                    .map(SlotId::asInt).forEach(cachedSlotIds::add);
+        }
+        return cachedSlotIds;
+    }
+
     protected boolean couldBound(Expr probeExpr, RuntimeFilterDescription rfDesc, DescriptorTable descTbl) {
         if (probeExpr instanceof SlotRef &&
                 rfDesc.runtimeFilterType().equals(RuntimeFilterDescription.RuntimeFilterType.TOPN_FILTER)) {
@@ -849,7 +865,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             }
             return false;
         } else {
-            return probeExpr.isBoundByTupleIds(getTupleIds());
+            return getSlotIds(descTbl).contains(probeExpr.getUsedSlotIds());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -157,19 +157,6 @@ public class ProjectNode extends PlanNode {
         }
         return newExprs.size() > 0 ? Optional.of(newExprs) : Optional.empty();
     }
-
-    @Override
-    public Optional<List<List<Expr>>> candidatesOfSlotExprs(List<Expr> exprs, Function<Expr, Boolean> couldBound) {
-        if (!exprs.stream().allMatch(expr -> candidatesOfSlotExpr(expr, couldBound).isPresent())) {
-            // NOTE: This is necessary, when expr is partition_by_epxr because
-            // partition_by_exprs may exist in JoinNode below the ProjectNode.
-            return Optional.of(ImmutableList.of(exprs));
-        }
-        List<List<Expr>> candidatesOfSlotExprs =
-                exprs.stream().map(expr -> candidatesOfSlotExpr(expr, couldBound).get()).collect(Collectors.toList());
-        return Optional.of(candidateOfPartitionByExprs(candidatesOfSlotExprs));
-    }
-
     @Override
     public boolean pushDownRuntimeFilters(DescriptorTable descTbl, RuntimeFilterDescription description,
                                           Expr probeExpr,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -611,6 +611,7 @@ public class PlanFragmentBuilder {
 
             TupleDescriptor tupleDescriptor = context.getDescTbl().createTupleDescriptor();
 
+            Map<SlotRef, SlotRef> slotRefMap = Maps.newHashMap();
             for (TupleId tupleId : inputFragment.getPlanRoot().getTupleIds()) {
                 TupleDescriptor childTuple = context.getDescTbl().getTupleDesc(tupleId);
                 ArrayList<SlotDescriptor> slots = childTuple.getSlots();
@@ -632,6 +633,9 @@ public class PlanFragmentBuilder {
                         // Note: must change the parent tuple id
                         SlotDescriptor slotDescriptor = new SlotDescriptor(slot.getId(), tupleDescriptor, slot);
                         tupleDescriptor.addSlot(slotDescriptor);
+                        SlotRef inputSlotRef = new SlotRef(slot);
+                        SlotRef outputSlotRef = new SlotRef(slotDescriptor);
+                        slotRefMap.put(outputSlotRef, inputSlotRef);
                     }
                 }
             }
@@ -651,7 +655,7 @@ public class PlanFragmentBuilder {
             DecodeNode decodeNode = new DecodeNode(context.getNextNodeId(),
                     tupleDescriptor,
                     inputFragment.getPlanRoot(),
-                    node.getDictToStrings(), projectMap);
+                    node.getDictToStrings(), projectMap, slotRefMap);
             decodeNode.computeStatistics(optExpression.getStatistics());
             decodeNode.setLimit(node.getLimit());
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -983,8 +983,17 @@ public class WindowTest extends PlanTestBase {
                 "  |  order by: [1, BIGINT, true] ASC, [2, BIGINT, true] DESC\n" +
                 "  |  offset: 0\n" +
                 "  |  cardinality: 1\n" +
-                "  |  probe runtime filters:\n" +
-                "  |  - filter_id = 0, probe_expr = (1: v1)");
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     table: t0, rollup: t0\n" +
+                "     preAggregation: on\n" +
+                "     Predicates: 1: v1 IS NOT NULL\n" +
+                "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
+                "     tabletList=\n" +
+                "     actualRows=0, avgRowSize=2.0\n" +
+                "     cardinality: 1\n" +
+                "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (1: v1)");
     }
 
     @Test


### PR DESCRIPTION
If the left side of HashJoin is ScanNode->...->DecodeNode->...->HashJoin, the runtime filter can not be pushed down across DecodeNode and arrives at ScanNode, because an new tuple descriptor with a distinct TupleId is generated, the  probe expr above  the DecodeNode is bound to the TupleId of PlanNode below the DecodeNode instead of the DecodeNode's own TupleId, this is caused by reusing the cached Expr during ScalarOperator transforming to Expr.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
