### PR TITLE
[BugFix] Fix pindex read-write concurrency between commit and apply

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4509,14 +4509,15 @@ Status PersistentIndex::_merge_compaction_advance() {
     RETURN_IF_ERROR(writer->finish());
     std::vector<std::unique_ptr<ImmutableIndex>> new_l1_vec;
     std::vector<int> new_l1_merged_num;
-    size_t merge_num = _l1_merged_num[merge_l1_start_idx];
-    for (int i = 0; i < merge_l1_start_idx; i++) {
-        new_l1_vec.emplace_back(std::move(_l1_vec[i]));
-        new_l1_merged_num.emplace_back(_l1_merged_num[i]);
-    }
-
+    size_t merge_num = 0;
     {
         std::unique_lock wrlock(_lock);
+        merge_num = _l1_merged_num[merge_l1_start_idx];
+        for (int i = 0; i < merge_l1_start_idx; i++) {
+            new_l1_vec.emplace_back(std::move(_l1_vec[i]));
+            new_l1_merged_num.emplace_back(_l1_merged_num[i]);
+        }
+
         for (int i = merge_l1_start_idx; i < _l1_vec.size(); i++) {
             _l1_vec[i]->destroy();
         }


### PR DESCRIPTION
During the execution of apply on the primary key table, the apply thread maybe clear or modify _l1_vec of persistent index.
And during the execution commit, the commit thread will update primary index memory usage and need to access _l1_vec.
So there are read/write conflicts between apply thread and commit thread which may cause BE crash. And we add `_lock` to prevent the read-write concurrency in previous pr but there are some scenarios where locks were inadvertently missed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
