### PR TITLE
[BugFix] Lockfree enqueue check if it is cancelled

### DIFF
--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -539,10 +539,8 @@ void DataStreamRecvr::PipelineSenderQueue::decrement_senders(int be_number) {
 }
 
 void DataStreamRecvr::PipelineSenderQueue::cancel() {
-    bool expected = false;
-    if (_is_cancelled.compare_exchange_strong(expected, true)) {
-        clean_buffer_queues();
-    }
+    _is_cancelled = true;
+    clean_buffer_queues();
 }
 
 void DataStreamRecvr::PipelineSenderQueue::close() {

--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -148,7 +148,7 @@ private:
 class DataStreamRecvr::PipelineSenderQueue final : public DataStreamRecvr::SenderQueue {
 public:
     PipelineSenderQueue(DataStreamRecvr* parent_recvr, int num_senders, int degree_of_parallism);
-    ~PipelineSenderQueue() override = default;
+    ~PipelineSenderQueue() override { close(); }
 
     Status get_chunk(Chunk** chunk, const int32_t driver_sequence = -1) override;
 


### PR DESCRIPTION
## Background

https://github.com/StarRocks/starrocks/pull/27515 this pr remove the lock around the enqueu process, and it only double-checks the short circuit but misses the `_is_cancelled`, so there's still a chance that a closure may be added into the queue, during which the query has been cancelled, and finally resulted in the closue leak, and RPC timeout.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
