### PR TITLE
[BugFix] fix lambda expr crash, backport

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LambdaFunctionExpr.java
@@ -53,6 +53,7 @@ public class LambdaFunctionExpr extends Expr {
 
     public LambdaFunctionExpr(LambdaFunctionExpr rhs) {
         super(rhs);
+        this.commonSubOperatorNum = rhs.commonSubOperatorNum;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -554,7 +554,7 @@ public class ScalarOperatorToExpr {
             newArguments.add(lambdaExpr);
             newArguments.addAll(arguments);
 
-            Expr result = new LambdaFunctionExpr(newArguments, commonSubOperatorMap);
+            LambdaFunctionExpr result = new LambdaFunctionExpr(newArguments, commonSubOperatorMap);
             result.setType(Type.FUNCTION);
             return result;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -613,6 +613,11 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("lambda common expressions:{<slot 8> <-> CAST(<slot 4> AS BIGINT)}{<slot 9> " +
                 "<-> <slot 8> * 2}{<slot 10> <-> <slot 9> + 6: abs}"));
+
+        sql = "SELECT max(g) FROM(SELECT array_sum(array_map(x -> ((x * x) + (x * b)), a)) AS g FROM " +
+                "(SELECT [1,2] a, 1 AS b) AS A) AS B";
+        plan = getFragmentPlan(sql);
+        Assert.assertTrue(plan.contains("lambda common expressions:{<slot 8> <-> CAST(<slot 4> AS SMALLINT)}"));
     }
 
     @Test


### PR DESCRIPTION
Fix:
```
*** Aborted at 1698598600 (unix time) try "date -d @1698598600" if you are using GNU date ***
PC: @          0x41395ad starrocks::ArrayMapExpr::evaluate_checked()
*** SIGSEGV (@0xc) received by PID 501117 (TID 0x7f33cc5ff700) from PID 12; stack trace: ***
    @          0x5e481a2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f350a8f5630 (unknown)
    @          0x41395ad starrocks::ArrayMapExpr::evaluate_checked()
    @          0x37bd023 starrocks::ExprContext::evaluate()
    @          0x4075014 starrocks::VectorizedFunctionCallExpr::evaluate_checked()
    @          0x37bd023 starrocks::ExprContext::evaluate()
    @          0x37bd36f starrocks::ExprContext::evaluate()
    @          0x2c54c69 starrocks::Aggregator::evaluate_agg_input_column()
    @          0x2c5631c starrocks::Aggregator::compute_single_agg_state()
    @          0x2b67134 starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk()
    @          0x2815d84 starrocks::pipeline::PipelineDriver::process()
    @          0x53b9b7e starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0x4caca22 starrocks::ThreadPool::dispatch_thread()
    @          0x4ca74ba starrocks::Thread::supervise_thread()
    @     0x7f350a8edea5 start_thread
    @     0x7f350a616b0d __clone
    @                0x0 (unknown)
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
