### PR TITLE
[Enhancement] Add GRF coordinator for OlapTableSink

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -493,22 +493,21 @@ public class DefaultCoordinator extends Coordinator {
 
     private void prepareResultSink() throws AnalysisException {
         ExecutionFragment rootExecFragment = executionDAG.getRootFragment();
+        long workerId = rootExecFragment.getInstances().get(0).getWorkerId();
+        ComputeNode worker = coordinatorPreprocessor.getWorkerProvider().getWorkerById(workerId);
+        // Select top fragment as global runtime filter merge address
+        setGlobalRuntimeFilterParams(rootExecFragment, worker.getBrpcAddress());
         boolean isLoadType = !(rootExecFragment.getPlanFragment().getSink() instanceof ResultSink);
         if (isLoadType) {
             return;
         }
 
-        long workerId = rootExecFragment.getInstances().get(0).getWorkerId();
-        ComputeNode worker = coordinatorPreprocessor.getWorkerProvider().getWorkerById(workerId);
         TNetworkAddress execBeAddr = worker.getAddress();
         receiver = new ResultReceiver(
                 rootExecFragment.getInstances().get(0).getInstanceId(),
                 workerId,
                 worker.getBrpcAddress(),
                 jobSpec.getQueryOptions().query_timeout * 1000);
-
-        // Select top fragment as global runtime filter merge address
-        setGlobalRuntimeFilterParams(rootExecFragment, worker.getBrpcIpAddress());
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("dispatch query job: {} to {}", DebugUtil.printId(jobSpec.getQueryId()), execBeAddr);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/ExecutionFragment.java
@@ -366,6 +366,10 @@ public class ExecutionFragment {
         }
     }
 
+    public boolean isRuntimeFilterCoordinator() {
+        return runtimeFilterParams.isSetRuntime_filter_builder_number();
+    }
+
     private boolean isReplicated(PlanNode root) {
         if (root instanceof ExchangeNode) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -332,6 +332,10 @@ public class FragmentInstanceExecState {
         }
     }
 
+    public boolean isRuntimeFilterCoordinator() {
+        return requestToDeploy.params.isSetRuntime_filter_params();
+    }
+
     /**
      * Cancel the fragment instance.
      *

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -332,10 +332,6 @@ public class FragmentInstanceExecState {
         }
     }
 
-    public boolean isRuntimeFilterCoordinator() {
-        return requestToDeploy.params.isSetRuntime_filter_params();
-    }
-
     /**
      * Cancel the fragment instance.
      *

--- a/test/sql/test_global_runtime_filter_olap_table_sink/R/test_global_runtime_filter_olap_table_sink
+++ b/test/sql/test_global_runtime_filter_olap_table_sink/R/test_global_runtime_filter_olap_table_sink
@@ -141,6 +141,9 @@ show variables like 'pipeline_dop';
 -- result:
 pipeline_dop	1
 -- !result
+set runtime_filter_scan_wait_time = 10000;
+-- result:
+-- !result
 INSERT INTO result_table
   (result)
   select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(dt,0))+murmur_hash3_32(ifnull(c1,0)))) as fingerprint from (select t1.c0,t1.dt,t1.c1 from t1 join[shuffle] t0 on t0.c1 = t1.c1) as t;

--- a/test/sql/test_global_runtime_filter_olap_table_sink/R/test_global_runtime_filter_olap_table_sink
+++ b/test/sql/test_global_runtime_filter_olap_table_sink/R/test_global_runtime_filter_olap_table_sink
@@ -1,0 +1,205 @@
+-- name: test_global_runtime_filter_olap_table_sink
+DROP TABLE if exists t0;
+-- result:
+-- !result
+CREATE TABLE if not exists t0
+(
+c0 BIGINT  NULL,
+dt DATE  NULL,
+c1 VARCHAR(64)  NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `dt`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `dt`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+-- result:
+-- !result
+DROP TABLE if exists t1;
+-- result:
+-- !result
+CREATE TABLE if not exists t1
+(
+c0 BIGINT NOT NULL,
+dt DATE NOT NULL,
+c1 VARCHAR(64) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `dt`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `dt`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+-- result:
+-- !result
+DROP TABLE if exists profile_table;
+-- result:
+-- !result
+CREATE TABLE if not exists profile_table
+(
+query_no BIGINT NOT NULL,
+line_no BIGINT NOT NULL,
+line VARCHAR(4096) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`query_no`, `line_no`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`query_no`, `line_no`) BUCKETS 2
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+-- result:
+-- !result
+DROP TABLE if exists result_table;
+-- result:
+-- !result
+CREATE TABLE if not exists result_table
+(
+result BIGINT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`result`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`result`) BUCKETS 1
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+-- result:
+-- !result
+DROP TABLE if exists seed0;
+-- result:
+-- !result
+CREATE TABLE if not exists seed0
+(
+c INT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+-- result:
+-- !result
+INSERT INTO seed0
+  (c)
+  select row_number() over() as r from (SELECT __tbl_7.__col_4 AS __col_8, __tbl_7.__col_5 AS __col_9, __tbl_7.__col_6 AS __col_10, __tbl_8.__col_7 AS __col_11 from (SELECT __tbl_4.__col_1 AS __col_4, __tbl_4.__col_2 AS __col_5, __tbl_5.__col_3 AS __col_6 from (SELECT __tbl_1.v AS __col_1, __tbl_2.__col_0 AS __col_2 from (select v from (values(0)) t(v)) AS __tbl_1, (SELECT __tbl_0.column_0 AS __col_0 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99),(100),(101)) __tbl_0) AS __tbl_2) AS __tbl_4, (SELECT __tbl_3.column_0 AS __col_3 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_3) AS __tbl_5) AS __tbl_7, (SELECT __tbl_6.column_0 AS __col_7 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_6) AS __tbl_8) as __tbl_9;
+-- result:
+-- !result
+DROP TABLE if exists seed1;
+-- result:
+-- !result
+CREATE TABLE if not exists seed1
+(
+c INT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+-- result:
+-- !result
+INSERT INTO seed1
+  (c)
+  select row_number() over() as r from (SELECT __tbl_20.__col_20 AS __col_25, __tbl_20.__col_21 AS __col_26, __tbl_20.__col_22 AS __col_27, __tbl_20.__col_23 AS __col_28, __tbl_21.__col_24 AS __col_29 from (SELECT __tbl_17.__col_16 AS __col_20, __tbl_17.__col_17 AS __col_21, __tbl_17.__col_18 AS __col_22, __tbl_18.__col_19 AS __col_23 from (SELECT __tbl_14.__col_13 AS __col_16, __tbl_14.__col_14 AS __col_17, __tbl_15.__col_15 AS __col_18 from (SELECT __tbl_11.v AS __col_13, __tbl_12.__col_12 AS __col_14 from (select v from (values(0)) t(v)) AS __tbl_11, (SELECT __tbl_10.column_0 AS __col_12 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) __tbl_10) AS __tbl_12) AS __tbl_14, (SELECT __tbl_13.column_0 AS __col_15 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_13) AS __tbl_15) AS __tbl_17, (SELECT __tbl_16.column_0 AS __col_19 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_16) AS __tbl_18) AS __tbl_20, (SELECT __tbl_19.column_0 AS __col_24 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_19) AS __tbl_21) as __tbl_22;
+-- result:
+-- !result
+INSERT INTO t0
+  (c0, dt, c1)
+  select cast((rand()+rand())*1024000/2 as int) as __col_30, to_date(days_add('2023-01-31', cast((rand()+rand())*180/2 as int))) as __col_31, cast((rand()+rand())*1024000/2 as int) as __col_32 from (SELECT c FROM seed0) __tbl_23;
+-- result:
+-- !result
+INSERT INTO t1
+  (c0, dt, c1)
+  select cast((rand()+rand())*10240000/2 as int) as __col_33, to_date(days_add('2023-01-31', cast((rand()+rand())*365/2 as int))) as __col_34, cast((rand()+rand())*10240000/2 as int) as __col_35 from (SELECT c FROM seed1) __tbl_24;
+-- result:
+-- !result
+set enable_profile='true';
+-- result:
+-- !result
+show variables like 'enable_profile';
+-- result:
+enable_profile	true
+-- !result
+set pipeline_dop='1';
+-- result:
+-- !result
+show variables like 'pipeline_dop';
+-- result:
+pipeline_dop	1
+-- !result
+INSERT INTO result_table
+  (result)
+  select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(dt,0))+murmur_hash3_32(ifnull(c1,0)))) as fingerprint from (select t1.c0,t1.dt,t1.c1 from t1 join[shuffle] t0 on t0.c1 = t1.c1) as t;
+-- result:
+-- !result
+INSERT INTO profile_table
+  (query_no, line_no, line)
+  select 0 as query_no, row_number() over() as line_no, profile.line  from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()),"\n")) profile(line);
+-- result:
+-- !result
+INSERT INTO result_table
+  (result)
+  select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(dt,0))+murmur_hash3_32(ifnull(c1,0)))) as fingerprint from (select t1.c0,t1.dt,t1.c1 from t1 join[broadcast] t0 on t0.c1 = t1.c1) as t;
+-- result:
+-- !result
+INSERT INTO profile_table
+  (query_no, line_no, line)
+  select 1 as query_no, row_number() over() as line_no, profile.line  from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()),"\n")) profile(line);
+-- result:
+-- !result
+with olap_scan as (
+select line from profile_table where query_no=0 and line_no >= (select line_no from profile_table where query_no=0 and line like "%OLAP_SCAN (plan_node_id=0)%") order by line_no limit 50
+),
+JoinRuntimeFilterInputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterInputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterInputRows%"
+),
+JoinRuntimeFilterOutputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterOutputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterOutputRows%"
+),
+rfInputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterInputRows) t
+),
+rfOutputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterOutputRows) t
+)
+select assert_true(rfOutputRows.value/rfInputRows.value < 0.5) from rfInputRows,rfOutputRows;
+-- result:
+1
+-- !result
+with olap_scan as (
+select line from profile_table where query_no=1 and line_no >= (select line_no from profile_table where query_no=1 and line like "%OLAP_SCAN (plan_node_id=0)%") order by line_no limit 50
+),
+JoinRuntimeFilterInputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterInputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterInputRows%"
+),
+JoinRuntimeFilterOutputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterOutputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterOutputRows%"
+),
+rfInputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterInputRows) t
+),
+rfOutputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterOutputRows) t
+)
+select assert_true(rfOutputRows.value/rfInputRows.value < 0.5) from rfInputRows,rfOutputRows;
+-- result:
+1
+-- !result
+select assert_true(count(distinct result)=1) from result_table;
+-- result:
+1
+-- !result

--- a/test/sql/test_global_runtime_filter_olap_table_sink/T/test_global_runtime_filter_olap_table_sink
+++ b/test/sql/test_global_runtime_filter_olap_table_sink/T/test_global_runtime_filter_olap_table_sink
@@ -1,0 +1,152 @@
+-- name: test_global_runtime_filter_olap_table_sink
+DROP TABLE if exists t0;
+
+CREATE TABLE if not exists t0
+(
+c0 BIGINT  NULL,
+dt DATE  NULL,
+c1 VARCHAR(64)  NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `dt`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `dt`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+DROP TABLE if exists t1;
+
+CREATE TABLE if not exists t1
+(
+c0 BIGINT NOT NULL,
+dt DATE NOT NULL,
+c1 VARCHAR(64) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`, `dt`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`, `dt`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+DROP TABLE if exists profile_table;
+
+CREATE TABLE if not exists profile_table
+(
+query_no BIGINT NOT NULL,
+line_no BIGINT NOT NULL,
+line VARCHAR(4096) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`query_no`, `line_no`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`query_no`, `line_no`) BUCKETS 2
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+DROP TABLE if exists result_table;
+
+CREATE TABLE if not exists result_table
+(
+result BIGINT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`result`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`result`) BUCKETS 1
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+DROP TABLE if exists seed0;
+
+CREATE TABLE if not exists seed0
+(
+c INT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+INSERT INTO seed0
+  (c)
+  select row_number() over() as r from (SELECT __tbl_7.__col_4 AS __col_8, __tbl_7.__col_5 AS __col_9, __tbl_7.__col_6 AS __col_10, __tbl_8.__col_7 AS __col_11 from (SELECT __tbl_4.__col_1 AS __col_4, __tbl_4.__col_2 AS __col_5, __tbl_5.__col_3 AS __col_6 from (SELECT __tbl_1.v AS __col_1, __tbl_2.__col_0 AS __col_2 from (select v from (values(0)) t(v)) AS __tbl_1, (SELECT __tbl_0.column_0 AS __col_0 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99),(100),(101)) __tbl_0) AS __tbl_2) AS __tbl_4, (SELECT __tbl_3.column_0 AS __col_3 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_3) AS __tbl_5) AS __tbl_7, (SELECT __tbl_6.column_0 AS __col_7 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_6) AS __tbl_8) as __tbl_9;
+DROP TABLE if exists seed1;
+
+CREATE TABLE if not exists seed1
+(
+c INT NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c`) BUCKETS 64
+PROPERTIES(
+"replication_num" = "1",
+"in_memory" = "false",
+"storage_format" = "default"
+);
+INSERT INTO seed1
+  (c)
+  select row_number() over() as r from (SELECT __tbl_20.__col_20 AS __col_25, __tbl_20.__col_21 AS __col_26, __tbl_20.__col_22 AS __col_27, __tbl_20.__col_23 AS __col_28, __tbl_21.__col_24 AS __col_29 from (SELECT __tbl_17.__col_16 AS __col_20, __tbl_17.__col_17 AS __col_21, __tbl_17.__col_18 AS __col_22, __tbl_18.__col_19 AS __col_23 from (SELECT __tbl_14.__col_13 AS __col_16, __tbl_14.__col_14 AS __col_17, __tbl_15.__col_15 AS __col_18 from (SELECT __tbl_11.v AS __col_13, __tbl_12.__col_12 AS __col_14 from (select v from (values(0)) t(v)) AS __tbl_11, (SELECT __tbl_10.column_0 AS __col_12 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9)) __tbl_10) AS __tbl_12) AS __tbl_14, (SELECT __tbl_13.column_0 AS __col_15 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_13) AS __tbl_15) AS __tbl_17, (SELECT __tbl_16.column_0 AS __col_19 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_16) AS __tbl_18) AS __tbl_20, (SELECT __tbl_19.column_0 AS __col_24 from (VALUES (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10),(11),(12),(13),(14),(15),(16),(17),(18),(19),(20),(21),(22),(23),(24),(25),(26),(27),(28),(29),(30),(31),(32),(33),(34),(35),(36),(37),(38),(39),(40),(41),(42),(43),(44),(45),(46),(47),(48),(49),(50),(51),(52),(53),(54),(55),(56),(57),(58),(59),(60),(61),(62),(63),(64),(65),(66),(67),(68),(69),(70),(71),(72),(73),(74),(75),(76),(77),(78),(79),(80),(81),(82),(83),(84),(85),(86),(87),(88),(89),(90),(91),(92),(93),(94),(95),(96),(97),(98),(99)) __tbl_19) AS __tbl_21) as __tbl_22;
+INSERT INTO t0
+  (c0, dt, c1)
+  select cast((rand()+rand())*1024000/2 as int) as __col_30, to_date(days_add('2023-01-31', cast((rand()+rand())*180/2 as int))) as __col_31, cast((rand()+rand())*1024000/2 as int) as __col_32 from (SELECT c FROM seed0) __tbl_23;
+INSERT INTO t1
+  (c0, dt, c1)
+  select cast((rand()+rand())*10240000/2 as int) as __col_33, to_date(days_add('2023-01-31', cast((rand()+rand())*365/2 as int))) as __col_34, cast((rand()+rand())*10240000/2 as int) as __col_35 from (SELECT c FROM seed1) __tbl_24;
+set enable_profile='true';
+show variables like 'enable_profile';
+set pipeline_dop='1';
+show variables like 'pipeline_dop';
+INSERT INTO result_table
+  (result)
+  select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(dt,0))+murmur_hash3_32(ifnull(c1,0)))) as fingerprint from (select t1.c0,t1.dt,t1.c1 from t1 join[shuffle] t0 on t0.c1 = t1.c1) as t;
+INSERT INTO profile_table
+  (query_no, line_no, line)
+  select 0 as query_no, row_number() over() as line_no, profile.line  from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()),"\n")) profile(line);
+INSERT INTO result_table
+  (result)
+  select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(dt,0))+murmur_hash3_32(ifnull(c1,0)))) as fingerprint from (select t1.c0,t1.dt,t1.c1 from t1 join[broadcast] t0 on t0.c1 = t1.c1) as t;
+INSERT INTO profile_table
+  (query_no, line_no, line)
+  select 1 as query_no, row_number() over() as line_no, profile.line  from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()),"\n")) profile(line);
+with olap_scan as (
+select line from profile_table where query_no=0 and line_no >= (select line_no from profile_table where query_no=0 and line like "%OLAP_SCAN (plan_node_id=0)%") order by line_no limit 50
+),
+JoinRuntimeFilterInputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterInputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterInputRows%"
+),
+JoinRuntimeFilterOutputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterOutputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterOutputRows%"
+),
+rfInputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterInputRows) t
+),
+rfOutputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterOutputRows) t
+)
+select assert_true(rfOutputRows.value/rfInputRows.value < 0.5) from rfInputRows,rfOutputRows;
+with olap_scan as (
+select line from profile_table where query_no=1 and line_no >= (select line_no from profile_table where query_no=1 and line like "%OLAP_SCAN (plan_node_id=0)%") order by line_no limit 50
+),
+JoinRuntimeFilterInputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterInputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterInputRows%"
+),
+JoinRuntimeFilterOutputRows as (
+select regexp_extract(line, ".*- JoinRuntimeFilterOutputRows: (\\d+(?:\\.\\d+[KMB])?).*",1) as value from olap_scan where line like "%- JoinRuntimeFilterOutputRows%"
+),
+rfInputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterInputRows) t
+),
+rfOutputRows as (
+select case unit when "B" then value0*1000000000 when "M" then value0*1000000 when "K" then value0*1000 else value1 end as value from (select right(value,1) as unit, cast(substr(value, 1, length(value)-1) as double) value0, cast(value as double) value1 from JoinRuntimeFilterOutputRows) t
+)
+select assert_true(rfOutputRows.value/rfInputRows.value < 0.5) from rfInputRows,rfOutputRows;
+select assert_true(count(distinct result)=1) from result_table;

--- a/test/sql/test_global_runtime_filter_olap_table_sink/T/test_global_runtime_filter_olap_table_sink
+++ b/test/sql/test_global_runtime_filter_olap_table_sink/T/test_global_runtime_filter_olap_table_sink
@@ -105,6 +105,7 @@ set enable_profile='true';
 show variables like 'enable_profile';
 set pipeline_dop='1';
 show variables like 'pipeline_dop';
+set runtime_filter_scan_wait_time = 10000;
 INSERT INTO result_table
   (result)
   select  (sum(murmur_hash3_32(ifnull(c0,0))+murmur_hash3_32(ifnull(dt,0))+murmur_hash3_32(ifnull(c1,0)))) as fingerprint from (select t1.c0,t1.dt,t1.c1 from t1 join[shuffle] t0 on t0.c1 = t1.c1) as t;


### PR DESCRIPTION
Plan contains other DataSink(such as OlapTableSink) except ResultSink has no global RuntimeFilter coordinator,  this causes that Scan operators miss chances to filter rows. so we choose backends that execute the first instance of PlanFragment carrying DataSink as global RuntimeFilter coordinator.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
