### PR TITLE
[BugFix] Fix spill right outer join missing rows

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -393,6 +393,7 @@ StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* stat
     size_t eofs = std::accumulate(_probe_read_eofs.begin(), _probe_read_eofs.end(), 0);
     if (_need_post_probe && _has_probe_remain) {
         if (_is_finishing) {
+            bool has_remain = false;
             for (size_t i = 0; i < _probers.size(); ++i) {
                 if (!_probe_post_eofs[i] && _probe_read_eofs[i]) {
                     bool has_remain = false;
@@ -403,8 +404,9 @@ StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* stat
                         return res;
                     }
                 }
+                has_remain |= !_probe_post_eofs[i];
             }
-            _has_probe_remain = false;
+            _has_probe_remain = has_remain;
         }
     } else {
         _has_probe_remain = false;

--- a/test/sql/test_spill/R/test_spill_hash_join
+++ b/test/sql/test_spill/R/test_spill_hash_join
@@ -161,3 +161,17 @@ select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l full outer join [
 -- result:
 4097	4097	6144.0	4097
 -- !result
+create table t2 like t0;
+-- result:
+-- !result
+insert into t2 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  409600));
+-- result:
+-- !result
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 > 400000;
+-- result:
+9600
+-- !result
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 < 400000;
+-- result:
+404095
+-- !result

--- a/test/sql/test_spill/T/test_spill_hash_join
+++ b/test/sql/test_spill/T/test_spill_hash_join
@@ -60,3 +60,9 @@ select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l right outer join 
 
 select count(*), count(l.c0), avg(l.c0), count(l.c1) from t1 l full outer join [bucket] empty_t r on l.c0 = r.c0;
 
+
+-- other conjuncts condition
+create table t2 like t0;
+insert into t2 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  409600));
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 > 400000;
+select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 < 400000;


### PR DESCRIPTION
```
        if (_is_finishing) {
            for (size_t i = 0; i < _probers.size(); ++i) {
                if (!_probe_post_eofs[i] && _probe_read_eofs[i]) {
                    bool has_remain = false;
	@@ -403,8 +404,9 @@ StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* stat
                        return res;
                    }
                }
            }
            _has_probe_remain = false; // _has_probe_remain should check all probe_remain has no data.
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
