### PR TITLE
[Enhancement] raise code standard bar, turn a few warnings into error(#33609)

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -542,7 +542,7 @@ set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -std=gnu++17 -D__STDC_FORMAT_MACROS")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-deprecated -Wno-vla -Wno-comment")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables -Werror=string-plus-int -Werror=pessimizing-move")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0")
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-reserved-identifier -Wno-suggest-destructor-override")
     endif()

--- a/be/src/exec/stream/aggregate/stream_aggregator.h
+++ b/be/src/exec/stream/aggregate/stream_aggregator.h
@@ -59,7 +59,7 @@ public:
 
     Status prepare(RuntimeState* state, ObjectPool* pool, RuntimeProfile* runtime_profile);
 
-    Status open(RuntimeState* state);
+    Status open(RuntimeState* state) override;
 
     // Process input's chunks util `Epoch` chunk is received.
     Status process_chunk(StreamChunk* chunk);

--- a/be/src/exprs/cast_expr.cpp
+++ b/be/src/exprs/cast_expr.cpp
@@ -1479,7 +1479,7 @@ StatusOr<ColumnPtr> MustNullExpr::evaluate_checked(ExprContext* context, Chunk* 
     // only null
     auto column = ColumnHelper::create_column(_type, true);
     column->append_nulls(1);
-    auto only_null = std::move(ConstColumn::create(column, 1));
+    auto only_null = ConstColumn::create(column, 1);
     if (ptr != nullptr) {
         only_null->resize(ptr->num_rows());
     }

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -345,8 +345,8 @@ Status SchemaChangeHandler::process_update_tablet_meta(const TUpdateTabletMetaIn
 Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo& tablet_meta_info, int64_t txn_id) {
     if (tablet_meta_info.meta_type != TTabletMetaType::ENABLE_PERSISTENT_INDEX) {
         // Only support ENABLE_PERSISTENT_INDEX for now
-        LOG(WARNING) << "not supported update meta type: " + tablet_meta_info.meta_type;
-        return Status::InternalError("not supported update meta type:" + tablet_meta_info.meta_type);
+        LOG(WARNING) << "not supported update meta type: " << tablet_meta_info.meta_type;
+        return Status::InternalError(fmt::format("not supported update meta type: {}", tablet_meta_info.meta_type));
     }
 
     MonotonicStopWatch timer;

--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -324,8 +324,7 @@ inline Status HeapMergeIterator::fill(size_t child) {
             return Status::InternalError(strings::Substitute(
                     "Merge iterator only supports merging chunks with rows less than $0", max_merge_chunk_size));
         }
-        _heap.push(ComparableChunk{chunk, child, _schema.num_key_fields(), std::move(_schema.sort_key_idxes()),
-                                   merge_condition});
+        _heap.push(ComparableChunk{chunk, child, _schema.num_key_fields(), _schema.sort_key_idxes(), merge_condition});
     } else if (st.is_end_of_file()) {
         // ignore Status::EndOfFile.
         close_child(child);

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -527,7 +527,7 @@ Status ChunkChanger::prepare() {
     for (int i = 0; i < _schema_mapping.size(); ++i) {
         ColumnMapping* column_mapping = get_mutable_column_mapping(i);
         if (column_mapping == nullptr) {
-            return Status::InternalError("referenced column was missing: " + i);
+            return Status::InternalError(fmt::format("referenced column was missing: {}", i));
         }
         int32_t ref_column = column_mapping->ref_column;
         if (ref_column < 0) {

--- a/be/src/util/arrow/row_batch.cpp
+++ b/be/src/util/arrow/row_batch.cpp
@@ -128,7 +128,7 @@ Status convert_to_arrow_type(const TypeDescriptor& type, std::shared_ptr<arrow::
         for (auto i = 0; i < type.children.size(); ++i) {
             std::shared_ptr<arrow::DataType> type0;
             convert_to_arrow_type(type.children[i], &type0);
-            fields.push_back(std::move(arrow::field(type.field_names[i], type0)));
+            fields.push_back(arrow::field(type.field_names[i], type0));
         }
         *result = arrow::struct_(fields);
         break;

--- a/be/test/column/map_column_test.cpp
+++ b/be/test/column/map_column_test.cpp
@@ -1308,8 +1308,8 @@ PARALLEL_TEST(MapColumnTest, test_remove_duplicated_keys) {
         nest_offsets->get_data().push_back(2);
         nest_offsets->get_data().push_back(4);
 
-        auto nest_map = MapColumn::create(std::move(nest_keys),
-                                          std::move(ColumnHelper::cast_to_nullable_column(column)), nest_offsets);
+        auto nest_map =
+                MapColumn::create(std::move(nest_keys), ColumnHelper::cast_to_nullable_column(column), nest_offsets);
         nest_map->remove_duplicated_keys(true);
 
         ASSERT_EQ("{1:{4:66}}", nest_map->debug_item(0));

--- a/be/test/exprs/map_functions_test.cpp
+++ b/be/test/exprs/map_functions_test.cpp
@@ -550,8 +550,8 @@ PARALLEL_TEST(MapFunctionsTest, test_distinct_map_keys) {
         nest_offsets->get_data().push_back(2);
         nest_offsets->get_data().push_back(4);
 
-        auto nest_map = MapColumn::create(std::move(nest_keys),
-                                          std::move(ColumnHelper::cast_to_nullable_column(column)), nest_offsets);
+        auto nest_map =
+                MapColumn::create(std::move(nest_keys), ColumnHelper::cast_to_nullable_column(column), nest_offsets);
         auto res = MapFunctions::distinct_map_keys(nullptr, {nest_map}).value();
 
         ASSERT_EQ("{1:{4:66}}", res->debug_item(0));

--- a/be/test/storage/memtable_test.cpp
+++ b/be/test/storage/memtable_test.cpp
@@ -223,7 +223,7 @@ public:
         writer_context.version.second = 10;
         ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &_writer).ok());
         _mem_table_sink = std::make_unique<MemTableRowsetWriterSink>(_writer.get());
-        _vectorized_schema = std::move(MemTable::convert_schema(_schema.get(), _slots));
+        _vectorized_schema = MemTable::convert_schema(_schema.get(), _slots);
         _mem_table =
                 std::make_unique<MemTable>(1, &_vectorized_schema, _slots, _mem_table_sink.get(), _mem_tracker.get());
     }

--- a/be/test/storage/rowset_merger_test.cpp
+++ b/be/test/storage/rowset_merger_test.cpp
@@ -416,8 +416,8 @@ TEST_F(RowsetMergerTest, vertical_merge_seq) {
     TestRowsetWriter writer;
     Schema schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
     ASSERT_TRUE(PrimaryKeyEncoder::create_column(schema, &writer.all_pks).ok());
-    writer.non_key_columns.emplace_back(std::move(Int16Column::create_mutable()));
-    writer.non_key_columns.emplace_back(std::move(Int32Column::create_mutable()));
+    writer.non_key_columns.emplace_back(Int16Column::create_mutable());
+    writer.non_key_columns.emplace_back(Int32Column::create_mutable());
     ASSERT_TRUE(compaction_merge_rowsets(*_tablet, version, rowsets, &writer, cfg).ok());
 
     ASSERT_EQ(pks.size(), writer.all_pks->size());


### PR DESCRIPTION
* turn on the following warnings into errors
 - -Werror=string-plus-int
 - -Werror=pessimizing-move

(cherry picked from commit dbfa7e79553b0fb28483adb33b35e47681da59ee)
Signed-off-by: Kevin Xiaohua Cai <caixiaohua@starrocks.com>

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
