### PR TITLE
[Feature] Support dynamic modification of datacache.enable

### DIFF
--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -81,8 +81,7 @@ StarOSWorker::~StarOSWorker() = default;
 absl::Status StarOSWorker::add_shard(const ShardInfo& shard) {
     std::unique_lock l(_mtx);
     auto it = _shards.find(shard.id);
-    if (it != _shards.end() && it->second.shard_info.path_info.has_fs_info() && shard.path_info.has_fs_info() &&
-        it->second.shard_info.path_info.fs_info().version() < shard.path_info.fs_info().version()) {
+    if (it != _shards.end() && has_shard_info_changed(it->second.shard_info, shard)) {
         auto st = invalidate_fs(it->second.shard_info);
         if (!st.ok()) {
             return st;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1530,6 +1530,9 @@ public class SchemaChangeHandler extends AlterHandler {
                 } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)) {
                     GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
                     return null;
+                }  else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+                    GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, olapTable, properties);
+                    return null;
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2466,6 +2466,15 @@ public class OlapTable extends Table {
         tableProperty.buildDataCachePartitionDuration();
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        if (tableProperty == null) {
+            tableProperty = new TableProperty(new HashMap<>());
+        }
+        tableProperty.modifyTableProperties(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE,
+                Boolean.valueOf(isEnable).toString());
+        tableProperty.buildDataCacheEnable();
+    }
+
     public void setStorageCoolDownTTL(PeriodDuration duration) {
         if (tableProperty == null) {
             tableProperty = new TableProperty(new HashMap<>());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -290,6 +290,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
             case OperationType.OP_ALTER_TABLE_PROPERTIES:
                 buildPartitionLiveNumber();
                 buildDataCachePartitionDuration();
+                buildDataCacheEnable();
                 break;
             case OperationType.OP_MODIFY_TABLE_CONSTRAINT_PROPERTY:
                 buildConstraint();
@@ -580,6 +581,19 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
+    public TableProperty buildDataCacheEnable() {
+        if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            boolean dataCacheEnable = Boolean.parseBoolean(
+                    properties.getOrDefault(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false"));
+            if (this.storageInfo != null) {
+                this.storageInfo.setDataCacheEnable(dataCacheEnable);
+            } else {
+                LOG.warn("Setting datacache.enable to {} while storage info is null", dataCacheEnable);
+            }
+        }
+        return this;
+    }
+
     public TableProperty buildStorageCoolDownTTL() {
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL)) {
             String storageCoolDownTTL = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_COOLDOWN_TTL);
@@ -850,5 +864,6 @@ public class TableProperty implements Writable, GsonPostProcessable {
         buildDataCachePartitionDuration();
         buildUseFastSchemaEvolution();
         buildStorageType();
+        buildDataCacheEnable();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -1116,6 +1116,10 @@ public class PropertyAnalyzer {
         }
     }
 
+    public static boolean analyzeDataCacheEnable(Map<String, String> properties) throws AnalysisException {
+        return analyzeBooleanProp(properties, PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, true);
+    }
+
     public static TPersistentIndexType analyzePersistentIndexType(Map<String, String> properties) throws AnalysisException {
         if (properties != null && properties.containsKey(PROPERTIES_PERSISTENT_INDEX_TYPE)) {
             String type = properties.get(PROPERTIES_PERSISTENT_INDEX_TYPE);

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StorageInfo.java
@@ -59,6 +59,10 @@ public class StorageInfo implements GsonPreProcessable, GsonPostProcessable {
         return new DataCacheInfo(getCacheInfo());
     }
 
+    public void setDataCacheEnable(boolean isEnable) {
+        this.cacheInfo = this.cacheInfo.toBuilder().setEnableCache(isEnable).build();
+    }
+
     @Override
     public void gsonPreProcess() throws IOException {
         if (storeInfo != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ModifyPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ModifyPartitionInfo.java
@@ -57,6 +57,8 @@ public class ModifyPartitionInfo implements Writable {
     private short replicationNum;
     @SerializedName(value = "isInMemory")
     private boolean isInMemory;
+    @SerializedName(value = "dataCacheEnable")
+    private boolean dataCacheEnable;
 
     public ModifyPartitionInfo() {
         // for persist
@@ -64,13 +66,14 @@ public class ModifyPartitionInfo implements Writable {
 
     public ModifyPartitionInfo(long dbId, long tableId, long partitionId,
                                DataProperty dataProperty, short replicationNum,
-                               boolean isInMemory) {
+                               boolean isInMemory, boolean dataCacheEnable) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.partitionId = partitionId;
         this.dataProperty = dataProperty;
         this.replicationNum = replicationNum;
         this.isInMemory = isInMemory;
+        this.dataCacheEnable = dataCacheEnable;
     }
 
     public long getDbId() {
@@ -97,6 +100,14 @@ public class ModifyPartitionInfo implements Writable {
         return isInMemory;
     }
 
+    public boolean getDataCacheEnable() {
+        return dataCacheEnable;
+    }
+
+    public void setDataCacheEnable(boolean isEnable) {
+        this.dataCacheEnable = isEnable;
+    }
+
     public static ModifyPartitionInfo read(DataInput in) throws IOException {
         ModifyPartitionInfo info = new ModifyPartitionInfo();
         info.readFields(in);
@@ -119,7 +130,7 @@ public class ModifyPartitionInfo implements Writable {
         ModifyPartitionInfo otherInfo = (ModifyPartitionInfo) other;
         return dbId == otherInfo.getDbId() && tableId == otherInfo.getTableId() &&
                 dataProperty.equals(otherInfo.getDataProperty()) && replicationNum == otherInfo.getReplicationNum()
-                && isInMemory == otherInfo.isInMemory();
+                && isInMemory == otherInfo.isInMemory() && dataCacheEnable == otherInfo.getDataCacheEnable();
     }
 
     @Override
@@ -137,6 +148,10 @@ public class ModifyPartitionInfo implements Writable {
 
         out.writeShort(replicationNum);
         out.writeBoolean(isInMemory);
+        //Writing in and out dataCacheEnable must be commented out, otherwise there will be compatibility
+        //issues when reading old logs. In fact, in the new version, persistence no longer needs to
+        //be implemented through write/readFields, but through gson.
+        //out.writeBoolean(dataCacheEnable);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -153,6 +168,7 @@ public class ModifyPartitionInfo implements Writable {
 
         replicationNum = in.readShort();
         isInMemory = in.readBoolean();
+        //dataCacheEnable = in.readBoolean();
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
@@ -297,6 +297,13 @@ public class AlterTableClauseVisitor extends AstVisitor<Void, ConnectContext> {
             } catch (DateTimeParseException e) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, e.getMessage());
             }
+        } else if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE)) {
+            if (!properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("true") &&
+                    !properties.get(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE).equalsIgnoreCase("false")) {
+                ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
+                        "Property " + PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE +
+                                " must be bool type(false/true)");
+            }
             clause.setNeedTableStable(false);
         } else {
             ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR, "Unknown properties: " + properties);

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/PropertyAnalyzerTest.java
@@ -57,4 +57,33 @@ public class PropertyAnalyzerTest {
             Assert.assertEquals("Cannot parse text to Duration", e.getMessage());
         }
     }
+
+    @Test
+    public void testAnalyzeDataCacheEnable() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "true");
+
+        try {
+            Assert.assertTrue(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+
+        Assert.assertTrue(properties.size() == 0);
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "false");
+        try {
+            Assert.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, "abcd");
+        // If the string passed in is not "true" (ignoring case),
+        // analyzeDataCacheEnable will return false instead of throwing an exception
+        try {
+            Assert.assertFalse(PropertyAnalyzer.analyzeDataCacheEnable(properties));
+        } catch (AnalysisException e) {
+            Assert.assertTrue(false);
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeTableTest.java
@@ -160,4 +160,16 @@ public class LakeTableTest {
         LakeTable lakeTable = new LakeTable();
         Assert.assertNotNull(lakeTable.getIndexIdToMeta());
     }
+
+    @Test
+    public void testSetDataCacheEnable() {
+        LakeTable lakeTable = new LakeTable();
+        FilePathInfo pathInfo = FilePathInfo.newBuilder().build();
+        lakeTable.setStorageInfo(pathInfo, new DataCacheInfo(false, false));
+
+        lakeTable.setDataCacheEnable(true);
+        Assert.assertTrue(lakeTable.getTableProperty().getStorageInfo().getDataCacheInfo().isEnabled());
+        lakeTable.setDataCacheEnable(false);
+        Assert.assertFalse(lakeTable.getTableProperty().getStorageInfo().getDataCacheInfo().isEnabled());
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/ModifyDatacaheEnableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/ModifyDatacaheEnableTest.java
@@ -1,0 +1,356 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.lake;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.PartitionInfo;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.ExceptionChecker;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.PropertyAnalyzer;
+import com.starrocks.lake.DataCacheInfo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.sql.ast.CreateDbStmt;
+import com.starrocks.sql.ast.CreateMaterializedViewStatement;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ModifyDatacaheEnableTest {
+    private static final Logger LOG = LogManager.getLogger(ModifyDatacaheEnableTest.class);
+    private static ConnectContext connectContext;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster(RunMode.SHARED_DATA);
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+        // create database
+        String createDbStmtStr = "create database lake_test;";
+        CreateDbStmt createDbStmt = (CreateDbStmt) UtFrameUtils.parseStmtWithNewParser(createDbStmtStr, connectContext);
+        GlobalStateMgr.getCurrentState().getMetadata().createDb(createDbStmt.getFullDbName());
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "CREATE TABLE IF NOT EXISTS `lake_test`.`lake_table` (\n" +
+                        "    `recruit_date`  DATE           NOT NULL COMMENT 'YYYY-MM-DD',\n" +
+                        "    `region_num`    TINYINT        COMMENT 'range [-128, 127]',\n" +
+                        "    `num_plate`     SMALLINT       COMMENT 'range [-32768, 32767]',\n" +
+                        "    `tel`           INT            COMMENT 'range [-2147483648, 2147483647]',\n" +
+                        "    `id`            BIGINT         COMMENT 'range [-2^63 + 1 ~ 2^63 - 1]',\n" +
+                        "    `password`      LARGEINT       COMMENT 'range [-2^127 + 1 ~ 2^127 - 1]',\n" +
+                        "    `name`          CHAR(20)       NOT NULL COMMENT 'range char(m),m in (1-255)',\n" +
+                        "    `profile`       VARCHAR(500)   NOT NULL COMMENT 'upper limit value 1048576 bytes',\n" +
+                        "    `hobby`         STRING         NOT NULL COMMENT 'upper limit value 65533 bytes',\n" +
+                        "    `leave_time`    DATETIME       COMMENT 'YYYY-MM-DD HH:MM:SS'\n" +
+                        ") ENGINE=OLAP\n" +
+                        "DUPLICATE KEY(`recruit_date`, `region_num`)\n" +
+                        "PARTITION BY RANGE(`recruit_date`)\n" +
+                        "(\n" +
+                        "    PARTITION p1 VALUES [('2022-03-11'), ('2022-03-12')),\n" +
+                        "    PARTITION p2 VALUES [('2022-03-12'), ('2022-03-13')),\n" +
+                        "    PARTITION p3 VALUES [('2022-03-13'), ('2022-03-14')),\n" +
+                        "    PARTITION p4 VALUES [('2022-03-14'), ('2022-03-15')),\n" +
+                        "    PARTITION p5 VALUES [('2022-03-15'), ('2022-03-16'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`recruit_date`, `region_num`) BUCKETS 100\n" +
+                        "PROPERTIES (\n" +
+                        "    'datacache.partition_duration' = '1 days',\n" +
+                        "    'datacache.enable' = 'true',\n" +
+                        "    'storage_volume' = 'builtin_storage_volume',\n" +
+                        "    'enable_async_write_back' = 'false',\n" +
+                        "    'enable_persistent_index' = 'false'\n" +
+                        ");"
+        ));
+
+        ExceptionChecker.expectThrowsNoException(() -> createTable(
+                "CREATE TABLE IF NOT EXISTS `lake_test`.`base` (\n" +
+                        "    `k1` date NULL,\n" +
+                        "    `k2` int(11) NULL,\n" +
+                        "    `v1` int(11) SUM NULL\n" +
+                        ") ENGINE=OLAP\n" +
+                        "AGGREGATE KEY(`k1`, `k2`)\n" +
+                        "COMMENT 'OLAP'\n" +
+                        "PARTITION BY RANGE(`k1`)\n" +
+                        "(\n" +
+                        "    PARTITION p1 VALUES [('0000-01-01'), ('2020-02-01')),\n" +
+                        "    PARTITION p2 VALUES [('2020-02-01'), ('2020-03-01'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(`k2`) BUCKETS 3\n" +
+                        "PROPERTIES (\n" +
+                        "    'replication_num' = '1',\n" +
+                        "    'datacache.enable' = 'true'\n" +
+                        ");"
+        ));
+        checkLakeTable("lake_test", "base");
+        ExceptionChecker.expectThrowsNoException(() -> createMaterializedView(
+                "CREATE MATERIALIZED VIEW `lake_test`.`lake_mv`\n" +
+                        "DISTRIBUTED BY HASH(`k1`)\n" +
+                        "PROPERTIES (\n" +
+                        "    'replication_num' = '1',\n" +
+                        "    'datacache.enable' = 'true',\n" +
+                        "    'datacache.partition_duration' = '25 hour'\n" +
+                        ")\n" +
+                        "AS SELECT `k1` FROM `lake_test`.`base`;"
+        ));
+        checkMaterializedView("lake_test", "lake_mv");
+
+        new MockUp<Preconditions>() {
+            @Mock
+            public void checkArgument(boolean param) {
+
+            }
+        };
+    }
+
+    @AfterClass
+    public static void afterClass() {
+    }
+
+    private static void createTable(String sql) throws Exception {
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createTable(createTableStmt);
+    }
+
+    private static void createMaterializedView(String sql) throws Exception {
+        CreateMaterializedViewStatement createMVStmt =
+                (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().getLocalMetastore().createMaterializedView(createMVStmt);
+    }
+
+    private static void checkLakeTable(String dbName, String tableName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Table table = db.getTable(tableName);
+        Assert.assertTrue(table.isCloudNativeTable());
+    }
+
+    private static void checkMaterializedView(String dbName, String mvName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        List<MaterializedView> mvsList = db.getMaterializedViews();
+        for (MaterializedView lakeMv : mvsList) {
+            Assert.assertTrue(lakeMv.isCloudNativeMaterializedView());
+        }
+    }
+
+    private LakeTable getLakeTable(String dbName, String tableName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        Table table = db.getTable(tableName);
+        Assert.assertTrue(table.isCloudNativeTable());
+        return (LakeTable) table;
+    }
+
+    private LakeMaterializedView getMaterializedView(String dbName, String mvName) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        List<MaterializedView> mvsList = db.getMaterializedViews();
+        for (MaterializedView lakeMv : mvsList) {
+            if (lakeMv.getName().equals(mvName)) {
+                return (LakeMaterializedView) lakeMv;
+            }
+        }
+        return null;
+    }
+
+    private static void alterTableProperties(String dbName, String tableName, boolean isEnable) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, String.valueOf(isEnable));
+        ExceptionChecker.expectThrowsNoException(() ->
+                GlobalStateMgr.getCurrentState().getLocalMetastore().alterTableProperties(db, table, properties));
+    }
+
+    private static void alterPartitionProperties(String dbName, String tableName,
+            List<String> partitionNames, boolean isEnable) {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        OlapTable table = (OlapTable) db.getTable(tableName);
+        Map<String, String> properties = new HashMap<>();
+        properties.put(PropertyAnalyzer.PROPERTIES_DATACACHE_ENABLE, String.valueOf(isEnable));
+        ExceptionChecker.expectThrowsNoException(() ->
+                GlobalStateMgr.getCurrentState().getAlterJobMgr().modifyPartitionsProperty(
+                        db, table, partitionNames, properties));
+    }
+
+    @Test
+    public void testModifyTableDatacacheEnable() throws UserException {
+        LakeTable table = getLakeTable("lake_test", "lake_table");
+        { // check the original state of datacache.enable
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertTrue(dataCacheInfo.isEnabled());
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertFalse(dataCacheInfo.isEnabled());
+            }
+        }
+        alterPartitionProperties("lake_test", "lake_table", List.of("p1", "p2"), true);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (partition.getName().equals("p1") || partition.getName().equals("p2")) {
+                    Assert.assertTrue(dataCacheInfo.isEnabled());
+                } else {
+                    Assert.assertFalse(dataCacheInfo.isEnabled());
+                }
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", true);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertTrue(dataCacheInfo.isEnabled());
+            }
+        }
+        alterPartitionProperties("lake_test", "lake_table", List.of("p4", "p5"), false);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                if (partition.getName().equals("p4") || partition.getName().equals("p5")) {
+                    Assert.assertFalse(dataCacheInfo.isEnabled());
+                } else {
+                    Assert.assertTrue(dataCacheInfo.isEnabled());
+                }
+            }
+        }
+        alterTableProperties("lake_test", "lake_table", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = table.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = table.getPartitionInfo();
+            Collection<Partition> partitions = table.getPartitions();
+            for (Partition partition : partitions) {
+                DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partition.getId());
+                Assert.assertFalse(dataCacheInfo.isEnabled());
+            }
+        }
+    }
+
+    @Test
+    public void testModifyPartitionDatacacheEnable() throws UserException {
+        LakeMaterializedView lakeMv = getMaterializedView("lake_test", "lake_mv");
+        { // check the original state of datacache.enable
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+        alterPartitionProperties("lake_test", "lake_mv", List.of("lake_mv"), true);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", true);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertTrue(dataCacheInfo.isEnabled());
+        }
+        alterPartitionProperties("lake_test", "lake_mv", List.of("lake_mv"), false);
+        { // check the state of datacache.enable after alter partition properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertTrue(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+        alterTableProperties("lake_test", "lake_mv", false);
+        { // check the state of datacache.enable after alter table properties
+            StorageInfo storageInfo = lakeMv.getTableProperty().getStorageInfo();
+            Assert.assertNotNull(storageInfo);
+            Assert.assertFalse(storageInfo.getDataCacheInfo().isEnabled());
+            PartitionInfo partitionInfo = lakeMv.getPartitionInfo();
+            Collection<Partition> partitions = lakeMv.getPartitions();
+            List<Partition> partitionsList = new ArrayList<>(partitions);
+            DataCacheInfo dataCacheInfo = partitionInfo.getDataCacheInfo(partitionsList.get(0).getId());
+            Assert.assertFalse(dataCacheInfo.isEnabled());
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/persist/BatchModifyPartitionsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/BatchModifyPartitionsInfoTest.java
@@ -56,7 +56,7 @@ public class BatchModifyPartitionsInfoTest {
         List<Long> partitionIds = Lists.newArrayList(PARTITION_ID_1, PARTITION_ID_2, PARTITION_ID_3);
         for (long partitionId : partitionIds) {
             partitionInfos.add(new ModifyPartitionInfo(DB_ID, TB_ID, partitionId,
-                    DataProperty.DEFAULT_DATA_PROPERTY, (short) 3, true));
+                    DataProperty.DEFAULT_DATA_PROPERTY, (short) 3, true, false));
         }
 
         BatchModifyPartitionsInfo batchModifyPartitionsInfo = new BatchModifyPartitionsInfo(partitionInfos);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -112,6 +112,9 @@ public class AnalyzeAlterTableStatementTest {
         analyzeSuccess("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\");");
         analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"10 days\");");
         analyzeFail("ALTER TABLE test.t0 SET (\"datacache.partition_duration\" = \"abcd\");", "Cannot parse text to Duration");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"true\");");
+        analyzeSuccess("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"false\");");
+        analyzeFail("ALTER TABLE test.t0 SET (\"datacache.enable\" = \"abcd\");", "must be bool type(false/true)");
         analyzeFail("ALTER TABLE test.t0 SET (\"default.replication_num\" = \"2\", \"dynamic_partition.enable\" = \"true\");",
                 "Can only set one table property at a time");
         analyzeFail("ALTER TABLE test.t0 SET (\"abc\" = \"2\");",


### PR DESCRIPTION
Supports dynamic modification of table partition level datacache.enable attributes:
1. StarOSWorker uses heartbeat to report the datacache.enable of the shards it manages.
2. StarManager compares the shardInfoMd5 of ShardReportInfos. If they are not equal, it
   sends rpc to starlet to update the corresponding shard.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
