### PR TITLE
[Feature] support more scene for CrossJoin RuntimeFilter

### DIFF
--- a/be/src/exec/olap_scan_prepare.h
+++ b/be/src/exec/olap_scan_prepare.h
@@ -82,6 +82,9 @@ private:
     void normalize_binary_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
 
     template <LogicalType SlotType, typename RangeValueType>
+    void normalize_bitmap_predicate(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
+
+    template <LogicalType SlotType, typename RangeValueType>
     void normalize_join_runtime_filter(const SlotDescriptor& slot, ColumnValueRange<RangeValueType>* range);
 
     template <LogicalType SlotType, typename RangeValueType>

--- a/be/src/exprs/column_ref.cpp
+++ b/be/src/exprs/column_ref.cpp
@@ -52,7 +52,7 @@ StatusOr<ColumnPtr> ColumnRef::evaluate_checked(ExprContext* context, Chunk* ptr
 }
 
 ColumnPtr& ColumnRef::get_column(Expr* expr, Chunk* chunk) {
-    auto* ref = (ColumnRef*)expr;
+    auto* ref = down_cast<ColumnRef*>(expr);
     ColumnPtr& column = (chunk)->get_column_by_slot_id(ref->slot_id());
     return column;
 }

--- a/be/src/exprs/expr.h
+++ b/be/src/exprs/expr.h
@@ -61,6 +61,7 @@ struct UserFunctionCacheEntry;
 class Chunk;
 class ColumnRef;
 class ColumnPredicateRewriter;
+class ExprRewriter;
 
 // This is the superclass of all expr evaluation nodes.
 class Expr {
@@ -220,6 +221,7 @@ protected:
     friend class Literal;
     friend class ExprContext;
     friend class ColumnPredicateRewriter;
+    friend class ExprRewriter;
 
     explicit Expr(TypeDescriptor type);
     explicit Expr(const TExprNode& node);

--- a/be/src/exprs/expr_rewriter.h
+++ b/be/src/exprs/expr_rewriter.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/object_pool.h"
+#include "exprs/expr.h"
+
+namespace starrocks {
+class ExprRewriter {
+public:
+    ExprRewriter(ObjectPool* pool, Expr* expr) : _pool(pool), _expr(expr) {}
+    // rewrite
+    template <class Rewriter>
+    StatusOr<Expr*> rewrite(Rewriter&& rewriter) {
+        return _rewrite(rewriter, _expr, _pool);
+    }
+
+private:
+    template <class Rewriter>
+    StatusOr<Expr*> _rewrite(Rewriter&& rewriter, Expr* expr, ObjectPool* pool) {
+        auto& children = expr->_children;
+        ASSIGN_OR_RETURN(expr, rewriter(expr, pool));
+        DCHECK(expr->children().empty());
+        for (auto child : children) {
+            ASSIGN_OR_RETURN(auto new_child, _rewrite(rewriter, child, pool));
+            expr->add_child(new_child);
+        }
+        return expr;
+    }
+
+    ObjectPool* _pool;
+    Expr* _expr;
+};
+} // namespace starrocks

--- a/be/src/exprs/literal.h
+++ b/be/src/exprs/literal.h
@@ -32,6 +32,8 @@ public:
 
     std::string debug_string() const override;
 
+    ColumnPtr value() const { return _value; }
+
 private:
     // @IMPORTANT: BinaryColumnPtr's build_slice will cause multi-thread(OLAP_SCANNER) crash
     ColumnPtr _value;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/NestLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/NestLoopJoinNode.java
@@ -58,7 +58,6 @@ public class NestLoopJoinNode extends JoinNode implements RuntimeFilterBuildNode
         if (!joinOp.isInnerJoin() && !joinOp.isLeftSemiJoin() && !joinOp.isRightJoin() && !joinOp.isCrossJoin()) {
             return;
         }
-
         if (!ConnectContext.get().getSessionVariable().isEnableCrossJoinRuntimeFilter()) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -318,6 +318,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GLOBAL_RUNTIME_FILTER_PROBE_MIN_SELECTIVITY =
             "global_runtime_filter_probe_min_selectivity";
     public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
+    public static final String ENABLE_CROSS_JOIN_RUNTIME_FILTER = "enable_cross_join_runtime_filter";
 
     public static final String ENABLE_COLUMN_EXPR_PREDICATE = "enable_column_expr_predicate";
     public static final String ENABLE_EXCHANGE_PASS_THROUGH = "enable_exchange_pass_through";
@@ -1018,6 +1019,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private float globalRuntimeFilterProbeMinSelectivity = 0.5f;
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY, flag = VariableMgr.INVISIBLE)
     private float runtimeFilterEarlyReturnSelectivity = 0.05f;
+
+    @VariableMgr.VarAttr(name = ENABLE_CROSS_JOIN_RUNTIME_FILTER)
+    private boolean enableCrossJoinRuntimeFilter = true;
 
     //In order to be compatible with the logic of the old planner,
     //When the column name is the same as the alias name,
@@ -2010,6 +2014,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public float getGlobalRuntimeFilterProbeMinSelectivity() {
         return globalRuntimeFilterProbeMinSelectivity;
+    }
+
+    public boolean isEnableCrossJoinRuntimeFilter() {
+        return enableCrossJoinRuntimeFilter;
     }
 
     public boolean isMVPlanner() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -403,7 +403,7 @@ class ParserTest {
         assertContains(res, "{'pipeline_dop', 'pipeline_sink_dop', 'pipeline_profile_level'}");
 
         res = VariableMgr.findSimilarVarNames("disable_joinreorder");
-        assertContains(res, "{'disable_join_reorder', 'disable_colocate_join', 'enable_predicate_reorder'}");
+        assertContains(res, "{'disable_join_reorder', 'disable_colocate_join', 'enable_cross_join_runtime_filter'}");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -319,7 +319,7 @@ public class NestLoopJoinTest extends PlanTestBase {
         assertVerbosePlanNotContains(sql, "  |  build runtime filters:");
 
         sql = "select * from t0 a join t0 b where a.v1 != b.v1";
-        assertVerbosePlanNotContains(sql, "  |  build runtime filters:");
+        assertVerbosePlanContains(sql, "  |  build runtime filters:");
 
         sql = "select * from t0 a join t0 b where a.v1 < a.v1 + b.v1";
         assertVerbosePlanNotContains(sql, "  |  build runtime filters:");

--- a/test/sql/test_join/R/test_cross_join_rf
+++ b/test/sql/test_join/R/test_cross_join_rf
@@ -73,3 +73,23 @@ select count(*) from t2 l join [broadcast] t3 r on l.c0 like concat('%',r.c0,'%'
 -- result:
 0
 -- !result
+create table t4 (
+    c0 int,
+    c1 bitmap BITMAP_UNION
+) AGGREGATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t4 values(1, to_bitmap(1));
+-- result:
+-- !result
+insert into t4 SELECT 2, to_bitmap(generate_series + 4096) FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+select count(*) from t0 l join [broadcast] t4 r on bitmap_contains(r.c1, l.c1) where r.c0 = 1;
+-- result:
+2
+-- !result
+select count(*) from t0 l join [broadcast] t4 r on bitmap_contains(r.c1, l.c1) where r.c0 = 2;
+-- result:
+0
+-- !result

--- a/test/sql/test_join/R/test_cross_join_rf
+++ b/test/sql/test_join/R/test_cross_join_rf
@@ -1,0 +1,75 @@
+-- name: test_cross_join_rf
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+create table t1 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+truncate table t1;
+-- result:
+-- !result
+insert into t1 values(1, 1);
+-- result:
+-- !result
+select count(*) from t0 l join [broadcast] t1 r on l.c0 <= r.c0;
+-- result:
+2
+-- !result
+select count(*) from t0 l join [broadcast] t1 r on r.c0 >= l.c0;
+-- result:
+2
+-- !result
+truncate table t1;
+-- result:
+-- !result
+insert into t1 values(NULL, NULL);
+-- result:
+-- !result
+select count(*) from t0 l join [broadcast] t1 r on l.c0 <= r.c0;
+-- result:
+0
+-- !result
+select count(*) from t0 l join [broadcast] t1 r on r.c0 >= l.c0;
+-- result:
+0
+-- !result
+select count(*) from t0 l join [broadcast] t1 r on l.c0 <= r.c0 and l.c0 >= r.c0;
+-- result:
+0
+-- !result
+create table t2 (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+create table t3 (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t2 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t3 values (9, 9)
+select count(*) from t2 l join [broadcast] t3 r on l.c0 like r.c0;
+-- result:
+E: (1064, "Getting syntax error at line 2, column 0. Detail message: Unexpected input 'select', the most similar input is {<EOF>, ';'}.")
+-- !result
+select count(*) from t2 l join [broadcast] t3 r on l.c0 like concat('%',r.c0,'%');
+-- result:
+0
+-- !result

--- a/test/sql/test_join/T/test_cross_join_rf
+++ b/test/sql/test_join/T/test_cross_join_rf
@@ -1,0 +1,41 @@
+-- name: test_cross_join_rf
+-- prepare probe table
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+insert into t0 select * from t0;
+-- prepare build table t1
+create table t1 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- nullable
+truncate table t1;
+insert into t1 values(1, 1);
+select count(*) from t0 l join [broadcast] t1 r on l.c0 <= r.c0;
+select count(*) from t0 l join [broadcast] t1 r on r.c0 >= l.c0;
+
+-- nullable only null
+truncate table t1;
+insert into t1 values(NULL, NULL);
+select count(*) from t0 l join [broadcast] t1 r on l.c0 <= r.c0;
+select count(*) from t0 l join [broadcast] t1 r on r.c0 >= l.c0;
+
+-- multi predicate
+select count(*) from t0 l join [broadcast] t1 r on l.c0 <= r.c0 and l.c0 >= r.c0;
+
+create table t2 (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+create table t3 (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t2 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+insert into t3 values (9, 9)
+-- special string expr
+select count(*) from t2 l join [broadcast] t3 r on l.c0 like r.c0;
+select count(*) from t2 l join [broadcast] t3 r on l.c0 like concat('%',r.c0,'%');

--- a/test/sql/test_join/T/test_cross_join_rf
+++ b/test/sql/test_join/T/test_cross_join_rf
@@ -39,3 +39,12 @@ insert into t3 values (9, 9)
 -- special string expr
 select count(*) from t2 l join [broadcast] t3 r on l.c0 like r.c0;
 select count(*) from t2 l join [broadcast] t3 r on l.c0 like concat('%',r.c0,'%');
+-- bitmap case
+create table t4 (
+    c0 int,
+    c1 bitmap BITMAP_UNION
+) AGGREGATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t4 values(1, to_bitmap(1));
+insert into t4 SELECT 2, to_bitmap(generate_series + 4096) FROM TABLE(generate_series(1,  4096));
+select count(*) from t0 l join [broadcast] t4 r on bitmap_contains(r.c1, l.c1) where r.c0 = 1;
+select count(*) from t0 l join [broadcast] t4 r on bitmap_contains(r.c1, l.c1) where r.c0 = 2;


### PR DESCRIPTION
1. The order relationship of cross join predicate child is no longer required

eg:
```
select count(*) from lineorder join [broadcast] t1 where bitmap_contains(bitmap_or(c2,to_bitmap(lo_orderkey)), lo_orderkey);
```
test 1:
```
mysql> set pipeline_dop=16;
Query OK, 0 rows affected (0.00 sec)

mysql>  select * from lineorderx2 join t4 on bitmap_contains(c1,lo_orderkey);
+-------------+---------------+------+------+
| lo_orderkey | lo_linenumber | c0   | c1   |
+-------------+---------------+------+------+
|           1 |             1 |    1 | NULL |
|           1 |             2 |    1 | NULL |
|           1 |             3 |    1 | NULL |
|           1 |             4 |    1 | NULL |
|           1 |             5 |    1 | NULL |
|           1 |             6 |    1 | NULL |
+-------------+---------------+------+------+
6 rows in set (6.77 sec)

mysql> set enable_cross_join_runtime_filter=true;
Query OK, 0 rows affected (0.00 sec)

mysql>  select * from lineorderx2 join t4 on bitmap_contains(c1,lo_orderkey);
+-------------+---------------+------+------+
| lo_orderkey | lo_linenumber | c0   | c1   |
+-------------+---------------+------+------+
|           1 |             1 |    1 | NULL |
|           1 |             2 |    1 | NULL |
|           1 |             3 |    1 | NULL |
|           1 |             4 |    1 | NULL |
|           1 |             5 |    1 | NULL |
|           1 |             6 |    1 | NULL |
+-------------+---------------+------+------+
6 rows in set (0.82 sec)
```
push down bitmap to storage:
```
mysql>  select * from lineorderx2 join t4 on bitmap_contains(c1,lo_orderkey);
+-------------+---------------+------+------+
| lo_orderkey | lo_linenumber | c0   | c1   |
+-------------+---------------+------+------+
|           1 |             1 |    1 | NULL |
|           1 |             2 |    1 | NULL |
|           1 |             3 |    1 | NULL |
|           1 |             4 |    1 | NULL |
|           1 |             5 |    1 | NULL |
|           1 |             6 |    1 | NULL |
+-------------+---------------+------+------+
6 rows in set (0.04 sec)
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
