### PR TITLE
[Enhancement] release update file's cache when memory tracker limit exceeds

### DIFF
--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -51,7 +51,7 @@ Status RowsetColumnUpdateState::load(Tablet* tablet, Rowset* rowset, MemTracker*
     }
     std::call_once(_load_once_flag, [&] {
         _tablet_id = tablet->tablet_id();
-        _status = _do_load(tablet, rowset);
+        _status = _do_load(tablet, rowset, update_mem_tracker);
         if (!_status.ok()) {
             LOG(WARNING) << "load RowsetColumnUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"
                          << get_stack_trace();
@@ -74,7 +74,8 @@ void RowsetColumnUpdateState::_release_upserts(uint32_t start_idx, uint32_t end_
     }
 }
 
-Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t start_idx, uint32_t* end_idx) {
+Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, MemTracker* update_mem_tracker, uint32_t start_idx,
+                                              uint32_t* end_idx) {
     RowsetReleaseGuard guard(rowset->shared_from_this());
     if (_upserts.size() == 0) {
         _upserts.resize(rowset->num_update_files());
@@ -98,15 +99,7 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t start_idx
     for (size_t i = 0; i < schema->num_key_columns(); i++) {
         pk_columns.push_back((uint32_t)i);
     }
-    std::vector<uint32_t> update_columns;
-    const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
-    for (uint32_t cid : txn_meta.partial_update_column_ids()) {
-        if (cid >= schema->num_key_columns()) {
-            update_columns.push_back(cid);
-        }
-    }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
-    Schema update_schema = ChunkHelper::convert_schema(schema, update_columns);
     std::unique_ptr<Column> pk_column;
     if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
         std::string err_msg = fmt::format("create column for primary key encoder failed, tablet_id: {}", _tablet_id);
@@ -121,7 +114,6 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t start_idx
     header_ptr->upserts = pk_column->clone();
     header_ptr->start_idx = start_idx;
     for (uint32_t idx = start_idx; idx < rowset->num_update_files(); idx++) {
-        _update_chunk_cache[idx] = ChunkHelper::new_chunk(update_schema, 0);
         header_ptr->offsets.push_back(header_ptr->upserts->size());
         auto chunk = chunk_shared_ptr.get();
         auto col = pk_column->clone();
@@ -151,7 +143,8 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t start_idx
         _upserts[idx] = header_ptr;
         *end_idx = idx + 1;
         // quit merge PK into BatchPKs when hiting memory limit
-        if (header_ptr->upserts->memory_usage() + _memory_usage > config::primary_key_batch_get_index_memory_limit) {
+        if (header_ptr->upserts->memory_usage() + _memory_usage > config::primary_key_batch_get_index_memory_limit ||
+            update_mem_tracker->any_limit_exceeded()) {
             break;
         }
     }
@@ -168,12 +161,12 @@ Status RowsetColumnUpdateState::_load_upserts(Rowset* rowset, uint32_t start_idx
     return Status::OK();
 }
 
-Status RowsetColumnUpdateState::_do_load(Tablet* tablet, Rowset* rowset) {
+Status RowsetColumnUpdateState::_do_load(Tablet* tablet, Rowset* rowset, MemTracker* update_mem_tracker) {
     auto span = Tracer::Instance().start_trace_txn_tablet("rowset_column_update_state_load", rowset->txn_id(),
                                                           tablet->tablet_id());
     if (rowset->num_update_files() > 0) {
         uint32_t end_idx = 0;
-        RETURN_IF_ERROR(_load_upserts(rowset, 0, &end_idx));
+        RETURN_IF_ERROR(_load_upserts(rowset, update_mem_tracker, 0, &end_idx));
         DCHECK(end_idx > 0);
         RETURN_IF_ERROR(_prepare_partial_update_states(tablet, rowset, 0, end_idx, true));
     }
@@ -274,6 +267,7 @@ Status RowsetColumnUpdateState::_check_and_resolve_conflict(Tablet* tablet, uint
 }
 
 Status RowsetColumnUpdateState::_finalize_partial_update_state(Tablet* tablet, Rowset* rowset,
+                                                               MemTracker* update_mem_tracker,
                                                                EditVersion latest_applied_version,
                                                                const PrimaryIndex& index) {
     const auto& rowset_meta_pb = rowset->rowset_meta()->get_meta_pb();
@@ -284,7 +278,7 @@ Status RowsetColumnUpdateState::_finalize_partial_update_state(Tablet* tablet, R
     RETURN_IF_ERROR(_init_rowset_seg_id(tablet));
     for (uint32_t i = 0; i < rowset->num_update_files();) {
         uint32_t end_idx = 0;
-        RETURN_IF_ERROR(_load_upserts(rowset, i, &end_idx));
+        RETURN_IF_ERROR(_load_upserts(rowset, update_mem_tracker, i, &end_idx));
         DCHECK(end_idx > i);
         // check and resolve conflict
         if (_partial_update_states.size() == 0 || !_partial_update_states[i].inited) {
@@ -357,7 +351,7 @@ StatusOr<std::unique_ptr<SegmentWriter>> RowsetColumnUpdateState::_prepare_delta
     return std::move(segment_writer);
 }
 
-static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const ChunkPtr& result_chunk) {
+static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const ChunkUniquePtr& result_chunk) {
     auto chunk = result_chunk->clone_empty(1024);
     while (true) {
         chunk->reset();
@@ -377,14 +371,15 @@ static Status read_chunk_from_update_file(const ChunkIteratorPtr& iter, const Ch
 // 1. get the rows from update files, store in `result_chunk`
 // 2. generate `rowids`, the rowid list marks the rows in source segment file which be updated.
 Status RowsetColumnUpdateState::_read_chunk_from_update(const RowidsToUpdateRowids& rowid_to_update_rowid,
-                                                        const Schema& partial_schema, Rowset* rowset,
-                                                        OlapReaderStatistics* stats, std::vector<uint32_t>& rowids,
-                                                        Chunk* result_chunk) {
+                                                        const Schema& partial_schema, MemTracker* tracker,
+                                                        Rowset* rowset, OlapReaderStatistics* stats,
+                                                        std::vector<uint32_t>& rowids, Chunk* result_chunk) {
     // We split the task into multiple rounds according to the update file where the updated rows are located.
     std::vector<uint32_t> batch_append_rowids;
     uint32_t cur_update_file_id = UINT32_MAX;
     auto prepare_update_chunk_cache_fn = [&]() {
-        if (_update_chunk_cache[cur_update_file_id]->is_empty()) {
+        if (_update_chunk_cache[cur_update_file_id].get() == nullptr) {
+            _update_chunk_cache[cur_update_file_id] = ChunkHelper::new_chunk(partial_schema, 0);
             ASSIGN_OR_RETURN(auto update_iterator,
                              rowset->get_update_file_iterator(partial_schema, cur_update_file_id, stats));
             DeferOp iter_defer([&]() {
@@ -395,8 +390,16 @@ Status RowsetColumnUpdateState::_read_chunk_from_update(const RowidsToUpdateRowi
             _update_chunk_cache[cur_update_file_id]->reserve(DEFAULT_CHUNK_SIZE);
             // if already read from this update file, iterator will return end of file, and continue
             RETURN_IF_ERROR(read_chunk_from_update_file(update_iterator, _update_chunk_cache[cur_update_file_id]));
+            tracker->consume(_update_chunk_cache[cur_update_file_id]->memory_usage());
         }
         return Status::OK();
+    };
+    auto clear_update_chunk_cache_fn = [&]() {
+        // clear cache if Update MemTracker limit exceeded
+        if (tracker->any_limit_exceeded() && _update_chunk_cache[cur_update_file_id].get() != nullptr) {
+            tracker->release(_update_chunk_cache[cur_update_file_id]->memory_usage());
+            _update_chunk_cache[cur_update_file_id].reset(nullptr);
+        }
     };
     for (const auto& each : rowid_to_update_rowid) {
         rowids.push_back(each.first);
@@ -413,6 +416,7 @@ Status RowsetColumnUpdateState::_read_chunk_from_update(const RowidsToUpdateRowi
             DCHECK(_update_chunk_cache[cur_update_file_id]->num_rows() >= batch_append_rowids.size());
             result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
                                            batch_append_rowids.size());
+            clear_update_chunk_cache_fn();
             cur_update_file_id = each.second.first;
             batch_append_rowids.clear();
             batch_append_rowids.push_back(each.second.second);
@@ -424,6 +428,7 @@ Status RowsetColumnUpdateState::_read_chunk_from_update(const RowidsToUpdateRowi
         DCHECK(_update_chunk_cache[cur_update_file_id]->num_rows() >= batch_append_rowids.size());
         result_chunk->append_selective(*_update_chunk_cache[cur_update_file_id], batch_append_rowids.data(), 0,
                                        batch_append_rowids.size());
+        clear_update_chunk_cache_fn();
     }
     return Status::OK();
 }
@@ -558,7 +563,7 @@ Status RowsetColumnUpdateState::_insert_new_rows(const TabletSchemaCSPtr& tablet
             });
             // 1. generate segment file
             auto chunk_ptr = ChunkHelper::new_chunk(schema, _partial_update_states[upt_id].insert_rowids.size());
-            ChunkPtr partial_chunk_ptr = ChunkHelper::new_chunk(partial_schema, DEFAULT_CHUNK_SIZE);
+            ChunkUniquePtr partial_chunk_ptr = ChunkHelper::new_chunk(partial_schema, DEFAULT_CHUNK_SIZE);
             ASSIGN_OR_RETURN(auto writer, _prepare_segment_writer(rowset, tablet_schema, segid));
             RETURN_IF_ERROR(read_chunk_from_update_file(update_iterator, partial_chunk_ptr));
             for (uint32_t column_id : read_update_column_ids.second) {
@@ -595,7 +600,7 @@ Status RowsetColumnUpdateState::_insert_new_rows(const TabletSchemaCSPtr& tablet
 }
 
 Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_t rowset_id,
-                                         PersistentIndexMetaPB& index_meta,
+                                         PersistentIndexMetaPB& index_meta, MemTracker* tracker,
                                          vector<std::pair<uint32_t, DelVectorPtr>>& delvecs, PrimaryIndex& index) {
     if (_finalize_finished) return Status::OK();
     std::stringstream cost_str;
@@ -608,7 +613,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     // 1. resolve conflicts and generate `ColumnPartialUpdateState` finally.
     EditVersion latest_applied_version;
     RETURN_IF_ERROR(tablet->updates()->get_latest_applied_version(&latest_applied_version));
-    RETURN_IF_ERROR(_finalize_partial_update_state(tablet, rowset, latest_applied_version, index));
+    RETURN_IF_ERROR(_finalize_partial_update_state(tablet, rowset, tracker, latest_applied_version, index));
 
     std::vector<int32_t> update_column_ids;
     std::vector<uint32_t> update_column_uids;
@@ -674,12 +679,18 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
         ASSIGN_OR_RETURN(auto source_chunk_ptr,
                          read_from_source_segment(rowset, partial_schema, tablet, &stats,
                                                   latest_applied_version.major_number(), rowsetid_segid, seg_path));
+        const size_t source_chunk_size = source_chunk_ptr->memory_usage();
+        tracker->consume(source_chunk_size);
+        DeferOp tracker_defer([&]() { tracker->release(source_chunk_size); });
         // 3.2 read from update segment
         int64_t t2 = MonotonicMillis();
         std::vector<uint32_t> rowids;
         auto update_chunk_ptr = ChunkHelper::new_chunk(partial_schema, each.second.size());
-        RETURN_IF_ERROR(
-                _read_chunk_from_update(each.second, partial_schema, rowset, &stats, rowids, update_chunk_ptr.get()));
+        RETURN_IF_ERROR(_read_chunk_from_update(each.second, partial_schema, tracker, rowset, &stats, rowids,
+                                                update_chunk_ptr.get()));
+        const size_t update_chunk_size = update_chunk_ptr->memory_usage();
+        tracker->consume(update_chunk_size);
+        DeferOp tracker_defer2([&]() { tracker->release(update_chunk_size); });
         int64_t t3 = MonotonicMillis();
         // 3.3 merge source chunk and update chunk
         RETURN_IF_EXCEPTION(source_chunk_ptr->update_rows(*update_chunk_ptr, rowids.data()));
@@ -715,6 +726,13 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
         cost_str << " [insert missing rows] " << watch.elapsed_time();
         watch.reset();
     }
+    // 5. release update chunk cache
+    std::for_each(_update_chunk_cache.begin(), _update_chunk_cache.end(), [&](auto& cache) {
+        if (cache.get() != nullptr) {
+            tracker->release(cache->memory_usage());
+            cache.reset(nullptr);
+        }
+    });
     cost_str << strings::Substitute(
             " seek_source_segment(ms):$0 read_column_from_update(ms):$1 avg_merge_column_time(ms):$2 "
             "avg_finalize_dcg_time(ms):$3 ",

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -959,7 +959,7 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
     vector<std::pair<uint32_t, DelVectorPtr>> new_del_vecs;
     span->AddEvent("gen_delta_column_group");
     // 3. finalize and generate delta column group
-    st = state.finalize(&_tablet, rowset.get(), rowset_id, index_meta, new_del_vecs, index);
+    st = state.finalize(&_tablet, rowset.get(), rowset_id, index_meta, manager->mem_tracker(), new_del_vecs, index);
     if (!st.ok()) {
         failure_handler("finalize failed", st);
         return;

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -934,6 +934,52 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_too_many_segment_and_check)
     ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
 }
 
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_too_many_segment_and_limit_mem_tracker) {
+    const int N = 10;
+    // generate M upt files in each partial rowset
+    const int M = 1000;
+    auto tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+    }
+    auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
+    auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(20);
+    // write full rowset first
+    for (int i = 0; i < 10; i++) {
+        rowsets.emplace_back(create_rowset(tablet, keys));
+    }
+    std::vector<std::shared_ptr<TabletSchema>> partial_schemas;
+    // partial update v1 and v2 one by one
+    for (int i = 0; i < 10; i++) {
+        std::vector<int32_t> column_indexes = {0, (i % 2) + 1};
+        partial_schemas.push_back(TabletSchema::create(tablet->tablet_schema(), column_indexes));
+        rowsets.emplace_back(
+                create_partial_rowset(tablet, keys, column_indexes, v1_func, v2_func, partial_schemas[i], M));
+        ASSERT_EQ(rowsets.back()->num_update_files(), M);
+    }
+
+    MemTracker* tracker = StorageEngine::instance()->update_manager()->mem_tracker();
+    const int64_t old_limit = tracker->limit();
+    tracker->set_limit(1);
+    int64_t version = 1;
+    commit_rowsets(tablet, rowsets, version);
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
+    }));
+    tracker->set_limit(old_limit);
+    // check refcnt
+    for (const auto& rs_ptr : rowsets) {
+        ASSERT_FALSE(StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
+    }
+    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+}
+
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
                          ::testing::Values(1, 1024, 104857600));
 


### PR DESCRIPTION
Fixes #20436
When handle PCU(Partial Column Update) apply task, we will cache data read from `.upt`, but it won't release until apply finish. If there is a very large PCU, and many apply thread will cost too many memory here.
So we need to release cache when `update` memory tracker limit exceeds.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
