### PR TITLE
[BugFix] Tablet may store overlapping rowset versions in the metadata(#33563)

### DIFF
--- a/be/src/storage/compaction_task.h
+++ b/be/src/storage/compaction_task.h
@@ -236,10 +236,21 @@ protected:
         return Status::OK();
     }
 
-    void _commit_compaction() {
+    Status _commit_compaction() {
         std::stringstream input_stream_info;
         {
             std::unique_lock wrlock(_tablet->get_header_lock());
+            // check input_rowsets exist. If not, tablet_meta maybe modify by some other thread, cancel this task
+            for (auto& rowset : _input_rowsets) {
+                if (_tablet->get_rowset_by_version(rowset->version()) == nullptr) {
+                    input_stream_info << "rowset:" << rowset->version()
+                                      << " is not exist in tablet:" << _tablet->tablet_id()
+                                      << ", maybe tablet meta is modify by other thread. cancel this compaction task";
+                    LOG(WARNING) << input_stream_info.str();
+                    return Status::InternalError(input_stream_info.str());
+                }
+            }
+
             for (int i = 0; i < 5 && i < _input_rowsets.size(); ++i) {
                 input_stream_info << _input_rowsets[i]->version() << ";";
             }
@@ -258,6 +269,8 @@ protected:
                 << ", output rowset version:" << _output_rowset->version()
                 << ", input rowsets:" << input_stream_info.str() << ", input rowsets size:" << _input_rowsets.size()
                 << ", max_version:" << _tablet->max_continuous_version();
+
+        return Status::OK();
     }
 
     void _success_callback();

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -42,7 +42,7 @@ Status HorizontalCompactionTask::run_impl() {
     RETURN_IF_ERROR(_validate_compaction(statistics));
     TRACE("[Compaction] horizontal compaction validated");
 
-    _commit_compaction();
+    RETURN_IF_ERROR(_commit_compaction());
     TRACE("[Compaction] horizontal compaction committed");
 
     return Status::OK();

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -42,7 +42,7 @@ Status VerticalCompactionTask::run_impl() {
     RETURN_IF_ERROR(_validate_compaction(statistics));
     TRACE("[Compaction] vertical compaction validated");
 
-    _commit_compaction();
+    RETURN_IF_ERROR(_commit_compaction());
     TRACE("[Compaction] vertical compaction committed");
 
     return Status::OK();


### PR DESCRIPTION
Tablet keeps all rowset version in `_rs_metas` and all rowset versions in `_rs_metas` should not be overlapping. But in some scenarios, `_rs_metas` may storage overlapping versions: e.g.
1. One tablet keep the rowset version: [0-10],[11-11],[14-16],[17-20]. And we pick rowset [14-16] and [17-20] to do cumulative compaction and submit the task into compaction pool but not started execution yet.
2. Due to the lack of versions, a clone operation occurred on the source side and we hold compaction lock during clone which will block the execution of compaction task generated in step1. Because the rowset version [12-12][13-13] in source side have already been compacted, so the clone operation degrade to a full clone. And the `_rs_metas` storages [0-10], [11-13], [14-14], [15-15], [16-16], [17-20] after clone finished.
3. The compaction task in step1 start to execution. After compaction finished, it remove version [14-16][17-20] from `_rs_metas` and add verison [14-20]. The final `_rs_metas` became [0-10], [11-13], [14-14], [15-15], [16-16], [14-20], resulting in overlapping versions in `_rs_metas`.

The solution is we will check the input rowsets of compaction task exist or not after finish compaction task. If not, the tablet meta maybe modified by other thread, we will cancel this task.