### PR TITLE
[BugFix] Potential schema change concurrency issue in shared data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -180,14 +180,14 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
     }
 
     // REQUIRE: has acquired the exclusive lock of database
-    void addShadowIndexToCatalog(@NotNull LakeTable table) {
-        Preconditions.checkState(watershedTxnId != -1);
+    void addShadowIndexToCatalog(@NotNull LakeTable table, long visibleTxnId) {
+        Preconditions.checkState(visibleTxnId != -1);
         for (long partitionId : partitionIndexMap.rowKeySet()) {
             Partition partition = table.getPartition(partitionId);
             Preconditions.checkState(partition != null);
             Map<Long, MaterializedIndex> shadowIndexMap = partitionIndexMap.row(partitionId);
             for (MaterializedIndex shadowIndex : shadowIndexMap.values()) {
-                shadowIndex.setVisibleTxnId(watershedTxnId);
+                shadowIndex.setVisibleTxnId(visibleTxnId);
                 Preconditions.checkState(shadowIndex.getState() == MaterializedIndex.IndexState.SHADOW,
                         shadowIndex.getState());
                 partition.createRollupIndex(shadowIndex);
@@ -261,6 +261,11 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
     @VisibleForTesting
     public static long getNextTransactionId() {
         return GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+    }
+
+    @VisibleForTesting
+    public static long peekNextTransactionId() {
+        return GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().peekNextTransactionId();
     }
 
     @Override
@@ -377,7 +382,21 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
             LakeTable table = getTableOrThrow(db, tableId);
             Preconditions.checkState(table.getState() == OlapTable.OlapTableState.SCHEMA_CHANGE);
             watershedTxnId = getNextTransactionId();
-            addShadowIndexToCatalog(table);
+            addShadowIndexToCatalog(table, watershedTxnId);
+        }
+
+        // Getting the `watershedTxnId` and adding the shadow index are not atomic. It's possible a
+        // transaction A begins between these operations. This is safe as long as A gets the tablet
+        // list(with database lock) after beginTransaction(), so that it sees the shadow index and
+        // writes to it. All current import transactions do this (beginTransaction first), so even
+        // without checking the `nextTxnId` here it should be safe. However, beginTransaction() first
+        // is just a convention not a requirement. If violated, transactions with IDs greater than
+        // the `watershedTxnId` may ignore the shadow index. To avoid this, we ensure no new
+        // beginTransaction() succeeds between getting the `watershedTxnId` and adding the shadow index.
+        long nextTxnId = peekNextTransactionId();
+        if (nextTxnId != watershedTxnId + 1) {
+            throw new AlterCancelException(
+                    "concurrent transaction detected while adding shadow index, please re-run the alter table command");
         }
 
         jobState = JobState.WAITING_TXN;
@@ -617,7 +636,8 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                 // modify column
                 for (Column col : shadowSchema) {
                     if (col.isNameWithPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX)) {
-                        modifiedColumns.add(col.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX, col.getName()));
+                        modifiedColumns.add(
+                                col.getNameWithoutPrefix(SchemaChangeHandler.SHADOW_NAME_PRFIX, col.getName()));
                     }
                 }
             } else if (shadowSchema.size() < originSchema.size()) {
@@ -733,7 +753,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                 addTabletToTabletInvertedIndex(table);
                 table.setState(OlapTable.OlapTableState.SCHEMA_CHANGE);
             } else if (jobState == JobState.WAITING_TXN) {
-                addShadowIndexToCatalog(table);
+                addShadowIndexToCatalog(table, watershedTxnId);
             } else if (jobState == JobState.FINISHED_REWRITING) {
                 updateNextVersion(table);
             } else if (jobState == JobState.FINISHED) {

--- a/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/LakeTableSchemaChangeJobTest.java
@@ -346,6 +346,11 @@ public class LakeTableSchemaChangeJobTest {
             public long getNextTransactionId() {
                 return 10101L;
             }
+
+            @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
+            }
         };
 
         schemaChangeJob.runPendingJob();
