### PR TITLE
[Feature]Support alter `enable_persistent_index`of lake table (backport #28329)

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -22,6 +22,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/snapshot_loader.h"
 #include "service/backend_options.h"
+#include "storage/lake/schema_change.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/snapshot_manager.h"
 #include "storage/tablet_manager.h"
@@ -723,6 +724,22 @@ void run_update_meta_info_task(const std::shared_ptr<UpdateTabletMetaInfoAgentTa
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;
 
+    // alter meta SHARED_DATA
+    if (update_tablet_meta_req.__isset.tablet_type &&
+        update_tablet_meta_req.tablet_type == TTabletType::TABLET_TYPE_LAKE) {
+        lake::SchemaChangeHandler handler(ExecEnv::GetInstance()->lake_tablet_manager());
+        auto res = handler.process_update_tablet_meta(update_tablet_meta_req);
+        if (!res.ok()) {
+            // TODO explict the error message and errorCode
+            error_msgs.emplace_back(res.get_error_msg());
+            status_code = TStatusCode::RUNTIME_ERROR;
+        }
+        unify_finish_agent_task(status_code, error_msgs, agent_task_req->task_type, agent_task_req->signature);
+        LOG(INFO) << "finish update tablet meta task. signature:" << agent_task_req->signature;
+        return;
+    }
+
+    // SHARED_NOTHING, tablet_type = TTabletType::TABLET_TYPE_DISK
     for (const auto& tablet_meta_info : update_tablet_meta_req.tabletMetaInfos) {
         TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(tablet_meta_info.tablet_id);
         if (tablet == nullptr) {

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -333,6 +333,53 @@ Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& req
     return Status::OK();
 }
 
+Status SchemaChangeHandler::process_update_tablet_meta(const TUpdateTabletMetaInfoReq& request) {
+    if (!request.__isset.txn_id) {
+        LOG(WARNING) << "txn_id not set in request";
+        return Status::InternalError("txn_id not set in request");
+    }
+    int64_t txn_id = request.txn_id;
+
+    for (const auto& tablet_meta_info : request.tabletMetaInfos) {
+        RETURN_IF_ERROR(do_process_update_tablet_meta(tablet_meta_info, txn_id));
+    }
+
+    return Status::OK();
+}
+
+Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo& tablet_meta_info, int64_t txn_id) {
+    if (tablet_meta_info.meta_type != TTabletMetaType::ENABLE_PERSISTENT_INDEX) {
+        // Only support ENABLE_PERSISTENT_INDEX for now
+        LOG(WARNING) << "not supported update meta type: " + tablet_meta_info.meta_type;
+        return Status::InternalError("not supported update meta type:" + tablet_meta_info.meta_type);
+    }
+
+    MonotonicStopWatch timer;
+    timer.start();
+    LOG(INFO) << "begin to update tablet, tablet: " << tablet_meta_info.tablet_id
+              << ", update meta type: " << tablet_meta_info.meta_type;
+
+    auto tablet_id = tablet_meta_info.tablet_id;
+    ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(tablet_id));
+
+    // create txn log
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(tablet_id);
+    txn_log->set_txn_id(txn_id);
+    auto op_alter_metadata = txn_log->mutable_op_alter_metadata();
+
+    auto metadata_update_info = op_alter_metadata->add_metadata_update_infos();
+    metadata_update_info->set_enable_persistent_index(tablet_meta_info.enable_persistent_index);
+
+    LOG(INFO) << "update lake tablet: " << tablet_id
+              << ", enable_persistent_index: " << tablet_meta_info.enable_persistent_index
+              << ", cost: " << timer.elapsed_time();
+
+    // write txn log
+    RETURN_IF_ERROR(tablet.put_txn_log(std::move(txn_log)));
+    return Status::OK();
+}
+
 Status SchemaChangeHandler::convert_historical_rowsets(const SchemaChangeParams& sc_params,
                                                        TxnLogPB_OpSchemaChange* op_schema_change) {
     auto base_tablet = sc_params.base_tablet;

--- a/be/src/storage/lake/schema_change.h
+++ b/be/src/storage/lake/schema_change.h
@@ -31,6 +31,8 @@ public:
 
     Status process_alter_tablet(const TAlterTabletReqV2& request);
 
+    // for update tablet meta
+    Status process_update_tablet_meta(const TUpdateTabletMetaInfoReq& request);
     DISALLOW_COPY_AND_MOVE(SchemaChangeHandler);
 
 private:
@@ -47,6 +49,8 @@ private:
 
     Status do_process_alter_tablet(const TAlterTabletReqV2& request);
     Status convert_historical_rowsets(const SchemaChangeParams& sc_params, TxnLogPB_OpSchemaChange* op_schema_change);
+
+    Status do_process_update_tablet_meta(const TTabletMetaInfo& request, int64_t txn_id);
 
     TabletManager* _tablet_manager;
 };

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -82,6 +82,9 @@ public:
         if (log.has_op_schema_change()) {
             RETURN_IF_ERROR(apply_schema_change_log(log.op_schema_change()));
         }
+        if (log.has_op_alter_metadata()) {
+            RETURN_IF_ERROR(apply_alter_meta_log(log.op_alter_metadata()));
+        }
         return Status::OK();
     }
 
@@ -148,6 +151,32 @@ private:
             auto base_meta = std::make_shared<TabletMetadata>(*_metadata);
             base_meta->set_version(_base_version);
             RETURN_IF_ERROR(_tablet.put_metadata(std::move(base_meta)));
+        }
+        return Status::OK();
+    }
+
+    Status apply_alter_meta_log(const TxnLogPB_OpAlterMetadata& op_alter_metas) {
+        DCHECK_EQ(_base_version + 1, _new_version);
+        for (const auto& alter_meta : op_alter_metas.metadata_update_infos()) {
+            if (alter_meta.has_enable_persistent_index()) {
+                // this should always be true,
+                // for FE will check whether the value of `enable_persisent_index` is changed or not
+                // then send the alter task to BE
+                if (_metadata->enable_persistent_index() != alter_meta.enable_persistent_index()) {
+                    _metadata->set_enable_persistent_index(alter_meta.enable_persistent_index());
+
+                    // Try remove index from index cache
+                    // If tablet is doing apply rowset right now, remove primary index from index cache may be failed
+                    // because the primary index is available in cache
+                    // But it will be remove from index cache after apply is finished
+                    (void)_tablet.update_mgr()->index_cache().try_remove_by_key(_tablet.id());
+                } else {
+                    LOG(WARNING) << strings::Substitute(
+                            "alter_meta_log not need to apply, for enable_persistent_index is the same, which is $0, "
+                            "base_version: $1, new_version: $2",
+                            _metadata->enable_persistent_index(), _base_version, _new_version);
+                }
+            }
         }
         return Status::OK();
     }

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -133,6 +133,8 @@ public:
     // release index entry if it isn't nullptr
     void release_primary_index(IndexEntry* index_entry);
 
