### PR TITLE
[BugFix] fix lake persistent index useless reload

### DIFF
--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -100,11 +100,6 @@ public:
 
 private:
     Status apply_write_log(const TxnLogPB_OpWrite& op_write, int64_t txn_id) {
-        if (op_write.dels_size() == 0 && op_write.rowset().num_rows() == 0 &&
-            !op_write.rowset().has_delete_predicate()) {
-            return Status::OK();
-        }
-
         // get lock to avoid gc
         _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
         DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
@@ -114,17 +109,16 @@ private:
         if (_index_entry == nullptr) {
             ASSIGN_OR_RETURN(_index_entry, _tablet.update_mgr()->prepare_primary_index(*_metadata, &_tablet, &_builder,
                                                                                        _base_version, _new_version));
+        }
+        if (op_write.dels_size() == 0 && op_write.rowset().num_rows() == 0 &&
+            !op_write.rowset().has_delete_predicate()) {
+            return Status::OK();
         }
         return _tablet.update_mgr()->publish_primary_key_tablet(op_write, txn_id, *_metadata, &_tablet, _index_entry,
                                                                 &_builder, _base_version);
     }
 
     Status apply_compaction_log(const TxnLogPB_OpCompaction& op_compaction) {
-        if (op_compaction.input_rowsets().empty()) {
-            DCHECK(!op_compaction.has_output_rowset() || op_compaction.output_rowset().num_rows() == 0);
-            return Status::OK();
-        }
-
         // get lock to avoid gc
         _tablet.update_mgr()->lock_shard_pk_index_shard(_tablet.id());
         DeferOp defer([&]() { _tablet.update_mgr()->unlock_shard_pk_index_shard(_tablet.id()); });
@@ -134,6 +128,10 @@ private:
         if (_index_entry == nullptr) {
             ASSIGN_OR_RETURN(_index_entry, _tablet.update_mgr()->prepare_primary_index(*_metadata, &_tablet, &_builder,
                                                                                        _base_version, _new_version));
+        }
+        if (op_compaction.input_rowsets().empty()) {
+            DCHECK(!op_compaction.has_output_rowset() || op_compaction.output_rowset().num_rows() == 0);
+            return Status::OK();
         }
         return _tablet.update_mgr()->publish_primary_compaction(op_compaction, *_metadata, _tablet, _index_entry,
                                                                 &_builder, _base_version);


### PR DESCRIPTION
 Update persistent index's meta version, even though this is empty load. If we don't update persistent index's meta version, next first publish may lead to persistent index to reload.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
