### PR TITLE
[BugFix] fix optimization bug when all partition columns on iceberg table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRule.java
@@ -78,6 +78,15 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
         // if not, we have to choose one materialized column from scan operator output columns
         // with the minimal cost.
         boolean canUseAnyColumn = false;
+
+        // if this scan operator columns are all partitions columns(like iceberg table)
+        // we have to take partition columns are materialized columns and read them from files.
+        // And we can not use `canUseAnyColumn` optimization either.
+        boolean allPartitionColumns =
+                scanOperator.getPartitionColumns()
+                        .containsAll(scanOperator.getColRefToColumnMetaMap().values().stream().map(x -> x.getName()).collect(
+                                Collectors.toList()));
+
         if (!containsMaterializedColumn(scanOperator, scanColumns)) {
             List<ColumnRefOperator> preOutputColumns =
                     new ArrayList<>(scanOperator.getColRefToColumnMetaMap().keySet());
@@ -88,7 +97,7 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
             int smallestIndex = -1;
             int smallestColumnLength = Integer.MAX_VALUE;
             for (int index = 0; index < outputColumns.size(); ++index) {
-                if (isPartitionColumn(scanOperator, outputColumns.get(index).getName())) {
+                if (!allPartitionColumns && isPartitionColumn(scanOperator, outputColumns.get(index).getName())) {
                     continue;
                 }
 
@@ -109,7 +118,7 @@ public class PruneHDFSScanColumnRule extends TransformationRule {
             canUseAnyColumn = true;
         }
 
-        if (!context.getSessionVariable().isEnableCountStarOptimization()) {
+        if (allPartitionColumns || !context.getSessionVariable().isEnableCountStarOptimization()) {
             canUseAnyColumn = false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/PruneHDFSScanColumnRuleTest.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class PruneHDFSScanColumnRuleTest {
     private PruneHDFSScanColumnRule icebergRule = PruneHDFSScanColumnRule.ICEBERG_SCAN;
@@ -48,16 +49,20 @@ public class PruneHDFSScanColumnRuleTest {
     ColumnRefOperator strColumnOperator = new ColumnRefOperator(2, Type.STRING, "name", true);
     ColumnRefOperator unknownColumnOperator = new ColumnRefOperator(3, Type.UNKNOWN_TYPE, "unknown", true);
 
-    Map<ColumnRefOperator, Column> scanColumnMap = new HashMap<ColumnRefOperator, Column>() {{
+    Map<ColumnRefOperator, Column> scanColumnMap = new HashMap<ColumnRefOperator, Column>() {
+        {
             put(intColumnOperator, new Column("id", Type.INT));
             put(strColumnOperator, new Column("name", Type.STRING));
-        }};
+        }
+    };
 
-    Map<ColumnRefOperator, Column> scanColumnMapWithUnknown = new HashMap<ColumnRefOperator, Column>() {{
+    Map<ColumnRefOperator, Column> scanColumnMapWithUnknown = new HashMap<ColumnRefOperator, Column>() {
+        {
             put(intColumnOperator, new Column("id", Type.INT));
             put(strColumnOperator, new Column("name", Type.STRING));
             put(unknownColumnOperator, new Column("name", Type.UNKNOWN_TYPE));
-        }};
+        }
+    };
 
     @Test
     public void transformIcebergWithPredicate(@Mocked IcebergTable table,
@@ -198,5 +203,37 @@ public class PruneHDFSScanColumnRuleTest {
         Map<ColumnRefOperator, Column> transferMap = scanOperator.getColRefToColumnMetaMap();
         Assert.assertEquals(transferMap.size(), 1);
         Assert.assertEquals(transferMap.get(intColumnOperator).getName(), "id");
+    }
+
+    @Test
+    public void transformIcebergWithAllPartitionColumns(@Mocked IcebergTable table,
+                                                        @Mocked OptimizerContext context,
+                                                        @Mocked TaskContext taskContext) {
+        OptExpression scan = new OptExpression(
+                new LogicalIcebergScanOperator(table,
+                        scanColumnMap, Maps.newHashMap(), -1, null));
+
+        List<TaskContext> taskContextList = new ArrayList<>();
+        taskContextList.add(taskContext);
+
+        ColumnRefSet requiredOutputColumns = new ColumnRefSet(new ArrayList<>());
+
+        new Expectations() {
+            {
+                context.getTaskContext();
+                minTimes = 0;
+                result = taskContextList;
+
+                taskContext.getRequiredColumns();
+                minTimes = 0;
+                result = requiredOutputColumns;
+
+                table.getPartitionColumnNames();
+                result = scanColumnMap.values().stream().map(x -> x.getName()).collect(Collectors.toList());
+            }
+        };
+        List<OptExpression> list = icebergRule.transform(scan, context);
+        LogicalIcebergScanOperator op = ((LogicalIcebergScanOperator) list.get(0).getOp());
+        Assert.assertEquals(op.getScanOptimzeOption().getCanUseAnyColumn(), false);
     }
 }


### PR DESCRIPTION
Fixes #issue

This bug was introduced in this PR https://github.com/StarRocks/starrocks/pull/31403

The root cause is during `PruneHdfsScanColumnRule`, we have a assumption that we have to select at least one materialized column from table to read.

This assumption is held before because we don't take iceberg partition column as REAL paritiotn column, but instead as materialized column.

However this assumption does not hold when iceberg table partition column value optimization is brought into.  We really take partition column as REAL partition column. 

So to fix this bug,  in this rule, we have to check if table columns are all partition columns. If that, we cat not use any optimization and have to fallback to normal process.

-----

to quickly reproduce this case, we can run

```sql
use iceberg_tbl_sink_test;
create table ice_tbl(a int) partition by (a);
insert into ice_tbl values (1);
select * from ice_tbl;
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
