### PR TITLE
[Enhancement] Disable group level and adaptive dop for queue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/GlobalVariable.java
@@ -63,6 +63,7 @@ public final class GlobalVariable {
     public static final String ENABLE_QUERY_QUEUE_SELECT = "enable_query_queue_select";
     public static final String ENABLE_QUERY_QUEUE_STATISTIC = "enable_query_queue_statistic";
     public static final String ENABLE_QUERY_QUEUE_LOAD = "enable_query_queue_load";
+    public static final String ENABLE_GROUP_LEVEL_QUERY_QUEUE = "enable_group_level_query_queue";
     public static final String QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS =
             "query_queue_fresh_resource_usage_interval_ms";
     public static final String QUERY_QUEUE_CONCURRENCY_LIMIT = "query_queue_concurrency_limit";
@@ -139,6 +140,8 @@ public final class GlobalVariable {
     private static boolean enableQueryQueueStatistic = false;
     @VariableMgr.VarAttr(name = ENABLE_QUERY_QUEUE_LOAD, flag = VariableMgr.GLOBAL)
     private static boolean enableQueryQueueLoad = false;
+    @VariableMgr.VarAttr(name = ENABLE_GROUP_LEVEL_QUERY_QUEUE, flag = VariableMgr.GLOBAL)
+    private static boolean enableGroupLevelQueryQueue = false;
     // Use the resource usage, only when the duration from the last report is within this interval.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_FRESH_RESOURCE_USAGE_INTERVAL_MS, flag = VariableMgr.GLOBAL)
     private static long queryQueueResourceUsageIntervalMs = 5000;
@@ -146,11 +149,13 @@ public final class GlobalVariable {
     @VariableMgr.VarAttr(name = QUERY_QUEUE_CONCURRENCY_LIMIT, flag = VariableMgr.GLOBAL)
     private static int queryQueueConcurrencyLimit = 0;
 
+    // Effective iff it is non-negative.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_DRIVER_HIGH_WATER, flag = VariableMgr.GLOBAL)
-    private static int queryQueueDriverHighWater = 0;
+    private static int queryQueueDriverHighWater = -1;
 
+    // Effective iff it is non-negative.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_DRIVER_LOW_WATER, flag = VariableMgr.GLOBAL)
-    private static int queryQueueDriverLowWater = 0;
+    private static int queryQueueDriverLowWater = -1;
 
     // Effective iff it is positive.
     @VariableMgr.VarAttr(name = QUERY_QUEUE_MEM_USED_PCT_LIMIT, flag = VariableMgr.GLOBAL)
@@ -190,6 +195,14 @@ public final class GlobalVariable {
 
     public static void setEnableQueryQueueLoad(boolean enableQueryQueueLoad) {
         GlobalVariable.enableQueryQueueLoad = enableQueryQueueLoad;
+    }
+
+    public static boolean isEnableGroupLevelQueryQueue() {
+        return enableGroupLevelQueryQueue;
+    }
+
+    public static void setEnableGroupLevelQueryQueue(boolean enableGroupLevelQueryQueue) {
+        GlobalVariable.enableGroupLevelQueryQueue = enableGroupLevelQueryQueue;
     }
 
     public static long getQueryQueueResourceUsageIntervalMs() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotRequestQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/slot/SlotRequestQueue.java
@@ -152,6 +152,10 @@ public class SlotRequestQueue {
             return true;
         }
 
+        if (!GlobalVariable.isEnableGroupLevelQueryQueue()) {
+            return true;
+        }
+
         if (group.isConcurrencyLimitEffective() && numAllocatedSlotsOfGroup >= group.getConcurrencyLimit()) {
             return false;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -102,6 +102,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
     private boolean prevQueueEnableSelect;
     private boolean prevQueueEnableStatistic;
     private boolean prevQueueEnableLoad;
+    private boolean prevEnableGroupLevelQueue;
     private int prevQueueConcurrencyHardLimit;
     private double prevQueueMemUsedPctHardLimit;
     private int prevQueuePendingTimeoutSecond;
@@ -120,11 +121,14 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
         prevQueueEnableSelect = GlobalVariable.isEnableQueryQueueSelect();
         prevQueueEnableStatistic = GlobalVariable.isEnableQueryQueueStatistic();
         prevQueueEnableLoad = GlobalVariable.isEnableQueryQueueLoad();
+        prevEnableGroupLevelQueue = GlobalVariable.isEnableGroupLevelQueryQueue();
         prevQueueConcurrencyHardLimit = GlobalVariable.getQueryQueueConcurrencyLimit();
         prevQueueMemUsedPctHardLimit = GlobalVariable.getQueryQueueMemUsedPctLimit();
         prevQueuePendingTimeoutSecond = GlobalVariable.getQueryQueuePendingTimeoutSecond();
         prevQueueTimeoutSecond = connectContext.getSessionVariable().getQueryTimeoutS();
         prevQueueMaxQueuedQueries = GlobalVariable.getQueryQueueMaxQueuedQueries();
+
+        GlobalVariable.setEnableGroupLevelQueryQueue(true);
 
         GlobalVariable.setQueryQueuePendingTimeoutSecond(1000_000);
         connectContext.getSessionVariable().setQueryTimeoutS(1000_000);
@@ -156,6 +160,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
         GlobalVariable.setEnableQueryQueueSelect(prevQueueEnableSelect);
         GlobalVariable.setEnableQueryQueueStatistic(prevQueueEnableStatistic);
         GlobalVariable.setEnableQueryQueueLoad(prevQueueEnableLoad);
+        GlobalVariable.setEnableGroupLevelQueryQueue(prevEnableGroupLevelQueue);
         GlobalVariable.setQueryQueueConcurrencyLimit(prevQueueConcurrencyHardLimit);
         GlobalVariable.setQueryQueueMemUsedPctLimit(prevQueueMemUsedPctHardLimit);
         GlobalVariable.setQueryQueuePendingTimeoutSecond(prevQueuePendingTimeoutSecond);
@@ -345,6 +350,32 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             allocatedCoords.forEach(DefaultCoordinator::onFinished);
             allocatedCoords.forEach(coord -> Assert.assertEquals(LogicalSlot.State.RELEASED, coord.getSlot().getState()));
         }
+    }
+
+    @Test
+    public void testDisableGroupLevelQueue() throws Exception {
+        final int concurrencyLimit = 100;
+        final int groupConcurrencyLimit = 1;
+
+        GlobalVariable.setEnableQueryQueueSelect(true);
+        GlobalVariable.setEnableGroupLevelQueryQueue(false);
+        GlobalVariable.setQueryQueueConcurrencyLimit(concurrencyLimit);
+
+        TWorkGroup group10 = new TWorkGroup().setId(10L).setConcurrency_limit(groupConcurrencyLimit);
+
+        List<DefaultCoordinator> runningCoords = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            mockResourceGroup(group10);
+            DefaultCoordinator coord = getSchedulerWithQueryId("select count(1) from lineitem");
+            manager.maybeWait(connectContext, coord);
+            Assert.assertEquals(0L, MetricRepo.COUNTER_QUERY_QUEUE_PENDING.getValue().longValue());
+            Assert.assertEquals(LogicalSlot.State.ALLOCATED, coord.getSlot().getState());
+
+            runningCoords.add(coord);
+        }
+
+        runningCoords.forEach(DefaultCoordinator::onFinished);
+        runningCoords.forEach(coord -> Assert.assertEquals(LogicalSlot.State.RELEASED, coord.getSlot().getState()));
     }
 
     /**


### PR DESCRIPTION
To avoid behaviour change between v3.2/v.3.1.4 and the older version, 
- add the session variable `enable_group_level_query_queue` to disable group level query queue by default.
- Modify the default value of `query_queue_driver_high_water` and `query_queue_driver_low_water` to `-1` to disable them by default.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
