### PR TITLE
[Enhancement] Allow larger string length in dla

### DIFF
--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -308,6 +308,7 @@ Status HdfsTextScanner::parse_csv(int chunk_size, ChunkPtr* chunk) {
 
     csv::Converter::Options options;
     // Use to custom Hive array format
+    options.is_hive = true;
     options.array_format_type = csv::ArrayFormatType::kHive;
     options.array_hive_collection_delimiter = _collection_delimiter;
     options.array_hive_mapkey_delimiter = _mapkey_delimiter;

--- a/be/src/formats/csv/converter.h
+++ b/be/src/formats/csv/converter.h
@@ -59,6 +59,7 @@ public:
         // TODO: user configurable.
         bool bool_alpha = true;
 
+        bool is_hive = false;
         // Here used to control array parse format.
         // Considering Hive array format is different from traditional array format,
         // so here we provide some variables to customize array format, and you can

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -63,10 +63,10 @@ bool StringConverter::read_string(Column* column, const Slice& s, const Options&
     bool length_check_status = true;
     // Hive table, not limit string length <= 1mb anymore
     if (options.is_hive) {
-        if (max_size > 0 && s.size > max_size) {
+        if (UNLIKELY(max_size > 0 && s.size > max_size)) {
             length_check_status = false;
         }
-    } else  {
+    } else {
         if ((config::enable_check_string_lengths &&
              ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size)))) {
             length_check_status = false;
@@ -126,7 +126,7 @@ bool StringConverter::read_quoted_string(Column* column, const Slice& tmp_s, con
         if (max_size > 0 && ext_size > max_size) {
             length_check_status = false;
         }
-    } else  {
+    } else {
         if (config::enable_check_string_lengths &&
             ((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
             length_check_status = false;

--- a/be/src/formats/csv/string_converter.cpp
+++ b/be/src/formats/csv/string_converter.cpp
@@ -60,12 +60,24 @@ bool StringConverter::read_string(Column* column, const Slice& s, const Options&
         max_size = options.type_desc->len;
     }
 
-    if (config::enable_check_string_lengths &&
-        ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size))) {
+    bool length_check_status = true;
+    // Hive table, not limit string length <= 1mb anymore
+    if (options.is_hive) {
+        if (max_size > 0 && s.size > max_size) {
+            length_check_status = false;
+        }
+    } else  {
+        if ((config::enable_check_string_lengths &&
+             ((s.size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && s.size > max_size)))) {
+            length_check_status = false;
+        }
+    }
+    if (!length_check_status) {
         VLOG(3) << strings::Substitute("Column [$0]'s length exceed max varchar length. str_size($1), max_size($2)",
                                        column->get_name(), s.size, max_size);
         return false;
     }
+
     down_cast<BinaryColumn*>(column)->append(s);
     return true;
 }
@@ -107,8 +119,20 @@ bool StringConverter::read_quoted_string(Column* column, const Slice& tmp_s, con
         max_size = options.type_desc->len;
     }
     size_t ext_size = new_size - old_size;
-    if (config::enable_check_string_lengths &&
-        ((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
+
+    bool length_check_status = true;
+    // Hive table, not limit string length <= 1mb anymore
+    if (options.is_hive) {
+        if (max_size > 0 && ext_size > max_size) {
+            length_check_status = false;
+        }
+    } else  {
+        if (config::enable_check_string_lengths &&
+            ((ext_size > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size > 0 && ext_size > max_size))) {
+            length_check_status = false;
+        }
+    }
+    if (!length_check_status) {
         bytes.resize(old_size);
         VLOG(3) << strings::Substitute(
                 "Column [$0]'s length exceed max varchar length. old_size($1), new_size($2), ext_size($3), "
@@ -116,6 +140,7 @@ bool StringConverter::read_quoted_string(Column* column, const Slice& tmp_s, con
                 column->get_name(), old_size, new_size, ext_size, max_size);
         return false;
     }
+
     offsets.push_back(bytes.size());
     return true;
 }

--- a/be/src/formats/csv/varbinary_converter.cpp
+++ b/be/src/formats/csv/varbinary_converter.cpp
@@ -84,7 +84,8 @@ bool VarBinaryConverter::read_string(Column* column, const Slice& s, const Optio
             length_check_status = false;
         }
     } else {
-        if (config::enable_check_string_lengths && ((len > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size != -1 && len > max_size)))  {
+        if (config::enable_check_string_lengths &&
+            ((len > TypeDescriptor::MAX_VARCHAR_LENGTH) || (max_size != -1 && len > max_size))) {
             length_check_status = false;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -310,8 +310,9 @@ public class ScalarType extends Type implements Cloneable {
 
     // Use for Hive string now.
     public static ScalarType createDefaultExternalTableString() {
-        ScalarType stringType = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
-        return stringType;
+        // 1GB for each line, it's enough
+        final int MAX_LENGTH = 1024 * 1024 * 1024;
+        return ScalarType.createVarcharType(MAX_LENGTH);
     }
 
     public static ScalarType createMaxVarcharType() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -251,7 +251,7 @@ public class TypeTest {
         String json = GsonUtils.GSON.toJson(mapType);
         Type deType = GsonUtils.GSON.fromJson(json, Type.class);
         Assert.assertTrue(deType.isMapType());
-        Assert.assertEquals("MAP<INT,struct<c1 int(11), cc1 varchar(1048576)>>", deType.toString());
+        Assert.assertEquals("MAP<INT,struct<c1 int(11), cc1 varchar(1073741824)>>", deType.toString());
         // Make sure select fields are false when initialized
         Assert.assertFalse(deType.selectedFields[0]);
         Assert.assertFalse(deType.selectedFields[1]);
@@ -271,7 +271,7 @@ public class TypeTest {
         String json = GsonUtils.GSON.toJson(root);
         Type deType = GsonUtils.GSON.fromJson(json, Type.class);
         Assert.assertTrue(deType.isStructType());
-        Assert.assertEquals("struct<struct_test int(11) COMMENT 'comment test', c1 struct<c1 int(11), cc1 varchar(1048576)>>",
+        Assert.assertEquals("struct<struct_test int(11) COMMENT 'comment test', c1 struct<c1 int(11), cc1 varchar(1073741824)>>",
                 deType.toString());
         // test initialed fieldMap by ctor in deserializer.
         Assert.assertEquals(1, ((StructType) deType).getFieldPos("c1"));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
@@ -85,7 +85,7 @@ public class TrinoViewTest {
         Assert.assertEquals(hiveView.getFullSchema().get(2).getName(), "salary");
         Assert.assertEquals(hiveView.getFullSchema().get(2).getType(), ScalarType.DOUBLE);
         Assert.assertEquals(hiveView.getFullSchema().get(3).getName(), "new_col");
-        Assert.assertEquals(hiveView.getFullSchema().get(3).getType(), ScalarType.STRING);
+        Assert.assertEquals(hiveView.getFullSchema().get(3).getType(), ScalarType.createDefaultExternalTableString());
     }
 
     @Test
@@ -133,11 +133,12 @@ public class TrinoViewTest {
         Assert.assertEquals(hiveView.getFullSchema().get(14).getName(), "array_col");
         Assert.assertEquals(hiveView.getFullSchema().get(14).getType(), ScalarType.ARRAY_INT);
         Assert.assertEquals(hiveView.getFullSchema().get(15).getName(), "map_col");
-        Assert.assertEquals(hiveView.getFullSchema().get(15).getType(), new MapType(ScalarType.STRING, ScalarType.INT));
+        Assert.assertEquals(hiveView.getFullSchema().get(15).getType(),
+                new MapType(ScalarType.createDefaultExternalTableString(), ScalarType.INT));
         Assert.assertEquals(hiveView.getFullSchema().get(16).getName(), "struct_col");
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(new StructField("field1", ScalarType.INT));
-        structFields.add(new StructField("field2", ScalarType.STRING));
+        structFields.add(new StructField("field2", ScalarType.createDefaultExternalTableString()));
         Assert.assertEquals(hiveView.getFullSchema().get(16).getType(), new StructType(structFields));
     }
 
@@ -173,14 +174,15 @@ public class TrinoViewTest {
         Assert.assertEquals(columnList.get(6).getType(), ScalarType.createDecimalV3NarrowestType(10, 2));
         Assert.assertEquals(columnList.get(7).getType(), ScalarType.createVarcharType(20));
         Assert.assertEquals(columnList.get(8).getType(), ScalarType.createCharType(10));
-        Assert.assertEquals(columnList.get(9).getType(), ScalarType.STRING);
+        Assert.assertEquals(columnList.get(9).getType(), ScalarType.createDefaultExternalTableString());
         Assert.assertEquals(columnList.get(10).getType(), ScalarType.BOOLEAN);
         Assert.assertEquals(columnList.get(11).getType(), ScalarType.DATETIME);
         Assert.assertEquals(columnList.get(12).getType(), ScalarType.ARRAY_INT);
-        Assert.assertEquals(columnList.get(13).getType(), new MapType(ScalarType.STRING, ScalarType.INT));
+        Assert.assertEquals(columnList.get(13).getType(),
+                new MapType(ScalarType.createDefaultExternalTableString(), ScalarType.INT));
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(new StructField("field1", ScalarType.INT));
-        structFields.add(new StructField("field2", ScalarType.STRING));
+        structFields.add(new StructField("field2", ScalarType.createDefaultExternalTableString()));
         Assert.assertEquals(columnList.get(14).getType(), new StructType(structFields));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsExecutorTest.java
@@ -137,8 +137,8 @@ public class StatisticsExecutorTest extends PlanTestBase {
                             "and column_name = \"c1\" " +
                             "GROUP BY table_uuid, column_name UNION ALL " +
                             "SELECT cast(6 as INT), column_name, sum(row_count), cast(sum(data_size) as bigint), " +
-                            "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as varchar(1048576))) as string), " +
-                            "cast(min(cast(min as varchar(1048576))) as string) " +
+                            "hll_union_agg(ndv), sum(null_count),  cast(max(cast(max as varchar(1073741824))) as string), " +
+                            "cast(min(cast(min as varchar(1073741824))) as string) " +
                             "FROM external_column_statistics " +
                             "WHERE table_uuid = \"hive0.partitioned_db.t1.0\"" +
                             " and column_name = \"c2\" " +


### PR DESCRIPTION
DLA now supports a single line of string's length up to 1G, it's enough for most cases.

Because SR uses `uint32_t` to store the string's offsets in `BinaryColumn`, which means each BinaryColumn's size can't be larger than 4G. But usually, this rarely happens. 

Of course, even if the offset overflows, it will only cause an error in the result and will not cause the BE to crash.

I've tested it in CSV, ORC, and Parquet.

For CSV, because we will split the file according to the file size, it will not happen to read a single column larger than 4GB.

For ORC and Parquet, we will also split the file according to the file size. So it is almost impossible to read a single column larger than 4g. 

But if the user stores the same and very large string in each row. Orc and Parquet will use dictionary encoding, which makes it possible for us to read a single column larger than 4g in a chunk, and the result will be wrong.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
