### PR TITLE
[Enhancement] Make scan metrics not duplicated for tablet internal parallel

### DIFF
--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -132,6 +132,7 @@ private:
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;
     RuntimeProfile::Counter* _block_load_timer = nullptr;
@@ -542,6 +543,8 @@ void LakeDataSource::init_counter(RuntimeState* state) {
     _zm_filtered_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "ZoneMapIndexFilterRows", TUnit::UNIT, segment_init_name);
     _sk_filtered_counter = ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyFilterRows", TUnit::UNIT, segment_init_name);
+    _rows_after_sk_filtered_counter =
+            ADD_CHILD_COUNTER(_runtime_profile, "RemainingRowsAfterShortKeyFilter", TUnit::UNIT, segment_init_name);
     _rows_key_range_counter =
             ADD_CHILD_COUNTER(_runtime_profile, "ShortKeyRangeNumber", TUnit::UNIT, segment_init_name);
     _column_iterator_init_timer = ADD_CHILD_TIMER(_runtime_profile, "ColumnIteratorInit", segment_init_name);
@@ -657,6 +660,7 @@ void LakeDataSource::update_counter() {
     COUNTER_UPDATE(_zm_filtered_counter, _reader->stats().rows_stats_filtered);
     COUNTER_UPDATE(_bf_filtered_counter, _reader->stats().rows_bf_filtered);
     COUNTER_UPDATE(_sk_filtered_counter, _reader->stats().rows_key_range_filtered);
+    COUNTER_UPDATE(_rows_after_sk_filtered_counter, _reader->stats().rows_after_key_range);
     COUNTER_UPDATE(_rows_key_range_counter, _reader->stats().rows_key_range_num);
 
     COUNTER_UPDATE(_bi_filtered_counter, _reader->stats().rows_bitmap_index_filtered);

--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -91,6 +91,11 @@ public:
         }
     }
 
+    virtual const std::unordered_set<std::string>& skip_min_max_metrics() const {
+        static const std::unordered_set<std::string> metrics;
+        return metrics;
+    }
+
 private:
     int32_t _plan_node_id;
     int64_t _from_version = 0;
@@ -140,33 +145,6 @@ private:
     int64_t _owner_id = 0;
     int64_t _version = 0;
     int64_t _partition_id = 0;
-};
-
-class PhysicalSplitScanMorsel final : public ScanMorsel {
-public:
-    PhysicalSplitScanMorsel(int32_t plan_node_id, const TScanRange& scan_range, RowidRangeOptionPtr rowid_range_option)
-            : ScanMorsel(plan_node_id, scan_range), _rowid_range_option(std::move(rowid_range_option)) {}
-
-    ~PhysicalSplitScanMorsel() override = default;
-
-    void init_tablet_reader_params(TabletReaderParams* params) override;
-
-private:
-    RowidRangeOptionPtr _rowid_range_option;
-};
-
-class LogicalSplitScanMorsel final : public ScanMorsel {
-public:
-    LogicalSplitScanMorsel(int32_t plan_node_id, const TScanRange& scan_range,
-                           std::vector<ShortKeyRangeOptionPtr> short_key_ranges)
-            : ScanMorsel(plan_node_id, scan_range), _short_key_ranges(std::move(short_key_ranges)) {}
-
-    ~LogicalSplitScanMorsel() override = default;
-
-    void init_tablet_reader_params(TabletReaderParams* params) override;
-
-private:
-    std::vector<ShortKeyRangeOptionPtr> _short_key_ranges;
 };
 
 /// MorselQueueFactory.
@@ -421,6 +399,7 @@ private:
     std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
 
     bool _has_init_any_segment = false;
+    bool _is_first_split_of_segment = true;
 
     size_t _rowset_idx = 0;
     size_t _segment_idx = 0;
@@ -483,6 +462,7 @@ private:
     std::vector<std::vector<RowsetSharedPtr>> _tablet_rowsets;
 
     bool _has_init_any_tablet = false;
+    bool _is_first_split_of_tablet = true;
 
     // Used to allocate memory for _tablet_seek_ranges.
     MemPool _mempool;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -59,6 +59,7 @@ private:
     Status _init_scanner_columns(std::vector<uint32_t>& scanner_columns);
     Status _init_unused_output_columns(const std::vector<std::string>& unused_output_columns);
     Status _init_olap_reader(RuntimeState* state);
+    TCounterMinMaxType::type _get_counter_min_max_type(const std::string& metric_name);
     void _init_counter(RuntimeState* state);
     Status _init_global_dicts(TabletReaderParams* params);
     Status _read_chunk_from_storage([[maybe_unused]] RuntimeState* state, Chunk* chunk);
@@ -134,6 +135,7 @@ private:
     RuntimeProfile::Counter* _seg_zm_filtered_counter = nullptr;
     RuntimeProfile::Counter* _seg_rt_filtered_counter = nullptr;
     RuntimeProfile::Counter* _sk_filtered_counter = nullptr;
