### PR TITLE
[Enhancement] optimize TOPN Filter desc case

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1098,4 +1098,7 @@ CONF_Int32(lake_service_max_concurrency, "0");
 
 CONF_mInt64(lake_vacuum_min_batch_delete_size, "1000");
 
+// TOPN RuntimeFilter parameters
+CONF_mInt32(desc_hint_split_range, "10");
+
 } // namespace starrocks::config

--- a/be/src/exec/chunks_sorter_heap_sort.cpp
+++ b/be/src/exec/chunks_sorter_heap_sort.cpp
@@ -175,6 +175,10 @@ std::vector<JoinRuntimeFilter*>* ChunksSorterHeapSort::runtime_filters(ObjectPoo
     const auto& top_cursor_column = top_cursor.data_segment()->order_by_columns[0];
     bool is_close_interval = _sort_desc.num_columns() != 1;
 
+    if (top_cursor_column->is_null(cursor_rid)) {
+        return nullptr;
+    }
+
     if (_runtime_filter.empty()) {
         auto rf = type_dispatch_predicate<JoinRuntimeFilter*>(
                 (*_sort_exprs)[0]->root()->type().type, false, detail::SortRuntimeFilterBuilder(), pool,

--- a/be/src/exec/chunks_sorter_topn.cpp
+++ b/be/src/exec/chunks_sorter_topn.cpp
@@ -124,6 +124,10 @@ std::vector<JoinRuntimeFilter*>* ChunksSorterTopn::runtime_filters(ObjectPool* p
     // _topn_type != TTopNType::RANK means we need reserve the max_value
     bool is_close_interval = _topn_type == TTopNType::RANK || _sort_desc.num_columns() != 1;
 
+    if (order_by_column->is_null(current_max_value_row_id)) {
+        return nullptr;
+    }
+
     if (_runtime_filter.empty()) {
         auto rf = type_dispatch_predicate<JoinRuntimeFilter*>(
                 (*_sort_exprs)[0]->root()->type().type, false, detail::SortRuntimeFilterBuilder(), pool,

--- a/be/src/exec/olap_scan_node.cpp
+++ b/be/src/exec/olap_scan_node.cpp
@@ -14,7 +14,9 @@
 
 #include "exec/olap_scan_node.h"
 
+#include <algorithm>
 #include <chrono>
+#include <functional>
 #include <thread>
 
 #include "column/column_pool.h"
@@ -66,6 +68,17 @@ Status OlapScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
 
     if (tnode.olap_scan_node.__isset.output_chunk_by_bucket) {
         _output_chunk_by_bucket = tnode.olap_scan_node.output_chunk_by_bucket;
+    }
+
+    // desc hint related optimize only takes effect when there is no order requirement
+    if (!_sorted_by_keys_per_tablet) {
+        if (tnode.olap_scan_node.__isset.output_asc_hint) {
+            _output_asc_hint = tnode.olap_scan_node.output_asc_hint;
+        }
+
+        if (tnode.olap_scan_node.__isset.partition_order_hint) {
+            _partition_order_hint = tnode.olap_scan_node.partition_order_hint;
+        }
     }
 
     if (_olap_scan_node.__isset.bucket_exprs) {
@@ -397,8 +410,21 @@ StatusOr<pipeline::MorselQueuePtr> OlapScanNode::convert_scan_range_to_morsel_qu
         morsels.emplace_back(std::make_unique<pipeline::ScanMorsel>(node_id, scan_range));
     }
 
+    if (partition_order_hint().has_value()) {
+        bool asc = partition_order_hint().value();
+        std::stable_sort(morsels.begin(), morsels.end(), [asc](auto& l, auto& r) {
+            auto l_partition_id = down_cast<pipeline::ScanMorsel*>(l.get())->partition_id();
+            auto r_partition_id = down_cast<pipeline::ScanMorsel*>(r.get())->partition_id();
+            if (asc) {
+                return std::less()(l_partition_id, r_partition_id);
+            } else {
+                return std::greater()(l_partition_id, r_partition_id);
+            }
+        });
+    }
+
     if (output_chunk_by_bucket()) {
-        std::sort(morsels.begin(), morsels.end(), [](auto& l, auto& r) {
+        std::stable_sort(morsels.begin(), morsels.end(), [](auto& l, auto& r) {
             return down_cast<pipeline::ScanMorsel*>(l.get())->owner_id() <
                    down_cast<pipeline::ScanMorsel*>(r.get())->owner_id();
         });

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -17,6 +17,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 #include "column/chunk.h"
@@ -96,6 +97,8 @@ public:
     }
 
     bool output_chunk_by_bucket() const override { return _output_chunk_by_bucket; }
+    bool is_asc_hint() const override { return _output_asc_hint; }
+    std::optional<bool> partition_order_hint() const override { return _partition_order_hint; }
 
     const std::vector<ExprContext*>& bucket_exprs() const { return _bucket_exprs; }
 
@@ -201,6 +204,8 @@ private:
 
     bool _sorted_by_keys_per_tablet = false;
     bool _output_chunk_by_bucket = false;
+    bool _output_asc_hint = true;
+    std::optional<bool> _partition_order_hint;
 
     std::vector<ExprContext*> _bucket_exprs;
 

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -112,6 +112,7 @@ public:
             _owner_id = _scan_range->internal_scan_range.__isset.bucket_sequence
                                 ? _scan_range->internal_scan_range.bucket_sequence
                                 : _owner_id;
+            _partition_id = _scan_range->internal_scan_range.partition_id;
         }
         if (_scan_range->__isset.binlog_scan_range) {
             _owner_id = _scan_range->binlog_scan_range.tablet_id;
@@ -132,11 +133,13 @@ public:
     }
 
     int32_t owner_id() const { return _owner_id; }
+    int32_t partition_id() const { return _partition_id; }
 
 private:
     std::unique_ptr<TScanRange> _scan_range;
     int64_t _owner_id = 0;
     int64_t _version = 0;
+    int64_t _partition_id = 0;
 };
 
 class PhysicalSplitScanMorsel final : public ScanMorsel {

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -337,6 +337,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     DCHECK(_params.global_dictmaps != nullptr);
     RETURN_IF_ERROR(_prj_iter->init_encoded_schema(*_params.global_dictmaps));
     RETURN_IF_ERROR(_prj_iter->init_output_schema(*_params.unused_output_column_ids));
+    _reader->set_is_asc_hint(_scan_op->is_asc());
 
     RETURN_IF_ERROR(_reader->prepare());
     RETURN_IF_ERROR(_reader->open(_params));

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -42,6 +42,7 @@ ScanOperator::ScanOperator(OperatorFactory* factory, int32_t id, int32_t driver_
           _dop(dop),
           _output_chunk_by_bucket(scan_node->output_chunk_by_bucket()),
           _io_tasks_per_scan_operator(scan_node->io_tasks_per_scan_operator()),
+          _is_asc(scan_node->is_asc_hint()),
           _chunk_source_profiles(_io_tasks_per_scan_operator),
           _is_io_task_running(_io_tasks_per_scan_operator),
           _chunk_sources(_io_tasks_per_scan_operator) {

--- a/be/src/exec/pipeline/scan/scan_operator.h
+++ b/be/src/exec/pipeline/scan/scan_operator.h
@@ -84,6 +84,7 @@ public:
         _op_pull_chunks += 1;
         _op_pull_rows += res->num_rows();
     }
+    bool is_asc() const { return _is_asc; }
     void end_pull_chunk(int64_t time) { _op_running_time_ns += time; }
     virtual void begin_driver_process() {}
     virtual void end_driver_process(PipelineDriver* driver) {}
@@ -143,6 +144,7 @@ protected:
     const int32_t _dop;
     const bool _output_chunk_by_bucket;
     const int _io_tasks_per_scan_operator;
+    const int _is_asc;
     // ScanOperator may do parallel scan, so each _chunk_sources[i] needs to hold
     // a profile indenpendently, to be more specificly, _chunk_sources[i] will go through
     // many ChunkSourcePtr in the entire life time, all these ChunkSources of _chunk_sources[i]

--- a/be/src/exec/scan_node.h
+++ b/be/src/exec/scan_node.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <cstddef>
+#include <optional>
 #include <string>
 
 #include "column/column_access_path.h"
@@ -120,6 +122,8 @@ public:
     virtual int io_tasks_per_scan_operator() const { return _io_tasks_per_scan_operator; }
     virtual bool always_shared_scan() const { return false; }
     virtual bool output_chunk_by_bucket() const { return false; }
+    virtual bool is_asc_hint() const { return true; }
+    virtual std::optional<bool> partition_order_hint() const { return std::nullopt; }
 
     // TODO: support more share_scan strategy
     void enable_shared_scan(bool enable);

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -599,6 +599,7 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.rowsetid = rowset_meta()->rowset_id();
     seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(options.meta);
     seg_options.short_key_ranges = options.short_key_ranges;
+    seg_options.asc_hint = options.asc_hint;
     if (options.runtime_state != nullptr) {
         seg_options.is_cancelled = &options.runtime_state->cancelled_ref();
     }

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -79,6 +79,8 @@ public:
     OlapRuntimeScanRangePruner runtime_range_pruner;
 
     std::vector<ColumnAccessPathPtr>* column_access_paths = nullptr;
+
+    bool asc_hint = true;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -423,6 +423,14 @@ Status SegmentIterator::_init() {
     RETURN_IF_ERROR(_rewrite_predicates());
     RETURN_IF_ERROR(_init_context());
     _init_column_predicates();
+
+    // reverse scan_range
+    if (!_opts.asc_hint) {
+        _scan_range.split(config::desc_hint_split_range, config::vector_chunk_size);
+        _scan_range.reverse();
+    }
+    // LOG(WARNING) << "TRACE:" << _opts.asc_hint << ":" << _scan_range.to_string();
+
     _range_iter = _scan_range.new_iterator();
 
     return Status::OK();
@@ -439,6 +447,7 @@ Status SegmentIterator::_try_to_update_ranges_by_runtime_filter() {
                 RETURN_IF_ERROR(_column_iterators[cid]->get_row_ranges_by_zone_map(predicates, del_pred, &r));
                 size_t prev_size = _scan_range.span_size();
                 SparseRange<> res;
+                res.set_normalized(_scan_range.is_normalized());
                 _range_iter = _range_iter.intersection(r, &res);
                 std::swap(res, _scan_range);
                 _range_iter.set_range(&_scan_range);
@@ -1017,6 +1026,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     const uint32_t chunk_capacity = _reserve_chunk_size;
     const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
     const bool has_predicate = !_opts.predicates.empty();
+    const bool scan_range_normalized = _scan_range.is_normalized();
     const int64_t prev_raw_rows_read = _opts.stats->raw_rows_read;
 
     _context->_read_chunk->reset();
@@ -1038,6 +1048,10 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
         }
         chunk_start = next_start;
         DCHECK_EQ(chunk_start, chunk->num_rows());
+
+        if (chunk_start && !scan_range_normalized) {
+            break;
+        }
     }
 
     size_t raw_chunk_size = chunk->num_rows();

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -429,7 +429,6 @@ Status SegmentIterator::_init() {
         _scan_range.split(config::desc_hint_split_range, config::vector_chunk_size);
         _scan_range.reverse();
     }
-    // LOG(WARNING) << "TRACE:" << _opts.asc_hint << ":" << _scan_range.to_string();
 
     _range_iter = _scan_range.new_iterator();
 

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -426,8 +426,7 @@ Status SegmentIterator::_init() {
 
     // reverse scan_range
     if (!_opts.asc_hint) {
-        _scan_range.split(config::desc_hint_split_range, config::vector_chunk_size);
-        _scan_range.reverse();
+        _scan_range.split_and_revese(config::desc_hint_split_range, config::vector_chunk_size);
     }
 
     _range_iter = _scan_range.new_iterator();
@@ -446,7 +445,7 @@ Status SegmentIterator::_try_to_update_ranges_by_runtime_filter() {
                 RETURN_IF_ERROR(_column_iterators[cid]->get_row_ranges_by_zone_map(predicates, del_pred, &r));
                 size_t prev_size = _scan_range.span_size();
                 SparseRange<> res;
-                res.set_normalized(_scan_range.is_normalized());
+                res.set_sorted(_scan_range.is_sorted());
                 _range_iter = _range_iter.intersection(r, &res);
                 std::swap(res, _scan_range);
                 _range_iter.set_range(&_scan_range);
@@ -1025,7 +1024,7 @@ Status SegmentIterator::_do_get_next(Chunk* result, vector<rowid_t>* rowid) {
     const uint32_t chunk_capacity = _reserve_chunk_size;
     const uint32_t return_chunk_threshold = std::max<uint32_t>(chunk_capacity - chunk_capacity / 4, 1);
     const bool has_predicate = !_opts.predicates.empty();
-    const bool scan_range_normalized = _scan_range.is_normalized();
+    const bool scan_range_normalized = _scan_range.is_sorted();
     const int64_t prev_raw_rows_read = _opts.stats->raw_rows_read;
 
     _context->_read_chunk->reset();

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -95,6 +95,8 @@ public:
 
     TabletSchemaCSPtr tablet_schema = nullptr;
 
+    bool asc_hint = true;
+
 public:
     Status convert_to(SegmentReadOptions* dst, const std::vector<LogicalType>& new_types, ObjectPool* obj_pool) const;
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/tablet_reader.h"
 
+#include <algorithm>
 #include <utility>
 
 #include "column/datum_convert.h"
@@ -278,6 +279,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.meta = _tablet->data_dir()->get_meta();
     rs_opts.rowid_range_option = params.rowid_range_option;
     rs_opts.short_key_ranges = params.short_key_ranges;
+    rs_opts.asc_hint = _is_asc_hint;
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
     for (auto& rowset : _rowsets) {
@@ -347,6 +349,10 @@ Status TabletReader::_init_collector(const TabletReaderParams& params) {
         }
     } else if (keys_type == PRIMARY_KEYS || keys_type == DUP_KEYS || (keys_type == UNIQUE_KEYS && skip_aggr) ||
                (select_all_keys && seg_iters.size() == 1)) {
+        // The segments may be in order after compaction. At this time, we prefer to read the later segments first.
+        if (!_is_asc_hint) {
+            std::reverse(seg_iters.begin(), seg_iters.end());
+        }
         //             UnionIterator
         //                   |
         //       +-----------+-----------+

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -44,6 +44,8 @@ public:
     TabletReader(TabletSharedPtr tablet, const Version& version, const TabletSchemaSPtr& tablet_schema, Schema schema);
     ~TabletReader() override { close(); }
 
+    void set_is_asc_hint(bool is_asc) { _is_asc_hint = is_asc; }
+
     Status prepare();
 
     // Precondition: the last method called must have been `prepare()`.
@@ -105,6 +107,7 @@ private:
 
     // used for pk index based pointer read
     const TabletReaderParams* _reader_params = nullptr;
+    bool _is_asc_hint = true;
 };
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -48,6 +48,7 @@ import com.starrocks.analysis.Analyzer;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
+import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DistributionInfo;
@@ -72,7 +73,6 @@ import com.starrocks.common.ErrorReport;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
-import com.starrocks.lake.LakeTable;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -155,6 +155,9 @@ public class OlapScanNode extends ScanNode {
     private boolean isFinalized = false;
     private boolean isSortedByKeyPerTablet = false;
     private boolean isOutputChunkByBucket = false;
+    private boolean outputAscHint = true;
+    private boolean sortKeyAscHint = true;
+    private Optional<Boolean> partitionKeyAscHint = Optional.empty();
 
     private Map<Long, Integer> tabletId2BucketSeq = Maps.newHashMap();
     private List<Expr> bucketExprs = Lists.newArrayList();
@@ -199,6 +202,10 @@ public class OlapScanNode extends ScanNode {
     public void disablePhysicalPropertyOptimize() {
         setIsSortedByKeyPerTablet(false);
         setIsOutputChunkByBucket(false);
+    }
+
+    public void setOrderHint(boolean isAsc) {
+        this.outputAscHint = isAsc;
     }
 
     public List<Long> getSelectedPartitionIds() {
@@ -784,6 +791,34 @@ public class OlapScanNode extends ScanNode {
         return result.size();
     }
 
+    private void assignOrderByHints(List<String> keyColumnNames) {
+        // assign order by hint
+        for (RuntimeFilterDescription probeRuntimeFilter : probeRuntimeFilters) {
+            if (RuntimeFilterDescription.RuntimeFilterType.TOPN_FILTER.equals(
+                    probeRuntimeFilter.runtimeFilterType())) {
+                Expr expr = probeRuntimeFilter.getNodeIdToProbeExpr().get(getId().asInt());
+                if (expr instanceof SlotRef) {
+                    // check key columns
+                    SlotId cid = ((SlotRef) expr).getSlotId();
+                    String columnName = desc.getSlot(cid.asInt()).getColumn().getName();
+                    if (!keyColumnNames.isEmpty() && keyColumnNames.get(0).equals(columnName)) {
+                        sortKeyAscHint = outputAscHint;
+                    }
+                    // check partition column
+                    PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+                    if (partitionInfo instanceof RangePartitionInfo) {
+                        List<Column> partitionColumns = ((RangePartitionInfo) partitionInfo).getPartitionColumns();
+                        if (!partitionColumns.isEmpty() && partitionColumns.get(0).getName().equals(columnName)) {
+                            partitionKeyAscHint = Optional.of(outputAscHint);
+                        }
+                    }
+                }
+                // we only care the first top-n filter
+                return;
+            }
+        }
+    }
+
     @Override
     protected void toThrift(TPlanNode msg) {
         List<String> keyColumnNames = new ArrayList<String>();
@@ -811,13 +846,15 @@ public class OlapScanNode extends ScanNode {
                         if (!col.isKey()) {
                             continue;
                         }
-    
+
                         keyColumnNames.add(col.getName());
                         keyColumnTypes.add(col.getPrimitiveType().toThrift());
                     }
                 }
             }
         }
+
+        assignOrderByHints(keyColumnNames);
 
         if (olapTable.isCloudNativeTableOrMaterializedView()) {
             msg.node_type = TPlanNodeType.LAKE_SCAN_NODE;
@@ -878,6 +915,8 @@ public class OlapScanNode extends ScanNode {
                 msg.olap_scan_node.setOutput_chunk_by_bucket(isOutputChunkByBucket);
             }
 
+            msg.olap_scan_node.setOutput_asc_hint(sortKeyAscHint);
+            partitionKeyAscHint.ifPresent(aBoolean -> msg.olap_scan_node.setPartition_order_hint(aBoolean));
             if (!bucketExprs.isEmpty()) {
                 msg.olap_scan_node.setBucket_exprs(Expr.treesToThrift(bucketExprs));
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SortNode.java
@@ -145,7 +145,7 @@ public class SortNode extends PlanNode implements RuntimeFilterBuildNode {
     public void buildRuntimeFilters(IdGenerator<RuntimeFilterId> generator, DescriptorTable descTbl) {
         SessionVariable sessionVariable = ConnectContext.get().getSessionVariable();
         // only support the runtime filter in TopN when limit > 0
-        if (limit < 0 || !sessionVariable.getEnableGlobalRuntimeFilter() ||
+        if (limit < 0 || !sessionVariable.getEnableTopNRuntimeFilter() ||
                 getSortInfo().getOrderingExprs().isEmpty()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -318,6 +318,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GLOBAL_RUNTIME_FILTER_PROBE_MIN_SELECTIVITY =
             "global_runtime_filter_probe_min_selectivity";
     public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
+    public static final String ENABLE_TOPN_RUNTIME_FILTER = "enable_topn_runtime_filter";
 
     public static final String ENABLE_COLUMN_EXPR_PREDICATE = "enable_column_expr_predicate";
     public static final String ENABLE_EXCHANGE_PASS_THROUGH = "enable_exchange_pass_through";
@@ -1003,6 +1004,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = ENABLE_GLOBAL_RUNTIME_FILTER)
     private boolean enableGlobalRuntimeFilter = true;
+
+    @VariableMgr.VarAttr(name = ENABLE_TOPN_RUNTIME_FILTER)
+    private boolean enableTopNRuntimeFilter = true;
 
     // Parameters to determine the usage of runtime filter
     // Either the build_max or probe_min equal to 0 would force use the filter,
@@ -1982,6 +1986,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableGlobalRuntimeFilter(boolean value) {
         enableGlobalRuntimeFilter = value;
+    }
+
+    public boolean getEnableTopNRuntimeFilter() {
+        return enableTopNRuntimeFilter;
     }
 
     public void setGlobalRuntimeFilterBuildMaxSize(long globalRuntimeFilterBuildMaxSize) {

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -506,6 +506,9 @@ struct TOlapScanNode {
   30: optional bool use_pk_index
   31: optional list<Descriptors.TColumn> columns_desc
   32: optional bool output_chunk_by_bucket
+  // order by hint for scan
+  33: optional bool output_asc_hint
+  34: optional bool partition_order_hint
 }
 
 struct TJDBCScanNode {

--- a/test/sql/test_sort/R/test_topn
+++ b/test/sql/test_sort/R/test_topn
@@ -1,0 +1,208 @@
+-- name: test_topn
+set pipeline_dop=1;
+-- result:
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT null, null FROM TABLE(generate_series(1,  65536));
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+select c0 from t0 order by 1 asc limit 10;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select c0 from t0 order by 1 asc nulls last limit 10;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+-- !result
+select c0 from t0 order by 1 asc nulls first limit 10;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select c0 from t0 order by 1 desc limit 10;
+-- result:
+40960
+40959
+40958
+40957
+40956
+40955
+40954
+40953
+40952
+40951
+-- !result
+select c0 from t0 order by 1 desc nulls last limit 10;
+-- result:
+40960
+40959
+40958
+40957
+40956
+40955
+40954
+40953
+40952
+40951
+-- !result
+select c0 from t0 order by 1 desc nulls first limit 10;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+None
+None
+-- !result
+select * from t0 order by 1,2 asc limit 5;
+-- result:
+None	None
+None	None
+None	None
+None	None
+None	None
+-- !result
+select * from t0 order by 1,2 desc limit 5;
+-- result:
+None	None
+None	None
+None	None
+None	None
+None	None
+-- !result
+select * from t0 order by 2,1 asc limit 5;
+-- result:
+None	None
+None	None
+None	None
+None	None
+None	None
+-- !result
+select * from t0 order by 2,1 desc limit 5;
+-- result:
+None	None
+None	None
+None	None
+None	None
+None	None
+-- !result
+select * from t0 order by 1 where c0 > 10 limit 10;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 28. Detail message: Unexpected input 'where', the most similar input is {<EOF>, ';'}.")
+-- !result
+select * from t0 order by 1 where c0 > 1000 limit 10;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 28. Detail message: Unexpected input 'where', the most similar input is {<EOF>, ';'}.")
+-- !result
+create table t1 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  10));
+-- result:
+-- !result
+select * from t1 order by 1 limit 10;
+-- result:
+-- !result
+CREATE TABLE `t2` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c1`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1");
+-- result:
+-- !result
+insert into t2 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  63336));
+-- result:
+-- !result
+select c0 from t2 order by c0 asc limit 10;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+-- !result
+select c1 from t2 order by c1 asc limit 10;
+-- result:
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+-- !result
+select c1,c0 from t2 order by c1,c0 asc limit 10;
+-- result:
+1	1
+2	2
+3	3
+4	4
+5	5
+6	6
+7	7
+8	8
+9	9
+10	10
+-- !result

--- a/test/sql/test_sort/T/test_topn
+++ b/test/sql/test_sort/T/test_topn
@@ -1,0 +1,54 @@
+-- name: test_topn
+-- 
+set pipeline_dop=1;
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- nulls first nulls last
+insert into t0 SELECT null, null FROM TABLE(generate_series(1,  65536));
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  40960));
+select c0 from t0 order by 1 asc limit 10;
+select c0 from t0 order by 1 asc nulls last limit 10;
+select c0 from t0 order by 1 asc nulls first limit 10;
+select c0 from t0 order by 1 desc limit 10;
+select c0 from t0 order by 1 desc nulls last limit 10;
+select c0 from t0 order by 1 desc nulls first limit 10;
+-- multi column
+select * from t0 order by 1,2 asc limit 5;
+select * from t0 order by 1,2 desc limit 5;
+select * from t0 order by 2,1 asc limit 5;
+select * from t0 order by 2,1 desc limit 5;
+-- materialize
+select * from t0 order by 1 where c0 > 10 limit 10;
+select * from t0 order by 1 where c0 > 1000 limit 10;
+-- little rows
+create table t1 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  10));
+select * from t1 order by 1 limit 10;
+-- partition key
+CREATE TABLE `t2` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c1`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1");
+insert into t2 SELECT generate_series, generate_series FROM TABLE(generate_series(1,  63336));
+select c0 from t2 order by c0 asc limit 10;
+select c1 from t2 order by c1 asc limit 10;
+select c1,c0 from t2 order by c1,c0 asc limit 10;


### PR DESCRIPTION
optimize case 1:
if a table has partition by column. and a query is order by partition column desc. we prefer scan by partition id desc.
```
select * from xxx order by partition_key desc limit 100;
```
optimize case 2:
if we need order by a key column. we perfer a desc scan order. but now we have not support by a full reversed scan range. so we will split a full scan range to multi sub scanrange.
eg:
[0, 1000000] -> [0, 100000), [100000, 200000)...
then we reverse the scan range. which may got better performance for order by key column

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
