### PR TITLE
[Refactor] Remove tuple column from network framework

### DIFF
--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -298,7 +298,7 @@ Status DataStreamSender::Channel::add_rows_selective(RuntimeState* state, Chunk*
                                                      uint32_t from, uint32_t size) {
     // TODO(kks): find a way to remove this if condition
     if (UNLIKELY(_chunk == nullptr)) {
-        _chunk = chunk->clone_empty_with_tuple();
+        _chunk = chunk->clone_empty();
     }
 
     if (_chunk->num_rows() + size > state->chunk_size()) {

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -40,11 +40,6 @@ Status DataStreamRecvr::SenderQueue::_build_chunk_meta(const ChunkPB& pb_chunk) 
         _chunk_meta.slot_id_to_index[pb_chunk.slot_id_map()[i]] = pb_chunk.slot_id_map()[i + 1];
     }
 
-    _chunk_meta.tuple_id_to_index.reserve(pb_chunk.tuple_id_map().size());
-    for (int i = 0; i < pb_chunk.tuple_id_map().size(); i += 2) {
-        _chunk_meta.tuple_id_to_index[pb_chunk.tuple_id_map()[i]] = pb_chunk.tuple_id_map()[i + 1];
-    }
-
     _chunk_meta.is_nulls.resize(pb_chunk.is_nulls().size());
     for (int i = 0; i < pb_chunk.is_nulls().size(); ++i) {
         _chunk_meta.is_nulls[i] = pb_chunk.is_nulls()[i];
@@ -70,10 +65,6 @@ Status DataStreamRecvr::SenderQueue::_build_chunk_meta(const ChunkPB& pb_chunk) 
                 ++column_index;
             }
         }
-    }
-    for (const auto& kv : _chunk_meta.tuple_id_to_index) {
-        _chunk_meta.types[kv.second] = TypeDescriptor(LogicalType::TYPE_BOOLEAN);
-        ++column_index;
     }
 
     if (UNLIKELY(column_index != _chunk_meta.is_nulls.size())) {

--- a/be/src/serde/protobuf_serde.cpp
+++ b/be/src/serde/protobuf_serde.cpp
@@ -48,19 +48,12 @@ StatusOr<ChunkPB> ProtobufChunkSerde::serialize(const Chunk& chunk, const std::s
     if (!res.ok()) return res.status();
 
     const auto& slot_id_to_index = chunk.get_slot_id_to_index_map();
-    const auto& tuple_id_to_index = chunk.get_tuple_id_to_index_map();
     const auto& columns = chunk.columns();
 
     res->mutable_slot_id_map()->Reserve(static_cast<int>(slot_id_to_index.size()) * 2);
     for (const auto& kv : slot_id_to_index) {
         res->mutable_slot_id_map()->Add(kv.first);
         res->mutable_slot_id_map()->Add(static_cast<int>(kv.second));
-    }
-
-    res->mutable_tuple_id_map()->Reserve(static_cast<int>(tuple_id_to_index.size()) * 2);
-    for (const auto& kv : tuple_id_to_index) {
-        res->mutable_tuple_id_map()->Add(kv.first);
-        res->mutable_tuple_id_map()->Add(static_cast<int>(kv.second));
     }
 
     res->mutable_is_nulls()->Reserve(static_cast<int>(columns.size()));
@@ -73,7 +66,7 @@ StatusOr<ChunkPB> ProtobufChunkSerde::serialize(const Chunk& chunk, const std::s
         res->mutable_is_consts()->Add(column->is_constant());
     }
 
-    DCHECK_EQ(columns.size(), tuple_id_to_index.size() + slot_id_to_index.size());
+    DCHECK_EQ(columns.size(), slot_id_to_index.size());
 
     // serialize extra meta
     auto* chunk_extra_data =
@@ -228,7 +221,7 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
     cur += 4;
 
     std::vector<ColumnPtr> columns;
-    columns.resize(_meta.slot_id_to_index.size() + _meta.tuple_id_to_index.size());
+    columns.resize(_meta.slot_id_to_index.size());
     for (size_t i = 0, sz = _meta.is_nulls.size(); i < sz; ++i) {
         columns[i] = ColumnHelper::create_column(_meta.types[i], _meta.is_nulls[i], _meta.is_consts[i], rows);
     }
@@ -282,7 +275,7 @@ StatusOr<Chunk> ProtobufChunkDeserializer::deserialize(std::string_view buff, in
     }
 
     if (deserialized_bytes != nullptr) *deserialized_bytes = cur - reinterpret_cast<const uint8_t*>(buff.data());
-    return Chunk(std::move(columns), _meta.slot_id_to_index, _meta.tuple_id_to_index, std::move(chunk_extra_data));
+    return Chunk(std::move(columns), _meta.slot_id_to_index, std::move(chunk_extra_data));
 }
 
 StatusOr<ProtobufChunkMeta> build_protobuf_chunk_meta(const RowDescriptor& row_desc, const ChunkPB& chunk_pb) {

--- a/be/src/serde/protobuf_serde.h
+++ b/be/src/serde/protobuf_serde.h
@@ -62,7 +62,6 @@ struct ProtobufChunkMeta {
     std::vector<bool> is_nulls;
     std::vector<bool> is_consts;
     Chunk::SlotHashMap slot_id_to_index;
-    Chunk::TupleHashMap tuple_id_to_index;
     // extra data meta
     std::vector<ChunkExtraColumnsMeta> extra_data_metas;
 };


### PR DESCRIPTION
Tuple column is already not generated on pipeline-engine, and branch-main already disable pipeline engine, so remove the tuple column from framework

As long as users enable the pipeline engine, there will be no compatibility issues when upgrade.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
