### PR TITLE
[BugFix] Remove key fields debug check in merge iterator

### DIFF
--- a/be/src/storage/merge_iterator.cpp
+++ b/be/src/storage/merge_iterator.cpp
@@ -140,13 +140,6 @@ public:
                 CHECK_EQ(_schema.field(j)->to_string(), _children[i]->schema().field(j)->to_string());
             }
         }
-        // ensure that the key fields are the first |num_key_fields| and sorted by id.
-        for (size_t i = 0; i < _schema.num_key_fields(); i++) {
-            CHECK(_schema.field(i)->is_key());
-        }
-        for (size_t i = 0; i + 1 < _schema.num_key_fields(); i++) {
-            CHECK_LT(_schema.field(i)->id(), _schema.field(i + 1)->id());
-        }
 #endif
     }
 


### PR DESCRIPTION
primary key table supports specifying any columns as sort keys, and in any order, so the two checks are no longer valid.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
