### PR TITLE
[BugFix] Fixup wrong partition_by_expr of runtime filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/ProjectNode.java
@@ -136,6 +136,18 @@ public class ProjectNode extends PlanNode {
         return getChildren().stream().allMatch(PlanNode::canUseRuntimeAdaptiveDop);
     }
 
+    public Optional<List<List<Expr>>> candidatesOfSlotExprs(List<Expr> exprs, Function<Expr, Boolean> couldBound) {
+        if (!exprs.stream().allMatch(expr -> candidatesOfSlotExpr(expr, couldBound).isPresent())) {
+            // NOTE: This is necessary, when expr is partition_by_epxr because
+            // partition_by_exprs may exist in JoinNode below the ProjectNode.
+            return Optional.of(ImmutableList.of(exprs));
+        }
+        List<List<Expr>> candidatesOfSlotExprs =
+                exprs.stream().map(expr -> candidatesOfSlotExpr(expr, couldBound).get()).collect(Collectors.toList());
+        return Optional.of(candidateOfPartitionByExprs(candidatesOfSlotExprs));
+    }
+
+
     @Override
     public Optional<List<Expr>> candidatesOfSlotExpr(Expr expr, Function<Expr, Boolean> couldBound) {
         if (!(expr instanceof SlotRef)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RuntimeFilterTest.java
@@ -1,0 +1,123 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/analysis/SelectStmtTest.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class RuntimeFilterTest {
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeAll
+    public static void setUp()
+            throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        String createTblStmtStr = "CREATE TABLE `duplicate_par_tbl` (\n" +
+                "  `k1` date NULL COMMENT \"\",\n" +
+                "  `k2` datetime NULL COMMENT \"\",\n" +
+                "  `k3` char(20) NULL COMMENT \"\",\n" +
+                "  `k4` varchar(20) NULL COMMENT \"\",\n" +
+                "  `k5` boolean NULL COMMENT \"\",\n" +
+                "  `k6` tinyint(4) NULL COMMENT \"\",\n" +
+                "  `k7` smallint(6) NULL COMMENT \"\",\n" +
+                "  `k8` int(11) NULL COMMENT \"\",\n" +
+                "  `k9` bigint(20) NULL COMMENT \"\",\n" +
+                "  `k10` largeint(40) NULL COMMENT \"\",\n" +
+                "  `k11` float NULL COMMENT \"\",\n" +
+                "  `k12` double NULL COMMENT \"\",\n" +
+                "  `k13` decimal128(27, 9) NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`k1`, `k2`, `k3`, `k4`, `k5`)\n" +
+                "PARTITION BY RANGE(`k1`)\n" +
+                "(PARTITION p202006 VALUES [(\"0000-01-01\"), (\"2020-07-01\")),\n" +
+                "PARTITION p202007 VALUES [(\"2020-07-01\"), (\"2020-08-01\")),\n" +
+                "PARTITION p202008 VALUES [(\"2020-08-01\"), (\"2020-09-01\")))\n" +
+                "DISTRIBUTED BY HASH(`k1`, `k2`, `k3`, `k4`, `k5`) BUCKETS 3 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"light_schema_change\" = \"true\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                "); ";
+        starRocksAssert = new StarRocksAssert();
+        starRocksAssert.withDatabase("db1").useDatabase("db1");
+        starRocksAssert.withTable(createTblStmtStr);
+        FeConstants.runningUnitTest = true;
+    }
+
+    @Test
+    void testRuntimeFilterPushDown()
+            throws Exception {
+        String sql =
+                "with tbl1 as (select * from duplicate_par_tbl partition(p202006) where k3 in('beijing','')),  \n" +
+                        "tbl2 as (select * from duplicate_par_tbl partition(p202007) where k5 is null),  \n" +
+                        "tbl3 as (select * from duplicate_par_tbl partition(p202008) where k13 > 60),  \n" +
+                        "tbl4 as (select * from duplicate_par_tbl where k6 in(''))  \n" +
+                        "select distinct k1 from(select t.k1\n" +
+                        "from tbl4 d left join[shuffle] \n" +
+                        "(select a.*, b.k13 as bk13, c.k13 as ck13 \n" +
+                        "from tbl1 a right join[shuffle] tbl2 b on a.k13 = b.k13 \n" +
+                        "right join[shuffle] tbl3 c on a.k13 = c.k13 and c.k5 = 1) t on " +
+                        "t.k13 = d.k13 and t.bk13 = d.k13 and t.ck13 = d.k13 \n" +
+                        "where d.k5 is null\n" +
+                        ") tbl order by 1 desc limit 15";
+        String plan = UtFrameUtils.getVerboseFragmentPlan(starRocksAssert.getCtx(), sql);
+        System.out.println(plan);
+        Assert.assertTrue(plan, plan.contains("  4:Project\n" +
+                "  |  output columns:\n" +
+                "  |  66 <-> [66: k1, DATE, true]\n" +
+                "  |  78 <-> [78: k13, DECIMAL128(27,9), true]\n" +
+                "  |  cardinality: 1\n" +
+                "  |  \n" +
+                "  3:OlapScanNode\n" +
+                "     table: duplicate_par_tbl, rollup: duplicate_par_tbl\n" +
+                "     preAggregation: on\n" +
+                "     Predicates: 68: k3 IN ('beijing', '')\n" +
+                "     partitionsRatio=1/3, tabletsRatio=3/3\n" +
+                "     tabletList=10010,10012,10014\n" +
+                "     actualRows=0, avgRowSize=3.0\n" +
+                "     cardinality: 1\n" +
+                "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (78: k13)\n" +
+                "\n" +
+                "PLAN FRAGMENT 7(F00)"));
+    }
+}


