### PR TITLE
[BugFix] Fix column overflow in RowsetUpdateState and CompactionState

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -291,6 +291,10 @@ void BinaryColumnBase<T>::append_value_multiple_times(const void* value, size_t 
 
 template <typename T>
 void BinaryColumnBase<T>::_build_slices() const {
+    if constexpr (std::is_same_v<T, uint32_t>) {
+        CHECK_LT(_bytes.size(), (size_t)UINT32_MAX) << "BinaryColumn size overflow";
+    }
+
     DCHECK(_offsets.size() > 0);
     _slices_cache = false;
     _slices.clear();

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -170,7 +170,7 @@ Status RowsetUpdateState::_do_load_upserts_deletes(const TxnLogPB_OpWrite& op_wr
     }
     Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true).ok()) {
         CHECK(false) << "create column for primary key encoder failed";
     }
 

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -19,6 +19,7 @@
 #include <utility>
 
 #include "fs/fs.h"
+#include "gutil/strings/escaping.h"
 #include "gutil/strings/substitute.h"
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
@@ -3773,8 +3774,8 @@ Status PersistentIndex::try_replace(size_t n, const Slice* keys, const IndexValu
     RETURN_IF_ERROR(get(n, keys, found_values.data()));
     std::vector<size_t> replace_idxes;
     for (size_t i = 0; i < n; ++i) {
-        if (found_values[i].get_value() != NullIndexValue &&
-            ((uint32_t)(found_values[i].get_value() >> 32)) <= max_src_rssid) {
+        auto found_value = found_values[i].get_value();
+        if (found_value != NullIndexValue && ((uint32_t)(found_value >> 32)) <= max_src_rssid) {
             replace_idxes.emplace_back(i);
         } else {
             failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1161,10 +1161,11 @@ Status PrimaryIndex::_build_persistent_values(uint32_t rssid, const vector<uint3
 
 const Slice* PrimaryIndex::_build_persistent_keys(const Column& pks, uint32_t idx_begin, uint32_t idx_end,
                                                   std::vector<Slice>* key_slices) const {
-    if (pks.is_binary()) {
+    if (pks.is_binary() || pks.is_large_binary()) {
         const Slice* vkeys = reinterpret_cast<const Slice*>(pks.raw_data());
         return vkeys + idx_begin;
     } else {
+        CHECK(_key_size > 0);
         const uint8_t* keys = pks.raw_data() + idx_begin * _key_size;
         for (size_t i = idx_begin; i < idx_end; i++) {
             key_slices->emplace_back(keys, _key_size);

--- a/be/src/storage/primary_key_encoder.cpp
+++ b/be/src/storage/primary_key_encoder.cpp
@@ -292,16 +292,16 @@ size_t PrimaryKeyEncoder::get_encoded_fixed_size(const Schema& schema) {
     return ret;
 }
 
-Status PrimaryKeyEncoder::create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn) {
+Status PrimaryKeyEncoder::create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn, bool large_column) {
     std::vector<ColumnId> key_idxes(schema.num_key_fields());
     for (ColumnId i = 0; i < schema.num_key_fields(); ++i) {
         key_idxes[i] = i;
     }
-    return PrimaryKeyEncoder::create_column(schema, pcolumn, key_idxes);
+    return PrimaryKeyEncoder::create_column(schema, pcolumn, key_idxes, large_column);
 }
 
 Status PrimaryKeyEncoder::create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn,
-                                        const std::vector<ColumnId>& key_idxes) {
+                                        const std::vector<ColumnId>& key_idxes, bool large_column) {
     if (!is_supported(schema, key_idxes)) {
         return Status::NotSupported("type not supported for primary key encoding");
     }
@@ -333,7 +333,11 @@ Status PrimaryKeyEncoder::create_column(const Schema& schema, std::unique_ptr<Co
             *pcolumn = Int128Column::create_mutable();
             break;
         case TYPE_VARCHAR:
-            *pcolumn = std::make_unique<BinaryColumn>();
+            if (large_column) {
+                *pcolumn = std::make_unique<LargeBinaryColumn>();
+            } else {
+                *pcolumn = std::make_unique<BinaryColumn>();
+            }
             break;
         case TYPE_DATE:
             *pcolumn = DateColumn::create_mutable();
@@ -347,7 +351,11 @@ Status PrimaryKeyEncoder::create_column(const Schema& schema, std::unique_ptr<Co
     } else {
         // composite keys encoding to binary
         // TODO(cbl): support fixed length encoded keys, e.g. (int32, int32) => int64
-        *pcolumn = std::make_unique<BinaryColumn>();
+        if (large_column) {
+            *pcolumn = std::make_unique<LargeBinaryColumn>();
+        } else {
+            *pcolumn = std::make_unique<BinaryColumn>();
+        }
     }
     return Status::OK();
 }
@@ -427,35 +435,46 @@ void PrimaryKeyEncoder::encode(const Schema& schema, const Chunk& chunk, size_t 
         auto& src = chunk.get_column_by_index(0);
         dest->append(*src, offset, len);
     } else {
-        CHECK(dest->is_binary()) << "dest column should be binary";
+        CHECK(dest->is_binary() || dest->is_large_binary()) << "dest column should be binary";
         int ncol = schema.num_key_fields();
         std::vector<EncodeOp> ops(ncol);
         std::vector<const void*> datas(ncol);
         std::vector<ColumnId> primary_key_iota_idxes(ncol);
         std::iota(primary_key_iota_idxes.begin(), primary_key_iota_idxes.end(), 0);
         prepare_ops_datas(schema, primary_key_iota_idxes, chunk, &ops, &datas);
-        auto& bdest = down_cast<BinaryColumn&>(*dest);
-        bdest.reserve(bdest.size() + len);
-        std::string buff;
-        for (size_t i = 0; i < len; i++) {
-            buff.clear();
-            for (int j = 0; j < ncol; j++) {
-                ops[j](datas[j], offset + i, &buff);
+        if (dest->is_binary()) {
+            auto& bdest = down_cast<BinaryColumn&>(*dest);
+            bdest.reserve(bdest.size() + len);
+            std::string buff;
+            for (size_t i = 0; i < len; i++) {
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
+                    ops[j](datas[j], offset + i, &buff);
+                }
+                bdest.append(buff);
             }
-            bdest.append(buff);
+        } else {
+            auto& bdest = down_cast<LargeBinaryColumn&>(*dest);
+            bdest.reserve(bdest.size() + len);
+            std::string buff;
+            for (size_t i = 0; i < len; i++) {
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
+                    ops[j](datas[j], offset + i, &buff);
+                }
+                bdest.append(buff);
+            }
         }
     }
 }
 
 void PrimaryKeyEncoder::encode_sort_key(const Schema& schema, const Chunk& chunk, size_t offset, size_t len,
                                         Column* dest) {
-    CHECK(dest->is_binary()) << "dest column should be binary";
+    CHECK(dest->is_binary() || dest->is_large_binary()) << "dest column should be binary";
     int ncol = schema.sort_key_idxes().size();
     std::vector<EncodeOp> ops(ncol);
     std::vector<const void*> datas(ncol);
     prepare_ops_datas(schema, schema.sort_key_idxes(), chunk, &ops, &datas);
-    auto& bdest = down_cast<BinaryColumn&>(*dest);
-    bdest.reserve(bdest.size() + len);
     std::vector<std::shared_ptr<Column>> cols(ncol);
     for (int i = 0; i < ncol; i++) {
         cols[i] = chunk.get_column_by_index(schema.sort_key_idxes()[i]);
@@ -467,27 +486,57 @@ void PrimaryKeyEncoder::encode_sort_key(const Schema& schema, const Chunk& chunk
             break;
         }
     }
-    std::string buff;
-    if (!has_nullable_sort_key) {
-        for (size_t i = 0; i < len; i++) {
-            buff.clear();
-            for (int j = 0; j < ncol; j++) {
-                ops[j](datas[j], offset + i, &buff);
-            }
-            bdest.append(buff);
-        }
-    } else {
-        for (size_t i = 0; i < len; i++) {
-            buff.clear();
-            for (int j = 0; j < ncol; j++) {
-                if (cols[j]->is_null(i)) {
-                    buff.push_back(SORT_KEY_NULL_FIRST_MARKER);
-                } else {
-                    buff.push_back(SORT_KEY_NORMAL_MARKER);
+    if (dest->is_binary()) {
+        auto& bdest = down_cast<BinaryColumn&>(*dest);
+        bdest.reserve(bdest.size() + len);
+        std::string buff;
+        if (!has_nullable_sort_key) {
+            for (size_t i = 0; i < len; i++) {
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
                     ops[j](datas[j], offset + i, &buff);
                 }
+                bdest.append(buff);
             }
-            bdest.append(buff);
+        } else {
+            for (size_t i = 0; i < len; i++) {
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
+                    if (cols[j]->is_null(i)) {
+                        buff.push_back(SORT_KEY_NULL_FIRST_MARKER);
+                    } else {
+                        buff.push_back(SORT_KEY_NORMAL_MARKER);
+                        ops[j](datas[j], offset + i, &buff);
+                    }
+                }
+                bdest.append(buff);
+            }
+        }
+    } else {
+        auto& bdest = down_cast<LargeBinaryColumn&>(*dest);
+        bdest.reserve(bdest.size() + len);
+        std::string buff;
+        if (!has_nullable_sort_key) {
+            for (size_t i = 0; i < len; i++) {
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
+                    ops[j](datas[j], offset + i, &buff);
+                }
+                bdest.append(buff);
+            }
+        } else {
+            for (size_t i = 0; i < len; i++) {
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
+                    if (cols[j]->is_null(i)) {
+                        buff.push_back(SORT_KEY_NULL_FIRST_MARKER);
+                    } else {
+                        buff.push_back(SORT_KEY_NORMAL_MARKER);
+                        ops[j](datas[j], offset + i, &buff);
+                    }
+                }
+                bdest.append(buff);
+            }
         }
     }
 }
@@ -499,23 +548,37 @@ void PrimaryKeyEncoder::encode_selective(const Schema& schema, const Chunk& chun
         auto& src = chunk.get_column_by_index(0);
         dest->append_selective(*src, indexes, 0, len);
     } else {
-        CHECK(dest->is_binary()) << "dest column should be binary";
+        CHECK(dest->is_binary() || dest->is_large_binary()) << "dest column should be binary";
         int ncol = schema.num_key_fields();
         std::vector<EncodeOp> ops(ncol);
         std::vector<const void*> datas(ncol);
         std::vector<ColumnId> primary_key_iota_idxes(ncol);
         std::iota(primary_key_iota_idxes.begin(), primary_key_iota_idxes.end(), 0);
         prepare_ops_datas(schema, primary_key_iota_idxes, chunk, &ops, &datas);
-        auto& bdest = down_cast<BinaryColumn&>(*dest);
-        bdest.reserve(bdest.size() + len);
-        std::string buff;
-        for (int i = 0; i < len; i++) {
-            uint32_t idx = indexes[i];
-            buff.clear();
-            for (int j = 0; j < ncol; j++) {
-                ops[j](datas[j], idx, &buff);
+        if (dest->is_binary()) {
+            auto& bdest = down_cast<BinaryColumn&>(*dest);
+            bdest.reserve(bdest.size() + len);
+            std::string buff;
+            for (int i = 0; i < len; i++) {
+                uint32_t idx = indexes[i];
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
+                    ops[j](datas[j], idx, &buff);
+                }
+                bdest.append(buff);
             }
-            bdest.append(buff);
+        } else {
+            auto& bdest = down_cast<LargeBinaryColumn&>(*dest);
+            bdest.reserve(bdest.size() + len);
+            std::string buff;
+            for (int i = 0; i < len; i++) {
+                uint32_t idx = indexes[i];
+                buff.clear();
+                for (int j = 0; j < ncol; j++) {
+                    ops[j](datas[j], idx, &buff);
+                }
+                bdest.append(buff);
+            }
         }
     }
 }
@@ -573,77 +636,88 @@ bool PrimaryKeyEncoder::encode_exceed_limit(const Schema& schema, const Chunk& c
     return false;
 }
 
+template <class T>
+Status decode_internal(const Schema& schema, const T& bkeys, size_t offset, size_t len, Chunk* dest) {
+    const int ncol = schema.num_key_fields();
+    for (int i = 0; i < len; i++) {
+        Slice s = bkeys.get_slice(offset + i);
+        for (int j = 0; j < ncol; j++) {
+            auto& column = *(dest->get_column_by_index(j));
+            switch (schema.field(j)->type()->type()) {
+            case TYPE_BOOLEAN: {
+                auto& tc = down_cast<UInt8Column&>(column);
+                uint8_t v;
+                decode_integral(&s, &v);
+                tc.append((int8_t)v);
+            } break;
+            case TYPE_TINYINT: {
+                auto& tc = down_cast<Int8Column&>(column);
+                int8_t v;
+                decode_integral(&s, &v);
+                tc.append(v);
+            } break;
+            case TYPE_SMALLINT: {
+                auto& tc = down_cast<Int16Column&>(column);
+                int16_t v;
+                decode_integral(&s, &v);
+                tc.append(v);
+            } break;
+            case TYPE_INT: {
+                auto& tc = down_cast<Int32Column&>(column);
+                int32_t v;
+                decode_integral(&s, &v);
+                tc.append(v);
+            } break;
+            case TYPE_BIGINT: {
+                auto& tc = down_cast<Int64Column&>(column);
+                int64_t v;
+                decode_integral(&s, &v);
+                tc.append(v);
+            } break;
+            case TYPE_LARGEINT: {
+                auto& tc = down_cast<Int128Column&>(column);
+                int128_t v;
+                decode_integral(&s, &v);
+                tc.append(v);
+            } break;
+            case TYPE_VARCHAR: {
+                auto& tc = down_cast<BinaryColumn&>(column);
+                std::string v;
+                RETURN_IF_ERROR(decode_slice(&s, &v, j + 1 == ncol));
+                tc.append(v);
+            } break;
+            case TYPE_DATE: {
+                auto& tc = down_cast<DateColumn&>(column);
+                DateValue v;
+                decode_integral(&s, &v._julian);
+                tc.append(v);
+            } break;
+            case TYPE_DATETIME_V1: {
+                auto& tc = down_cast<TimestampColumn&>(column);
+                TimestampValue v;
+                decode_integral(&s, &v._timestamp);
+                tc.append(v);
+            } break;
+            default:
+                CHECK(false) << "type not supported for primary key encoding";
+            }
+        }
+    }
+    return Status::OK();
+}
+
 Status PrimaryKeyEncoder::decode(const Schema& schema, const Column& keys, size_t offset, size_t len, Chunk* dest) {
     if (schema.num_key_fields() == 1) {
         // simple decoding, src & dest should have same type
         dest->get_column_by_index(0)->append(keys, offset, len);
     } else {
-        CHECK(keys.is_binary()) << "keys column should be binary";
-        auto& bkeys = down_cast<const BinaryColumn&>(keys);
-        const int ncol = schema.num_key_fields();
-        for (int i = 0; i < len; i++) {
-            Slice s = bkeys.get_slice(offset + i);
-            for (int j = 0; j < ncol; j++) {
-                auto& column = *(dest->get_column_by_index(j));
-                switch (schema.field(j)->type()->type()) {
-                case TYPE_BOOLEAN: {
-                    auto& tc = down_cast<UInt8Column&>(column);
-                    uint8_t v;
-                    decode_integral(&s, &v);
-                    tc.append((int8_t)v);
-                } break;
-                case TYPE_TINYINT: {
-                    auto& tc = down_cast<Int8Column&>(column);
-                    int8_t v;
-                    decode_integral(&s, &v);
-                    tc.append(v);
-                } break;
-                case TYPE_SMALLINT: {
-                    auto& tc = down_cast<Int16Column&>(column);
-                    int16_t v;
-                    decode_integral(&s, &v);
-                    tc.append(v);
-                } break;
-                case TYPE_INT: {
-                    auto& tc = down_cast<Int32Column&>(column);
-                    int32_t v;
-                    decode_integral(&s, &v);
-                    tc.append(v);
-                } break;
-                case TYPE_BIGINT: {
-                    auto& tc = down_cast<Int64Column&>(column);
-                    int64_t v;
-                    decode_integral(&s, &v);
-                    tc.append(v);
-                } break;
-                case TYPE_LARGEINT: {
-                    auto& tc = down_cast<Int128Column&>(column);
-                    int128_t v;
-                    decode_integral(&s, &v);
-                    tc.append(v);
-                } break;
-                case TYPE_VARCHAR: {
-                    auto& tc = down_cast<BinaryColumn&>(column);
-                    std::string v;
-                    RETURN_IF_ERROR(decode_slice(&s, &v, j + 1 == ncol));
-                    tc.append(v);
-                } break;
-                case TYPE_DATE: {
-                    auto& tc = down_cast<DateColumn&>(column);
-                    DateValue v;
-                    decode_integral(&s, &v._julian);
-                    tc.append(v);
-                } break;
-                case TYPE_DATETIME_V1: {
-                    auto& tc = down_cast<TimestampColumn&>(column);
-                    TimestampValue v;
-                    decode_integral(&s, &v._timestamp);
-                    tc.append(v);
-                } break;
-                default:
-                    CHECK(false) << "type not supported for primary key encoding";
-                }
-            }
+        CHECK(keys.is_binary() || keys.is_large_binary()) << "keys column should be binary";
+        if (keys.is_binary()) {
+            auto& bkeys = down_cast<const BinaryColumn&>(keys);
+            return decode_internal(schema, bkeys, offset, len, dest);
+        } else {
+            auto& bkeys = down_cast<const LargeBinaryColumn&>(keys);
+            return decode_internal(schema, bkeys, offset, len, dest);
         }
     }
     return Status::OK();

--- a/be/src/storage/primary_key_encoder.h
+++ b/be/src/storage/primary_key_encoder.h
@@ -46,9 +46,19 @@ public:
     // Return -1 if encoded key is not fixed size
     static size_t get_encoded_fixed_size(const Schema& schema);
 
-    static Status create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn);
+    // create suitable column to hold encoded key
+    //   schema: schema of the table
+    //   pcolumn: output column
+    //   large_column: some usage may fill the column with more than uint32_max elements, set true to support this
+    static Status create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn, bool large_column = false);
+
+    // create suitable column to hold encoded key
+    //   schema: schema of the table
+    //   pcolumn: output column
+    //   key_idxes: indexes of columns for encoding
+    //   large_column: some usage may fill the column with more than uint32_max elements, set true to support this
     static Status create_column(const Schema& schema, std::unique_ptr<Column>* pcolumn,
-                                const std::vector<ColumnId>& key_idxes);
+                                const std::vector<ColumnId>& key_idxes, bool large_column = false);
 
     static void encode(const Schema& schema, const Chunk& chunk, size_t offset, size_t len, Column* dest);
 

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -205,7 +205,7 @@ Status RowsetUpdateState::load_upserts(Rowset* rowset, uint32_t upsert_id) {
     }
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true).ok()) {
         CHECK(false) << "create column for primary key encoder failed";
     }
     return _load_upserts(rowset, upsert_id, pk_column.get());

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -75,7 +75,7 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
     Schema pkey_schema = ChunkHelper::convert_schema(schema, pk_columns);
 
     std::unique_ptr<Column> pk_column;
-    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+    if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true).ok()) {
         CHECK(false) << "create column for primary key encoder failed";
     }
 
@@ -120,7 +120,6 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
         CHECK(col->size() == num_rows) << "read segment: iter rows != num rows";
     }
     dest = std::move(col);
-    dest->raw_data();
     _memory_usage += dest->memory_usage();
     tracker->consume(dest->memory_usage());
 
@@ -128,14 +127,17 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
         // currently we can only log error here, and allow memory over usage
         LOG(ERROR) << " memory limit exceeded when loading compaction state pk tablet_id:"
                    << rowset->rowset_meta()->tablet_id() << " rowset #rows:" << rowset->num_rows()
-                   << " size:" << rowset->data_disk_size() << " total segs:" << itrs.size()
-                   << " memory:" << _memory_usage << " stats:" << update_manager->memory_stats();
+                   << " size:" << rowset->data_disk_size() << " seg:" << segment_id << "/" << rowset->num_segments()
+                   << " #rows:" << rowset->segments()[segment_id]->num_rows() << " memory:" << _memory_usage
+                   << " stats:" << update_manager->memory_stats();
     }
 
     if (_memory_usage > large_compaction_memory_threshold) {
         LOG(INFO) << " loading large compaction state tablet_id:" << rowset->rowset_meta()->tablet_id()
                   << " rowset #rows:" << rowset->num_rows() << " size:" << rowset->data_disk_size()
-                  << " memory:" << _memory_usage << " stats:" << update_manager->memory_stats();
+                  << " seg:" << segment_id << "/" << rowset->num_segments()
+                  << " #rows:" << rowset->segments()[segment_id]->num_rows() << " memory:" << _memory_usage
+                  << " stats:" << update_manager->memory_stats();
     }
     return Status::OK();
 }


### PR DESCRIPTION
Fixes #33247

When the compaction output file is too large and contains many rows, the resulting buffer containing all encoded pk in this segment file may be huge and overflow. This PR fixes this by changing `BinaryColumn<uint32>` to `BinaryColumn<int64>`, adding some checks for overflow, and refactoring some compaction memory logs.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
