### PR TITLE
[Enhancement] Add exception handling to avoid FE startup failure

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -32,6 +32,7 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PartitionExprAnalyzer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.parser.SqlParser;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
@@ -116,7 +117,11 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
                 Column partitionColumn = partitionNameColumnMap.get(slotRef.getColumnName());
                 slotRef.setType(partitionColumn.getType());
                 slotRef.setNullable(partitionColumn.isAllowNull());
-                PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
+                try {
+                    PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
+                } catch (SemanticException ex) {
+                    LOG.warn("Failed to analyze partition expr: {}", expr.toSql(), ex);
+                }
             }
         }
         this.partitionExprs = partitionExprs;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -528,4 +528,38 @@ public class ExpressionRangePartitionInfoTest {
         starRocksAssert.dropMaterializedView("test_mv1");
         starRocksAssert.dropTable("test_table");
     }
+
+    @Test
+    public void testExpressionRangePartitionInfoSerializedWrongNotFailed() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE `game_log` (\n" +
+                "  `cloud_id` varchar(65533) NULL COMMENT \"\",\n" +
+                "  `user_id` varchar(65533) NULL COMMENT \"\",\n" +
+                "  `day` date NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP \n" +
+                "DUPLICATE KEY(`cloud_id`, `user_id`)\n" +
+                "PARTITION BY date_trunc('day', day)\n" +
+                "DISTRIBUTED BY HASH(`cloud_id`, `user_id`) BUCKETS 1 \n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"compression\" = \"ZSTD\"\n" +
+                ");";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+        OlapTable olapTable = (OlapTable) db.getTable("game_log");
+        ExpressionRangePartitionInfo expressionRangePartitionInfo =
+                (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
+        List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns();
+        partitionColumns.get(0).setType(Type.VARCHAR);
+        // serialize
+        String json = GsonUtils.GSON.toJson(olapTable);
+        // deserialize
+        OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
+    }
+
 }


### PR DESCRIPTION
avoid:
ERROR (stateChangeExecutor|80) [GlobalStateMgr.transferToLeader():1221] failed to init journal after transfer to leader! will exit
com.starrocks.sql.analyzer.SemanticException: Getting analyzing error from line 1, column 0 to line 1, column 21. Detail message: Unsupported partition type VARCHAR(1048576) for function date_trunc('day', day).
 at com.starrocks.sql.analyzer.PartitionExprAnalyzer.analyzePartitionExpr(PartitionExprAnalyzer.java:62) ~[starrocks-fe.jar:?]
 at com.starrocks.catalog.ExpressionRangePartitionInfo.gsonPostProcess(ExpressionRangePartitionInfo.java:96) ~[starrocks-fe.jar:?]
 at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:672) ~[starrocks-fe.jar:?]
 at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:285) ~[spark-dpp-1.0.0.jar:?]
 at com.starrocks.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:386) ~[starrocks-fe.jar:?]
 at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199) ~[spark-dpp-1.0.0.jar:?]
 at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
 at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
 at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:670) ~[starrocks-fe.jar:?]
 at com.google.gson.TypeAdapter.fromJsonTree(TypeAdapter.java:285) ~[spark-dpp-1.0.0.jar:?]
 at com.starrocks.persist.gson.RuntimeTypeAdapterFactory$1.read(RuntimeTypeAdapterFactory.java:386) ~[starrocks-fe.jar:?]
 at com.google.gson.TypeAdapter$1.read(TypeAdapter.java:199) ~[spark-dpp-1.0.0.jar:?]
 at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$1.read(ReflectiveTypeAdapterFactory.java:131) ~[spark-dpp-1.0.0.jar:?]
 at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:222) ~[spark-dpp-1.0.0.jar:?]
 at com.starrocks.persist.gson.GsonUtils$ProcessHookTypeAdapterFactory$1.read(GsonUtils.java:670) ~[starrocks-fe.jar:?]
 at com.google.gson.Gson.fromJson(Gson.java:963) ~[spark-dpp-1.0.0.jar:?]
 at com.google.gson.Gson.fromJson(Gson.java:928) ~[spark-dpp-1.0.0.jar:?]
 at com.google.gson.Gson.fromJson(Gson.java:877) ~[spark-dpp-1.0.0.jar:?]
 at com.google.gson.Gson.fromJson(Gson.java:848) ~[spark-dpp-1.0.0.jar:?]
 at com.starrocks.journal.JournalEntity.readFields(JournalEntity.java:263) ~[starrocks-fe.jar:?]
 at com.starrocks.journal.bdbje.BDBJournalCursor.deserializeData(BDBJournalCursor.java:251) ~[starrocks-fe.jar:?]
 at com.starrocks.journal.bdbje.BDBJournalCursor.next(BDBJournalCursor.java:295) ~[starrocks-fe.jar:?]
 at com.starrocks.server.GlobalStateMgr.replayJournalInner(GlobalStateMgr.java:2290) ~[starrocks-fe.jar:?]
 at com.starrocks.server.GlobalStateMgr.replayJournal(GlobalStateMgr.java:2250) ~[starrocks-fe.jar:?]
 at com.starrocks.server.GlobalStateMgr.transferToLeader(GlobalStateMgr.java:1216) ~[starrocks-fe.jar:?]
 at com.starrocks.server.GlobalStateMgr.access$100(GlobalStateMgr.java:342) ~[starrocks-fe.jar:?]
 at com.starrocks.server.GlobalStateMgr$1.transferToLeader(GlobalStateMgr.java:773) ~[starrocks-fe.jar:?]
 at com.starrocks.ha.StateChangeExecutor.runOneCycle(StateChangeExecutor.java:103) ~[starrocks-fe.jar:?]
 at com.starrocks.common.util.Daemon.run(Daemon.java:115) ~[starrocks-fe.jar:?]

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
