### PR TITLE
[Enhancement] Mask access_key/access_secret of s3 broker load in audit log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -52,6 +52,10 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("gcp.gcs.service_account_private_key_id");
         SENSITIVE_KEY.add("gcp.gcs.service_account_private_key");
         SENSITIVE_KEY.add("azure.blob.shared_key");
+        SENSITIVE_KEY.add("azure.blob.sas_token");
+        SENSITIVE_KEY.add("azure.adls1.oauth2_credential");
+        SENSITIVE_KEY.add("azure.adls2.shared_key");
+        SENSITIVE_KEY.add("azure.adls2.oauth2_client_secret");
     }
 
     public PrintableMap(Map<K, V> map, String keyValueSaperator,

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -49,6 +49,9 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("property.sasl.password");
         SENSITIVE_KEY.add("broker.password");
         SENSITIVE_KEY.add("confluent.schema.registry.url");
+        SENSITIVE_KEY.add("gcp.gcs.service_account_private_key_id");
+        SENSITIVE_KEY.add("gcp.gcs.service_account_private_key");
+        SENSITIVE_KEY.add("azure.blob.shared_key");
     }
 
     public PrintableMap(Map<K, V> map, String keyValueSaperator,

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -40,6 +40,8 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("bos_secret_accesskey");
         SENSITIVE_KEY.add("fs.s3a.access.key");
         SENSITIVE_KEY.add("fs.s3a.secret.key");
+        SENSITIVE_KEY.add("aws.s3.access_key");
+        SENSITIVE_KEY.add("aws.s3.secret_key");
         SENSITIVE_KEY.add("fs.oss.accessKeyId");
         SENSITIVE_KEY.add("fs.oss.accessKeySecret");
         SENSITIVE_KEY.add("fs.cosn.userinfo.secretId");

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
@@ -119,6 +119,13 @@ public class LoadStmtTest {
                 "(\"password\"  =  \"***\", \"username\"  =  \"sr\") PROPERTIES (\"strict_mode\" = \"true\")",
                 AstToStringBuilder.toString(stmt));
 
+        stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"wasbs://aa@bb.blob.core.windows.net/*\") INTO TABLE `t0`) WITH BROKER " +
+                "(\"gcp.gcs.service_account_email\" = \"someone@gmail.com\",\n" +
+                "\"gcp.gcs.service_account_private_key_id\" = \"some_private_key_id\",\n" +
+                "\"gcp.gcs.service_account_private_key\" = \"some_private_key\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('wasbs://aa@bb.blob.core.windows.net/*') INTO TABLE t0) WITH BROKER  " +
+                "(\"gcp.gcs.service_account_email\"  =  \"someone@gmail.com\", \"gcp.gcs.service_account_private_key_id\"  =  \"***\", \"gcp.gcs.service_account_private_key\"  =  \"***\")", AstToStringBuilder.toString(stmt));
+
         stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"s3a://us-west-benchmark-data/tpch_100g/parquet/part/000004_0\") INTO TABLE `t0`) WITH BROKER " +
                 "(\"aws.s3.use_instance_profile\" = \"false\",\"aws.s3.access_key\" = \"some_key\", \"aws.s3.secret_key\" = \"some_secret\", \"aws.s3.region\" = \"us-west-2\")" +
                 " PROPERTIES (\"strict_mode\"=\"true\")");
@@ -127,9 +134,35 @@ public class LoadStmtTest {
 
         stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"wasbs://aa@bb.blob.core.windows.net/*\") INTO TABLE `t0`) WITH BROKER " +
                 "(\"azure.blob.storage_account\" = \"some_account\",\n" +
-                "    \"azure.blob.shared_key\" = \"some_shared_key\") " +
-                " PROPERTIES (\"strict_mode\"=\"true\")");
+                "    \"azure.blob.shared_key\" = \"some_shared_key\")");
         Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('wasbs://aa@bb.blob.core.windows.net/*') INTO TABLE t0) WITH BROKER  " +
