### PR TITLE
[Feature] filter partition with join predicate when refresh mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -407,6 +407,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     @SerializedName(value = "maxMVRewriteStaleness")
     private int maxMVRewriteStaleness = 0;
 
+    @SerializedName(value = "partitionExprMaps")
+    private Map<GsonUtils.ExpressionSerializedObject, GsonUtils.ExpressionSerializedObject> serializedPartitionExprMaps;
+    private Map<Expr, SlotRef> partitionExprMaps;
+
     // Materialized view's output columns may be different from defined query's output columns.
     // Record the indexes based on materialized view's column output.
     // eg: create materialized view mv as select col1, col2, col3 from tbl
@@ -559,6 +563,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
     public void setMaxMVRewriteStaleness(int maxMVRewriteStaleness) {
         this.maxMVRewriteStaleness = maxMVRewriteStaleness;
+    }
+
+    public Map<Expr, SlotRef> getPartitionExprMaps() {
+        return partitionExprMaps;
+    }
+
+    public void setPartitionExprMaps(Map<Expr, SlotRef> partitionExprMaps) {
+        this.partitionExprMaps = partitionExprMaps;
     }
 
     public List<Integer> getQueryOutputIndices() {
@@ -735,16 +747,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             return result;
         } else {
             Set<String> updatePartitionNames = getUpdatedPartitionNamesOfExternalTable(baseTable, isQueryRewrite);
-            Pair<Table, Column> partitionTableAndColumn = getBaseTableAndPartitionColumn();
-            if (partitionTableAndColumn == null) {
-                return updatePartitionNames;
-            }
-            if (!baseTable.getTableIdentifier().equals(partitionTableAndColumn.first.getTableIdentifier())) {
+            Map<Table, Column> partitionTableAndColumns = getRelatedPartitionTableAndColumn();
+            if (!partitionTableAndColumns.containsKey(baseTable)) {
                 return updatePartitionNames;
             }
             try {
                 boolean isListPartition = partitionInfo instanceof ListPartitionInfo;
-                return PartitionUtil.getMVPartitionName(baseTable, partitionTableAndColumn.second,
+                return PartitionUtil.getMVPartitionName(baseTable, partitionTableAndColumns.get(baseTable),
                         Lists.newArrayList(updatePartitionNames), isListPartition, partitionExpr);
             } catch (AnalysisException e) {
                 LOG.warn("Mv {}'s base table {} get partition name fail", name, baseTable.name, e);
@@ -794,6 +803,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         // write type first
         Text.writeString(out, type.name());
         Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static SlotRef getMvPartitionSlotRef(Expr expr) {
+        if (expr instanceof SlotRef) {
+            return ((SlotRef) expr);
+        } else {
+            List<SlotRef> slotRefs = Lists.newArrayList();
+            expr.collect(SlotRef.class, slotRefs);
+            Preconditions.checkState(slotRefs.size() == 1);
+            return slotRefs.get(0);
+        }
     }
 
     public static MaterializedView read(DataInput in) throws IOException {
@@ -1179,6 +1199,42 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return false;
     }
 
+    public Map<Table, Expr> getTableToPartitionExprMap() {
+        Map<Table, Expr> tableToJoinExprMap = new HashMap<>();
+        for (BaseTableInfo tableInfo : baseTableInfos) {
+            Table table = tableInfo.getTable();
+            for (Map.Entry<Expr, SlotRef> entry : partitionExprMaps.entrySet()) {
+                SlotRef slotRef = entry.getValue();
+                if (com.starrocks.common.util.StringUtils.areTableNamesEqual(table,
+                        slotRef.getTblNameWithoutAnalyzed().getTbl())) {
+                    tableToJoinExprMap.put(table, entry.getKey());
+                    break;
+                }
+            }
+        }
+        return tableToJoinExprMap;
+    }
+
+    public Map<Table, SlotRef> getTableToPartitionSlotMap() {
+        Map<Table, SlotRef> tableToJoinExprMap = new HashMap<>();
+        for (BaseTableInfo tableInfo : baseTableInfos) {
+            Table table = tableInfo.getTable();
+            for (Map.Entry<Expr, SlotRef> entry : partitionExprMaps.entrySet()) {
+                SlotRef slotRef = entry.getValue();
+                if (com.starrocks.common.util.StringUtils.areTableNamesEqual(table,
+                        slotRef.getTblNameWithoutAnalyzed().getTbl())) {
+                    tableToJoinExprMap.put(table, slotRef);
+                    break;
+                }
+            }
+        }
+        return tableToJoinExprMap;
+    }
+
+    private boolean supportPartialPartitionQueryRewriteForExternalTable(Table table) {
+        return table.isHiveTable();
+    }
+
     /**
      * Once the materialized view's base tables have updated, we need to check correspond materialized views' partitions
      * to be refreshed.
@@ -1283,15 +1339,13 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         Preconditions.checkState(partitionInfo instanceof ExpressionRangePartitionInfo);
         // If non-partition-by table has changed, should refresh all mv partitions
         Expr partitionExpr = getFirstPartitionRefTableExpr();
-        Pair<Table, Column> partitionInfo = getBaseTableAndPartitionColumn();
-        if (partitionInfo == null) {
+        Map<Table, Column> partitionInfos = getRelatedPartitionTableAndColumn();
+        if (partitionInfos.isEmpty()) {
             setInactiveAndReason("partition configuration changed");
             LOG.warn("mark mv:{} inactive for get partition info failed", name);
             throw new RuntimeException(String.format("getting partition info failed for mv: %s", name));
         }
 
-        Table refBaseTable = partitionInfo.first;
-        Column refBasePartitionCol = partitionInfo.second;
         for (BaseTableInfo tableInfo : baseTableInfos) {
             Table baseTable = tableInfo.getTable();
             // skip view
@@ -1307,7 +1361,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                     return false;
                 }
             }
-            if (baseTable.getTableIdentifier().equals(refBaseTable.getTableIdentifier())) {
+            if (partitionInfos.containsKey(baseTable)) {
                 continue;
             }
             // If the non ref table has already changed, need refresh all materialized views' partitions.
@@ -1323,47 +1377,57 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         // - deleted partitions.
         // - added partitions.
         Set<String> needRefreshMvPartitionNames = Sets.newHashSet();
-        Map<String, Range<PartitionKey>> basePartitionNameToRangeMap;
-        try {
-            basePartitionNameToRangeMap =
-                    PartitionUtil.getPartitionKeyRange(refBaseTable, refBasePartitionCol, partitionExpr);
-        } catch (UserException e) {
-            LOG.warn("Materialized view compute partition difference with base table failed.", e);
-            toRefreshedPartitioins.addAll(getVisiblePartitionNames());
-            return false;
+        Map<Table, Map<String, Range<PartitionKey>>> basePartitionNameToRangeMap = Maps.newHashMap();
+        Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = getRangePartitionMap();
+        Map<Table, Set<String>> baseChangedPartitionNames = Maps.newHashMap();
+        for (Map.Entry<Table, Column> entry : partitionInfos.entrySet()) {
+            Table table = entry.getKey();
+            try {
+                basePartitionNameToRangeMap.put(table,
+                        PartitionUtil.getPartitionKeyRange(table, entry.getValue(), partitionExpr));
+            } catch (UserException e) {
+                LOG.warn("Materialized view compute partition difference with base table failed.", e);
+                toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                return false;
+            }
+
+            // step1.2: check ref base table's updated partition names by checking its ref tables recursively.
+            Set<String> baseChangedPartition =
+                    getUpdatedPartitionNamesOfTable(table, true, isQueryRewrite, partitionExpr);
+            if (baseChangedPartition == null) {
+                toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                return true;
+            } else {
+                baseChangedPartitionNames.put(table, baseChangedPartition);
+            }
         }
 
-        Map<String, Range<PartitionKey>> mvPartitionNameToRangeMap = getRangePartitionMap();
+        Pair<Table, Column> directTableAndPartitionColumn = getDirectTableAndPartitionColumn();
         // TODO: prune the partitions based on ttl
-        RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr, partitionInfo.second,
-                basePartitionNameToRangeMap, mvPartitionNameToRangeMap, null);
+        RangePartitionDiff rangePartitionDiff = PartitionUtil.getPartitionDiff(partitionExpr,
+                directTableAndPartitionColumn.second,
+                basePartitionNameToRangeMap.get(directTableAndPartitionColumn.first),
+                mvPartitionNameToRangeMap, null);
         needRefreshMvPartitionNames.addAll(rangePartitionDiff.getDeletes().keySet());
         // remove ref base table's deleted partitions from `mvPartitionMap`
         for (String deleted : rangePartitionDiff.getDeletes().keySet()) {
             mvPartitionNameToRangeMap.remove(deleted);
         }
 
-        // step1.2: refresh ref base table's new added partitions
+        // step2: refresh ref base table's new added partitions
         needRefreshMvPartitionNames.addAll(rangePartitionDiff.getAdds().keySet());
         mvPartitionNameToRangeMap.putAll(rangePartitionDiff.getAdds());
+        Map<Table, Map<String, Set<String>>> baseToMvNameRef = SyncPartitionUtils
+                .generateBaseRefMap(basePartitionNameToRangeMap, getTableToPartitionExprMap(), mvPartitionNameToRangeMap);
+        Map<String, Map<Table, Set<String>>> mvToBaseNameRef = SyncPartitionUtils
+                .generateMvRefMap(mvPartitionNameToRangeMap, getTableToPartitionExprMap(), basePartitionNameToRangeMap);
 
-        Map<String, Set<String>> baseToMvNameRef = SyncPartitionUtils
-                .getIntersectedPartitions(basePartitionNameToRangeMap, mvPartitionNameToRangeMap);
-        Map<String, Set<String>> mvToBaseNameRef = SyncPartitionUtils
-                .getIntersectedPartitions(mvPartitionNameToRangeMap, basePartitionNameToRangeMap);
-
-        // step2: check ref base table's updated partition names by checking its ref tables recursively.
-        Set<String> baseChangedPartitionNames =
-                getUpdatedPartitionNamesOfTable(refBaseTable, true, isQueryRewrite, partitionExpr);
-        if (baseChangedPartitionNames == null) {
-            toRefreshedPartitioins.addAll(mvToBaseNameRef.keySet());
-            return true;
+        for (Map.Entry<Table, Set<String>> entry : baseChangedPartitionNames.entrySet()) {
+            entry.getValue().stream().forEach(x ->
+                    needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(entry.getKey()).get(x))
+            );
         }
-
-        if (partitionExpr instanceof SlotRef) {
-            baseChangedPartitionNames.stream().forEach(x -> needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(x)));
-        } else if (partitionExpr instanceof FunctionCallExpr) {
-            baseChangedPartitionNames.stream().forEach(x -> needRefreshMvPartitionNames.addAll(baseToMvNameRef.get(x)));
+        if (partitionExpr instanceof FunctionCallExpr) {
             // because the relation of partitions between materialized view and base partition table is n : m,
             // should calculate the candidate partitions recursively.
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
@@ -1380,7 +1444,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      *
      * @return : The materialized view's referred base table and its partition column.
      */
-    public Pair<Table, Column> getBaseTableAndPartitionColumn() {
+    public Pair<Table, Column> getDirectTableAndPartitionColumn() {
         if (partitionRefTableExprs == null ||
                 !(partitionInfo instanceof ExpressionRangePartitionInfo || partitionInfo instanceof ListPartitionInfo)) {
             return null;
@@ -1395,6 +1459,49 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             if (partitionSlotRef.getTblNameWithoutAnalyzed().getTbl().equals(table.getName())) {
                 return Pair.create(table, table.getColumn(partitionSlotRef.getColumnName()));
             }
+        }
+        String baseTableNames = baseTableInfos.stream()
+                .map(tableInfo -> tableInfo.getTable().getName()).collect(Collectors.joining(","));
+        throw new RuntimeException(
+                String.format("can not find partition info for mv:%s on base tables:%s", name, baseTableNames));
+    }
+
+    public Map<Table, Column> getRelatedPartitionTableAndColumn() {
+        Map<Table, Column> result = Maps.newHashMap();
+        if (partitionExprMaps == null || partitionExprMaps.isEmpty()) {
+            return result;
+        }
+        Map<Table, SlotRef> tableToSlotMap = getTableToPartitionSlotMap();
+        for (BaseTableInfo baseTableInfo : baseTableInfos) {
+            Table table = baseTableInfo.getTable();
+            if (!tableToSlotMap.containsKey(table)) {
+                continue;
+            }
+            List<Column> partitionColumns = PartitionUtil.getPartitionColumns(table);
+            if (partitionColumns == null) {
+                continue;
+            }
+            SlotRef slotRef = tableToSlotMap.get(table);
+            if (table.isNativeTableOrMaterializedView()) {
+                if (partitionColumns.size() != 1) {
+                    continue;
+                }
+                Column partitionColumn = partitionColumns.get(0);
+                if (com.starrocks.common.util.StringUtils.areColumnNamesEqual(slotRef.getColumnName(),
+                        partitionColumn.getName())) {
+                    result.put(table, partitionColumn);
+                }
+            } else {
+                for (Column partitionColumn : partitionColumns) {
+                    if (com.starrocks.common.util.StringUtils.areColumnNamesEqual(slotRef.getColumnName(),
+                            partitionColumn.getName())) {
+                        result.put(table, partitionColumn);
+                    }
+                }
+            }
+        }
+        if (!result.isEmpty()) {
+            return result;
         }
         String baseTableNames = baseTableInfos.stream()
                 .map(tableInfo -> tableInfo.getTable().getName()).collect(Collectors.joining(","));
@@ -1460,6 +1567,17 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 }
             }
         }
+        this.serializedPartitionExprMaps = Maps.newHashMap();
+        if (partitionExprMaps != null) {
+            for (Map.Entry<Expr, SlotRef> entry : partitionExprMaps.entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    serializedPartitionExprMaps.put(
+                            new GsonUtils.ExpressionSerializedObject(entry.getKey().toSql()),
+                            new GsonUtils.ExpressionSerializedObject(entry.getValue().toSql())
+                    );
+                }
+            }
+        }
     }
 
     @Override
@@ -1473,6 +1591,22 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                             SqlParser.parseSqlToExpr(expressionSql.expressionSql, SqlModeHelper.MODE_DEFAULT));
                 }
             }
