### PR TITLE
[Enhancement] primary key using persistent index by default (backport #29850)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2414,6 +2414,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int max_download_task_per_be = 0;
 
+    /*
+     * Using persistent index in primary key table by default when creating table.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_persistent_index_by_default = false;
+
     /**
      * timeout for external table commit
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -58,6 +58,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.lake.DataCacheInfo;
 import com.starrocks.qe.ConnectContext;
@@ -688,6 +689,19 @@ public class PropertyAnalyzer {
             return Boolean.parseBoolean(val);
         }
         return defaultVal;
+    }
+
+    public static Pair<Boolean, Boolean> analyzeEnablePersistentIndex(Map<String, String> properties, boolean isPrimaryKey) {
+        if (properties != null && properties.containsKey(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX)) {
+            String val = properties.get(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX);
+            properties.remove(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX);
+            return Pair.create(Boolean.parseBoolean(val), true);
+        } else {
+            if (isPrimaryKey) {
+                return Pair.create(Config.enable_persistent_index_by_default, false);
+            }
+            return Pair.create(false, false);
+        }
     }
 
     // analyze property like : "type" = "xxx";

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1285,6 +1285,10 @@ public class GlobalStateMgr {
                                 LiteralExpr.create("true", Type.BOOLEAN)),
                         false);
             }
+            if (nodeMgr.isFirstTimeStartUp()) {
+                // When the cluster is initially deployed, we use persistent index by default
+                Config.enable_persistent_index_by_default = true;
+            }
         } catch (UserException e) {
             LOG.warn("Failed to set ENABLE_ADAPTIVE_SINK_DOP", e);
         } catch (Throwable t) {

--- a/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/PropertyAnalyzerTest.java
@@ -216,6 +216,55 @@ public class PropertyAnalyzerTest {
     }
 
     @Test
+    public void testEnablePersistentIndex() throws AnalysisException {
+        // empty property
+        Map<String, String> property = new HashMap<>();
+        Pair<Boolean, Boolean> ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property, true);
+        Assert.assertEquals(false, ret.first);
+        Assert.assertEquals(false, ret.second);
+        // with property
+        Map<String, String> property2 = new HashMap<>();
+        property2.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "true");
+        ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property2, true);
+        Assert.assertEquals(true, ret.first);
+        Assert.assertEquals(true, ret.second);
+
+        Map<String, String> property3 = new HashMap<>();
+        property3.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "false");
+        ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property3, true);
+        Assert.assertEquals(false, ret.first);
+        Assert.assertEquals(true, ret.second);
+
+        // change config
+        Config.enable_persistent_index_by_default = false;
+
+        // empty property
+        Map<String, String> property4 = new HashMap<>();
+        ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property4, true);
+        Assert.assertEquals(false, ret.first);
+        Assert.assertEquals(false, ret.second);
+        // with property
+        Map<String, String> property5 = new HashMap<>();
+        property5.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "true");
+        ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property5, true);
+        Assert.assertEquals(true, ret.first);
+        Assert.assertEquals(true, ret.second);
+
+        Map<String, String> property6 = new HashMap<>();
+        property6.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "false");
+        ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property6, true);
+        Assert.assertEquals(false, ret.first);
+        Assert.assertEquals(true, ret.second);
+        Config.enable_persistent_index_by_default = true;
+        
+        // non primary key
+        Map<String, String> property7 = new HashMap<>();
+        ret = PropertyAnalyzer.analyzeEnablePersistentIndex(property7, false);
+        Assert.assertEquals(false, ret.first);
+        Assert.assertEquals(false, ret.second);
+    }
+
+    @Test
     public void testDefaultTableCompression() throws AnalysisException {
         // No session
         Assert.assertEquals(TCompressionType.LZ4_FRAME, (PropertyAnalyzer.analyzeCompressionType(ImmutableMap.of())));

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -56,7 +56,7 @@ DISTRIBUTED BY HASH(`id`) BUCKETS 7
 PROPERTIES (
 "replication_num" = "1",
 "in_memory" = "false",
-"enable_persistent_index" = "false",
+"enable_persistent_index" = "true",
 "replicated_storage" = "true",
 "compression" = "LZ4"
 );
@@ -465,7 +465,7 @@ DISTRIBUTED BY HASH(`id`) BUCKETS 7
 PROPERTIES (
 "replication_num" = "1",
 "in_memory" = "false",
-"enable_persistent_index" = "false",
+"enable_persistent_index" = "true",
 "replicated_storage" = "true",
 "compression" = "LZ4"
 );


### PR DESCRIPTION
Backport #29850
And the cluster is initially deployed, we use persistent index by default.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
