### PR TITLE
[Enhancement] Support bitmap_hash for count(distinct x) rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
@@ -75,13 +75,6 @@ public class AggregateFunctionRewriter {
         if (aggFuncName.equals(FunctionSet.AVG)) {
             return true;
         }
-        // BITMAP
-        if (aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct()) {
-            return true;
-        }
-        if (aggFuncName.equals(FunctionSet.BITMAP_UNION_COUNT) || aggFuncName.equals(FunctionSet.MULTI_DISTINCT_COUNT)) {
-            return true;
-        }
         // HLL
         if (aggFuncName.equals(FunctionSet.APPROX_COUNT_DISTINCT) || aggFuncName.equals(FunctionSet.NDV) ||
                 aggFuncName.equals(FunctionSet.HLL_UNION_AGG) || aggFuncName.equals(FunctionSet.HLL_CARDINALITY)) {
@@ -96,11 +89,7 @@ public class AggregateFunctionRewriter {
 
     public CallOperator rewriteAggFunction(CallOperator aggFunc) {
         String aggFuncName = aggFunc.getFnName();
-        if ((aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct()) ||
-                aggFuncName.equals(FunctionSet.BITMAP_UNION_COUNT) ||
-                aggFuncName.equals(FunctionSet.MULTI_DISTINCT_COUNT)) {
-            return rewriteCountDistinct(aggFunc);
-        } else if (aggFuncName.equals(FunctionSet.AVG)) {
+        if (aggFuncName.equals(FunctionSet.AVG)) {
             return rewriteAvg(aggFunc);
         } else if (aggFuncName.equals(FunctionSet.APPROX_COUNT_DISTINCT) || aggFuncName.equals(FunctionSet.NDV) ||
                 aggFuncName.equals(FunctionSet.HLL_UNION_AGG) || aggFuncName.equals(FunctionSet.HLL_CARDINALITY)) {
@@ -161,43 +150,6 @@ public class AggregateFunctionRewriter {
             newColumnRefToAggFuncMap.put(countCallOp.first, countCallOp.second);
         }
         return newAvg;
-    }
-
-    private CallOperator rewriteCountDistinct(CallOperator aggFunc) {
-        // What if bitmap_union aggregate table?
-        Type childType = aggFunc.getChild(0).getType();
-        List<ScalarOperator> aggChild = aggFunc.getChildren();
-        if (!childType.isBitmapType()) {
-            // add `to_bitmap` function for input
-            CallOperator toBitmapOp = new CallOperator(FunctionSet.TO_BITMAP,
-                    Type.BITMAP,
-                    aggFunc.getChildren(),
-                    Expr.getBuiltinFunction(FunctionSet.TO_BITMAP, new Type[] { aggChild.get(0).getType() },
-                            IS_IDENTICAL));
-            toBitmapOp = (CallOperator) scalarRewriter.rewrite(toBitmapOp,
-                    Lists.newArrayList(new ImplicitCastRule()));
-            aggChild = Lists.newArrayList(toBitmapOp);
-        }
-
-        // rewrite count distinct to bitmap_count(bitmap_union(to_bitmap(x)));
-        CallOperator bitmapUnionOp = new CallOperator(FunctionSet.BITMAP_UNION,
-                Type.BITMAP,
-                aggChild,
-                Expr.getBuiltinFunction(FunctionSet.BITMAP_UNION, new Type[] {Type.BITMAP},
-                        IS_IDENTICAL));
-        List<ScalarOperator> newAggFunc = Lists.newArrayList(bitmapUnionOp);
-        if (newColumnRefToAggFuncMap != null) {
-            ColumnRefOperator newColRef =
-                    queryColumnRefFactory.create(bitmapUnionOp, bitmapUnionOp.getType(), bitmapUnionOp.isNullable());
-            newColumnRefToAggFuncMap.put(newColRef, bitmapUnionOp);
-            newAggFunc = Lists.newArrayList(newColRef);
-        }
-
-        return new CallOperator(FunctionSet.BITMAP_COUNT,
-                aggFunc.getType(),
-                newAggFunc,
-                Expr.getBuiltinFunction(FunctionSet.BITMAP_COUNT, new Type[] { Type.BITMAP },
-                        IS_IDENTICAL));
     }
 
     private CallOperator rewriteApproxCount(CallOperator aggFunc) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Utils;
@@ -45,6 +46,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.EquivalentShuttleContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -618,20 +620,9 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : aggregates.entrySet()) {
             Preconditions.checkState(entry.getValue() instanceof CallOperator);
             CallOperator aggCall = (CallOperator) entry.getValue();
-            ScalarOperator targetColumn = equationRewriter.replaceExprWithTarget(aggCall);
-            if (targetColumn == null || !isAllExprReplaced(targetColumn, queryColumnSet)) {
-                // it means there is some column that can not be rewritten by outputs of mv
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: partially rewrite", aggCall.toString());
-                return null;
-            }
-            // TODO: Support non column-ref agg function.
-            if (!(targetColumn instanceof ColumnRefOperator)) {
-                logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: only column-ref is supported after rewrite",
-                        aggCall.toString());
-                return null;
-            }
+
             // Aggregate must be CallOperator
-            CallOperator newAggregate = getRollupAggregate(aggCall, (ColumnRefOperator) targetColumn);
+            CallOperator newAggregate = getRollupAggregate(equationRewriter, queryColumnSet, aggCall);
             if (newAggregate == null) {
                 logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: cannot get rollup aggregate",
                         aggCall.toString());
@@ -643,6 +634,36 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         }
 
         return newAggregations;
+    }
+
+    private CallOperator getRollupAggregate(EquationRewriter equationRewriter,
+                                            ColumnRefSet queryColumnSet,
+                                            CallOperator aggCall) {
+        Pair<ScalarOperator, EquivalentShuttleContext> pair = equationRewriter.replaceExprWithRollup(aggCall);
+        ScalarOperator targetColumn = pair.first;
+        if (targetColumn == null || !isAllExprReplaced(targetColumn, queryColumnSet)) {
+            // it means there is some column that can not be rewritten by outputs of mv
+            logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: partially rewrite", aggCall.toString());
+            return null;
+        }
+        EquivalentShuttleContext shuttleContext = pair.second;
+        if (shuttleContext.isRewrittenByEquivalent()) {
+            Preconditions.checkState(targetColumn instanceof CallOperator);
+            return (CallOperator) targetColumn;
+        }
+        if (!targetColumn.isColumnRef()) {
+            logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: only column-ref is supported after rewrite",
+                    aggCall.toString());
+            return null;
+        }
+        // Aggregate must be CallOperator
+        CallOperator newAggregate = getRollupAggregate(aggCall, (ColumnRefOperator) targetColumn);
+        if (newAggregate == null) {
+            logMVRewrite(mvRewriteContext, "Rewrite aggregate {} failed: cannot get rollup aggregate",
+                    aggCall.toString());
+            return null;
+        }
+        return newAggregate;
     }
 
     private Map<ColumnRefOperator, CallOperator> rewriteAggregatesForUnion(
@@ -692,7 +713,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
 
     // generate new aggregates for rollup
     // eg: count(col) -> sum(col)
-    private CallOperator getRollupAggregate(CallOperator aggCall, ColumnRefOperator targetColumn) {
+    public static CallOperator getRollupAggregate(CallOperator aggCall, ColumnRefOperator targetColumn) {
         if (!SUPPORTED_ROLLUP_FUNCTIONS.contains(aggCall.getFnName())) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
@@ -25,33 +26,37 @@ import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.DateTruncReplaceChecker;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.EquivalentShuttleContext;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.IRewriteEquivalent;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.TimeSliceReplaceChecker;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.RewriteEquivalent;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.RewriteEquivalent.EQUIVALENTS;
 
 public class EquationRewriter {
 
     private Multimap<ScalarOperator, Pair<ColumnRefOperator, ScalarOperator>> equationMap;
-    private Multimap<ScalarOperator, Pair<ColumnRefOperator, IRewriteEquivalent>> predicateProbMap;
+    private Map<IRewriteEquivalent.RewriteEquivalentType, List<RewriteEquivalent>> rewriteEquivalents;
     private Map<ColumnRefOperator, ColumnRefOperator> columnMapping;
+
     private AggregateFunctionRewriter aggregateFunctionRewriter;
     boolean underAggFunctionRewriteContext;
 
     public EquationRewriter() {
         this.equationMap = ArrayListMultimap.create();
-        this.predicateProbMap = ArrayListMultimap.create();
+        this.rewriteEquivalents = Maps.newHashMap();
     }
 
     public void setOutputMapping(Map<ColumnRefOperator, ColumnRefOperator> columnMapping) {
         this.columnMapping = columnMapping;
     }
+
 
     public void setAggregateFunctionRewriter(AggregateFunctionRewriter aggregateFunctionRewriter) {
         this.aggregateFunctionRewriter = aggregateFunctionRewriter;
@@ -65,148 +70,139 @@ public class EquationRewriter {
         this.underAggFunctionRewriteContext = underAggFunctionRewriteContext;
     }
 
-    protected ScalarOperator replaceExprWithTarget(ScalarOperator expr) {
 
-        BaseScalarOperatorShuttle shuttle = new BaseScalarOperatorShuttle() {
-            @Override
-            public ScalarOperator visit(ScalarOperator scalarOperator, Void context) {
+
+    private final class EquivalentShuttle extends BaseScalarOperatorShuttle {
+        private final EquivalentShuttleContext shuttleContext;
+
+        public EquivalentShuttle(EquivalentShuttleContext eqContext) {
+            this.shuttleContext = eqContext;
+        }
+
+        @Override
+        public ScalarOperator visit(ScalarOperator scalarOperator, Void context) {
+            return null;
+        }
+
+        @Override
+        public Optional<ScalarOperator> preprocess(ScalarOperator scalarOperator) {
+            return replace(scalarOperator);
+        }
+
+        @Override
+        public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
+            Optional<ScalarOperator> tmp = replace(predicate);
+            if (tmp.isPresent()) {
+                return tmp.get();
+            }
+
+            // rewrite by equivalent
+            ScalarOperator rewritten = rewriteByEquivalent(predicate, IRewriteEquivalent.RewriteEquivalentType.PREDICATE);
+            if (rewritten != null) {
+                shuttleContext.setRewrittenByEquivalent(true);
+                return rewritten;
+            }
+
+            return super.visitBinaryPredicate(predicate, context);
+        }
+
+        private ScalarOperator rewriteByEquivalent(ScalarOperator input,
+                                                   IRewriteEquivalent.RewriteEquivalentType type) {
+            if (!rewriteEquivalents.containsKey(type)) {
                 return null;
             }
-
-            @Override
-            public Optional<ScalarOperator> preprocess(ScalarOperator scalarOperator) {
-                return replace(scalarOperator);
-            }
-
-            @Override
-            public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate, Void context) {
-                Optional<ScalarOperator> tmp = replace(predicate);
-                if (tmp.isPresent()) {
-                    return tmp.get();
-                }
-
-                ScalarOperator replaced = rewriteByEquivalent(predicate);
+            for (RewriteEquivalent equivalent : rewriteEquivalents.get(type)) {
+                ScalarOperator replaced = equivalent.rewrite(shuttleContext, columnMapping, input);
                 if (replaced != null) {
                     return replaced;
                 }
+            }
+            return null;
+        }
 
-                return super.visitBinaryPredicate(predicate, context);
+        @Override
+        public ScalarOperator visitCall(CallOperator call, Void context) {
+            // 1. rewrite query's predicate
+            Optional<ScalarOperator> tmp = replace(call);
+            if (tmp.isPresent()) {
+                return tmp.get();
             }
 
-            private ScalarOperator rewriteByEquivalent(BinaryPredicateOperator predicate) {
-                ScalarOperator left = predicate.getChild(0);
-                ScalarOperator right = predicate.getChild(1);
-                if (!predicateProbMap.containsKey(left)) {
-                    return null;
-                }
-                Pair<ColumnRefOperator, IRewriteEquivalent> pair = predicateProbMap.get(left).iterator().next();
-                if (!pair.second.isEquivalent(right)) {
-                    return null;
-
-                }
-
-                ColumnRefOperator replaced = pair.first;
-                if (columnMapping != null) {
-                    replaced = columnMapping.get(pair.first);
-                    if (replaced == null) {
-                        return null;
-                    }
-                }
-                ScalarOperator clonePredicate = predicate.clone();
-                clonePredicate.setChild(0, replaced.clone());
-                return clonePredicate;
+            // rewrite by equivalent
+            ScalarOperator rewritten = rewriteByEquivalent(call, IRewriteEquivalent.RewriteEquivalentType.AGGREGATE);
+            if (rewritten != null) {
+                shuttleContext.setRewrittenByEquivalent(true);
+                return rewritten;
             }
 
-            @Override
-            public ScalarOperator visitCall(CallOperator call, Void context) {
-                // 1. rewrite query's predicate
-                Optional<ScalarOperator> tmp = replace(call);
-                if (tmp.isPresent()) {
-                    return tmp.get();
+            // retry again by using aggregateFunctionRewriter when predicate cannot be rewritten.
+            if (aggregateFunctionRewriter != null && aggregateFunctionRewriter.canRewriteAggFunction(call) &&
+                    !isUnderAggFunctionRewriteContext()) {
+                ScalarOperator newChooseScalarOp = aggregateFunctionRewriter.rewriteAggFunction(call);
+                if (newChooseScalarOp != null) {
+                    setUnderAggFunctionRewriteContext(true);
+                    // NOTE: To avoid repeating `rewriteAggFunction` by `aggregateFunctionRewriter`, use
+                    // `underAggFunctionRewriteContext` to mark it's under agg function rewriter and no need rewrite again.
+                    rewritten = newChooseScalarOp.accept(this, null);
+                    setUnderAggFunctionRewriteContext(false);
+                    return rewritten;
                 }
-
-                // 2. normalize predicate to better match mv
-                // TODO: merge into aggregateFunctionRewriter later.
-                CallOperator normalizedCall = normalizeCallOperator(call);
-                tmp = replace(normalizedCall);
-                if (tmp.isPresent()) {
-                    return tmp.get();
-                }
-
-                // 3. retry again by using aggregateFunctionRewriter when predicate cannot be rewritten.
-                if (aggregateFunctionRewriter != null && aggregateFunctionRewriter.canRewriteAggFunction(normalizedCall) &&
-                        !isUnderAggFunctionRewriteContext()) {
-                    ScalarOperator newChooseScalarOp = aggregateFunctionRewriter.rewriteAggFunction(normalizedCall);
-                    if (newChooseScalarOp != null) {
-                        setUnderAggFunctionRewriteContext(true);
-                        // NOTE: To avoid repeating `rewriteAggFunction` by `aggregateFunctionRewriter`, use
-                        // `underAggFunctionRewriteContext` to mark it's under agg function rewriter and no need rewrite again.
-                        ScalarOperator rewritten = newChooseScalarOp.accept(this, null);
-                        setUnderAggFunctionRewriteContext(false);
-                        return rewritten;
-                    }
-                }
-
-                return super.visitCall(call, context);
             }
 
-            Optional<ScalarOperator> replace(ScalarOperator scalarOperator) {
-                if (equationMap.containsKey(scalarOperator)) {
-                    Optional<Pair<ColumnRefOperator, ScalarOperator>> mappedColumnAndExprRef =
-                            equationMap.get(scalarOperator).stream().findFirst();
+            return super.visitCall(call, context);
+        }
 
-                    ColumnRefOperator basedColumn = mappedColumnAndExprRef.get().first;
-                    ScalarOperator extendedExpr = mappedColumnAndExprRef.get().second;
+        Optional<ScalarOperator> replace(ScalarOperator scalarOperator) {
+            if (equationMap.containsKey(scalarOperator)) {
+                Optional<Pair<ColumnRefOperator, ScalarOperator>> mappedColumnAndExprRef =
+                        equationMap.get(scalarOperator).stream().findFirst();
 
-                    if (columnMapping == null) {
-                        return extendedExpr == null ? Optional.of(basedColumn.clone()) : Optional.of(extendedExpr.clone());
-                    }
+                ColumnRefOperator basedColumn = mappedColumnAndExprRef.get().first;
+                ScalarOperator extendedExpr = mappedColumnAndExprRef.get().second;
 
-                    ColumnRefOperator replaced = columnMapping.get(basedColumn);
-                    if (replaced == null) {
-                        return Optional.empty();
-                    }
-
-                    if (extendedExpr == null) {
-                        return Optional.of(replaced.clone());
-                    }
-                    ScalarOperator newExpr = extendedExpr.clone();
-                    return replaceColInExpr(newExpr, basedColumn,
-                            replaced.clone()) ? Optional.of(newExpr) : Optional.empty();
+                if (columnMapping == null) {
+                    return extendedExpr == null ? Optional.of(basedColumn.clone()) : Optional.of(extendedExpr.clone());
                 }
 
-                return Optional.empty();
-            }
-
-            private boolean replaceColInExpr(ScalarOperator expr, ColumnRefOperator oldCol, ScalarOperator newCol) {
-                for (int i = 0; i < expr.getChildren().size(); i++) {
-                    if (oldCol.equals(expr.getChild(i))) {
-                        expr.setChild(i, newCol);
-                        return true;
-                    } else if (replaceColInExpr(expr.getChild(i), oldCol, newCol)) {
-                        return true;
-                    }
+                ColumnRefOperator replaced = columnMapping.get(basedColumn);
+                if (replaced == null) {
+                    return Optional.empty();
                 }
-                return false;
+
+                if (extendedExpr == null) {
+                    return Optional.of(replaced.clone());
+                }
+                ScalarOperator newExpr = extendedExpr.clone();
+                return replaceColInExpr(newExpr, basedColumn,
+                        replaced.clone()) ? Optional.of(newExpr) : Optional.empty();
             }
 
-        };
+            return Optional.empty();
+        }
 
+        private boolean replaceColInExpr(ScalarOperator expr, ColumnRefOperator oldCol, ScalarOperator newCol) {
+            for (int i = 0; i < expr.getChildren().size(); i++) {
+                if (oldCol.equals(expr.getChild(i))) {
+                    expr.setChild(i, newCol);
+                    return true;
+                } else if (replaceColInExpr(expr.getChild(i), oldCol, newCol)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+    }
+
+    private final EquivalentShuttle shuttle = new EquivalentShuttle(new EquivalentShuttleContext(false));
+
+    protected ScalarOperator replaceExprWithTarget(ScalarOperator expr) {
         return expr.accept(shuttle, null);
     }
 
-    private static CallOperator normalizeCallOperator(CallOperator aggFunc) {
-        String aggFuncName = aggFunc.getFnName();
-        if (!aggFuncName.equals(FunctionSet.COUNT) || aggFunc.isDistinct()) {
-            return aggFunc;
-        }
-
-        // unify count(*) or count(non-nullable column) to count(1) to be better for rewrite.
-        if (aggFunc.getChildren().size() == 0 || !aggFunc.getChild(0).isNullable()) {
-            return new CallOperator(FunctionSet.COUNT, aggFunc.getType(),
-                    Lists.newArrayList(ConstantOperator.createTinyInt((byte) 1)));
-        }
-        return aggFunc;
+    protected Pair<ScalarOperator, EquivalentShuttleContext> replaceExprWithRollup(ScalarOperator expr) {
+        final EquivalentShuttleContext shuttleContext = new EquivalentShuttleContext(true);
+        final EquivalentShuttle shuttle = new EquivalentShuttle(shuttleContext);
+        return Pair.create(expr.accept(shuttle, null), shuttleContext);
     }
 
     public boolean containsKey(ScalarOperator scalarOperator) {
@@ -222,28 +218,17 @@ public class EquationRewriter {
             equationMap.put(extendedEntry.first, Pair.create(col, extendedEntry.second));
         }
 
-        if (expr instanceof CallOperator) {
-            CallOperator aggFunc = (CallOperator) expr;
-            if (aggFunc.getFnName().equals(FunctionSet.TIME_SLICE)) {
-                // mv:    SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table
-                // query: SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table WHERE dt > '2023-06-01'
-                // if '2023-06-01'=time_slice('2023-06-01', INTERVAL 5 MINUTE), can replace predicate dt => t
-                ScalarOperator first = expr.getChild(0);
-                predicateProbMap.put(first, Pair.create(col, new TimeSliceReplaceChecker(aggFunc)));
-            } else if (aggFunc.getFnName().equals(FunctionSet.COUNT) && !aggFunc.isDistinct()) {
-                CallOperator newAggFunc = normalizeCallOperator(aggFunc);
-                if (newAggFunc != null && newAggFunc != aggFunc) {
-                    equationMap.put(newAggFunc,  Pair.create(col, null));
-                }
-            } else if (aggFunc.getFnName().equals(FunctionSet.DATE_TRUNC)) {
-                ScalarOperator first = expr.getChild(1);
-                predicateProbMap.put(first, Pair.create(col, new DateTruncReplaceChecker(aggFunc)));
+        for (IRewriteEquivalent equivalent : EQUIVALENTS) {
+            IRewriteEquivalent.RewriteEquivalentContext eqContext = equivalent.prepare(expr);
+            if (eqContext != null) {
+                RewriteEquivalent eq = new RewriteEquivalent(eqContext, equivalent, col);
+                rewriteEquivalents.computeIfAbsent(eq.getRewriteEquivalentType(), x -> Lists.newArrayList())
+                        .add(eq);
             }
         }
     }
 
     private static class EquationTransformer extends ScalarOperatorVisitor<Void, Void> {
-
         private static final Map<String, String> COMMUTATIVE_MAP = ImmutableMap.<String, String>builder()
                 .put(FunctionSet.ADD, FunctionSet.SUBTRACT)
                 .put(FunctionSet.SUBTRACT, FunctionSet.ADD)
@@ -289,7 +274,6 @@ public class EquationRewriter {
 
             return null;
         }
-
 
         private Function findArithmeticFunction(CallOperator call, String fnName) {
             return Expr.getBuiltinFunction(fnName, call.getFunction().getArgs(), Function.CompareMode.IS_IDENTICAL);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
@@ -26,8 +26,8 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.DateTruncReplaceChecker;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.TimeSliceReplaceChecker;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.DateTruncEquivalent;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.TimeSliceRewriteEquivalent;
 
 import java.util.List;
 import java.util.Optional;
@@ -133,11 +133,11 @@ public class PredicateExtractor extends ScalarOperatorVisitor<RangePredicate, Pr
             return null;
         }
 
-        if (DateTruncReplaceChecker.INSTANCE.isEquivalent(op1, op2)) {
+        if (DateTruncEquivalent.INSTANCE.isEquivalent(op1, op2)) {
             TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
             rangeSet.addAll(range(predicate.getBinaryType(), op2));
             return new ColumnRangePredicate(op1.getChild(1).cast(), rangeSet);
-        } else if (TimeSliceReplaceChecker.INSTANCE.isEquivalent(op1, op2)) {
+        } else if (TimeSliceRewriteEquivalent.INSTANCE.isEquivalent(op1, op2)) {
             TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
             rangeSet.addAll(range(predicate.getBinaryType(), op2));
             return new ColumnRangePredicate(op1.getChild(0).cast(), rangeSet);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/BitmapRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/BitmapRewriteEquivalent.java
@@ -1,0 +1,125 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.Arrays;
+
+import static com.starrocks.catalog.Function.CompareMode.IS_IDENTICAL;
+import static com.starrocks.catalog.FunctionSet.BITMAP_HASH;
+import static com.starrocks.catalog.FunctionSet.BITMAP_UNION;
+import static com.starrocks.catalog.FunctionSet.BITMAP_UNION_COUNT;
+import static com.starrocks.catalog.FunctionSet.MULTI_DISTINCT_COUNT;
+import static com.starrocks.catalog.FunctionSet.TO_BITMAP;
+
+public class BitmapRewriteEquivalent extends IAggregateRewriteEquivalent {
+    public static IRewriteEquivalent INSTANCE = new BitmapRewriteEquivalent();
+
+    public BitmapRewriteEquivalent() {}
+
+    @Override
+    public RewriteEquivalentContext prepare(ScalarOperator op) {
+        if (op == null || !(op instanceof CallOperator)) {
+            return null;
+        }
+        CallOperator aggFunc = (CallOperator) op;
+        String aggFuncName = aggFunc.getFnName();
+
+        if (aggFuncName.equals(BITMAP_UNION)) {
+            ScalarOperator arg0 = aggFunc.getChild(0);
+            if (arg0 == null) {
+                return null;
+            }
+            if (!arg0.getType().isBitmapType()) {
+                return null;
+            }
+            if (arg0 instanceof CallOperator) {
+                CallOperator call0 = (CallOperator) arg0;
+                if (call0.getFnName().equals(FunctionSet.TO_BITMAP)) {
+                    // bitmap_union(to_bitmap()) can be used for rewrite
+                    return new RewriteEquivalentContext(call0.getChild(0), op);
+                } else if (call0.getFnName().equals(FunctionSet.BITMAP_HASH)) {
+                    // bitmap_union(bitmap_hash()) can be used for rewrite
+                    return new RewriteEquivalentContext(call0.getChild(0), op);
+                }
+            } else {
+                return new RewriteEquivalentContext(arg0, op);
+            }
+        }
+        return null;
+    }
+
+    private ScalarOperator rewriteImpl(CallOperator aggFunc,
+                                       ScalarOperator replace,
+                                       boolean isRollup) {
+        if (isRollup) {
+            return new CallOperator(BITMAP_UNION_COUNT,
+                    aggFunc.getType(),
+                    Arrays.asList(replace),
+                    Expr.getBuiltinFunction(FunctionSet.BITMAP_UNION_COUNT, new Type[] {Type.BITMAP},
+                            IS_IDENTICAL));
+        } else {
+            return new CallOperator(FunctionSet.BITMAP_COUNT,
+                    aggFunc.getType(),
+                    Arrays.asList(replace),
+                    Expr.getBuiltinFunction(FunctionSet.BITMAP_COUNT, new Type[] { Type.BITMAP },
+                            IS_IDENTICAL));
+        }
+    }
+
+    @Override
+    public ScalarOperator rewrite(RewriteEquivalentContext eqContext,
+                                  EquivalentShuttleContext shuttleContext,
+                                  ColumnRefOperator replace,
+                                  ScalarOperator newInput) {
+        if (newInput == null || !(newInput instanceof CallOperator)) {
+            return null;
+        }
+        ScalarOperator eqChild = eqContext.getEquivalent();
+        CallOperator aggFunc = (CallOperator) newInput;
+        String aggFuncName = aggFunc.getFnName();
+        boolean isRollup = shuttleContext.isRollup();
+        if (aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct() || aggFuncName.equals(MULTI_DISTINCT_COUNT)) {
+            ScalarOperator arg0 = aggFunc.getChild(0);
+            if (!arg0.equals(eqChild)) {
+                return null;
+            }
+            return rewriteImpl(aggFunc, replace, isRollup);
+        } else if (aggFuncName.equals(BITMAP_UNION_COUNT)) {
+            ScalarOperator arg0 = aggFunc.getChild(0);
+            if (arg0 == null) {
+                return null;
+            }
+            if (arg0 instanceof CallOperator) {
+                CallOperator arg00 = (CallOperator) arg0;
+                if (!arg00.getFnName().equals(TO_BITMAP) && !arg00.getFnName().equals(BITMAP_HASH)) {
+                    return null;
+                }
+                if (!arg00.getChild(0).equals(eqChild)) {
+                    return null;
+                }
+            } else if (!arg0.equals(eqChild)) {
+                return null;
+            }
+            return rewriteImpl(aggFunc, replace, isRollup);
+        }
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/CountRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/CountRewriteEquivalent.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.AggregatedMaterializedViewRewriter;
+
+public class CountRewriteEquivalent extends IAggregateRewriteEquivalent {
+    public static IRewriteEquivalent INSTANCE = new CountRewriteEquivalent();
+
+    public CountRewriteEquivalent() {}
+
+    private boolean check(ScalarOperator op) {
+        if (op == null || !(op instanceof CallOperator)) {
+            return false;
+        }
+        CallOperator agg = (CallOperator) op;
+        String aggFuncName = agg.getFnName();
+        if (!aggFuncName.equals(FunctionSet.COUNT) || agg.isDistinct()) {
+            return false;
+        }
+        return isNonNullableCount(agg);
+    }
+
+    @Override
+    public RewriteEquivalentContext prepare(ScalarOperator input) {
+        if (!check(input)) {
+            return null;
+        }
+        return new RewriteEquivalentContext(null, input);
+    }
+
+    private static boolean isNonNullableCount(CallOperator aggFunc) {
+        return aggFunc.getChildren().size() == 0 || !aggFunc.getChild(0).isNullable();
+    }
+
+    @Override
+    public ScalarOperator rewrite(RewriteEquivalentContext eqContext,
+                                  EquivalentShuttleContext shuttleContext,
+                                  ColumnRefOperator replace,
+                                  ScalarOperator newInput) {
+        if (!check(newInput)) {
+            return null;
+        }
+        if (shuttleContext.isRollup()) {
+            return AggregatedMaterializedViewRewriter.getRollupAggregate((CallOperator) eqContext.getInput(), replace);
+        } else {
+            return replace;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/EquivalentShuttleContext.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+public class EquivalentShuttleContext {
+    private boolean isRewrittenByEquivalent;
+    private final boolean isRollup;
+
+    public EquivalentShuttleContext(boolean isRollup) {
+        this.isRollup = isRollup;
+    }
+
+    public boolean isRewrittenByEquivalent() {
+        return isRewrittenByEquivalent;
+    }
+
+    public boolean isRollup() {
+        return isRollup;
+    }
+
+    public void setRewrittenByEquivalent(boolean rewrittenByEquivalent) {
+        isRewrittenByEquivalent = rewrittenByEquivalent;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IAggregateRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IAggregateRewriteEquivalent.java
@@ -1,0 +1,21 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+public abstract class  IAggregateRewriteEquivalent implements IRewriteEquivalent {
+    public RewriteEquivalentType getRewriteEquivalentType() {
+        return RewriteEquivalentType.AGGREGATE;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IPredicateRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IPredicateRewriteEquivalent.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+/**
+ * Two expression can be equivalent even they are not the same expressions especially for partition datetime functions,
+ * example1:
+ *   a. time_slice(dt, INTERVAL 1 HOUR) >= '2023-11-21 00:00:00'
+ *   b. dt >= '2023-11-21 00:00:00'
+ * example2:
+ *   a. date_trunc('hour', dt) >= '2023-11-21 00:00:00'
+ *   b. dt >= '2023-11-21 00:00:00'
+ *
+ * {@code IRewriteEquivalent} is used to check whether different expression are equivalent or not.
+ */
+public abstract class IPredicateRewriteEquivalent implements IRewriteEquivalent {
+    public RewriteEquivalentType getRewriteEquivalentType() {
+        return RewriteEquivalentType.PREDICATE;
+    }
+
+    /**
+     * @param operator : The input scalar operator eg:date_trunc/time_slice expression
+     * @param constantOperator : const operator of the binary predicate's right child
+     * @return : The input operator can be replaced by the {@code IRewriteEquivalent}
+     */
+    abstract boolean isEquivalent(ScalarOperator operator, ConstantOperator constantOperator);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
@@ -14,31 +14,85 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
 
-import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 /**
  * Two expression can be equivalent even they are not the same expressions especially for partition datetime functions,
+ *  <p>
  * example1:
  *   a. time_slice(dt, INTERVAL 1 HOUR) >= '2023-11-21 00:00:00'
  *   b. dt >= '2023-11-21 00:00:00'
  * example2:
  *   a. date_trunc('hour', dt) >= '2023-11-21 00:00:00'
  *   b. dt >= '2023-11-21 00:00:00'
- *
+ *  </p>
  * {@code IRewriteEquivalent} is used to check whether different expression are equivalent or not.
  */
+
 public interface IRewriteEquivalent {
     /**
-     * @param operator : The input scalar operator to be checked
-     * @return: The input operator can be replaced by the {@code IRewriteEquivalent}
+     * Different {@code RewriteEquivalentType} will be used to rewrite different scalar operators.
+     * eg:
+     *  `PREDICATE` will be used to rewrite for `BinaryPredicateOperator`;
+     *  `CallOperator` will be used to rewrite for `BinaryPredicateOperator`;
      */
-    boolean isEquivalent(ScalarOperator operator);
+    enum RewriteEquivalentType {
+        PREDICATE,
+        AGGREGATE
+    }
+
+    class RewriteEquivalentContext {
+        // input or newInput should always have an equivalent, record it in the prepare stage.
+        // eg:
+        //  reference : time_slice(dt, 1 hour interval) = '2023-11-23 00:00:00'
+        //  newInput  : dt = '2023-11-23 00:00:00',
+        // then equivalent is `dt`
+        private final ScalarOperator equivalent;
+        private final ScalarOperator input;
+
+        private ColumnRefOperator replace;
+
+        public RewriteEquivalentContext(ScalarOperator equivalent, ScalarOperator input) {
+            this.equivalent = equivalent;
+            this.input = input;
+        }
+
+        public ScalarOperator getEquivalent() {
+            return equivalent;
+        }
+
+        public ColumnRefOperator getReplace() {
+            return replace;
+        }
+
+        public void setReplace(ColumnRefOperator replace) {
+            this.replace = replace;
+        }
+
+        public ScalarOperator getInput() {
+            return input;
+        }
+    }
+
+    RewriteEquivalentType getRewriteEquivalentType();
 
     /**
-     * @param operator : The input scalar operator eg:date_trunc/time_slice expression
-     * @param constantOperator : const operator of the binary predicate's right child
-     * @return : The input operator can be replaced by the {@code IRewriteEquivalent}
+     * Check input scalar operator can be used for equivalent compare.
+     * @param input : scalar operator that can be used for generating other equivalents.
+     * @return      : true if it can be used, otherwise false.
      */
-    boolean isEquivalent(ScalarOperator operator, ConstantOperator constantOperator);
+    RewriteEquivalentContext prepare(ScalarOperator input);
+
+    /**
+     * Rewrite newInput if it is equivalent with input by using input's column ref mapping replace.
+     * @param input         : original scalar operator.
+     * @param replace       : original scalar operator's mapping column ref.
+     * @param newInput      : the new scalar operator to rewrite.
+     * @return              : return a new scalar operator that is rewritten by newInput and replace.
+     */
+    ScalarOperator rewrite(RewriteEquivalentContext eqContext,
+                           EquivalentShuttleContext shuttleContext,
+                           ColumnRefOperator replace,
+                           ScalarOperator newInput);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/RewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/RewriteEquivalent.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+import java.util.List;
+import java.util.Map;
+
+public class RewriteEquivalent {
+    public static final List<IRewriteEquivalent> EQUIVALENTS = Lists.newArrayList(
+            TimeSliceRewriteEquivalent.INSTANCE,
+            DateTruncEquivalent.INSTANCE,
+            CountRewriteEquivalent.INSTANCE,
+            BitmapRewriteEquivalent.INSTANCE);
+    private final IRewriteEquivalent.RewriteEquivalentContext rewriteEquivalentContext;
+    private final IRewriteEquivalent iRewriteEquivalent;
+
+
+    public RewriteEquivalent(IRewriteEquivalent.RewriteEquivalentContext rewriteEquivalentContext,
+                             IRewriteEquivalent iRewriteEquivalent,
+                             ColumnRefOperator replace) {
+        this.rewriteEquivalentContext = rewriteEquivalentContext;
+        this.iRewriteEquivalent = iRewriteEquivalent;
+        this.rewriteEquivalentContext.setReplace(replace);
+    }
+
+    public IRewriteEquivalent.RewriteEquivalentContext getEquivalentContext() {
+        return rewriteEquivalentContext;
+    }
+
+    public IRewriteEquivalent.RewriteEquivalentType getRewriteEquivalentType() {
+        return this.iRewriteEquivalent.getRewriteEquivalentType();
+    }
+
+    public ScalarOperator rewrite(EquivalentShuttleContext shuttleContext,
+                                  Map<ColumnRefOperator, ColumnRefOperator> columnMapping,
+                                  ScalarOperator newInput) {
+        if (columnMapping == null) {
+            return this.iRewriteEquivalent.rewrite(this.rewriteEquivalentContext,
+                    shuttleContext, rewriteEquivalentContext.getReplace(), newInput);
+        } else {
+            ColumnRefOperator oldReplace = rewriteEquivalentContext.getReplace();
+            if (!columnMapping.containsKey(oldReplace)) {
+                return null;
+            }
+            ColumnRefOperator target = columnMapping.get(oldReplace);
+            return this.iRewriteEquivalent.rewrite(this.rewriteEquivalentContext,
+                    shuttleContext, target, newInput);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceRewriteEquivalent.java
@@ -11,38 +11,25 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
 
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+// mv:    SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table
+// query: SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table WHERE dt > '2023-06-01'
+// if '2023-06-01'=time_slice('2023-06-01', INTERVAL 5 MINUTE), can replace predicate dt => t
+public class TimeSliceRewriteEquivalent extends IPredicateRewriteEquivalent {
+    public static TimeSliceRewriteEquivalent INSTANCE = new TimeSliceRewriteEquivalent();
 
-public class TimeSliceReplaceChecker implements IRewriteEquivalent {
-    public static final TimeSliceReplaceChecker INSTANCE = new TimeSliceReplaceChecker();
-
-    private CallOperator mvTimeSlice;
-
-    public TimeSliceReplaceChecker() {}
-
-    public TimeSliceReplaceChecker(CallOperator mvTimeSlice) {
-        this.mvTimeSlice = mvTimeSlice;
-    }
-
-    @Override
-    public boolean isEquivalent(ScalarOperator operator) {
-        if (mvTimeSlice == null) {
-            return false;
-        }
-        if (!operator.isConstantRef()) {
-            return false;
-        }
-        return isEquivalent(mvTimeSlice, (ConstantOperator) operator);
-    }
+    public TimeSliceRewriteEquivalent() {}
 
     @Override
     public boolean isEquivalent(ScalarOperator op1, ConstantOperator op2) {
@@ -69,5 +56,41 @@ public class TimeSliceReplaceChecker implements IRewriteEquivalent {
         } catch (AnalysisException e) {
             return false;
         }
+    }
+
+    @Override
+    public RewriteEquivalentContext prepare(ScalarOperator input) {
+        if (input == null || !(input instanceof CallOperator)) {
+            return null;
+        }
+        CallOperator func = (CallOperator) input;
+        if (!func.getFnName().equals(FunctionSet.TIME_SLICE)) {
+            return null;
+        }
+        if (!func.getChild(0).isColumnRef()) {
+            return null;
+        }
+        return new RewriteEquivalentContext(func.getChild(0), input);
+    }
+
+    @Override
+    public ScalarOperator rewrite(RewriteEquivalentContext eqContext,
+                                  EquivalentShuttleContext shuttleContext,
+                                  ColumnRefOperator replace,
+                                  ScalarOperator newInput) {
+        if (!(newInput instanceof BinaryPredicateOperator)) {
+            return null;
+        }
+        ScalarOperator left = newInput.getChild(0);
+        ScalarOperator right = newInput.getChild(1);
+        if (!right.isConstantRef() || !left.equals(eqContext.getEquivalent())) {
+            return null;
+        }
+        if (!isEquivalent(eqContext.getInput(), (ConstantOperator) right)) {
+            return null;
+        }
+        BinaryPredicateOperator predicate = (BinaryPredicateOperator) newInput.clone();
+        predicate.setChild(0, replace);
+        return predicate;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2758,6 +2758,71 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
+    public void testStrColumnCountDistinctToBitmapCount1() {
+        {
+            String mv = "select user_id, bitmap_union(bitmap_hash(user_name)) from user_tags group by user_id;";
+            testRewriteOK(mv, "select user_id, bitmap_union(bitmap_hash(user_name)) x from user_tags group by user_id;");
+            testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x from user_tags group by user_id;");
+            testRewriteOK(mv, "select user_id, count(distinct user_name) x from user_tags group by user_id;");
+        }
+
+        {
+            String mv = "select user_id, time, bitmap_union(bitmap_hash(user_name)) from user_tags group by user_id, time;";
+            testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x from user_tags group by user_id;");
+            testRewriteOK(mv, "select user_id, count(distinct user_name) x from user_tags group by user_id;");
+        }
+        {
+            String mv = "select user_id, time, bitmap_union(bitmap_hash(concat(user_name, \"|\"))) from user_tags group by user_id, time;";
+            testRewriteOK(mv, "select user_id, bitmap_union(bitmap_hash(concat(user_name, \"|\"))) x from user_tags group by user_id;");
+            testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(concat(user_name, \"|\")))) x from user_tags group by user_id;");
+            // rewrite count distinct to bitmap_count(bitmap_union(bitmap_hash(x)));
+            testRewriteOK(mv, "select user_id, count(distinct concat(user_name, \"|\")) x from user_tags group by user_id;");
+        }
+        {
+            String mv = "select user_id, tag_id, user_name from user_tags where user_id > 10;";
+            testRewriteOK(mv, "select user_id, bitmap_union(bitmap_hash(user_name)) x from user_tags where user_id > 10 group by user_id ;");
+            testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x from user_tags where user_id > 10 group by user_id;");
+            testRewriteOK(mv, "select user_id, count(distinct user_name) x from user_tags  where user_id > 10 group by user_id;");
+        }
+        {
+            String mv = "select user_id, tag_id, user_name from user_tags;";
+            testRewriteOK(mv, "select user_id, bitmap_union(bitmap_hash(user_name)) x from user_tags where user_id > 10 group by user_id ;");
+            testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x from user_tags where user_id > 10 group by user_id;");
+            testRewriteOK(mv, "select user_id, count(distinct user_name) x from user_tags group by user_id;");
+        }
+        {
+            String mv = "select user_id, count(user_name) from user_tags group by user_id;";
+            testRewriteFail(mv, "select user_id, bitmap_union(bitmap_hash(user_name)) x from user_tags where user_id > 10 group by user_id ;");
+            testRewriteFail(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x from user_tags where user_id > 10 group by user_id;");
+            testRewriteFail(mv, "select user_id, count(distinct user_name) x from user_tags group by user_id;");
+        }
+    }
+
+    @Test
+    public void testStrColumnCountDistinctToBitmapCount2() {
+        String mv = "select user_id, time, bitmap_union(bitmap_hash(user_name)), " +
+                "bitmap_union(bitmap_hash(concat(user_name, \"a\"))), " +
+                "bitmap_union(bitmap_hash(concat(user_name, \"b\"))), " +
+                "bitmap_union(bitmap_hash(concat(user_name, \"c\"))) from user_tags group by user_id, time;";
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        testRewriteOK(mv, "select user_id, bitmap_union(bitmap_hash(user_name)) x from user_tags group by user_id;");
+        testRewriteOK(mv, "select user_id, bitmap_count(bitmap_union(bitmap_hash(user_name))) x " +
+                "from user_tags group by user_id;");
+        // FIXME: MV Rewrite should take care cte reuse node later.
+        connectContext.getSessionVariable().setCboCteReuse(false);
+        testRewriteOK(mv, "select user_id, count(distinct user_name), " +
+                " count(distinct concat(user_name, \"a\")), count(distinct concat(user_name, \"b\"))," +
+                " count(distinct concat(user_name, \"c\"))  from user_tags group by user_id;");
+        testRewriteOK(mv, "select user_id, count(distinct user_name), " +
+                " count(distinct concat(user_name, \"a\")), count(distinct concat(user_name, \"b\"))," +
+                " count(distinct concat(user_name, \"c\"))  from user_tags group by user_id, time;");
+        testRewriteOK(mv, "select user_id, time, count(distinct user_name), " +
+                " count(distinct concat(user_name, \"a\")), count(distinct concat(user_name, \"b\"))," +
+                " count(distinct concat(user_name, \"c\"))  from user_tags group by user_id, time;");
+        connectContext.getSessionVariable().setCboCteReuse(true);
+    }
+
+    @Test
     public void testBitmapUnionCountToBitmapCount1() {
         String mv = "select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;";
         testRewriteOK(mv, "select user_id, bitmap_union_count(to_bitmap(tag_id)) x from user_tags group by user_id;");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -395,9 +395,13 @@ public class MaterializedViewTestBase extends PlanTestBase {
         return testRewriteOK(mv, query, null);
     }
 
-    protected MVRewriteChecker testRewriteOK(String mv, String query, String properties) {
+    protected MVRewriteChecker testRewriteOK(String mv, String query, String properties) throws RuntimeException {
         MVRewriteChecker fixture = new MVRewriteChecker(mv, query, properties);
-        return fixture.rewrite().ok();
+        MVRewriteChecker checker = fixture.rewrite();
+        if (checker.getException() != null) {
+            throw new RuntimeException(checker.getException());
+        }
+        return checker.ok();
     }
 
     protected MVRewriteChecker testRewriteFail(String mv, String query, String properties) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -427,6 +427,30 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     rollup: test_mv1");
         }
 
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d < '2023-08-02';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
         starRocksAssert.dropMaterializedView(mvName);
     }
 
@@ -1596,6 +1620,220 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     partitions=1/1\n" +
                     "     rollup: test_mv1");
         }
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewriteWithBitmapHash_LeftJoin() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(b) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, bitmap_union_count(bitmap_hash(t1.a)) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        {
+            String query = "select t1.d, t2.b, t3.c, count(distinct t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(distinct t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        {
+            String query = "select  t1.d, count(distinct t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "15:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+        starRocksAssert.dropMaterializedView(mvName);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
+    }
+    @Test
+    public void testStr2DateMVRefreshRewriteWithBitmapHash_InnerJoin() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(b) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, bitmap_union_count(bitmap_hash(t1.a)) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        {
+            String query = "select t1.d, t2.b, t3.c, count(distinct t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(distinct t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        {
+            String query = "select  t1.d, count(distinct t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "15:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView(mvName);
     }
 }


### PR DESCRIPTION

Why I'm doing:
- Only support bitmap_union(to_bitmap(x)) rewrite for count(distinct x) which x must be numeric column or string column that can be converted to numeric
- If column x is string column, we cannot rewrite bitmap_union(bitmap_hash(x)) for count distinct

What I'm doing:
- Support bitmap_hash for count(distinct x) rewrite
- Refactor `AggregateFunctionRewriter` into `IRewriteEquivalent` to support more cases.
```
-- MV
select user_id, bitmap_union(bitmap_hash(user_name)) from user_tags group by user_id;
-- Query
select user_id, count(distinct user_name) x from user_tags group by user_id;
```
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
