### PR TITLE
[BugFix] Tablet may store overlapping rowset versions in the metadata.

### DIFF
--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -287,7 +287,7 @@ protected:
                 << ", output rowset version:" << _output_rowset->version()
                 << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size()
                 << ", max_version:" << _tablet->max_continuous_version();
-        
+
         return Status::OK();
     }
 

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -287,6 +287,8 @@ protected:
                 << ", output rowset version:" << _output_rowset->version()
                 << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size()
                 << ", max_version:" << _tablet->max_continuous_version();
+        
+        return Status::OK();
     }
 
     void _success_callback();

--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -257,12 +257,11 @@ protected:
             // check input_rowsets exist. If not, tablet_meta maybe modify by some other thread, cancel this task
             for (auto& rowset : _input_rowsets) {
                 if (_tablet->get_rowset_by_version(rowset->version()) == nullptr) {
-                    std::string msg = strings::Substitute(
-                            "rowset: $1 is not exist in tablet:$2, maybe tablet meta is modify by other thread. cancel "
-                            "this compaction task",
-                            rowset->version().to_string(), _tablet->tablet_id());
-                    LOG(WANRING) << msg;
-                    return Status::InternalError(msg);
+                    input_stream_info << "rowset:" << rowset->version()
+                                      << " is not exist in tablet:" << _tablet->tablet_id()
+                                      << ", maybe tablet meta is modify by other thread. cancel this compaction task";
+                    LOG(WARNING) << input_stream_info.str();
+                    return Status::InternalError(input_stream_info.str());
                 }
             }
 

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -43,7 +43,7 @@ Status HorizontalCompactionTask::run_impl() {
     RETURN_IF_ERROR(_validate_compaction(statistics));
     TRACE("[Compaction] horizontal compaction validated");
 
-    _commit_compaction();
+    RETURN_IF_ERROR(_commit_compaction());
     TRACE("[Compaction] horizontal compaction committed");
 
     return Status::OK();

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -189,6 +189,12 @@ struct Version {
             return first > rhs.first;
         }
     }
+
+    std::string to_string() {
+        std::stringstream ss;
+        ss << "[" << version.first << "-" << version.second << "]";
+        return ss.str();
+    }
 };
 
 typedef std::vector<Version> Versions;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -189,12 +189,6 @@ struct Version {
             return first > rhs.first;
         }
     }
-
-    std::string to_string() {
-        std::stringstream ss;
-        ss << "[" << version.first << "-" << version.second << "]";
-        return ss.str();
-    }
 };
 
 typedef std::vector<Version> Versions;

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -43,7 +43,7 @@ Status VerticalCompactionTask::run_impl() {
     RETURN_IF_ERROR(_validate_compaction(statistics));
     TRACE("[Compaction] vertical compaction validated");
 
-    _commit_compaction();
+    RETURN_IF_ERROR(_commit_compaction());
     TRACE("[Compaction] vertical compaction committed");
 
     return Status::OK();


### PR DESCRIPTION
Tablet keeps all rowset version in `_rs_metas` and all rowset versions in `_rs_metas` should not be overlapping. But in some scenarios, `_rs_metas` may storage overlapping versions:
e.g.
1. One tablet keep the rowset version: [0-10],[11-11],[14-16],[17-20]. And we pick rowset [14-16] and [17-20] to do cumulative compaction and submit the task into compaction pool but not started execution yet.
2. Due to the lack of versions, a clone operation occurred on the source side and we hold compaction lock during clone which will block the execution of compaction task generated in step1. Because the rowset version [12-12][13-13] in source side have already been compacted, so the clone operation degrade to a full clone. And the `_rs_metas` storages [0-10], [11-13], [14-14], [15-15], [16-16], [17-20] after clone finished.
3. The compaction task in step1 start to execution. After compaction finished, it remove version [14-16][17-20] from `_rs_metas` and add verison [14-20]. The final `_rs_metas` became [0-10], [11-13], [14-14], [15-15], [16-16], [14-20], resulting in overlapping versions in `_rs_metas`.

The solution is we will check the input rowsets of compaction task exist or not after finish compaction task. If not, the tablet meta maybe modified by other thread, we will cancel this task.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
