### PR TITLE
[BugFix] Fix issue with incorrect limitation of Routine load task count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -255,6 +255,19 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
             }
         }
         int partitionNum = currentKafkaPartitions.size();
+        if (partitionNum == 0) {
+            // In non-stop states (NEED_SCHEDULE/RUNNING), having `partitionNum` as 0 is equivalent 
+            // to `currentKafkaPartitions` being uninitialized. When `currentKafkaPartitions` is 
+            // uninitialized, it indicates that the job has just been created and hasn't been scheduled yet. 
+            // At this point, the user-specified number of partitions is used.
+            partitionNum = customKafkaPartitions.size();
+            if (partitionNum == 0) {
+                // If the user hasn't specified partition information, then we no longer take the `partition` 
+                // variable into account when calculating concurrency.
+                partitionNum = Integer.MAX_VALUE;
+            }
+        }
+
         if (desireTaskConcurrentNum == 0) {
             desireTaskConcurrentNum = Config.max_routine_load_task_concurrent_num;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -241,7 +241,7 @@ public class RoutineLoadMgr implements Writable {
                 throw new DdlException("Name " + routineLoadJob.getName() + " already used in db "
                         + dbName);
             }
-            long allSlotNum = beNum * Config.max_routine_load_task_num_per_be;
+            long maxConcurrentTasks = beNum * Config.max_routine_load_task_num_per_be;
             // When calculating the used slots, we only consider Jobs in the NEED_SCHEDULE and RUNNING states.
             List<RoutineLoadJob> jobs = getRoutineLoadJobByState(Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE,
                         RoutineLoadJob.JobState.RUNNING));
@@ -249,10 +249,10 @@ public class RoutineLoadMgr implements Writable {
             for (RoutineLoadJob job : jobs) {
                 curTaskNum += job.calculateCurrentConcurrentTaskNum();
             }
-            int needSlotNum = routineLoadJob.calculateCurrentConcurrentTaskNum();
-            if (curTaskNum + needSlotNum > allSlotNum) {
+            int newTaskNum = routineLoadJob.calculateCurrentConcurrentTaskNum();
+            if (curTaskNum + newTaskNum > maxConcurrentTasks) {
                 throw new DdlException("Current routine load tasks is " + curTaskNum + ". "
-                        + "The new job need " + needSlotNum + " tasks. "
+                        + "The new job need " + newTaskNum + " tasks. "
                         + "But we only support " + beNum + "*" + Config.max_routine_load_task_num_per_be + " tasks."
                         + "Please modify FE config max_routine_load_task_num_per_be if you want more job");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load.routineload;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -218,6 +219,11 @@ public class RoutineLoadMgr implements Writable {
 
         routineLoadJob.setOrigStmt(createRoutineLoadStmt.getOrigStmt());
         addRoutineLoadJob(routineLoadJob, createRoutineLoadStmt.getDBName());
+    }
+
+    @VisibleForTesting
+    public Map<Long, Integer> getBeTasksNum() {
+        return beTasksNum;
     }
 
     public void addRoutineLoadJob(RoutineLoadJob routineLoadJob, String dbName) throws DdlException {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -236,15 +236,16 @@ public class RoutineLoadMgr implements Writable {
                         + dbName);
             }
             long allSlotNum = beNum * Config.max_routine_load_task_num_per_be;
+            // When calculating the used slots, we only consider Jobs in the NEED_SCHEDULE and RUNNING states.
             List<RoutineLoadJob> jobs = getRoutineLoadJobByState(Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE,
-                        RoutineLoadJob.JobState.RUNNING, RoutineLoadJob.JobState.PAUSED));
-            long curSlotNum = 0;
+                        RoutineLoadJob.JobState.RUNNING));
+            long curTaskNum = 0;
             for (RoutineLoadJob job : jobs) {
-                curSlotNum += job.calculateCurrentConcurrentTaskNum();
+                curTaskNum += job.calculateCurrentConcurrentTaskNum();
             }
             int needSlotNum = routineLoadJob.calculateCurrentConcurrentTaskNum();
-            if (curSlotNum + needSlotNum > allSlotNum) {
-                throw new DdlException("Current routine load job is " + curSlotNum + ". "
+            if (curTaskNum + needSlotNum > allSlotNum) {
+                throw new DdlException("Current routine load tasks is " + curTaskNum + ". "
                         + "The new job need " + needSlotNum + " tasks. "
                         + "But we only support " + beNum + "*" + Config.max_routine_load_task_num_per_be + " tasks."
                         + "Please modify FE config max_routine_load_task_num_per_be if you want more job");

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -397,6 +397,8 @@ public class GlobalTransactionMgrTest {
         TxnCommitAttachment txnCommitAttachment = new RLTaskTxnCommitAttachment(rlTaskTxnCommitAttachment);
 
         RoutineLoadMgr routineLoadManager = new RoutineLoadMgr();
+        Map<Long, Integer> beTasksNum = routineLoadManager.getBeTasksNum();
+        beTasksNum.put(1L, 0);
         routineLoadManager.addRoutineLoadJob(routineLoadJob, "db");
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),
@@ -470,6 +472,8 @@ public class GlobalTransactionMgrTest {
         TxnCommitAttachment txnCommitAttachment = new RLTaskTxnCommitAttachment(rlTaskTxnCommitAttachment);
 
         RoutineLoadMgr routineLoadManager = new RoutineLoadMgr();
+        Map<Long, Integer> beTasksNum = routineLoadManager.getBeTasksNum();
+        beTasksNum.put(1L, 0);
         routineLoadManager.addRoutineLoadJob(routineLoadJob, "db");
 
         Deencapsulation.setField(masterTransMgr.getDatabaseTransactionMgr(GlobalStateMgrTestUtil.testDbId1),


### PR DESCRIPTION
Currently, the creation of Routine load jobs and the update of the corresponding Kafka partition number for these jobs are asynchronous. This results in the partition number of newly created jobs being set to 0 initially. We calculate the concurrency of a task as the 
`min(partitionNum, desireTaskConcurrentNum, aliveNodeNum, and max_routine_load_task_concurrent_num)`.
The calculateCurrentConcurrentTaskNum function computing a concurrency of 0. Consequently, it fails to correctly limit the number of routine load tasks in the cluster.
This PR addresses the issue by modifying the calculateCurrentConcurrentTaskNum function. When calculating the partition number for a job, if the job is still in the phase of acquiring partition information, the partition number is set to the user-specified partition information. If the user hasn't specified partition information, we no longer consider the partition number as a factor when calculating concurrency.
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
