### PR TITLE
[Refactor] Remove tuple column from hash join

### DIFF
--- a/be/src/exec/hash_join_components.cpp
+++ b/be/src/exec/hash_join_components.cpp
@@ -74,7 +74,7 @@ void HashJoinBuilder::reset_probe(RuntimeState* state) {
     _ht.reset_probe_state(state);
 }
 
-Status HashJoinBuilder::append_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+Status HashJoinBuilder::append_chunk(const ChunkPtr& chunk) {
     if (UNLIKELY(_ht.get_row_count() + chunk->num_rows() >= max_hash_table_element_size)) {
         return Status::NotSupported(strings::Substitute("row count of right table in hash join > $0", UINT32_MAX));
     }
@@ -82,7 +82,7 @@ Status HashJoinBuilder::append_chunk(RuntimeState* state, const ChunkPtr& chunk)
     RETURN_IF_ERROR(_hash_joiner.prepare_build_key_columns(&_key_columns, chunk));
     // copy chunk of right table
     SCOPED_TIMER(_hash_joiner.build_metrics().copy_right_table_chunk_timer);
-    TRY_CATCH_BAD_ALLOC(_ht.append_chunk(state, chunk, _key_columns));
+    TRY_CATCH_BAD_ALLOC(_ht.append_chunk(chunk, _key_columns));
     return Status::OK();
 }
 

--- a/be/src/exec/hash_join_components.h
+++ b/be/src/exec/hash_join_components.h
@@ -59,7 +59,7 @@ public:
 
     void reset(const HashTableParam& param);
 
-    Status append_chunk(RuntimeState* state, const ChunkPtr& chunk);
+    Status append_chunk(const ChunkPtr& chunk);
 
     Status build(RuntimeState* state);
 

--- a/be/src/exec/hash_join_node.h
+++ b/be/src/exec/hash_join_node.h
@@ -111,7 +111,6 @@ private:
     std::set<SlotId> _output_slots;
 
     bool _is_push_down = false;
-    bool _need_create_tuple_columns = true;
 
     JoinHashTable _ht;
 
@@ -142,7 +141,6 @@ private:
     RuntimeProfile::Counter* _search_ht_timer = nullptr;
     RuntimeProfile::Counter* _output_build_column_timer = nullptr;
     RuntimeProfile::Counter* _output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* _output_tuple_column_timer = nullptr;
     RuntimeProfile::Counter* _build_rows_counter = nullptr;
     RuntimeProfile::Counter* _probe_rows_counter = nullptr;
     RuntimeProfile::Counter* _build_buckets_counter = nullptr;

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -19,17 +19,14 @@
 #include <memory>
 
 #include "column/column_helper.h"
-#include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exec/hash_join_components.h"
 #include "exec/spill/spiller.hpp"
 #include "exprs/column_ref.h"
 #include "exprs/expr.h"
-#include "exprs/runtime_filter_bank.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
-#include "runtime/runtime_filter_worker.h"
 #include "simd/simd.h"
 #include "util/debug_util.h"
 #include "util/runtime_profile.h"
@@ -40,7 +37,6 @@ void HashJoinProbeMetrics::prepare(RuntimeProfile* runtime_profile) {
     search_ht_timer = ADD_TIMER(runtime_profile, "SearchHashTableTime");
     output_build_column_timer = ADD_TIMER(runtime_profile, "OutputBuildColumnTime");
     output_probe_column_timer = ADD_TIMER(runtime_profile, "OutputProbeColumnTime");
-    output_tuple_column_timer = ADD_TIMER(runtime_profile, "OutputTupleColumnTime");
     probe_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "ProbeConjunctEvaluateTime");
     other_join_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "OtherJoinConjunctEvaluateTime");
     where_conjunct_evaluate_timer = ADD_TIMER(runtime_profile, "WhereConjunctEvaluateTime");
@@ -128,19 +124,16 @@ Status HashJoiner::prepare_prober(RuntimeState* state, RuntimeProfile* runtime_p
 
     auto& hash_table = _hash_join_builder->hash_table();
     hash_table.set_probe_profile(probe_metrics().search_ht_timer, probe_metrics().output_probe_column_timer,
-                                 probe_metrics().output_tuple_column_timer, probe_metrics().output_build_column_timer);
+                                 probe_metrics().output_build_column_timer);
 
     _hash_table_param.search_ht_timer = probe_metrics().search_ht_timer;
     _hash_table_param.output_build_column_timer = probe_metrics().output_build_column_timer;
     _hash_table_param.output_probe_column_timer = probe_metrics().output_probe_column_timer;
