### PR TITLE
[Refactor] Add interface reset() for BitmapValue

### DIFF
--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -226,7 +226,6 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
             break;
         case SINGLE:
             if (_sv != rhs._sv) {
-                _type = EMPTY;
                 reset();
             }
             break;
@@ -256,7 +255,6 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
             break;
         case SINGLE:
             if (!rhs._bitmap->contains(_sv)) {
-                _type = EMPTY;
                 reset();
             }
             break;
@@ -282,7 +280,6 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
             break;
         case SINGLE:
             if (!rhs._set->contains(_sv)) {
-                _type = EMPTY;
                 reset();
             }
             break;
@@ -320,7 +317,6 @@ void BitmapValue::remove(uint64_t rhs) {
         break;
     case SINGLE:
         if (_sv == rhs) {
-            _type = EMPTY;
             reset();
         }
         break;
@@ -343,7 +339,6 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
             break;
         case SINGLE:
             if (_sv == rhs._sv) {
-                _type = EMPTY;
                 reset();
             }
             break;
@@ -361,7 +356,6 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
             break;
         case SINGLE:
             if (rhs._bitmap->contains(_sv)) {
-                _type = EMPTY;
                 reset();
             }
             break;
@@ -387,7 +381,6 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
             break;
         case SINGLE:
             if (rhs._set->contains(_sv)) {
-                _type = EMPTY;
                 reset();
             }
             break;
@@ -425,7 +418,6 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
             break;
         case SINGLE:
             if (_sv == rhs._sv) {
-                _type = EMPTY;
                 reset();
             } else {
                 add(rhs._sv);

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -237,7 +237,7 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
                 _type = SINGLE;
                 _sv = rhs._sv;
             }
-            _bitmap->clear();
+            _bitmap.reset();
             break;
         case SET:
             if (!_set->contains(rhs._sv)) {

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -392,7 +392,6 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
             }
             break;
         case BITMAP: {
-            detail::Roaring64Map bitmap;
             for (auto x : *rhs._set) {
                 _bitmap->remove(x);
             }

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -65,6 +65,13 @@ class Roaring64Map;
 // for streaming load scenario.
 class BitmapValue {
 public:
+    enum BitmapDataType {
+        EMPTY = 0,
+        SINGLE = 1, // single element
+        BITMAP = 2, // more than one elements
+        SET = 3
+    };
+
     // Construct an empty bitmap.
     BitmapValue();
 
@@ -159,16 +166,11 @@ public:
     int64_t bitmap_subset_in_range_internal(const int64_t& range_start, const int64_t& range_end,
                                             BitmapValue* ret_bitmap);
 
+    BitmapDataType type() const { return _type; }
+
 private:
     void _from_bitmap_to_smaller_type();
     void _from_set_to_bitmap();
-
-    enum BitmapDataType {
-        EMPTY = 0,
-        SINGLE = 1, // single element
-        BITMAP = 2, // more than one elements
-        SET = 3
-    };
 
     // Use shared_ptr, not unique_ptr, because we want to avoid unnecessary copy
     std::shared_ptr<detail::Roaring64Map> _bitmap = nullptr;

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -150,6 +150,7 @@ public:
     void compress() const;
 
     void clear();
+    void reset();
 
     int64_t sub_bitmap_internal(const int64_t& offset, const int64_t& len, BitmapValue* ret_bitmap);
 
@@ -159,7 +160,7 @@ public:
                                             BitmapValue* ret_bitmap);
 
 private:
-    void _convert_to_smaller_type();
+    void _from_bitmap_to_smaller_type();
     void _from_set_to_bitmap();
 
     enum BitmapDataType {

--- a/be/test/exprs/bitmap_functions_test.cpp
+++ b/be/test/exprs/bitmap_functions_test.cpp
@@ -2041,7 +2041,6 @@ TEST_F(VecBitmapFunctionsTest, bitmapToBase64Test) {
         Columns columns;
         auto s = BitmapColumn::create();
         BitmapValue empty;
-        empty.clear();
         s->append(&empty);
         columns.push_back(s);
 
@@ -2381,7 +2380,6 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_special_cases) {
     {
         auto bitmap_column = BitmapColumn::create();
         BitmapValue empty;
-        empty.clear();
         bitmap_column->append(&empty);
 
         Columns columns;
@@ -2830,7 +2828,6 @@ TEST_F(VecBitmapFunctionsTest, sub_bitmap_limit_special_cases) {
     {
         auto bitmap_column = BitmapColumn::create();
         BitmapValue empty;
-        empty.clear();
         bitmap_column->append(&empty);
 
         Columns columns;
@@ -3299,7 +3296,6 @@ TEST_F(VecBitmapFunctionsTest, bitmap_subset_in_range_special_cases) {
     {
         auto bitmap_column = BitmapColumn::create();
         BitmapValue empty;
-        empty.clear();
         bitmap_column->append(&empty);
 
         Columns columns;

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -19,14 +19,11 @@
 #include <cstdint>
 #include <string>
 
-#include "util/coding.h"
-#define private public
 #include "column/vectorized_fwd.h"
 #include "exprs/bitmap_functions.h"
 #include "exprs/function_context.h"
-#include "types/bitmap_value.h"
 #include "types/bitmap_value_detail.h"
-#include "util/phmap/phmap.h"
+#include "util/coding.h"
 
 namespace starrocks {
 
@@ -331,18 +328,18 @@ TEST(BitmapValueTest, bitmap_single_convert) {
     ASSERT_STREQ("1", bitmap.to_string().c_str());
     bitmap.add(1);
     ASSERT_STREQ("1", bitmap.to_string().c_str());
-    ASSERT_EQ(BitmapValue::SINGLE, bitmap._type);
+    ASSERT_EQ(BitmapValue::SINGLE, bitmap.type());
 
     BitmapValue bitmap_u;
     bitmap_u.add(1);
     bitmap |= bitmap_u;
-    ASSERT_EQ(BitmapValue::SINGLE, bitmap._type);
+    ASSERT_EQ(BitmapValue::SINGLE, bitmap.type());
 
     bitmap_u.add(2);
-    ASSERT_EQ(BitmapValue::SET, bitmap_u._type);
+    ASSERT_EQ(BitmapValue::SET, bitmap_u.type());
 
     bitmap |= bitmap_u;
-    ASSERT_EQ(BitmapValue::SET, bitmap._type);
+    ASSERT_EQ(BitmapValue::SET, bitmap.type());
 }
 
 TEST(BitmapValueTest, bitmap_max) {


### PR DESCRIPTION
Use `clear` when reuse is needed, and when `RoaringBitmap` no longer in use, release memory as quickly as possible through reset.

Later, when implementing `CopyOnWrite`, these two interfaces must be treated differently.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