-                "(\"azure.blob.storage_account\"  =  \"some_account\", \"azure.blob.shared_key\"  =  \"***\") PROPERTIES (\"strict_mode\" = \"true\")", AstToStringBuilder.toString(stmt));
+                "(\"azure.blob.storage_account\"  =  \"some_account\", \"azure.blob.shared_key\"  =  \"***\")", AstToStringBuilder.toString(stmt));
+
+        stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"wasbs://aa@bb.blob.core.windows.net/*\") INTO TABLE `t0`) WITH BROKER " +
+                "(\"azure.blob.account_name\" = \"some_account\",\n" +
+                "\"azure.blob.container_name\" = \"some_container\",\n" +
+                "\"azure.blob.sas_token\" = \"some_token\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('wasbs://aa@bb.blob.core.windows.net/*') INTO TABLE t0) WITH BROKER  " +
+                "(\"azure.blob.account_name\"  =  \"some_account\", \"azure.blob.container_name\"  =  \"some_container\", \"azure.blob.sas_token\"  =  \"***\")", AstToStringBuilder.toString(stmt));
+
+        stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"wasbs://aa@bb.blob.core.windows.net/*\") INTO TABLE `t0`) WITH BROKER " +
+                "(\"azure.adls1.oauth2_client_id\" = \"some_client_id\",\n" +
+                "\"azure.adls1.oauth2_credential\" = \"some_credential\",\n" +
+                "\"azure.adls1.oauth2_endpoint\" = \"some_endpoint\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('wasbs://aa@bb.blob.core.windows.net/*') INTO TABLE t0) WITH BROKER  " +
+                "(\"azure.adls1.oauth2_credential\"  =  \"***\", \"azure.adls1.oauth2_endpoint\"  =  \"some_endpoint\", \"azure.adls1.oauth2_client_id\"  =  \"some_client_id\")", AstToStringBuilder.toString(stmt));
+
+        stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"wasbs://aa@bb.blob.core.windows.net/*\") INTO TABLE `t0`) WITH BROKER " +
+                "(\"azure.adls2.storage_account\" = \"some_account\",\n" +
+                "\"azure.adls2.shared_key\" = \"some_key\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('wasbs://aa@bb.blob.core.windows.net/*') INTO TABLE t0) WITH BROKER  " +
+                "(\"azure.adls2.shared_key\"  =  \"***\", \"azure.adls2.storage_account\"  =  \"some_account\")", AstToStringBuilder.toString(stmt));
+
+        stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"wasbs://aa@bb.blob.core.windows.net/*\") INTO TABLE `t0`) WITH BROKER " +
+                "(\"azure.adls2.oauth2_client_id\" = \"some_client_id\",\n" +
+                "\"azure.adls2.oauth2_client_secret\" = \"some_secret\",\n" +
+                "\"azure.adls2.oauth2_client_endpoint\" = \"some_endpoint\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('wasbs://aa@bb.blob.core.windows.net/*') INTO TABLE t0) WITH BROKER  " +
+                "(\"azure.adls2.oauth2_client_id\"  =  \"some_client_id\", \"azure.adls2.oauth2_client_endpoint\"  =  \"some_endpoint\", \"azure.adls2.oauth2_client_secret\"  =  \"***\")", AstToStringBuilder.toString(stmt));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
@@ -124,5 +124,12 @@ public class LoadStmtTest {
                 " PROPERTIES (\"strict_mode\"=\"true\")");
         Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('s3a://us-west-benchmark-data/tpch_100g/parquet/part/000004_0') INTO TABLE t0) WITH BROKER  " +
                 "(\"aws.s3.access_key\"  =  \"***\", \"aws.s3.secret_key\"  =  \"***\", \"aws.s3.use_instance_profile\"  =  \"false\", \"aws.s3.region\"  =  \"us-west-2\") PROPERTIES (\"strict_mode\" = \"true\")", AstToStringBuilder.toString(stmt));
+
+        stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"wasbs://aa@bb.blob.core.windows.net/*\") INTO TABLE `t0`) WITH BROKER " +
+                "(\"azure.blob.storage_account\" = \"some_account\",\n" +
+                "    \"azure.blob.shared_key\" = \"some_shared_key\") " +
+                " PROPERTIES (\"strict_mode\"=\"true\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('wasbs://aa@bb.blob.core.windows.net/*') INTO TABLE t0) WITH BROKER  " +
+                "(\"azure.blob.storage_account\"  =  \"some_account\", \"azure.blob.shared_key\"  =  \"***\") PROPERTIES (\"strict_mode\" = \"true\")", AstToStringBuilder.toString(stmt));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/LoadStmtTest.java
@@ -118,5 +118,11 @@ public class LoadStmtTest {
                 "INTO TABLE t0 (`v1`, `v2`, `v3`)) WITH BROKER hdfs_broker " +
                 "(\"password\"  =  \"***\", \"username\"  =  \"sr\") PROPERTIES (\"strict_mode\" = \"true\")",
                 AstToStringBuilder.toString(stmt));
+
+        stmt = (LoadStmt) analyzeSuccess("LOAD  LABEL test.testLabel (DATA INFILE(\"s3a://us-west-benchmark-data/tpch_100g/parquet/part/000004_0\") INTO TABLE `t0`) WITH BROKER " +
+                "(\"aws.s3.use_instance_profile\" = \"false\",\"aws.s3.access_key\" = \"some_key\", \"aws.s3.secret_key\" = \"some_secret\", \"aws.s3.region\" = \"us-west-2\")" +
+                " PROPERTIES (\"strict_mode\"=\"true\")");
+        Assert.assertEquals("LOAD LABEL `test`.`testLabel` (DATA INFILE ('s3a://us-west-benchmark-data/tpch_100g/parquet/part/000004_0') INTO TABLE t0) WITH BROKER  " +
+                "(\"aws.s3.access_key\"  =  \"***\", \"aws.s3.secret_key\"  =  \"***\", \"aws.s3.use_instance_profile\"  =  \"false\", \"aws.s3.region\"  =  \"us-west-2\") PROPERTIES (\"strict_mode\" = \"true\")", AstToStringBuilder.toString(stmt));
     }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/13324
This PR would mask the access_key/access_secret of s3 broker load statement in audit log. The new output would be like
```
2023-10-26 14:45:41,430 [query] |Client=127.0.0.1:53202|User=root|AuthorizedUser='root'@'%'|ResourceGroup=|Catalog=default_catalog|Db=db0|State=OK|ErrorCode=|Time=20|ScanBytes=0|ScanRows=0|ReturnRows=0|StmtId=4|QueryId=47bb5a82-73cb-11ee-ab15-4efe77b34720|IsQuery=false|feIp=127.0.0.1|Stmt=LOAD LABEL `db0`.`tpch100ag_part1` (DATA INFILE ('s3a://us-west-benchmark-data/tpch_100g/parquet/part/000004_0') INTO TABLE part) WITH BROKER  ("aws.s3.access_key"  =  "***", "aws.s3.secret_key"  =  "***", "aws.s3.use_instance_profile"  =  "false", "aws.s3.region"  =  "us-west-2")|Digest=
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5