### PR TITLE
[Enhancement] Avoid lock when get the length of pipeline block queue

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -179,6 +179,7 @@ void PipelineDriverPoller::run_internal() {
 void PipelineDriverPoller::add_blocked_driver(const DriverRawPtr driver) {
     std::unique_lock<std::mutex> lock(_global_mutex);
     _blocked_drivers.push_back(driver);
+    _blocked_driver_queue_len++;
     driver->_pending_timer_sw->reset();
     driver->driver_acct().clean_local_queue_infos();
     _cond.notify_one();
@@ -230,6 +231,7 @@ void PipelineDriverPoller::remove_blocked_driver(DriverList& local_blocked_drive
     auto& driver = *driver_it;
     driver->_pending_timer->update(driver->_pending_timer_sw->elapsed_time());
     local_blocked_drivers.erase(driver_it++);
+    _blocked_driver_queue_len--;
 }
 
 void PipelineDriverPoller::on_cancel(DriverRawPtr driver, std::vector<DriverRawPtr>& ready_drivers,


### PR DESCRIPTION
Currently, cancel operator maybe consume long time, results in the lock being occupied for too long. At this time, obtaining Metrics will be stuck.

In the pr, obtaining the queue length is no longer locked.

```
Thread 1931 (Thread 0x2ad55809f700 (LWP 223310)):
#0  0x00002ad54e94c0b4 in pthread_rwlock_rdlock () from /lib64/libpthread.so.0
#1  0x0000000004f8f2fa in std::_Function_handler<unsigned long (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda()#3}>::_M_invoke(std::_Any_data const&) ()
#2  0x0000000004f8f350 in std::_Function_handler<void (), starrocks::pipeline::GlobalDriverExecutor::initialize(int)::{lambda(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::unique_ptr<starrocks::AtomicGauge<unsigned long>, std::default_delete<starrocks::AtomicGauge<unsigned long> > >&, std::function<unsigned long ()> const&)#1}::operator()(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::unique_ptr<starrocks::AtomicGauge<unsigned long>, std::default_delete<starrocks::AtomicGauge<unsigned long> > >&, std::function<unsigned long ()> const&) const::{lambda()#1}>::_M_invoke(std::_Any_data const&) ()
#3  0x0000000002c60a13 in starrocks::calculate_metrics(void*) ()
#4  0x0000000007e71840 in execute_native_thread_routine ()
#5  0x00002ad54e948dd5 in start_thread () from /lib64/libpthread.so.0
#6  0x00002ad54f368ead in clone () from /lib64/libc.so.6

Thread 1564 (Thread 0x2ad5f1833700 (LWP 224278)):
#0  0x0000000003f16ef5 in starrocks::vectorized::RuntimeBloomFilter<(starrocks::PrimitiveType)10>::insert(starrocks::Slice*) ()
#1  0x0000000003f09972 in starrocks::vectorized::RuntimeFilterHelper::fill_runtime_bloom_filter(std::shared_ptr<starrocks::vectorized::Column> const&, starrocks::PrimitiveType, starrocks::vectorized::JoinRuntimeFilter*, unsigned long, bool) ()
#2  0x0000000003050d4a in starrocks::pipeline::PartialRuntimeFilterMerger::merge_local_bloom_filters() ()
#3  0x000000000304df7d in starrocks::pipeline::HashJoinBuildOperator::set_finishing(starrocks::RuntimeState*) ()
#4  0x0000000002d1c9e9 in starrocks::pipeline::PipelineDriver::_mark_operator_finishing(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*) ()
#5  0x0000000002d1ca99 in starrocks::pipeline::PipelineDriver::_mark_operator_finished(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*) ()
#6  0x0000000002d1d08b in starrocks::pipeline::PipelineDriver::_mark_operator_cancelled(std::shared_ptr<starrocks::pipeline::Operator>&, starrocks::RuntimeState*) ()
#7  0x0000000002d1d66a in starrocks::pipeline::PipelineDriver::cancel_operators(starrocks::RuntimeState*) ()
#8  0x0000000004f9371f in starrocks::pipeline::PipelineDriverPoller::run_internal() ()
#9  0x000000000497e54a in starrocks::Thread::supervise_thread(void*) ()
#10 0x00002ad54e948dd5 in start_thread () from /lib64/libpthread.so.0
#11 0x00002ad54f368ead in clone () from /lib64/libc.so.6
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
