### PR TITLE
[BugFix] Fix spiller scope timer use-after-free (#33676)

### DIFF
--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -107,6 +107,8 @@ struct SyncTaskExecutor {
     }
 };
 
+#define DEFER_GUARD_END(guard) auto VARNAME_LINENUM(defer) = DeferOp([&]() { guard.scoped_end(); });
+
 #define RESOURCE_TLS_MEMTRACER_GUARD(state, ...) \
     spill::ResourceMemTrackerGuard(tls_mem_tracker, state->query_ctx()->weak_from_this(), ##__VA_ARGS__)
 


### PR DESCRIPTION
spiller->timer maybe free when guard.scope_end() called

Fixes the stack:
```
PC: @          0x2a6bd20 starrocks::ScopedTimer<>::~ScopedTimer()
*** SIGSEGV (@0x0) received by PID 11471 (TID 0x7fddce6b2700) from PID 0; stack trace: ***
    @          0x62f3702 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fdea56ac5f0 (unknown)
    @          0x2a6bd20 starrocks::ScopedTimer<>::~ScopedTimer()
    @          0x2d787a4 _ZNSt17_Function_handlerIFvvEZN9starrocks5spill16RawSpillerWriter5flushIRNS2_14IOTaskExecutorERNS2_23ResourceMemTrackerGuardIJSt8weak_ptrINS1_8pipeline12QueryContextEES8_INS2_7SpillerEEEEEEENS1_6StatusEPNS1_12RuntimeStateEOT_OT0_EUlvE0_E9_M_invokeERKSt9_Any_data
    @          0x2aa6881 starrocks::workgroup::ScanExecutor::worker_thread()
    @          0x4f07072 starrocks::ThreadPool::dispatch_thread()
    @          0x4f01b6a starrocks::Thread::supervise_thread()
    @     0x7fdea56a4e65 start_thread
    @     0x7fdea4cbf88d __clone
```
cherry-pick (#33676)