### PR TITLE
[BugFix] fix predicate normalize bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/Explain.java
@@ -752,7 +752,7 @@ public class Explain {
 
         @Override
         public String visit(ScalarOperator scalarOperator, Void context) {
-            return scalarOperator.accept(this, null);
+            return scalarOperator.toString();
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -54,23 +54,29 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
 
     // Comparator to normalize predicates, only use scalar operators' string to compare.
     private static final Comparator<ScalarOperator> SCALAR_OPERATOR_COMPARATOR_IGNORE_COLUMN_ID =
-            new Comparator<ScalarOperator>() {
-                @Override
-                public int compare(ScalarOperator o1, ScalarOperator o2) {
-                    if (o1 == null && o2 == null) {
-                        return 0;
-                    } else if (o1 == null) {
-                        return -1;
-                    } else if (o2 == null) {
-                        return 1;
-                    } else {
-                        String s1 = o1.toString();
-                        String s2 = o2.toString();
-                        String n1 = s1.replaceAll("\\d: ", "");
-                        String n2 = s2.replaceAll("\\d: ", "");
-                        int ret = n1.compareTo(n2);
-                        return (ret == 0) ? s1.compareTo(s2) : ret;
+            (o1, o2) -> {
+                if (o1 == null && o2 == null) {
+                    return 0;
+                } else if (o1 == null) {
+                    return -1;
+                } else if (o2 == null) {
+                    return 1;
+                } else {
+                    if (o1.isColumnRef() && o2.isColumnRef()) {
+                        ColumnRefOperator c1 = (ColumnRefOperator) o1;
+                        ColumnRefOperator c2 = (ColumnRefOperator) o2;
+                        int ret = c1.getName().compareTo(c2.getName());
+                        if (ret != 0) {
+                            return ret;
+                        }
+                        return Integer.compare(c1.getId(), c2.getId());
                     }
+                    String s1 = o1.toString();
+                    String s2 = o2.toString();
+                    String n1 = s1.replaceAll("\\d: ", "");
+                    String n2 = s2.replaceAll("\\d: ", "");
+                    int ret = n1.compareTo(n2);
+                    return (ret == 0) ? s1.compareTo(s2) : ret;
                 }
             };
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriterTest.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.Lists;
@@ -27,10 +26,12 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.scalar.ImplicitCastRule;
+import com.starrocks.sql.optimizer.rewrite.scalar.MvNormalizePredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.NegateFilterShuttle;
 import com.starrocks.sql.optimizer.rewrite.scalar.NormalizePredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
+import org.junit.Assert;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -118,5 +119,34 @@ public class ScalarOperatorRewriterTest {
         constFalse = ConstantOperator.NULL;
         assertEquals(new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.NOT, constFalse),
                 NegateFilterShuttle.getInstance().negateFilter(constFalse));
+    }
+
+    @Test
+    public void testNormalizePredicate() {
+        // b > a => a < b
+        {
+            BinaryPredicateOperator op = new BinaryPredicateOperator(BinaryType.GT,
+                    new ColumnRefOperator(0, Type.VARCHAR, "b", true),
+                    new ColumnRefOperator(1, Type.BIGINT, "a", true)
+            );
+
+            ScalarOperatorRewriter operatorRewriter = new ScalarOperatorRewriter();
+            ScalarOperator result = operatorRewriter.rewrite(op, Lists.newArrayList(new MvNormalizePredicateRule()));
+
+            Assert.assertEquals("1: a < 0: b", result.toString());
+        }
+
+        // b:101 > b:2 => b:2 < b:101
+        {
+            BinaryPredicateOperator op = new BinaryPredicateOperator(BinaryType.GT,
+                    new ColumnRefOperator(101, Type.VARCHAR, "b", true),
+                    new ColumnRefOperator(2, Type.BIGINT, "b", true)
+            );
+
+            ScalarOperatorRewriter operatorRewriter = new ScalarOperatorRewriter();
+            ScalarOperator result = operatorRewriter.rewrite(op, Lists.newArrayList(new MvNormalizePredicateRule()));
+
+            Assert.assertEquals("2: b < 101: b", result.toString());
+        }
     }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q12.sql
@@ -33,6 +33,6 @@ TOP-N (order by [[24: l_shipmode ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(28: sum), 29: sum=sum(29: sum)}] group by [[24: l_shipmode]] having [null]
             EXCHANGE SHUFFLE[24]
                 AGGREGATE ([LOCAL] aggregate [{28: sum=sum(26: case), 29: sum=sum(27: case)}] group by [[24: l_shipmode]] having [null]
-                    SCAN (mv[lineitem_mv] columns[41: l_commitdate, 47: l_receiptdate, 49: l_shipdate, 51: l_shipmode, 55: o_orderpriority] predicate[47: l_receiptdate >= 1997-01-01 AND 47: l_receiptdate < 1998-01-01 AND 51: l_shipmode IN (MAIL, REG AIR) AND 49: l_shipdate < 41: l_commitdate AND 41: l_commitdate < 47: l_receiptdate])
+                    SCAN (mv[lineitem_mv] columns[41: l_commitdate, 47: l_receiptdate, 49: l_shipdate, 51: l_shipmode, 55: o_orderpriority] predicate[47: l_receiptdate >= 1997-01-01 AND 47: l_receiptdate < 1998-01-01 AND 51: l_shipmode IN (MAIL, REG AIR) AND 41: l_commitdate < 47: l_receiptdate AND 41: l_commitdate > 49: l_shipdate])
 [end]
 


### PR DESCRIPTION
Fixes #issue

- Scenario: When normalizing the predicate, we sort the children of BinaryPredicate by name
- Cause: it's not correct, since if two columns have same name, they should be sorted by `ColumnRefId`, otherwise two predicates could not be matched even if they are equivlent. E.g `b:2 > b:1` and `b:1 < b:2`
- Fix: Compare the ColumnRef by name first, then id

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
