### PR TITLE
[Enhancement] Avoid build slice for unary function

### DIFF
--- a/be/src/column/column_helper.h
+++ b/be/src/column/column_helper.h
@@ -513,14 +513,20 @@ template <LogicalType ltype>
 struct GetContainer {
     using ColumnType = typename RunTimeTypeTraits<ltype>::ColumnType;
     const auto& get_data(const Column* column) { return ColumnHelper::as_raw_column<ColumnType>(column)->get_data(); }
+    const auto& get_data(const ColumnPtr& column) {
+        return ColumnHelper::as_raw_column<ColumnType>(column.get())->get_data();
+    }
 };
 
-#define GET_CONTAINER(ltype)                                                            \
-    template <>                                                                         \
-    struct GetContainer<ltype> {                                                        \
-        const auto& get_data(const Column* column) {                                    \
-            return ColumnHelper::as_raw_column<BinaryColumn>(column)->get_proxy_data(); \
-        }                                                                               \
+#define GET_CONTAINER(ltype)                                                                  \
+    template <>                                                                               \
+    struct GetContainer<ltype> {                                                              \
+        const auto& get_data(const Column* column) {                                          \
+            return ColumnHelper::as_raw_column<BinaryColumn>(column)->get_proxy_data();       \
+        }                                                                                     \
+        const auto& get_data(const ColumnPtr& column) {                                       \
+            return ColumnHelper::as_raw_column<BinaryColumn>(column.get())->get_proxy_data(); \
+        }                                                                                     \
     };
 APPLY_FOR_ALL_STRING_TYPE(GET_CONTAINER)
 #undef GET_CONTAINER


### PR DESCRIPTION
Avoid build slice for unary function, otherwise it will use extra memory

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
