### PR TITLE
[BugFix] reuse http brpc stub and config rpc_connect_timeout_ms

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -840,7 +840,7 @@ CONF_Int64(deliver_broadcast_rf_passthrough_bytes_limit, "131072");
 CONF_Int64(deliver_broadcast_rf_passthrough_inflight_num, "10");
 CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
 
-CONF_Int64(rpc_connect_timeout_ms, "3000");
+CONF_Int64(rpc_connect_timeout_ms, "30000");
 
 CONF_Int32(max_batch_publish_latency_ms, "100");
 

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -840,6 +840,8 @@ CONF_Int64(deliver_broadcast_rf_passthrough_bytes_limit, "131072");
 CONF_Int64(deliver_broadcast_rf_passthrough_inflight_num, "10");
 CONF_Int64(send_rpc_runtime_filter_timeout_ms, "1000");
 
+CONF_Int64(rpc_connect_timeout_ms, "3000");
+
 CONF_Int32(max_batch_publish_latency_ms, "100");
 
 // Config for opentelemetry tracing.

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -458,7 +458,7 @@ Status SinkBuffer::_send_rpc(DisposableClosure<PTransmitChunkResult, ClosureCont
         }
         closure->cntl.http_request().set_content_type("application/proto");
         // create http_stub as needed