-    _hash_table_param.output_tuple_column_timer = probe_metrics().output_tuple_column_timer;
 
     return Status::OK();
 }
 
 void HashJoiner::_init_hash_table_param(HashTableParam* param) {
-    // Pipeline query engine always needn't create tuple columns
-    param->need_create_tuple_columns = false;
     param->with_other_conjunct = !_other_join_conjunct_ctxs.empty();
     param->join_type = _join_type;
     param->row_desc = &_row_descriptor;
@@ -169,7 +162,7 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
         }
     }
 }
-Status HashJoiner::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk) {
+Status HashJoiner::append_chunk_to_ht(const ChunkPtr& chunk) {
     if (_phase != HashJoinPhase::BUILD) {
         return Status::OK();
     }
@@ -178,7 +171,7 @@ Status HashJoiner::append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk
     }
 
     update_build_rows(chunk->num_rows());
-    RETURN_IF_ERROR(_hash_join_builder->append_chunk(state, chunk));
+    RETURN_IF_ERROR(_hash_join_builder->append_chunk(chunk));
 
     return Status::OK();
 }
@@ -260,7 +253,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
     auto& ht = _hash_join_builder->hash_table();
 
     if (_phase == HashJoinPhase::PROBE || !_hash_join_prober->probe_chunk_empty()) {
-        ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_chunk(state, &ht));
+        ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_chunk(state, &ht))
         return chunk;
     }
 
@@ -271,7 +264,7 @@ StatusOr<ChunkPtr> HashJoiner::_pull_probe_output_chunk(RuntimeState* state) {
         }
 
         bool has_remain = false;
