### PR TITLE
[BugFix] Fix the memory evaluation for parquet file metadata when writing to cache.

### DIFF
--- a/be/src/formats/parquet/file_reader.h
+++ b/be/src/formats/parquet/file_reader.h
@@ -66,7 +66,7 @@ private:
     void _build_metacache_key();
 
     // parse footer of parquet file
-    Status _parse_footer(FileMetaData** file_metadata, size_t* metadata_size);
+    Status _parse_footer(FileMetaData** file_metadata, int64_t* file_metadata_size);
 
     void _prepare_read_columns();
 

--- a/be/src/formats/parquet/metadata.h
+++ b/be/src/formats/parquet/metadata.h
@@ -87,12 +87,6 @@ public:
 
     const ApplicationVersion& writer_version() const { return _writer_version; }
 
-    size_t estimate_memory() const {
-        // An approximate memory statistics, not accurate
-        size_t version_size = _writer_version.application_.length() + _writer_version.build_.length();
-        return sizeof(tparquet::FileMetaData) + sizeof(uint64_t) + _schema.estimate_memory() + version_size;
-    }
-
 private:
     tparquet::FileMetaData _t_metadata;
     uint64_t _num_rows{0};

--- a/be/src/formats/parquet/schema.h
+++ b/be/src/formats/parquet/schema.h
@@ -94,21 +94,6 @@ public:
         return _field_id_2_field_idx.find(field_id) != _field_id_2_field_idx.end();
     }
 
-    size_t estimate_memory() const {
-        // This is only a rough approximate statistics, we try to calculate the maximum possible memory usage.
-        size_t static_object_size = sizeof(*this);
-        size_t fields_elem_size = _fields.size() * sizeof(ParquetField);
-        size_t physical_fields_elem_size = _physical_fields.size() * 8;
-        // 15 represents an average column name length.
-        size_t name2field_elem_size = _formatted_column_name_2_field_idx.size() * (15 + sizeof(size_t));
-        size_t id2field_elem_size = _field_id_2_field_idx.size() * (sizeof(int32_t) + sizeof(size_t));
-        // We multiply 2 because some container reserve much element space than the elment size.
-        // `_fields` is directly resized to the element size, so we skip considering the redundant space.
-        size_t elem_data_size =
-                fields_elem_size + (physical_fields_elem_size + name2field_elem_size + id2field_elem_size) * 2;
-        return static_object_size + elem_data_size;
-    }
-
 private:
     void leaf_to_field(const tparquet::SchemaElement& t_schema, const LevelInfo& cur_level_info, bool is_nullable,
                        ParquetField* field);


### PR DESCRIPTION
The old memory evaluation is not accurate because the `FileMetadata` object is a complex object and it is difficult to calculate its real memory usage. If we estimate too little, it may actually occupy too much memory, further leading to process OOM.
So we choose the memory tracker for current thread to calculate the memory usage of `FileMetadata` object.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
