### PR TITLE
[BugFix] fix enable persistent index by default

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -352,6 +352,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String PIPELINE_SINK_DOP = "pipeline_sink_dop";
     public static final String ENABLE_ADAPTIVE_SINK_DOP = "enable_adaptive_sink_dop";
+    public static final String ENABLE_PERSISTENT_INDEX_BY_DEFAULT = "enable_persistent_index_by_default";
     public static final String RUNTIME_FILTER_SCAN_WAIT_TIME = "runtime_filter_scan_wait_time";
     public static final String RUNTIME_FILTER_ON_EXCHANGE_NODE = "runtime_filter_on_exchange_node";
     public static final String ENABLE_MULTI_COLUMNS_ON_GLOBAL_RUNTIME_FILTER =
@@ -1045,6 +1046,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_ADAPTIVE_SINK_DOP)
     private boolean enableAdaptiveSinkDop = false;
 
+    @VariableMgr.VarAttr(name = ENABLE_PERSISTENT_INDEX_BY_DEFAULT, flag = VariableMgr.INVISIBLE)
+    private boolean enablePersistentIndexByDefault = false;
+
     @VariableMgr.VarAttr(name = JOIN_IMPLEMENTATION_MODE_V2, alias = JOIN_IMPLEMENTATION_MODE)
     private String joinImplementationMode = "auto"; // auto, merge, hash, nestloop
 
@@ -1527,6 +1531,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableAdaptiveSinkDop(boolean e) {
         this.enableAdaptiveSinkDop = e;
+    }
+
+    public boolean getEnablePersistentIndexByDefault() {
+        return enablePersistentIndexByDefault;
     }
 
     public long getMaxExecMemByte() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1291,8 +1291,13 @@ public class GlobalStateMgr {
             }
             if (nodeMgr.isFirstTimeStartUp()) {
                 // When the cluster is initially deployed, we use persistent index by default
-                Config.enable_persistent_index_by_default = true;
+                VariableMgr.setSystemVariable(VariableMgr.getDefaultSessionVariable(), new SystemVariable(SetType.GLOBAL,
+                                SessionVariable.ENABLE_PERSISTENT_INDEX_BY_DEFAULT,
+                                LiteralExpr.create("true", Type.BOOLEAN)),
+                        false);
             }
+            Config.enable_persistent_index_by_default = VariableMgr.getDefaultSessionVariable()
+                .getEnablePersistentIndexByDefault();
         } catch (UserException e) {
             LOG.warn("Failed to set ENABLE_ADAPTIVE_SINK_DOP", e);
         } catch (Throwable t) {


### PR DESCRIPTION
Use global session var `enable_persistent_index_by_default` to persist the state, or the config will be lost after FE restart.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
