### PR TITLE
[Enhancement] raise code standard bar, turn a few warnings into error

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -602,7 +602,7 @@ set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-deprecated -Wno-vla -Wno-comment"
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fno-sized-deallocation")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables -Werror=string-plus-int -Werror=pessimizing-move")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0")
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-reserved-identifier -Wno-suggest-destructor-override")
     endif()

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -350,8 +350,8 @@ Status SchemaChangeHandler::process_update_tablet_meta(const TUpdateTabletMetaIn
 Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo& tablet_meta_info, int64_t txn_id) {
     if (tablet_meta_info.meta_type != TTabletMetaType::ENABLE_PERSISTENT_INDEX) {
         // Only support ENABLE_PERSISTENT_INDEX for now
-        LOG(WARNING) << "not supported update meta type: " + tablet_meta_info.meta_type;
-        return Status::InternalError("not supported update meta type:" + tablet_meta_info.meta_type);
+        LOG(WARNING) << "not supported update meta type: " << tablet_meta_info.meta_type;
+        return Status::InternalError(fmt::format("not supported update meta type: {}", tablet_meta_info.meta_type));
     }
 
     MonotonicStopWatch timer;

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1308,8 +1308,8 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
         nest_offsets->get_data().push_back(2);
         nest_offsets->get_data().push_back(4);
 
-        auto nest_map = MapColumn::create(std::move(nest_keys),
-                                          std::move(ColumnHelper::cast_to_nullable_column(column)), nest_offsets);
+        auto nest_map =
+                MapColumn::create(std::move(nest_keys), ColumnHelper::cast_to_nullable_column(column), nest_offsets);
         nest_map->remove_duplicated_keys(true);
 
         ASSERT_EQ("{1:{4:66}}", nest_map->debug_item(0));

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -550,8 +550,8 @@ PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
         nest_offsets->get_data().push_back(2);
         nest_offsets->get_data().push_back(4);
 
-        auto nest_map = MapColumn::create(std::move(nest_keys),
-                                          std::move(ColumnHelper::cast_to_nullable_column(column)), nest_offsets);
+        auto nest_map =
+                MapColumn::create(std::move(nest_keys), ColumnHelper::cast_to_nullable_column(column), nest_offsets);
         auto res = MapFunctions::distinct_map_keys(nullptr, {nest_map}).value();
 
         ASSERT_EQ("{1:{4:66}}", res->debug_item(0));

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -223,7 +223,7 @@ public:
         writer_context.version.second = 10;
         ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &_writer).ok());
         _mem_table_sink = std::make_unique<MemTableRowsetWriterSink>(_writer.get());
-        _vectorized_schema = std::move(MemTable::convert_schema(_schema, _slots));
+        _vectorized_schema = MemTable::convert_schema(_schema, _slots);
         _mem_table =
                 std::make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
     }

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -416,8 +416,8 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
     ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
-    writer.non_key_columns.emplace_back(std::move(Int16Column::create_mutable()));
-    writer.non_key_columns.emplace_back(std::move(Int32Column::create_mutable()));
+    writer.non_key_columns.emplace_back(Int16Column::create_mutable());
+    writer.non_key_columns.emplace_back(Int32Column::create_mutable());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
 
     ASSERT_EQ(pks.size(), writer.all_pks->size());


### PR DESCRIPTION
* turn on the following warnings into errors
  - -Werror=string-plus-int
  - -Werror=pessimizing-move

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
