### PR TITLE
[BugFix] Fix count(*) error during adding smaller type column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -58,6 +58,7 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -422,6 +423,16 @@ public class Utils {
             gid = gid * 2 + (bitSet.get(b) ? 1 : 0);
         }
         return gid;
+    }
+
+    public static ColumnRefOperator findSmallestColumnRefFromTable(Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                                                   Table table) {
+        Set<Column> baseSchema = new HashSet<>(table.getBaseSchema());
+        List<ColumnRefOperator> visibleColumnRefs = colRefToColumnMetaMap.entrySet().stream()
+                .filter(e -> baseSchema.contains(e.getValue()))
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toList());
+        return findSmallestColumnRef(visibleColumnRefs);
     }
 
     public static ColumnRefOperator findSmallestColumnRef(List<ColumnRefOperator> columnRefOperatorList) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -29,7 +29,6 @@ import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -62,9 +61,9 @@ public class PruneScanColumnRule extends TransformationRule {
                         .collect(Collectors.toSet());
         outputColumns.addAll(Utils.extractColumnRef(scanOperator.getPredicate()));
         boolean canUseAnyColumn = false;
-        if (outputColumns.size() == 0) {
-            outputColumns.add(Utils.findSmallestColumnRef(
-                    new ArrayList<>(scanOperator.getColRefToColumnMetaMap().keySet())));
+        if (outputColumns.isEmpty()) {
+            outputColumns.add(
+                    Utils.findSmallestColumnRefFromTable(scanOperator.getColRefToColumnMetaMap(), scanOperator.getTable()));
             canUseAnyColumn = true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -33,7 +33,6 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -64,9 +63,9 @@ public class MVColumnPruner {
                     scanOperator.getColRefToColumnMetaMap().keySet().stream().filter(requiredOutputColumns::contains)
                             .collect(Collectors.toSet());
             outputColumns.addAll(Utils.extractColumnRef(scanOperator.getPredicate()));
-            if (outputColumns.size() == 0) {
-                outputColumns.add(Utils.findSmallestColumnRef(
-                        new ArrayList<>(scanOperator.getColRefToColumnMetaMap().keySet())));
+            if (outputColumns.isEmpty()) {
+                outputColumns.add(
+                        Utils.findSmallestColumnRefFromTable(scanOperator.getColRefToColumnMetaMap(), scanOperator.getTable()));
             }
 
             ImmutableMap.Builder<ColumnRefOperator, Column> columnRefColumnMapBuilder = new ImmutableMap.Builder<>();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTaskTest.java
@@ -145,15 +145,25 @@ public class OptimizerTaskTest {
         scan1ColumnMap.put(column1, new Column("t1", ScalarType.INT, true));
         scan1ColumnMap.put(column2, new Column("t2", ScalarType.INT, true));
 
-        Map<ColumnRefOperator, Column> scan2ColumnMap = Maps.newHashMap();
-        scan2ColumnMap.put(column3, new Column("t3", ScalarType.INT, true));
-        scan2ColumnMap.put(column4, new Column("t4", ScalarType.INT, true));
-
         OptExpression logicOperatorTree = OptExpression.create(new LogicalJoinOperator(),
                 OptExpression.create(new LogicalOlapScanOperator(olapTable1,
                         scan1ColumnMap, Maps.newHashMap(), null, -1, null)),
                 OptExpression.create(new LogicalOlapScanOperator(olapTable2,
                         scan1ColumnMap, Maps.newHashMap(), null, -1, null)));
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scan1ColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable2.getBaseSchema();
+                result = new ArrayList<>(scan1ColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         Optimizer optimizer = new Optimizer();
         optimizer.optimize(ctx, logicOperatorTree, new PhysicalPropertySet(), new ColumnRefSet(),
@@ -222,6 +232,26 @@ public class OptimizerTaskTest {
                 bottomJoin,
                 new OptExpression(new LogicalOlapScanOperator(olapTable3,
                         scanColumnMap, Maps.newHashMap(), null, -1, null)));
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable2.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable3.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         Optimizer optimizer = new Optimizer();
         optimizer.optimize(ctx, topJoin, new PhysicalPropertySet(), new ColumnRefSet(),
@@ -300,6 +330,32 @@ public class OptimizerTaskTest {
         scan3ColumnMap.put(column3, new Column("t3", ScalarType.INT, true));
         Map<ColumnRefOperator, Column> scan4ColumnMap = Maps.newHashMap();
         scan4ColumnMap.put(column4, new Column("t4", ScalarType.INT, true));
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scan1ColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable2.getBaseSchema();
+                result = new ArrayList<>(scan2ColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable3.getBaseSchema();
+                result = new ArrayList<>(scan3ColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable4.getBaseSchema();
+                result = new ArrayList<>(scan4ColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         OptExpression bottomJoin = OptExpression.create(new LogicalJoinOperator(),
                 OptExpression.create(new LogicalOlapScanOperator(olapTable1,
@@ -382,6 +438,34 @@ public class OptimizerTaskTest {
                 new OptExpression(
                         new LogicalOlapScanOperator(olapTable4, scanColumnMap,
                                 Maps.newHashMap(), null, -1, null)));
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+            {
+                olapTable2.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+            {
+                olapTable3.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+            {
+                olapTable4.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+            {
+                olapTable5.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         Optimizer optimizer = new Optimizer();
         optimizer.optimize(ctx, topJoin, new PhysicalPropertySet(), new ColumnRefSet(),
@@ -479,6 +563,56 @@ public class OptimizerTaskTest {
                 new OptExpression(
                         new LogicalOlapScanOperator(olapTable4, scanColumnMap,
                                 Maps.newHashMap(), null, -1, null)));
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable2.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable3.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable4.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable5.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable6.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable7.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+
+            {
+                olapTable8.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         Optimizer optimizer = new Optimizer();
         optimizer.optimize(ctx, topJoin, new PhysicalPropertySet(), new ColumnRefSet(),
@@ -600,6 +734,14 @@ public class OptimizerTaskTest {
                 OptExpression.create(new LogicalOlapScanOperator(olapTable1,
                         scanColumnMap, Maps.newHashMap(), null, -1, null)));
 
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
+
         Optimizer optimizer = new Optimizer();
         OptExpression physicalTree = optimizer.optimize(ctx, expression, new PhysicalPropertySet(), new ColumnRefSet(),
                 columnRefFactory);
@@ -670,6 +812,14 @@ public class OptimizerTaskTest {
                 OptExpression.create(
                         new LogicalOlapScanOperator(olapTable1, scanColumnMap, Maps.newHashMap(), null,
                                 -1, null)));
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         Optimizer optimizer = new Optimizer();
         OptExpression physicalTree = optimizer.optimize(ctx, expression, new PhysicalPropertySet(),
@@ -814,6 +964,14 @@ public class OptimizerTaskTest {
         scanColumnMap.put(column3, new Column("t3", ScalarType.INT, true));
         scanColumnMap.put(column4, new Column("t4", ScalarType.INT, true));
 
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
+
         Map<ColumnRefOperator, CallOperator> map = Maps.newHashMap();
         map.put(column5, call);
         LogicalAggregationOperator aggregationOperator =
@@ -873,6 +1031,14 @@ public class OptimizerTaskTest {
 
         ColumnRefSet outputColumns = new ColumnRefSet(column4.getId());
 
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
+
         Optimizer optimizer = new Optimizer();
         try {
             optimizer.optimize(ctx, expression, new PhysicalPropertySet(), outputColumns, columnRefFactory);
@@ -921,6 +1087,14 @@ public class OptimizerTaskTest {
                 new LogicalProjectOperator(projectColumnMap), limit);
 
         ColumnRefSet outputColumns = new ColumnRefSet(column4.getId());
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         Optimizer optimizer = new Optimizer();
         try {
@@ -1076,8 +1250,6 @@ public class OptimizerTaskTest {
             }
         };
 
-        List<ColumnRefOperator> scanColumns = Lists.newArrayList(column1, column2);
-
         Map<ColumnRefOperator, Column> scanColumnMap = Maps.newHashMap();
         scanColumnMap.put(column1, new Column("t1", ScalarType.INT, true));
         scanColumnMap.put(column2, new Column("t2", ScalarType.INT, true));
@@ -1092,6 +1264,14 @@ public class OptimizerTaskTest {
         OptExpression expression = OptExpression.create(aggregationOperator, OptExpression.create(scanOperator));
 
         ColumnRefSet outputColumns = new ColumnRefSet(Lists.newArrayList(column3));
+
+        new Expectations() {
+            {
+                olapTable1.getBaseSchema();
+                result = new ArrayList<>(scanColumnMap.values());
+                minTimes = 0;
+            }
+        };
 
         Optimizer optimizer = new Optimizer();
         try {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -981,6 +981,24 @@ class StarrocksSQLApiLib(object):
             sleep_time += 0.5
         tools.assert_equal("FINISHED", status, "wait alter table finish error")
 
+    def wait_alter_table_not_pending(self, alter_type="COLUMN"):
+        """
+        wait until the status of the latest alter table job becomes from PNEDING to others
+        """
+        status = ""
+        while True:
+            res = self.execute_sql(
+                "SHOW ALTER TABLE %s ORDER BY CreateTime DESC LIMIT 1" % alter_type,
+                True,
+            )
+            if (not res["status"]) or len(res["result"]) <= 0:
+                return None
+
+            status = res["result"][0][9]
+            if status != "PENDING":
+                break
+            time.sleep(0.5)
+
     def wait_optimize_table_finish(self, alter_type="OPTIMIZE"):
         """
         wait alter table job finish and return status

--- a/test/sql/test_add_column/R/test_add_column
+++ b/test/sql/test_add_column/R/test_add_column
@@ -1,0 +1,69 @@
+-- name: test_count_star_after_adding_column @sequential
+ADMIN SET FRONTEND CONFIG ("allow_default_light_schema_change"="false");
+-- result:
+-- !result
+create table t0(
+    k1 INT,
+    c1 INT
+) 
+DUPLICATE KEY(k1) 
+DISTRIBUTED BY HASH(k1) BUCKETS 3;
+-- result:
+-- !result
+insert into t0 values (1,1);
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+select * from t0 order by k1;
+-- result:
+1	1
+-- !result
+alter table t0 add column b1 BOOLEAN;
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+function: wait_alter_table_not_pending()
+-- result:
+None
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+select count(*) from t0;
+-- result:
+1
+-- !result
+select * from t0 order by k1;
+-- result:
+1	1	None
+-- !result
+ADMIN SET FRONTEND CONFIG ("allow_default_light_schema_change"="true");
+-- result:
+-- !result

--- a/test/sql/test_add_column/T/test_add_column
+++ b/test/sql/test_add_column/T/test_add_column
@@ -1,0 +1,30 @@
+-- name: test_count_star_after_adding_column @sequential
+ADMIN SET FRONTEND CONFIG ("allow_default_light_schema_change"="false");
+
+create table t0(
+    k1 INT,
+    c1 INT
+) 
+DUPLICATE KEY(k1) 
+DISTRIBUTED BY HASH(k1) BUCKETS 3;
+
+insert into t0 values (1,1);
+select count(*) from t0;
+select * from t0 order by k1;
+
+alter table t0 add column b1 BOOLEAN;
+select count(*) from t0;
+
+function: wait_alter_table_not_pending()
+select count(*) from t0;
+select count(*) from t0;
+select count(*) from t0;
+
+function: wait_alter_table_finish()
+select count(*) from t0;
+select count(*) from t0;
+select count(*) from t0;
+
+select * from t0 order by k1;
+
+ADMIN SET FRONTEND CONFIG ("allow_default_light_schema_change"="true");


### PR DESCRIPTION
Fixes #33242.

`select count(*) from t1` select the smallest column from the table `t1`. However, the candidates includes invisible columns. Therefore, if a smaller column `boolean_col` is added to the table and the schema change job is still running, the invisible column `boolean_col` will be selected wrongly.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
