### PR TITLE
[BugFix] Fix BE graceful exit

### DIFF
--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -27,7 +27,9 @@ namespace starrocks {
 
 CompactionManager::CompactionManager() : _next_task_id(0) {}
 
-CompactionManager::~CompactionManager() {
+CompactionManager::~CompactionManager() {}
+
+void CompactionManager::stop() {
     _stop.store(true, std::memory_order_release);
     if (_scheduler_thread.joinable()) {
         _scheduler_thread.join();

--- a/be/src/storage/compaction_manager.cpp
+++ b/be/src/storage/compaction_manager.cpp
@@ -27,8 +27,6 @@ namespace starrocks {
 
 CompactionManager::CompactionManager() : _next_task_id(0) {}
 
-CompactionManager::~CompactionManager() {}
-
 void CompactionManager::stop() {
     _stop.store(true, std::memory_order_release);
     if (_scheduler_thread.joinable()) {

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -38,7 +38,7 @@ class CompactionManager {
 public:
     CompactionManager();
 
-    ~CompactionManager();
+    ~CompactionManager() = default;
 
     void stop();
 

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -39,7 +39,7 @@ public:
     CompactionManager();
 
     ~CompactionManager();
-    
+
     void stop();
 
     void init_max_task_num(int32_t num);

--- a/be/src/storage/compaction_manager.h
+++ b/be/src/storage/compaction_manager.h
@@ -39,6 +39,8 @@ public:
     CompactionManager();
 
     ~CompactionManager();
+    
+    void stop();
 
     void init_max_task_num(int32_t num);
 

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -643,6 +643,10 @@ void StorageEngine::stop() {
     if (_update_manager) {
         _update_manager->stop();
     }
+
+    if (_compaction_manager) {
+        _compaction_manager->stop();
+    }
 }
 
 void StorageEngine::clear_transaction_task(const TTransactionId transaction_id) {


### PR DESCRIPTION
When BE exit, we will first call destructor function of `StorageEngine` and release the variable of the class secondly. And when we release the `_compaction_manager`, we maybe attach the `_storage_engine` which is set to nullptr. So the BE maybe crash.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