+    RuntimeProfile::Counter* _rows_after_sk_filtered_counter = nullptr;
     RuntimeProfile::Counter* _block_seek_timer = nullptr;
     RuntimeProfile::Counter* _block_seek_counter = nullptr;
     RuntimeProfile::Counter* _block_load_timer = nullptr;

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -249,6 +249,7 @@ struct OlapReaderStatistics {
 
     int64_t segment_stats_filtered = 0;
     int64_t rows_key_range_filtered = 0;
+    int64_t rows_after_key_range = 0;
     int64_t rows_key_range_num = 0;
     int64_t rows_stats_filtered = 0;
     int64_t rows_bf_filtered = 0;

--- a/be/src/storage/rowset/rowid_range_option.cpp
+++ b/be/src/storage/rowset/rowid_range_option.cpp
@@ -21,30 +21,31 @@
 
 namespace starrocks {
 
-void RowidRangeOption::add(const Rowset* rowset, const Segment* segment, SparseRangePtr rowid_range) {
+void RowidRangeOption::add(const Rowset* rowset, const Segment* segment, SparseRangePtr rowid_range,
+                           bool is_first_split_of_segment) {
     auto rowset_it = rowid_range_per_segment_per_rowset.find(rowset->rowset_id());
     if (rowset_it == rowid_range_per_segment_per_rowset.end()) {
         rowset_it = rowid_range_per_segment_per_rowset.emplace(rowset->rowset_id(), SetgmentRowidRangeMap()).first;
     }
 
     auto& segment_map = rowset_it->second;
-    segment_map.emplace(segment->id(), std::move(rowid_range));
+    segment_map.emplace(segment->id(), SegmentSplit{std::move(rowid_range), is_first_split_of_segment});
 }
 
-bool RowidRangeOption::match_rowset(const Rowset* rowset) const {
+bool RowidRangeOption::contains_rowset(const Rowset* rowset) const {
     return rowid_range_per_segment_per_rowset.find(rowset->rowset_id()) != rowid_range_per_segment_per_rowset.end();
 }
 
-SparseRangePtr RowidRangeOption::get_segment_rowid_range(const Rowset* rowset, const Segment* segment) {
+RowidRangeOption::SegmentSplit RowidRangeOption::get_segment_rowid_range(const Rowset* rowset, const Segment* segment) {
     auto rowset_it = rowid_range_per_segment_per_rowset.find(rowset->rowset_id());
     if (rowset_it == rowid_range_per_segment_per_rowset.end()) {
-        return nullptr;
+        return {nullptr, false};
     }
 
     auto& segment_map = rowset_it->second;
     auto segment_it = segment_map.find(segment->id());
     if (segment_it == segment_map.end()) {
-        return nullptr;
+        return {nullptr, false};
     }
     return segment_it->second;
 }

--- a/be/src/storage/rowset/rowid_range_option.h
+++ b/be/src/storage/rowset/rowid_range_option.h
@@ -27,15 +27,20 @@ class Segment;
 // It represents a specific rowid range on the segment with `segment_id` of the rowset with `rowset_id`.
 struct RowidRangeOption {
 public:
+    struct SegmentSplit {
+        SparseRangePtr row_id_range;
+        bool is_first_split_of_segment;
+    };
+
     RowidRangeOption() = default;
 
-    void add(const Rowset* rowset, const Segment* segment, SparseRangePtr rowid_range);
+    void add(const Rowset* rowset, const Segment* segment, SparseRangePtr rowid_range, bool is_first_split_of_segment);
 
-    bool match_rowset(const Rowset* rowset) const;
-    SparseRangePtr get_segment_rowid_range(const Rowset* rowset, const Segment* segment);
+    bool contains_rowset(const Rowset* rowset) const;
+    SegmentSplit get_segment_rowid_range(const Rowset* rowset, const Segment* segment);
 
 public:
-    using SetgmentRowidRangeMap = std::unordered_map<uint64_t, SparseRangePtr>;
+    using SetgmentRowidRangeMap = std::unordered_map<uint64_t, SegmentSplit>;
     using RowsetRowidRangeMap = std::map<RowsetId, SetgmentRowidRangeMap>;
 
     RowsetRowidRangeMap rowid_range_per_segment_per_rowset;

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -51,6 +51,7 @@
 #include "storage/merge_iterator.h"
 #include "storage/projection_iterator.h"
 #include "storage/rowset/rowid_range_option.h"
+#include "storage/rowset/short_key_range_option.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_meta_manager.h"
@@ -598,7 +599,9 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
     seg_options.tablet_id = rowset_meta()->tablet_id();
     seg_options.rowsetid = rowset_meta()->rowset_id();
     seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(options.meta);
-    seg_options.short_key_ranges = options.short_key_ranges;
+    if (options.short_key_ranges_option != nullptr) { // logical split.
+        seg_options.short_key_ranges = options.short_key_ranges_option->short_key_ranges;
+    }
     seg_options.asc_hint = options.asc_hint;
     if (options.runtime_state != nullptr) {
         seg_options.is_cancelled = &options.runtime_state->cancelled_ref();
@@ -626,11 +629,18 @@ Status Rowset::get_segment_iterators(const Schema& schema, const RowsetReadOptio
             continue;
         }
 
-        if (options.rowid_range_option != nullptr) {
-            seg_options.rowid_range_option = options.rowid_range_option->get_segment_rowid_range(this, seg_ptr.get());
-            if (seg_options.rowid_range_option == nullptr) {
+        if (options.rowid_range_option != nullptr) { // physical split.
+            auto [rowid_range, is_first_split_of_segment] =
+                    options.rowid_range_option->get_segment_rowid_range(this, seg_ptr.get());
+            if (rowid_range == nullptr) {
                 continue;
             }
+            seg_options.rowid_range_option = std::move(rowid_range);
+            seg_options.is_first_split_of_segment = is_first_split_of_segment;
+        } else if (options.short_key_ranges_option != nullptr) { // logical split.
+            seg_options.is_first_split_of_segment = options.short_key_ranges_option->is_first_split_of_tablet;
+        } else {
+            seg_options.is_first_split_of_segment = true;
         }
 
         auto res = seg_ptr->new_iterator(segment_schema, seg_options);

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -37,11 +37,11 @@ class TabletSchema;
 class ColumnPredicate;
 class DeletePredicates;
 struct RowidRangeOption;
-struct ShortKeyRangeOption;
+struct ShortKeyRangesOption;
 
 class RowsetReadOptions {
     using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
-    using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
+    using ShortKeyRangesOptionPtr = std::shared_ptr<ShortKeyRangesOption>;
     using PredicateList = std::vector<const ColumnPredicate*>;
 
 public:
@@ -74,7 +74,7 @@ public:
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
-    std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
+    ShortKeyRangesOptionPtr short_key_ranges_option = nullptr;
 
     OlapRuntimeScanRangePruner runtime_range_pruner;
 

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -252,7 +252,9 @@ StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const Se
         if (!_column_readers.at(column_unique_id)->segment_zone_map_filter(pair.second)) {
             // skip segment zonemap filter when this segment has column files link to it.
             if (tablet_column.is_key() || _use_segment_zone_map_filter(read_options)) {
-                read_options.stats->segment_stats_filtered += _column_readers.at(column_unique_id)->num_rows();
+                if (read_options.is_first_split_of_segment) {
+                    read_options.stats->segment_stats_filtered += _column_readers.at(column_unique_id)->num_rows();
+                }
                 return Status::EndOfFile(strings::Substitute("End of file $0, empty iterator", _fname));
             } else {
                 break;

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1853,7 +1853,7 @@ Status SegmentIterator::_get_row_ranges_by_rowid_range() {
     _scan_range.add(Range<>(0, num_rows()));
 
     if (_opts.rowid_range_option != nullptr) {
-        _scan_range |= (*_opts.rowid_range_option);
+        _scan_range &= (*_opts.rowid_range_option);
 
         // The rowid range is already applied key ranges at the short key block level.
         // For example, as for the following N-rows segment,

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -1850,9 +1850,9 @@ Status SegmentIterator::_get_row_ranges_by_bloom_filter() {
 Status SegmentIterator::_get_row_ranges_by_rowid_range() {
     DCHECK_EQ(0, _scan_range.span_size());
 
-    if (_opts.rowid_range_option == nullptr) {
-        _scan_range.add(Range<>(0, num_rows()));
-    } else {
+    _scan_range.add(Range<>(0, num_rows()));
+
+    if (_opts.rowid_range_option != nullptr) {
         _scan_range |= (*_opts.rowid_range_option);
 
         // The rowid range is already applied key ranges at the short key block level.

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -192,8 +192,8 @@ private:
     template <bool check_global_dict>
     Status _init_column_iterators(const Schema& schema);
     Status _get_row_ranges_by_keys();
-    Status _get_row_ranges_by_key_ranges();
-    Status _get_row_ranges_by_short_key_ranges();
+    StatusOr<SparseRange<>> _get_row_ranges_by_key_ranges();
+    StatusOr<SparseRange<>> _get_row_ranges_by_short_key_ranges();
     Status _get_row_ranges_by_zone_map();
     Status _get_row_ranges_by_bloom_filter();
     Status _get_row_ranges_by_rowid_range();
@@ -412,8 +412,8 @@ Status SegmentIterator::_init() {
     RETURN_IF_ERROR(_init_column_iterators<true>(_schema));
     // filter by index stage
     // Use indexes and predicates to filter some data page
-    RETURN_IF_ERROR(_get_row_ranges_by_keys());
     RETURN_IF_ERROR(_get_row_ranges_by_rowid_range());
+    RETURN_IF_ERROR(_get_row_ranges_by_keys());
     RETURN_IF_ERROR(_apply_del_vector());
     RETURN_IF_ERROR(_apply_bitmap_index());
     RETURN_IF_ERROR(_get_row_ranges_by_zone_map());
@@ -660,28 +660,54 @@ void SegmentIterator::_init_column_predicates() {
 }
 
 Status SegmentIterator::_get_row_ranges_by_keys() {
-    StarRocksMetrics::instance()->segment_row_total.increment(num_rows());
+    if (_opts.is_first_split_of_segment) {
+        StarRocksMetrics::instance()->segment_row_total.increment(num_rows());
+    }
     SCOPED_RAW_TIMER(&_opts.stats->rows_key_range_filter_ns);
 
-    if (!_opts.short_key_ranges.empty()) {
-        RETURN_IF_ERROR(_get_row_ranges_by_short_key_ranges());
+    const uint32_t prev_num_rows = _scan_range.span_size();
+    const bool is_logical_split = !_opts.short_key_ranges.empty();
+
+    SparseRange<> scan_range_by_keys;
+    if (is_logical_split) {
+        ASSIGN_OR_RETURN(scan_range_by_keys, _get_row_ranges_by_short_key_ranges());
         _opts.stats->rows_key_range_num += _opts.short_key_ranges.size();
     } else {
-        RETURN_IF_ERROR(_get_row_ranges_by_key_ranges());
+        ASSIGN_OR_RETURN(scan_range_by_keys, _get_row_ranges_by_key_ranges());
     }
 
-    _opts.stats->rows_key_range_filtered += num_rows() - _scan_range.span_size();
+    _scan_range &= scan_range_by_keys;
+
+    if (!is_logical_split) {
+        _opts.stats->rows_key_range_filtered += prev_num_rows - _scan_range.span_size();
+    } else {
+        // For the multiple splits from the same segment, rows_key_range_filtered=N-n1-...-nk, where N denotes the
+        // number of rows of the segment, and ni denotes the number of rows of i-th split after short key index.
+        //             N rows
+        // ┌─────────────────────────────┐
+        // │  key range 1   key range 2  │ 2 key ranges
+        // │  ┌────┬────┐   ┌────┬────┐  │
+        // │  │ n1 │ n2 │   │ n3 │ n4 │  │ 4 splits
+        // └──┴────┴────┴───┴────┴────┴──┘
+        _opts.stats->rows_key_range_filtered += -static_cast<int64_t>(_scan_range.span_size());
+        if (_opts.is_first_split_of_segment) {
+            _opts.stats->rows_key_range_filtered += prev_num_rows;
+        }
+    }
+    _opts.stats->rows_after_key_range += _scan_range.span_size();
     StarRocksMetrics::instance()->segment_rows_by_short_key.increment(_scan_range.span_size());
+
     return Status::OK();
 }
 
-Status SegmentIterator::_get_row_ranges_by_key_ranges() {
+StatusOr<SparseRange<>> SegmentIterator::_get_row_ranges_by_key_ranges() {
     DCHECK(_opts.short_key_ranges.empty());
-    DCHECK_EQ(0, _scan_range.span_size());
+
+    SparseRange<> res;
 
     if (_opts.ranges.empty()) {
-        _scan_range.add(Range<>(0, num_rows()));
-        return Status::OK();
+        res.add(Range<>(0, num_rows()));
+        return res;
     }
 
     RETURN_IF_ERROR(_segment->load_index(_skip_fill_data_cache()));
@@ -698,21 +724,22 @@ Status SegmentIterator::_get_row_ranges_by_key_ranges() {
             RETURN_IF_ERROR(_lookup_ordinal(range.lower(), range.inclusive_lower(), upper_rowid, &lower_rowid));
         }
         if (lower_rowid <= upper_rowid) {
-            _scan_range.add(Range{lower_rowid, upper_rowid});
+            res.add(Range{lower_rowid, upper_rowid});
         }
     }
 
-    return Status::OK();
+    return res;
 }
 
-Status SegmentIterator::_get_row_ranges_by_short_key_ranges() {
+StatusOr<SparseRange<>> SegmentIterator::_get_row_ranges_by_short_key_ranges() {
     DCHECK(!_opts.short_key_ranges.empty());
-    DCHECK_EQ(0, _scan_range.span_size());
+
+    SparseRange<> res;
 
     if (_opts.short_key_ranges.size() == 1 && _opts.short_key_ranges[0]->lower->is_infinite() &&
         _opts.short_key_ranges[0]->upper->is_infinite()) {
-        _scan_range.add(Range<>(0, num_rows()));
-        return Status::OK();
+        res.add(Range<>(0, num_rows()));
+        return res;
     }
 
     RETURN_IF_ERROR(_segment->load_index(_skip_fill_data_cache()));
@@ -743,11 +770,11 @@ Status SegmentIterator::_get_row_ranges_by_short_key_ranges() {
         }
 
         if (lower_rowid <= upper_rowid) {
-            _scan_range.add(Range{lower_rowid, upper_rowid});
+            res.add(Range{lower_rowid, upper_rowid});
         }
     }
 
-    return Status::OK();
+    return res;
 }
 
 Status SegmentIterator::_get_row_ranges_by_zone_map() {
@@ -1821,8 +1848,44 @@ Status SegmentIterator::_get_row_ranges_by_bloom_filter() {
 }
 
 Status SegmentIterator::_get_row_ranges_by_rowid_range() {
-    RETURN_IF(_opts.rowid_range_option == nullptr || _scan_range.empty(), Status::OK());
-    _scan_range = _scan_range.intersection(*_opts.rowid_range_option);
+    DCHECK_EQ(0, _scan_range.span_size());
+
+    if (_opts.rowid_range_option == nullptr) {
+        _scan_range.add(Range<>(0, num_rows()));
+    } else {
+        _scan_range |= (*_opts.rowid_range_option);
+
+        // The rowid range is already applied key ranges at the short key block level.
+        // For example, as for the following N-rows segment,
+        // - after applying the rowid ranges, it contains n1+n2=b2+b3+b4=N-b1-b5 rows and filters out N-n1-n2 rows.
+        // - after applying the short key range index, it contains n1.2+n2.1=n1+n2-b2.1-b4.2 rows and filters out
+        //   n1+n2-n1.2-n2.1 rows.
+        // Therefore, here rowid range index accounts rows_key_range_filtered=N-n1-...-nk, where N denotes the
+        // number of rows of the segment, and ni denotes the number of rows of i-th split after rowid range index.
+        //
+        //                              N rows
+        // ┌──────────────────────────────────────────────────────────────┐
+        // │                                                              │
+        // │                  b2                    b4                    │
+        // │   ┌──────────┬────┬─────┬──────────┬────┬─────┬──────────┐   │
+        // │   │    b1    │b2.1│ b2.2│    b3    │b4.1│ b4.2│    b5    │   │ short key blocks
+        // │   └──────────┴────▲─────┴──────────┴────▲─────┴──────────┘   │
+        // │                   │                     │                    │
+        // │              ┌────┴──────────┬──────────┴─────┐              │
+        // │              │     n1        │      n2        │              │ rowid ranges
+        // │              └────▲──────────┴──────────▲─────┘              │
+        // │               n1.1│                     │ n2.2               │
+        // │                   ├──────────┬──────────┤                    │
+        // │                   │   n1.2   │   n2.1   │                    │ key ranges
+        // │                   └──────────┴──────────┘                    │
+        // │                                                              │
+        // └──────────────────────────────────────────────────────────────┘
+        _opts.stats->rows_key_range_filtered += -static_cast<int64_t>(_scan_range.span_size());
+        if (_opts.is_first_split_of_segment) {
+            _opts.stats->rows_key_range_filtered += num_rows();
+        }
+    }
+
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_options.cpp
+++ b/be/src/storage/rowset/segment_options.cpp
@@ -46,6 +46,7 @@ Status SegmentReadOptions::convert_to(SegmentReadOptions* dst, const std::vector
     dst->global_dictmaps = global_dictmaps;
     dst->rowid_range_option = rowid_range_option;
     dst->short_key_ranges = short_key_ranges;
+    dst->is_first_split_of_segment = is_first_split_of_segment;
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -82,6 +82,9 @@ public:
 
     bool has_delete_pred = false;
 
+    /// Mark whether this is the first split of a segment.
+    /// A segment may be divided into multiple split to scan concurrently.
+    bool is_first_split_of_segment = true;
     SparseRangePtr rowid_range_option = nullptr;
     std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
 

--- a/be/src/storage/rowset/short_key_range_option.h
+++ b/be/src/storage/rowset/short_key_range_option.h
@@ -26,6 +26,10 @@ class Schema;
 using SchemaPtr = std::shared_ptr<Schema>;
 struct ShortKeyOption;
 using ShortKeyOptionPtr = std::unique_ptr<ShortKeyOption>;
+struct ShortKeyRangeOption;
+using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
+struct ShortKeyRangesOption;
+using ShortKeyRangesOptionPtr = std::shared_ptr<ShortKeyRangesOption>;
 
 // ShortKeyOption represents a sub key range endpoint splitted from a key range.
 // It could be a completed tuple key, or a short key with specific short_key_schema.
@@ -63,6 +67,15 @@ public:
 public:
     const ShortKeyOptionPtr lower;
     const ShortKeyOptionPtr upper;
+};
+
+struct ShortKeyRangesOption {
+public:
+    ShortKeyRangesOption(vector<ShortKeyRangeOptionPtr>&& short_key_ranges, bool is_first_split_of_tablet)
+            : short_key_ranges(std::move(short_key_ranges)), is_first_split_of_tablet(is_first_split_of_tablet) {}
+
+    std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
+    const bool is_first_split_of_tablet;
 };
 
 } // namespace starrocks

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -278,12 +278,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     }
     rs_opts.meta = _tablet->data_dir()->get_meta();
     rs_opts.rowid_range_option = params.rowid_range_option;
-<<<<<<< HEAD
-    rs_opts.short_key_ranges = params.short_key_ranges;
-=======
     rs_opts.short_key_ranges_option = params.short_key_ranges_option;
     rs_opts.asc_hint = _is_asc_hint;
->>>>>>> 964970feb7 ([Enhancement] Make scan metrics not duplicated for tablet internal parallel)
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
     for (auto& rowset : _rowsets) {

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -209,7 +209,7 @@ Status TabletReader::_init_collector_for_pk_index_read() {
         return Status::InternalError(strings::Substitute("segment_idx out of range tablet:$0 $1 >= $2",
                                                          _tablet->tablet_id(), segment_idx, rowset->num_segments()));
     }
-    rs_opts.rowid_range_option->add(rowset.get(), rowset->segments()[segment_idx].get(), rowid_range);
+    rs_opts.rowid_range_option->add(rowset.get(), rowset->segments()[segment_idx].get(), rowid_range, true);
 
     std::vector<ChunkIteratorPtr> iters;
     RETURN_IF_ERROR(rowset->get_segment_iterators(schema(), rs_opts, &iters));
@@ -278,12 +278,16 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     }
     rs_opts.meta = _tablet->data_dir()->get_meta();
     rs_opts.rowid_range_option = params.rowid_range_option;
+<<<<<<< HEAD
     rs_opts.short_key_ranges = params.short_key_ranges;
+=======
+    rs_opts.short_key_ranges_option = params.short_key_ranges_option;
     rs_opts.asc_hint = _is_asc_hint;
+>>>>>>> 964970feb7 ([Enhancement] Make scan metrics not duplicated for tablet internal parallel)
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
     for (auto& rowset : _rowsets) {
-        if (params.rowid_range_option != nullptr && !params.rowid_range_option->match_rowset(rowset.get())) {
+        if (params.rowid_range_option != nullptr && !params.rowid_range_option->contains_rowset(rowset.get())) {
             continue;
         }
 

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -33,8 +33,8 @@ class RuntimeState;
 class ColumnPredicate;
 struct RowidRangeOption;
 using RowidRangeOptionPtr = std::shared_ptr<RowidRangeOption>;
-struct ShortKeyRangeOption;
-using ShortKeyRangeOptionPtr = std::shared_ptr<ShortKeyRangeOption>;
+struct ShortKeyRangesOption;
+using ShortKeyRangesOptionPtr = std::shared_ptr<ShortKeyRangesOption>;
 
 static inline std::unordered_set<uint32_t> EMPTY_FILTERED_COLUMN_IDS;
 
@@ -77,7 +77,7 @@ struct TabletReaderParams {
     const std::unordered_set<uint32_t>* unused_output_column_ids = &EMPTY_FILTERED_COLUMN_IDS;
 
     RowidRangeOptionPtr rowid_range_option = nullptr;
-    std::vector<ShortKeyRangeOptionPtr> short_key_ranges;
+    ShortKeyRangesOptionPtr short_key_ranges_option = nullptr;
 
     bool sorted_by_keys_per_tablet = false;
     OlapRuntimeScanRangePruner runtime_range_pruner;

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -812,9 +812,6 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
                                                           bool require_identical) {
     DCHECK(!profiles.empty());
 
-    static const std::string MERGED_INFO_PREFIX_MIN = "__MIN_OF_";
-    static const std::string MERGED_INFO_PREFIX_MAX = "__MAX_OF_";
-
     // all metrics will be merged into the first profile
     auto* merged_profile = obj_pool->add(new RuntimeProfile(profiles[0]->name(), profiles[0]->_is_averaged_profile));
 
@@ -926,20 +923,23 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
                     break;
                 }
 
-                auto* min_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name));
-                if (min_counter != nullptr) {
-                    already_merged = true;
-                    if (min_counter->value() < min_value) {
-                        min_value = min_counter->value();
+                if (!counter->skip_min_max()) {
+                    auto* min_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name));
+                    if (min_counter != nullptr) {
+                        already_merged = true;
+                        if (min_counter->value() < min_value) {
+                            min_value = min_counter->value();
+                        }
+                    }
+                    auto* max_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name));
+                    if (max_counter != nullptr) {
+                        already_merged = true;
+                        if (max_counter->value() > max_value) {
+                            max_value = max_counter->value();
+                        }
                     }
                 }
-                auto* max_counter = profile->get_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name));
-                if (max_counter != nullptr) {
-                    already_merged = true;
-                    if (max_counter->value() > max_value) {
-                        max_value = max_counter->value();
-                    }
-                }
+
                 counters.push_back(counter);
             }
 
@@ -966,14 +966,16 @@ RuntimeProfile* RuntimeProfile::merge_isomorphic_profiles(ObjectPool* obj_pool, 
 
                 merged_counter->set(merged_value);
 
-                auto* min_counter =
-                        merged_profile->add_child_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name),
-                                                          type, merged_counter->strategy(), name);
-                auto* max_counter =
-                        merged_profile->add_child_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name),
-                                                          type, merged_counter->strategy(), name);
-                min_counter->set(min_value);
-                max_counter->set(max_value);
+                if (!merged_counter->skip_min_max()) {
+                    auto* min_counter =
+                            merged_profile->add_child_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MIN, name),
+                                                              type, merged_counter->strategy(), name);
+                    auto* max_counter =
+                            merged_profile->add_child_counter(strings::Substitute("$0$1", MERGED_INFO_PREFIX_MAX, name),
+                                                              type, merged_counter->strategy(), name);
+                    min_counter->set(min_value);
+                    max_counter->set(max_value);
+                }
             }
         }
     }

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -80,6 +80,10 @@ inline unsigned long long operator"" _ms(unsigned long long x) {
     (profile)->add_child_counter(name, type, RuntimeProfile::Counter::create_strategy(type), parent)
 #define ADD_CHILD_COUNTER_SKIP_MERGE(profile, name, type, merge_type, parent) \
     (profile)->add_child_counter(name, type, RuntimeProfile::Counter::create_strategy(type, merge_type), parent)
+#define ADD_CHILD_COUNTER_SKIP_MIN_MAX(profile, name, type, min_max_type, parent)                                      \
+    (profile)->add_child_counter(                                                                                      \
+            name, type, RuntimeProfile::Counter::create_strategy(type, TCounterMergeType::MERGE_ALL, 0, min_max_type), \
+            parent)
 #define ADD_CHILD_TIMER_THESHOLD(profile, name, parent, threshold) \
     (profile)->add_child_counter(                                  \
             name, TUnit::TIME_NS,                                  \
@@ -122,23 +126,29 @@ class ObjectPool;
 // Thread-safe.
 class RuntimeProfile {
 public:
+    inline static const std::string MERGED_INFO_PREFIX_MIN = "__MIN_OF_";
+    inline static const std::string MERGED_INFO_PREFIX_MAX = "__MAX_OF_";
+
     class Counter {
     public:
-        static TCounterStrategy create_strategy(TCounterAggregateType::type aggregate_type,
-                                                TCounterMergeType::type merge_type = TCounterMergeType::MERGE_ALL,
-                                                int64_t display_threshold = 0) {
+        static TCounterStrategy create_strategy(
+                TCounterAggregateType::type aggregate_type,
+                TCounterMergeType::type merge_type = TCounterMergeType::MERGE_ALL, int64_t display_threshold = 0,
+                TCounterMinMaxType::type min_max_type = TCounterMinMaxType::MIN_MAX_ALL) {
             TCounterStrategy strategy;
             strategy.aggregate_type = aggregate_type;
             strategy.merge_type = merge_type;
             strategy.display_threshold = display_threshold;
+            strategy.min_max_type = min_max_type;
             return strategy;
         }
 
-        static TCounterStrategy create_strategy(TUnit::type type,
-                                                TCounterMergeType::type merge_type = TCounterMergeType::MERGE_ALL,
-                                                int64_t display_threshold = 0) {
+        static TCounterStrategy create_strategy(
+                TUnit::type type, TCounterMergeType::type merge_type = TCounterMergeType::MERGE_ALL,
+                int64_t display_threshold = 0,
+                TCounterMinMaxType::type min_max_type = TCounterMinMaxType::MIN_MAX_ALL) {
             auto aggregate_type = is_time_type(type) ? TCounterAggregateType::AVG : TCounterAggregateType::SUM;
-            return create_strategy(aggregate_type, merge_type, display_threshold);
+            return create_strategy(aggregate_type, merge_type, display_threshold, min_max_type);
         }
 
         explicit Counter(TUnit::type type, int64_t value = 0)
@@ -178,6 +188,8 @@ public:
             return _strategy.merge_type == TCounterMergeType::SKIP_ALL ||
                    _strategy.merge_type == TCounterMergeType::SKIP_FIRST_MERGE;
         }
+
+        bool skip_min_max() const { return _strategy.min_max_type == TCounterMinMaxType::SKIP_ALL; }
 
         int64_t display_threshold() const { return _strategy.display_threshold; }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -96,7 +96,7 @@ public class Counter {
 
     public Counter(TUnit type, TCounterStrategy strategy, long value) {
         this.type = type.getValue();
-        if (strategy == null || strategy.aggregate_type == null || strategy.merge_type == null) {
+        if (strategy == null || strategy.aggregate_type == null || strategy.merge_type == null || strategy.min_max_type == null) {
             this.strategy = Counter.createStrategy(type);
         } else {
             this.strategy = strategy;
@@ -117,6 +117,7 @@ public class Counter {
         TCounterMergeType mergeType = TCounterMergeType.MERGE_ALL;
         strategy.aggregate_type = aggregateType;
         strategy.merge_type = mergeType;
+        strategy.min_max_type = TCounterMinMaxType.MIN_MAX_ALL;
         return strategy;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Counter.java
@@ -36,6 +36,7 @@ package com.starrocks.common.util;
 
 import com.starrocks.thrift.TCounterAggregateType;
 import com.starrocks.thrift.TCounterMergeType;
+import com.starrocks.thrift.TCounterMinMaxType;
 import com.starrocks.thrift.TCounterStrategy;
 import com.starrocks.thrift.TUnit;
 
@@ -79,6 +80,10 @@ public class Counter {
     public boolean isSkipMerge() {
         return Objects.equals(strategy.merge_type, TCounterMergeType.SKIP_ALL)
                 || Objects.equals(strategy.merge_type, TCounterMergeType.SKIP_SECOND_MERGE);
+    }
+
+    public boolean isSkipMinMax() {
+        return Objects.equals(strategy.min_max_type, TCounterMinMaxType.SKIP_ALL);
     }
 
     public void setStrategy(TCounterStrategy strategy) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/RuntimeProfile.java
@@ -651,20 +651,23 @@ public class RuntimeProfile {
                     break;
                 }
 
-                Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
-                if (minCounter != null) {
-                    alreadyMerged = true;
-                    if (minCounter.getValue() < minValue) {
-                        minValue = minCounter.getValue();
+                if (!counter.isSkipMinMax()) {
+                    Counter minCounter = profile.getCounter(MERGED_INFO_PREFIX_MIN + name);
+                    if (minCounter != null) {
+                        alreadyMerged = true;
+                        if (minCounter.getValue() < minValue) {
+                            minValue = minCounter.getValue();
+                        }
+                    }
+                    Counter maxCounter = profile.getCounter(MERGED_INFO_PREFIX_MAX + name);
+                    if (maxCounter != null) {
+                        alreadyMerged = true;
+                        if (maxCounter.getValue() > maxValue) {
+                            maxValue = maxCounter.getValue();
+                        }
                     }
                 }
-                Counter maxCounter = profile.getCounter(MERGED_INFO_PREFIX_MAX + name);
-                if (maxCounter != null) {
-                    alreadyMerged = true;
-                    if (maxCounter.getValue() > maxValue) {
-                        maxValue = maxCounter.getValue();
-                    }
-                }
+
                 counters.add(counter);
             }
             Counter mergedCounter;
@@ -688,14 +691,16 @@ public class RuntimeProfile {
                 }
                 mergedCounter.setValue(mergedValue);
 
-                Counter minCounter =
-                        mergedProfile.addCounter(MERGED_INFO_PREFIX_MIN + name, type, mergedCounter.getStrategy(),
-                                name);
-                Counter maxCounter =
-                        mergedProfile.addCounter(MERGED_INFO_PREFIX_MAX + name, type, mergedCounter.getStrategy(),
-                                name);
-                minCounter.setValue(minValue);
-                maxCounter.setValue(maxValue);
+                if (!mergedCounter.isSkipMinMax()) {
+                    Counter minCounter =
+                            mergedProfile.addCounter(MERGED_INFO_PREFIX_MIN + name, type, mergedCounter.getStrategy(),
+                                    name);
+                    Counter maxCounter =
+                            mergedProfile.addCounter(MERGED_INFO_PREFIX_MAX + name, type, mergedCounter.getStrategy(),
+                                    name);
+                    minCounter.setValue(minValue);
+                    maxCounter.setValue(maxValue);
+                }
             }
 
         }

--- a/gensrc/thrift/RuntimeProfile.thrift
+++ b/gensrc/thrift/RuntimeProfile.thrift
@@ -32,10 +32,16 @@ enum TCounterMergeType {
     SKIP_SECOND_MERGE,
 }
 
+enum TCounterMinMaxType {
+  MIN_MAX_ALL = 0,
+  SKIP_ALL = 1
+}
+
 struct TCounterStrategy {
     1: required TCounterAggregateType aggregate_type
     2: required TCounterMergeType merge_type
     3: required i64 display_threshold = 0
+    4: optional TCounterMinMaxType min_max_type = TCounterMinMaxType.MIN_MAX_ALL
 }
 
 // Counter data

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1342,7 +1342,7 @@ class StarrocksSQLApiLib(object):
         backends = self._get_backend_http_endpoints()
         for backend in backends:
             exec_url = f"http://{backend['host']}:{backend['port']}/api/update_config?{key}={value}"
-            print(f"fetch {exec_url}")
+            print(f"post {exec_url}")
             res = self.post_http_request(exec_url)
 
             res_json = json.loads(res)

--- a/test/sql/test_tablet_internal_parallel/R/test_profile
+++ b/test/sql/test_tablet_internal_parallel/R/test_profile
@@ -42,7 +42,7 @@ properties("replication_num" = "1");
 insert into uniq_t select * from dup_t;
 -- result:
 -- !result
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
 -- result:
 -31585402830
 -- !result
@@ -73,71 +73,7 @@ RemainingRowsAfterShortKeyFilter	991
 SegmentZoneMapFilterRows	0
 ShortKeyFilterRows	9009
 -- !result
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
--- result:
--31585402830
--- !result
-with 
-    profile as (
-        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
-    ), result as (
-        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
-        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
-        UNION ALL
-        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
-        UNION ALL
-        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
-        UNION ALL
-        
-        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
-        UNION ALL
-        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
-        UNION ALL
-        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
-        UNION ALL
-
-        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
-    )
-select * from result order by `key`, value;
--- result:
-RemainingRowsAfterShortKeyFilter	991
-SegmentZoneMapFilterRows	0
-ShortKeyFilterRows	9009
-__MAX_OF_ShortKeyFilterRows	3021
-__MIN_OF_ShortKeyFilterRows	2986
--- !result
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
--- result:
--31585402830
--- !result
-with 
-    profile as (
-        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
-    ), result as (
-        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
-        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
-        UNION ALL
-        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
-        UNION ALL
-        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
-        UNION ALL
-        
-        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
-        UNION ALL
-        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
-        UNION ALL
-        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
-        UNION ALL
-
-        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
-    )
-select * from result order by `key`, value;
--- result:
-RemainingRowsAfterShortKeyFilter	991
-SegmentZoneMapFilterRows	0
-ShortKeyFilterRows	9009
--- !result
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
 -- result:
 -31585402830
 -- !result
@@ -170,7 +106,71 @@ ShortKeyFilterRows	9009
 __MAX_OF_ShortKeyFilterRows	3021
 __MIN_OF_ShortKeyFilterRows	2986
 -- !result
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+-- result:
+-31585402830
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	991
+SegmentZoneMapFilterRows	0
+ShortKeyFilterRows	9009
+-- !result
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+-- result:
+-31585402830
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	991
+SegmentZoneMapFilterRows	0
+ShortKeyFilterRows	9009
+__MAX_OF_ShortKeyFilterRows	3021
+__MIN_OF_ShortKeyFilterRows	2986
+-- !result
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
 -- result:
 None
 -- !result
@@ -201,7 +201,7 @@ RemainingRowsAfterShortKeyFilter	0
 SegmentZoneMapFilterRows	10000
 ShortKeyFilterRows	0
 -- !result
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
 -- result:
 None
 -- !result
@@ -234,7 +234,7 @@ ShortKeyFilterRows	0
 __MAX_OF_SegmentZoneMapFilterRows	3365
 __MIN_OF_SegmentZoneMapFilterRows	3302
 -- !result
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
 -- result:
 None
 -- !result
@@ -265,7 +265,7 @@ RemainingRowsAfterShortKeyFilter	0
 SegmentZoneMapFilterRows	10000
 ShortKeyFilterRows	0
 -- !result
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
 -- result:
 None
 -- !result

--- a/test/sql/test_tablet_internal_parallel/R/test_profile
+++ b/test/sql/test_tablet_internal_parallel/R/test_profile
@@ -1,0 +1,316 @@
+-- name: test_tablet_internal_parallel_profile @sequential
+function: update_be_config("tablet_internal_parallel_min_splitted_scan_rows", "1")
+-- result:
+None
+-- !result
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_rows", "1")
+-- result:
+None
+-- !result
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_bytes", "1")
+-- result:
+None
+-- !result
+function: update_be_config("tablet_internal_parallel_min_scan_dop", "1")
+-- result:
+None
+-- !result
+create table dup_t (
+    k1 int,
+    k2 int,
+    c1 string
+)
+duplicate key(k1, k2)
+distributed by hash(k1) buckets 3
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into dup_t
+select generate_series, generate_series + 10000, concat('a', generate_series) from TABLE(generate_series(0, 10000 - 1));
+-- result:
+-- !result
+create table uniq_t (
+    k1 int,
+    k2 int,
+    c1 string
+)
+unique key(k1, k2)
+distributed by hash(k1) buckets 3
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into uniq_t select * from dup_t;
+-- result:
+-- !result
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
+-- result:
+-31585402830
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	991
+SegmentZoneMapFilterRows	0
+ShortKeyFilterRows	9009
+-- !result
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
+-- result:
+-31585402830
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	991
+SegmentZoneMapFilterRows	0
+ShortKeyFilterRows	9009
+__MAX_OF_ShortKeyFilterRows	3021
+__MIN_OF_ShortKeyFilterRows	2986
+-- !result
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+-- result:
+-31585402830
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	991
+SegmentZoneMapFilterRows	0
+ShortKeyFilterRows	9009
+-- !result
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+-- result:
+-31585402830
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	991
+SegmentZoneMapFilterRows	0
+ShortKeyFilterRows	9009
+__MAX_OF_ShortKeyFilterRows	3021
+__MIN_OF_ShortKeyFilterRows	2986
+-- !result
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+-- result:
+None
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	0
+SegmentZoneMapFilterRows	10000
+ShortKeyFilterRows	0
+-- !result
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+-- result:
+None
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	0
+SegmentZoneMapFilterRows	10000
+ShortKeyFilterRows	0
+__MAX_OF_SegmentZoneMapFilterRows	3365
+__MIN_OF_SegmentZoneMapFilterRows	3302
+-- !result
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+-- result:
+None
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	0
+SegmentZoneMapFilterRows	10000
+ShortKeyFilterRows	0
+-- !result
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+-- result:
+None
+-- !result
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+-- result:
+RemainingRowsAfterShortKeyFilter	0
+SegmentZoneMapFilterRows	10000
+ShortKeyFilterRows	0
+__MAX_OF_SegmentZoneMapFilterRows	3365
+__MIN_OF_SegmentZoneMapFilterRows	3302
+-- !result
+function: update_be_config("tablet_internal_parallel_min_splitted_scan_rows", "16384")
+-- result:
+None
+-- !result
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_rows", "1048576")
+-- result:
+None
+-- !result
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_bytes", "536870912")
+-- result:
+None
+-- !result
+function: update_be_config("tablet_internal_parallel_min_scan_dop", "4")
+-- result:
+None
+-- !result

--- a/test/sql/test_tablet_internal_parallel/T/test_profile
+++ b/test/sql/test_tablet_internal_parallel/T/test_profile
@@ -31,7 +31,7 @@ properties("replication_num" = "1");
 insert into uniq_t select * from dup_t;
 
 -- 1. ShortKeyFilterRows for physical split.
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
 
 -- There are no min and max for "ShortKeyFilterRows".
 with 
@@ -58,7 +58,7 @@ with
 select * from result order by `key`, value;
 
 
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
 
 with 
     profile as (
@@ -84,7 +84,7 @@ with
 select * from result order by `key`, value;
 
 -- 2. ShortKeyFilterRows for logical split.
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
 
 -- There are no min and max for "ShortKeyFilterRows".
 with 
@@ -110,7 +110,7 @@ with
     )
 select * from result order by `key`, value;
 
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
 
 with 
     profile as (
@@ -137,7 +137,7 @@ select * from result order by `key`, value;
 
 
 -- 3. SegmentZoneMapFilterRows for physical split.
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
 
 -- There are no min and max for "SegmentZoneMapFilterRows".
 with 
@@ -164,7 +164,7 @@ with
 select * from result order by `key`, value;
 
 
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
 
 with 
     profile as (
@@ -190,7 +190,7 @@ with
 select * from result order by `key`, value;
 
 -- 4. SegmentZoneMapFilterRows for logical split.
-select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
 
 -- There are no min and max for "SegmentZoneMapFilterRows".
 with 
@@ -216,7 +216,7 @@ with
     )
 select * from result order by `key`, value;
 
-select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+select /*+SET_VAR(enable_tablet_internal_parallel="false",enable_profile="true")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
 
 with 
     profile as (

--- a/test/sql/test_tablet_internal_parallel/T/test_profile
+++ b/test/sql/test_tablet_internal_parallel/T/test_profile
@@ -1,0 +1,249 @@
+-- name: test_tablet_internal_parallel_profile @sequential
+
+-- setup be config to minimize the split size.
+function: update_be_config("tablet_internal_parallel_min_splitted_scan_rows", "1")
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_rows", "1")
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_bytes", "1")
+function: update_be_config("tablet_internal_parallel_min_scan_dop", "1")
+
+-- prepare data.
+create table dup_t (
+    k1 int,
+    k2 int,
+    c1 string
+)
+duplicate key(k1, k2)
+distributed by hash(k1) buckets 3
+properties("replication_num" = "1");
+
+insert into dup_t
+select generate_series, generate_series + 10000, concat('a', generate_series) from TABLE(generate_series(0, 10000 - 1));
+
+create table uniq_t (
+    k1 int,
+    k2 int,
+    c1 string
+)
+unique key(k1, k2)
+distributed by hash(k1) buckets 3
+properties("replication_num" = "1");
+
+insert into uniq_t select * from dup_t;
+
+-- 1. ShortKeyFilterRows for physical split.
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
+
+-- There are no min and max for "ShortKeyFilterRows".
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 10 and 1000;
+
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+-- 2. ShortKeyFilterRows for logical split.
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+
+-- There are no min and max for "ShortKeyFilterRows".
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 10 and 1000;
+
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+
+-- 3. SegmentZoneMapFilterRows for physical split.
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+
+-- There are no min and max for "SegmentZoneMapFilterRows".
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from dup_t where k1 between 20000 and 20100;
+
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+-- 4. SegmentZoneMapFilterRows for logical split.
+select /*+SET_VAR(tablet_internal_parallel_mode="force_split")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+
+-- There are no min and max for "SegmentZoneMapFilterRows".
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+select /*+SET_VAR(enable_tablet_internal_parallel="false")*/ sum(murmur_hash3_32(k2)) + sum(murmur_hash3_32(k1)) from uniq_t where k1 between 20000 and 20100;
+
+with 
+    profile as (
+        select unnest as line from (values(1))t(v) join unnest(split(get_query_profile(last_query_id()), "\n") )
+    ), result as (
+        -- format: "ShortKeyFilterRows: 9.009K (9009)" or "ShortKeyFilterRows: 100"
+        select "ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- ShortKeyFilterRows%"
+        UNION ALL
+        select "__MAX_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_ShortKeyFilterRows%"
+        UNION ALL
+        select "__MIN_OF_ShortKeyFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_ShortKeyFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_ShortKeyFilterRows%"
+        UNION ALL
+        
+        select "SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MAX_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MAX_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MAX_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+        select "__MIN_OF_SegmentZoneMapFilterRows" as `key`, regexp_extract(line, ".*- __MIN_OF_SegmentZoneMapFilterRows: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- __MIN_OF_SegmentZoneMapFilterRows%"
+        UNION ALL
+
+        select "RemainingRowsAfterShortKeyFilter" as `key`, regexp_extract(line, ".*- RemainingRowsAfterShortKeyFilter: (?:.*\\()?(\\d+)\\)?", 1) as value from profile where line like "%- RemainingRowsAfterShortKeyFilter%"
+    )
+select * from result order by `key`, value;
+
+
+-- reset be config to default values.
+function: update_be_config("tablet_internal_parallel_min_splitted_scan_rows", "16384")
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_rows", "1048576")
+function: update_be_config("tablet_internal_parallel_max_splitted_scan_bytes", "536870912")
+function: update_be_config("tablet_internal_parallel_min_scan_dop", "4")


### PR DESCRIPTION
When the tablet internal parallel strategy is triggered, the metrics `SegmentZoneMapFilterRows` and `ShortKeyFilterRows` in the profile are counted multiple times.

- For `SegmentZoneMapFilterRows`
    - only the first split of multiple splits from the same segment contributes to the metric count.
- For `ShortKeyFilterRows`
    - For `PhysicalSplitMorselQueue`, the reason for the duplicate count is that applying the rowid range occurs after applying the short key range. So, moving the application of the rowid range before the application of the short key range will resolve this issue.
    - For LogicalSplitMorselQueue, the reason for the duplicate count is that the number of rows filtered out by the short key range for each split overlaps. For example, for a segment with N rows and a short key range, if it is split into four splits, each with its corresponding sub short key range, they will have $n1$, $n2$, $n3$, and $n4$ rows  after applying short key index respectively. The `ShortKeyFilterRows` counted by the current 4 ChunkSources are $N-n1$, $N-n2$, $N-n3$, and $N-n4$, respectively. Therefore, two modifications are needed:
        - Only the first split ChunkSource's `ShortKeyFilterRows` is counted as $N-n1$, while the others are counted as $-n2$, $-n3$, and $-n4$, respectively. This ensures that the sum of `ShortKeyFilterRows` is correct ($N - n1 - n2 - n3 -n4$), but the min and max values are incorrect.
        - Thus, in this case, the min and max values should not be displayed.



## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
