### PR TITLE
[UT] Fix unstable ut for colocate balancer

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/clone/ColocateTableBalancerTest.java
@@ -336,9 +336,21 @@ public class ColocateTableBalancerTest {
 
     @Test
     public void testPerGroupBalance(@Mocked SystemInfoService infoService,
-                                    @Mocked ClusterLoadStatistic statistic) {
+                                    @Mocked ClusterLoadStatistic statistic) throws InterruptedException {
         new Expectations() {
             {
+                // try to fix the unstable test
+                // java.util.ConcurrentModificationException
+                //    at mockit.internal.expectations.state.ExecutingTest.isInjectableMock(ExecutingTest.java:142)
+                //    at mockit.internal.expectations.state.ExecutingTest.addInjectableMock(ExecutingTest.java:137)
+                //    at com.starrocks.clone.ColocateTableBalancerTest$2.<init>(ColocateTableBalancerTest.java:342)
+                //    at com.starrocks.clone.ColocateTableBalancerTest.testPerGroupBalance(ColocateTableBalancerTest.java:340)
+                //
+                // this exception happens at the internal of the mockit, probably a bug of mockit
+                // need to use concurrent safe list for mockit.internal.expectations.state.ExecutingTest#injectableMocks
+                // because mockit itself will start some background thread to clean `injectableMocks` which will have
+                // conflict with our test thread, here is just a workaround, wait for a while to avoid that.
+                Thread.sleep(2000);
                 infoService.getBackend(1L);
                 result = backend1;
                 minTimes = 0;


### PR DESCRIPTION
Try to fix the unstable test
```
java.util.ConcurrentModificationException
     at mockit.internal.expectations.state.ExecutingTest.isInjectableMock(ExecutingTest.java:142)
     at mockit.internal.expectations.state.ExecutingTest.addInjectableMock(ExecutingTest.java:137)
     at com.starrocks.clone.ColocateTableBalancerTest$2.<init>(ColocateTableBalancerTest.java:342)
     at com.starrocks.clone.ColocateTableBalancerTest.testPerGroupBalance(ColocateTableBalancerTest.java:340)
```
this exception happens at the internal of the mockit, probably a bug of mockit
need to use concurrent safe list for mockit.internal.expectations.state.ExecutingTest#injectableMocks
because mockit itself will start some background thread to clean `injectableMocks` which will have
conflict with our test thread, here is just a workaround, wait for a while to avoid that.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
