### PR TITLE
[BugFix] Fix the data buffer out of bounds when read data from datacache.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -985,6 +985,8 @@ CONF_Int64(block_cache_lru_insertion_point, "1");
 // If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".
 CONF_String(block_cache_engine, "");
 CONF_Bool(block_cache_direct_io_enable, "false");
+// Whether to use block buffer to hold the datacache block data.
+CONF_Bool(block_cache_block_buffer_enable, "true");
 
 CONF_mInt64(l0_l1_merge_ratio, "10");
 CONF_mInt64(l0_max_file_size, "209715200"); // 200MB

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -242,6 +242,7 @@ Status HdfsScanner::open_random_access_file() {
             _cache_input_stream = std::make_shared<io::CacheInputStream>(_shared_buffered_input_stream, filename,
                                                                          file_size, _scanner_params.modification_time);
             _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_block_cache);
+            _cache_input_stream->set_enable_block_buffer(config::block_cache_block_buffer_enable);
             _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
             input_stream = _cache_input_stream;
         }

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -56,6 +56,8 @@ public:
 
     void set_enable_populate_cache(bool v) { _enable_populate_cache = v; }
 
+    void set_enable_block_buffer(bool v) { _enable_block_buffer = v; }
+
     int64_t get_align_size() const;
 
     StatusOr<std::string_view> peek(int64_t count) override;
@@ -83,6 +85,7 @@ private:
     Stats _stats;
     int64_t _size;
     bool _enable_populate_cache = false;
+    bool _enable_block_buffer = false;
     int64_t _block_size = 0;
     std::unordered_map<int64_t, BlockBuffer> _block_map;
 };


### PR DESCRIPTION
When read data from datacache, we only get the `can_zero_copy` before reading blocks. If the output buffer is larger than block size, it will always be `true`.
In fact, as subsequent blocks are read, the available buffer area will continue to decrease. At this time, data filling will be out of bounds due to misjudgment in some cases.
So, we need to update this value before reading each block.

Also, we add a new configuration switch to control whether use the block buffer.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
