### PR TITLE
[BugFix] avoid to invoke publish_runtime_filter multi times

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_build_operator.cpp
@@ -130,8 +130,10 @@ Status SpillableHashJoinBuildOperator::publish_runtime_filters(RuntimeState* sta
     // (unless FE can give an estimate of the hash table size), so we currently empty all the hash tables first
     // we could build global runtime filter for this case later.
     auto merged = _partial_rf_merger->set_always_true();
+    // for spillable operator, this interface never returns error status because we skip building rf here
+    DCHECK(merged.ok());
 
-    if (merged) {
+    if (merged.value()) {
         RuntimeInFilterList in_filters;
         RuntimeBloomFilterList bloom_filters;
         // publish empty runtime bloom-filters

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -218,10 +218,9 @@ public:
     }
 
     // mark runtime_filter as always true.
-    bool set_always_true() {
+    StatusOr<bool> set_always_true() {
         _always_true = true;
-        (void)_try_do_merge({});
-        return true;
+        return _try_do_merge({});
     }
 
     // HashJoinBuildOperator call add_partial_filters to gather partial runtime filters. the last HashJoinBuildOperator
@@ -404,7 +403,7 @@ private:
 private:
     ObjectPool* _pool;
     const size_t _limit;
-    bool _always_true = false;
+    std::atomic<bool> _always_true = false;
     std::atomic<size_t> _num_active_builders{0};
     std::vector<size_t> _ht_row_counts;
     std::vector<RuntimeInFilters> _partial_in_filters;


### PR DESCRIPTION


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
