### PR TITLE
[Enhancement] add header option for "INTO OUTFILE" with csv format

### DIFF
--- a/be/src/exec/plain_text_builder.cpp
+++ b/be/src/exec/plain_text_builder.cpp
@@ -37,6 +37,20 @@ Status PlainTextBuilder::init() {
         }
         _converters.emplace_back(std::move(conv));
     }
+
+    if (_options.csv_header)
+    {
+        const std::string& row_delimiter = _options.line_terminated_by;
+        const std::string& column_delimiter = _options.column_terminated_by;
+        auto size = _options.column_names.size();
+        size_t i = 0;
+        auto* os = _output_stream.get();
+        for (auto & column_name: _options.column_names) {
+            os->write(column_name);
+            RETURN_IF_ERROR(os->write((++i == size) ? row_delimiter : column_delimiter));
+        }
+    }
+    
     _init = true;
 
     return Status::OK();

--- a/be/src/exec/plain_text_builder.cpp
+++ b/be/src/exec/plain_text_builder.cpp
@@ -38,7 +38,7 @@ Status PlainTextBuilder::init() {
         _converters.emplace_back(std::move(conv));
     }
 
-    if (_options.csv_header)
+    if (_options.print_header)
     {
         const std::string& row_delimiter = _options.line_terminated_by;
         const std::string& column_delimiter = _options.column_terminated_by;
@@ -46,7 +46,7 @@ Status PlainTextBuilder::init() {
         size_t i = 0;
         auto* os = _output_stream.get();
         for (auto & column_name: _options.column_names) {
-            os->write(column_name);
+            RETURN_IF_ERROR(os->write(column_name));
             RETURN_IF_ERROR(os->write((++i == size) ? row_delimiter : column_delimiter));
         }
     }

--- a/be/src/exec/plain_text_builder.h
+++ b/be/src/exec/plain_text_builder.h
@@ -36,7 +36,7 @@ struct PlainTextBuilderOptions {
     std::string column_terminated_by;
     std::string line_terminated_by;
     std::vector<std::string> column_names;
-    bool csv_header;
+    bool print_header;
 };
 
 class PlainTextBuilder final : public FileBuilder {

--- a/be/src/exec/plain_text_builder.h
+++ b/be/src/exec/plain_text_builder.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "exec/file_builder.h"
 
@@ -34,6 +35,8 @@ class FileWriter;
 struct PlainTextBuilderOptions {
     std::string column_terminated_by;
     std::string line_terminated_by;
+    std::vector<std::string> column_names;
+    bool csv_header;
 };
 
 class PlainTextBuilder final : public FileBuilder {

--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -101,7 +101,7 @@ Status FileResultWriter::_create_file_writer() {
     switch (_file_opts->file_format) {
     case TFileFormatType::FORMAT_CSV_PLAIN:
         _file_builder = std::make_unique<PlainTextBuilder>(
-                PlainTextBuilderOptions{_file_opts->column_separator, _file_opts->row_delimiter},
+                PlainTextBuilderOptions{_file_opts->column_separator, _file_opts->row_delimiter, _file_opts->file_column_names, _file_opts->csv_header},
                 std::move(writable_file), _output_expr_ctxs);
         break;
     case TFileFormatType::FORMAT_PARQUET: {

--- a/be/src/runtime/file_result_writer.cpp
+++ b/be/src/runtime/file_result_writer.cpp
@@ -101,8 +101,8 @@ Status FileResultWriter::_create_file_writer() {
     switch (_file_opts->file_format) {
     case TFileFormatType::FORMAT_CSV_PLAIN:
         _file_builder = std::make_unique<PlainTextBuilder>(
-                PlainTextBuilderOptions{_file_opts->column_separator, _file_opts->row_delimiter, _file_opts->file_column_names, _file_opts->csv_header},
-                std::move(writable_file), _output_expr_ctxs);
+                PlainTextBuilderOptions{_file_opts->csv_options.column_separator, _file_opts->csv_options.row_delimiter, 
+                _file_opts->file_column_names, _file_opts->csv_options.print_header}, std::move(writable_file), _output_expr_ctxs);
         break;
     case TFileFormatType::FORMAT_PARQUET: {
         ASSIGN_OR_RETURN(auto properties, parquet::ParquetBuildHelper::make_properties(_file_opts->parquet_options));

--- a/be/src/runtime/file_result_writer.h
+++ b/be/src/runtime/file_result_writer.h
@@ -62,6 +62,7 @@ struct ResultFileOptions {
     bool use_broker;
     std::vector<std::string> file_column_names;
     parquet::ParquetBuilderOptions parquet_options;
+    bool csv_header;
 
     ResultFileOptions(const TResultFileSinkOptions& t_opt) {
         file_path = t_opt.file_path;
@@ -69,6 +70,7 @@ struct ResultFileOptions {
         column_separator = t_opt.__isset.column_separator ? t_opt.column_separator : "\t";
         row_delimiter = t_opt.__isset.row_delimiter ? t_opt.row_delimiter : "\n";
         max_file_size_bytes = t_opt.__isset.max_file_size_bytes ? t_opt.max_file_size_bytes : max_file_size_bytes;
+        csv_header = t_opt.csv_header;
 
         if (t_opt.__isset.broker_addresses) {
             broker_addresses = t_opt.broker_addresses;

--- a/be/src/runtime/file_result_writer.h
+++ b/be/src/runtime/file_result_writer.h
@@ -35,6 +35,7 @@
 #pragma once
 
 #include "exec/parquet_builder.h"
+#include "formats/csv/csv_builder_options.h"
 #include "fs/fs.h"
 #include "gen_cpp/DataSinks_types.h"
 #include "parquet/file_writer.h"
@@ -52,8 +53,6 @@ class WritableFile;
 struct ResultFileOptions {
     std::string file_path;
     TFileFormatType::type file_format;
-    std::string column_separator;
-    std::string row_delimiter;
     size_t max_file_size_bytes = 1 * 1024 * 1024 * 1024; // 1GB
     std::vector<TNetworkAddress> broker_addresses;
     std::map<std::string, std::string> broker_properties;
@@ -62,15 +61,12 @@ struct ResultFileOptions {
     bool use_broker;
     std::vector<std::string> file_column_names;
     parquet::ParquetBuilderOptions parquet_options;
-    bool csv_header;
+    csv::CsvBuilderOptions csv_options;
 
     ResultFileOptions(const TResultFileSinkOptions& t_opt) {
         file_path = t_opt.file_path;
         file_format = t_opt.file_format;
-        column_separator = t_opt.__isset.column_separator ? t_opt.column_separator : "\t";
-        row_delimiter = t_opt.__isset.row_delimiter ? t_opt.row_delimiter : "\n";
         max_file_size_bytes = t_opt.__isset.max_file_size_bytes ? t_opt.max_file_size_bytes : max_file_size_bytes;
-        csv_header = t_opt.csv_header;
 
         if (t_opt.__isset.broker_addresses) {
             broker_addresses = t_opt.broker_addresses;
@@ -98,6 +94,20 @@ struct ResultFileOptions {
         }
         if (t_opt.__isset.parquet_options && t_opt.parquet_options.__isset.compression_type) {
             parquet_options.compression_type = t_opt.parquet_options.compression_type;
+        }
+
+        if (t_opt.__isset.csv_options && t_opt.csv_options.__isset.column_separator) {
+            csv_options.column_separator = t_opt.csv_options.column_separator;
+        } else {
+            csv_options.column_separator = "\t";
+        }
+        if (t_opt.__isset.csv_options && t_opt.csv_options.__isset.row_delimiter) {
+            csv_options.row_delimiter = t_opt.csv_options.row_delimiter;
+        } else {
+            csv_options.row_delimiter = "\n";
+        }
+        if (t_opt.__isset.csv_options && t_opt.csv_options.__isset.print_header) {
+            csv_options.print_header = t_opt.csv_options.print_header;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -54,6 +54,7 @@ import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.thrift.TCompressionType;
+import com.starrocks.thrift.TCsvOptions;
 import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.THdfsProperties;
 import com.starrocks.thrift.TParquetOptions;
@@ -417,10 +418,12 @@ public class OutFileClause implements ParseNode {
     public TResultFileSinkOptions toSinkOptions(List<String> columnOutputNames) {
         TResultFileSinkOptions sinkOptions = new TResultFileSinkOptions(filePath, fileFormatType);
         if (isCsvFormat()) {
-            sinkOptions.setCsv_header(csvHeader);
+            TCsvOptions csvOptions = new TCsvOptions();
+            csvOptions.setColumn_separator(columnSeparator);
+            csvOptions.setRow_delimiter(rowDelimiter);
+            csvOptions.setPrint_header(csvHeader);
+            sinkOptions.setCsv_options(csvOptions);
             sinkOptions.setFile_column_names(columnOutputNames);
-            sinkOptions.setColumn_separator(columnSeparator);
-            sinkOptions.setRow_delimiter(rowDelimiter);
         } else if (isParquetFormat()) {
             TParquetOptions parquetOptions = new TParquetOptions();
             parquetOptions.setCompression_type(compressionType);

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -77,24 +77,28 @@ struct TParquetOptions {
     3: optional bool use_dict
 }
 
+struct TCsvOptions {
+    1: optional string column_separator
+    2: optional string row_delimiter
+    3: optional bool print_header
+}
+
 struct TResultFileSinkOptions {
     1: required string file_path
     2: required PlanNodes.TFileFormatType file_format
-    3: optional string column_separator    // only for csv
-    4: optional string row_delimiter  // only for csv
-    5: optional i64 max_file_size_bytes
-    6: optional list<Types.TNetworkAddress> broker_addresses; // only for remote file
-    7: optional map<string, string> broker_properties // only for remote file.
+    3: optional i64 max_file_size_bytes
+    4: optional list<Types.TNetworkAddress> broker_addresses; // only for remote file
+    5: optional map<string, string> broker_properties // only for remote file.
     // If use_broker is set, we will write hdfs thourgh broker
     // If use_broker is not set, we will write through libhdfs/S3 directly
-    8: optional bool use_broker
+    6: optional bool use_broker
     // hdfs_write_buffer_size_kb for writing through lib hdfs directly
-    9: optional i32 hdfs_write_buffer_size_kb = 0
+    7: optional i32 hdfs_write_buffer_size_kb = 0
     // properties from hdfs-site.xml, core-site.xml and load_properties
-    10: optional PlanNodes.THdfsProperties hdfs_properties
-    11: optional TParquetOptions parquet_options
-    12: optional list<string> file_column_names
-    13: optional bool csv_header
+    8: optional PlanNodes.THdfsProperties hdfs_properties
+    9: optional TParquetOptions parquet_options
+    10: optional TCsvOptions csv_options
+    11: optional list<string> file_column_names
 }
 
 struct TMemoryScratchSink {

--- a/gensrc/thrift/DataSinks.thrift
+++ b/gensrc/thrift/DataSinks.thrift
@@ -94,6 +94,7 @@ struct TResultFileSinkOptions {
     10: optional PlanNodes.THdfsProperties hdfs_properties
     11: optional TParquetOptions parquet_options
     12: optional list<string> file_column_names
+    13: optional bool csv_header
 }
 
 struct TMemoryScratchSink {


### PR DESCRIPTION
Fixes #issue
```
select now() as time  
INTO OUTFILE "xxx"  
FORMAT AS CSV PROPERTIES(); 
```
When we select to CSV outfile, the information of csv headers is missing. So we want to add a new CSV format properties "csv.header" to enable printing headers in csv.
example： 
```
select now() as time  
INTO OUTFILE "xxx"  
FORMAT AS CSV PROPERTIES ( "csv.header"="true" );
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5