### PR TITLE
[Enhancement] limit global runtime filter size (#32909)

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -21,10 +21,13 @@ public:
     // The filter is divided up into Buckets:
     static constexpr int BITS_SET_PER_BLOCK = 8;
     using Bucket = uint32_t[BITS_SET_PER_BLOCK];
+    static constexpr size_t MINIMUM_ELEMENT_NUM = 1UL;
 
     SimdBlockFilter() = default;
 
-    ~SimdBlockFilter() noexcept { free(_directory); }
+    ~SimdBlockFilter() noexcept {
+        if (_directory) free(_directory);
+    }
 
     SimdBlockFilter(const SimdBlockFilter& bf) = delete;
     SimdBlockFilter(SimdBlockFilter&& bf) noexcept;
@@ -47,6 +50,10 @@ public:
     }
 
     bool test_hash(const uint64_t hash) const noexcept {
+        if (UNLIKELY(_directory == nullptr)) {
+            DCHECK(false) << "unexpected test_hash on cleared bf";
+            return true;
+        }
         const uint32_t bucket_idx = hash & _directory_mask;
 #ifdef __AVX2__
         const __m256i mask = make_mask(hash >> _log_num_buckets);
@@ -99,6 +106,14 @@ public:
     bool check_equal(const SimdBlockFilter& bf) const;
     uint32_t directory_mask() const { return _directory_mask; }
 
+    void clear();
+    // whether this bloom filter can be used
+    // if the bloom filter's size of partial rf has exceed the size limit of global rf,
+    // we still send this rf but ignore bloom filter and only keep min/max filter,
+    // in this case, we will use clear() to release the memory of bloom filter,
+    // we can use can_use() to check if this bloom filter can be used
+    bool can_use() const { return _directory != nullptr; }
+
 private:
     // The number of bits to set in a tiny Bloom filter block
 
@@ -124,7 +139,9 @@ private:
     // log2(number of bytes in a bucket):
     static constexpr int LOG_BUCKET_BYTE_SIZE = 5;
 
-    size_t get_alloc_size() const { return 1ull << (_log_num_buckets + LOG_BUCKET_BYTE_SIZE); }
+    size_t get_alloc_size() const {
+        return _log_num_buckets == 0 ? 0 : (1ull << (_log_num_buckets + LOG_BUCKET_BYTE_SIZE));
+    }
 
     // Common:
     // log_num_buckets_ is the log (base 2) of the number of buckets in the directory:
@@ -217,6 +234,15 @@ public:
 
     void set_join_mode(int8_t join_mode) { _join_mode = join_mode; }
 
+    void clear_bf();
+
+    bool can_use_bf() const {
+        if (_num_hash_partitions == 0) {
+            return _bf.can_use();
+        }
+        return _hash_partition_bf[0].can_use();
+    }
+
     virtual size_t max_serialized_size() const;
     virtual size_t serialize(uint8_t* data) const;
     virtual size_t deserialize(const uint8_t* data);
@@ -300,8 +326,10 @@ public:
     }
 
     void insert(const CppType& value) {
-        size_t hash = compute_hash(value);
-        _bf.insert_hash(hash);
+        if (LIKELY(_bf.can_use())) {
+            size_t hash = compute_hash(value);
+            _bf.insert_hash(hash);
+        }
 
         _min = std::min(value, _min);
         _max = std::max(value, _max);
@@ -313,16 +341,21 @@ public:
 
     CppType max_value() const { return _max; }
 
+    template <bool can_use_bf = true>
     bool test_data(CppType value) const {
         if constexpr (!IsSlice<CppType>) {
             if (value < _min || value > _max) {
                 return false;
             }
         }
-        size_t hash = compute_hash(value);
-        return _bf.test_hash(hash);
+        if constexpr (can_use_bf) {
+            size_t hash = compute_hash(value);
+            return _bf.test_hash(hash);
+        }
+        return true;
     }
 
+    template <bool can_use_bf = true>
     bool test_data_with_hash(CppType value, const uint32_t shuffle_hash) const {
         static constexpr uint32_t BUCKET_ABSENT = 2147483647;
         if (shuffle_hash == BUCKET_ABSENT) {
@@ -333,10 +366,13 @@ public:
                 return false;
             }
         }
-        // module has been done outside, so actually here is bucket idx.
-        const uint32_t bucket_idx = shuffle_hash;
-        size_t hash = compute_hash(value);
-        return _hash_partition_bf[bucket_idx].test_hash(hash);
+        if constexpr (can_use_bf) {
+            // module has been done outside, so actually here is bucket idx.
+            const uint32_t bucket_idx = shuffle_hash;
+            size_t hash = compute_hash(value);
+            return _hash_partition_bf[bucket_idx].test_hash(hash);
+        }
+        return true;
     }
 
     void compute_hash_values_for_multi_part(RunningContext* running_ctx, int8_t join_mode,
@@ -415,9 +451,11 @@ public:
 
     void evaluate(Column* input_column, RunningContext* ctx) const override {
         if (_num_hash_partitions != 0) {
-            return t_evaluate<true>(input_column, ctx);
+            return _hash_partition_bf[0].can_use() ? t_evaluate<true, true>(input_column, ctx)
+                                                   : t_evaluate<true, false>(input_column, ctx);
         } else {
-            return t_evaluate<false>(input_column, ctx);
+            return _bf.can_use() ? t_evaluate<false, true>(input_column, ctx)
+                                 : t_evaluate<false, false>(input_column, ctx);
         }
     }
 
@@ -426,7 +464,7 @@ public:
     // and for global runtime filter, since it concates multiple runtime filters from partitions
     // so it has multiple `simd-block-filter` and `hash_partition` is true.
     // For more information, you can refers to doc `shuffle-aware runtime filter`.
-    template <bool hash_partition = false>
+    template <bool hash_partition = false, bool can_use_bf = true>
     void t_evaluate(Column* input_column, RunningContext* ctx) const {
         size_t size = input_column->size();
         Column::Filter& _selection = ctx->use_merged_selection ? ctx->merged_selection : ctx->selection;
@@ -446,9 +484,9 @@ public:
             } else {
                 auto* input_data = down_cast<const ColumnType*>(const_column->data_column().get())->get_data().data();
                 if constexpr (hash_partition) {
-                    sel = test_data_with_hash(input_data[0], _hash_values[0]);
+                    sel = test_data_with_hash<can_use_bf>(input_data[0], _hash_values[0]);
                 } else {
-                    sel = test_data(input_data[0]);
+                    sel = test_data<can_use_bf>(input_data[0]);
                 }
             }
             for (int i = 0; i < size; i++) {
@@ -464,18 +502,18 @@ public:
                         _selection[i] = _has_null;
                     } else {
                         if constexpr (hash_partition) {
-                            _selection[i] = test_data_with_hash(input_data[i], _hash_values[i]);
+                            _selection[i] = test_data_with_hash<can_use_bf>(input_data[i], _hash_values[i]);
                         } else {
-                            _selection[i] = test_data(input_data[i]);
+                            _selection[i] = test_data<can_use_bf>(input_data[i]);
                         }
                     }
                 }
             } else {
                 for (int i = 0; i < size; ++i) {
                     if constexpr (hash_partition) {
-                        _selection[i] = test_data_with_hash(input_data[i], _hash_values[i]);
+                        _selection[i] = test_data_with_hash<can_use_bf>(input_data[i], _hash_values[i]);
                     } else {
-                        _selection[i] = test_data(input_data[i]);
+                        _selection[i] = test_data<can_use_bf>(input_data[i]);
                     }
                 }
             }
