### PR TITLE
[Enhancement] Write fatal log to stderr together with crash stack trace

### DIFF
--- a/be/src/common/logconfig.cpp
+++ b/be/src/common/logconfig.cpp
@@ -142,8 +142,8 @@ bool init_glog(const char* basename, bool install_signal_handler) {
         google::InstallFailureSignalHandler();
     }
 
-    // Don't log to stderr.
-    FLAGS_stderrthreshold = 5;
+    // only write fatal log to stderr
+    FLAGS_stderrthreshold = 3;
     // Set glog log dir.
     FLAGS_log_dir = config::sys_log_dir;
     // 0 means buffer INFO only.


### PR DESCRIPTION
This PR changes glog config to output fatal log to stderr, so when the user get a crash stacktrace caused by FATAL log, he can provide stacktrace together with actual FATAL log to the helping person, saving an extra round of communication.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