+    DynamicCache<uint64_t, LakePrimaryIndex>& index_cache() { return _index_cache; }
+
 private:
     // print memory tracker state
     void _print_memory_stats();

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -206,6 +206,7 @@ set(EXEC_FILES
         ./storage/lake/location_provider_test.cpp
         ./storage/lake/rowset_test.cpp
         ./storage/lake/schema_change_test.cpp
+        ./storage/lake/alter_tablet_meta_test.cpp
         ./storage/lake/tablet_manager_test.cpp
         ./storage/lake/partial_update_test.cpp
         ./storage/lake/auto_increment_partial_update_test.cpp

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -82,7 +82,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
 
-    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1);
+    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
 
@@ -98,7 +98,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
     update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
 
-    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1);
+    auto new_tablet_meta2 = publish_single_version(tablet_id, 3, txn_id2);
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(false, new_tablet_meta2.value()->enable_persistent_index());
 }
@@ -118,7 +118,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
     update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
 
-    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1);
+    auto new_tablet_meta = publish_single_version(tablet_id, 2, txn_id);
     ASSERT_OK(new_tablet_meta.status());
     ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
 
@@ -135,7 +135,7 @@ TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
     update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
     ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
 
-    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1);
+    auto new_tablet_meta2 = publish_single_version(tablet_id, 3, txn_id2);
     ASSERT_OK(new_tablet_meta2.status());
     ASSERT_EQ(true, new_tablet_meta2.value()->enable_persistent_index());
 }

--- a/be/test/storage/lake/alter_tablet_meta_test.cpp
+++ b/be/test/storage/lake/alter_tablet_meta_test.cpp
@@ -1,0 +1,158 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "agent/agent_task.h"
+#include "fs/fs_util.h"
+#include "storage/lake/schema_change.h"
+#include "storage/lake/tablet_manager.h"
+#include "test_util.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+using namespace starrocks;
+
+class AlterTabletMetaTest : public TestBase {
+public:
+    AlterTabletMetaTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+
+        auto base_schema = _tablet_metadata->mutable_schema();
+        base_schema->set_id(next_id());
+        base_schema->set_keys_type(KeysType::PRIMARY_KEYS);
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_alter_tablet_meta";
+
+    std::unique_ptr<TabletMetadata> _tablet_metadata;
+};
+
+TEST_F(AlterTabletMetaTest, test_missing_txn_id) {
+    lake::SchemaChangeHandler handler(_tablet_mgr.get());
+    TUpdateTabletMetaInfoReq update_tablet_meta_req;
+
+    TTabletMetaInfo tablet_meta_info;
+    auto tablet_id = _tablet_metadata->id();
+    tablet_meta_info.__set_tablet_id(tablet_id);
+    tablet_meta_info.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
+    tablet_meta_info.__set_enable_persistent_index(true);
+
+    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
+    auto status = handler.process_update_tablet_meta(update_tablet_meta_req);
+    ASSERT_ERROR(status);
+    ASSERT_EQ("txn_id not set in request", status.get_error_msg());
+}
+
+TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index) {
+    lake::SchemaChangeHandler handler(_tablet_mgr.get());
+    TUpdateTabletMetaInfoReq update_tablet_meta_req;
+    int64_t txn_id = 1;
+    update_tablet_meta_req.__set_txn_id(txn_id);
+
+    TTabletMetaInfo tablet_meta_info;
+    auto tablet_id = _tablet_metadata->id();
+    tablet_meta_info.__set_tablet_id(tablet_id);
+    tablet_meta_info.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
+    tablet_meta_info.__set_enable_persistent_index(true);
+
+    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
+    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
+
+    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1);
+    ASSERT_OK(new_tablet_meta.status());
+    ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
+
+    int64_t txn_id2 = txn_id + 1;
+    TUpdateTabletMetaInfoReq update_tablet_meta_req2;
+    update_tablet_meta_req2.__set_txn_id(txn_id2);
+
+    TTabletMetaInfo tablet_meta_info2;
+    tablet_meta_info2.__set_tablet_id(tablet_id);
+    tablet_meta_info2.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
+    tablet_meta_info2.__set_enable_persistent_index(false);
+
+    update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
+    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
+
+    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1);
+    ASSERT_OK(new_tablet_meta2.status());
+    ASSERT_EQ(false, new_tablet_meta2.value()->enable_persistent_index());
+}
+
+TEST_F(AlterTabletMetaTest, test_alter_enable_persistent_index_not_change) {
+    lake::SchemaChangeHandler handler(_tablet_mgr.get());
+    TUpdateTabletMetaInfoReq update_tablet_meta_req;
+    int64_t txn_id = 1;
+    update_tablet_meta_req.__set_txn_id(txn_id);
+
+    TTabletMetaInfo tablet_meta_info;
+    auto tablet_id = _tablet_metadata->id();
+    tablet_meta_info.__set_tablet_id(tablet_id);
+    tablet_meta_info.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
+    tablet_meta_info.__set_enable_persistent_index(true);
+
+    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
+    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req));
+
+    auto new_tablet_meta = _tablet_mgr->publish_version(tablet_id, 1, 2, &txn_id, 1);
+    ASSERT_OK(new_tablet_meta.status());
+    ASSERT_EQ(true, new_tablet_meta.value()->enable_persistent_index());
+
+    int64_t txn_id2 = txn_id + 1;
+    TUpdateTabletMetaInfoReq update_tablet_meta_req2;
+    update_tablet_meta_req2.__set_txn_id(txn_id2);
+
+    // `enable_persistent_index` is still set to true
+    TTabletMetaInfo tablet_meta_info2;
+    tablet_meta_info2.__set_tablet_id(tablet_id);
+    tablet_meta_info2.__set_meta_type(TTabletMetaType::ENABLE_PERSISTENT_INDEX);
+    tablet_meta_info2.__set_enable_persistent_index(true);
+
+    update_tablet_meta_req2.tabletMetaInfos.push_back(tablet_meta_info2);
+    ASSERT_OK(handler.process_update_tablet_meta(update_tablet_meta_req2));
+
+    auto new_tablet_meta2 = _tablet_mgr->publish_version(tablet_id, 2, 3, &txn_id2, 1);
+    ASSERT_OK(new_tablet_meta2.status());
+    ASSERT_EQ(true, new_tablet_meta2.value()->enable_persistent_index());
+}
+
+TEST_F(AlterTabletMetaTest, test_alter_not_persistent_index) {
+    lake::SchemaChangeHandler handler(_tablet_mgr.get());
+    TUpdateTabletMetaInfoReq update_tablet_meta_req;
+    int64_t txn_id = 1;
+    update_tablet_meta_req.__set_txn_id(txn_id);
+
+    TTabletMetaInfo tablet_meta_info;
+    auto tablet_id = _tablet_metadata->id();
+    tablet_meta_info.__set_tablet_id(tablet_id);
+    tablet_meta_info.__set_meta_type(TTabletMetaType::INMEMORY);
+
+    update_tablet_meta_req.tabletMetaInfos.push_back(tablet_meta_info);
+    ASSERT_ERROR(handler.process_update_tablet_meta(update_tablet_meta_req));
+}
+
+} // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -517,6 +517,10 @@ public class AlterJobMgr {
                 // if modify storage type to v2, do schema change to convert all related tablets to segment v2 format
                 schemaChangeHandler.process(alterClauses, db, olapTable);
                 isSynchronous = false;
