### PR TITLE
[BugFix] fix trino parser doesn't process information function correctly

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -469,6 +469,20 @@ public class FunctionSet {
     public static final String MILLISECONDS_ADD = "milliseconds_add";
     public static final String MILLISECONDS_SUB = "milliseconds_sub";
 
+    public static final String CONNECTION_ID = "connection_id";
+
+    public static final String CATALOG = "catalog";
+
+    public static final String DATABASE = "database";
+
+    public static final String SCHEMA = "schema";
+
+    public static final String USER = "user";
+
+    public static final String CURRENT_USER = "current_user";
+
+    public static final String CURRENT_ROLE = "current_role";
+
     private static final Logger LOGGER = LogManager.getLogger(FunctionSet.class);
 
     private static final Set<Type> STDDEV_ARG_TYPE =
@@ -626,6 +640,16 @@ public class FunctionSet {
             .add(ARRAY_AGG)
             .add(ARRAY_CONCAT)
             .add(ARRAY_SLICE)
+            .build();
+
+    public static final Set<String> INFORMATION_FUNCTIONS = ImmutableSet.<String>builder()
+            .add(CONNECTION_ID)
+            .add(CATALOG)
+            .add(DATABASE)
+            .add(SCHEMA)
+            .add(USER)
+            .add(CURRENT_USER)
+            .add(CURRENT_ROLE)
             .build();
 
     public static final java.util.function.Function<Type, ArrayType> APPROX_TOP_N_RET_TYPE_BUILDER =

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -1088,7 +1088,7 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
         return new InformationFunction(FunctionSet.CURRENT_USER.toUpperCase());
     }
 
-                                         @Override
+    @Override
     protected ParseNode visitCurrentTime(CurrentTime node, ParseTreeContext context) {
         return new FunctionCallExpr(node.getFunction().getName(), new ArrayList<>());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1589,20 +1589,20 @@ public class ExpressionAnalyzer {
         @Override
         public Void visitInformationFunction(InformationFunction node, Scope context) {
             String funcType = node.getFuncType();
-            if (funcType.equalsIgnoreCase("DATABASE") || funcType.equalsIgnoreCase("SCHEMA")) {
+            if (funcType.equalsIgnoreCase(FunctionSet.DATABASE) || funcType.equalsIgnoreCase(FunctionSet.SCHEMA)) {
                 node.setType(Type.VARCHAR);
                 node.setStrValue(ClusterNamespace.getNameFromFullName(session.getDatabase()));
-            } else if (funcType.equalsIgnoreCase("USER")) {
+            } else if (funcType.equalsIgnoreCase(FunctionSet.USER)) {
                 node.setType(Type.VARCHAR);
 
                 String user = session.getQualifiedUser();
                 String remoteIP = session.getRemoteIP();
 
                 node.setStrValue(new UserIdentity(user, remoteIP).toString());
-            } else if (funcType.equalsIgnoreCase("CURRENT_USER")) {
+            } else if (funcType.equalsIgnoreCase(FunctionSet.CURRENT_USER)) {
                 node.setType(Type.VARCHAR);
                 node.setStrValue(session.getCurrentUserIdentity().toString());
-            } else if (funcType.equalsIgnoreCase("CURRENT_ROLE")) {
+            } else if (funcType.equalsIgnoreCase(FunctionSet.CURRENT_ROLE)) {
                 node.setType(Type.VARCHAR);
                 AuthorizationMgr manager = GlobalStateMgr.getCurrentState().getAuthorizationMgr();
                 List<String> roleName = new ArrayList<>();
@@ -1624,11 +1624,11 @@ public class ExpressionAnalyzer {
                 } else {
                     node.setStrValue(Joiner.on(", ").join(roleName));
                 }
-            } else if (funcType.equalsIgnoreCase("CONNECTION_ID")) {
+            } else if (funcType.equalsIgnoreCase(FunctionSet.CONNECTION_ID)) {
                 node.setType(Type.BIGINT);
                 node.setIntValue(session.getConnectionId());
                 node.setStrValue("");
-            } else if (funcType.equalsIgnoreCase("CATALOG")) {
+            } else if (funcType.equalsIgnoreCase(FunctionSet.CATALOG)) {
                 node.setType(Type.VARCHAR);
                 node.setStrValue(session.getCurrentCatalog());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5630,8 +5630,8 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             return new FunctionCallExpr(functionName, ImmutableList.of(split, e2), pos);
         }
 
-        if (fnName.getFunction().equalsIgnoreCase("CONNECTION_ID")) {
-            return new InformationFunction("CONNECTION_ID");
+        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.CONNECTION_ID)) {
+            return new InformationFunction(FunctionSet.CONNECTION_ID.toUpperCase());
         }
 
         if (functionName.equals(FunctionSet.MAP)) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -330,4 +330,28 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         System.out.println(getFragmentPlan(sql));
     }
 
+    @Test
+    public void testInformationFunction() throws Exception {
+        String sql = "select connection_id() from tall";
+        assertPlanContains(sql, "<slot 12> : CONNECTION_ID()");
+
+        sql = "select catalog() from tall";
+        assertPlanContains(sql, "<slot 12> : CATALOG()");
+
+        sql = "select database() from tall";
+        assertPlanContains(sql, "<slot 12> : 'test'");
+
+        sql = "select schema() from tall";
+        assertPlanContains(sql, "<slot 12> : 'test'");
+
+        sql = "select user() from tall";
+        assertPlanContains(sql, "<slot 12> : USER()");
+
+        sql = "select CURRENT_USER from tall";
+        assertPlanContains(sql, "<slot 12> : CURRENT_USER()");
+
+        sql = "select CURRENT_ROLE from tall";
+        assertPlanContains(sql, "<slot 12> : CURRENT_ROLE()");
+    }
+
 }


### PR DESCRIPTION
Fixes #issue
`select connection_id()` The `connection_id()` had been transfromed to `fucntioncallExpr` which shoud be `InformationFunction`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