-        auto res = BrpcStubCache::create_http_stub(request.brpc_addr);
+        auto res = HttpBrpcStubCache::getInstance()->get_http_stub(request.brpc_addr);
         if (!res.ok()) {
             return res.status();
         }

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -219,7 +219,7 @@ void NodeChannel::_open(int64_t index_id, RefCountClosure<PTabletWriterOpenResul
         brpc_addr.hostname = _node_info->host;
         brpc_addr.port = _node_info->brpc_port;
         open_closure->cntl.http_request().set_content_type("application/proto");
-        auto res = BrpcStubCache::create_http_stub(brpc_addr);
+        auto res = HttpBrpcStubCache::getInstance()->get_http_stub(brpc_addr);
         if (!res.ok()) {
             LOG(ERROR) << res.status().get_error_msg();
             return;
@@ -573,7 +573,7 @@ Status NodeChannel::_send_request(bool eos, bool wait_all_sender_close) {
             brpc_addr.hostname = _node_info->host;
             brpc_addr.port = _node_info->brpc_port;
             _add_batch_closures[_current_request_index]->cntl.http_request().set_content_type("application/proto");
-            auto res = BrpcStubCache::create_http_stub(brpc_addr);
+            auto res = HttpBrpcStubCache::getInstance()->get_http_stub(brpc_addr);
             if (!res.ok()) {
                 return res.status();
             }
@@ -593,7 +593,7 @@ Status NodeChannel::_send_request(bool eos, bool wait_all_sender_close) {
             brpc_addr.hostname = _node_info->host;
             brpc_addr.port = _node_info->brpc_port;
             _add_batch_closures[_current_request_index]->cntl.http_request().set_content_type("application/proto");
-            auto res = BrpcStubCache::create_http_stub(brpc_addr);
+            auto res = HttpBrpcStubCache::getInstance()->get_http_stub(brpc_addr);
             if (!res.ok()) {
                 return res.status();
             }

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -77,36 +77,6 @@ public:
         return (*stub_pool)->get_or_create(endpoint);
     }
 
-    // rarely used, so create as needed
-    static StatusOr<std::unique_ptr<doris::PBackendService_Stub>> create_http_stub(const TNetworkAddress& taddr) {
-        butil::EndPoint endpoint;
-        std::string realhost;
-        realhost = taddr.hostname;
-        if (!is_valid_ip(taddr.hostname)) {
-            realhost = hostname_to_ip(taddr.hostname);
-            if (realhost == "") {
-                return Status::RuntimeError("failed to get ip from host " + taddr.hostname);
-            }
-        }
-        if (str2endpoint(realhost.c_str(), taddr.port, &endpoint)) {
-            return Status::RuntimeError("unknown endpoint, host = " + taddr.hostname);
-        }
-        // create
-        brpc::ChannelOptions options;
-        options.connect_timeout_ms = config::rpc_connect_timeout_ms;
-        options.protocol = "http";
-        // Explicitly set the max_retry
-        // TODO(meegoo): The retry strategy can be customized in the future
-        options.max_retry = 3;
-        std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
-        if (channel->Init(endpoint, &options)) {
-            return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
-                                        std::to_string(taddr.port));
-        }
-        return std::make_unique<doris::PBackendService_Stub>(channel.release(),
-                                                             google::protobuf::Service::STUB_OWNS_CHANNEL);
-    }
-
     doris::PBackendService_Stub* get_stub(const TNetworkAddress& taddr) { return get_stub(taddr.hostname, taddr.port); }
 
     doris::PBackendService_Stub* get_stub(const std::string& host, int port) {
@@ -172,6 +142,63 @@ private:
 
     SpinLock _lock;
     butil::FlatMap<butil::EndPoint, StubPool*> _stub_map;
+};
+
+class HttpBrpcStubCache {
+public:
+    static HttpBrpcStubCache* getInstance() {
+        static HttpBrpcStubCache cache;
+        return &cache;
+    }
+
+    StatusOr<doris::PBackendService_Stub*> get_http_stub(const TNetworkAddress& taddr) {
+        butil::EndPoint endpoint;
+        std::string realhost;
+        realhost = taddr.hostname;
+        if (!is_valid_ip(taddr.hostname)) {
+            realhost = hostname_to_ip(taddr.hostname);
+            if (realhost == "") {
+                return Status::RuntimeError("failed to get ip from host " + taddr.hostname);
+            }
+        }
+        if (str2endpoint(realhost.c_str(), taddr.port, &endpoint)) {
+            return Status::RuntimeError("unknown endpoint, host = " + taddr.hostname);
+        }
+        // get is exist
+        std::lock_guard<SpinLock> l(_lock);
+        auto stub_ptr = _stub_map.seek(endpoint);
+        if (stub_ptr != nullptr) {
+            return *stub_ptr;
+        }
+        // create
+        brpc::ChannelOptions options;
+        options.connect_timeout_ms = config::rpc_connect_timeout_ms;
+        options.protocol = "http";
+        // Explicitly set the max_retry
+        // TODO(meegoo): The retry strategy can be customized in the future
+        options.max_retry = 3;
+        std::unique_ptr<brpc::Channel> channel(new brpc::Channel());
+        if (channel->Init(endpoint, &options)) {
+            return Status::RuntimeError("init brpc http channel error on " + taddr.hostname + ":" +
+                                        std::to_string(taddr.port));
+        }
+        auto stub = new doris::PBackendService_Stub(channel.release(), google::protobuf::Service::STUB_OWNS_CHANNEL);
+        _stub_map.insert(endpoint, stub);
+        return stub;
+    }
+
+private:
+    HttpBrpcStubCache() { _stub_map.init(500); }
+    ~HttpBrpcStubCache() {
+        for (auto& stub : _stub_map) {
+            delete stub.second;
+        }
+    }
+    HttpBrpcStubCache(const HttpBrpcStubCache& cache) = delete;
+    HttpBrpcStubCache& operator=(const HttpBrpcStubCache& cache) = delete;
+
+    SpinLock _lock;
+    butil::FlatMap<butil::EndPoint, doris::PBackendService_Stub*> _stub_map;
 };
 
 } // namespace starrocks

--- a/be/src/util/brpc_stub_cache.h
+++ b/be/src/util/brpc_stub_cache.h
@@ -38,6 +38,7 @@
 #include <mutex>
 #include <vector>
 
+#include "common/config.h"
 #include "common/statusor.h"
 #include "gen_cpp/Types_types.h" // TNetworkAddress
 #include "gen_cpp/doris_internal_service.pb.h"
@@ -92,7 +93,7 @@ public:
         }
         // create
         brpc::ChannelOptions options;
-        options.connect_timeout_ms = 3000;
+        options.connect_timeout_ms = config::rpc_connect_timeout_ms;
         options.protocol = "http";
         // Explicitly set the max_retry
         // TODO(meegoo): The retry strategy can be customized in the future
@@ -142,7 +143,7 @@ private:
         doris::PBackendService_Stub* get_or_create(const butil::EndPoint& endpoint) {
             if (UNLIKELY(_stubs.size() < config::brpc_max_connections_per_server)) {
                 brpc::ChannelOptions options;
-                options.connect_timeout_ms = 3000;
+                options.connect_timeout_ms = config::rpc_connect_timeout_ms;
                 // Explicitly set the max_retry
                 // TODO(meegoo): The retry strategy can be customized in the future
                 options.max_retry = 3;


### PR DESCRIPTION
Close https://github.com/StarRocks/starrocks/issues/33495

1. reuse http brpc stub to avoid `Cannot assign requested address`
2. support config rpc_connect_timeout_ms, and set its default value 30s to avoid `timeout connections`.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