+            } else if (currentAlterOps.contains(AlterOpType.MODIFY_TABLE_PROPERTY_SYNC) &&
+                    olapTable.isCloudNativeTable()) {
+                schemaChangeHandler.processLakeTableAlterMeta(alterClauses, db, olapTable);
+                isSynchronous = false;
             } else if (currentAlterOps.hasRollupOp()) {
                 materializedViewHandler.process(alterClauses, db, olapTable);
                 isSynchronous = false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2.java
@@ -78,7 +78,7 @@ public abstract class AlterJobV2 implements Writable {
 
     public enum JobType {
         // DECOMMISSION_BACKEND is for compatible with older versions of metadata
-        ROLLUP, SCHEMA_CHANGE, DECOMMISSION_BACKEND 
+        ROLLUP, SCHEMA_CHANGE, DECOMMISSION_BACKEND
     }
 
     @SerializedName(value = "type")

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -1,0 +1,500 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.collect.Table;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PhysicalPartition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.MarkedCountDownLatch;
+import com.starrocks.common.Pair;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.Utils;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTaskExecutor;
+import com.starrocks.task.AgentTaskQueue;
+import com.starrocks.task.UpdateTabletMetaInfoTask;
+import com.starrocks.thrift.TTabletMetaType;
+import com.starrocks.thrift.TTabletType;
+import com.starrocks.thrift.TTaskType;
+import io.opentelemetry.api.trace.StatusCode;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.validation.constraints.NotNull;
+
+public class LakeTableAlterMetaJob extends AlterJobV2 {
+
+    private static final Logger LOG = LogManager.getLogger(LakeTableAlterMetaJob.class);
+
+    @SerializedName(value = "metaType")
+    private TTabletMetaType metaType;
+
+    @SerializedName(value = "metaValue")
+    private boolean metaValue;
+
+    @SerializedName(value = "watershedTxnId")
+    private long watershedTxnId = -1;
+
+    // PartitionId -> indexId -> MaterializedIndex
+    @SerializedName(value = "partitionIndexMap")
+    private Table<Long, Long, MaterializedIndex> partitionIndexMap = HashBasedTable.create();
+
+    @SerializedName(value = "commitVersionMap")
+    // Mapping from partition id to commit version
+    private Map<Long, Long> commitVersionMap = new HashMap<>();
+
+    public LakeTableAlterMetaJob(long jobId, long dbId, long tableId, String tableName,
+                                 long timeoutMs, TTabletMetaType metaType, boolean metaValue) {
+        super(jobId, JobType.SCHEMA_CHANGE, dbId, tableId, tableName, timeoutMs);
+        this.metaType = metaType;
+        this.metaValue = metaValue;
+    }
+
+    @Override
+    protected void runPendingJob() throws AlterCancelException {
+        // send task to be
+        List<Partition> partitions = Lists.newArrayList();
+        OlapTable olapTable;
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+
+        if (db == null) {
+            throw new AlterCancelException("database does not exist, dbId:" + dbId);
+        }
+        db.readLock();
+        try {
+            olapTable = (OlapTable) db.getTable(tableName);
+            if (olapTable == null) {
+                throw new AlterCancelException("table does not exist, tableName:" + tableName);
+            }
+            partitions.addAll(olapTable.getPartitions());
+        } finally {
+            db.readUnlock();
+        }
+
+        if (this.watershedTxnId == -1) {
+            this.watershedTxnId =
+                    GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+        }
+
+        try {
+            for (Partition partition : partitions) {
+                updatePartitionTabletMeta(db, olapTable.getName(), partition.getName(), metaValue, metaType);
+            }
+        } catch (DdlException e) {
+            throw new AlterCancelException(e.getMessage());
+        }
+
+        this.jobState = JobState.RUNNING;
+    }
+
+    @Override
+    protected void runWaitingTxnJob() throws AlterCancelException {
+        // do nothing
+    }
+
+    @Override
+    protected void runRunningJob() throws AlterCancelException {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            // database has been dropped
+            throw new AlterCancelException("database does not exist, dbId:" + dbId);
+        }
+        db.writeLock();
+
+        LakeTable table = (LakeTable) db.getTable(tableId);
+        if (table == null) {
+            // table has been dropped
+            throw new AlterCancelException("table does not exist, tableId:" + tableId);
+        }
+        try {
+            commitVersionMap.clear();
+            for (long partitionId : partitionIndexMap.rowKeySet()) {
+                Partition partition = table.getPartition(partitionId);
+                Preconditions.checkNotNull(partition, partitionId);
+                long commitVersion = partition.getNextVersion();
+                commitVersionMap.put(partitionId, commitVersion);
+                LOG.debug("commit version of partition {} is {}. jobId={}", partitionId, commitVersion, jobId);
+            }
+
+            this.jobState = JobState.FINISHED_REWRITING;
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+
+            // NOTE: !!! below this point, this update meta job must success unless the database or table been dropped. !!!
+            updateNextVersion(table);
+        } finally {
+            db.writeUnlock();
+        }
+
+    }
+
+    @Override
+    protected void runFinishedRewritingJob() throws AlterCancelException {
+        // run publish version
+        Preconditions.checkState(jobState == JobState.FINISHED_REWRITING);
+        // If the table or database has been dropped, `readyToPublishVersion()` will throw AlterCancelException and
+        // this schema change job will be cancelled.
+        if (!readyToPublishVersion()) {
+            return;
+        }
+
+        if (!publishVersion()) {
+            LOG.info("publish version failed, will retry later. jobId={}", jobId);
+            return;
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            // database has been dropped
+            LOG.warn("database does not exist, dbId:" + dbId);
+            throw new AlterCancelException("database does not exist, dbId:" + dbId);
+        }
+        db.writeLock();
+
+        try {
+            LakeTable table = (LakeTable) db.getTable(tableId);
+            if (table == null) {
+                // table has been dropped
+                LOG.warn("table does not exist, tableId:" + tableId);
+                throw new AlterCancelException("table does not exist, tableId:" + tableId);
+            } else {
+                // modify table meta
+                if (metaType == TTabletMetaType.ENABLE_PERSISTENT_INDEX) {
+                    Map<String, String> tempProperties = new HashMap<>();
+                    tempProperties.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, String.valueOf(metaValue));
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().modifyTableMeta(db, table, tempProperties, metaType);
+                }
+
+            }
+            this.jobState = JobState.FINISHED;
+            GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+
+            // set visible version
+            updateVisibleVersion(table);
+            table.setState(OlapTable.OlapTableState.NORMAL);
+
+        } finally {
+            db.writeUnlock();
+        }
+
+        LOG.info("update meta job finished: {}", jobId);
+    }
+
+    boolean readyToPublishVersion() throws AlterCancelException {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            // database has been dropped
+            throw new AlterCancelException("database does not exist, dbId:" + dbId);
+        }
+        db.readLock();
+
+        LakeTable table = (LakeTable) db.getTable(tableId);
+        if (table == null) {
+            // table has been dropped
+            throw new AlterCancelException("table does not exist, tableId:" + tableId);
+        }
+        try {
+            for (long partitionId : partitionIndexMap.rowKeySet()) {
+                Partition partition = table.getPartition(partitionId);
+                Preconditions.checkState(partition != null, partitionId);
+                long commitVersion = commitVersionMap.get(partitionId);
+                if (commitVersion != partition.getVisibleVersion() + 1) {
+                    Preconditions.checkState(partition.getVisibleVersion() < commitVersion,
+                            "partition=" + partitionId + " visibleVersion=" + partition.getVisibleVersion() +
+                                    " commitVersion=" + commitVersion);
+                    return false;
+                }
+            }
+        } finally {
+            db.readUnlock();
+        }
+        return true;
+    }
+
+    boolean publishVersion() {
+        try {
+            for (long partitionId : partitionIndexMap.rowKeySet()) {
+                long commitVersion = commitVersionMap.get(partitionId);
+                Map<Long, MaterializedIndex> dirtyIndexMap = partitionIndexMap.row(partitionId);
+                for (MaterializedIndex index : dirtyIndexMap.values()) {
+                    Utils.publishVersion(index.getTablets(), watershedTxnId, commitVersion - 1, commitVersion);
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            LOG.error("Fail to publish version for schema change job {}: {}", jobId, e.getMessage());
+            return false;
+        }
+    }
+
+    public void addDirtyPartitionIndex(long partitionId, long indexId, MaterializedIndex index) {
+        partitionIndexMap.put(partitionId, indexId, index);
+    }
+
+    public void updatePartitionTabletMeta(Database db,
+                                          String tableName,
+                                          String partitionName,
+                                          boolean metaValue,
+                                          TTabletMetaType metaType) throws DdlException {
+        // be id -> <tablet id,schemaHash>
+        Map<Long, Set<Pair<Long, Integer>>> beIdToTabletIdWithHash = Maps.newHashMap();
+        db.readLock();
+        try {
+            OlapTable olapTable = (OlapTable) db.getTable(tableName);
+            Partition partition = olapTable.getPartition(partitionName);
+            if (partition == null) {
+                throw new DdlException(
+                        "Partition[" + partitionName + "] does not exist in table[" + olapTable.getName() + "]");
+            }
+
+            for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                for (MaterializedIndex index : physicalPartition.getMaterializedIndices(
+                        MaterializedIndex.IndexExtState.VISIBLE)) {
+                    addDirtyPartitionIndex(partition.getId(), index.getId(), index);
+                    int schemaHash = olapTable.getSchemaHashByIndexId(index.getId());
+                    for (Tablet tablet : index.getTablets()) {
+                        Long backendId = Utils.chooseBackend((LakeTablet) tablet);
+                        Set<Pair<Long, Integer>> tabletIdWithHash =
+                                beIdToTabletIdWithHash.computeIfAbsent(backendId, k -> Sets.newHashSet());
+                        tabletIdWithHash.add(new Pair<>(tablet.getId(), schemaHash));
+                    }
+                }
+            }
+        } finally {
+            db.readUnlock();
+        }
+
+        int totalTaskNum = beIdToTabletIdWithHash.keySet().size();
+        MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> countDownLatch = new MarkedCountDownLatch<>(totalTaskNum);
+        AgentBatchTask batchTask = new AgentBatchTask();
+        for (Map.Entry<Long, Set<Pair<Long, Integer>>> kv : beIdToTabletIdWithHash.entrySet()) {
+            countDownLatch.addMark(kv.getKey(), kv.getValue());
+            UpdateTabletMetaInfoTask task = new UpdateTabletMetaInfoTask(kv.getKey(), kv.getValue(),
+                    metaValue, countDownLatch, metaType, TTabletType.TABLET_TYPE_LAKE, watershedTxnId);
+            batchTask.addTask(task);
+        }
+        if (!FeConstants.runningUnitTest) {
+            // send all tasks and wait them finished
+            AgentTaskQueue.addBatchTask(batchTask);
+            AgentTaskExecutor.submit(batchTask);
+            LOG.info("send update tablet meta task for table {}, partitions {}, number: {}",
+                    tableName, partitionName, batchTask.getTaskNum());
+
+            // estimate timeout
+            long timeout = Config.tablet_create_timeout_second * 1000L * totalTaskNum;
+            timeout = Math.min(timeout, Config.max_create_table_timeout_second * 1000L);
+            boolean ok = false;
+            try {
+                ok = countDownLatch.await(timeout, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                LOG.warn("InterruptedException: ", e);
+            }
+
+            if (!ok || !countDownLatch.getStatus().ok()) {
+                String errMsg = "Failed to update partition[" + partitionName + "]. tablet meta.";
+                // clear tasks
+                AgentTaskQueue.removeBatchTask(batchTask, TTaskType.UPDATE_TABLET_META_INFO);
+
+                if (!countDownLatch.getStatus().ok()) {
+                    errMsg += " Error: " + countDownLatch.getStatus().getErrorMsg();
+                } else {
+                    List<Map.Entry<Long, Set<Pair<Long, Integer>>>> unfinishedMarks = countDownLatch.getLeftMarks();
+                    // only show at most 3 results
+                    List<Map.Entry<Long, Set<Pair<Long, Integer>>>> subList =
+                            unfinishedMarks.subList(0, Math.min(unfinishedMarks.size(), 3));
+                    if (!subList.isEmpty()) {
+                        errMsg += " Unfinished mark: " + Joiner.on(", ").join(subList);
+                    }
+                }
+                errMsg += ". This operation maybe partial successfully, You should retry until success.";
+                LOG.warn(errMsg);
+                throw new DdlException(errMsg);
+            }
+        }
+    }
+
+    void updateNextVersion(@NotNull LakeTable table) {
+        for (long partitionId : partitionIndexMap.rowKeySet()) {
+            Partition partition = table.getPartition(partitionId);
+            long commitVersion = commitVersionMap.get(partitionId);
+            Preconditions.checkState(partition.getNextVersion() == commitVersion,
+                    "partitionNextVersion=" + partition.getNextVersion() + " commitVersion=" + commitVersion);
+            partition.setNextVersion(commitVersion + 1);
+            LOG.info("LakeTableAlterMetaJob id: {} update next version of partition: {}, commitVersion: {}",
+                    jobId, partition.getName(), commitVersion);
+        }
+    }
+
+    void updateVisibleVersion(@NotNull LakeTable table) {
+        for (long partitionId : partitionIndexMap.rowKeySet()) {
+            Partition partition = table.getPartition(partitionId);
+            long commitVersion = commitVersionMap.get(partitionId);
+            Preconditions.checkState(partition.getVisibleVersion() == commitVersion - 1,
+                    "partitionVisitionVersion=" + partition.getVisibleVersion() + " commitVersion=" + commitVersion);
+            partition.updateVisibleVersion(commitVersion);
+            LOG.info("partitionVisibleVersion=" + partition.getVisibleVersion() + " commitVersion=" + commitVersion);
+            LOG.info("LakeTableAlterMetaJob id: {} update visible version of partition: {}, visible Version: {}",
+                    jobId, partition.getName(), commitVersion);
+        }
+    }
+
+    @Override
+    protected boolean cancelImpl(String errMsg) {
+        if (jobState == JobState.CANCELLED || jobState == JobState.FINISHED) {
+            return false;
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            // database has been dropped
+            return false;
+        }
+        db.writeLock();
+        LakeTable table;
+        try {
+            table = (LakeTable) db.getTable(tableId);
+
+            // Cancel a job of state `FINISHED_REWRITING` only when the database or table has been dropped.
+            if (jobState == JobState.FINISHED_REWRITING && table != null) {
+                return false;
+            }
+
+            this.jobState = JobState.CANCELLED;
+            this.errMsg = errMsg;
+            this.finishedTimeMs = System.currentTimeMillis();
+
+            if (table != null) {
+                table.setState(OlapTable.OlapTableState.NORMAL);
+            }
+
+            if (span != null) {
+                span.setStatus(StatusCode.ERROR, errMsg);
+                span.end();
+            }
+        } finally {
+            db.writeUnlock();
+        }
+
+        GlobalStateMgr.getCurrentState().getEditLog().logAlterJob(this);
+        return true;
+    }
+
+    @Override
+    protected void getInfo(List<List<Comparable>> infos) {
+        // LakeTableAlterMetaJob is not supported by show for now
+    }
+
+    @Override
+    public void replay(AlterJobV2 replayedJob) {
+        LakeTableAlterMetaJob other = (LakeTableAlterMetaJob) replayedJob;
+
+        LOG.info("Replaying lake table update meta job. state={} jobId={}", replayedJob.jobState, replayedJob.jobId);
+
+        if (this != other) {
+            Preconditions.checkState(this.type.equals(other.type));
+            Preconditions.checkState(this.jobId == other.jobId);
+            Preconditions.checkState(this.dbId == other.dbId);
+            Preconditions.checkState(this.tableId == other.tableId);
+
+            this.jobState = other.jobState;
+            this.createTimeMs = other.createTimeMs;
+            this.finishedTimeMs = other.finishedTimeMs;
+            this.errMsg = other.errMsg;
+            this.timeoutMs = other.timeoutMs;
+
+            this.partitionIndexMap = other.partitionIndexMap;
+            this.watershedTxnId = other.watershedTxnId;
+            this.commitVersionMap = other.commitVersionMap;
+        }
+
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        if (db == null) {
+            // database has been dropped
+            LOG.warn("database does not exist, dbId:" + dbId);
+            return;
+        }
+        db.writeLock();
+        LakeTable table = (LakeTable) db.getTable(tableId);
+        if (table == null) {
+            return;
+        }
+
+        try  {
+            if (jobState == JobState.FINISHED_REWRITING) {
+                updateNextVersion(table);
+            } else if (jobState == JobState.FINISHED) {
+                updateVisibleVersion(table);
+                table.setState(OlapTable.OlapTableState.NORMAL);
+            } else if (jobState == JobState.CANCELLED) {
+                table.setState(OlapTable.OlapTableState.NORMAL);
+            } else if (jobState == JobState.PENDING || jobState == JobState.WAITING_TXN) {
+                // do nothing
+            } else {
+                throw new RuntimeException("unknown job state '{}'" + jobState.name());
+            }
+        } finally {
+            db.writeUnlock();
+        }
+    }
+
+    // for test
+    public Table<Long, Long, MaterializedIndex> getPartitionIndexMap() {
+        return partitionIndexMap;
+    }
+
+    // for test
+    public  Map<Long, Long> getCommitVersionMap() {
+        return commitVersionMap;
+    }
+
+
+    @Override
+    public Optional<Long> getTransactionId() {
+        return watershedTxnId < 0 ? Optional.empty() : Optional.of(watershedTxnId);
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        String json = GsonUtils.GSON.toJson(this, AlterJobV2.class);
+        Text.writeString(out, json);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableAlterMetaJob.java
@@ -256,7 +256,8 @@ public class LakeTableAlterMetaJob extends AlterJobV2 {
                 long commitVersion = commitVersionMap.get(partitionId);
                 Map<Long, MaterializedIndex> dirtyIndexMap = partitionIndexMap.row(partitionId);
                 for (MaterializedIndex index : dirtyIndexMap.values()) {
-                    Utils.publishVersion(index.getTablets(), watershedTxnId, commitVersion - 1, commitVersion);
+                    Utils.publishVersion(index.getTablets(), watershedTxnId, commitVersion - 1, commitVersion,
+                            finishedTimeMs / 1000);
                 }
             }
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -153,7 +153,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
     private boolean enablePersistentIndex = false;
 
     // Only meaningful when enablePersistentIndex = true.
-    // and it's null in SHARED NOTHGING
     TPersistentIndexType persistendIndexType;
 
     private int primaryIndexCacheExpireSec = 0;
@@ -255,6 +254,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
                 break;
             case OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX:
                 buildEnablePersistentIndex();
+                buildPersistentIndexType();
                 break;
             case OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC:
                 buildPrimaryIndexCacheExpireSec();

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -62,6 +62,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.alter.LakeTableAlterMetaJob;
 import com.starrocks.alter.LakeTableSchemaChangeJob;
 import com.starrocks.alter.RollupJobV2;
 import com.starrocks.alter.SchemaChangeJobV2;
@@ -246,7 +247,8 @@ public class GsonUtils {
             RuntimeTypeAdapterFactory.of(AlterJobV2.class, "clazz")
                     .registerSubtype(RollupJobV2.class, "RollupJobV2")
                     .registerSubtype(SchemaChangeJobV2.class, "SchemaChangeJobV2")
-                    .registerSubtype(LakeTableSchemaChangeJob.class, "LakeTableSchemaChangeJob");
+                    .registerSubtype(LakeTableSchemaChangeJob.class, "LakeTableSchemaChangeJob")
+                    .registerSubtype(LakeTableAlterMetaJob.class, "LakeTableAlterMetaJob");
 
     // runtime adapter for class "LoadJobStateUpdateInfo"
     private static final RuntimeTypeAdapterFactory<LoadJobStateUpdateInfo>

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3958,6 +3958,11 @@ public class LocalMetastore implements ConnectorMetadata {
         }
         tableProperty.buildEnablePersistentIndex();
 
+        if (table.isCloudNativeTable()) {
+            // now default to LOCAL
+            tableProperty.buildPersistentIndexType();
+        }
+
         ModifyTablePropertyOperationLog info =
                 new ModifyTablePropertyOperationLog(db.getId(), table.getId(), properties);
         GlobalStateMgr.getCurrentState().getEditLog().logModifyEnablePersistentIndex(info);
@@ -4213,6 +4218,9 @@ public class LocalMetastore implements ConnectorMetadata {
                     }
                 } else if (opCode == OperationType.OP_MODIFY_ENABLE_PERSISTENT_INDEX) {
                     olapTable.setEnablePersistentIndex(tableProperty.enablePersistentIndex());
+                    if (olapTable.isCloudNativeTable()) {
+                        olapTable.setPersistentIndexType(tableProperty.getPersistentIndexType());
+                    }
                 } else if (opCode == OperationType.OP_MODIFY_PRIMARY_INDEX_CACHE_EXPIRE_SEC) {
                     olapTable.setPrimaryIndexCacheExpireSec(tableProperty.primaryIndexCacheExpireSec());
                 } else if (opCode == OperationType.OP_MODIFY_BINLOG_CONFIG) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/UpdateTabletMetaInfoTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/UpdateTabletMetaInfoTask.java
@@ -44,6 +44,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTabletMetaInfo;
 import com.starrocks.thrift.TTabletMetaType;
+import com.starrocks.thrift.TTabletType;
 import com.starrocks.thrift.TTaskType;
 import com.starrocks.thrift.TUpdateTabletMetaInfoReq;
 import org.apache.commons.lang3.tuple.Triple;
@@ -68,6 +69,10 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
     private BinlogConfig binlogConfig;
 
     private TTabletMetaType metaType;
+
+    private TTabletType tabletType;
+
+    private long txnId;
 
     // <tablet id, tablet schema hash, tablet in memory> or
     // <tablet id, tablet schema hash, tablet enable persistent index>
@@ -99,6 +104,16 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
             this.enablePersistentIndex = metaValue;
         }
         this.latch = latch;
+    }
+
+    public UpdateTabletMetaInfoTask(long backendId,
+                                    Set<Pair<Long, Integer>> tableIdWithSchemaHash,
+                                    boolean metaValue,
+                                    MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> latch,
+                                    TTabletMetaType metaType, TTabletType tabletType, long txnId) {
+        this(backendId, tableIdWithSchemaHash, metaValue, latch, metaType);
+        this.tabletType = tabletType;
+        this.txnId = txnId;
     }
 
     public UpdateTabletMetaInfoTask(long backendId,
@@ -281,6 +296,12 @@ public class UpdateTabletMetaInfoTask extends AgentTask {
 
         }
         updateTabletMetaInfoReq.setTabletMetaInfos(metaInfos);
+
+        if (tabletType != null) {
+            updateTabletMetaInfoReq.setTablet_type(tabletType);
+            updateTabletMetaInfoReq.setTxn_id(txnId);
+        }
+
         return updateTabletMetaInfoReq;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -288,7 +288,8 @@ public class LakeTableAlterMetaJobTest {
             }
 
             @Mock
-            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion) throws
+            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion,
+                                       long commitTime) throws
                     RpcException {
             }
         };