@@ -483,9 +521,9 @@ public:
             auto* input_data = down_cast<const ColumnType*>(input_column)->get_data().data();
             for (int i = 0; i < size; ++i) {
                 if constexpr (hash_partition) {
-                    _selection[i] = test_data_with_hash(input_data[i], _hash_values[i]);
+                    _selection[i] = test_data_with_hash<can_use_bf>(input_data[i], _hash_values[i]);
                 } else {
-                    _selection[i] = test_data(input_data[i]);
+                    _selection[i] = test_data<can_use_bf>(input_data[i]);
                 }
             }
         }

--- a/be/src/exprs/vectorized/runtime_filter_bank.cpp
+++ b/be/src/exprs/vectorized/runtime_filter_bank.cpp
@@ -432,6 +432,7 @@ void RuntimeFilterProbeCollector::compute_hash_values(vectorized::Chunk* chunk, 
     if (filter->num_hash_partitions() == 0) {
         return;
     }
+
     if (rf_desc->partition_by_expr_contexts()->empty()) {
         filter->compute_hash({column}, &eval_context.running_context);
     } else {

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -122,7 +122,7 @@ void RuntimeFilterPort::publish_runtime_filters(std::list<vectorized::RuntimeFil
         VLOG_FILE << "RuntimeFilterPort::publish_runtime_filters. merge_node[0] = " << rf_desc->merge_nodes()[0]
                   << ", filter_size = " << filter->size() << ", query_id = " << params.query_id()
                   << ", finst_id = " << params.finst_id() << ", be_number = " << params.build_be_number()
-                  << ", is_pipeline = " << params.is_pipeline();
+                  << ", is_pipeline = " << params.is_pipeline() << ", can_use_bf = " << filter->can_use_bf();
 
         std::string* rf_data = params.mutable_data();
         size_t max_size = vectorized::RuntimeFilterHelper::max_runtime_filter_serialized_size(filter);
@@ -170,7 +170,8 @@ void RuntimeFilterPort::receive_shared_runtime_filter(int32_t filter_id,
     if (it == _listeners.end()) return;
     auto& wait_list = it->second;
     VLOG_FILE << "RuntimeFilterPort::receive_runtime_filter(shared). filter_id = " << filter_id
-              << ", filter_size = " << rf->size() << ", wait_list_size = " << wait_list.size();
+              << ", filter_size = " << rf->size() << ", wait_list_size = " << wait_list.size()
+              << ", can_use_bf = " << rf->can_use_bf();
     for (auto* rf_desc : wait_list) {
         rf_desc->set_shared_runtime_filter(rf);
     }
@@ -241,16 +242,19 @@ void RuntimeFilterMerger::merge_runtime_filter(PTransmitRuntimeFilterParams& par
         // something wrong with deserialization.
         return;
     }
+    if (!rf->can_use_bf()) {
+        VLOG_FILE << "RuntimeFilterMerger::merge_runtime_filter. some partial rf's size exceeds "
+                     "global_runtime_filter_build_max_size, stop building bf and only reserve min/max filter";
+        status->can_use_bf = false;
+    }
 
-    // exceeds max size, stop building it.
     status->current_size += rf->size();
     if (status->current_size > status->max_size) {
-        // alreay exceeds max size, no need to build it.
-        VLOG_FILE << "RuntimeFilterMerger::merge_runtime_filter. stop building since size too "
+        // alreay exceeds max size, no need to build bloom filter, but still reserve min/max filter.
+        VLOG_FILE << "RuntimeFilterMerger::merge_runtime_filter. stop building bf since size too "
                      "large. filter_id = "
                   << filter_id << ", size = " << status->current_size;
-        status->stop = true;
-        return;
+        status->can_use_bf = false;
     }
 
     VLOG_FILE << "RuntimeFilterMerger::merge_runtime_filter. assembled filter_id = " << filter_id
@@ -260,6 +264,12 @@ void RuntimeFilterMerger::merge_runtime_filter(PTransmitRuntimeFilterParams& par
 
     // not ready. still have to wait more filters.
     if (status->filters.size() < status->expect_number) return;
+    if (!status->can_use_bf) {
+        VLOG_FILE << "RuntimeFilterMerger::merge_runtime_filter, clear bf in all filters";
+        for (auto& [be_number, rf] : status->filters) {
+            rf->clear_bf();
+        }
+    }
     _send_total_runtime_filter(filter_id);
 }
 
@@ -309,6 +319,10 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int32_t filter_id) {
     vectorized::JoinRuntimeFilter* first = status->filters.begin()->second;
     ObjectPool* pool = &(status->pool);
     out = first->create_empty(pool);
+    if (!status->can_use_bf) {
+        out->clear_bf();
+    }
+
     for (auto it : status->filters) {
         out->concat(it.second);
     }
@@ -321,6 +335,7 @@ void RuntimeFilterMerger::_send_total_runtime_filter(int32_t filter_id) {
     }
     request.set_filter_id(filter_id);
     request.set_is_partial(false);
+
     PUniqueId* query_id = request.mutable_query_id();
     query_id->set_hi(_query_id.hi);
     query_id->set_lo(_query_id.lo);

--- a/be/src/runtime/runtime_filter_worker.h
+++ b/be/src/runtime/runtime_filter_worker.h
@@ -74,6 +74,7 @@ public:
     size_t current_size = 0;
     size_t max_size = 0;
     bool stop = false;
+    bool can_use_bf = true;
 
     // statistics.
     // timestamp in ms since unix epoch;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -265,6 +265,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String GLOBAL_RUNTIME_FILTER_PROBE_MIN_SIZE = "global_runtime_filter_probe_min_size";
     public static final String GLOBAL_RUNTIME_FILTER_PROBE_MIN_SELECTIVITY =
             "global_runtime_filter_probe_min_selectivity";
+    public static final String GLOBAL_RUNTIME_FILTER_WAIT_TIMEOUT = "global_runtime_filter_wait_timeout";
+    public static final String GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT = "global_runtime_filter_rpc_timeout";
     public static final String RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY = "runtime_filter_early_return_selectivity";
 
     public static final String ENABLE_COLUMN_EXPR_PREDICATE = "enable_column_expr_predicate";
@@ -787,6 +789,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private long globalRuntimeFilterProbeMinSize = 100L * 1024L;
     @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_PROBE_MIN_SELECTIVITY, flag = VariableMgr.INVISIBLE)
     private float globalRuntimeFilterProbeMinSelectivity = 0.5f;
+    @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_WAIT_TIMEOUT, flag = VariableMgr.INVISIBLE)
+    private int globalRuntimeFilterWaitTimeout = 20;
+    @VariableMgr.VarAttr(name = GLOBAL_RUNTIME_FILTER_RPC_TIMEOUT, flag = VariableMgr.INVISIBLE)
+    private int globalRuntimeFilterRpcTimeout = 400;
     @VariableMgr.VarAttr(name = RUNTIME_FILTER_EARLY_RETURN_SELECTIVITY, flag = VariableMgr.INVISIBLE)
     private float runtimeFilterEarlyReturnSelectivity = 0.05f;
 
@@ -1964,10 +1970,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         }
 
         tResult.setRuntime_join_filter_pushdown_limit(runtimeJoinFilterPushDownLimit);
-        final int global_runtime_filter_wait_timeout = 20;
-        final int global_runtime_filter_rpc_timeout = 400;
-        tResult.setRuntime_filter_wait_timeout_ms(global_runtime_filter_wait_timeout);
-        tResult.setRuntime_filter_send_timeout_ms(global_runtime_filter_rpc_timeout);
+        tResult.setGlobal_runtime_filter_build_max_size(globalRuntimeFilterBuildMaxSize);
+        tResult.setRuntime_filter_wait_timeout_ms(globalRuntimeFilterWaitTimeout);
+        tResult.setRuntime_filter_send_timeout_ms(globalRuntimeFilterRpcTimeout);
         tResult.setRuntime_filter_scan_wait_time_ms(runtimeFilterScanWaitTime);
         tResult.setPipeline_dop(pipelineDop);
         switch (pipelineProfileLevel) {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -242,6 +242,8 @@ struct TQueryOptions {
   104: optional TOverflowMode overflow_mode = TOverflowMode.OUTPUT_NULL;
   105: optional bool use_column_pool = true;
 
+  107: optional i64 global_runtime_filter_build_max_size;
+
   109: optional i64 big_query_profile_second_threshold;
 }
 


### PR DESCRIPTION
backport #32909

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
