### PR TITLE
[BugFix] Revert "[BugFix][Cherry-pick][Branch-3.1] BE crash in ASAN mode when we do column mode partial update for primary key table which separate primary keys and sort keys (#31219) (#33483)"

### DIFF
--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -215,7 +215,7 @@ Status DeltaWriter::_init() {
             _memtable_buffer_row = config::write_buffer_size / average_row_size;
         }
 
-        auto partial_update_schema =
+        writer_context.partial_update_tablet_schema =
                 TabletSchema::create(_tablet->tablet_schema(), writer_context.referenced_column_ids);
         auto sort_key_idxes = _tablet->tablet_schema().sort_key_idxes();
         std::sort(sort_key_idxes.begin(), sort_key_idxes.end());
@@ -226,17 +226,6 @@ Status DeltaWriter::_init() {
         if (!_opt.merge_condition.empty()) {
             writer_context.merge_condition = _opt.merge_condition;
         }
-        // In column mode partial update, we need to modify sort key idxes and short key column num in partial
-        // tablet schema
-        if (_opt.partial_update_mode == PartialUpdateMode::COLUMN_UPSERT_MODE ||
-            _opt.partial_update_mode == PartialUpdateMode::COLUMN_UPDATE_MODE) {
-            std::vector<ColumnId> sort_key_idxes(_tablet_schema->num_key_columns());
-            std::iota(sort_key_idxes.begin(), sort_key_idxes.end(), 0);
-            partial_update_schema->set_num_short_key_columns(1);
-            partial_update_schema->set_sort_key_idxes(sort_key_idxes);
-        }
-
-        writer_context.partial_update_tablet_schema = partial_update_schema;
         writer_context.tablet_schema = writer_context.partial_update_tablet_schema.get();
         writer_context.partial_update_mode = _opt.partial_update_mode;
     } else {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -255,11 +255,9 @@ public:
     const TabletColumn& column(size_t ordinal) const;
     const std::vector<TabletColumn>& columns() const;
     const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }
-
     size_t num_columns() const { return _cols.size(); }
     size_t num_key_columns() const { return _num_key_columns; }
     size_t num_short_key_columns() const { return _num_short_key_columns; }
-
     size_t num_rows_per_row_block() const { return _num_rows_per_row_block; }
     KeysType keys_type() const { return static_cast<KeysType>(_keys_type); }
     size_t next_column_unique_id() const { return _next_column_unique_id; }
@@ -270,28 +268,6 @@ public:
     // The in-memory property is no longer supported, but leave this API for compatibility.
     // Newly-added code should not rely on this method, it may be removed at any time.
     static bool is_in_memory() { return false; }
-
-    // Please call the following function with caution. Most of the time,
-    // the following two functions should not be called explicitly.
-    // When we do column partial update for primary key table which seperate primary keys
-    // and sort keys, we will create a partial tablet schema for rowset writer. However,
-    // the sort key columns maybe not exist in the partial tablet schema and the partial tablet
-    // schema will keep a wrong sort key idxes and short key column num. So BE will crash in ASAN
-    // mode. However, the sort_key_idxes and short_key_column_num in partial tablet schema is not
-    // important actually, because the update segment file does not depend on it and the update
-    // segment file will be rewrite to col file after apply. So these function are used to modify
-    // the sort_key_idxes and short_key_column_num in partial tablet schema to avoid BE crash so far.
-    void set_sort_key_idxes(std::vector<ColumnId> sort_key_idxes) {
-        for (auto idx : _sort_key_idxes) {
-            _cols[idx].set_is_sort_key(false);
-        }
-        _sort_key_idxes.clear();
-        _sort_key_idxes.assign(sort_key_idxes.begin(), sort_key_idxes.end());
-        for (auto idx : _sort_key_idxes) {
-            _cols[idx].set_is_sort_key(true);
-        }
-    }
-    void set_num_short_key_columns(uint16_t num_short_key_columns) { _num_short_key_columns = num_short_key_columns; }
 
     std::string debug_string() const;
 

--- a/test/sql/test_partial_update_column_mode/R/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/R/test_partial_update
@@ -43,8 +43,8 @@ insert into tab1 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
 select * from tab1;
 -- result:
 200	k2_200	200	200	200	v4_200	v5_200