-        ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_remain(state, &ht, &has_remain));
+        ASSIGN_OR_RETURN(chunk, _hash_join_prober->probe_remain(state, &ht, &has_remain))
 
         if (!has_remain) {
             enter_eos_phase();
@@ -322,7 +315,7 @@ void HashJoiner::reference_hash_table(HashJoiner* src_join_builder) {
     _hash_table_param = src_join_builder->hash_table_param();
     hash_table = src_join_builder->_hash_join_builder->hash_table().clone_readable_table();
     hash_table.set_probe_profile(probe_metrics().search_ht_timer, probe_metrics().output_probe_column_timer,
-                                 probe_metrics().output_tuple_column_timer, probe_metrics().output_build_column_timer);
+                                 probe_metrics().output_build_column_timer);
 
     // _hash_table_build_rows is root truth, it used to by _short_circuit_break().
     _hash_table_build_rows = src_join_builder->_hash_table_build_rows;
@@ -384,7 +377,7 @@ Status HashJoiner::_calc_filter_for_other_conjunct(ChunkPtr* chunk, Filter& filt
     filter.assign((*chunk)->num_rows(), 1);
 
     for (auto* ctx : _other_join_conjunct_ctxs) {
-        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate((*chunk).get()));
+        ASSIGN_OR_RETURN(ColumnPtr column, ctx->evaluate((*chunk).get()))
         size_t true_count = ColumnHelper::count_true_with_notnull(column);
 
         if (true_count == column->size()) {

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -140,7 +140,6 @@ inline bool is_spillable(TJoinOp::type join_type) {
 struct HashJoinProbeMetrics {
     RuntimeProfile::Counter* search_ht_timer = nullptr;
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* output_tuple_column_timer = nullptr;
     RuntimeProfile::Counter* probe_conjunct_evaluate_timer = nullptr;
     RuntimeProfile::Counter* other_join_conjunct_evaluate_timer = nullptr;
     RuntimeProfile::Counter* where_conjunct_evaluate_timer = nullptr;
@@ -200,7 +199,7 @@ public:
 
     void enter_eos_phase() { _phase = HashJoinPhase::EOS; }
     // build phase
-    [[nodiscard]] Status append_chunk_to_ht(RuntimeState* state, const ChunkPtr& chunk);
+    [[nodiscard]] Status append_chunk_to_ht(const ChunkPtr& chunk);
 
     [[nodiscard]] Status append_chunk_to_spill_buffer(RuntimeState* state, const ChunkPtr& chunk);
 

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -101,8 +101,6 @@ struct JoinHashTableItems {
     Columns key_columns;
     Buffer<HashTableSlotDescriptor> build_slots;
     Buffer<HashTableSlotDescriptor> probe_slots;
-    Buffer<TupleId> output_build_tuple_ids;
-    Buffer<TupleId> output_probe_tuple_ids;
     const RowDescriptor* row_desc;
     // A hash value is the bucket index of the hash map. "JoinHashTableItems.first" is the
     // buckets of the hash map, and it holds the index of the first key value saved in each bucket,
@@ -120,7 +118,6 @@ struct JoinHashTableItems {
     size_t build_column_count = 0;
     size_t probe_column_count = 0;
     bool with_other_conjunct = false;
-    bool need_create_tuple_columns = true;
     bool left_to_nullable = false;
     bool right_to_nullable = false;
     bool has_large_column = false;
@@ -175,10 +172,6 @@ struct HashTableProbeState {
     // 1: all match one
     JoinMatchFlag match_flag = JoinMatchFlag::NORMAL; // all match one
 
-    // true: generated chunk has null build tuple.
-    // e.g. left join and there is not matched row in build table
-    bool has_null_build_tuple = false;
-
     bool has_remain = false;
     // When one-to-many, one probe may not be able to probe all the data,
     // cur_probe_index records the position of the last probe
@@ -189,7 +182,6 @@ struct HashTableProbeState {
 
     RuntimeProfile::Counter* search_ht_timer = nullptr;
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* output_tuple_column_timer = nullptr;
     RuntimeProfile::Counter* output_build_column_timer = nullptr;
 
     HashTableProbeState() = default;
@@ -236,14 +228,12 @@ struct HashTableProbeState {
               count(rhs.count),
               probe_row_count(rhs.probe_row_count),
               match_flag(rhs.match_flag),
-              has_null_build_tuple(rhs.has_null_build_tuple),
               has_remain(rhs.has_remain),
               cur_probe_index(rhs.cur_probe_index),
               cur_row_match_count(rhs.cur_row_match_count),
               probe_pool(rhs.probe_pool == nullptr ? nullptr : std::make_unique<MemPool>()),
               search_ht_timer(rhs.search_ht_timer),
-              output_probe_column_timer(rhs.output_probe_column_timer),
-              output_tuple_column_timer(rhs.output_tuple_column_timer) {}
+              output_probe_column_timer(rhs.output_probe_column_timer) {}
 
     // Disable copy assignment.
     HashTableProbeState& operator=(const HashTableProbeState& rhs) = delete;
@@ -263,7 +253,6 @@ struct HashTableProbeState {
 
 struct HashTableParam {
     bool with_other_conjunct = false;
-    bool need_create_tuple_columns = true;
     TJoinOp::type join_type = TJoinOp::INNER_JOIN;
     const RowDescriptor* row_desc = nullptr;
     const RowDescriptor* build_row_desc = nullptr;
@@ -275,7 +264,6 @@ struct HashTableParam {
     RuntimeProfile::Counter* search_ht_timer = nullptr;
     RuntimeProfile::Counter* output_build_column_timer = nullptr;
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
-    RuntimeProfile::Counter* output_tuple_column_timer = nullptr;
 };
 
 template <class T>
@@ -612,11 +600,9 @@ public:
 
 private:
     void _probe_output(ChunkPtr* probe_chunk, ChunkPtr* chunk);
-    void _probe_tuple_output(ChunkPtr* probe_chunk, ChunkPtr* chunk);
     void _probe_null_output(ChunkPtr* chunk, size_t count);
 
     void _build_output(ChunkPtr* chunk);
-    void _build_tuple_output(ChunkPtr* chunk);
     void _build_default_output(ChunkPtr* chunk, size_t count);
 
     void _copy_probe_column(ColumnPtr* src_column, ChunkPtr* chunk, const SlotDescriptor* slot, bool to_nullable);
@@ -753,7 +739,6 @@ public:
     // and the different probe state from this.
     JoinHashTable clone_readable_table();
     void set_probe_profile(RuntimeProfile::Counter* search_ht_timer, RuntimeProfile::Counter* output_probe_column_timer,
-                           RuntimeProfile::Counter* output_tuple_column_timer,
                            RuntimeProfile::Counter* output_build_column_timer);
 
     void create(const HashTableParam& param);
@@ -765,7 +750,7 @@ public:
                                bool* eos);
     [[nodiscard]] Status probe_remain(RuntimeState* state, ChunkPtr* chunk, bool* eos);
 
-    void append_chunk(RuntimeState* state, const ChunkPtr& chunk, const Columns& key_columns);
+    void append_chunk(const ChunkPtr& chunk, const Columns& key_columns);
     // convert input column to spill schema order
     [[nodiscard]] StatusOr<ChunkPtr> convert_to_spill_schema(const ChunkPtr& chunk) const;
 
@@ -816,7 +801,6 @@ private:
     std::unique_ptr<JoinHashMapForFixedSizeKey(TYPE_LARGEINT)> _fixed128 = nullptr;
 
     JoinHashMapType _hash_map_type = JoinHashMapType::empty;
-    bool _need_create_tuple_columns = true;
 
     std::shared_ptr<JoinHashTableItems> _table_items;
     std::unique_ptr<HashTableProbeState> _probe_state = std::make_unique<HashTableProbeState>();

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -455,12 +455,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
             SCOPED_TIMER(_probe_state->output_build_column_timer);
             _build_output(chunk);
         }
-        {
-            SCOPED_TIMER(_probe_state->output_tuple_column_timer);
-            if (_table_items->need_create_tuple_columns) {
-                _build_tuple_output(chunk);
-            }
-        }
     } else if (_table_items->join_type == TJoinOp::LEFT_SEMI_JOIN ||
                _table_items->join_type == TJoinOp::LEFT_ANTI_JOIN ||
                _table_items->join_type == TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN) {
@@ -480,12 +474,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
                 _build_output(chunk);
             }
         }
-        {
-            SCOPED_TIMER(_probe_state->output_tuple_column_timer);
-            if (_table_items->need_create_tuple_columns) {
-                _probe_tuple_output(probe_chunk, chunk);
-            }
-        }
     } else {
         {
             SCOPED_TIMER(_probe_state->output_probe_column_timer);
@@ -494,13 +482,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         {
             SCOPED_TIMER(_probe_state->output_build_column_timer);
             _build_output(chunk);
-        }
-        {
-            SCOPED_TIMER(_probe_state->output_tuple_column_timer);
-            if (_table_items->need_create_tuple_columns) {
-                _probe_tuple_output(probe_chunk, chunk);
-                _build_tuple_output(chunk);
-            }
         }
     }
 }
@@ -518,22 +499,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe_remain(RuntimeState* state, Ch
         // right anti/semi join without other conjunct output default value of probe-columns as placeholder.
         _probe_null_output(chunk, _probe_state->count);
         _build_output(chunk);
-
-        if (_table_items->need_create_tuple_columns) {
-            _build_tuple_output(chunk);
-        }
     } else {
         // RIGHT_OUTER_JOIN || FULL_OUTER_JOIN
         _probe_null_output(chunk, _probe_state->count);
         _build_output(chunk);
-
-        if (_table_items->need_create_tuple_columns) {
-            for (int tuple_id : _table_items->output_probe_tuple_ids) {
-                ColumnPtr column = BooleanColumn::create(_probe_state->count, 0);
-                (*chunk)->append_tuple_column(column, tuple_id);
-            }
-            _build_tuple_output(chunk);
-        }
     }
 }
 
@@ -555,39 +524,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_output(ChunkPtr* probe_chunk,
             ColumnPtr default_column = ColumnHelper::create_column(slot->type(), column->is_nullable() || to_nullable);
             default_column->append_default(_probe_state->count);
             (*chunk)->append_column(std::move(default_column), slot->id());
-        }
-    }
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_tuple_output(ChunkPtr* probe_chunk, ChunkPtr* chunk) {
-    bool to_nullable = _table_items->left_to_nullable;
-
-    for (int tuple_id : _table_items->output_probe_tuple_ids) {
-        //TODO: only calc one time
-        if ((*probe_chunk)->is_tuple_exist(tuple_id)) {
-            ColumnPtr& src_column = (*probe_chunk)->get_tuple_column_by_id(tuple_id);
-            if (_probe_state->match_flag == JoinMatchFlag::ALL_MATCH_ONE) {
-                (*chunk)->append_tuple_column(src_column, tuple_id);
-            } else if (_probe_state->match_flag == JoinMatchFlag::MOST_MATCH_ONE) {
-                src_column->filter(_probe_state->probe_match_filter, _probe_state->probe_row_count);
-                (*chunk)->append_tuple_column(src_column, tuple_id);
-            } else {
-                ColumnPtr dest_column = BooleanColumn::create(_probe_state->count);
-                auto& src_data = ColumnHelper::as_raw_column<BooleanColumn>(src_column)->get_data();
-                auto& dest_data = ColumnHelper::as_raw_column<BooleanColumn>(dest_column)->get_data();
-
-                size_t end = _probe_state->count;
-                for (size_t i = 0; i < end; i++) {
-                    dest_data[i] = src_data[_probe_state->probe_index[i]];
-                }
-                (*chunk)->append_tuple_column(dest_column, tuple_id);
-            }
-        } else {
-            if (to_nullable) {
-                ColumnPtr dest_column = BooleanColumn::create(_probe_state->count, 1);
-                (*chunk)->append_tuple_column(dest_column, tuple_id);
-            }
         }
     }
 }
@@ -619,54 +555,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_build_output(ChunkPtr* chunk) {
             ColumnPtr default_column = ColumnHelper::create_column(slot->type(), column->is_nullable() || to_nullable);
             default_column->append_default(_probe_state->count);
             (*chunk)->append_column(std::move(default_column), slot->id());
-        }
-    }
-}
-
-template <LogicalType LT, class BuildFunc, class ProbeFunc>
-void JoinHashMap<LT, BuildFunc, ProbeFunc>::_build_tuple_output(ChunkPtr* chunk) {
-    // TODO: performance
-    // The function will be deleted when IfTupleIsNull is removed
-    bool to_nullable = _table_items->right_to_nullable;
-
-    for (int tuple_id : _table_items->output_build_tuple_ids) {
-        if (_table_items->build_chunk->is_tuple_exist(tuple_id)) {
-            // tuple column exist
-            ColumnPtr& src_column = _table_items->build_chunk->get_tuple_column_by_id(tuple_id);
-            auto& src_data = ColumnHelper::as_raw_column<BooleanColumn>(src_column)->get_data();
-            ColumnPtr dest_column = BooleanColumn::create(_probe_state->count);
-            auto& dest_data = ColumnHelper::as_raw_column<BooleanColumn>(dest_column)->get_data();
-            size_t row_count = _probe_state->count;
-
-            if (!_probe_state->has_null_build_tuple) {
-                // all match
-                for (size_t i = 0; i < row_count; i++) {
-                    dest_data[i] = src_data[_probe_state->build_index[i]];
-                }
-            } else {
-                for (size_t i = 0; i < row_count; i++) {
-                    dest_data[i] = (_probe_state->build_index[i] != 0) & src_data[_probe_state->build_index[i]];
-                }
-            }
-            (*chunk)->append_tuple_column(dest_column, tuple_id);
-        } else {
-            // tuple column not exist
-            if (to_nullable) {
-                if (!_probe_state->has_null_build_tuple) {
-                    // all match
-                    ColumnPtr dest_column = BooleanColumn::create(_probe_state->count, 1);
-                    (*chunk)->append_tuple_column(dest_column, tuple_id);
-                } else {
-                    ColumnPtr dest_column = BooleanColumn::create(_probe_state->count);
-                    auto& dest_data = ColumnHelper::as_raw_column<BooleanColumn>(dest_column)->get_data();
-
-                    size_t end = _probe_state->count;
-                    for (size_t i = 0; i < end; i++) {
-                        dest_data[i] = _probe_state->build_index[i] != 0;
-                    }
-                    (*chunk)->append_tuple_column(dest_column, tuple_id);
-                }
-            }
         }
     }
 }
@@ -1170,7 +1058,6 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
             _probe_state->probe_index[_probe_state->match_count] = i;
             _probe_state->build_index[_probe_state->match_count] = 0;
             _probe_state->match_count++;
-            _probe_state->has_null_build_tuple = true;
         } else if (cur_row_match_count > 1) {
             // one key of left table match multi key of right table
             _probe_state->cur_row_match_count = cur_row_match_count;
@@ -1217,7 +1104,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
             _probe_state->probe_index[match_count] = i;
             _probe_state->build_index[match_count] = 0;
             match_count++;
-            _probe_state->has_null_build_tuple = true;
 
             RETURN_IF_CHUNK_FULL()
         } else {
@@ -1237,7 +1123,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_join(R
                 _probe_state->probe_index[match_count] = i;
                 _probe_state->build_index[match_count] = 0;
                 match_count++;
-                _probe_state->has_null_build_tuple = true;
 
                 RETURN_IF_CHUNK_FULL()
             } else if (_probe_state->cur_row_match_count > 1) {
@@ -1282,7 +1167,6 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     // only the last coroutine does
     auto match_count = _probe_state->match_count;
     PROBE_OVER()
-    _probe_state->has_null_build_tuple = true;
 }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
@@ -1309,7 +1193,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join(Ru
     }
 
     PROBE_OVER()
-    _probe_state->has_null_build_tuple = true;
 }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
@@ -1372,7 +1255,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_anti_join(Ru
     }
 
     PROBE_OVER()
-    _probe_state->has_null_build_tuple = true;
 }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
@@ -1439,7 +1321,6 @@ HashTableProbeState::ProbeCoroutine JoinHashMap<LT, BuildFunc, ProbeFunc>::_prob
     // only the last coroutine does
     auto match_count = _probe_state->match_count;
     PROBE_OVER()
-    _probe_state->has_null_build_tuple = true;
 }
 
 template <LogicalType LT, class BuildFunc, class ProbeFunc>
