### PR TITLE
[BugFix] Fix ConstColumn::append_nulls

### DIFF
--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -111,9 +111,10 @@ public:
     ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
 
     bool append_nulls(size_t count) override {
+        DCHECK_GT(count, 0);
         if (_data->is_nullable()) {
             bool ok = true;
-            if (count > 0 && _size == 0) {
+            if (_size == 0) {
                 ok = _data->append_nulls(1);
             }
             _size += count;

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -113,10 +113,10 @@ public:
     bool append_nulls(size_t count) override {
         if (_data->is_nullable()) {
             bool ok = true;
-            if (_size == 0) {
+            if (count > 0 && _size == 0) {
                 ok = _data->append_nulls(1);
             }
-            _size += ok;
+            _size += count;
             return ok;
         } else {
             return false;

--- a/test/sql/test_window_function/R/test_leadlag_window_function
+++ b/test/sql/test_window_function/R/test_leadlag_window_function
@@ -1,0 +1,154 @@
+-- name: test_cume_window_function
+CREATE TABLE `t1` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NOT NULL,
+  `v4` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (1, 1, 1, NULL),
+    (1, 1, 2, NULL),
+    (1, NULL, 3, NULL),
+    (1, NULL, 4, NULL),
+    (1, 2, 5, NULL),
+    (1, 2, 6, NULL),
+    (1, NULL, 7, NULL),
+    (1, NULL, 8, NULL),
+    (2, 3, 9, NULL),
+    (2, 3, 10, NULL),
+    (2, NULL, 11, NULL),
+    (2, NULL, 12, NULL),
+    (2, 4, 13, NULL),
+    (2, 4, 14, NULL),
+    (2, NULL, 15, NULL),
+    (2, NULL, 16, NULL),
+    (NULL, 3, 17, NULL),
+    (NULL, 3, 18, NULL),
+    (NULL, NULL, 19, NULL),
+    (NULL, NULL, 20, NULL),
+    (NULL, 4, 21, NULL),
+    (NULL, 4, 22, NULL),
+    (NULL, NULL, 23, NULL),
+    (NULL, NULL, 24, NULL);
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (101, 101, 101, NULL),
+    (101, 101, 102, NULL),
+    (101, NULL, 103, NULL),
+    (101, NULL, 104, NULL),
+    (101, 102, 105, NULL),
+    (101, 102, 106, NULL),
+    (101, NULL, 107, NULL),
+    (101, NULL, 108, NULL),
+    (102, 103, 109, NULL),
+    (102, 103, 110, NULL),
+    (102, NULL, 111, NULL),
+    (102, NULL, 112, NULL),
+    (102, 104, 113, NULL),
+    (102, 104, 114, NULL),
+    (102, NULL, 115, NULL),
+    (102, NULL, 116, NULL),
+    (NULL, 103, 117, NULL),
+    (NULL, 103, 118, NULL),
+    (NULL, NULL, 119, NULL),
+    (NULL, NULL, 120, NULL),
+    (NULL, 104, 121, NULL),
+    (NULL, 104, 122, NULL),
+    (NULL, NULL, 123, NULL),
+    (NULL, NULL, 124, NULL);
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+INSERT INTO `t1` SELECT * FROM `t1`;
+-- result:
+-- !result
+CREATE TABLE `t5` (
+  `v1` decimal64(18,5) NULL,
+  `v2` decimal64(18,5) NULL,
+  `v3` decimal64(18,5) NOT NULL,
+  `v4` decimal64(18,5) NOT NULL,
+  `v5` decimal64(18,5) NOT NULL,
+  `v6` decimal64(18,5) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO `t5` (v1, v2, v3, v4, v5, v6)
+SELECT v1, v2, v3,
+row_number() OVER (ORDER BY v1, v2, v3, v4) as v4,
+row_number() OVER (PARTITION BY v1 ORDER BY v2, v3, v4) as v5,
+1 as v6
+FROM `t1`;
+-- result:
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lead(v3, 1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+-- result:
+2467893.00000	12.54680088462	1.00000	124.00000
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lead(v3) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+-- result:
+2467893.00000	12.54680088462	1.00000	124.00000
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lead(v3, 10, -1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+-- result:
+2463672.00000	12.52476817960	-1.00000	124.00000
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lag(v3, 1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+-- result:
+2467820.00000	12.54642975165	1.00000	124.00000
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lag(v3) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+-- result:
+2467820.00000	12.54642975165	1.00000	124.00000
+-- !result
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lag(v3, 10, -1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+-- result:
+2462926.00000	12.52097567919	-1.00000	124.00000
+-- !result

--- a/test/sql/test_window_function/T/test_leadlag_window_function
+++ b/test/sql/test_window_function/T/test_leadlag_window_function
@@ -1,0 +1,108 @@
+-- name: test_cume_window_function
+CREATE TABLE `t1` (
+  `v1` int(11) NULL,
+  `v2` int(11) NULL,
+  `v3` int(11) NOT NULL,
+  `v4` int(11) NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (1, 1, 1, NULL),
+    (1, 1, 2, NULL),
+    (1, NULL, 3, NULL),
+    (1, NULL, 4, NULL),
+    (1, 2, 5, NULL),
+    (1, 2, 6, NULL),
+    (1, NULL, 7, NULL),
+    (1, NULL, 8, NULL),
+    (2, 3, 9, NULL),
+    (2, 3, 10, NULL),
+    (2, NULL, 11, NULL),
+    (2, NULL, 12, NULL),
+    (2, 4, 13, NULL),
+    (2, 4, 14, NULL),
+    (2, NULL, 15, NULL),
+    (2, NULL, 16, NULL),
+    (NULL, 3, 17, NULL),
+    (NULL, 3, 18, NULL),
+    (NULL, NULL, 19, NULL),
+    (NULL, NULL, 20, NULL),
+    (NULL, 4, 21, NULL),
+    (NULL, 4, 22, NULL),
+    (NULL, NULL, 23, NULL),
+    (NULL, NULL, 24, NULL);
+
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+
+INSERT INTO `t1` (v1, v2, v3, v4) values
+    (101, 101, 101, NULL),
+    (101, 101, 102, NULL),
+    (101, NULL, 103, NULL),
+    (101, NULL, 104, NULL),
+    (101, 102, 105, NULL),
+    (101, 102, 106, NULL),
+    (101, NULL, 107, NULL),
+    (101, NULL, 108, NULL),
+    (102, 103, 109, NULL),
+    (102, 103, 110, NULL),
+    (102, NULL, 111, NULL),
+    (102, NULL, 112, NULL),
+    (102, 104, 113, NULL),
+    (102, 104, 114, NULL),
+    (102, NULL, 115, NULL),
+    (102, NULL, 116, NULL),
+    (NULL, 103, 117, NULL),
+    (NULL, 103, 118, NULL),
+    (NULL, NULL, 119, NULL),
+    (NULL, NULL, 120, NULL),
+    (NULL, 104, 121, NULL),
+    (NULL, 104, 122, NULL),
+    (NULL, NULL, 123, NULL),
+    (NULL, NULL, 124, NULL);
+
+INSERT INTO `t1` SELECT * FROM `t1`;
+INSERT INTO `t1` SELECT * FROM `t1`;
+
+CREATE TABLE `t5` (
+  `v1` decimal64(18,5) NULL,
+  `v2` decimal64(18,5) NULL,
+  `v3` decimal64(18,5) NOT NULL,
+  `v4` decimal64(18,5) NOT NULL,
+  `v5` decimal64(18,5) NOT NULL,
+  `v6` decimal64(18,5) NOT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+ "replication_num" = "1"
+);
+
+INSERT INTO `t5` (v1, v2, v3, v4, v5, v6)
+SELECT v1, v2, v3,
+row_number() OVER (ORDER BY v1, v2, v3, v4) as v4,
+row_number() OVER (PARTITION BY v1 ORDER BY v2, v3, v4) as v5,
+1 as v6
+FROM `t1`;
+
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lead(v3, 1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lead(v3) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lead(v3, 10, -1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lag(v3, 1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lag(v3) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;
+SELECT SUM(wv), AVG(wv), MIN(wv), MAX(wv) FROM (SELECT lag(v3, 10, -1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5) a;


### PR DESCRIPTION
## Background

This bug may lead to sql like this `SELECT lead(v3, 1) OVER(PARTITION BY v2 ORDER BY v4) AS wv FROM t5` to failed for `Row count of const column reach limit`, because the window process will go through `remove_unused_buffer_values` to cut the first n elements. There is how it works:

```cpp
ConstColumn::append_nulls(count) {
    _size+=1;
}

ConstColumn::remove_first_n_values(count) {
   _size-=count; // This may lead to overflow, because append_nulls only increase by 1 rather than the parameter count.
}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
