### PR TITLE
[BugFix] Fix early return from bthreads::Future::wait_for

### DIFF
--- a/be/src/util/bthreads/future_impl.h
+++ b/be/src/util/bthreads/future_impl.h
@@ -114,8 +114,8 @@ protected:
                           std::chrono::ceil<std::chrono::system_clock::duration>(dur));
     }
 
-    template <typename Clock, typename Duration>
-    future_status wait_until(const std::chrono::time_point<Clock, Duration>& abs) {
+    template <typename Duration>
+    future_status wait_until(const std::chrono::time_point<std::chrono::system_clock, Duration>& abs) {
         int curr_status;
         timespec ts = TimespecFromTimePoint(abs);
         while ((curr_status = _status->load(butil::memory_order_acquire)) != Status::kReady) {

--- a/be/src/util/bthreads/future_impl.h
+++ b/be/src/util/bthreads/future_impl.h
@@ -110,8 +110,8 @@ protected:
     future_status wait_for(const std::chrono::duration<Rep, Period>& dur) {
         if (_status->load(butil::memory_order_acquire) == Status::kReady) return future_status::ready;
 
-        return wait_until(std::chrono::steady_clock::now() +
-                          std::chrono::ceil<std::chrono::steady_clock::duration>(dur));
+        return wait_until(std::chrono::system_clock::now() +
+                          std::chrono::ceil<std::chrono::system_clock::duration>(dur));
     }
 
     template <typename Clock, typename Duration>

--- a/be/src/util/bthreads/semaphore.h
+++ b/be/src/util/bthreads/semaphore.h
@@ -1,8 +1,0 @@
-//
-// Created by alex on 10/24/23.
-//
-
-#ifndef STARROCKS_SEMAPHORE_H
-#define STARROCKS_SEMAPHORE_H
-
-#endif //STARROCKS_SEMAPHORE_H

--- a/be/src/util/bthreads/semaphore.h
+++ b/be/src/util/bthreads/semaphore.h
@@ -1,0 +1,8 @@
+//
+// Created by alex on 10/24/23.
+//
+
+#ifndef STARROCKS_SEMAPHORE_H
+#define STARROCKS_SEMAPHORE_H
+
+#endif //STARROCKS_SEMAPHORE_H

--- a/be/src/util/time.h
+++ b/be/src/util/time.h
@@ -152,17 +152,8 @@ std::string ToUtcStringFromUnixMicros(int64_t us, TimePrecision p = TimePrecisio
 template <typename Duration>
 inline ::timespec TimespecFromTimePoint(const std::chrono::time_point<std::chrono::system_clock, Duration>& atime) {
     auto s = std::chrono::time_point_cast<std::chrono::seconds>(atime);
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(atime - s);
-
-    ::timespec spec = {.tv_sec = static_cast<std::time_t>(s.time_since_epoch().count()),
-                       .tv_nsec = static_cast<long>(ns.count())};
-    return spec;
-}
-
-template <typename Duration>
-inline ::timespec TimespecFromTimePoint(const std::chrono::time_point<std::chrono::steady_clock, Duration>& atime) {
-    auto s = std::chrono::time_point_cast<std::chrono::seconds>(atime);
-    auto ns = std::chrono::duration_cast<std::chrono::nanoseconds>(atime - s);
+    auto ns = std::chrono::time_point_cast<std::chrono::nanoseconds>(atime) -
+              std::chrono::time_point_cast<std::chrono::nanoseconds>(s);
 
     ::timespec spec = {.tv_sec = static_cast<std::time_t>(s.time_since_epoch().count()),
                        .tv_nsec = static_cast<long>(ns.count())};

--- a/be/test/util/bthreads/future_test.cpp
+++ b/be/test/util/bthreads/future_test.cpp
@@ -284,7 +284,13 @@ TEST(FutureTest, test_wait_for01) {
 
     std::chrono::milliseconds delay(100);
 
+    auto t0 = std::chrono::steady_clock::now();
     EXPECT_TRUE(f1.wait_for(delay) == future_status::timeout);
+    auto t1 = std::chrono::steady_clock::now();
+    auto d = std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count();
+    EXPECT_GE(d, delay.count());
+    // Assuming that the delay due to scheduling does not exceed 50ms
+    EXPECT_LT(d, delay.count() + 50);
 
     p1.set_value(1);
 


### PR DESCRIPTION
Converting from std::chrono::steady_clock::time_point to struct timespec is not portable.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
