### PR TITLE
[BugFix] Table disable light schema change throws no global dict in meta scan

### DIFF
--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -44,7 +44,8 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     _reader_params.id_to_names = &_parent->_meta_scan_node.id_to_names;
     TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
     tablet_schema->copy_from(_tablet->tablet_schema());
-    if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty()) {
+    if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty()
+        && _parent->_meta_scan_node.columns[0].col_unique_id > 0) {
         tablet_schema->clear_columns();
         for (auto& column : _parent->_meta_scan_node.columns) {
             tablet_schema->append_column(TabletColumn(column));

--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -44,8 +44,8 @@ Status OlapMetaScanner::_init_meta_reader_params() {
     _reader_params.id_to_names = &_parent->_meta_scan_node.id_to_names;
     TabletSchemaSPtr tablet_schema = std::make_shared<TabletSchema>();
     tablet_schema->copy_from(_tablet->tablet_schema());
-    if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty()
-        && _parent->_meta_scan_node.columns[0].col_unique_id > 0) {
+    if (_parent->_meta_scan_node.__isset.columns && !_parent->_meta_scan_node.columns.empty() &&
+        _parent->_meta_scan_node.columns[0].col_unique_id > 0) {
         tablet_schema->clear_columns();
         for (auto& column : _parent->_meta_scan_node.columns) {
             tablet_schema->append_column(TabletColumn(column));

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1219,3 +1219,70 @@ class StarrocksSQLApiLib(object):
 
             res = self._stream_load(label, db, table_name, data, headers)
             tools.assert_equal(res["Status"], "Success", "Prepare %s data error: %s" % (data_name, res["Message"]))
+
+    def execute_cmd(self, exec_url):
+        cmd_template = "curl -XPOST -u {user}:{passwd} '" + exec_url + "'"
+        cmd = cmd_template.format(user=self.mysql_user, passwd=self.mysql_password)
+        res = subprocess.run(
+            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, encoding="utf-8", timeout=1800
+        )
+        return str(res)
+
+    def manual_compact(self, database_name, table_name):
+        sql = "show tablet from " + database_name + "." + table_name
+        res = self.execute_sql(sql, "dml")
+        tools.assert_true(res["status"], res["msg"])
+        url = res["result"][0][20]
+
+        pos = url.find("api")
+        exec_url = url[0:pos] + "api/update_config?min_cumulative_compaction_num_singleton_deltas=0"
+        res = self.execute_cmd(exec_url)
+        print(res)
+
+        exec_url = url[0:pos] + "api/update_config?base_compaction_interval_seconds_since_last_operation=0"
+        res = self.execute_cmd(exec_url)
+        print(res)
+
+        exec_url = url[0:pos] + "api/update_config?cumulative_compaction_skip_window_seconds=1"
+        res = self.execute_cmd(exec_url)
+        print(res)
+
+        exec_url = url.replace("compaction/show", "compact") + "&compaction_type=cumulative"
+        res = self.execute_cmd(exec_url)
+        print(res)
+
+        exec_url = url.replace("compaction/show", "compact") + "&compaction_type=base"
+        res = self.execute_cmd(exec_url)
+        print(res)
+
+    def wait_analyze_finish(self, database_name, table_name, sql):
+        timeout = 300
+        analyze_sql = "show analyze status where `Database` = 'default_catalog.%s'" % database_name
+        res = self.execute_sql(analyze_sql, "dml")
+        while timeout > 0:
+            res = self.execute_sql(analyze_sql, "dml")
+            if len(res["result"]) > 0:
+                for table in res["result"]:
+                    if table[2] == table_name and table[4] == "FULL" and table[6] == "SUCCESS":
+                        break
+                break
+            else:
+                time.sleep(1)
+                timeout -= 1
+        else:
+            tools.assert_true(False, "analyze timeout")
+
+        finished = False
+        counter = 0
+        while True:
+            res = self.execute_sql(sql, "dml")
+            tools.assert_true(res["status"], res["msg"])
+            if str(res["result"]).find("Decode") > 0:
+                finished = True
+                break
+            time.sleep(5)
+            if counter > 10:
+                break
+            counter = counter + 1
+
+        tools.assert_true(finished, "analyze timeout")

--- a/test/sql/test_light_schema_change/R/test_light_schema_change
+++ b/test/sql/test_light_schema_change/R/test_light_schema_change
@@ -54,8 +54,8 @@ insert into t1 values(2, 2, 3);
 select * from t1 order by k;
 -- result:
 1	None	None
-2	2	3
 2	3	5
+2	2	3
 -- !result
 alter table t1 add column k2 int key;
 -- result:
@@ -67,8 +67,8 @@ None
 select * from t1 order by k;
 -- result:
 1	None	None	None
-2	None	2	3
 2	None	3	5
+2	None	2	3
 -- !result
 insert into t1 values(3, 2, 3, 4);
 -- result:
@@ -76,8 +76,8 @@ insert into t1 values(3, 2, 3, 4);
 select * from t1 order by k;
 -- result:
 1	None	None	None
-2	None	2	3
 2	None	3	5
+2	None	2	3
 3	2	3	4
 -- !result
 delete from t1 where v3>4;
@@ -280,5 +280,145 @@ drop table tab1;
 -- result:
 -- !result
 drop database test_light_schema_change;
+-- result:
+-- !result
+-- name: test_meta_scan
+create database meta_scan;
+-- result:
+-- !result
+use meta_scan;
+-- result:
+-- !result
+CREATE TABLE `reproducex4` (
+    `id_int` int(11) NULL COMMENT "",
+    `v1` varchar(255) NULL COMMENT ""
+)
+DUPLICATE KEY(`id_int`, `v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT",
+    "enable_persistent_index" = "false",
+    "light_schema_change" = "true"
+);
+-- result:
+-- !result
+insert into reproducex4 values (1,2),(3,4),(5,6);
+-- result:
+-- !result
+alter table reproducex4 add column v2 varchar(256) default "-1000" after v1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table reproducex4;
+-- result:
+reproducex4	CREATE TABLE `reproducex4` (
+  `id_int` int(11) NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT "",
+  `v2` varchar(256) NULL DEFAULT "-1000" COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id_int`, `v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- !result
+insert into reproducex4 values (7,8,9);
+-- result:
+-- !result
+function: manual_compact("meta_scan", "reproducex4")
+-- result:
+None
+-- !result
+select dict_merge(v2) from reproducex4 [_META_];
+-- result:
+{"2":{"lst":["str",2,"LTEwMDA","OQ"]},"3":{"lst":["i32",2,1,2]}}
+-- !result
+analyze full table reproducex4;
+-- result:
+meta_scan.reproducex4	analyze	status	OK
+-- !result
+function: wait_analyze_finish("meta_scan", "reproducex4", "explain select v2 from reproducex4 group by v2;")
+-- result:
+None
+-- !result
+drop table reproducex4;
+-- result:
+-- !result
+CREATE TABLE `reproducex4` (
+    `id_int` int(11) NULL COMMENT "",
+    `v1` varchar(255) NULL COMMENT ""
+)
+DUPLICATE KEY(`id_int`, `v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT",
+    "enable_persistent_index" = "false",
+    "light_schema_change" = "false"
+);
+-- result:
+-- !result
+insert into reproducex4 values (1,2),(3,4),(5,6);
+-- result:
+-- !result
+alter table reproducex4 add column v2 varchar(256) default "-1000" after v1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+show create table reproducex4;
+-- result:
+reproducex4	CREATE TABLE `reproducex4` (
+  `id_int` int(11) NULL COMMENT "",
+  `v1` varchar(255) NULL COMMENT "",
+  `v2` varchar(256) NULL DEFAULT "-1000" COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id_int`, `v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- !result
+insert into reproducex4 values (7,8,9);
+-- result:
+-- !result
+function: manual_compact("meta_scan", "reproducex4")
+-- result:
+None
+-- !result
+select dict_merge(v2) from reproducex4 [_META_];
+-- result:
+{"2":{"lst":["str",2,"LTEwMDA","OQ"]},"3":{"lst":["i32",2,1,2]}}
+-- !result
+analyze full table reproducex4;
+-- result:
+meta_scan.reproducex4	analyze	status	OK
+-- !result
+function: wait_analyze_finish("meta_scan", "reproducex4", "explain select v2 from reproducex4 group by v2;")
+-- result:
+None
+-- !result
+drop database meta_scan;
 -- result:
 -- !result

--- a/test/sql/test_light_schema_change/T/test_light_schema_change
+++ b/test/sql/test_light_schema_change/T/test_light_schema_change
@@ -93,3 +93,70 @@ select * from tab1;
 drop table t1;
 drop table tab1;
 drop database test_light_schema_change;
+
+
+-- name: test_meta_scan
+create database meta_scan;
+use meta_scan;
+CREATE TABLE `reproducex4` (
+    `id_int` int(11) NULL COMMENT "",
+    `v1` varchar(255) NULL COMMENT ""
+)
+DUPLICATE KEY(`id_int`, `v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT",
+    "enable_persistent_index" = "false",
+    "light_schema_change" = "true"
+);
+
+insert into reproducex4 values (1,2),(3,4),(5,6);
+alter table reproducex4 add column v2 varchar(256) default "-1000" after v1;
+function: wait_alter_table_finish()
+
+show create table reproducex4;
+
+insert into reproducex4 values (7,8,9);
+function: manual_compact("meta_scan", "reproducex4")
+
+select dict_merge(v2) from reproducex4 [_META_];
+analyze full table reproducex4;
+
+function: wait_analyze_finish("meta_scan", "reproducex4", "explain select v2 from reproducex4 group by v2;")
+
+
+drop table reproducex4;
+CREATE TABLE `reproducex4` (
+    `id_int` int(11) NULL COMMENT "",
+    `v1` varchar(255) NULL COMMENT ""
+)
+DUPLICATE KEY(`id_int`, `v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`id_int`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "in_memory" = "false",
+    "storage_format" = "DEFAULT",
+    "enable_persistent_index" = "false",
+    "light_schema_change" = "false"
+);
+
+insert into reproducex4 values (1,2),(3,4),(5,6);
+alter table reproducex4 add column v2 varchar(256) default "-1000" after v1;
+function: wait_alter_table_finish()
+
+show create table reproducex4;
+
+insert into reproducex4 values (7,8,9);
+function: manual_compact("meta_scan", "reproducex4")
+
+select dict_merge(v2) from reproducex4 [_META_];
+analyze full table reproducex4;
+
+function: wait_analyze_finish("meta_scan", "reproducex4", "explain select v2 from reproducex4 group by v2;")
+
+
+drop database meta_scan;


### PR DESCRIPTION
After we enable light schema change, the tablet schema in BE maybe not the latest. So we need to regenerate tablet schema according to FE and we will generate a column unique id for each column in FE. But if a table created in old version, the column unique id in FE is default value(-1) and BE will assign the unique id to each column.  So when we do meta scan and we generate the tablet schema according to FE, the column unique id is -1. And when we create column iterator, we can not find the right column iterator according to the unique id and it will throw `no global dict` exception when we do meta scan.

The solution is when we do meta scan for the table disable light schema change, we still use tablet schema in BE,

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
