### PR TITLE
[BugFix] Fix partition predicate push down for mv rewrite with string type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -43,6 +43,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.planner.PartitionColumnFilter;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.PartitionDiffer;
 import com.starrocks.sql.common.RangePartitionDiff;
@@ -421,7 +422,6 @@ public class PartitionUtil {
 
     /**
      * If base table column type is string but partition type is date, we need to convert the string to date
-     *
      * @param partitionExpr   PARTITION BY expr
      * @param partitionColumn PARTITION BY referenced column
      * @return
@@ -430,20 +430,76 @@ public class PartitionUtil {
         if (!(partitionExpr instanceof FunctionCallExpr)) {
             return false;
         }
-        PrimitiveType columnType = partitionColumn.getPrimitiveType();
-        PrimitiveType partitionType = partitionExpr.getType().getPrimitiveType();
-        return partitionType.isDateType() && !columnType.isDateType();
+        return isConvertToDate(partitionExpr.getType(), partitionColumn.getType());
     }
 
-    private static PartitionKey  convertToDate(PartitionKey partitionKey) {
-        PartitionKey newPartitionKey = new PartitionKey();
-        String dateLiteral = partitionKey.getKeys().get(0).getStringValue();
-        LocalDateTime dateValue = DateUtils.parseStrictDateTime(dateLiteral);
+    /**
+     * Check whether convert filter to date type.
+     * @param partitionType     : Partition defined type.
+     * @param filterType        : Filter type from query.
+     * @return: true if convert is needed, false if not.
+     */
+    public static boolean isConvertToDate(Type partitionType, Type filterType) {
+        if (partitionType == null || filterType == null) {
+            return false;
+        }
+
+        PrimitiveType filterPrimitiveType = filterType.getPrimitiveType();
+        PrimitiveType partitionPrimitiveType = partitionType.getPrimitiveType();
+        return partitionPrimitiveType.isDateType() && !filterPrimitiveType.isDateType();
+    }
+
+    /**
+     * Check whether convert partition column filter to date type.
+     * @param partitionColumn           : Partition column which is defined in adding partitions.
+     * @param partitionColumnFilter     : Partition column filter from query.
+     * @return : true if partition column is defined as date type but filter is not date type.
+     */
+    public static boolean isConvertToDate(Column partitionColumn, PartitionColumnFilter partitionColumnFilter) {
+        if (partitionColumnFilter == null || partitionColumn == null) {
+            return false;
+        }
+        LiteralExpr lowerBound = partitionColumnFilter.getLowerBound();
+        LiteralExpr upperBound = partitionColumnFilter.getUpperBound();
+        LiteralExpr literalExpr = (lowerBound == null) ? upperBound : lowerBound;
+        if (literalExpr == null) {
+            return false;
+        }
+        return isConvertToDate(partitionColumn.getType(), literalExpr.getType());
+    }
+
+    /**
+     * Convert a string literal expr to a date literal.
+     * @param stringLiteral: input string literal to convert.
+     * @return             : date literal if string literal can be converted, otherwise throw SemanticException.
+     */
+    public static DateLiteral convertToDateLiteral(LiteralExpr stringLiteral) throws SemanticException {
+        if (stringLiteral == null) {
+            return null;
+        }
         try {
-            newPartitionKey.pushColumn(new DateLiteral(dateValue, Type.DATE), PrimitiveType.DATE);
+            String dateLiteral = stringLiteral.getStringValue();
+            LocalDateTime dateValue = DateUtils.parseStrictDateTime(dateLiteral);
+            return new DateLiteral(dateValue, Type.DATE);
+        } catch (Exception e) {
+            throw new SemanticException("create string to date literal failed:" +  stringLiteral.getStringValue(), e);
+        }
+    }
+
+    /**
+     * Convert a string type partition key to date type partition key.
+     * @param partitionKey : input string partition key to convert.
+     * @return             : partition key with date type if input can be converted.
+     */
+    private static PartitionKey convertToDate(PartitionKey partitionKey) throws SemanticException {
+        PartitionKey newPartitionKey = new PartitionKey();
+        try {
+            DateLiteral dateLiteral = convertToDateLiteral(partitionKey.getKeys().get(0));
+            newPartitionKey.pushColumn(dateLiteral, PrimitiveType.DATE);
             return newPartitionKey;
-        } catch (AnalysisException e) {
-            throw new SemanticException("create date string:{} failed:", partitionKey.getKeys().get(0).getStringValue(), e);
+        } catch (SemanticException e) {
+            throw new SemanticException("convert string {} to date partition key failed:",
+                    partitionKey.getKeys().get(0).getStringValue(), e);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashDistributionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashDistributionPruner.java
@@ -41,6 +41,7 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.catalog.Column;
 import com.starrocks.common.Config;
+import com.starrocks.connector.PartitionUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -100,14 +101,22 @@ public class HashDistributionPruner implements DistributionPruner {
         List<LiteralExpr> inPredicateLiterals = filter.getInPredicateLiterals();
         if (null == inPredicateLiterals ||
                 inPredicateLiterals.size() * complex > Config.max_distribution_pruner_recursion_depth) {
+            LiteralExpr lowerBound = filter.getLowerBound();
+            LiteralExpr upperBound = filter.getUpperBound();
             // equal one value
             if (filter.lowerBoundInclusive && filter.upperBoundInclusive
-                    && filter.lowerBound != null && filter.upperBound != null
-                    && 0 == filter.lowerBound.compareLiteral(filter.upperBound)) {
-                hashKey.pushColumn(filter.lowerBound, keyColumn.getType());
-                Collection<Long> result = prune(columnId + 1, hashKey, complex);
-                hashKey.popColumn();
-                return result;
+                    && lowerBound != null && upperBound != null
+                    && 0 == lowerBound.compareLiteral(upperBound)) {
+                try {
+                    boolean isConvertToDate = PartitionUtil.isConvertToDate(keyColumn.getType(), lowerBound.getType());
+                    hashKey.pushColumn(filter.getLowerBound(isConvertToDate), keyColumn.getType());
+                    Collection<Long> result = prune(columnId + 1, hashKey, complex);
+                    hashKey.popColumn();
+                    return result;
+                } catch (Exception e) {
+                    LOG.warn("Prune distribution key {} with predicate {} failed:", keyColumn, filter, e);
+                    return Lists.newArrayList(bucketsList);
+                }
             }
             // return all SubPartition
             return Lists.newArrayList(bucketsList);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
@@ -39,6 +39,8 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.connector.PartitionUtil;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
@@ -50,9 +52,9 @@ import java.util.List;
 
 public class PartitionColumnFilter {
     private static final Logger LOG = LogManager.getLogger(PartitionColumnFilter.class);
-    public LiteralExpr lowerBound;
+    private LiteralExpr lowerBound;
+    private LiteralExpr upperBound;
     public boolean lowerBoundInclusive;
-    public LiteralExpr upperBound;
     public boolean upperBoundInclusive;
     // InPredicate
     // planner and TestUT use
@@ -118,6 +120,30 @@ public class PartitionColumnFilter {
                 upperBound = newUpperBound;
                 upperBoundInclusive = newUpperBoundInclusive;
             }
+        }
+    }
+
+    public LiteralExpr getLowerBound() {
+        return lowerBound;
+    }
+
+    public LiteralExpr getUpperBound() {
+        return upperBound;
+    }
+
+    public LiteralExpr getLowerBound(boolean isConvertToDate) throws SemanticException {
+        if (isConvertToDate) {
+            return PartitionUtil.convertToDateLiteral(lowerBound);
+        } else {
+            return lowerBound;
+        }
+    }
+
+    public LiteralExpr getUpperBound(boolean isConvertToDate) throws SemanticException {
+        if (isConvertToDate) {
+            return PartitionUtil.convertToDateLiteral(upperBound);
+        } else {
+            return upperBound;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
@@ -46,6 +46,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
@@ -111,21 +112,28 @@ public class RangePartitionPruner implements PartitionPruner {
         if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable() != null) {
             inPredicateMaxLen = ConnectContext.get().getSessionVariable().getRangePrunerPredicateMaxLen();
         }
+
+        boolean isConvertToDate = PartitionUtil.isConvertToDate(keyColumn, filter);
         if (null == inPredicateLiterals || inPredicateLiterals.size() * complex > inPredicateMaxLen) {
+            LiteralExpr lowerBound = filter.getLowerBound();
+            LiteralExpr upperBound = filter.getUpperBound();
             if (filter.lowerBoundInclusive && filter.upperBoundInclusive
-                    && filter.lowerBound != null && filter.upperBound != null
-                    && 0 == filter.lowerBound.compareLiteral(filter.upperBound)) {
+                    && lowerBound != null && upperBound != null
+                    && 0 == lowerBound.compareLiteral(upperBound)) {
+
+                LiteralExpr lowerBoundExpr = filter.getLowerBound(isConvertToDate);
+                LiteralExpr upperBoundExpr = filter.getUpperBound(isConvertToDate);
 
                 // eg: [10, 10], [null, null]
-                if (filter.lowerBound instanceof NullLiteral && filter.upperBound instanceof NullLiteral) {
+                if (lowerBoundExpr instanceof NullLiteral && upperBoundExpr instanceof NullLiteral) {
                     // replace Null with min value
                     LiteralExpr minKeyValue = LiteralExpr.createInfinity(
                             Type.fromPrimitiveType(keyColumn.getPrimitiveType()), false);
                     minKey.pushColumn(minKeyValue, keyColumn.getPrimitiveType());
                     maxKey.pushColumn(minKeyValue, keyColumn.getPrimitiveType());
                 } else {
-                    minKey.pushColumn(filter.lowerBound, keyColumn.getPrimitiveType());
-                    maxKey.pushColumn(filter.upperBound, keyColumn.getPrimitiveType());
+                    minKey.pushColumn(lowerBoundExpr, keyColumn.getPrimitiveType());
+                    maxKey.pushColumn(upperBoundExpr, keyColumn.getPrimitiveType());
                 }
                 List<Long> result = prune(rangeMap, columnIdx + 1, minKey, maxKey, complex);
                 minKey.popColumn();
@@ -139,8 +147,8 @@ public class RangePartitionPruner implements PartitionPruner {
             int pushMinCount = 0;
             int pushMaxCount = 0;
             int lastColumnId = partitionColumns.size() - 1;
-            if (filter.lowerBound != null) {
-                minKey.pushColumn(filter.lowerBound, keyColumn.getPrimitiveType());
+            if (lowerBound != null) {
+                minKey.pushColumn(filter.getLowerBound(isConvertToDate), keyColumn.getPrimitiveType());
                 pushMinCount++;
                 if (filter.lowerBoundInclusive && columnIdx != lastColumnId) {
                     Column column = partitionColumns.get(columnIdx + 1);
@@ -153,8 +161,8 @@ public class RangePartitionPruner implements PartitionPruner {
                 minKey.pushColumn(LiteralExpr.createInfinity(type, false), keyColumn.getPrimitiveType());
                 pushMinCount++;
             }
-            if (filter.upperBound != null) {
-                maxKey.pushColumn(filter.upperBound, keyColumn.getPrimitiveType());
+            if (upperBound != null) {
+                maxKey.pushColumn(filter.getUpperBound(isConvertToDate), keyColumn.getPrimitiveType());
                 pushMaxCount++;
                 if (filter.upperBoundInclusive && columnIdx != lastColumnId) {
                     Column column = partitionColumns.get(columnIdx + 1);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -166,27 +166,31 @@ public class OptOlapPartitionPruner {
             }
 
             // None/Null bound predicate can't prune
-            if ((null == pcf.lowerBound || pcf.lowerBound.isConstantNull()) &&
-                    (null == pcf.upperBound || pcf.upperBound.isConstantNull())) {
+            LiteralExpr lowerBound = pcf.getLowerBound();
+            LiteralExpr upperBound = pcf.getUpperBound();
+            if ((null == lowerBound || lowerBound.isConstantNull()) &&
+                    (null == upperBound || upperBound.isConstantNull())) {
                 continue;
             }
 
             boolean lowerBind = true;
             boolean upperBind = true;
-            if (null != pcf.lowerBound) {
+            if (null != lowerBound) {
                 lowerBind = false;
                 PartitionKey min = new PartitionKey();
-                min.pushColumn(pcf.lowerBound, column.getPrimitiveType());
+                // TODO: take care `isConvertToDate` for olap table
+                min.pushColumn(pcf.getLowerBound(), column.getPrimitiveType());
                 int cmp = minRange.compareTo(min);
                 if (cmp > 0 || (0 == cmp && pcf.lowerBoundInclusive)) {
                     lowerBind = true;
                 }
             }
 
-            if (null != pcf.upperBound) {
+            if (null != upperBound) {
                 upperBind = false;
                 PartitionKey max = new PartitionKey();
-                max.pushColumn(pcf.upperBound, column.getPrimitiveType());
+                // TODO: take care `isConvertToDate` for olap table
+                max.pushColumn(upperBound, column.getPrimitiveType());
                 int cmp = maxRange.compareTo(max);
                 if (cmp < 0 || (0 == cmp && pcf.upperBoundInclusive)) {
                     upperBind = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
@@ -172,7 +172,7 @@ public class PartitionColPredicateEvaluator {
                 if (constantOperator.isNull()) {
                     literalExpr = LiteralExpr.createInfinity(childType, false);
                 } else {
-                    literalExpr = ColumnFilterConverter.convertLiteral(constantOperator);
+                    literalExpr = ColumnFilterConverter.convertLiteral(partitionColumn, constantOperator);
                 }
             } catch (AnalysisException e) {
                 return createAllTrueBitSet();
@@ -239,7 +239,7 @@ public class PartitionColPredicateEvaluator {
             if (IN_OPERANDS_LIMIT >= constList.size()) {
                 for (ConstantOperator constantOperator : constList) {
                     try {
-                        LiteralExpr literalExpr = ColumnFilterConverter.convertLiteral(constantOperator);
+                        LiteralExpr literalExpr = ColumnFilterConverter.convertLiteral(partitionColumn, constantOperator);
                         PartitionKey conditionKey = new PartitionKey();
                         conditionKey.pushColumn(literalExpr, childType);
                         Range<PartitionKey> predicateRange = Range.closed(conditionKey, conditionKey);
@@ -251,8 +251,8 @@ public class PartitionColPredicateEvaluator {
                 }
             } else {
                 try {
-                    LiteralExpr min = ColumnFilterConverter.convertLiteral(constList.get(0));
-                    LiteralExpr max = ColumnFilterConverter.convertLiteral(constList.get(constList.size() - 1));
+                    LiteralExpr min = ColumnFilterConverter.convertLiteral(partitionColumn, constList.get(0));
+                    LiteralExpr max = ColumnFilterConverter.convertLiteral(partitionColumn, constList.get(constList.size() - 1));
                     PartitionKey minKey = new PartitionKey();
                     minKey.pushColumn(min, childType);
                     PartitionKey maxKey = new PartitionKey();
@@ -358,7 +358,7 @@ public class PartitionColPredicateEvaluator {
             if (result.isConstantRef()) {
                 LiteralExpr newLiteralExpr;
                 try {
-                    newLiteralExpr = ColumnFilterConverter.convertLiteral((ConstantOperator) result);
+                    newLiteralExpr = ColumnFilterConverter.convertLiteral(partitionColumn, (ConstantOperator) result);
                 } catch (Exception e) {
                     return Optional.empty();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -59,7 +59,7 @@ public class ScalarRangePredicateExtractor {
     }
 
     private ScalarOperator rewrite(ScalarOperator predicate, boolean onlyExtractColumnRef) {
-        if (predicate.getOpType() != OperatorType.COMPOUND) {
+        if (predicate == null || predicate.getOpType() != OperatorType.COMPOUND) {
             return predicate;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -42,6 +42,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -59,6 +60,25 @@ public class MockIcebergMetadata implements ConnectorMetadata {
     public static final String MOCKED_UNPARTITIONED_DB_NAME = "unpartitioned_db";
     public static final String MOCKED_PARTITIONED_DB_NAME = "partitioned_db";
 
+    public static final String MOCKED_UNPARTITIONED_TABLE_NAME0 = "t0";
+    public static final String MOCKED_PARTITIONED_TABLE_NAME1 = "t1";
+
+    // string partition table
+    public static final String MOCKED_STRING_PARTITIONED_TABLE_NAME1 = "part_tbl1";
+    public static final String MOCKED_STRING_PARTITIONED_TABLE_NAME2 = "part_tbl2";
+    public static final String MOCKED_STRING_PARTITIONED_TABLE_NAME3 = "part_tbl3";
+
+    private static final List<String> PARTITION_TABLE_NAMES = ImmutableList.of(MOCKED_PARTITIONED_TABLE_NAME1,
+            MOCKED_STRING_PARTITIONED_TABLE_NAME1, MOCKED_STRING_PARTITIONED_TABLE_NAME2,
+            MOCKED_STRING_PARTITIONED_TABLE_NAME3);
+
+    private static final List<String> PARTITION_NAMES_0 = Lists.newArrayList("date=2020-01-01",
+            "date=2020-01-02",
+            "date=2020-01-03",
+            "date=2020-01-04");
+    private static final List<String> PARTITION_NAMES_1 = Lists.newArrayList("d=2023-08-01",
+            "d=2023-08-02",
+            "d=2023-08-03");
     public static String getStarRocksHome() throws IOException {
         String starRocksHome = System.getenv("STARROCKS_HOME");
         if (Strings.isNullOrEmpty(starRocksHome)) {
@@ -92,12 +112,14 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         PartitionSpec spec =
                 PartitionSpec.builderFor(schema).build();
         TestTables.TestTable baseTable = TestTables.create(
-                new File(getStarRocksHome() + "/" + MOCKED_UNPARTITIONED_DB_NAME + "/" + "t0"), "t0",
+                new File(getStarRocksHome() + "/" + MOCKED_UNPARTITIONED_DB_NAME + "/" +
+                        MOCKED_UNPARTITIONED_TABLE_NAME0), MOCKED_UNPARTITIONED_TABLE_NAME0,
                 schema, spec, 1);
 
-        String tableIdentifier = Joiner.on(":").join("t0", UUID.randomUUID());
-        MockIcebergTable mockIcebergTable = new MockIcebergTable(1, "t0", MOCKED_ICEBERG_CATALOG_NAME,
-                null, MOCKED_UNPARTITIONED_DB_NAME, "t0", schemas, baseTable, null,
+        String tableIdentifier = Joiner.on(":").join(MOCKED_UNPARTITIONED_TABLE_NAME0, UUID.randomUUID());
+        MockIcebergTable mockIcebergTable = new MockIcebergTable(1, MOCKED_UNPARTITIONED_TABLE_NAME0,
+                MOCKED_ICEBERG_CATALOG_NAME, null, MOCKED_UNPARTITIONED_DB_NAME,
+                MOCKED_UNPARTITIONED_TABLE_NAME0, schemas, baseTable, null,
                 tableIdentifier);
 
         Map<String, ColumnStatistic> columnStatisticMap;
@@ -105,44 +127,82 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
                 col -> ColumnStatistic.unknown()));
 
-        icebergTableInfoMap.put("t0", new IcebergTableInfo(mockIcebergTable, Lists.newArrayList(), 100,
-                columnStatisticMap));
+        icebergTableInfoMap.put(MOCKED_UNPARTITIONED_TABLE_NAME0,
+                new IcebergTableInfo(mockIcebergTable, Lists.newArrayList(), 100, columnStatisticMap));
     }
 
     public static void mockPartitionedTable() throws IOException {
         MOCK_TABLE_MAP.putIfAbsent(MOCKED_PARTITIONED_DB_NAME, new CaseInsensitiveMap<>());
         Map<String, IcebergTableInfo> icebergTableInfoMap = MOCK_TABLE_MAP.get(MOCKED_PARTITIONED_DB_NAME);
 
-        List<Column> schemas = ImmutableList.of(new Column("id", Type.INT, true),
-                new Column("data", Type.STRING, true),
-                new Column("date", Type.STRING, true));
+        for (String tblName : PARTITION_TABLE_NAMES) {
+            List<Column> columns = getSchema(tblName);
+            MockIcebergTable icebergTable = getIcebergTable(tblName, columns);
+            Map<String, ColumnStatistic> columnStatisticMap;
+            List<String> colNames = columns.stream().map(Column::getName).collect(Collectors.toList());
+            columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
+                    col -> ColumnStatistic.unknown()));
+            if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
+                icebergTableInfoMap.put(tblName, new IcebergTableInfo(icebergTable, PARTITION_NAMES_0, 100,
+                        columnStatisticMap));
+            } else {
+                icebergTableInfoMap.put(tblName, new IcebergTableInfo(icebergTable, PARTITION_NAMES_1, 100,
+                        columnStatisticMap));
+            }
+        }
+    }
 
-        Schema schema =
-                new Schema(required(3, "id", Types.IntegerType.get()),
-                        required(4, "data", Types.StringType.get()),
-                        required(5, "date", Types.StringType.get()));
-        PartitionSpec spec =
-                PartitionSpec.builderFor(schema).identity("date").build();
-        TestTables.TestTable baseTable = TestTables.create(
-                new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_DB_NAME + "/" + "t1"), "t1",
-                schema, spec, 1);
+    private static List<Column> getSchema(String tblName) {
+        if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
+            return ImmutableList.of(new Column("id", Type.INT, true),
+                    new Column("data", Type.STRING, true),
+                    new Column("date", Type.STRING, true));
+        } else {
+            return Arrays.asList(new Column("a", Type.VARCHAR), new Column("b", Type.VARCHAR),
+                    new Column("c", Type.INT), new Column("d", Type.VARCHAR));
+        }
+    }
 
-        String tableIdentifier = Joiner.on(":").join("t1", UUID.randomUUID());
-        MockIcebergTable mockIcebergTable = new MockIcebergTable(1, "t1", MOCKED_ICEBERG_CATALOG_NAME,
-                null, MOCKED_PARTITIONED_DB_NAME, "t1", schemas, baseTable, null,
+    private static Schema getIcebergSchema(String tblName) {
+        if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
+            return new Schema(required(3, "id", Types.IntegerType.get()),
+                    required(4, "data", Types.StringType.get()),
+                    required(5, "date", Types.StringType.get()));
+        } else {
+            return new Schema(required(3, "a", Types.StringType.get()),
+                    required(4, "b", Types.StringType.get()),
+                    required(5, "c", Types.StringType.get()),
+                    required(6, "d", Types.StringType.get()));
+        }
+    }
+
+    private static TestTables.TestTable getTestTable(String tblName, Schema schema) throws IOException {
+        if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema).identity("date").build();
+            return  TestTables.create(
+                    new File(getStarRocksHome() + "/" + MOCKED_PARTITIONED_DB_NAME + "/"
+                            + MOCKED_PARTITIONED_TABLE_NAME1), MOCKED_PARTITIONED_TABLE_NAME1,
+                    schema, spec, 1);
+
+        } else {
+            PartitionSpec spec =
+                    PartitionSpec.builderFor(schema).identity("d").build();
+            return TestTables.create(
+                    new File(getStarRocksHome() + "/" + tblName + "/" + tblName),
+                    tblName,
+                    schema, spec, 1);
+        }
+    }
+
+    public static MockIcebergTable getIcebergTable(String tblName, List<Column> schemas) throws IOException {
+        Schema schema = getIcebergSchema(tblName);
+        TestTables.TestTable baseTable = getTestTable(tblName, schema);
+
+        String tableIdentifier = Joiner.on(":").join(tblName, UUID.randomUUID());
+        return new MockIcebergTable(tblName.hashCode(), tblName, MOCKED_ICEBERG_CATALOG_NAME,
+                null, MOCKED_PARTITIONED_DB_NAME, tblName, schemas, baseTable, null,
                 tableIdentifier);
-
-        List<String> partitionNames = Lists.newArrayList("date=2020-01-01",
-                "date=2020-01-02",
-                "date=2020-01-03",
-                "date=2020-01-04");
-        Map<String, ColumnStatistic> columnStatisticMap;
-        List<String> colNames = schemas.stream().map(Column::getName).collect(Collectors.toList());
-        columnStatisticMap = colNames.stream().collect(Collectors.toMap(Function.identity(),
-                col -> ColumnStatistic.unknown()));
-
-        icebergTableInfoMap.put("t1", new IcebergTableInfo(mockIcebergTable, partitionNames, 100,
-                columnStatisticMap));
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MockedJDBCMetadata.java
@@ -39,6 +39,11 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     public static final String MOCKED_PARTITIONED_TABLE_NAME1 = "tbl1";
     public static final String MOCKED_PARTITIONED_TABLE_NAME2 = "tbl2";
     public static final String MOCKED_PARTITIONED_TABLE_NAME3 = "tbl3";
+
+    // string partition table
+    public static final String MOCKED_STRING_PARTITIONED_TABLE_NAME1 = "part_tbl1";
+    public static final String MOCKED_STRING_PARTITIONED_TABLE_NAME2 = "part_tbl2";
+    public static final String MOCKED_STRING_PARTITIONED_TABLE_NAME3 = "part_tbl3";
     private Map<String, String> properties;
     private Map<String, JDBCTable> tables = new HashMap<>();
 
@@ -63,7 +68,6 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
         try {
             if (tables.get(tblName) == null) {
                 if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME0)) {
-
                     tables.put(tblName, new JDBCTable(100000, MOCKED_PARTITIONED_TABLE_NAME0, getSchema(tblName),
                             getPartitionColumns(tblName), MOCKED_PARTITIONED_DB_NAME, MOCKED_JDBC_CATALOG_NAME, properties));
                 } else if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME1)) {
@@ -74,6 +78,9 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
                             getPartitionColumns(tblName), MOCKED_PARTITIONED_DB_NAME, MOCKED_JDBC_CATALOG_NAME, properties));
                 } else if (tblName.equals(MOCKED_PARTITIONED_TABLE_NAME3)) {
                     tables.put(tblName, new JDBCTable(100002, MOCKED_PARTITIONED_TABLE_NAME3, getSchema(tblName),
+                            getPartitionColumns(tblName), MOCKED_PARTITIONED_DB_NAME, MOCKED_JDBC_CATALOG_NAME, properties));
+                } else {
+                    tables.put(tblName, new JDBCTable(tblName.hashCode(), tblName, getSchema(tblName),
                             getPartitionColumns(tblName), MOCKED_PARTITIONED_DB_NAME, MOCKED_JDBC_CATALOG_NAME, properties));
                 }
             }
@@ -99,7 +106,6 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
                 return Arrays.asList(new Column("a", Type.VARCHAR), new Column("b", Type.VARCHAR),
                         new Column("c", Type.INT), new Column("d", Type.VARCHAR));
             }
-
         } finally {
             readUnlock();
         }
@@ -161,7 +167,10 @@ public class MockedJDBCMetadata implements ConnectorMetadata {
     public List<String> listTableNames(String dbName) {
         readLock();
         try {
-            return Arrays.asList(MOCKED_PARTITIONED_TABLE_NAME0, MOCKED_PARTITIONED_TABLE_NAME1, MOCKED_PARTITIONED_TABLE_NAME2);
+            return Arrays.asList(MOCKED_PARTITIONED_TABLE_NAME0, MOCKED_PARTITIONED_TABLE_NAME1,
+                    MOCKED_PARTITIONED_TABLE_NAME2, MOCKED_PARTITIONED_TABLE_NAME3,
+                    MOCKED_STRING_PARTITIONED_TABLE_NAME1, MOCKED_STRING_PARTITIONED_TABLE_NAME2,
+                    MOCKED_STRING_PARTITIONED_TABLE_NAME3);
         } finally {
             readUnlock();
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
@@ -1,0 +1,108 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.scheduler;
+
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
+import com.starrocks.pseudocluster.PseudoCluster;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.statistic.StatisticsMetaManager;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
+
+import java.util.List;
+
+public class MVRefreshTestBase {
+    private static final Logger LOG = LogManager.getLogger(MvRewriteTestBase.class);
+    protected static ConnectContext connectContext;
+    protected static PseudoCluster cluster;
+    protected static StarRocksAssert starRocksAssert;
+    @ClassRule
+    public static TemporaryFolder temp = new TemporaryFolder();
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        FeConstants.runningUnitTest = true;
+        FeConstants.enablePruneEmptyOutputScan = false;
+        Config.enable_experimental_mv = true;
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        ConnectorPlanTestBase.mockCatalog(connectContext, temp.newFolder().toURI().toString());
+        starRocksAssert = new StarRocksAssert(connectContext);
+        if (!starRocksAssert.databaseExist("_statistics_")) {
+            StatisticsMetaManager m = new StatisticsMetaManager();
+            m.createStatisticsTablesForTest();
+        }
+        starRocksAssert.withDatabase("test");
+        starRocksAssert.useDatabase("test");
+
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                if (stmt instanceof InsertStmt) {
+                    InsertStmt insertStmt = (InsertStmt) stmt;
+                    TableName tableName = insertStmt.getTableName();
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    if (tbl != null) {
+                        for (Partition partition : tbl.getPartitions()) {
+                            if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
+                                setPartitionVersion(partition, partition.getVisibleVersion() + 1);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private static void setPartitionVersion(Partition partition, long version) {
+        partition.setVisibleVersion(version, System.currentTimeMillis());
+        MaterializedIndex baseIndex = partition.getBaseIndex();
+        List<Tablet> tablets = baseIndex.getTablets();
+        for (Tablet tablet : tablets) {
+            List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
+            for (Replica replica : replicas) {
+                replica.updateVersionInfo(version, -1, version);
+            }
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -18,22 +18,16 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.JDBCResource;
 import com.starrocks.catalog.JDBCTable;
-import com.starrocks.catalog.LocalTablet;
-import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
-import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
-import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.util.DebugUtil;
@@ -52,23 +46,17 @@ import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.common.SyncPartitionUtils;
-import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
-import com.starrocks.statistic.StatisticsMetaManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TUniqueId;
-import com.starrocks.utframe.StarRocksAssert;
-import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -83,29 +71,11 @@ import java.util.stream.Collectors;
 import static com.starrocks.scheduler.TaskRun.PARTITION_END;
 import static com.starrocks.scheduler.TaskRun.PARTITION_START;
 
-public class PartitionBasedMvRefreshProcessorTest {
-
-    private static ConnectContext connectContext;
-    private static StarRocksAssert starRocksAssert;
-
-    @ClassRule
-    public static TemporaryFolder temp = new TemporaryFolder();
+public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
     @BeforeClass
     public static void beforeClass() throws Exception {
-        FeConstants.runningUnitTest = true;
-        FeConstants.enablePruneEmptyOutputScan = false;
-        Config.enable_experimental_mv = true;
-        UtFrameUtils.createMinStarRocksCluster();
-        connectContext = UtFrameUtils.createDefaultCtx();
-        ConnectorPlanTestBase.mockCatalog(connectContext, temp.newFolder().toURI().toString());
-        starRocksAssert = new StarRocksAssert(connectContext);
-        if (!starRocksAssert.databaseExist("_statistics_")) {
-            StatisticsMetaManager m = new StatisticsMetaManager();
-            m.createStatisticsTablesForTest();
-        }
-        starRocksAssert.withDatabase("test");
-        starRocksAssert.useDatabase("test");
+        MVRefreshTestBase.beforeClass();
 
         starRocksAssert.withTable("CREATE TABLE test.tbl1\n" +
                         "(\n" +
@@ -336,25 +306,6 @@ public class PartitionBasedMvRefreshProcessorTest {
                         "\"partition_refresh_number\" = \"1\"" +
                         ") " +
                         "as select str2date(d,'%Y%m%d') ss, a, b, c from jdbc0.partitioned_db0.tbl1;");
-
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
-                if (stmt instanceof InsertStmt) {
-                    InsertStmt insertStmt = (InsertStmt) stmt;
-                    TableName tableName = insertStmt.getTableName();
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
-                    if (tbl != null) {
-                        for (Partition partition : tbl.getPartitions()) {
-                            if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
-                                setPartitionVersion(partition, partition.getVisibleVersion() + 1);
-                            }
-                        }
-                    }
-                }
-            }
-        };
     }
 
     protected void assertPlanContains(ExecPlan execPlan, String... explain) throws Exception {
@@ -537,22 +488,6 @@ public class PartitionBasedMvRefreshProcessorTest {
 
     @Test
     public void testRefreshPriority() throws Exception {
-        new MockUp<StmtExecutor>() {
-            @Mock
-            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
-                if (stmt instanceof InsertStmt) {
-                    InsertStmt insertStmt = (InsertStmt) stmt;
-                    TableName tableName = insertStmt.getTableName();
-                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
-                    for (Partition partition : tbl.getPartitions()) {
-                        if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
-                            setPartitionVersion(partition, partition.getVisibleVersion() + 1);
-                        }
-                    }
-                }
-            }
-        };
         String mvName = "mv_refresh_priority";
         starRocksAssert.withMaterializedView("create materialized view test.mv_refresh_priority\n" +
                 "partition by date_trunc('month',k1) \n" +
@@ -1521,7 +1456,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     }
 
     @Test
-    public void test_str2date_date_trunc() throws Exception {
+    public void testStr2Date_DateTrunc() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
                 (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
@@ -1583,7 +1518,7 @@ public class PartitionBasedMvRefreshProcessorTest {
     }
 
     @Test
-    public void test_str2date_ttl() throws Exception {
+    public void testStr2Date_TTL() throws Exception {
         MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
         MockedJDBCMetadata mockedJDBCMetadata =
                 (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
@@ -2041,18 +1976,6 @@ public class PartitionBasedMvRefreshProcessorTest {
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assert.assertNotNull(baseTableVisibleVersionMap.get(tbl1.getId()).get("p100"));
         Assert.assertEquals(3, baseTableVisibleVersionMap.get(tbl1.getId()).get("p100").getVersion());
-    }
-
-    private static void setPartitionVersion(Partition partition, long version) {
-        partition.setVisibleVersion(version, System.currentTimeMillis());
-        MaterializedIndex baseIndex = partition.getBaseIndex();
-        List<Tablet> tablets = baseIndex.getTablets();
-        for (Tablet tablet : tablets) {
-            List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
-            for (Replica replica : replicas) {
-                replica.updateVersionInfo(version, -1, version);
-            }
-        }
     }
 
     @Test
@@ -2935,4 +2858,39 @@ public class PartitionBasedMvRefreshProcessorTest {
         }
         starRocksAssert.dropMaterializedView("test_drop_partition_mv1");
     }
+
+
+    @Test
+    public void testStr2DateMVRefresh_Rewrite() throws Exception {
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
+        MockedJDBCMetadata mockedJDBCMetadata =
+                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+        mockedJDBCMetadata.initPartitions();
+
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y%m%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
 }
+
+

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverterTest.java
@@ -127,8 +127,8 @@ public class ColumnFilterConverterTest {
         assertTrue(result.containsKey("name"));
         assertTrue(result.containsKey("sex"));
 
-        assertEquals(new IntLiteral(1), result.get("age").lowerBound);
-        assertEquals(new IntLiteral(1), result.get("age").upperBound);
+        assertEquals(new IntLiteral(1), result.get("age").getLowerBound());
+        assertEquals(new IntLiteral(1), result.get("age").getUpperBound());
 
         assertEquals(4, result.get("name").getInPredicateLiterals().size());
         assertEquals(new StringLiteral("1"), result.get("name").getInPredicateLiterals().get(0));
@@ -136,8 +136,8 @@ public class ColumnFilterConverterTest {
         assertEquals(new StringLiteral("3"), result.get("name").getInPredicateLiterals().get(2));
         assertEquals(new StringLiteral("4"), result.get("name").getInPredicateLiterals().get(3));
 
-        assertEquals(new NullLiteral(), result.get("sex").lowerBound);
-        assertEquals(new NullLiteral(), result.get("sex").upperBound);
+        assertEquals(new NullLiteral(), result.get("sex").getLowerBound());
+        assertEquals(new NullLiteral(), result.get("sex").getUpperBound());
     }
 
     @Test
@@ -158,8 +158,8 @@ public class ColumnFilterConverterTest {
             Map<String, PartitionColumnFilter> result = ColumnFilterConverter.convertColumnFilter(list);
             assertEquals(result.size(), 1);
             PartitionColumnFilter filter = result.get("c0");
-            assertEquals(filter.lowerBound, new NullLiteral());
-            assertEquals(filter.upperBound, new NullLiteral());
+            assertEquals(filter.getLowerBound(), new NullLiteral());
+            assertEquals(filter.getUpperBound(), new NullLiteral());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -1,0 +1,315 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Partition;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_FullRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d >= '20230801'\n" +
+                    "     partitions=3/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d < '20230802';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_PartialRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d < '20230802';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_LeftJoin_FullRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d >= '20230801'\n" +
+                    "     partitions=3/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d < '20230802';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_LeftJoin_PartialRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d < '20230802';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "12:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
@@ -1,0 +1,264 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Partition;
+import com.starrocks.connector.MockedMetadataMgr;
+import com.starrocks.connector.jdbc.MockedJDBCMetadata;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+        MockedMetadataMgr metadataMgr = (MockedMetadataMgr) connectContext.getGlobalStateMgr().getMetadataMgr();
+        MockedJDBCMetadata mockedJDBCMetadata =
+                (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
+        mockedJDBCMetadata.initPartitions();
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_FullRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y%m%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d = '20230801'\n" +
+                    "     partitions=1/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d >= '20230801'\n" +
+                    "     partitions=3/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d < '20230802';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_PartialRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y%m%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('20230801') " +
+                "end ('20230802') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_LeftJoin_FullRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y%m%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d = '20230801'\n" +
+                    "     partitions=1/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d >= '20230801'\n" +
+                    "     partitions=3/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d < '20230802';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_LeftJoin_PartialRefresh() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y%m%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('20230801') " +
+                "end ('20230802') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d " +
+                    " from  jdbc0.partitioned_db0.part_tbl1 as t1 " +
+                    " inner join jdbc0.partitioned_db0.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join jdbc0.partitioned_db0.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='20230801';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+}


### PR DESCRIPTION
Since MV has support to be partitioned by string data type after https://github.com/StarRocks/starrocks/pull/33214/files . Partition pruner should also support for string data type.

1. `deriveLogicalProperty` new OptExpressions When push down partition predicates after mv rewrite;
2. ScalarRangePredicateExtractor will prevent null input because pushdownPredicatesForJoin will push down null predicate.
3. Support string type partition prune in `RangePartitionPruner `  and  [PartitionColPredicateEvaluator.java](https://github.com/StarRocks/starrocks/pull/33897/files#diff-0fc29d8367ad4b1ed725f85beff86a7ee2f5efde7f3d7626b8c4e7e60dec6d24) for external tables, the strategy is simple: convert the string partition type to date when query's partition predicate is different from mv's defined date type.

### Further
- Support olap table partition prune for string type later.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
