### PR TITLE
[BugFix] Use the id in PipePEntryObject

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
@@ -224,6 +224,18 @@ public class PipeManager {
         }
     }
 
+    public List<Pipe> getAllPipesOfDb(long dbId) {
+        try {
+            lock.readLock().lock();
+            return pipeMap.entrySet().stream()
+                    .filter(x -> x.getKey().getDbId() == dbId)
+                    .map(Map.Entry::getValue)
+                    .collect(Collectors.toList());
+        } finally {
+            lock.readLock().unlock();
+        }
+    }
+
     public String getPipesOfDb(long dbId) {
         try {
             lock.readLock().lock();

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeBuiltinConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/PrivilegeBuiltinConstants.java
@@ -59,6 +59,6 @@ public class  PrivilegeBuiltinConstants {
 
     public static final String ALL_STORAGE_VOLUMES_ID = "ALL_STORAGE_VOLUMES_ID";
 
-    public static final String ALL_PIPES_ID = "ALL_PIPES_ID";
+    public static final long ALL_PIPES_ID = -5;
 
 }


### PR DESCRIPTION
Fixes #issue

Use the id instead of name in PipePEntryObject, to survive recreation of pipe.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
