### PR TITLE
[BugFix] Fix core in cocurrent schema change and load

### DIFF
--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -47,7 +47,6 @@ void MetaFileBuilder::append_delvec(const DelVectorPtr& delvec, uint32_t segment
         delvec->save_to(&delvec_str);
         _buf.insert(_buf.end(), delvec_str.begin(), delvec_str.end());
         const uint64_t size = _buf.size() - offset;
-        DCHECK(_delvecs.find(segment_id) == _delvecs.end());
         _delvecs[segment_id].set_offset(offset);
         _delvecs[segment_id].set_size(size);
         _segmentid_to_delvec[segment_id] = delvec;


### PR DESCRIPTION
Multiple txn logs will be applied If there are concurrent schema changes and loads. There will be multiple delvecs of a segment. So the check should be removed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
