### PR TITLE
[BugFix] BE in ASAN mode may crash when ingestion and drop tablet concurrently

### DIFF
--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -4245,6 +4245,7 @@ Status TabletUpdates::clear_meta() {
     std::lock_guard l1(_lock);
     std::lock_guard l2(_rowsets_lock);
     std::lock_guard l3(_rowset_stats_lock);
+    std::lock_guard l4(_drop_lock);
     // TODO: tablet is already marked to be deleted, so maybe don't need to clear unused rowsets here
     _remove_unused_rowsets();
     if (_unused_rowsets.get_size() != 0) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1739,8 +1739,8 @@ Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo) {
                     "compaction. And this could be the reason of the compaction failure",
                     _tablet.tablet_id());
             LOG(WARNING) << msg << ", compaction status:" << st;
-            return st;
         }
+        return st;
     }
     auto output_rowset = rowset_writer->build();
     if (!output_rowset.ok()) return output_rowset.status();

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -335,6 +335,7 @@ private:
     friend class Tablet;
     friend class PrimaryIndex;
     friend class PersistentIndex;
+    friend class UpdateManager;
     friend class RowsetUpdateState;
 
     template <typename K, typename V>
@@ -442,12 +443,22 @@ private:
     void check_for_apply() { _check_for_apply(); }
 
     std::timed_mutex* get_index_lock() { return &_index_lock; }
+    std::mutex* get_drop_lock() { return &_drop_lock; }
 
 private:
     Tablet& _tablet;
 
     // |_lock| protects |_edit_version_infos|, |_next_rowset_id|, |_next_log_id|, |_apply_version_idx|, |_pending_commits|.
     mutable std::mutex _lock;
+    // |_drop_lock| prevents meta read/write conflicts when importing and dropping concurrently between function
+    // `UpdateManager::on_rowset_finished` and `TabletUpdates::clear_meta`
+    // In function `UpdateManager::on_rowset_finished`, we will preload rowset_updates and primary index to speed apply.
+    // But in function `TabletUpdates::clear_meta`, we will clear tablet meta. So the import task maybe get `no del vector found`
+    // exception and the primary index maybe referenced by ingestion thread, and the drop_tablet thread will cause BE crash whe it
+    // try to remove the primary index from cache in ASAN mode.
+    // Actually |_lock| also can prevent the read/write conflicts, but preload may take a long time and using |_lock| may stuck apply
+    // thread.
+    mutable std::mutex _drop_lock;
     std::vector<std::unique_ptr<EditVersionInfo>> _edit_version_infos;
     uint32_t _next_rowset_id = 0;
     uint64_t _next_log_id = 0;

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -453,11 +453,11 @@ private:
     // |_drop_lock| prevents meta read/write conflicts when importing and dropping concurrently between function
     // `UpdateManager::on_rowset_finished` and `TabletUpdates::clear_meta`
     // In function `UpdateManager::on_rowset_finished`, we will preload rowset_updates and primary index to speed apply.
-    // But in function `TabletUpdates::clear_meta`, we will clear tablet meta. So the import task maybe get `no del vector found`
-    // exception and the primary index maybe referenced by ingestion thread, and the drop_tablet thread will cause BE crash whe it
-    // try to remove the primary index from cache in ASAN mode.
-    // Actually |_lock| also can prevent the read/write conflicts, but preload may take a long time and using |_lock| may stuck apply
-    // thread.
+    // But in function `TabletUpdates::clear_meta`, we will clear tablet meta. So the import task maybe get
+    // `no del vector found` exception and the primary index maybe referenced by ingestion thread, and the drop_tablet
+    // thread will cause BE crash when it try to remove the primary index from cache in ASAN mode.
+    // Actually |_lock| also can prevent the read/write conflicts, but preload may take a long time and using |_lock| may
+    // stuck apply thread.
     mutable std::mutex _drop_lock;
     std::vector<std::unique_ptr<EditVersionInfo>> _edit_version_infos;
     uint32_t _next_rowset_id = 0;

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -505,6 +505,12 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
     Status st;
 
     std::lock_guard lg(*tablet->updates()->get_drop_lock());
+    if (tablet->tablet_state() == TABLET_SHUTDOWN) {
+        std::string msg = strings::Substitute("tablet $0 in TABLET_SHUTDOWN, maybe deleted by other thread", 
+                                              tablet->tablet_id());
+        LOG(WARNING) << msg;
+        return Status::InternalError(msg);
+    }
     if (rowset->is_column_mode_partial_update()) {
         auto state_entry = _update_column_state_cache.get_or_create(
                 strings::Substitute("$0_$1", tablet->tablet_id(), rowset_unique_id));

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -504,6 +504,7 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
 
     Status st;
 
+    std::lock_guard lg(*tablet->updates()->get_drop_lock());
     if (rowset->is_column_mode_partial_update()) {
         auto state_entry = _update_column_state_cache.get_or_create(
                 strings::Substitute("$0_$1", tablet->tablet_id(), rowset_unique_id));

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -506,8 +506,8 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
 
     std::lock_guard lg(*tablet->updates()->get_drop_lock());
     if (tablet->tablet_state() == TABLET_SHUTDOWN) {
-        std::string msg = strings::Substitute("tablet $0 in TABLET_SHUTDOWN, maybe deleted by other thread", 
-                                              tablet->tablet_id());
+        std::string msg =
+                strings::Substitute("tablet $0 in TABLET_SHUTDOWN, maybe deleted by other thread", tablet->tablet_id());
         LOG(WARNING) << msg;
         return Status::InternalError(msg);
     }

--- a/be/src/storage/update_manager.cpp
+++ b/be/src/storage/update_manager.cpp
@@ -549,7 +549,6 @@ Status UpdateManager::on_rowset_finished(Tablet* tablet, Rowset* rowset) {
             std::string msg = strings::Substitute("tablet $0 in TABLET_SHUTDOWN, maybe deleted by other thread",
                                                   tablet->tablet_id());
             LOG(WARNING) << msg;
-            return st;
         }
     }
 


### PR DESCRIPTION
When we drop a primary key tablet, we will delete the tablet meta include primary index cache, delete vector and so on.  But when the  ingestion and drop tablet run concurrently, there are some issues:
1. When we delete primary index, we will check only one thread holds it, otherwise BE will crash in ASAN mode. But the ingestion thread also hold the primary index when it preload `RowsetUpdateState`, so BE maybe crash in ASAN mode when drop tablet.
2. Ingestion maybe get `no delete vector found` exception because  delete vector maybe deleted due to drop tablet.

BTW, this pr is just a temporary solution and the root cause is when we drop primary key table, we will clean up the tablet metadata include primary index, delete vector, etc. and these metadata might still be accessed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
