### PR TITLE
[BugFix] Partial update may lost some column's data

### DIFF
--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -578,24 +578,24 @@ Status RowsetUpdateState::_check_and_resolve_conflict(Tablet* tablet, Rowset* ro
         return Status::InternalError(msg);
     }
 
-    // _read_version is equal to latest_applied_version which means there is no other rowset is applied
-    // the data of write_columns can be write to segment file directly
-    VLOG(2) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
-            << _partial_update_states[segment_id].read_version.to_string();
-    if (latest_applied_version == _partial_update_states[segment_id].read_version &&
-        _partial_update_states[segment_id].schema_version >= tablet_schema->schema_version()) {
-        return Status::OK();
-    }
-
     // TODO
     // we don't need to rebuil all partial update state but just resolve the conflict rows and columns
-    if (_partial_update_states[segment_id].schema_version >= tablet_schema->schema_version()) {
+    if (_partial_update_states[segment_id].schema_version < tablet_schema->schema_version()) {
         Status st = _rebuild_partial_update_states(tablet, rowset, rowset_id, segment_id, tablet_schema);
         LOG(INFO) << "tablet schema version change from " << _partial_update_states[segment_id].schema_version << " to "
                   << tablet_schema->schema_version() << " before partial state apply finished, rebuild"
                   << " segment: " << segment_id << ", status: " << st;
         return st;
     }
+
+    // _read_version is equal to latest_applied_version which means there is no other rowset is applied
+    // the data of write_columns can be write to segment file directly
+    VLOG(2) << "latest_applied_version is " << latest_applied_version.to_string() << " read version is "
+            << _partial_update_states[segment_id].read_version.to_string();
+    if (latest_applied_version == _partial_update_states[segment_id].read_version) {
+        return Status::OK();
+    }
+
     // check if there are delta column files generated from read_version to now.
     // If yes, then need to force resolve conflict.
     const bool need_resolve_conflict = tablet->updates()->check_delta_column_generate_from_version(

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -277,6 +277,7 @@ public:
     void append_column(TabletColumn column);
 
     int32_t schema_version() const { return _schema_version; }
+    void set_schema_version(int32_t version) { _schema_version = version; }
     void clear_columns();
     void copy_from(const std::shared_ptr<const TabletSchema>& tablet_schema);
 

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -2832,7 +2832,7 @@ TEST_F(TabletUpdatesTest, test_partial_update_with_lsc) {
     _tablet = create_tablet(rand(), rand());
     std::vector<int64_t> keys;
     int N = 100;
-    for (int i = 0 ; i < N; i++) {
+    for (int i = 0; i < N; i++) {
         keys.push_back(i);
     }
     {


### PR DESCRIPTION
If we update the tablet schema during a partial update(add a column), the newly added column data may be lost in the full segment due to the error logic in the check conflict.

The following is the origin code:
```
    if (latest_applied_version == _partial_update_states[segment_id].read_version &&
        _partial_update_states[segment_id].schema_version >= tablet_schema->schema_version()) {
        return Status::OK();
    }

    if (_partial_update_states[segment_id].schema_version >= tablet_schema->schema_version()) {
        Status st = _rebuild_partial_update_states(tablet, rowset, rowset_id, segment_id, tablet_schema);
        return st;
    }

```
If we update the schema during the partial update and find the tablet schema version is newer, we should rebuild  `RowsetUpdateState` because we may lose some columns. But in the logic, as shown above, we don't rebuild it.

e.g
1. The table schema is k1,v1,v2 before partial update, schema version is 0. We will prepare the data of column v2 in order to append it to the full rowset.
2. Add a new column v3 before apply and the tablet schema is k1,v1,v2,v3 and the schema version is 1.
3. During application, we should rebuild `RowsetUpdateState` and prepare the data of column v3. However according to the logic above, the data of column v3 is lost.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This PR needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the PR will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
