### PR TITLE
[BugFix][Cherry-pick][Branch-3.1] BE crash in ASAN mode when we do column mode partial update for primary key table which separate primary keys and sort keys (#31219)

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -215,8 +215,8 @@ Status DeltaWriter::_init() {
             _memtable_buffer_row = config::write_buffer_size / average_row_size;
         }
 
-        writer_context.partial_update_tablet_schema =
-                TabletSchema::create(_tablet->tablet_schema(), writer_context.referenced_column_ids);
+        auto partial_update_schema = 
+                        TabletSchema::create(_tablet->tablet_schema(), writer_context.referenced_column_ids);
         auto sort_key_idxes = _tablet->tablet_schema().sort_key_idxes();
         std::sort(sort_key_idxes.begin(), sort_key_idxes.end());
         if (!std::includes(writer_context.referenced_column_ids.begin(), writer_context.referenced_column_ids.end(),
@@ -236,9 +236,9 @@ Status DeltaWriter::_init() {
             partial_update_schema->set_sort_key_idxes(sort_key_idxes);
         }
 
+        writer_context.partial_update_tablet_schema = partial_update_schema;
         writer_context.tablet_schema = writer_context.partial_update_tablet_schema.get();
         writer_context.partial_update_mode = _opt.partial_update_mode;
-        _tablet_schema = partial_update_schema;
     } else {
         writer_context.tablet_schema = &_tablet->tablet_schema();
         if (_tablet->tablet_schema().keys_type() == KeysType::PRIMARY_KEYS && !_opt.merge_condition.empty()) {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -215,8 +215,8 @@ Status DeltaWriter::_init() {
             _memtable_buffer_row = config::write_buffer_size / average_row_size;
         }
 
-        auto partial_update_schema = 
-                        TabletSchema::create(_tablet->tablet_schema(), writer_context.referenced_column_ids);
+        auto partial_update_schema =
+                TabletSchema::create(_tablet->tablet_schema(), writer_context.referenced_column_ids);
         auto sort_key_idxes = _tablet->tablet_schema().sort_key_idxes();
         std::sort(sort_key_idxes.begin(), sort_key_idxes.end());
         if (!std::includes(writer_context.referenced_column_ids.begin(), writer_context.referenced_column_ids.end(),

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -279,6 +279,10 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchemaPB& schema_
     return std::make_shared<TabletSchema>(schema_pb, schema_map);
 }
 
+// Be careful
+// When you use this function to create a new partial tablet schema, please make sure `referenced_column_ids` include
+// all sort key column index of `src_tablet_schema`. Otherwise you need to recalculate the short key columns of the
+// partial tablet schema
 std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchema& src_tablet_schema,
                                                    const std::vector<int32_t>& referenced_column_ids) {
     TabletSchemaPB partial_tablet_schema_pb;
@@ -290,10 +294,17 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchema& src_table
     if (src_tablet_schema.has_bf_fpp()) {
         partial_tablet_schema_pb.set_bf_fpp(src_tablet_schema.bf_fpp());
     }
+    std::vector<ColumnId> sort_key_idxes;
+    uint32_t cid = 0;
     for (const auto referenced_column_id : referenced_column_ids) {
         auto* tablet_column = partial_tablet_schema_pb.add_column();
-        src_tablet_schema.column(referenced_column_id).to_schema_pb(tablet_column);
+        src_tablet_schema->column(referenced_column_id).to_schema_pb(tablet_column);
+        if (src_tablet_schema->column(referenced_column_id).is_sort_key()) {
+            sort_key_idxes.emplace_back(cid);
+        }
+        cid++;
     }
+    partial_tablet_schema_pb.mutable_sort_key_idxes()->Add(sort_key_idxes.begin(), sort_key_idxes.end());
     return std::make_shared<TabletSchema>(partial_tablet_schema_pb);
 }
 

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -298,8 +298,8 @@ std::shared_ptr<TabletSchema> TabletSchema::create(const TabletSchema& src_table
     uint32_t cid = 0;
     for (const auto referenced_column_id : referenced_column_ids) {
         auto* tablet_column = partial_tablet_schema_pb.add_column();
-        src_tablet_schema->column(referenced_column_id).to_schema_pb(tablet_column);
-        if (src_tablet_schema->column(referenced_column_id).is_sort_key()) {
+        src_tablet_schema.column(referenced_column_id).to_schema_pb(tablet_column);
+        if (src_tablet_schema.column(referenced_column_id).is_sort_key()) {
             sort_key_idxes.emplace_back(cid);
         }
         cid++;

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update
@@ -43,8 +43,8 @@ insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
 select * from tab1;
 -- result:
 200	k2_200	200	200	200	v4_200	v5_200
-100	k2_100	100	100	100	v4_100	v5_100
 300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
 -- !result
 insert into tab2 values (100, 100, 100, 100);
 -- result:
@@ -67,17 +67,17 @@ E: (1064, 'Getting analyzing error. Detail message: must specify where clause to
 -- !result
 select * from tab1;
 -- result:
-200	k2_200	200	200	200	v4_200	v5_200
-100	k2_100	100	100	100	v4_100	v5_100
 300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
 -- !result
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2) where k1 = 100;
 -- result:
 -- !result
 select * from tab1;
 -- result:
-100	k2_100	600	600	100	v4_100	v5_100
 300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	600	600	100	v4_100	v5_100
 200	k2_200	200	200	200	v4_200	v5_200
 -- !result
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
@@ -85,7 +85,49 @@ update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) 
 -- !result
 select * from tab1;
 -- result:
-200	k2_200	600	600	200	v4_200	v5_200
 100	k2_100	600	600	100	v4_100	v5_100
+200	k2_200	600	600	200	v4_200	v5_200
 300	k3_300	600	600	300	v4_300	v5_300
+-- !result
+CREATE table tab3 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+ORDER BY (`v1`, `v2`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+insert into tab3 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab3 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab3 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+select * from tab3;
+-- result:
+300	k3_300	300	300	300	v4_300	v5_300
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+-- !result
+update tab3 set v1 = 1111, v2 = (select sum(tab2.v2) from tab2);
+-- result:
+-- !result
+select * from tab3;
+-- result:
+300	k3_300	1111	600	300	v4_300	v5_300
+100	k2_100	1111	600	100	v4_100	v5_100
+200	k2_200	1111	600	200	v4_200	v5_200
 -- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update
@@ -41,3 +41,28 @@ update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) 
 select * from tab1;
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
 select * from tab1;
+
+
+CREATE table tab3 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 10
+ORDER BY (`v1`, `v2`)
+PROPERTIES (
+    "replication_num" = "1"
+);
+insert into tab3 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab3 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab3 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
+select * from tab3;
+
+update tab3 set v1 = 1111, v2 = (select sum(tab2.v2) from tab2);
+select * from tab3;


### PR DESCRIPTION
When we do a column partial update for the primary key table which separates primary keys and sort keys, we will create a partial tablet schema for the rowset writer. However, the sort key columns may not exist in the partial tablet schema and the partial tablet schema will keep a wrong sort key idxes and short key column num. So BE will crash in ASAN mode. However, the sort_key_idxes and short_key_column_num in partial tablet schema are not important because the update segment file does not depend on it and the update segment file will be rewritten to a col file after apply. So we should modify the sort key idxes and short key column num in column mode partial update.