### PR TITLE
[BugFix] fix pk index compaction thread pool init in CN node

### DIFF
--- a/be/src/storage/persistent_index_compaction_manager.cpp
+++ b/be/src/storage/persistent_index_compaction_manager.cpp
@@ -29,9 +29,10 @@ PersistentIndexCompactionManager::~PersistentIndexCompactionManager() {
 }
 
 Status PersistentIndexCompactionManager::init() {
-    int max_pk_index_compaction_thread_cnt = config::pindex_major_compaction_num_threads > 0
-                                                     ? config::pindex_major_compaction_num_threads
-                                                     : StorageEngine::instance()->get_store_num() * 2;
+    int max_pk_index_compaction_thread_cnt =
+            config::pindex_major_compaction_num_threads > 0
+                    ? config::pindex_major_compaction_num_threads
+                    : std::max((size_t)1, StorageEngine::instance()->get_store_num() * 2);
     RETURN_IF_ERROR(ThreadPoolBuilder("pk_index_compaction_worker")
                             .set_min_threads(1)
                             .set_max_threads(max_pk_index_compaction_thread_cnt)


### PR DESCRIPTION
In CN node, storage count could be 0, we need to handle this.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