-300	k3_300	300	300	300	v4_300	v5_300
 100	k2_100	100	100	100	v4_100	v5_100
+300	k3_300	300	300	300	v4_300	v5_300
 -- !result
 insert into tab2 values (100, 100, 100, 100);
 -- result:
@@ -67,17 +67,17 @@ E: (1064, 'Getting analyzing error. Detail message: must specify where clause to
 -- !result
 select * from tab1;
 -- result:
-300	k3_300	300	300	300	v4_300	v5_300
-100	k2_100	100	100	100	v4_100	v5_100
 200	k2_200	200	200	200	v4_200	v5_200
+100	k2_100	100	100	100	v4_100	v5_100
+300	k3_300	300	300	300	v4_300	v5_300
 -- !result
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2) where k1 = 100;
 -- result:
 -- !result
 select * from tab1;
 -- result:
-300	k3_300	300	300	300	v4_300	v5_300
 100	k2_100	600	600	100	v4_100	v5_100
+300	k3_300	300	300	300	v4_300	v5_300
 200	k2_200	200	200	200	v4_200	v5_200
 -- !result
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
@@ -85,49 +85,7 @@ update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) 
 -- !result
 select * from tab1;
 -- result:
-100	k2_100	600	600	100	v4_100	v5_100
 200	k2_200	600	600	200	v4_200	v5_200
+100	k2_100	600	600	100	v4_100	v5_100
 300	k3_300	600	600	300	v4_300	v5_300
--- !result
-CREATE table tab3 (
-      k1 INTEGER,
-      k2 VARCHAR(50),
-      v1 INTEGER,
-      v2 INTEGER,
-      v3 INTEGER,
-      v4 varchar(50),
-      v5 varchar(50)
-)
-ENGINE=OLAP
-PRIMARY KEY(`k1`,`k2`)
-DISTRIBUTED BY HASH(`k1`) BUCKETS 10
-ORDER BY (`v1`, `v2`)
-PROPERTIES (
-    "replication_num" = "1"
-);
--- result:
--- !result
-insert into tab3 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
--- result:
--- !result
-insert into tab3 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
--- result:
--- !result
-insert into tab3 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
--- result:
--- !result
-select * from tab3;
--- result:
-300	k3_300	300	300	300	v4_300	v5_300
-100	k2_100	100	100	100	v4_100	v5_100
-200	k2_200	200	200	200	v4_200	v5_200
--- !result
-update tab3 set v1 = 1111, v2 = (select sum(tab2.v2) from tab2);
--- result:
--- !result
-select * from tab3;
--- result:
-300	k3_300	1111	600	300	v4_300	v5_300
-100	k2_100	1111	600	100	v4_100	v5_100
-200	k2_200	1111	600	200	v4_200	v5_200
 -- !result

--- a/test/sql/test_partial_update_column_mode/T/test_partial_update
+++ b/test/sql/test_partial_update_column_mode/T/test_partial_update
@@ -41,28 +41,3 @@ update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) 
 select * from tab1;
 update tab1 set v1 = (select sum(tab2.v1) from tab2), v2 = (select sum(tab2.v2) from tab2);
 select * from tab1;
-
-
-CREATE table tab3 (
-      k1 INTEGER,
-      k2 VARCHAR(50),
-      v1 INTEGER,
-      v2 INTEGER,
-      v3 INTEGER,
-      v4 varchar(50),
-      v5 varchar(50)
-)
-ENGINE=OLAP
-PRIMARY KEY(`k1`,`k2`)
-DISTRIBUTED BY HASH(`k1`) BUCKETS 10
-ORDER BY (`v1`, `v2`)
-PROPERTIES (
-    "replication_num" = "1"
-);
-insert into tab3 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
-insert into tab3 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
-insert into tab3 values (300, "k3_300", 300, 300, 300, "v4_300", "v5_300");
-select * from tab3;
-
-update tab3 set v1 = 1111, v2 = (select sum(tab2.v2) from tab2);
-select * from tab3;


### PR DESCRIPTION


This reverts commit 517a649607c50b943741e023e8fae1ca728b15fa.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