@@ -1761,7 +1642,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_wi
         }
     }
 
-    _probe_state->has_null_build_tuple = true;
     PROBE_OVER()
 }
 
@@ -1792,7 +1672,6 @@ JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_semi_join_with_ot
         co_return;
     }
     // only the last coroutine does
-    _probe_state->has_null_build_tuple = true;
     auto match_count = _probe_state->match_count;
     PROBE_OVER()
 }
@@ -1887,7 +1766,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_j
             RETURN_IF_CHUNK_FULL()
         }
     }
-    _probe_state->has_null_build_tuple = true;
     PROBE_OVER()
 }
 
@@ -1967,7 +1845,6 @@ JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_null_aware_anti_join_w
         co_return;
     }
     // only the last coroutine does
-    _probe_state->has_null_build_tuple = true;
     auto match_count = _probe_state->match_count;
     PROBE_OVER()
 }
@@ -2090,7 +1967,6 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_a
         _probe_state->cur_row_match_count = 0;
     }
 
-    _probe_state->has_null_build_tuple = true;
     PROBE_OVER()
 }
 
@@ -2127,7 +2003,6 @@ JoinHashMap<LT, BuildFunc, ProbeFunc>::_probe_from_ht_for_left_outer_left_anti_f
         co_return;
     }
     // only the last coroutine does
