### PR TITLE
[Enhancement] Remove tuple column from cross join

### DIFF
--- a/be/src/exec/cross_join_node.h
+++ b/be/src/exec/cross_join_node.h
@@ -114,11 +114,8 @@ private:
     size_t _probe_rows_index = 0;
 
     bool _eos = false;
-    bool _need_create_tuple_columns = true;
 
     Buffer<SlotDescriptor*> _col_types;
-    Buffer<TupleId> _output_build_tuple_ids;
-    Buffer<TupleId> _output_probe_tuple_ids;
     size_t _probe_column_count = 0;
     size_t _build_column_count = 0;
 


### PR DESCRIPTION
Tuple column is already not generated on pipeline-engine, and branch-main already disable pipeline engine, so remove the tuple column from hash join.

As long as users enable the pipeline engine, there will be no compatibility issues with the upgrade.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