### PR DESCRIPTION
Sometimes probePartitionByExprs of runtime filters derived from physical property "Distribution" of  HashJoin(SHUFFLE_HASH_BUCKET)  is illegal, so do not used these runtime filters. see the example as follows:
```
|   12:HASH JOIN                                                                                                                     |
|   |  join op: RIGHT OUTER JOIN (BUCKET_SHUFFLE(S))                                                                                 |
|   |  equal join conjunct: [78: k13, DECIMAL128(27,9), true] = [104: k13, DECIMAL128(27,9), true]                                   |
|   |  other join predicates: cast([96: k5, BOOLEAN, true] as TINYINT) = 1                                                           |
|   |  build runtime filters:                                                                                                        |
|   |  - filter_id = 1, build_expr = (104: k13), remote = true                                                                       |
|   |  output columns: 66, 78, 91, 96, 104                                                                                           |
|   |  cardinality: 6400                                                                                                             |
|   |  column statistics:                                                                                                            |
|   |  * k1-->[-6.2167248343E10, 1.5935328E9, 0.0, 1.0, 1.0] UNKNOWN                                                                 |
|   |  * k13-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                          |
|   |  * k13-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                          |
|   |  * k5-->[1.0, 1.0, 0.0, 1.0, 1.0] UNKNOWN                                                                                      |
|   |  * k13-->[60.0, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                               |
|   |                                                                                                                                |
|   |----11:EXCHANGE                                                                                                                 |
|   |       distribution type: SHUFFLE                                                                                               |
|   |       partition exprs: [104: k13, DECIMAL128(27,9), true]                                                                      |
|   |       cardinality: 12800                                                                                                       |
|   |                                                                                                                                |
|   9:HASH JOIN                                                                                                                      |
|   |  join op: RIGHT OUTER JOIN (PARTITIONED)                                                                                       |
|   |  equal join conjunct: [78: k13, DECIMAL128(27,9), true] = [91: k13, DECIMAL128(27,9), true]                                    |
|   |  build runtime filters:                                                                                                        |
|   |  - filter_id = 0, build_expr = (91: k13), remote = true                                                                        |
|   |  cardinality: 4101                                                                                                             |
|   |  column statistics:                                                                                                            |
|   |  * k1-->[-6.2167248343E10, 1.5935328E9, 0.0, 1.0, 1.0] UNKNOWN                                                                 |
|   |  * k13-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                                                                          |
|   |  * k13-->[-Infinity, Infinity, 0.0, 1.0, 1.0] UNKNOWN                      
```
From HashJoin(9), Slot(78) and Slot(91) are equivalent,  in HashJoin(12), the left distribution is SHUFFLE(slot(91)) instead of SHUFFLE(slot(78)), so the probePartitionByExprs is Slot(91), when filter=1  is pushed down along left side:
1. in the old version: ProjectNode is the destination where this rf reach the farthest,  the ProjectNode do not have Slot(91); BE do not apply this rf, so it does not crash.
2. in the new version: OlapScanNode is the farthest destination, BE apply this rf, so crashes.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
