### PR TITLE
[Enhancement] support discrete partition for mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionKey.java
@@ -105,6 +105,15 @@ public class PartitionKey implements Comparable<PartitionKey>, Writable {
         return partitionKey;
     }
 
+    public static PartitionKey createMinPartition(List<PrimitiveType> types) {
+        try {
+            return createInfinityPartitionKeyWithType(types, false);
+        } catch (AnalysisException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
     public static PartitionKey createInfinityPartitionKeyWithType(List<PrimitiveType> types, boolean isMax)
             throws AnalysisException {
         PartitionKey partitionKey = new PartitionKey();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/MvPartitionConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/MvPartitionConverter.java
@@ -1,0 +1,182 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Range;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.Expr;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.DateUtils;
+import com.starrocks.sql.analyzer.SemanticException;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Convert external table partitions to MV partitions.
+ * <p>
+ * External tables support various partitions type, like Hive column partition, each partition represents a value.
+ * But for MySQL external table, which supports native range-partition/range-column-partition/hash-partition.
+ * <p>
+ * Meanwhile, MV also supports various types of partitions, including RANGE/LIST...
+ */
+abstract class MvPartitionConverter {
+
+    abstract Map<String, Range<PartitionKey>> convert(Map<String, PartitionKey> partitions);
+
+    public static MvPartitionConverter buildConverter(Expr partitionExpr, Column partitionColumn) {
+        boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, partitionColumn);
+        PrimitiveType partitionColumnType = partitionColumn.getPrimitiveType();
+
+        // TODO: support more converter types
+        if (partitionColumnType == PrimitiveType.DATE || partitionColumnType.isNumericType()) {
+            return new ArithmeticTypePartitionConverter(partitionColumnType);
+        } else {
+            return new ConsecutivePartitionConverter(isConvertToDate, partitionColumnType);
+        }
+    }
+
+    /**
+     * Convert the col=value to [value, value+1), so the data type must be arithmetic
+     */
+    static class ArithmeticTypePartitionConverter extends MvPartitionConverter {
+
+        private PrimitiveType columnType;
+
+        public ArithmeticTypePartitionConverter(PrimitiveType columnType) {
+            this.columnType = columnType;
+        }
+
+        @Override
+        public Map<String, Range<PartitionKey>> convert(Map<String, PartitionKey> sourcePartitions) {
+            Map<String, Range<PartitionKey>> mvPartitionRangeMap = new LinkedHashMap<>();
+            boolean hasNull = false;
+            String nullPartitionName = null;
+            for (Map.Entry<String, PartitionKey> entry : sourcePartitions.entrySet()) {
+                String partitionName = entry.getKey();
+                PartitionKey startKey = entry.getValue();
+
+                if (startKey.isNullLiteral()) {
+                    hasNull = true;
+                    nullPartitionName = partitionName;
+                } else {
+                    PartitionKey endKey = startKey.successor();
+                    mvPartitionRangeMap.put(partitionName, Range.closedOpen(startKey, endKey));
+                }
+            }
+
+            // create the null partition as [0000-00-00, MIN_VALUE) if has null
+            if (hasNull) {
+                try {
+                    PartitionKey minLiteral = PartitionKey.createInfinityPartitionKeyWithType(
+                            ImmutableList.of(columnType), false);
+                    PartitionKey minValue = sourcePartitions.values().stream()
+                            .filter(x -> !x.isNullLiteral())
+                            .min(Comparator.naturalOrder())
+                            .orElseThrow(() -> new SemanticException("only null partition "));
+                    mvPartitionRangeMap.put(nullPartitionName, Range.closedOpen(minLiteral, minValue));
+                } catch (AnalysisException ignored) {
+                }
+            }
+
+            return mvPartitionRangeMap;
+        }
+    }
+
+    /**
+     * Convert the partitions [[a, b, c]] to [[MIN, a), [a, b), [b, c)].
+     * So the original values must be consecutive.
+     */
+    static class ConsecutivePartitionConverter extends MvPartitionConverter {
+
+        private final boolean isConvertToDate;
+        private final PrimitiveType partitionColumnType;
+
+        public ConsecutivePartitionConverter(boolean isConvertToDate, PrimitiveType partitionColumnType) {
+            this.isConvertToDate = isConvertToDate;
+            this.partitionColumnType = partitionColumnType;
+        }
+
+        private static PartitionKey convertToDate(PartitionKey partitionKey) {
+            PartitionKey newPartitionKey = new PartitionKey();
+            String dateLiteral = partitionKey.getKeys().get(0).getStringValue();
+            LocalDateTime dateValue = DateUtils.parseStrictDateTime(dateLiteral);
+            try {
+                newPartitionKey.pushColumn(new DateLiteral(dateValue, Type.DATE), PrimitiveType.DATE);
+                return newPartitionKey;
+            } catch (AnalysisException e) {
+                throw new SemanticException("create date string:{} failed:",
+                        partitionKey.getKeys().get(0).getStringValue(),
+                        e);
+            }
+        }
+
+        @Override
+        public Map<String, Range<PartitionKey>> convert(Map<String, PartitionKey> sourcePartitions) {
+            Map<String, Range<PartitionKey>> mvPartitionRangeMap = new LinkedHashMap<>();
+            PrimitiveType resultColumnType = isConvertToDate ? PrimitiveType.DATE : partitionColumnType;
+
+            // sort the partitions by value
+            LinkedHashMap<String, PartitionKey> sortedPartitionLinkMap = sourcePartitions.entrySet().stream()
+                    .sorted(Map.Entry.comparingByValue(PartitionKey::compareTo))
+                    .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1,
+                            LinkedHashMap::new));
+
+            // build the range map by discrete values
+            int index = 0;
+            PartitionKey lastPartitionKey = null;
+            String lastPartitionName = null;
+            for (Map.Entry<String, PartitionKey> entry : sortedPartitionLinkMap.entrySet()) {
+                if (index == 0) {
+                    lastPartitionName = entry.getKey();
+                    lastPartitionKey = isConvertToDate ? convertToDate(entry.getValue()) : entry.getValue();
+                    if (lastPartitionKey.getKeys().get(0).isNullable()) {
+                        // If partition key is NULL literal, rewrite it to min value.
+                        try {
+                            lastPartitionKey = PartitionKey.createInfinityPartitionKeyWithType(
+                                    ImmutableList.of(resultColumnType), false);
+                        } catch (Exception ignored) {
+                        }
+                    }
+                    ++index;
+                    continue;
+                }
+                Preconditions.checkState(!mvPartitionRangeMap.containsKey(lastPartitionName));
+                PartitionKey upperBound = isConvertToDate ? convertToDate(entry.getValue()) : entry.getValue();
+                mvPartitionRangeMap.put(lastPartitionName, Range.closedOpen(lastPartitionKey, upperBound));
+                lastPartitionName = entry.getKey();
+                lastPartitionKey = upperBound;
+            }
+            if (lastPartitionName != null) {
+                PartitionKey endKey = new PartitionKey();
+                endKey.pushColumn(PartitionUtil.addOffsetForLiteralUnchecked(lastPartitionKey.getKeys().get(0), 1),
+                        resultColumnType);
+
+                Preconditions.checkState(!mvPartitionRangeMap.containsKey(lastPartitionName));
+                mvPartitionRangeMap.put(lastPartitionName, Range.closedOpen(lastPartitionKey, endKey));
+            }
+            return mvPartitionRangeMap;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/PartitionDiffer.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.common;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
@@ -22,7 +21,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionKey;
-import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
@@ -31,7 +29,6 @@ import com.starrocks.common.util.RangeUtils;
 import com.starrocks.scheduler.TaskRun;
 import com.starrocks.scheduler.TaskRunContext;
 import com.starrocks.sql.analyzer.SemanticException;
-import org.apache.commons.collections4.ListUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.threeten.extra.PeriodDuration;
@@ -42,7 +39,6 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -201,20 +197,6 @@ public class PartitionDiffer {
             }
         }
         return result;
-    }
-
-    public static Map<String, Range<PartitionKey>> diffRange(List<PartitionRange> srcRanges,
-                                                             List<PartitionRange> dstRanges) {
-        if (!srcRanges.isEmpty() && !dstRanges.isEmpty()) {
-            List<PrimitiveType> srcTypes = srcRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
-            List<PrimitiveType> dstTypes = dstRanges.get(0).getPartitionKeyRange().lowerEndpoint().getTypes();
-            Preconditions.checkArgument(Objects.equals(srcTypes, dstTypes), "types must be identical");
-        }
-        List<PartitionRange> diffs = ListUtils.subtract(srcRanges, dstRanges);
-        return diffs.stream()
-                .collect(Collectors.toMap(PartitionRange::getPartitionName,
-                        diff -> SyncPartitionUtils.convertToDatePartitionRange(diff).getPartitionKeyRange()
-                ));
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -228,10 +228,6 @@ public class SyncPartitionUtils {
         return result;
     }
 
-    public static PartitionRange convertToDatePartitionRange(PartitionRange range) {
-        return new PartitionRange(range.getPartitionName(), convertToDatePartitionRange(range.getPartitionKeyRange()));
-    }
-
     public static Range<PartitionKey> convertToDatePartitionRange(Range<PartitionKey> range) {
         LiteralExpr lower = range.lowerEndpoint().getKeys().get(0);
         LiteralExpr upper = range.upperEndpoint().getKeys().get(0);

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -343,29 +343,6 @@ public class StarRocksAssert {
     }
 
     public StarRocksAssert refreshMvPartition(String sql) throws Exception {
-        //        StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
-        //        if (stmt instanceof RefreshMaterializedViewStatement) {
-        ////            RefreshMaterializedViewStatement refreshMaterializedViewStatement = (RefreshMaterializedViewStatement) stmt;
-        //
-        //            TableName mvName = refreshMaterializedViewStatement.getMvName();
-        //            Database db = GlobalStateMgr.getCurrentState().getDb(mvName.getDb());
-        //            Table table = db.getTable(mvName.getTbl());
-        //            Assert.assertNotNull(table);
-        //            Assert.assertTrue(table instanceof MaterializedView);
-        //            MaterializedView mv = (MaterializedView) table;
-        //
-        //            HashMap<String, String> taskRunProperties = new HashMap<>();
-        //            PartitionRangeDesc range = refreshMaterializedViewStatement.getPartitionRangeDesc();
-        //            taskRunProperties.put(TaskRun.PARTITION_START, range == null ? null : range.getPartitionStart());
-        //            taskRunProperties.put(TaskRun.PARTITION_END, range == null ? null : range.getPartitionEnd());
-        //            taskRunProperties.put(TaskRun.FORCE, "true");
-        //
-        //            Task task = TaskBuilder.rebuildMvTask(mv, "test", taskRunProperties);
-        //            TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(taskRunProperties).build();
-        //            taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        //            taskRun.executeTaskRun();
-        //            waitingTaskFinish(taskRun);
-        //        }
         if (!sql.contains("sync")) {
             sql += " with sync mode";
         }


### PR DESCRIPTION
Fixes #issue

External table could support discrete partitions like `2020-01-01, 2020-03-01`, which could not be converted to RANGE PARTITION in SR easily.

So here we try to convert it to `[2020-01-01, 2020-01-02), [2020-03-01, 2020-03-02)`.


TODO:
- Convert external list partition types to ListPartition in SR

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
