### PR TITLE
[BugFix] fix hudi scanner type mapping for complex type

### DIFF
--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
@@ -79,9 +79,6 @@ public class HudiSliceScanner extends ConnectorScanner {
     private final ClassLoader classLoader;
     private final String fsOptionsProps;
 
-    public static final int MAX_DECIMAL32_PRECISION = 9;
-    public static final int MAX_DECIMAL64_PRECISION = 18;
-
     public HudiSliceScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;
         this.hiveColumnNames = params.get("hive_column_names");
@@ -130,12 +127,7 @@ public class HudiSliceScanner extends ConnectorScanner {
         for (int i = 0; i < requiredFields.length; i++) {
             requiredColumnIds[i] = hiveColumnNameToIndex.get(requiredFields[i]);
             String type = hiveColumnNameToType.get(requiredFields[i]);
-
-            if (type.startsWith("decimal")) {
-                parseDecimal(type, i);
-            } else {
-                requiredTypes[i] = new ColumnType(requiredFields[i], type);
-            }
+            requiredTypes[i] = new ColumnType(requiredFields[i], type);
         }
 
         // prune fields
@@ -148,28 +140,6 @@ public class HudiSliceScanner extends ConnectorScanner {
             String name = requiredFields[i];
             type.pruneOnField(ssf, name);
         }
-    }
-
-    // convert decimal(x,y) to decimal
-    private void parseDecimal(String type, int i) {
-        int precision = -1;
-        int scale = -1;
-        int s = type.indexOf('(');
-        int e = type.indexOf(')');
-        if (s != -1 && e != -1) {
-            String[] ps = type.substring(s + 1, e).split(",");
-            precision = Integer.parseInt(ps[0].trim());
-            scale = Integer.parseInt(ps[1].trim());
-            if (precision <= MAX_DECIMAL32_PRECISION) {
-                type = "decimal32";
-            } else if (precision <= MAX_DECIMAL64_PRECISION) {
-                type = "decimal64";
-            } else {
-                type = "decimal128";
-            }
-        }
-        requiredTypes[i] = new ColumnType(requiredFields[i], type);
-        requiredTypes[i].setScale(scale);
     }
 
     private Properties makeProperties() {
@@ -193,9 +163,10 @@ public class HudiSliceScanner extends ConnectorScanner {
         // recover INT64 based timestamp mark to hive type, TimestampMicros/TimestampMillis => timestamp
 
         List<String> types = new ArrayList<>();
+        String[] hiveColumnNames = this.hiveColumnNames.split(",");
         for (int i = 0; i < this.hiveColumnTypes.length; i++) {
-            String type = this.hiveColumnTypes[i];
-            type = HudiScannerUtils.mapToHiveType(type);
+            ColumnType columnType = new ColumnType(hiveColumnNames[i], hiveColumnTypes[i]);
+            String type = HudiScannerUtils.mapColumnTypeToHiveType(columnType);
             types.add(type);
         }
         properties.setProperty("columns.types", types.stream().collect(Collectors.joining(",")));

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
@@ -51,7 +51,6 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 import static com.google.common.base.Preconditions.checkArgument;
-import static com.starrocks.hudi.reader.HudiScannerUtils.HIVE_TYPE_MAPPING;
 import static java.util.stream.Collectors.toList;
 
 public class HudiSliceScanner extends ConnectorScanner {
@@ -192,12 +191,11 @@ public class HudiSliceScanner extends ConnectorScanner {
         }
         properties.setProperty("columns", this.hiveColumnNames);
         // recover INT64 based timestamp mark to hive type, TimestampMicros/TimestampMillis => timestamp
+
         List<String> types = new ArrayList<>();
         for (int i = 0; i < this.hiveColumnTypes.length; i++) {
             String type = this.hiveColumnTypes[i];
-            if (HIVE_TYPE_MAPPING.containsKey(type)) {
-                type = HIVE_TYPE_MAPPING.get(type);
-            }
+            type = HudiScannerUtils.mapToHiveType(type);
             types.add(type);
         }
         properties.setProperty("columns.types", types.stream().collect(Collectors.joining(",")));


### PR DESCRIPTION
Fixes #issue

Major Changes:
- move `parseDecimal` into `ColumnType`
- map Type to HiveType in `ColumnType`.

Because `columnType` supports complex type, so it's right behaviour.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