@@ -322,7 +323,8 @@ public class LakeTableAlterMetaJobTest {
             }
 
             @Mock
-            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion) throws
+            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion,
+                                       long commitTime) throws
                     RpcException {
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableAlterMetaJobTest.java
@@ -1,0 +1,386 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.google.common.collect.Table;
+import com.staros.proto.FileCacheInfo;
+import com.staros.proto.FilePathInfo;
+import com.staros.proto.FileStoreInfo;
+import com.staros.proto.FileStoreType;
+import com.staros.proto.S3FileStoreInfo;
+import com.starrocks.catalog.AggregateType;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.DataProperty;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.HashDistributionInfo;
+import com.starrocks.catalog.KeysType;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.RangePartitionInfo;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
+import com.starrocks.common.MarkedCountDownLatch;
+import com.starrocks.common.Pair;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.lake.LakeTable;
+import com.starrocks.lake.LakeTablet;
+import com.starrocks.lake.StarOSAgent;
+import com.starrocks.lake.Utils;
+import com.starrocks.persist.EditLog;
+import com.starrocks.persist.ModifyTablePropertyOperationLog;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AlterClause;
+import com.starrocks.sql.ast.ModifyTablePropertiesClause;
+import com.starrocks.task.UpdateTabletMetaInfoTask;
+import com.starrocks.thrift.TStorageMedium;
+import com.starrocks.thrift.TStorageType;
+import com.starrocks.thrift.TTabletMetaType;
+import com.starrocks.thrift.TTabletType;
+import com.starrocks.thrift.TUpdateTabletMetaInfoReq;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ArrayBlockingQueue;
+import javax.validation.constraints.NotNull;
+
+public class LakeTableAlterMetaJobTest {
+    private static final int NUM_BUCKETS = 4;
+    private ConnectContext connectContext;
+    private LakeTableAlterMetaJob alterMetaJob;
+    private Database db;
+    private LakeTable table;
+    private List<Long> shadowTabletIds = new ArrayList<>();
+
+    public LakeTableAlterMetaJobTest() {
+        connectContext = new ConnectContext(null);
+        connectContext.setStartTime();
+        connectContext.setThreadLocalInfo();
+    }
+
+    @Before
+    public void before() throws Exception {
+        FeConstants.runningUnitTest = true;
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> createShards(int shardCount, FilePathInfo path, FileCacheInfo cache, long groupId,
+                                           List<Long> matchShardIds, Map<String, String> properties)
+                    throws DdlException {
+                for (int i = 0; i < shardCount; i++) {
+                    shadowTabletIds.add(GlobalStateMgr.getCurrentState().getNextId());
+                }
+                return shadowTabletIds;
+            }
+        };
+
+        new MockUp<EditLog>() {
+            @Mock
+            public void logSaveNextId(long nextId) {
+
+            }
+
+            @Mock
+            public void logAlterJob(AlterJobV2 alterJob) {
+
+            }
+
+            @Mock
+            public void logSaveTransactionId(long transactionId) {
+
+            }
+
+            @Mock
+            public void logModifyEnablePersistentIndex(ModifyTablePropertyOperationLog info) {
+
+            }
+        };
+
+        GlobalStateMgr.getCurrentState().setEditLog(new EditLog(new ArrayBlockingQueue<>(100)));
+        final long dbId = GlobalStateMgr.getCurrentState().getNextId();
+        final long partitionId = GlobalStateMgr.getCurrentState().getNextId();
+        final long tableId = GlobalStateMgr.getCurrentState().getNextId();
+        final long indexId = GlobalStateMgr.getCurrentState().getNextId();
+
+        GlobalStateMgr.getCurrentState().setStarOSAgent(new StarOSAgent());
+
+        KeysType keysType = KeysType.DUP_KEYS;
+        db = new Database(dbId, "db0");
+
+        Database oldDb = GlobalStateMgr.getCurrentState().getIdToDb().putIfAbsent(db.getId(), db);
+        Assert.assertNull(oldDb);
+
+        Column c0 = new Column("c0", Type.INT, true, AggregateType.NONE, false, null, null);
+        DistributionInfo dist = new HashDistributionInfo(NUM_BUCKETS, Collections.singletonList(c0));
+        PartitionInfo partitionInfo = new RangePartitionInfo(Collections.singletonList(c0));
+        partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+
+        table = new LakeTable(tableId, "t0", Collections.singletonList(c0), keysType, partitionInfo, dist);
+        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(partitionId, "t0", index, dist);
+        TStorageMedium storage = TStorageMedium.HDD;
+        TabletMeta tabletMeta = new TabletMeta(db.getId(), table.getId(), partition.getId(), index.getId(), 0, storage, true);
+        for (int i = 0; i < NUM_BUCKETS; i++) {
+            Tablet tablet = new LakeTablet(GlobalStateMgr.getCurrentState().getNextId());
+            index.addTablet(tablet, tabletMeta);
+        }
+        table.addPartition(partition);
+
+        table.setIndexMeta(index.getId(), "t0", Collections.singletonList(c0), 0, 0, (short) 1, TStorageType.COLUMN, keysType);
+        table.setBaseIndexId(index.getId());
+
+        FilePathInfo.Builder builder = FilePathInfo.newBuilder();
+        FileStoreInfo.Builder fsBuilder = builder.getFsInfoBuilder();
+
+        S3FileStoreInfo.Builder s3FsBuilder = fsBuilder.getS3FsInfoBuilder();
+        s3FsBuilder.setBucket("test-bucket");
+        s3FsBuilder.setRegion("test-region");
+        S3FileStoreInfo s3FsInfo = s3FsBuilder.build();
+
+        fsBuilder.setFsType(FileStoreType.S3);
+        fsBuilder.setFsKey("test-bucket");
+        fsBuilder.setS3FsInfo(s3FsInfo);
+        FileStoreInfo fsInfo = fsBuilder.build();
+
+        builder.setFsInfo(fsInfo);
+        builder.setFullPath("s3://test-bucket/object-1");
+        FilePathInfo pathInfo = builder.build();
+
+        table.setStorageInfo(pathInfo, new DataCacheInfo(false, false));
+        DataCacheInfo dataCacheInfo = new DataCacheInfo(false, false);
+        partitionInfo.setDataCacheInfo(partitionId, dataCacheInfo);
+
+        db.registerTableUnlocked(table);
+
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_ENABLE_PERSISTENT_INDEX, "true");
+        ModifyTablePropertiesClause modify = new ModifyTablePropertiesClause(properties);
+        SchemaChangeHandler schemaChangeHandler = new SchemaChangeHandler();
+
+        List<AlterClause> alterList = Collections.singletonList(modify);
+        alterMetaJob = (LakeTableAlterMetaJob) schemaChangeHandler.createAlterMetaJob(alterList, db, table);
+        table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
+    }
+
+    @After
+    public void after() throws Exception {
+        db.dropTable(table.getName());
+    }
+
+    @Test
+    public void testRunPendingJob() throws AlterCancelException {
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1L;
+            }
+        };
+        Assert.assertEquals(alterMetaJob.jobState, AlterJobV2.JobState.PENDING);
+        alterMetaJob.runPendingJob();
+        Assert.assertEquals(alterMetaJob.jobState, AlterJobV2.JobState.RUNNING);
+        Assert.assertNotEquals(alterMetaJob.getTransactionId().get().longValue(), -1L);
+
+    }
+
+    @Test
+    public void testUpdatePartitonMetaFailed() throws AlterCancelException {
+        FeConstants.runningUnitTest = false;
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1L;
+            }
+        };
+
+        Assert.assertEquals(alterMetaJob.jobState, AlterJobV2.JobState.PENDING);
+        Exception exception = Assert.assertThrows(AlterCancelException.class, () -> {
+            alterMetaJob.runPendingJob();
+        });
+
+        Assert.assertTrue(exception.getMessage().contains("Failed to update partition"));
+        Assert.assertEquals(alterMetaJob.jobState, AlterJobV2.JobState.PENDING);
+    }
+
+    @Test
+    public void testCancelPendingJob() {
+        alterMetaJob.cancel("cancel test");
+        Assert.assertEquals(AlterJobV2.JobState.CANCELLED, alterMetaJob.getJobState());
+
+        // test cancel again
+        Assert.assertFalse(alterMetaJob.cancel("test"));
+    }
+
+    @Test
+    public void testDropTableBeforeCancel() {
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1L;
+            }
+        };
+
+        db.dropTable(table.getName());
+        Assert.assertTrue(alterMetaJob.cancel("test"));
+        Assert.assertEquals(AlterJobV2.JobState.CANCELLED, alterMetaJob.getJobState());
+    }
+
+    @Test
+    public void testRunningJob() throws AlterCancelException {
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1L;
+            }
+        };
+
+        alterMetaJob.runPendingJob();
+        Assert.assertEquals(AlterJobV2.JobState.RUNNING, alterMetaJob.getJobState());
+
+        Table<Long, Long, MaterializedIndex> partitionIndexMap = alterMetaJob.getPartitionIndexMap();
+        Map<Long, Long> commitVersionMap = alterMetaJob.getCommitVersionMap();
+        Assert.assertEquals(1, partitionIndexMap.size());
+        Assert.assertEquals(0, commitVersionMap.size());
+
+        alterMetaJob.runRunningJob();
+        for (long partitionId : partitionIndexMap.rowKeySet()) {
+            Partition partition = table.getPartition(partitionId);
+            Assert.assertEquals(commitVersionMap.get(partitionId).longValue(), partition.getCommittedVersion());
+        }
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, alterMetaJob.getJobState());
+    }
+
+    @Test
+    public void testFinishedRewritingJob() throws AlterCancelException {
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1L;
+            }
+
+            @Mock
+            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion) throws
+                    RpcException {
+            }
+        };
+
+        alterMetaJob.runPendingJob();
+        Assert.assertEquals(AlterJobV2.JobState.RUNNING, alterMetaJob.getJobState());
+
+        alterMetaJob.runRunningJob();
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED_REWRITING, alterMetaJob.getJobState());
+
+        alterMetaJob.runFinishedRewritingJob();
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterMetaJob.getJobState());
+
+        Table<Long, Long, MaterializedIndex> partitionIndexMap = alterMetaJob.getPartitionIndexMap();
+        Map<Long, Long> commitVersionMap = alterMetaJob.getCommitVersionMap();
+        for (long partitionId : partitionIndexMap.rowKeySet()) {
+            Partition partition = table.getPartition(partitionId);
+            Assert.assertEquals(commitVersionMap.get(partitionId).longValue(), partition.getVisibleVersion());
+        }
+
+        Assert.assertTrue(table.enablePersistentIndex());
+    }
+
+
+    @Test
+    public void testReplay() throws AlterCancelException {
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1L;
+            }
+
+            @Mock
+            public void publishVersion(@NotNull List<Tablet> tablets, long txnId, long baseVersion, long newVersion) throws
+                    RpcException {
+            }
+        };
+
+        LakeTableAlterMetaJob replayAlterMetaJob = new LakeTableAlterMetaJob(alterMetaJob.jobId,
+                alterMetaJob.dbId, alterMetaJob.tableId, alterMetaJob.tableName,
+                alterMetaJob.timeoutMs, TTabletMetaType.ENABLE_PERSISTENT_INDEX, true);
+
+        alterMetaJob.runPendingJob();
+        alterMetaJob.runRunningJob();
+        alterMetaJob.runFinishedRewritingJob();
+
+        Database db = GlobalStateMgr.getCurrentState().getDb(alterMetaJob.getDbId());
+        LakeTable table = (LakeTable) db.getTable(alterMetaJob.getTableId());
+
+        Table<Long, Long, MaterializedIndex> partitionIndexMap = alterMetaJob.getPartitionIndexMap();
+        Map<Long, Long> commitVersionMap = alterMetaJob.getCommitVersionMap();
+
+        // for replay will check partition.getVisibleVersion()
+        // here we reduce the visibleVersion for test
+        for (long partitionId : partitionIndexMap.rowKeySet()) {
+            Partition partition = table.getPartition(partitionId);
+            long commitVersion = commitVersionMap.get(partitionId);
+            Assert.assertEquals(partition.getVisibleVersion(), commitVersion);
+            partition.updateVisibleVersion(commitVersion - 1);
+        }
+
+        replayAlterMetaJob.replay(alterMetaJob);
+
+        Assert.assertEquals(AlterJobV2.JobState.FINISHED, replayAlterMetaJob.getJobState());
+        Assert.assertEquals(alterMetaJob.getTransactionId(), replayAlterMetaJob.getTransactionId());
+        Assert.assertEquals(alterMetaJob.getJobId(), replayAlterMetaJob.getJobId());
+        Assert.assertEquals(alterMetaJob.getTableId(), replayAlterMetaJob.getTableId());
+        Assert.assertEquals(alterMetaJob.getDbId(), replayAlterMetaJob.getDbId());
+        Assert.assertEquals(alterMetaJob.getCommitVersionMap(), replayAlterMetaJob.getCommitVersionMap());
+        Assert.assertEquals(alterMetaJob.getPartitionIndexMap(), replayAlterMetaJob.getPartitionIndexMap());
+
+        for (long partitionId : partitionIndexMap.rowKeySet()) {
+            Partition partition = table.getPartition(partitionId);
+            long commitVersion = commitVersionMap.get(partitionId);
+            Assert.assertEquals(partition.getVisibleVersion(), commitVersion);
+        }
+    }
+
+    @Test
+    public void testUpdateTabletMetaInfoTaskToThrift() throws AlterCancelException {
+        long backend = 1L;
+        long txnId = 1L;
+        Set<Pair<Long, Integer>> tableIdWithSchemaHash = new HashSet<>();
+        Pair<Long, Integer> item = new Pair<>(1L, 1);
+        tableIdWithSchemaHash.add(item);
+        MarkedCountDownLatch<Long, Set<Pair<Long, Integer>>> latch = new MarkedCountDownLatch<>(1);
+
+        UpdateTabletMetaInfoTask updateTabletMetaInfoTask = new UpdateTabletMetaInfoTask(backend, tableIdWithSchemaHash,
+                true, latch, TTabletMetaType.ENABLE_PERSISTENT_INDEX, TTabletType.TABLET_TYPE_LAKE, txnId);
+        TUpdateTabletMetaInfoReq result = updateTabletMetaInfoTask.toThrift();
+        Assert.assertEquals(result.txn_id, txnId);
+        Assert.assertEquals(result.tablet_type, TTabletType.TABLET_TYPE_LAKE);
+    }
+
+}

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -89,6 +89,10 @@ message TabletMetadataPB {
     optional int64 commit_time = 13;
 }
 
