### PR TITLE
Optimize single table cost calc for 3.1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/SingleTableRewriteBaseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/SingleTableRewriteBaseRule.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.ExpressionContext;
@@ -60,7 +61,8 @@ public abstract class SingleTableRewriteBaseRule extends BaseMaterializedViewRew
         }
     }
 
-    private static class CandidateContext {
+    @VisibleForTesting
+    public static class CandidateContext {
         private Statistics mvStatistics;
         private int index;
 
@@ -78,7 +80,8 @@ public abstract class SingleTableRewriteBaseRule extends BaseMaterializedViewRew
         }
     }
 
-    private static class CandidateContextComparator implements Comparator<CandidateContext> {
+    @VisibleForTesting
+    public static class CandidateContextComparator implements Comparator<CandidateContext> {
         @Override
         public int compare(CandidateContext context1, CandidateContext context2) {
             int ret = Double.compare(context1.getMvStatistics().getOutputRowCount(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/SingleTableRewriteBaseRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/SingleTableRewriteBaseRule.java
@@ -78,8 +78,13 @@ public abstract class SingleTableRewriteBaseRule extends BaseMaterializedViewRew
         private int index;
 
         public CandidateContext(Statistics mvStatistics, int schemaColumnNum) {
+            this(mvStatistics, schemaColumnNum, 0);
+        }
+
+        public CandidateContext(Statistics mvStatistics, int schemaColumnNum, int index) {
             this.mvStatistics = mvStatistics;
             this.schemaColumnNum = schemaColumnNum;
+            this.index = index;
             this.groupbyColumnNum = Integer.MAX_VALUE;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/SingleTableRewriteBaseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/SingleTableRewriteBaseRuleTest.java
@@ -1,0 +1,158 @@
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.rule.SingleTableRewriteBaseRule;
+import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
+import com.starrocks.sql.optimizer.statistics.Statistics;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class SingleTableRewriteBaseRuleTest {
+    @Test
+    public void testComparator() {
+        // test different output row count
+        {
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic1 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator2 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic2 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics.put(columnRefOperator1, columnStatistic1);
+            columnStatistics.put(columnRefOperator2, columnStatistic2);
+            Statistics.Builder statisticsBuilder1 = new Statistics.Builder();
+            statisticsBuilder1.setTableRowCountMayInaccurate(true);
+            statisticsBuilder1.setOutputRowCount(100);
+            statisticsBuilder1.addColumnStatistics(columnStatistics);
+            Statistics statistics1 = statisticsBuilder1.build();
+
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics2 = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator3 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic3 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator4 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic4 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics2.put(columnRefOperator3, columnStatistic3);
+            columnStatistics2.put(columnRefOperator4, columnStatistic4);
+            Statistics.Builder statisticsBuilder2 = new Statistics.Builder();
+            statisticsBuilder2.setTableRowCountMayInaccurate(true);
+            statisticsBuilder2.setOutputRowCount(10000);
+            statisticsBuilder2.addColumnStatistics(columnStatistics2);
+            Statistics statistics2 = statisticsBuilder2.build();
+
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics3 = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator5 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic5 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator6 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic6 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics3.put(columnRefOperator5, columnStatistic5);
+            columnStatistics3.put(columnRefOperator6, columnStatistic6);
+            Statistics.Builder statisticsBuilder3 = new Statistics.Builder();
+            statisticsBuilder3.setTableRowCountMayInaccurate(true);
+            statisticsBuilder3.setOutputRowCount(1000);
+            statisticsBuilder3.addColumnStatistics(columnStatistics3);
+            Statistics statistics3 = statisticsBuilder3.build();
+
+            {
+                List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
+                Assert.assertEquals(1, contexts.get(0).getIndex());
+                Assert.assertEquals(3, contexts.get(1).getIndex());
+                Assert.assertEquals(2, contexts.get(2).getIndex());
+            }
+
+            {
+                List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
+                contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
+                Assert.assertEquals(1, contexts.get(0).getIndex());
+                Assert.assertEquals(3, contexts.get(1).getIndex());
+                Assert.assertEquals(2, contexts.get(2).getIndex());
+            }
+        }
+
+        // test different compute size
+        {
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic1 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics.put(columnRefOperator1, columnStatistic1);
+            Statistics.Builder statisticsBuilder1 = new Statistics.Builder();
+            statisticsBuilder1.setTableRowCountMayInaccurate(true);
+            statisticsBuilder1.setOutputRowCount(100);
+            statisticsBuilder1.addColumnStatistics(columnStatistics);
+            Statistics statistics1 = statisticsBuilder1.build();
+
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics2 = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator3 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic3 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator4 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic4 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics2.put(columnRefOperator3, columnStatistic3);
+            columnStatistics2.put(columnRefOperator4, columnStatistic4);
+            Statistics.Builder statisticsBuilder2 = new Statistics.Builder();
+            statisticsBuilder2.setTableRowCountMayInaccurate(true);
+            statisticsBuilder2.setOutputRowCount(100);
+            statisticsBuilder2.addColumnStatistics(columnStatistics2);
+            Statistics statistics2 = statisticsBuilder2.build();
+
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics3 = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator5 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic5 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator6 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic6 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator7 = new ColumnRefOperator(3, Type.INT, "c", true);
+            ColumnStatistic columnStatistic7 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics3.put(columnRefOperator5, columnStatistic5);
+            columnStatistics3.put(columnRefOperator6, columnStatistic6);
+            columnStatistics3.put(columnRefOperator7, columnStatistic7);
+            Statistics.Builder statisticsBuilder3 = new Statistics.Builder();
+            statisticsBuilder3.setTableRowCountMayInaccurate(true);
+            statisticsBuilder3.setOutputRowCount(100);
+            statisticsBuilder3.addColumnStatistics(columnStatistics3);
+            Statistics statistics3 = statisticsBuilder3.build();
+
+            {
+                List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
+                Assert.assertEquals(1, contexts.get(0).getIndex());
+                Assert.assertEquals(2, contexts.get(1).getIndex());
+                Assert.assertEquals(3, contexts.get(2).getIndex());
+            }
+
+            {
+                List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
+                contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
+                Assert.assertEquals(1, contexts.get(0).getIndex());
+                Assert.assertEquals(2, contexts.get(1).getIndex());
+                Assert.assertEquals(3, contexts.get(2).getIndex());
+            }
+
+            {
+                List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
+                Assert.assertEquals(1, contexts.get(0).getIndex());
+                Assert.assertEquals(2, contexts.get(1).getIndex());
+                Assert.assertEquals(3, contexts.get(2).getIndex());
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/SingleTableRewriteBaseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/SingleTableRewriteBaseRuleTest.java
@@ -30,6 +30,80 @@ import java.util.Map;
 public class SingleTableRewriteBaseRuleTest {
     @Test
     public void testComparator() {
+        // test different group by key nums
+        {
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator1 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic1 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator2 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic2 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics.put(columnRefOperator1, columnStatistic1);
+            columnStatistics.put(columnRefOperator2, columnStatistic2);
+            Statistics.Builder statisticsBuilder1 = new Statistics.Builder();
+            statisticsBuilder1.setTableRowCountMayInaccurate(true);
+            statisticsBuilder1.setOutputRowCount(100);
+            statisticsBuilder1.addColumnStatistics(columnStatistics);
+            Statistics statistics1 = statisticsBuilder1.build();
+
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics2 = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator3 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic3 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator4 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic4 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics2.put(columnRefOperator3, columnStatistic3);
+            columnStatistics2.put(columnRefOperator4, columnStatistic4);
+            Statistics.Builder statisticsBuilder2 = new Statistics.Builder();
+            statisticsBuilder2.setTableRowCountMayInaccurate(true);
+            statisticsBuilder2.setOutputRowCount(10000);
+            statisticsBuilder2.addColumnStatistics(columnStatistics2);
+            Statistics statistics2 = statisticsBuilder2.build();
+
+            Map<ColumnRefOperator, ColumnStatistic> columnStatistics3 = Maps.newHashMap();
+            ColumnRefOperator columnRefOperator5 = new ColumnRefOperator(1, Type.INT, "a", true);
+            ColumnStatistic columnStatistic5 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            ColumnRefOperator columnRefOperator6 = new ColumnRefOperator(2, Type.INT, "b", true);
+            ColumnStatistic columnStatistic6 = new ColumnStatistic(10, 1000, 0, 4, 100);
+            columnStatistics3.put(columnRefOperator5, columnStatistic5);
+            columnStatistics3.put(columnRefOperator6, columnStatistic6);
+            Statistics.Builder statisticsBuilder3 = new Statistics.Builder();
+            statisticsBuilder3.setTableRowCountMayInaccurate(true);
+            statisticsBuilder3.setOutputRowCount(1000);
+            statisticsBuilder3.addColumnStatistics(columnStatistics3);
+            Statistics statistics3 = statisticsBuilder3.build();
+
+            SingleTableRewriteBaseRule.CandidateContext candidateContext1 =
+                    new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1, 1);
+            candidateContext1.setGroupbyColumnNum(1);
+            SingleTableRewriteBaseRule.CandidateContext candidateContext2 =
+                    new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2, 2);
+            candidateContext2.setGroupbyColumnNum(2);
+            SingleTableRewriteBaseRule.CandidateContext candidateContext3 =
+                    new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3, 3);
+            candidateContext3.setGroupbyColumnNum(3);
+
+            {
+                List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
+                contexts.add(candidateContext1);
+                contexts.add(candidateContext2);
+                contexts.add(candidateContext3);
+                contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
+                Assert.assertEquals(1, contexts.get(0).getIndex());
+                Assert.assertEquals(2, contexts.get(1).getIndex());
+                Assert.assertEquals(3, contexts.get(2).getIndex());
+            }
+
+            {
+                List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
+                contexts.add(candidateContext2);
+                contexts.add(candidateContext3);
+                contexts.add(candidateContext1);
+                contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
+                Assert.assertEquals(1, contexts.get(0).getIndex());
+                Assert.assertEquals(2, contexts.get(1).getIndex());
+                Assert.assertEquals(3, contexts.get(2).getIndex());
+            }
+        }
+
         // test different output row count
         {
             Map<ColumnRefOperator, ColumnStatistic> columnStatistics = Maps.newHashMap();
@@ -73,9 +147,9 @@ public class SingleTableRewriteBaseRuleTest {
 
             {
                 List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3, 3));
                 contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
                 Assert.assertEquals(1, contexts.get(0).getIndex());
                 Assert.assertEquals(3, contexts.get(1).getIndex());
@@ -84,9 +158,9 @@ public class SingleTableRewriteBaseRuleTest {
 
             {
                 List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3, 3));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1, 1));
                 contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
                 Assert.assertEquals(1, contexts.get(0).getIndex());
                 Assert.assertEquals(3, contexts.get(1).getIndex());
@@ -137,9 +211,9 @@ public class SingleTableRewriteBaseRuleTest {
 
             {
                 List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3, 3));
                 contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
                 Assert.assertEquals(1, contexts.get(0).getIndex());
                 Assert.assertEquals(2, contexts.get(1).getIndex());
@@ -148,9 +222,9 @@ public class SingleTableRewriteBaseRuleTest {
 
             {
                 List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3, 3));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1, 1));
                 contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
                 Assert.assertEquals(1, contexts.get(0).getIndex());
                 Assert.assertEquals(2, contexts.get(1).getIndex());
@@ -159,9 +233,9 @@ public class SingleTableRewriteBaseRuleTest {
 
             {
                 List<SingleTableRewriteBaseRule.CandidateContext> contexts = Lists.newArrayList();
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1));
-                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics2, 2, 2));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics1, 1, 1));
+                contexts.add(new SingleTableRewriteBaseRule.CandidateContext(statistics3, 3, 3));
                 contexts.sort(new SingleTableRewriteBaseRule.CandidateContextComparator());
                 Assert.assertEquals(1, contexts.get(0).getIndex());
                 Assert.assertEquals(2, contexts.get(1).getIndex());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/SingleTableRewriteBaseRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/SingleTableRewriteBaseRuleTest.java
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
 import com.google.common.collect.Lists;

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite
@@ -584,3 +584,38 @@ from emps right anti join depts using (deptno);
 -- result:
 2
 -- !result
+
+
+-- name: test_single_table_mv_rewrite
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+
+create materialized view agg_count_mv1
+distributed by hash(user_id)
+as
+select user_id, count(1) as cnt
+from user_tags
+group by user_id;
+
+refresh materialized view agg_count_mv1 with sync mode;
+analyze table agg_count_mv1 with sync mode;
+
+create materialized view agg_count_mv2
+distributed by hash(user_id)
+as
+select user_id, user_name, count(1) as cnt
+from user_tags
+group by user_id, user_name;
+
+refresh materialized view agg_count_mv2 with sync mode;
+analyze table agg_count_mv2 with sync mode;
+
+explain select user_id, count(1) as cnt
+from user_tags
+group by user_id;
+-- result:
+[REGEX]agg_count_mv1

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite
@@ -619,3 +619,68 @@ from user_tags
 group by user_id;
 -- result:
 [REGEX]agg_count_mv1
+
+CREATE TABLE `user_tags_2` (
+  `time` date NULL COMMENT "",
+  `user_id` int(11) NULL COMMENT "",
+  `user_name` varchar(20) NULL COMMENT "",
+  `tag_id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`time`, `user_id`, `user_name`)
+PARTITION BY RANGE(`time`)
+(PARTITION p1 VALUES [("0000-01-01"), (MAXVALUE)))
+DISTRIBUTED BY HASH(`time`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+
+insert into user_tags_2 values('2023-04-13', 1, 'a', 1);
+insert into user_tags_2 values('2023-04-13', 2, 'b', 2);
+insert into user_tags_2 values('2023-04-13', 3, 'c', 3);
+insert into user_tags_2 values('2023-04-13', 4, 'd', 4);
+insert into user_tags_2 values('2023-04-13', 5, 'e', 5);
+
+create materialized view agg_count_mv3
+distributed by hash(user_id)
+as
+select user_id, count(1) as cnt
+from user_tags_2
+group by user_id;
+
+refresh materialized view agg_count_mv3 with sync mode;
+
+create materialized view agg_count_mv4
+distributed by hash(user_id)
+as
+select user_id, user_name, count(1) as cnt
+from user_tags_2
+group by user_id, user_name;
+
+refresh materialized view agg_count_mv4 with sync mode;
+
+
+explain select user_id, count(1) as cnt
+from user_tags_2
+group by user_id;
+-- result:
+[REGEX]agg_count_mv3
+
+create materialized view agg_count_mv5
+distributed by hash(user_id)
+as
+select user_id, user_name, count(1) as cnt, sum(tag_id) as total
+from user_tags_2
+group by user_id, user_name;
+
+refresh materialized view agg_count_mv5 with sync mode;
+
+explain select user_id, user_name, count(1) as cnt
+from user_tags_2
+group by user_id, user_name;
+-- result:
+[REGEX]agg_count_mv4

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -282,6 +282,7 @@ from user_tags
 group by user_id;
 
 refresh materialized view agg_count_mv1 with sync mode;
+analyze table agg_count_mv1 with sync mode;
 
 create materialized view agg_count_mv2
 distributed by hash(user_id)
@@ -291,6 +292,7 @@ from user_tags
 group by user_id, user_name;
 
 refresh materialized view agg_count_mv2 with sync mode;
+analyze table agg_count_mv2 with sync mode;
 
 explain select user_id, count(1) as cnt
 from user_tags

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -282,7 +282,6 @@ from user_tags
 group by user_id;
 
 refresh materialized view agg_count_mv1 with sync mode;
-analyze table agg_count_mv1 with sync mode;
 
 create materialized view agg_count_mv2
 distributed by hash(user_id)
@@ -292,8 +291,69 @@ from user_tags
 group by user_id, user_name;
 
 refresh materialized view agg_count_mv2 with sync mode;
-analyze table agg_count_mv2 with sync mode;
 
 explain select user_id, count(1) as cnt
 from user_tags
 group by user_id;
+
+CREATE TABLE `user_tags_2` (
+  `time` date NULL COMMENT "",
+  `user_id` int(11) NULL COMMENT "",
+  `user_name` varchar(20) NULL COMMENT "",
+  `tag_id` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`time`, `user_id`, `user_name`)
+PARTITION BY RANGE(`time`)
+(PARTITION p1 VALUES [("0000-01-01"), (MAXVALUE)))
+DISTRIBUTED BY HASH(`time`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+
+insert into user_tags_2 values('2023-04-13', 1, 'a', 1);
+insert into user_tags_2 values('2023-04-13', 2, 'b', 2);
+insert into user_tags_2 values('2023-04-13', 3, 'c', 3);
+insert into user_tags_2 values('2023-04-13', 4, 'd', 4);
+insert into user_tags_2 values('2023-04-13', 5, 'e', 5);
+
+create materialized view agg_count_mv3
+distributed by hash(user_id)
+as
+select user_id, count(1) as cnt
+from user_tags_2
+group by user_id;
+
+refresh materialized view agg_count_mv3 with sync mode;
+
+create materialized view agg_count_mv4
+distributed by hash(user_id)
+as
+select user_id, user_name, count(1) as cnt
+from user_tags_2
+group by user_id, user_name;
+
+refresh materialized view agg_count_mv4 with sync mode;
+
+
+explain select user_id, count(1) as cnt
+from user_tags_2
+group by user_id;
+
+
+create materialized view agg_count_mv5
+distributed by hash(user_id)
+as
+select user_id, user_name, count(1) as cnt, sum(tag_id) as total
+from user_tags_2
+group by user_id, user_name;
+
+refresh materialized view agg_count_mv5 with sync mode;
+
+explain select user_id, user_name, count(1) as cnt
+from user_tags_2
+group by user_id, user_name;

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -265,3 +265,33 @@ from emps right anti join depts using (deptno);
 
 select depts.deptno 
 from emps right anti join depts using (deptno);
+
+-- name: test_single_table_mv_rewrite
+create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+insert into user_tags values('2023-04-13', 1, 'a', 1);
+insert into user_tags values('2023-04-13', 1, 'b', 2);
+insert into user_tags values('2023-04-13', 1, 'c', 3);
+insert into user_tags values('2023-04-13', 1, 'd', 4);
+insert into user_tags values('2023-04-13', 1, 'e', 5);
+
+create materialized view agg_count_mv1
+distributed by hash(user_id)
+as
+select user_id, count(1) as cnt
+from user_tags
+group by user_id;
+
+refresh materialized view agg_count_mv1 with sync mode;
+
+create materialized view agg_count_mv2
+distributed by hash(user_id)
+as
+select user_id, user_name, count(1) as cnt
+from user_tags
+group by user_id, user_name;
+
+refresh materialized view agg_count_mv2 with sync mode;
+
+explain select user_id, count(1) as cnt
+from user_tags
+group by user_id;


### PR DESCRIPTION
Optimize single table cost calculation, choose the final plan based on the mv's output rows, column compute size, instead of uncorrected estimated statistics.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