+        }
+        partitionExprMaps = Maps.newHashMap();
+        if (serializedPartitionExprMaps != null) {
+            for (Map.Entry<GsonUtils.ExpressionSerializedObject, GsonUtils.ExpressionSerializedObject> entry :
+                    serializedPartitionExprMaps.entrySet()) {
+                if (entry.getKey() != null && entry.getValue() != null) {
+                    partitionExprMaps.put(
+                            SqlParser.parseSqlToExpr(entry.getKey().expressionSql, SqlModeHelper.MODE_DEFAULT),
+                            (SlotRef) SqlParser.parseSqlToExpr(entry.getValue().expressionSql, SqlModeHelper.MODE_DEFAULT)
+                    );
+                }
+            }
+        } else if (!partitionRefTableExprs.isEmpty()) {
+            // for compatibility
+            Expr partitionExpr = partitionRefTableExprs.get(0);
+            partitionExprMaps.put(partitionExpr, getMvPartitionSlotRef(partitionExpr));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MvJoinFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MvJoinFilter.java
@@ -1,0 +1,247 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.CompoundPredicate;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.PartitionExprAnalyzer;
+import com.starrocks.sql.analyzer.SlotRefResolver;
+import com.starrocks.sql.ast.QueryRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.UnionRelation;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+
+// The MvJoinFilter class is responsible for optimizing partition pruning during the refresh of materialized views.
+// It accomplishes this by analyzing join conditions and efficiently mapping expressions to corresponding slot references.
+// This optimization is crucial for handling large datasets where partition pruning can significantly reduce refresh execution time.
+// The class includes mechanisms to process various types of expressions and predicates, ensuring compatibility with
+// different SQL functions, only 'date_trunc' function is supported now.
+public class MvJoinFilter {
+    static final Set<String> FN_NAME_TO_PARTITION = Sets.newHashSet("date_trunc");
+
+    public static void insertIntoMapper(List<Map<Expr, SlotRef>> mapper,
+                                        Pair<Expr, SlotRef> a, Pair<Expr, SlotRef> b) {
+        Map<Expr, SlotRef> targetMap = null;
+
+        // Iterate through the LinkedList to find a HashSet that already contains either a or b
+        for (Map<Expr, SlotRef> map : mapper) {
+            if (map.containsKey(a.first) || map.containsKey(b.first)) {
+                targetMap = map;
+                break;
+            }
+        }
+
+        // If a matching HashSet is found, add both a and b to it. If not, create a new HashSet
+        // that includes a and b, and add this new HashSet to the LinkedList.
+        if (targetMap != null) {
+            targetMap.put(a.first, a.second);
+            targetMap.put(b.first, b.second);
+        } else {
+            Map<Expr, SlotRef> newMap = Maps.newHashMap();
+            newMap.put(a.first, a.second);
+            newMap.put(b.first, b.second);
+            mapper.add(newMap);
+        }
+    }
+
+    // Only date_trunc are supported
+    // A' => A, date_trunc(A') => date_trunc(A)
+    static Pair<Expr, SlotRef> getSupportMvPartitionExpr(Expr expr) {
+        if (expr instanceof SlotRef) {
+            return new Pair<>(expr, (SlotRef) expr);
+        }
+        if (expr instanceof FunctionCallExpr) {
+            FunctionCallExpr functionCallExpr = ((FunctionCallExpr) expr);
+            String functionName = functionCallExpr.getFnName().getFunction();
+            if (!FN_NAME_TO_PARTITION.contains(functionName.toLowerCase())) {
+                return null;
+            }
+            if (!(functionCallExpr.getChild(1) instanceof SlotRef)) {
+                return null;
+            }
+            return new Pair<>(functionCallExpr, (SlotRef) functionCallExpr.getChild(1));
+        }
+        return null;
+    }
+
+    private static Expr getExprFromRelations(Expr expr, Relation[] relations) {
+        Preconditions.checkArgument(relations.length == 2);
+        Expr resolved = SlotRefResolver.resolveExpr(expr, relations[0]);
+        if (resolved != null) {
+            return resolved;
+        }
+        return SlotRefResolver.resolveExpr(expr, relations[1]);
+    }
+
+    private static Pair<Expr, Expr> getBinaryPredicate(BinaryPredicate expr, Relation[] relations) {
+        if (!BinaryPredicate.IS_EQ_PREDICATE.apply(expr)) {
+            return null;
+        }
+        Expr expr1 = getExprFromRelations(expr.getChild(0), relations);
+        Expr expr2 = getExprFromRelations(expr.getChild(1), relations);
+        if (expr1 == null || expr2 == null) {
+            return null;
+        }
+        return Pair.create(expr1, expr2);
+    }
+
+    private static List<Pair<Expr, Expr>> getCompoundPredicate(CompoundPredicate compoundPredicate, Relation[] relations) {
+        List<Pair<Expr, Expr>> predicateExprs = Lists.newArrayList();
+        if (compoundPredicate.getOp() != CompoundPredicate.Operator.AND) {
+            return predicateExprs;
+        }
+        for (Expr expr : compoundPredicate.getChildren()) {
+            predicateExprs.addAll(mvGetJoinEqualPredicate(expr, relations));
+        }
+        return predicateExprs;
+    }
+
+    // A = B => {A, B}
+    // A = B OR C = D => {}
+    // A = B AND C = D => {A, B}, {C, D}
+    // A = B AND A = C => {A, B}, {A, C}
+    // A = B AND (C = D OR E = F) => {A, B}
+    private static List<Pair<Expr, Expr>> mvGetJoinEqualPredicate(Expr expr, Relation[] relations) {
+        List<Pair<Expr, Expr>> predicateExprs = Lists.newArrayList();
+        if (expr instanceof BinaryPredicate) {
+            Pair<Expr, Expr> exprs = getBinaryPredicate((BinaryPredicate) expr, relations);
+            if (exprs != null) {
+                predicateExprs.add(exprs);
+            }
+        }
+        if (expr instanceof CompoundPredicate) {
+            predicateExprs.addAll(getCompoundPredicate((CompoundPredicate) expr, relations));
+        }
+        return predicateExprs;
+    }
+
+    // Constructs a mapping of partitioned expressions to slot references for join operations in a materialized view.
+    public static Map<Expr, SlotRef> getPartitionJoinMap(Expr partitionExpr, QueryStatement statement) {
+        Map<Expr, SlotRef> mapper = Maps.newHashMap();
+        if (statement.getQueryRelation() instanceof UnionRelation) {
+            UnionRelation relations = (UnionRelation) statement.getQueryRelation();
+            SlotRef slot = MaterializedView.getMvPartitionSlotRef(partitionExpr);
+            Integer slotIndex = null;
+            for (int i = 0; i < relations.getOutputExpression().size(); i++) {
+                String column = relations.getRelations().get(0).getColumnOutputNames().get(i);
+                if (com.starrocks.common.util.StringUtils.areColumnNamesEqual(slot.getColumnName(), column)) {
+                    slotIndex = i;
+                    break;
+                }
+            }
+            if (slotIndex == null) {
+                return mapper;
+            }
+            for (QueryRelation relation : relations.getRelations()) {
+                Expr unionExpr = partitionExpr.clone();
+                if (unionExpr instanceof FunctionCallExpr) {
+                    FunctionCallExpr functionCallExpr = (FunctionCallExpr) unionExpr;
+                    if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
+                        functionCallExpr.setChild(1, relation.getOutputExpression().get(slotIndex));
+                    } else if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
+                        functionCallExpr.setChild(0, relation.getOutputExpression().get(slotIndex));
+                    }
+                } else {
+                    unionExpr = relation.getOutputExpression().get(slotIndex);
+                }
+                mapper.putAll(getPartitionJoinMap(unionExpr, new QueryStatement(relation)));
+            }
+            return mapper;
+        }
+        Expr partitionRefExpr = SlotRefResolver.resolveExpr(partitionExpr, statement);
+        PartitionExprAnalyzer.analyzePartitionExpr(partitionRefExpr,
+                MaterializedView.getMvPartitionSlotRef(partitionRefExpr));
+        List<Pair<Expr, Expr>> predicateExprs = Lists.newArrayList();
+        for (Pair<Expr, Relation[]> predicate : AnalyzerUtils.collectAllJoinPredicatesRelations(statement)) {
+            predicateExprs.addAll(mvGetJoinEqualPredicate(predicate.first, predicate.second));
+        }
+        SlotRef partitionSlotRef = MaterializedView.getMvPartitionSlotRef(partitionRefExpr);
+        //TODO: Should make sure the slotref (may be a wrapper?) with different desc and label is equal
+        //TODO: hive table with uppercase table name
+        //clear desc to avoid the slotref is not equal
+        partitionSlotRef.setDesc(null);
+        if (predicateExprs.isEmpty()) {
+            // no join predicate
+            mapper.put(partitionRefExpr, partitionSlotRef);
+            return mapper;
+        }
+        class TableInfo {
+            final List<Expr> exprs = Lists.newArrayList();
+            final List<TableRelation> relations = Lists.newArrayList();
+        }
+        Map<TableName, TableInfo> tableInfos = Maps.newHashMap();
+        List<TableRelation> tables = AnalyzerUtils.collectTableRelations(statement);
+        tables.forEach(table -> {
+            TableName tblName = table.getName();
+            TableInfo tableInfo = tableInfos.getOrDefault(tblName, new TableInfo());
+            tableInfo.relations.add(table);
+            tableInfos.put(tblName, tableInfo);
+        });
+        List<Map<Expr, SlotRef>> mappers = Lists.newArrayList();
+        predicateExprs.forEach(pair -> {
+            Pair<Expr, SlotRef> node1 = getSupportMvPartitionExpr(pair.first);
+            Pair<Expr, SlotRef> node2 = getSupportMvPartitionExpr(pair.second);
+            if (node1 == null || node2 == null) {
+                return;
+            }
+            insertIntoMapper(mappers, node1, node2);
+            tableInfos.get(node1.second.getTblNameWithoutAnalyzed()).exprs.add(node1.first);
+            tableInfos.get(node2.second.getTblNameWithoutAnalyzed()).exprs.add(node2.first);
+        });
+
+        for (Map<Expr, SlotRef> map : mappers) {
+            if (map.containsKey(partitionRefExpr)) {
+                mapper.putAll(map);
+                break;
+            }
+        }
+        if (mapper.isEmpty()) {
+            mapper.put(partitionRefExpr, partitionSlotRef);
+            return mapper;
+        }
+
+        tableInfos.forEach((table, tableInfo) -> tableInfo.exprs.removeIf(expr -> !mapper.containsKey(expr)));
+
+        // For a table appears more than once, we should remove them
+        // For example:
+        // t1 join a on t1.k1 = a.k1 join a on t1.k1 = date_trunc(a.k1)
+        // t1 join a on t1.k1 = a.k1 join a on t1.k1 = a.k2
+        mapper.entrySet().removeIf(entry -> {
+            TableName table = entry.getValue().getTblNameWithoutAnalyzed();
+            TableInfo tableInfo = tableInfos.get(table);
+            return tableInfo.relations.size() != 1;
+        });
+
+        // at least the partition expr should be in mapper
+        mapper.put(partitionRefExpr, partitionSlotRef);
+        return mapper;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -348,6 +348,15 @@ public abstract class ConnectorPartitionTraits {
             }
             return result;
         }
