### PR TITLE
[BugFix] unexpected set bad for restore replica (#33566)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -1435,10 +1435,10 @@ public class RestoreJob extends AbstractJob {
     protected void updateTablets(MaterializedIndex idx, PhysicalPartition part) {
         for (Tablet tablet : idx.getTablets()) {
             for (Replica replica : ((LocalTablet) tablet).getImmutableReplicas()) {
-                if (!replica.checkVersionCatchUp(part.getVisibleVersion(), false)) {
-                    replica.updateRowCount(part.getVisibleVersion(),
-                            replica.getDataSize(), replica.getRowCount());
-                }
+                // force update all info for all replica
+                replica.updateForRestore(part.getVisibleVersion(),
+                        replica.getDataSize(), replica.getRowCount());
+                replica.setLastReportVersion(part.getVisibleVersion());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Replica.java
@@ -398,6 +398,15 @@ public class Replica implements Writable {
                 this.lastSuccessVersion, this.minReadableVersion, dataSize, rowCount);
     }
 
+    public synchronized void updateForRestore(long newVersion, long newDataSize,
+                                              long newRowCount) {
+        this.version = newVersion;
+        this.lastFailedVersion = -1;
+        this.lastSuccessVersion = newVersion;
+        this.dataSize = newDataSize;
+        this.rowCount = newRowCount;
+    }
+
     /* last failed version:  LFV
      * last success version: LSV
      * version:              V


### PR DESCRIPTION
Problem:
suppose we have the restore table t_new, and t_old is the table before restore with the same schema. If we have `t_new.version < t_old.version`, we will lose some replicas cause of the unexpected set bad by tablet report. The reason is that the replica's last report version has not been reset in the restore process. It leads that be `version < replica.lastreportversion(t_old.version)`, all replicas will be set bad and can not be reset to normal state anymore.

Solution:
force reset replica info including the last report version if the restore table has already existed

Fixes #33566

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
