### PR TITLE
[BugFix] Fix orc timestamp min-max filter error

### DIFF
--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -97,9 +97,9 @@ Status OrcChunkReader::init(std::unique_ptr<orc::InputStream> input_stream) {
     return Status::OK();
 }
 
-void OrcChunkReader::build_column_name_to_id_mapping(std::unordered_map<std::string, int>* mapping,
-                                                     const std::vector<std::string>* hive_column_names,
-                                                     const orc::Type& root_type, bool case_sensitive) {
+void OrcChunkReader::build_column_name_to_orc_type_mapping(std::unordered_map<std::string, const orc::Type*>* mapping,
+                                                           const std::vector<std::string>* hive_column_names,
+                                                           const orc::Type& root_type, bool case_sensitive) {
     mapping->clear();
     if (hive_column_names != nullptr) {
         // build hive column names index.
@@ -109,14 +109,14 @@ void OrcChunkReader::build_column_name_to_id_mapping(std::unordered_map<std::str
         for (int i = 0; i < size; i++) {
             const auto& sub_type = root_type.getSubtype(i);
             std::string col_name = format_column_name(hive_column_names->at(i), case_sensitive);
-            mapping->insert(make_pair(col_name, static_cast<int>(sub_type->getColumnId())));
+            mapping->insert(make_pair(col_name, sub_type));
         }
     } else {
         // build orc column names index.
         for (int i = 0; i < root_type.getSubtypeCount(); i++) {
             const auto& sub_type = root_type.getSubtype(i);
             std::string col_name = format_column_name(root_type.getFieldName(i), case_sensitive);
-            mapping->insert(make_pair(col_name, static_cast<int>(sub_type->getColumnId())));
+            mapping->insert(make_pair(col_name, sub_type));
         }
     }
 }
@@ -143,8 +143,8 @@ void OrcChunkReader::build_column_name_set(std::unordered_set<std::string>* name
 
 Status OrcChunkReader::_init_include_columns(const std::unique_ptr<OrcMapping>& mapping) {
     // TODO(SmithCruise) delete _name_to_column_id, _hive_column_names when develop subfield lazy load.
-    build_column_name_to_id_mapping(&_formatted_slot_name_to_column_id, _hive_column_names, _reader->getType(),
-                                    _case_sensitive);
+    build_column_name_to_orc_type_mapping(&_formatted_slot_name_to_orc_type, _hive_column_names, _reader->getType(),
+                                          _case_sensitive);
 
     std::list<uint64_t> include_column_id;
 
@@ -255,14 +255,14 @@ Status OrcChunkReader::_init_position_in_orc() {
 
         if (slot_desc == nullptr) continue;
         std::string col_name = format_column_name(slot_desc->col_name(), _case_sensitive);
-        auto it = _formatted_slot_name_to_column_id.find(col_name);
-        if (it == _formatted_slot_name_to_column_id.end()) {
+        auto it = _formatted_slot_name_to_orc_type.find(col_name);
+        if (it == _formatted_slot_name_to_orc_type.end()) {
             auto s = strings::Substitute(
                     "OrcChunkReader::init_position_in_orc. failed to find position. col_name = $0, file = $1", col_name,
                     _current_file_name);
             return Status::NotFound(s);
         }
-        int col_id = it->second;
+        int col_id = it->second->getColumnId();
         auto it2 = column_id_to_pos.find(col_id);
         if (it2 == column_id_to_pos.end()) {
             auto s = strings::Substitute(
@@ -1235,13 +1235,13 @@ void OrcChunkReader::report_error_message(const std::string& error_msg) {
     _state->append_error_msg_to_file("", error_msg);
 }
 
-int OrcChunkReader::get_column_id_by_slot_name(const std::string& slot_name) const {
+const orc::Type* OrcChunkReader::get_orc_type_by_slot_name(const std::string& slot_name) const {
     const std::string& formatted_slot_name = format_column_name(slot_name, _case_sensitive);
-    const auto& it = _formatted_slot_name_to_column_id.find(formatted_slot_name);
-    if (it != _formatted_slot_name_to_column_id.end()) {
+    const auto& it = _formatted_slot_name_to_orc_type.find(formatted_slot_name);
+    if (it != _formatted_slot_name_to_orc_type.end()) {
         return it->second;
     }
-    return -1;
+    return nullptr;
 }
 
 bool OrcChunkReader::is_implicit_castable(TypeDescriptor& starrocks_type, const TypeDescriptor& orc_type) {

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -108,9 +108,9 @@ public:
     }
     void set_case_sensitive(bool case_sensitive) { _case_sensitive = case_sensitive; }
 
-    static void build_column_name_to_id_mapping(std::unordered_map<std::string, int>* mapping,
-                                                const std::vector<std::string>* hive_column_names,
-                                                const orc::Type& root_type, bool case_sensitive);
+    static void build_column_name_to_orc_type_mapping(std::unordered_map<std::string, const orc::Type*>* mapping,
+                                                      const std::vector<std::string>* hive_column_names,
+                                                      const orc::Type& root_type, bool case_sensitive);
     static void build_column_name_set(std::unordered_set<std::string>* name_set,
                                       const std::vector<std::string>* hive_column_names, const orc::Type& root_type,
                                       bool case_sensitive);
@@ -124,7 +124,7 @@ public:
     SlotDescriptor* get_current_slot() const { return _current_slot; }
     void set_current_file_name(const std::string& name) { _current_file_name = name; }
     void report_error_message(const std::string& error_msg);
-    int get_column_id_by_slot_name(const std::string& name) const;
+    const orc::Type* get_orc_type_by_slot_name(const std::string& name) const;
 
     void set_lazy_load_context(LazyLoadContext* ctx) { _lazy_load_ctx = ctx; }
     bool has_lazy_load_context() { return _lazy_load_ctx != nullptr; }
@@ -201,7 +201,7 @@ private:
     const std::vector<std::string>* _hive_column_names = nullptr;
     bool _case_sensitive = false;
     // Key is slot name formatted with case sensitive
-    std::unordered_map<std::string, int> _formatted_slot_name_to_column_id;
+    std::unordered_map<std::string, const orc::Type*> _formatted_slot_name_to_orc_type;
     RuntimeState* _state = nullptr;
     SlotDescriptor* _current_slot = nullptr;
     std::string _current_file_name;

--- a/be/src/formats/orc/orc_min_max_decoder.h
+++ b/be/src/formats/orc/orc_min_max_decoder.h
@@ -32,8 +32,8 @@ namespace starrocks {
 class OrcMinMaxDecoder {
 public:
     // to decode min and max value from column stats.
-    static Status decode(SlotDescriptor* slot, const orc::proto::ColumnStatistics& stats, ColumnPtr min_col,
-                         ColumnPtr max_col, int64_t tz_offset_in_seconds);
+    static Status decode(SlotDescriptor* slot, const orc::Type* type, const orc::proto::ColumnStatistics& stats,
+                         ColumnPtr min_col, ColumnPtr max_col, int64_t tz_offset_in_seconds);
 };
 
 } // namespace starrocks

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -85,7 +85,7 @@ public:
         tv->from_timestamp(tp.year(), tp.month(), tp.day(), tp.hour(), tp.minute(), tp.second(), 0);
     }
     static void orc_ts_to_native_ts(TimestampValue* tv, const cctz::time_zone& tz, int64_t tzoffset, int64_t seconds,
-                                    int64_t nanoseconds, bool is_instant = false) {
+                                    int64_t nanoseconds, bool is_instant) {
         if (seconds >= 0) {
             seconds = is_instant ? seconds + tzoffset : seconds;
             orc_ts_to_native_ts_after_unix_epoch(tv, seconds, nanoseconds);

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -784,7 +784,6 @@ TEST_F(HdfsScannerTest, TestOrcGetNextWithDatetimeMinMaxFilter) {
     SlotDesc datetime_orc_descs[] = {{"c0", TypeDescriptor::from_logical_type(LogicalType::TYPE_DATETIME)}, {""}};
     const std::string datetime_orc_file = "./be/test/exec/test_data/orc_scanner/datetime_20k.orc.zlib";
 
-    _create_runtime_state("GMT");
     auto scanner = std::make_shared<HdfsOrcScanner>();
 
     auto* range = _create_scan_range(datetime_orc_file, 0, 0);
@@ -987,6 +986,7 @@ TEST_F(HdfsScannerTest, DecodeMinMaxDateTime) {
                                                {"c1", TypeDescriptor::from_logical_type(LogicalType::TYPE_DATE)},
                                                {""}};
 
+    // They are a timestamp type, we will ignore all timezone information
     const std::string timezone_datetime_shanghai_orc_file =
             "./be/test/exec/test_data/orc_scanner/writer_tz_shanghai.orc";
     const std::string timezone_datetime_utc_orc_file = "./be/test/exec/test_data/orc_scanner/writer_tz_utc.orc";
@@ -999,10 +999,10 @@ TEST_F(HdfsScannerTest, DecodeMinMaxDateTime) {
     };
     std::vector<Case> cases = {
             {timezone_datetime_shanghai_orc_file, "2022-04-09 07:13:00", "Asia/Shanghai", 1},
-            {timezone_datetime_shanghai_orc_file, "2022-04-09 07:13:00", "UTC", 0},
-            {timezone_datetime_shanghai_orc_file, "2022-04-08 23:13:00", "UTC", 1},
-            {timezone_datetime_utc_orc_file, "2022-04-09 07:13:00", "Asia/Shanghai", 0},
-            {timezone_datetime_utc_orc_file, "2022-04-09 15:13:00", "Asia/Shanghai", 1},
+            {timezone_datetime_shanghai_orc_file, "2022-04-09 07:13:00", "UTC", 1},
+            {timezone_datetime_shanghai_orc_file, "2022-04-08 23:13:00", "UTC", 0},
+            {timezone_datetime_utc_orc_file, "2022-04-09 07:13:00", "Asia/Shanghai", 1},
+            {timezone_datetime_utc_orc_file, "2022-04-09 15:13:00", "Asia/Shanghai", 0},
             {timezone_datetime_utc_orc_file, "2022-04-09 07:13:00", "UTC", 1},
     };
 


### PR DESCRIPTION
Orc min-max timestamp's filter should consider orc type is timestamp or timestamp with instant.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
