### PR TITLE
[BugFix] Fix the data buffer out of bounds when read data from datacache.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -981,6 +981,8 @@ CONF_Bool(datacache_adaptor_enable, "true");
 // the more requests will be sent to the network.
 // Usually there is no need to modify it.
 CONF_Int64(datacache_skip_read_factor, "1");
+// Whether to use block buffer to hold the datacache block data.
+CONF_Bool(datacache_block_buffer_enable, "true");
 // DataCache engines, alternatives: cachelib, starcache.
 // Set the default value empty to indicate whether it is manully configured by users.
 // If not, we need to adjust the default engine based on build switches like "WITH_CACHELIB" and "WITH_STARCACHE".

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -243,6 +243,7 @@ Status HdfsScanner::open_random_access_file() {
             _cache_input_stream = std::make_shared<io::CacheInputStream>(_shared_buffered_input_stream, filename,
                                                                          file_size, _scanner_params.modification_time);
             _cache_input_stream->set_enable_populate_cache(_scanner_params.enable_populate_datacache);
+            _cache_input_stream->set_enable_block_buffer(config::datacache_block_buffer_enable);
             _shared_buffered_input_stream->set_align_size(_cache_input_stream->get_align_size());
             input_stream = _cache_input_stream;
         }

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -89,14 +89,16 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
     int64_t shift = offset - block_offset;
 
     SharedBufferedInputStream::SharedBuffer* sb = nullptr;
-    auto ret = _sb_stream->find_shared_buffer(offset, size);
-    if (ret.ok()) {
-        sb = ret.value();
-        if (sb->buffer.capacity() > 0) {
-            strings::memcpy_inlined(out, sb->buffer.data() + offset - sb->offset, size);
-            _populate_cache_from_zero_copy_buffer((const char*)sb->buffer.data() + block_offset - sb->offset,
-                                                  block_offset, load_size);
-            return Status::OK();
+    if (_enable_block_buffer) {
+        auto ret = _sb_stream->find_shared_buffer(offset, size);
+        if (ret.ok()) {
+            sb = ret.value();
+            if (sb->buffer.capacity() > 0) {
+                strings::memcpy_inlined(out, sb->buffer.data() + offset - sb->offset, size);
+                _populate_cache_from_zero_copy_buffer((const char*)sb->buffer.data() + block_offset - sb->offset,
+                                                      block_offset, load_size);
+                return Status::OK();
+            }
         }
     }
 
@@ -105,24 +107,34 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
     int64_t read_cache_ns = 0;
     BlockBuffer block;
     ReadCacheOptions options;
+    size_t read_size = 0;
     {
         SCOPED_RAW_TIMER(&read_cache_ns);
-        res = _cache->read_cache(_cache_key, block_offset, load_size, &block.buffer, &options);
+        if (_enable_block_buffer) {
+            res = _cache->read_cache(_cache_key, block_offset, load_size, &block.buffer);
+            read_size = load_size;
+        } else {
+            StatusOr<size_t> r = _cache->read_cache(_cache_key, offset, size, out);
+            res = r.status();
+            read_size = size;
+        }
     }
     if (res.ok()) {
-        block.buffer.copy_to(out, size, shift);
-        block.offset = block_offset;
-        _block_map[block_id] = block;
+        if (_enable_block_buffer) {
+            block.buffer.copy_to(out, size, shift);
+            block.offset = block_offset;
+            _block_map[block_id] = block;
+        }
+        _stats.read_cache_bytes += read_size;
         _stats.read_cache_count += 1;
-        _stats.read_cache_bytes += load_size;
         _stats.read_mem_cache_bytes += options.stats.read_mem_bytes;
         _stats.read_disk_cache_bytes += options.stats.read_disk_bytes;
         _stats.read_cache_ns += read_cache_ns;
-        _cache->record_read_cache(load_size, read_cache_ns / 1000);
+        _cache->record_read_cache(read_size, read_cache_ns / 1000);
         return Status::OK();
     } else if (res.is_resource_busy()) {
         _stats.skip_read_cache_count += 1;
-        _stats.skip_read_cache_bytes += load_size;
+        _stats.skip_read_cache_bytes += read_size;
     }
     if (!res.is_not_found() && !res.is_resource_busy()) return res;
 
@@ -170,7 +182,7 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
 }
 
 void CacheInputStream::_deduplicate_shared_buffer(SharedBufferedInputStream::SharedBuffer* sb) {
-    if (sb->size == 0) {
+    if (sb->size == 0 || _block_map.empty()) {
         return;
     }
     int64_t end_offset = sb->offset + sb->size;
@@ -212,11 +224,11 @@ Status CacheInputStream::read_at_fully(int64_t offset, void* out, int64_t count)
     int64_t end_offset = offset + count;
     int64_t start_block_id = offset / _block_size;
     int64_t end_block_id = (end_offset - 1) / _block_size;
-    bool can_zero_copy = p + _block_size < pe;
     for (int64_t i = start_block_id; i <= end_block_id; i++) {
         size_t off = std::max(offset, i * _block_size);
         size_t end = std::min((i + 1) * _block_size, end_offset);
         size_t size = end - off;
+        bool can_zero_copy = p + _block_size < pe;
         Status st = _read_block(off, size, p, can_zero_copy);
         if (!st.ok()) return st;
         offset += size;

--- a/be/src/io/cache_input_stream.h
+++ b/be/src/io/cache_input_stream.h
@@ -65,6 +65,8 @@ public:
 
     void set_enable_populate_cache(bool v) { _enable_populate_cache = v; }
 
+    void set_enable_block_buffer(bool v) { _enable_block_buffer = v; }
+
     int64_t get_align_size() const;
 
     StatusOr<std::string_view> peek(int64_t count) override;
@@ -92,6 +94,7 @@ private:
     Stats _stats;
     int64_t _size;
     bool _enable_populate_cache = false;
+    bool _enable_block_buffer = false;
     BlockCache* _cache = nullptr;
     int64_t _block_size = 0;
     std::unordered_map<int64_t, BlockBuffer> _block_map;


### PR DESCRIPTION
When read data from datacache, we only get the `can_zero_copy` before reading blocks. If the output buffer is larger than block size, it will always be `true`.
In fact, as subsequent blocks are read, the available buffer area will continue to decrease. At this time, data filling will be out of bounds due to misjudgment in some cases.
So, we need to update this value before reading each block.

Also, we add a new configuration switch to control whether use the block buffer.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