-    _probe_state->has_null_build_tuple = true;
     auto match_count = _probe_state->match_count;
     PROBE_OVER()
 }

--- a/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/hash_join_build_operator.cpp
@@ -31,7 +31,7 @@ HashJoinBuildOperator::HashJoinBuildOperator(OperatorFactory* factory, int32_t i
           _distribution_mode(distribution_mode) {}
 
 Status HashJoinBuildOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
-    return _join_builder->append_chunk_to_ht(state, chunk);
+    return _join_builder->append_chunk_to_ht(chunk);
 }
 
 Status HashJoinBuildOperator::prepare(RuntimeState* state) {

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -257,7 +257,7 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(RuntimeState* 
         auto chunk_st = reader->restore(state, spill::SyncTaskExecutor{}, spill::MemTrackerGuard(tls_mem_tracker));
         if (chunk_st.ok() && chunk_st.value() != nullptr && !chunk_st.value()->is_empty()) {
             int64_t old_mem_usage = hash_table_mem_usage;
-            RETURN_IF_ERROR(builder->append_chunk(state, std::move(chunk_st.value())));
+            RETURN_IF_ERROR(builder->append_chunk(std::move(chunk_st.value())));
             hash_table_mem_usage = builder->hash_table_mem_usage();
             COUNTER_ADD(metrics.build_partition_peak_memory_usage, hash_table_mem_usage - old_mem_usage);
         } else if (chunk_st.status().is_end_of_file()) {


### PR DESCRIPTION
Tuple column is already not generated on pipeline-engine, and branch-main already disable pipeline engine, so remove the tuple column from hash join.

As long as users enable the pipeline engine, there will be no compatibility issues with the upgrade. 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
