### PR TITLE
[BugFix] check lambda argument only after to expr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
@@ -54,7 +54,6 @@ public class LambdaFunctionExpr extends Expr {
     public LambdaFunctionExpr(LambdaFunctionExpr rhs) {
         super(rhs);
         this.commonSubOperatorNum = rhs.commonSubOperatorNum;
-        this.checkValid();
     }
 
     @Override
@@ -112,14 +111,14 @@ public class LambdaFunctionExpr extends Expr {
         return String.format("%s -> %s%s", names, getChild(0).explain(), commonSubOp);
     }
 
-    public void checkValid() {
+    public void checkValidAfterToExpr() { // before to operator, its type is LambdaArgument, after to SlotRef
         // 1 lambda expr, at least 1 lambda argument and common sub op's slotref + expr
         Preconditions.checkState(children.size() >= 2 + 2 * commonSubOperatorNum,
                 "lambda expr's children num " + children.size() + " should >= " + (2 + 2 * commonSubOperatorNum));
         int realChildrenNum = getChildren().size() - 2 * commonSubOperatorNum;
         for (int i = 1; i < realChildrenNum; i++) {
             Preconditions.checkState(getChild(i) instanceof SlotRef,
-                    i + "-th lambda argument should be type of SlotRef, but actually " + getChild(i).toSql());
+                    i + "-th lambda argument should be type of SlotRef, but actually " + getChild(i));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -558,7 +558,7 @@ public class ScalarOperatorToExpr {
 
             LambdaFunctionExpr result = new LambdaFunctionExpr(newArguments, commonSubOperatorMap);
             result.setType(Type.FUNCTION);
-            result.checkValid();
+            result.checkValidAfterToExpr();
             return result;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -616,6 +616,10 @@ public class ExpressionTest extends PlanTestBase {
                 "(SELECT [1,2] a, 1 AS b) AS A) AS B";
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("lambda common expressions:{<slot 8> <-> CAST(<slot 4> AS SMALLINT)}"));
+
+        sql = "SELECT [array_map(x -> ((x * x) + (x * b)), a)] AS g from (SELECT [1,2] a, 1 AS b) AS A";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("lambda common expressions:{<slot 7> <-> CAST(<slot 4> AS SMALLINT)}"));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/33784

as https://github.com/StarRocks/starrocks/pull/33036 check valid in clone() before transform LambdaArgument to SlotRef, which should be LambdaArgument, so don't check valid in clone().

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
