### PR TITLE
[BugFix] clear state when lambda expr close

### DIFF
--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -101,4 +101,20 @@ StatusOr<ColumnPtr> LambdaFunction::evaluate_checked(ExprContext* context, Chunk
     return get_child(0)->evaluate_checked(context, chunk);
 }
 
+void LambdaFunction::close() {
+    _captured_slot_ids.clear();
+    _arguments_ids.clear();
+    _common_sub_expr_ids.clear();
+    _common_sub_expr.clear();
+    Expr::close();
+}
+
+void LambdaFunction::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+    _captured_slot_ids.clear();
+    _arguments_ids.clear();
+    _common_sub_expr_ids.clear();
+    _common_sub_expr.clear();
+    Expr::close(state, context, scope);
+}
+
 } // namespace starrocks

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -59,6 +59,10 @@ public:
 
     Expr* get_lambda_expr() const { return _children[0]; }
 
+    void close() override;
+
+    void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
+
 private:
     std::vector<SlotId> _captured_slot_ids;
     std::vector<SlotId> _arguments_ids;


### PR DESCRIPTION
When lambda expr call `close`, we need to clear it's internal state. Otherwise when expr call `prepare` again later, the state of expr could be invalid.
This may cause error:
```
Lambda arguments get ids failed, just get 2 ids from 1 arguments. backend:59edfc7d0cc1
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
