### PR TITLE
[BugFix] Fix BE slot leak

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -219,6 +219,17 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
             return;
         }
 
+        // Double check if task has been abandoned
+        if (!routineLoadManager.checkTaskInJob(routineLoadTaskInfo.getId())) {
+            releaseBeSlot(routineLoadTaskInfo);
+            // task has been abandoned while renew task has been added in queue
+            // or database has been deleted
+            LOG.warn(new LogBuilder(LogKey.ROUTINE_LOAD_TASK, routineLoadTaskInfo.getId())
+                    .add("error_msg", "task has been abandoned after BE was allocated")
+                    .build());
+            return;
+        }
+
         // begin txn
         try {
             routineLoadTaskInfo.beginTxn();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -48,6 +48,7 @@ import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.LogBuilder;
 import com.starrocks.common.util.LogKey;
 import com.starrocks.load.routineload.RoutineLoadJob.JobState;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.BackendService;
@@ -112,6 +113,7 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
         updateBackendSlotIfNecessary();
 
         int idleSlotNum = routineLoadManager.getClusterIdleSlotNum();
+        MetricRepo.GAUGE_ROUTINE_LOAD_IDLE_SLOT_NUM.setValue((long) idleSlotNum);
         // scheduler will be blocked when there is no slot for task in cluster
         if (idleSlotNum <= 0) {
             LOG.warn("no available be slot to scheduler tasks, wait for {} seconds to scheduler again, " +

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -152,6 +152,7 @@ public final class MetricRepo {
     public static GaugeMetricImpl<Long> GAUGE_MAX_TABLET_COMPACTION_SCORE;
     public static GaugeMetricImpl<Long> GAUGE_STACKED_JOURNAL_NUM;
 
+    public static GaugeMetricImpl<Long> GAUGE_ROUTINE_LOAD_IDLE_SLOT_NUM;
     public static List<GaugeMetricImpl<Long>> GAUGE_ROUTINE_LOAD_LAGS;
 
     // Currently, we use gauge for safe mode metrics, since we do not have unTyped metrics till now
@@ -310,6 +311,11 @@ public final class MetricRepo {
                 "editlog_stacked_num", MetricUnit.OPERATIONS, "counter of edit log that are stacked");
         GAUGE_STACKED_JOURNAL_NUM.setValue(0L);
         STARROCKS_METRIC_REGISTER.addMetric(GAUGE_STACKED_JOURNAL_NUM);
+
+        GAUGE_ROUTINE_LOAD_IDLE_SLOT_NUM = new GaugeMetricImpl<>("routine_load_idle_slot_num", MetricUnit.OPERATIONS,
+                "idle slot num for routine load");
+        GAUGE_ROUTINE_LOAD_IDLE_SLOT_NUM.setValue(0L);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_ROUTINE_LOAD_IDLE_SLOT_NUM);
 
         GAUGE_QUERY_LATENCY_MEAN =
                 new GaugeMetricImpl<>("query_latency", MetricUnit.MILLISECONDS, "mean of query latency");


### PR DESCRIPTION
Fixes #33549

If BE was allocated to routine load task but `routineLoadTaskInfoList` was cleared before, allocated BE for this task won't be released.

Double check in this PR will fix this issue.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