+
+        public List<Column> getPartitionColumns() {
+            // TODO: check partition type
+            try {
+                return ((OlapTable) table).getPartitionInfo().getPartitionColumns();
+            } catch (com.starrocks.common.NotImplementedException e) {
+                return null;
+            }
+        }
     }
 
     static class HivePartitionTraits extends DefaultTraits {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -29,17 +29,19 @@ import java.util.Set;
 public class MvTaskRunContext extends TaskRunContext {
 
     // all the RefBaseTable's partition name to its intersected materialized view names.
-    private Map<String, Set<String>> refBaseTableMVIntersectedPartitions;
+    //baseTable -> basePartition -> mvPartitions
+    private Map<Table, Map<String, Set<String>>> refBaseTableMVIntersectedPartitions;
     // all the materialized view's partition name to its intersected RefBaseTable's partition names.
-    private Map<String, Set<String>> mvRefBaseTableIntersectedPartitions;
+    //mvPartition -> baseTable -> basePartitions
+    private Map<String, Map<Table, Set<String>>> mvRefBaseTableIntersectedPartitions;
     // all the RefBaseTable's partition name to its partition key range.
-    private Map<String, Range<PartitionKey>> refBaseTableRangePartitionMap;
+    private Map<Table, Map<String, Range<PartitionKey>>> refBaseTableRangePartitionMap;
     // all the RefBaseTable's partition name to its list partition keys.
     private Map<String, List<List<String>>> refBaseTableListPartitionMap;
     // the external ref base table's mv partition name to original partition names map because external
     // table supports multi partition columns, one converted partition name(mv partition name) may have
     // multi original partition names.
-    private Map<String, Set<String>> externalRefBaseTableMVPartitionMap;
+    private Map<Table, Map<String, Set<String>>> externalRefBaseTableMVPartitionMap;
 
     // The Table which materialized view' partition column comes from is called `RefBaseTable`:
     // - Materialized View's to-refresh partitions is synced from its `refBaseTable`.
@@ -63,19 +65,21 @@ public class MvTaskRunContext extends TaskRunContext {
         this.status = context.status;
     }
 
-    public Map<String, Set<String>> getRefBaseTableMVIntersectedPartitions() {
+    public Map<Table, Map<String, Set<String>>> getRefBaseTableMVIntersectedPartitions() {
         return refBaseTableMVIntersectedPartitions;
     }
 
-    public void setRefBaseTableMVIntersectedPartitions(Map<String, Set<String>> refBaseTableMVIntersectedPartitions) {
+    public void setRefBaseTableMVIntersectedPartitions(
+            Map<Table, Map<String, Set<String>>> refBaseTableMVIntersectedPartitions) {
         this.refBaseTableMVIntersectedPartitions = refBaseTableMVIntersectedPartitions;
     }
 
-    public Map<String, Set<String>> getMvRefBaseTableIntersectedPartitions() {
+    public Map<String, Map<Table, Set<String>>> getMvRefBaseTableIntersectedPartitions() {
         return mvRefBaseTableIntersectedPartitions;
     }
 
-    public void setMvRefBaseTableIntersectedPartitions(Map<String, Set<String>> mvRefBaseTableIntersectedPartitions) {
+    public void setMvRefBaseTableIntersectedPartitions(
+            Map<String, Map<Table, Set<String>>> mvRefBaseTableIntersectedPartitions) {
         this.mvRefBaseTableIntersectedPartitions = mvRefBaseTableIntersectedPartitions;
     }
 
@@ -99,11 +103,12 @@ public class MvTaskRunContext extends TaskRunContext {
         this.nextPartitionEnd = nextPartitionEnd;
     }
 
-    public Map<String, Range<PartitionKey>> getRefBaseTableRangePartitionMap() {
+    public Map<Table, Map<String, Range<PartitionKey>>> getRefBaseTableRangePartitionMap() {
         return refBaseTableRangePartitionMap;
     }
 
-    public void setRefBaseTableRangePartitionMap(Map<String, Range<PartitionKey>> refBaseTableRangePartitionMap) {
+    public void setRefBaseTableRangePartitionMap(
+            Map<Table, Map<String, Range<PartitionKey>>> refBaseTableRangePartitionMap) {
         this.refBaseTableRangePartitionMap = refBaseTableRangePartitionMap;
     }
 
@@ -115,11 +120,12 @@ public class MvTaskRunContext extends TaskRunContext {
         this.refBaseTableListPartitionMap = refBaseTableListPartitionMap;
     }
 
-    public Map<String, Set<String>> getExternalRefBaseTableMVPartitionMap() {
+    public Map<Table, Map<String, Set<String>>> getExternalRefBaseTableMVPartitionMap() {
         return externalRefBaseTableMVPartitionMap;
     }
 
-    public void setExternalRefBaseTableMVPartitionMap(Map<String, Set<String>> externalRefBaseTableMVPartitionMap) {
+    public void setExternalRefBaseTableMVPartitionMap(
+            Map<Table, Map<String, Set<String>>> externalRefBaseTableMVPartitionMap) {
         this.externalRefBaseTableMVPartitionMap = externalRefBaseTableMVPartitionMap;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -82,6 +82,7 @@ import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.MvJoinFilter;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
@@ -3181,7 +3182,10 @@ public class LocalMetastore implements ConnectorMetadata {
         materializedView.setViewDefineSql(stmt.getInlineViewDef());
         materializedView.setSimpleDefineSql(stmt.getSimpleViewDef());
         // set partitionRefTableExprs
-        materializedView.setPartitionRefTableExprs(Lists.newArrayList(stmt.getPartitionRefTableExpr()));
+        if (stmt.getPartitionRefTableExpr() != null) {
+            //avoid to get a list of null inside
+            materializedView.setPartitionRefTableExprs(Lists.newArrayList(stmt.getPartitionRefTableExpr()));
+        }
         // set base index id
         long baseIndexId = getNextId();
         materializedView.setBaseIndexId(baseIndexId);
@@ -3230,6 +3234,15 @@ public class LocalMetastore implements ConnectorMetadata {
                 Partition partition = createPartition(db, materializedView, partitionId, mvName, version, tabletIdSet);
                 buildPartitions(db, materializedView, partition.getSubPartitions().stream().collect(Collectors.toList()));
                 materializedView.addPartition(partition);
+            } else {
+                Expr partitionExpr = stmt.getPartitionExpDesc().getExpr();
+                Map<Expr, SlotRef> partitionExprMaps = MvJoinFilter.getPartitionJoinMap(partitionExpr, stmt.getQueryStatement());
+                partitionExpr = stmt.getPartitionRefTableExpr();
+                if (!partitionExprMaps.containsKey(partitionExpr)) {
+                    LOG.warn("Failed to get partition expr from multiple base tables: " + stmt.getOrigStmt());
+                    partitionExprMaps.put(partitionExpr, MaterializedView.getMvPartitionSlotRef(partitionExpr));
+                }
+                materializedView.setPartitionExprMaps(partitionExprMaps);
             }
 
             MaterializedViewMgr.getInstance().prepareMaintenanceWork(stmt, materializedView);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -67,6 +67,7 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.Pair;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.meta.lock.LockType;
@@ -552,6 +553,12 @@ public class AnalyzerUtils {
         }
     }
 
+    public static List<Pair<Expr, Relation[]>> collectAllJoinPredicatesRelations(StatementBase statementBase) {
+        List<Pair<Expr, Relation[]>> joinPredicates = Lists.newArrayList();
+        new AnalyzerUtils.JoinPredicateRelationCollector(joinPredicates).visit(statementBase);
+        return joinPredicates;
+    }
+
     private static class TableAndViewCollector extends TableCollector {
         public TableAndViewCollector(Map<TableName, Table> dbs) {
             super(dbs);
@@ -772,6 +779,30 @@ public class AnalyzerUtils {
                 return null;
             }
             allTableAndViewRelations.put(node.getName(), node);
+            return null;
+        }
+    }
+
+    private static class JoinPredicateRelationCollector extends TableCollector {
+        private final List<Pair<Expr, Relation[]>> joinPredicates;
+
+        public JoinPredicateRelationCollector(List<Pair<Expr, Relation[]>> joinPredicates) {
+            super(null);
+            this.joinPredicates = joinPredicates;
+        }
+        @Override
+        public Void visitJoin(JoinRelation node, Void context) {
+            Relation[] relations = new Relation[2];
+            relations[0] = node.getLeft();
+            relations[1] = node.getRight();
+            joinPredicates.add(Pair.create(node.getOnPredicate(), relations));
+            visit(node.getLeft());
+            visit(node.getRight());
+            return null;
+        }
+
+        @Override
+        public Void visitTable(TableRelation node, Void context) {
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -641,8 +641,6 @@ public class MaterializedViewAnalyzer {
                             functionCallExpr.getFnName().getFunction() +
                             " must related with column", functionCallExpr.getPos());
                 }
-                SlotRef slotRef = getSlotRef(functionCallExpr);
-                slotRef.setType(partitionColumn.getType());
                 // copy function and set it into partitionRefTableExpr
                 Expr partitionRefTableExpr = functionCallExpr.clone();
                 List<Expr> children = partitionRefTableExpr.getChildren();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -57,6 +57,8 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -275,6 +277,54 @@ public class SyncPartitionUtils {
         return new PartitionMapping(truncLowerDateTime, truncUpperDateTime);
     }
 
+    // TODO: should support like to_date(ds) + 1 day ?
+    public static Range<PartitionKey> transferRange(Range<PartitionKey> baseRange, Expr partitionExpr)
+            throws AnalysisException {
+        if (!(partitionExpr instanceof FunctionCallExpr)) {
+            return baseRange;
+        }
+        FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
+        if (functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE)) {
+            return baseRange;
+        }
+        if (!functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
+            throw new SemanticException("Do not support function: {}", functionCallExpr.getFnName().getFunction());
+        }
+
+        String granularity = ((StringLiteral) functionCallExpr.getChild(0)).getValue().toLowerCase();
+        // assume expr partition must be DateLiteral and only one partition
+        LiteralExpr lowerExpr = baseRange.lowerEndpoint().getKeys().get(0);
+        LiteralExpr upperExpr = baseRange.upperEndpoint().getKeys().get(0);
+        Preconditions.checkArgument(lowerExpr instanceof DateLiteral);
+        DateLiteral lowerDate = (DateLiteral) lowerExpr;
+        LocalDateTime lowerDateTime = lowerDate.toLocalDateTime();
+        LocalDateTime truncLowerDateTime = getLowerDateTime(lowerDateTime, granularity);
+
+        DateLiteral upperDate;
+        LocalDateTime truncUpperDateTime;
+        if (upperExpr instanceof MaxLiteral) {
+            upperDate = new DateLiteral(Type.DATE, true);
+            truncUpperDateTime = upperDate.toLocalDateTime();
+        } else {
+            upperDate = (DateLiteral) upperExpr;
+            truncUpperDateTime = getLowerDateTime(upperDate.toLocalDateTime(), granularity);
+        }
+
+        Preconditions.checkState(baseRange.lowerEndpoint().getTypes().size() == 1);
+        PrimitiveType partitionType = baseRange.lowerEndpoint().getTypes().get(0);
+
+        PartitionKey lowerPartitionKey = new PartitionKey();
+        PartitionKey upperPartitionKey = new PartitionKey();
+        if (partitionType == PrimitiveType.DATE) {
+            lowerPartitionKey.pushColumn(new DateLiteral(truncLowerDateTime, Type.DATE), partitionType);
+            upperPartitionKey.pushColumn(new DateLiteral(truncUpperDateTime, Type.DATE), partitionType);
+        } else {
+            lowerPartitionKey.pushColumn(new DateLiteral(truncLowerDateTime, Type.DATETIME), partitionType);
+            upperPartitionKey.pushColumn(new DateLiteral(truncUpperDateTime, Type.DATETIME), partitionType);
+        }
+        return Range.closedOpen(lowerPartitionKey, upperPartitionKey);
+    }
+
     /**
      * return all src partition name to intersected dst partition names which the src partition
      * is intersected with dst partitions.
@@ -338,30 +388,174 @@ public class SyncPartitionUtils {
         return result;
     }
 
+    public static void updatePartitionRefMap(Map<String, Map<Table, Set<String>>> result,
+                                             String partitionKey,
+                                             Table table, String partitionValue) {
+        Map<Table, Set<String>> partitionMap = result.computeIfAbsent(partitionKey, k -> new HashMap<>());
+        Set<String> basePartitions = partitionMap.computeIfAbsent(table, k -> new HashSet<>());
+        basePartitions.add(partitionValue);
+    }
+
+    public static void updateTableRefMap(Map<Table, Map<String, Set<String>>> result,
+                                         Table table,
+                                         String partitionKey, String partitionValue) {
+        Map<String, Set<String>> partitionMap = result.computeIfAbsent(table, k -> new HashMap<>());
+        Set<String> basePartitions = partitionMap.computeIfAbsent(partitionKey, k -> new HashSet<>());
+        basePartitions.add(partitionValue);
+    }
+
+    public static void initialMvRefMap(Map<String, Map<Table, Set<String>>> result,
+                                       List<PartitionRange> partitionRanges,
+                                       Table table) {
+        for (PartitionRange partitionRange : partitionRanges) {
+            Map<Table, Set<String>> partitionMap =
+                    result.computeIfAbsent(partitionRange.getPartitionName(), k -> new HashMap<>());
+            partitionMap.computeIfAbsent(table, k -> new HashSet<>());
+        }
+    }
+
+    public static void initialBaseRefMap(
+            Map<Table, Map<String, Set<String>>> result, Table table, PartitionRange partitionRange) {
+        Map<String, Set<String>> partitionMap = result.computeIfAbsent(table, k -> new HashMap<>());
+        partitionMap.computeIfAbsent(partitionRange.getPartitionName(), k -> new HashSet<>());
+    }
+
+    public static Map<Table, Map<String, Set<String>>> generateBaseRefMap(
+            Map<Table, Map<String, Range<PartitionKey>>> baseRangeMap,
+            Map<Table, Expr> basePartitionExprMap,
+            Map<String, Range<PartitionKey>> mvRangeMap) {
+        Map<Table, Map<String, Set<String>>> result = Maps.newHashMap();
+        // for each partition of base, find the corresponding partition of mv
+        List<PartitionRange> mvRanges = mvRangeMap.keySet().stream().map(name -> new PartitionRange(name,
+                mvRangeMap.get(name))).sorted(PartitionRange::compareTo).collect(Collectors.toList());
+
+        for (Map.Entry<Table, Map<String, Range<PartitionKey>>> entry : baseRangeMap.entrySet()) {
+            List<PartitionRange> baseRanges = entry.getValue().keySet().stream().map(name -> {
+                try {
+                    Range<PartitionKey> baseRange = transferRange(entry.getValue().get(name),
+                            basePartitionExprMap.get(entry.getKey()));
+                    return new PartitionRange(name, baseRange);
+                } catch (AnalysisException e) {
+                    throw new SemanticException("Convert to PartitionMapping failed:", e);
+                }
+            }).sorted(PartitionRange::compareTo).collect(Collectors.toList());
+            for (PartitionRange baseRange : baseRanges) {
+                int mid = Collections.binarySearch(mvRanges, baseRange);
+                if (mid < 0) {
+                    initialBaseRefMap(result, entry.getKey(), baseRange);
+                    continue;
+                }
+                PartitionRange mvRange = mvRanges.get(mid);
+                updateTableRefMap(result, entry.getKey(), baseRange.getPartitionName(), mvRange.getPartitionName());
+
+                int lower = mid - 1;
+                while (lower >= 0 && mvRanges.get(lower).isIntersected(baseRange)) {
+                    updateTableRefMap(
+                            result, entry.getKey(), baseRange.getPartitionName(), mvRanges.get(lower).getPartitionName());
+                    lower--;
+                }
+
+                int higher = mid + 1;
+                while (higher < mvRanges.size() && mvRanges.get(higher).isIntersected(baseRange)) {
+                    updateTableRefMap(
+                            result, entry.getKey(), baseRange.getPartitionName(), mvRanges.get(higher).getPartitionName());
+                    higher++;
+                }
+            }
+        }
+        return result;
+    }
+
+    public static Map<String, Map<Table, Set<String>>> generateMvRefMap(
+            Map<String, Range<PartitionKey>> mvRangeMap,
+            Map<Table, Expr> basePartitionExprMap,
+            Map<Table, Map<String, Range<PartitionKey>>> baseRangeMap) {
+        Map<String, Map<Table, Set<String>>> result = Maps.newHashMap();
+        // for each partition of mv, find all corresponding partition of base
+        List<PartitionRange> mvRanges = mvRangeMap.keySet().stream().map(name -> new PartitionRange(name,
+                mvRangeMap.get(name))).collect(Collectors.toList());
+
+        // [min, max) -> [date_trunc(min), date_trunc(max))
+        // if [date_trunc(min), date_trunc(max)), overlap with [mvMin, mvMax), then [min, max) is corresponding partition
+        Map<Table, List<PartitionRange>> baseRangesMap = new HashMap<>();
+        for (Map.Entry<Table, Map<String, Range<PartitionKey>>> entry : baseRangeMap.entrySet()) {
+            List<PartitionRange> baseRanges = entry.getValue().keySet().stream().map(name -> {
+                try {
+                    Range<PartitionKey> baseRange = transferRange(entry.getValue().get(name),
+                            basePartitionExprMap.get(entry.getKey()));
+                    return new PartitionRange(name, baseRange);
+                } catch (AnalysisException e) {
+                    throw new SemanticException("Convert to PartitionMapping failed:", e);
+                }
+            }).sorted(PartitionRange::compareTo).collect(Collectors.toList());
+            baseRangesMap.put(entry.getKey(), baseRanges);
+        }
+        Collections.sort(mvRanges, PartitionRange::compareTo);
+
+        for (Map.Entry<Table, List<PartitionRange>> entry : baseRangesMap.entrySet()) {
+            initialMvRefMap(result, mvRanges, entry.getKey());
+            List<PartitionRange> baseRanges = entry.getValue();
+            for (PartitionRange baseRange : baseRanges) {
+                int mid = Collections.binarySearch(mvRanges, baseRange);
+                if (mid < 0) {
+                    continue;
+                }
+                PartitionRange mvRange = mvRanges.get(mid);
+                updatePartitionRefMap(result, mvRange.getPartitionName(), entry.getKey(), baseRange.getPartitionName());
+
+                int lower = mid - 1;
+                while (lower >= 0 && mvRanges.get(lower).isIntersected(baseRange)) {
+                    updatePartitionRefMap(
+                            result, mvRanges.get(lower).getPartitionName(), entry.getKey(), baseRange.getPartitionName());
+                    lower--;
+                }
+
+                int higher = mid + 1;
+                while (higher < mvRanges.size() && mvRanges.get(higher).isIntersected(baseRange)) {
+                    updatePartitionRefMap(
+                            result, mvRanges.get(higher).getPartitionName(), entry.getKey(), baseRange.getPartitionName());
+                    higher++;
+                }
+            }
+        }
+        return result;
+    }
+
     public static void calcPotentialRefreshPartition(Set<String> needRefreshMvPartitionNames,
-                                                     Set<String> baseChangedPartitionNames,
-                                                     Map<String, Set<String>> baseToMvNameRef,
-                                                     Map<String, Set<String>> mvToBaseNameRef) {
+                                                     Map<Table, Set<String>> baseChangedPartitionNames,
+                                                     Map<Table, Map<String, Set<String>>> baseToMvNameRef,
+                                                     Map<String, Map<Table, Set<String>>> mvToBaseNameRef) {
         gatherPotentialRefreshPartitionNames(needRefreshMvPartitionNames, baseChangedPartitionNames,
                 baseToMvNameRef, mvToBaseNameRef);
     }
 
     private static void gatherPotentialRefreshPartitionNames(Set<String> needRefreshMvPartitionNames,
-                                                             Set<String> baseChangedPartitionNames,
-                                                             Map<String, Set<String>> baseToMvNameRef,
-                                                             Map<String, Set<String>> mvToBaseNameRef) {
+                                                             Map<Table, Set<String>> baseChangedPartitionNames,
+                                                             Map<Table, Map<String, Set<String>>> baseToMvNameRef,
+                                                             Map<String, Map<Table, Set<String>>> mvToBaseNameRef) {
         int curNameCount = needRefreshMvPartitionNames.size();
-        Set<String> newBaseChangedPartitionNames = Sets.newHashSet();
+        Map<Table, Set<String>> newBaseChangedPartitionNames = Maps.newHashMap();
         Set<String> newNeedRefreshMvPartitionNames = Sets.newHashSet();
         for (String needRefreshMvPartitionName : needRefreshMvPartitionNames) {
-            Set<String> baseNames = mvToBaseNameRef.get(needRefreshMvPartitionName);
-            newBaseChangedPartitionNames.addAll(baseNames);
-            for (String baseName : baseNames) {
-                Set<String> mvNames = baseToMvNameRef.get(baseName);
-                newNeedRefreshMvPartitionNames.addAll(mvNames);
-            }
+            Map<Table, Set<String>> baseNames = mvToBaseNameRef.get(needRefreshMvPartitionName);
+            baseNames.forEach((key, value) -> {
+                newBaseChangedPartitionNames.merge(key, value, (set1, set2) -> {
+                    //we should copy set1 here, otherwise the mvToBaseNameRef will be changed
+                    HashSet<String> set = Sets.newHashSet(set1);
+                    set.addAll(set2);
+                    return set;
+                });
+                for (String baseName : value) {
+                    newNeedRefreshMvPartitionNames.addAll(baseToMvNameRef.get(key).get(baseName));
+                }
+            });
         }
-        baseChangedPartitionNames.addAll(newBaseChangedPartitionNames);
+        newBaseChangedPartitionNames.forEach((key, value) ->
+                baseChangedPartitionNames.merge(key, value, (set1, set2) -> {
+                    set1.addAll(set2);
+                    return set1;
+                })
+        );
         needRefreshMvPartitionNames.addAll(newNeedRefreshMvPartitionNames);
         if (curNameCount != needRefreshMvPartitionNames.size()) {
             gatherPotentialRefreshPartitionNames(needRefreshMvPartitionNames, baseChangedPartitionNames,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -300,7 +300,7 @@ public class MvRewritePreprocessor {
 
         List<Table> baseTables = MvUtils.getAllTables(mvPlan);
         List<Table> intersectingTables = baseTables.stream().filter(queryTables::contains).collect(Collectors.toList());
-        Pair<Table, Column> partitionTableAndColumns = mv.getBaseTableAndPartitionColumn();
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
 
         // Only record `refTableUpdatedPartitionNames` when `mvPartialPartitionPredicates` is not null and it needs
         // to be compensated by using it.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -993,7 +993,7 @@ public class MvUtils {
 
         // If no partition table and columns, no need compensate
         MaterializedView mv = mvContext.getMv();
-        Pair<Table, Column> partitionTableAndColumns = mv.getBaseTableAndPartitionColumn();
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
         if (partitionTableAndColumns == null) {
             return false;
         }
@@ -1153,7 +1153,7 @@ public class MvUtils {
             MaterializedView mv,
             OptExpression mvPlan,
             Set<String> mvPartitionNamesToRefresh) throws AnalysisException {
-        Pair<Table, Column> partitionTableAndColumns = mv.getBaseTableAndPartitionColumn();
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
         if (partitionTableAndColumns == null) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/OptExpressionDuplicator.java
@@ -68,7 +68,7 @@ public class OptExpressionDuplicator {
         this.columnRefFactory = materializationContext.getQueryRefFactory();
         this.columnMapping = Maps.newHashMap();
         this.rewriter = new ReplaceColumnRefRewriter(columnMapping);
-        Pair<Table, Column> partitionInfo = materializationContext.getMv().getBaseTableAndPartitionColumn();
+        Pair<Table, Column> partitionInfo = materializationContext.getMv().getDirectTableAndPartitionColumn();
         this.partitionByTable = partitionInfo == null ? null : partitionInfo.first;
         this.partitionColumn = partitionInfo == null ? null : partitionInfo.second;
         this.partialPartitionRewrite = !materializationContext.getMvPartitionNamesToRefresh().isEmpty();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MvJoinFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MvJoinFilterTest.java
@@ -1,0 +1,155 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import com.google.common.collect.Lists;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
+import com.starrocks.analysis.TableName;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+public class MvJoinFilterTest {
+    private static List<Map<Expr, SlotRef>> mapper = new ArrayList<>();
+    private static ConnectContext connectContext;
+    private static StarRocksAssert starRocksAssert;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        // create connect context
+        UtFrameUtils.createMinStarRocksCluster();
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test").useDatabase("test");
+
+        starRocksAssert.withTable("CREATE TABLE test.tbl1\n" +
+                "(\n" +
+                "    k1 date,\n" +
+                "    k2 int,\n" +
+                "    v1 int sum\n" +
+                ")\n" +
+                "PARTITION BY RANGE(k1)\n" +
+                "(\n" +
+                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                "    PARTITION p2 values less than('2020-03-01')\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2)\n" +
+                "PROPERTIES(\"replication_num\" = \"1\");");
+
+        starRocksAssert.withTable("CREATE TABLE test.tbl2\n" +
+                "(\n" +
+                "    k1 date,\n" +
+                "    k2 int,\n" +
+                "    v1 int sum\n" +
+                ")\n" +
+                "PARTITION BY RANGE(k1)\n" +
+                "(\n" +
+                "    PARTITION p1 values less than('2020-02-01'),\n" +
+                "    PARTITION p2 values less than('2020-03-01')\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(k2)\n" +
+                "PROPERTIES(\"replication_num\" = \"1\");");
+    }
+
+    @Test
+    public void testInsertIntoMapper() {
+        // Set up test data
+        SlotRef slotRefA = new SlotRef(new TableName("db", "table"), "columnA");
+        Expr exprA = new SlotRef(new TableName("db", "table"), "columnA");
+        Pair<Expr, SlotRef> pairA = new Pair<>(exprA, slotRefA);
+
+        SlotRef slotRefB = new SlotRef(new TableName("db", "table"), "columnB");
+        Expr exprB = new SlotRef(new TableName("db", "table"), "columnB");
+        Pair<Expr, SlotRef> pairB = new Pair<>(exprB, slotRefB);
+
+        // Execute the method under test
+        MvJoinFilter.insertIntoMapper(mapper, pairA, pairB);
+
+        // Assertions
+        Assert.assertEquals(1, mapper.size());
+        Assert.assertTrue(mapper.get(0).containsKey(exprA));
+        Assert.assertTrue(mapper.get(0).containsKey(exprB));
+    }
+
+    @Test
+    public void testGetSupportMvPartitionExpr() {
+        // Set up test data for SlotRef
+        SlotRef slotRef = new SlotRef(new TableName("db", "table"), "column");
+
+        // Execute the method under test
+        Pair<Expr, SlotRef> result = MvJoinFilter.getSupportMvPartitionExpr(slotRef);
+
+        // Assertions
+        Assert.assertNotNull(result);
+        Assert.assertEquals(slotRef, result.first);
+        Assert.assertEquals(slotRef, result.second);
+
+        // Set up test data for FunctionCallExpr
+        slotRef = new SlotRef(new TableName("db", "table"), "column");
+        StringLiteral day = new StringLiteral("day");
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("date_trunc", Lists.newArrayList(day, slotRef));
+
+        // Execute the method under test
+        result = MvJoinFilter.getSupportMvPartitionExpr(functionCallExpr);
+
+        // Assertions
+        Assert.assertNotNull(result);
+        Assert.assertEquals(functionCallExpr, result.first);
+        Assert.assertEquals(slotRef, result.second);
+    }
+
+    @Test
+    public void testGetPartitionJoinMap() throws Exception {
+        SlotRef slot1 = new SlotRef(new TableName("test", "tbl1"), "k1", "k1");
+        slot1.getTblNameWithoutAnalyzed().normalization(connectContext);
+        slot1.setType(Type.DATE);
+
+        SlotRef slot2 = new SlotRef(new TableName("test", "tbl2"), "k1", "k1");
+        slot2.getTblNameWithoutAnalyzed().normalization(connectContext);
+        slot2.setType(Type.DATE);
+
+        String sql1 = "select t1.k1, t2.k2 from tbl1 t1 join tbl2 t2 on t1.k1 = t2.k1 and t1.v1 = t2.v1;";
+        QueryStatement query = (QueryStatement) UtFrameUtils.parseStmtWithNewParser(sql1, connectContext);
+        Map<Expr, SlotRef> result = MvJoinFilter.getPartitionJoinMap(slot1, query);
+        Assert.assertEquals(2, result.size());
+        Assert.assertTrue(result.containsKey(slot1));
+        Assert.assertTrue(result.containsKey(slot2));
+
+        StringLiteral day = new StringLiteral("day");
+        FunctionCallExpr functionCallExpr = new FunctionCallExpr("date_trunc", Lists.newArrayList(day, slot2));
+        String sql2 = "select t1.k1, t2.k2 from tbl1 t1 join tbl2 t2 on t1.k1 = date_trunc('day', t2.k1);";
+        query = (QueryStatement) UtFrameUtils.parseStmtWithNewParser(sql2, connectContext);
+        result = MvJoinFilter.getPartitionJoinMap(functionCallExpr, query);
+        Assert.assertEquals(2, result.size());
+
+        String sql3 = "select k1, k2 from tbl1 union select k1, k2 from tbl2";
+        query = (QueryStatement) UtFrameUtils.parseStmtWithNewParser(sql3, connectContext);
+        result = MvJoinFilter.getPartitionJoinMap(slot1, query);
+        Assert.assertEquals(2, result.size());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -169,6 +169,38 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                         ")\n" +
                         "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
                         "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.tbl15\n" +
+                        "(\n" +
+                        "    k1 datetime,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p20220101 values [('2022-01-01 00:00:00'),('2022-01-02 00:00:00')),\n" +
+                        "    PARTITION p20220102 values [('2022-01-02 00:00:00'),('2022-01-03 00:00:00')),\n" +
+                        "    PARTITION p20220103 values [('2022-01-03 00:00:00'),('2022-01-04 00:00:00')),\n" +
+                        "    PARTITION p20220201 values [('2022-02-01 00:00:00'),('2022-02-02 00:00:00')),\n" +
+                        "    PARTITION p20220202 values [('2022-02-02 00:00:00'),('2022-02-03 00:00:00'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
+                .withTable("CREATE TABLE test.tbl16\n" +
+                        "(\n" +
+                        "    k1 datetime,\n" +
+                        "    k2 int,\n" +
+                        "    v1 int sum\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(k1)\n" +
+                        "(\n" +
+                        "    PARTITION p20220101 values [('2022-01-01 00:00:00'),('2022-01-02 00:00:00')),\n" +
+                        "    PARTITION p20220102 values [('2022-01-02 00:00:00'),('2022-01-03 00:00:00')),\n" +
+                        "    PARTITION p20220103 values [('2022-01-03 00:00:00'),('2022-01-04 00:00:00')),\n" +
+                        "    PARTITION p20220201 values [('2022-02-01 00:00:00'),('2022-02-02 00:00:00')),\n" +
+                        "    PARTITION p20220202 values [('2022-02-02 00:00:00'),('2022-02-03 00:00:00'))\n" +
+                        ")\n" +
+                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
+                        "PROPERTIES('replication_num' = '1');")
                 .withMaterializedView("create materialized view test.union_all_mv\n" +
                         "partition by dt \n" +
                         "distributed by hash(k2) buckets 10\n" +
@@ -2247,7 +2279,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         // run 3
         {
-            // TODO: non-ref base table partition's updated will cause the materialized view's refresh all partitions
             String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
             new StmtExecutor(connectContext, insertSql).execute();
 
@@ -2257,9 +2288,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            Assert.assertTrue(plan.contains("partitions=5/5\n" +
+            Assert.assertTrue(plan.contains("partitions=1/5\n" +
                     "     rollup: tbl5"));
-            Assert.assertTrue(plan.contains("partitions=5/5\n" +
+            Assert.assertTrue(plan.contains("partitions=1/5\n" +
                     "     rollup: tbl4"));
         }
         starRocksAssert.dropMaterializedView("partition_prune_non_ref_tables1");
@@ -2313,7 +2344,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         // run 3
         {
-            // TODO: non-ref base table partition's updated will cause the materialized view's refresh all partitions
             String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
             new StmtExecutor(connectContext, insertSql).execute();
 
@@ -2323,9 +2353,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            Assert.assertTrue(plan.contains("partitions=5/5\n" +
+            Assert.assertTrue(plan.contains("partitions=1/5\n" +
                     "     rollup: tbl5"));
-            Assert.assertTrue(plan.contains("partitions=5/5\n" +
+            Assert.assertTrue(plan.contains("partitions=1/5\n" +
                     "     rollup: tbl4"));
         }
         starRocksAssert.dropMaterializedView("partition_prune_non_ref_tables2");
@@ -2380,7 +2410,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         // run 3
         {
-            // TODO: non-ref base table partition's updated will cause the materialized view's refresh all partitions
             String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
             new StmtExecutor(connectContext, insertSql).execute();
 
@@ -2390,11 +2419,10 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             MvTaskRunContext mvContext = processor.getMvContext();
             ExecPlan execPlan = mvContext.getExecPlan();
             String plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            Assert.assertTrue(plan.contains("k1 > '2022-01-01', 2: k2 > 0\n" +
-                    "     partitions=4/5\n" +
+            Assert.assertTrue(plan.contains("PREDICATES: 2: k2 > 0\n" +
+                    "     partitions=1/5\n" +
                     "     rollup: tbl4"));
-            Assert.assertTrue(plan.contains("4: dt > '2022-01-01'\n" +
-                    "     partitions=4/5\n" +
+            Assert.assertTrue(plan.contains("partitions=1/5\n" +
                     "     rollup: tbl5"));
         }
         starRocksAssert.dropMaterializedView("partition_prune_non_ref_tables1");
@@ -2895,6 +2923,279 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                 "p20230803_99991231"), partitions);
 
         starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testFilterPartitionByJoinPredicate() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        //normal case, join predicate is partition column
+        // a.k1 = date_trunc(month, b.k1)
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by k1 \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '10000')" +
+                "refresh manual\n" +
+                "as select a.k1, b.k2 from test.tbl15 as a join test.tbl16 as b " +
+                "on a.k1 = date_trunc('month', b.k1);");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(2, materializedView.getPartitionExprMaps().size());
+
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Map<Table, Set<String>> baseTables = processor.getRefTableRefreshPartitions(Sets.newHashSet("p20220101"));
+        Assert.assertEquals(2, baseTables.size());
+        Assert.assertEquals(Sets.newHashSet("p20220101"), baseTables.get(testDb.getTable("tbl15")));
+        Assert.assertEquals(Sets.newHashSet("p20220101", "p20220102", "p20220103"), baseTables.get(testDb.getTable("tbl16")));
+
+        // insert new data into tbl16's p20220202 partition
+        String insertSql = "insert into tbl16 partition(p20220202) values('2022-02-02', 3, 10);";
+        new StmtExecutor(connectContext, insertSql).execute();
+        taskRun.executeTaskRun();
+        Assert.assertEquals(Sets.newHashSet("p20220201"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl15=[p20220201], tbl16=[p20220202, p20220201]}",
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+        // join predicate has no equal condition
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by k1 \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '10000')" +
+                "refresh manual\n" +
+                "as select tbl1.k1, tbl2.k2 from tbl1  join tbl2 on tbl1.k1 = tbl2.k1 or tbl1.k2 = tbl2.k2;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
+        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        new StmtExecutor(connectContext, "insert into tbl1 partition(p2) values('2022-02-02', 3, 10);").execute();
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Assert.assertEquals(Sets.newHashSet("p2"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl1=[p2]}",
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+
+        new StmtExecutor(connectContext, "insert into tbl2 partition(p2) values('2022-02-02', 3, 10);").execute();
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        ExecPlan execPlan = processor.getMvContext().getExecPlan();
+        assertPlanContains(execPlan, "partitions=5/5\n     rollup: tbl1", "partitions=2/2\n     rollup: tbl2");
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+        // join predicate is not mv partition expr
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by date_trunc('month',k1) \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '100')" +
+                "refresh manual\n" +
+                "as select tbl1.k1, tbl2.k2 from tbl1  join tbl2 using(k1);");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+
+        // nest table alias join
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by date_trunc('month', k1) \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "refresh manual\n" +
+                "as select a.k1, b.k2 from test.tbl15 as a join test.tbl16 as b " +
+                "on date_trunc('month', a.k1) = b.k1;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(2, materializedView.getPartitionExprMaps().size());
+        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        new StmtExecutor(connectContext, "insert into tbl15 partition(p20220202) values('2022-02-02', 3, 10);").execute();
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Assert.assertEquals(Sets.newHashSet("p202202_202203"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl15=[p20220202, p20220201], tbl16=[p20220202, p20220201]}",
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+        // nest table alias join
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by k1\n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '100')" +
+                "refresh manual\n" +
+                "as select a.ds as k1, a.k2 from" +
+                "(select date_trunc('DAY', k1) as ds, k1, k2 from (select k1, k2 from (select * from tbl1)t1 )t2 ) a left join " +
+                "(select date_trunc('DAY', k1) as ds, k2 from (select * from tbl2)t ) b " +
+                "on date_trunc('DAY', a.k1) = b.ds and a.k2 = b.k2 left join " +
+                "(select date_trunc('DAY', k1) as ds, k2 from tbl15) c " +
+                "on a.k2 = c.k2 and a.ds = c.ds;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(3, materializedView.getPartitionExprMaps().size());
+        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        new StmtExecutor(connectContext, "insert into tbl2 partition(p1) values('2022-01-02', 3, 10);").execute();
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Assert.assertEquals(Sets.newHashSet("p20211201_20220101", "p20220101_20220201"),
+                processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl2=[p1], tbl15=[p20220103, p20220102, p20220101], tbl1=[p0, p1]}",
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+        // nest function in join predicate
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by k1\n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '100')" +
+                "refresh manual\n" +
+                "as select a.ds as k1, a.k2 from" +
+                "(select date_trunc('day', k1) as ds, k2 from tbl1) a " +
+                "left join " +
+                "(select k1 as ds, k2 from tbl2) b " +
+                "on date_trunc('day', a.ds) = b.ds and a.k2 = b.k2 ;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+        // duplicate table join
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by k1\n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '100')" +
+                "refresh manual\n" +
+                "as select a.ds as k1, a.k2 from" +
+                "(select k1 as ds, k2 from tbl1) a left join " +
+                "(select k1 as ds, k2 from tbl2) b " +
+                "on a.ds = b.ds and a.k2 = b.k2 left join " +
+                "(select k1 as ds, k2 from tbl2) c " +
+                "on a.ds = c.ds and a.k2 = c.k2;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by k1\n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '100')" +
+                "refresh manual\n" +
+                "as select a.ds as k1, a.k2 from" +
+                "(select date_trunc('day', k1) as ds, k2 from tbl1) a " +
+                "left join " +
+                "(select date_trunc('day', k1) as ds, k2 from tbl1) b " +
+                "on a.ds = b.ds and a.k2 = b.k2 " +
+                "left join " +
+                "(select date_trunc('day', k1) as ds, k2 from tbl1) c " +
+                "on a.ds = c.ds;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+
+        // unsupported function in join predicate
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_join_predicate\n" +
+                "partition by k1\n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '100')" +
+                "refresh manual\n" +
+                "as select a.ds as k1, a.k2 from" +
+                "(select k1 as ds, k2 from tbl1) a left join " +
+                "(select k1 as ds, k2 from tbl2) b " +
+                "on a.ds = b.ds and a.k2 = b.k2 left join " +
+                "(select date_add(k1, INTERVAL 1 DAY) as ds, k2 from tbl15) c " +
+                "on a.ds = c.ds and a.k2 = c.k2;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        new StmtExecutor(connectContext, "insert into tbl2 partition(p1) values('2022-01-02', 3, 10);").execute();
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Assert.assertEquals(Sets.newHashSet("p0", "p1"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl2=[p1], tbl1=[p0, p1]}",
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
+
+    @Test
+    public void testFilterPartitionByUnion() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_union_filter\n" +
+                "partition by k1 \n" +
+                "distributed by hash(k2) buckets 10\n" +
+                "PROPERTIES('partition_refresh_number' = '10000')\n" +
+                "refresh manual\n" +
+                "as select k1, k2 from test.tbl15 \n" +
+                "union " +
+                "select k1, k2 from test.tbl16;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_union_filter"));
+        Assert.assertEquals(2, materializedView.getPartitionExprMaps().size());
+
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Map<Table, Set<String>> baseTables = processor.getRefTableRefreshPartitions(Sets.newHashSet("p20220101"));
+        Assert.assertEquals(2, baseTables.size());
+        Assert.assertEquals(Sets.newHashSet("p20220101"), baseTables.get(testDb.getTable("tbl15")));
+        Assert.assertEquals(Sets.newHashSet("p20220101"), baseTables.get(testDb.getTable("tbl16")));
+
+        // insert new data into tbl16's p20220202 partition
+        String insertSql = "insert into tbl16 partition(p20220202) values('2022-02-02', 3, 10);";
+        new StmtExecutor(connectContext, insertSql).execute();
+        taskRun.executeTaskRun();
+        Assert.assertEquals(Sets.newHashSet("p20220202"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl15=[p20220202], tbl16=[p20220202]}",
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_union_filter");
+
+
+        starRocksAssert.useDatabase("test").withMaterializedView(
+                "create materialized view test.mv_union_filter\n" +
+                        "partition by k1 \n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '10000')\n" +
+                        "refresh manual\n" +
+                        "as " +
+                        "select date_trunc('month', k1) as k1, k2 from test.tbl16\n" +
+                        "union " +
+                        "select k1, k2 from test.tbl15;");
+        materializedView = ((MaterializedView) testDb.getTable("mv_union_filter"));
+        Assert.assertEquals(2, materializedView.getPartitionExprMaps().size());
+
+        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        taskRun = TaskRunBuilder.newBuilder(task).build();
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+
+        // insert new data into tbl16's p20220202 partition
+        insertSql = "insert into tbl16 partition(p20220202) values('2022-02-02', 3, 10);";
+        new StmtExecutor(connectContext, insertSql).execute();
+        taskRun.executeTaskRun();
+        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Assert.assertEquals(Sets.newHashSet("p202202_202203"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl15=[p20220202, p20220201], tbl16=[p20220202, p20220201]}",
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        starRocksAssert.useDatabase("test").dropMaterializedView("mv_union_filter");
     }
 }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/OptimizerTest.java
@@ -270,7 +270,7 @@ public class OptimizerTest {
             Assert.assertEquals("mv_4", materializationContext.getMv().getName());
 
             MaterializedView mv = getMv("test", "mv_4");
-            Pair<Table, Column> partitionTableAndColumn = mv.getBaseTableAndPartitionColumn();
+            Pair<Table, Column> partitionTableAndColumn = mv.getDirectTableAndPartitionColumn();
             Assert.assertEquals("tbl_with_mv", partitionTableAndColumn.first.getName());
 
             ScalarOperator scalarOperator = materializationContext.getMvPartialPartitionPredicate();


### PR DESCRIPTION
In the materializedView class, add a partitionExprMaps field to store expressions equivalent to the partition column of the materialized view, collected from join predicates. With this information, we can identify the related partition tables, which will undergo partition pruning during the refresh of the materialized view.
Regarding the union statement, by merging all sub-clauses, we can obtain partitionExprMaps.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
