### PR TITLE
[Enhancement] Implement append_shallow_copy for NullalbeColumn

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -96,6 +96,11 @@ void AdaptiveNullableColumn::append(const Column& src, size_t offset, size_t cou
     NullableColumn::append(src, offset, count);
 }
 
+void AdaptiveNullableColumn::append_shallow_copy(const Column& src, size_t offset, size_t count) {
+    materialized_nullable();
+    NullableColumn::append_shallow_copy(src, offset, count);
+}
+
 void AdaptiveNullableColumn::append_selective(const Column& src, const uint32_t* indexes, uint32_t from,
                                               uint32_t size) {
     materialized_nullable();

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -268,6 +268,8 @@ public:
 
     void append(const Column& src, size_t offset, size_t count) override;
 
+    void append_shallow_copy(const Column& src, size_t offset, size_t count) override;
+
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -131,8 +131,6 @@ void NullableColumn::append_value_multiple_times(const Column& src, uint32_t ind
 }
 
 void NullableColumn::append_shallow_copy(const Column& src, size_t offset, size_t count) {
-    DCHECK_EQ(_null_column->size(), _data_column->size());
-
     if (src.only_null()) {
         append_nulls(count);
     } else if (src.is_nullable()) {

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -130,6 +130,27 @@ void NullableColumn::append_value_multiple_times(const Column& src, uint32_t ind
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
+void NullableColumn::append_shallow_copy(const Column& src, size_t offset, size_t count) {
+    DCHECK_EQ(_null_column->size(), _data_column->size());
+
+    if (src.only_null()) {
+        append_nulls(count);
+    } else if (src.is_nullable()) {
+        const auto& c = down_cast<const NullableColumn&>(src);
+
+        DCHECK_EQ(c._null_column->size(), c._data_column->size());
+
+        _null_column->append(*c._null_column, offset, count);
+        _data_column->append_shallow_copy(*c._data_column, offset, count);
+        _has_null = _has_null || SIMD::contain_nonzero(c._null_column->get_data(), offset, count);
+    } else {
+        _null_column->resize(_null_column->size() + count);
+        _data_column->append_shallow_copy(src, offset, count);
+    }
+
+    DCHECK_EQ(_null_column->size(), _data_column->size());
+}
+
 ColumnPtr NullableColumn::replicate(const std::vector<uint32_t>& offsets) {
     return NullableColumn::create(this->_data_column->replicate(offsets),
                                   std::dynamic_pointer_cast<NullColumn>(this->_null_column->replicate(offsets)));

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -142,6 +142,8 @@ public:
 
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
+    void append_shallow_copy(const Column& src, size_t offset, size_t count) override;
+
     bool append_nulls(size_t count) override;
 
     StatusOr<ColumnPtr> upgrade_if_overflow() override;


### PR DESCRIPTION
Avoid deep copy for bitmap column(nullable)

```
CREATE TABLE `t1` (
  `c1` int(11) NULL COMMENT "",
  `c2` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"compression" = "LZ4"
);

mysql> select c1, bitmap_count(c2) from t1;
+----------+------------------+
| c1       | bitmap_count(c2) |
+----------+------------------+
| 19980802 |            12416 |
+----------+------------------+
1 row in set (0.01 sec)

select count(*) from lineorder join [broadcast] t1 where bitmap_contains(c2, lo_orderkey) and lo_orderkey<10000
```

before optimization: 
* Time: 11.223s 
* PeakMem: 230M

After optimization:
* Time: 0.048s
* PeakMem: 3.5M


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