+message MetadataUpdateInfoPB {
+    optional bool enable_persistent_index = 1;
+}
+
 message TxnLogPB {
     message OpWrite {
         optional RowsetMetadataPB rowset = 1;
@@ -119,11 +123,16 @@ message TxnLogPB {
         optional DelvecMetadataPB delvec_meta = 4;
     }
 
+    message OpAlterMetadata {
+        repeated MetadataUpdateInfoPB metadata_update_infos = 1;
+    }
+
     optional int64 tablet_id = 1;
     optional int64 txn_id = 2;
     optional OpWrite op_write = 3;
     optional OpCompaction op_compaction = 4;
     optional OpSchemaChange op_schema_change = 5;
+    optional OpAlterMetadata op_alter_metadata = 6;
 }
 
 message TabletMetadataLockPB {}

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -365,6 +365,9 @@ struct TTabletMetaInfo {
 
 struct TUpdateTabletMetaInfoReq {
     1: optional list<TTabletMetaInfo> tabletMetaInfos
+    // for update lake tablet meta
+    2: optional TTabletType tablet_type
+    3: optional i64 txn_id
 }
 
 struct TPluginMetaInfo {


### PR DESCRIPTION
Signed-off-by: lixianhai <lixianhai.lxh@alibaba-inc.com>
backport #28329
(cherry picked from commit 0fe40222334dc03ed0b403ac83f0f573800543fd)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