@@ -385,6 +390,11 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public long getNextTransactionId() {
                 return 10101L;
+            }
+
+            @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
             }
 
             @Mock
@@ -436,6 +446,11 @@ public class LakeTableSchemaChangeJobTest {
             }
 
             @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
+            }
+
+            @Mock
             public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) throws AnalysisException {
                 throw new AnalysisException("isPreviousLoadFinished exception");
             }
@@ -484,6 +499,11 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public long getNextTransactionId() {
                 return 10101L;
+            }
+
+            @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
             }
 
             @Mock
@@ -551,6 +571,11 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public long getNextTransactionId() {
                 return 10101L;
+            }
+
+            @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
             }
 
             @Mock
@@ -625,6 +650,11 @@ public class LakeTableSchemaChangeJobTest {
             }
 
             @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
+            }
+
+            @Mock
             public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) throws AnalysisException {
                 return true;
             }
@@ -680,6 +710,11 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public long getNextTransactionId() {
                 return 10101L;
+            }
+
+            @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
             }
 
             @Mock
@@ -765,6 +800,11 @@ public class LakeTableSchemaChangeJobTest {
             @Mock
             public long getNextTransactionId() {
                 return 10101L;
+            }
+
+            @Mock
+            public long peekNextTransactionId() {
+                return 10102L;
             }
 
             @Mock
@@ -880,5 +920,64 @@ public class LakeTableSchemaChangeJobTest {
         // Does not support cancel job in FINISHED state.
         schemaChangeJob.cancel("test");
         Assert.assertEquals(AlterJobV2.JobState.FINISHED, schemaChangeJob.getJobState());
+    }
+
+    @Test
+    public void testTransactionRaceCondition() throws AlterCancelException {
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1L;
+            }
+        };
+
+        new MockUp<LakeTableSchemaChangeJob>() {
+            @Mock
+            public void sendAgentTaskAndWait(AgentBatchTask batchTask, MarkedCountDownLatch<Long, Long> countDownLatch,
+                                             long timeoutSeconds) throws AlterCancelException {
+                // nothing to do.
+            }
+
+            @Mock
+            public void sendAgentTask(AgentBatchTask batchTask) {
+                batchTask.getAllTasks().forEach(t -> t.setFinished(true));
+            }
+
+            @Mock
+            public void writeEditLog(LakeTableSchemaChangeJob job) {
+                // nothing to do.
+            }
+
+            @Mock
+            public Future<Boolean> writeEditLogAsync(LakeTableSchemaChangeJob job) {
+                return ConcurrentUtils.constantFuture(true);
+            }
+
+            @Mock
+            public long getNextTransactionId() {
+                return 10101L;
+            }
+
+            @Mock
+            public long peekNextTransactionId() {
+                return 10103L; // !!!! <-------- 10103 != 10101 + 1
+            }
+
+            @Mock
+            public boolean isPreviousLoadFinished(long dbId, long tableId, long txnId) throws AnalysisException {
+                return true;
+            }
+        };
+
+        Exception exception = Assert.assertThrows(AlterCancelException.class, () -> {
+            schemaChangeJob.runPendingJob();
+        });
+        Assert.assertTrue(exception.getMessage().contains(
+                "concurrent transaction detected while adding shadow index, please re-run the alter table command"));
+        Assert.assertEquals(AlterJobV2.JobState.PENDING, schemaChangeJob.getJobState());
+        Assert.assertEquals(10101L, schemaChangeJob.getWatershedTxnId());
+
+        schemaChangeJob.cancel("test");
+        Assert.assertEquals(AlterJobV2.JobState.CANCELLED, schemaChangeJob.getJobState());
     }
 }


### PR DESCRIPTION
Add mechanism to prevent transactions missing new shadow indexes during alter table.

The key objective is to prevent transactions with IDs higher than watershed from missing the new shadow index during alter table. This is done by getting the watershed ID first, then ensuring no concurrent transactions start before adding the index.
If any transaction slips between, the alter table is canceled to prevent new transactions from not seeing the shadow index.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
