### PR TITLE
[BugFix] Make unique/foreign key constraints case insensitive

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -939,7 +939,7 @@ public class PropertyAnalyzer {
         List<UniqueConstraint> mvUniqueConstraints = Lists.newArrayList();
         if (analyzedTable.isMaterializedView() && analyzedTable.hasUniqueConstraints()) {
             mvUniqueConstraints = analyzedTable.getUniqueConstraints().stream().filter(
-                    uniqueConstraint -> parentTable.getName().equals(uniqueConstraint.getTableName()))
+                    uniqueConstraint -> StringUtils.areTableNamesEqual(parentTable, uniqueConstraint.getTableName()))
                     .collect(Collectors.toList());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
@@ -69,4 +69,12 @@ public class StringUtils {
             return table.getName().equalsIgnoreCase(toCheck);
         }
     }
+
+    public static boolean areColumnNamesEqual(String columName, String toCheck) {
+        if (columName == null) {
+            return false;
+        }
+
+        return columName.equalsIgnoreCase(toCheck);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
@@ -34,6 +34,8 @@
 
 package com.starrocks.common.util;
 
+import com.starrocks.catalog.Table;
+
 import java.security.SecureRandom;
 
 public class StringUtils {
@@ -52,4 +54,19 @@ public class StringUtils {
         return randomString.toString();
     }
 
+    /**
+     * Check two table names are equal or not.
+     * NOTE: OLAP table name is case-sensitive and other catalogs are not.
+     */
+    public static boolean areTableNamesEqual(Table table, String toCheck) {
+        if (table == null) {
+            return false;
+        }
+
+        if (table.isNativeTableOrMaterializedView()) {
+            return table.getName().equals(toCheck);
+        } else {
+            return table.getName().equalsIgnoreCase(toCheck);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/StringUtils.java
@@ -70,6 +70,9 @@ public class StringUtils {
         }
     }
 
+    /**
+     * Check two column names are equal or not, column names are always case-insensitive.
+     */
     public static boolean areColumnNamesEqual(String columName, String toCheck) {
         if (columName == null) {
             return false;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.operator.scalar;
 
 import com.starrocks.catalog.Type;
+import com.starrocks.common.util.StringUtils;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 
@@ -172,7 +173,7 @@ public final class ColumnRefOperator extends ScalarOperator {
 
         ColumnRefOperator leftColumn = (ColumnRefOperator) this;
         ColumnRefOperator rightColumn = (ColumnRefOperator) obj;
-        return leftColumn.getName().equals(rightColumn.getName())
+        return StringUtils.areColumnNamesEqual(leftColumn.getName(), rightColumn.getName())
                 && leftColumn.getType().equals(rightColumn.getType())
                 && leftColumn.isNullable() == rightColumn.isNullable();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ColumnRefOperator.java
@@ -171,11 +171,10 @@ public final class ColumnRefOperator extends ScalarOperator {
             return true;
         }
 
-        ColumnRefOperator leftColumn = (ColumnRefOperator) this;
         ColumnRefOperator rightColumn = (ColumnRefOperator) obj;
-        return StringUtils.areColumnNamesEqual(leftColumn.getName(), rightColumn.getName())
-                && leftColumn.getType().equals(rightColumn.getType())
-                && leftColumn.isNullable() == rightColumn.isNullable();
+        return StringUtils.areColumnNamesEqual(this.getName(), rightColumn.getName())
+                && this.getType().equals(rightColumn.getType())
+                && this.isNullable() == rightColumn.isNullable();
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -70,13 +70,14 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
                             return ret;
                         }
                         return Integer.compare(c1.getId(), c2.getId());
+                    } else {
+                        String s1 = o1.toString();
+                        String s2 = o2.toString();
+                        String n1 = s1.replaceAll("\\d+: ", "");
+                        String n2 = s2.replaceAll("\\d+: ", "");
+                        int ret = n1.compareTo(n2);
+                        return (ret == 0) ? s1.compareTo(s2) : ret;
                     }
-                    String s1 = o1.toString();
-                    String s2 = o2.toString();
-                    String n1 = s1.replaceAll("\\d: ", "");
-                    String n2 = s2.replaceAll("\\d: ", "");
-                    int ret = n1.compareTo(n2);
-                    return (ret == 0) ? s1.compareTo(s2) : ret;
                 }
             };
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -41,6 +41,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.StringUtils;
 import com.starrocks.sql.common.PermutationGenerator;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
@@ -1127,8 +1128,8 @@ public class MaterializedViewRewriter {
         List<UniqueConstraint> mvUniqueConstraints = Lists.newArrayList();
         if (materializedView.hasUniqueConstraints()) {
             mvUniqueConstraints = materializedView.getUniqueConstraints().stream().filter(
-                            uniqueConstraint -> table.getName().equals(uniqueConstraint.getTableName()))
-                    .collect(Collectors.toList());
+                           uniqueConstraint -> StringUtils.areTableNamesEqual(table, uniqueConstraint.getTableName()))
+                   .collect(Collectors.toList());
         }
 
         KeysType tableKeyType = KeysType.DUP_KEYS;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -4638,5 +4639,81 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 .contains("0:OlapScanNode\n" +
                         "     TABLE: mv0\n" +
                         "     PREAGGREGATION: ON\n");
+    }
+
+    @Test
+    public void testOlapTable_ViewDeltaJoin_CaseSensitive1() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps_no_constraint emps\n"
+                + "join dependents using (empid)"
+                + "inner join depts b on (emps.deptno=b.deptno)\n"
+                + "where emps.empid = 1";
+        String query = "select empid, emps.deptno from emps_no_constraint emps join depts b on (emps.deptno=b.deptno) \n"
+                + "where empid = 1";
+        // Olap Table doesn't support case-insensitive.
+        String constraint = "\"unique_constraints\" = \"DEPENDENTS.empid\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid)\" ";
+        try {
+            rewrite(mv, query, constraint);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("test_mv.DEPENDENTS does not exist."));
+        }
+    }
+
+    @Test
+    public void testOlapTable_ViewDeltaJoin_CaseSensitive2() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps_no_constraint emps\n"
+                + "join dependents using (empid)"
+                + "inner join depts b on (emps.deptno=b.deptno)\n"
+                + "where emps.empid = 1";
+        String query = "select empid, emps.deptno from emps_no_constraint emps join depts b on (emps.deptno=b.deptno) \n"
+                + "where empid = 1";
+        // Olap Table doesn't support case-insensitive.
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"EMPS_NO_CONSTRAINT(empid) references DEPENDENTS(empid)\" ";
+        try {
+            rewrite(mv, query, constraint);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("table:DEPENDENTS do not exist."));
+        }
+    }
+
+    @Test
+    public void testOlapTable_ViewDeltaJoin_CaseSensitive3() {
+        String mv = "select emps.empid, emps.deptno, dependents.name from emps_no_constraint emps\n"
+                + "join dependents using (empid)"
+                + "inner join depts b on (emps.deptno=b.deptno)\n"
+                + "where emps.empid = 1";
+        String query = "SELECT EMPID, EMPS.DEPTNO FROM EMPS_NO_CONSTRAINT EMPS JOIN DEPTS B ON (EMPS.DEPTNO=B.DEPTNO) \n"
+                + "WHERE EMPID = 1";
+        // Olap Table doesn't support case-insensitive.
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid)\" ";
+        try {
+            rewrite(mv, query, constraint);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Unknown table 'test_mv.EMPS_NO_CONSTRAINT'."));
+        }
+    }
+
+    @Test
+    public void testOlapTable_ViewDeltaJoin_CaseSensitive4() {
+        try {
+        String mv = "SELECT EMPS.EMPID, EMPS.DEPTNO, DEPENDENTS.NAME FROM EMPS_NO_CONSTRAINT EMPS\n"
+                + "JOIN DEPENDENTS USING (EMPID)"
+                + "INNER JOIN DEPTS B ON (EMPS.DEPTNO=B.DEPTNO)\n"
+                + "WHERE EMPS.EMPID = 1";
+        String query = "SELECT EMPID, EMPS.DEPTNO FROM EMPS_NO_CONSTRAINT EMPS JOIN DEPTS B ON (EMPS.DEPTNO=B.DEPTNO) \n"
+                + "WHERE EMPID = 1";
+        // Olap Table doesn't support case-insensitive.
+        String constraint = "\"unique_constraints\" = \"dependents.empid\"," +
+                "\"foreign_key_constraints\" = \"emps_no_constraint(empid) references dependents(empid)\" ";
+            rewrite(mv, query, constraint);
+            Assert.fail();
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Unknown table 'test_mv.EMPS_NO_CONSTRAINT'."));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -256,7 +256,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
 
                 this.rewritePlan = getFragmentPlan(query);
             } catch (Exception e) {
-                LOG.warn("test rewwrite failed:", e);
+                LOG.warn("test rewrite failed:", e);
                 this.exception = e;
             } finally {
                 if (mv != null && !mv.isEmpty()) {
@@ -268,6 +268,10 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 }
             }
             return this;
+        }
+
+        Exception getException() {
+            return this.exception;
         }
 
         public MVRewriteChecker ok() {
@@ -360,6 +364,15 @@ public class MaterializedViewTestBase extends PlanTestBase {
     protected MVRewriteChecker testRewriteNonmatch(String mv, String query) {
         MVRewriteChecker fixture = new MVRewriteChecker(mv, query, null);
         return fixture.rewrite().nonMatch();
+    }
+
+    protected MVRewriteChecker rewrite(String mv, String query, String properties) throws Exception {
+        MVRewriteChecker fixture = new MVRewriteChecker(mv, query, properties);
+        MVRewriteChecker checker = fixture.rewrite();
+        if (checker.getException() != null) {
+            throw checker.getException();
+        }
+        return checker;
     }
 
     protected static Table getTable(String dbName, String mvName) {


### PR DESCRIPTION
For MV Rewrite's constraints:
- For non-OlapTable table names, support case-insensitive; OlapTable name does not support case-insensitive.
- For columns, always support case-insensitive.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
