### PR TITLE
[BugFix] Fix CTAS from catalog to olap table, max string length analyze error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/TypeDef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/TypeDef.java
@@ -128,7 +128,7 @@ public class TypeDef implements ParseNode {
                 int maxLen;
                 if (type == PrimitiveType.VARCHAR) {
                     name = "Varchar";
-                    maxLen = ScalarType.MAX_VARCHAR_LENGTH;
+                    maxLen = ScalarType.OLAP_MAX_VARCHAR_LENGTH;
                 } else {
                     name = "Char";
                     maxLen = ScalarType.MAX_CHAR_LENGTH;
@@ -147,7 +147,7 @@ public class TypeDef implements ParseNode {
             }
             case VARBINARY: {
                 String name = "VARBINARY";
-                int maxLen = ScalarType.MAX_VARCHAR_LENGTH;
+                int maxLen = ScalarType.OLAP_MAX_VARCHAR_LENGTH;
                 int len = scalarType.getLength();
                 // len is decided by child, when it is -1.
                 if (scalarType.getLength() > maxLen) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarType.java
@@ -69,7 +69,9 @@ public class ScalarType extends Type implements Cloneable {
     public static final int DEFAULT_SCALE = 0; // SQL standard
     // Longest supported VARCHAR and CHAR, chosen to match Hive.
     public static final int DEFAULT_STRING_LENGTH = 65533;
-    public static final int MAX_VARCHAR_LENGTH = 1048576;
+    public static final int OLAP_MAX_VARCHAR_LENGTH = 1048576;
+    // 1GB for each line, it's enough
+    public static final int CATALOG_MAX_VARCHAR_LENGTH = 1024 * 1024 * 1024;
     public static final int MAX_CHAR_LENGTH = 255;
     // HLL DEFAULT LENGTH  2^14(registers) + 1(type)
     public static final int MAX_HLL_LENGTH = 16385;
@@ -309,14 +311,12 @@ public class ScalarType extends Type implements Cloneable {
     }
 
     // Use for Hive string now.
-    public static ScalarType createDefaultExternalTableString() {
-        // 1GB for each line, it's enough
-        final int MAX_LENGTH = 1024 * 1024 * 1024;
-        return ScalarType.createVarcharType(MAX_LENGTH);
+    public static ScalarType createDefaultCatalogString() {
+        return ScalarType.createVarcharType(CATALOG_MAX_VARCHAR_LENGTH);
     }
 
-    public static ScalarType createMaxVarcharType() {
-        ScalarType stringType = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+    public static ScalarType createOlapMaxVarcharType() {
+        ScalarType stringType = ScalarType.createVarcharType(ScalarType.OLAP_MAX_VARCHAR_LENGTH);
         return stringType;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Type.java
@@ -120,7 +120,7 @@ public abstract class Type implements Cloneable {
             ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 0);
 
     public static final ScalarType VARCHAR = ScalarType.createVarcharType(-1);
-    public static final ScalarType STRING = ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+    public static final ScalarType STRING = ScalarType.createVarcharType(ScalarType.OLAP_MAX_VARCHAR_LENGTH);
     public static final ScalarType DEFAULT_STRING = ScalarType.createDefaultString();
     public static final ScalarType HLL = ScalarType.createHllType();
     public static final ScalarType CHAR = ScalarType.createCharType(-1);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -62,7 +62,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.starrocks.catalog.ScalarType.MAX_VARCHAR_LENGTH;
+import static com.starrocks.catalog.ScalarType.OLAP_MAX_VARCHAR_LENGTH;
 import static com.starrocks.catalog.Type.BIGINT;
 import static com.starrocks.catalog.Type.BOOLEAN;
 import static com.starrocks.catalog.Type.DATE;
@@ -136,7 +136,7 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DATE;
                 break;
             case "STRING":
-                return ScalarType.createDefaultExternalTableString();
+                return ScalarType.createDefaultCatalogString();
             case "VARCHAR":
                 return ScalarType.createVarcharType(getVarcharLength(hiveType));
             case "CHAR":
@@ -217,7 +217,7 @@ public class ColumnTypeConverter {
             throw new StarRocksConnectorException("Unsupported Hive type: %s. Supported CHAR types: CHAR(<=%d).",
                     type, HiveChar.MAX_CHAR_LENGTH);
         } else if (type.isVarchar()) {
-            if (type.getColumnSize() == -1 || type.getColumnSize() == MAX_VARCHAR_LENGTH) {
+            if (type.getColumnSize() == -1 || type.getColumnSize() == OLAP_MAX_VARCHAR_LENGTH) {
                 return stringTypeInfo;
             }
             if (type.getColumnSize() <= HiveVarchar.MAX_VARCHAR_LENGTH) {
@@ -285,7 +285,7 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DOUBLE;
                 break;
             case STRING:
-                return ScalarType.createDefaultExternalTableString();
+                return ScalarType.createDefaultCatalogString();
             case ARRAY:
                 Type type = new ArrayType(fromHudiType(avroSchema.getElementType()));
                 if (type.isArrayType()) {
@@ -333,7 +333,7 @@ public class ColumnTypeConverter {
 
                 if (!isConvertedFailed) {
                     // Hudi map's key must be string
-                    return new MapType(ScalarType.createDefaultExternalTableString(), valueType);
+                    return new MapType(ScalarType.createDefaultCatalogString(), valueType);
                 }
                 break;
             case UNION:
@@ -468,7 +468,7 @@ public class ColumnTypeConverter {
                 primitiveType = PrimitiveType.DATETIME;
                 break;
             case STRING:
-                return ScalarType.createDefaultExternalTableString();
+                return ScalarType.createDefaultCatalogString();
             case DECIMAL:
                 int precision = ((io.delta.standalone.types.DecimalType) dataType).getPrecision();
                 int scale = ((io.delta.standalone.types.DecimalType) dataType).getScale();
@@ -508,7 +508,7 @@ public class ColumnTypeConverter {
         }
 
         public Type visit(VarCharType varCharType) {
-            return ScalarType.createDefaultExternalTableString();
+            return ScalarType.createDefaultCatalogString();
         }
 
         public Type visit(BooleanType booleanType) {
@@ -607,7 +607,7 @@ public class ColumnTypeConverter {
                 break;
             case STRING:
             case UUID:
-                return ScalarType.createDefaultExternalTableString();
+                return ScalarType.createDefaultCatalogString();
             case DECIMAL:
                 int precision = ((Types.DecimalType) icebergType).precision();
                 int scale = ((Types.DecimalType) icebergType).scale();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/elasticsearch/EsUtil.java
@@ -170,7 +170,7 @@ public class EsUtil {
             case "nested":
             case "object":
             default:
-                return ScalarType.createDefaultExternalTableString();
+                return ScalarType.createDefaultCatalogString();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -112,7 +112,7 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
                 if (typeName.equalsIgnoreCase("varchar")) {
                     return ScalarType.createVarcharType(columnSize);
                 } else if (typeName.equalsIgnoreCase("text")) {
-                    return ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+                    return ScalarType.createVarcharType(ScalarType.OLAP_MAX_VARCHAR_LENGTH);
                 }
                 primitiveType = PrimitiveType.UNKNOWN_TYPE;
                 break;
@@ -134,7 +134,7 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
             // if user not specify numeric precision and scale, the default value is 0,
             // we can't defer the precision and scale, can only deal it as string.
             if (precision == 0) {
-                return ScalarType.createVarcharType(ScalarType.MAX_VARCHAR_LENGTH);
+                return ScalarType.createVarcharType(ScalarType.OLAP_MAX_VARCHAR_LENGTH);
             }
             return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/trino/TrinoViewColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/trino/TrinoViewColumnTypeConverter.java
@@ -82,13 +82,13 @@ public class TrinoViewColumnTypeConverter {
                 primitiveType = PrimitiveType.DATE;
                 break;
             case "STRING":
-                return ScalarType.createDefaultExternalTableString();
+                return ScalarType.createDefaultCatalogString();
             case "VARCHAR":
                 int length = 0;
                 try {
                     length = getVarcharLength(trinoType);
                 } catch (StarRocksConnectorException e) {
-                    return ScalarType.createDefaultExternalTableString();
+                    return ScalarType.createDefaultCatalogString();
                 }
                 return ScalarType.createVarcharType(length);
             case "CHAR":

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -811,15 +811,15 @@ public class AnalyzerUtils {
             if (PrimitiveType.VARCHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.CHAR == srcType.getPrimitiveType() ||
                     PrimitiveType.NULL_TYPE == srcType.getPrimitiveType()) {
-                int len = ScalarType.MAX_VARCHAR_LENGTH;
+                int len = ScalarType.OLAP_MAX_VARCHAR_LENGTH;
                 if (srcType instanceof ScalarType) {
                     ScalarType scalarType = (ScalarType) srcType;
                     if (scalarType.getLength() > 0) {
-                        len = scalarType.getLength();
+                        // Catalog's varchar length may larger than olap's max varchar length
+                        len = Integer.min(scalarType.getLength(), ScalarType.OLAP_MAX_VARCHAR_LENGTH);
                     }
                 }
-                ScalarType stringType = ScalarType.createVarcharType(len);
-                newType = stringType;
+                newType = ScalarType.createVarcharType(len);
             } else if (PrimitiveType.FLOAT == srcType.getPrimitiveType() ||
                     PrimitiveType.DOUBLE == srcType.getPrimitiveType()) {
                 if (convertDouble) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -321,7 +321,7 @@ public class CreateFunctionStmt extends DdlStmt {
         argsDef.analyze();
         returnType.analyze();
 
-        intermediateType = TypeDef.createVarchar(ScalarType.MAX_VARCHAR_LENGTH);
+        intermediateType = TypeDef.createVarchar(ScalarType.OLAP_MAX_VARCHAR_LENGTH);
 
         String type = properties.get(TYPE_KEY);
         if (TYPE_STARROCKS_JAR.equals(type)) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticUtils.java
@@ -291,10 +291,10 @@ public class StatisticUtils {
         ScalarType tableUUIDType = ScalarType.createVarcharType(65530);
         ScalarType partitionNameType = ScalarType.createVarcharType(65530);
         ScalarType dbNameType = ScalarType.createVarcharType(65530);
-        ScalarType maxType = ScalarType.createMaxVarcharType();
-        ScalarType minType = ScalarType.createMaxVarcharType();
-        ScalarType bucketsType = ScalarType.createMaxVarcharType();
-        ScalarType mostCommonValueType = ScalarType.createMaxVarcharType();
+        ScalarType maxType = ScalarType.createOlapMaxVarcharType();
+        ScalarType minType = ScalarType.createOlapMaxVarcharType();
+        ScalarType bucketsType = ScalarType.createOlapMaxVarcharType();
+        ScalarType mostCommonValueType = ScalarType.createOlapMaxVarcharType();
         ScalarType catalogNameType = ScalarType.createVarcharType(65530);
 
         if (tableName.equals(StatsConstants.SAMPLE_STATISTICS_TABLE_NAME)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ColumnDefTest.java
@@ -240,7 +240,7 @@ public class ColumnDefTest {
 
     @Test(expected = AnalysisException.class)
     public void testInvalidVarcharInsideArray() throws AnalysisException {
-        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.MAX_VARCHAR_LENGTH + 1);
+        Type tooLongVarchar = ScalarType.createVarchar(ScalarType.OLAP_MAX_VARCHAR_LENGTH + 1);
         ColumnDef column = new ColumnDef("col", new TypeDef(new ArrayType(tooLongVarchar)), false, null, true,
                 DefaultValueDef.NOT_SET, "");
         column.analyze(true);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -186,7 +186,7 @@ public class HudiTableTest {
         Assert.assertEquals(ColumnTypeConverter.fromHudiType(Schema.create(Schema.Type.DOUBLE)),
                 ScalarType.createType(PrimitiveType.DOUBLE));
         Assert.assertEquals(ColumnTypeConverter.fromHudiType(Schema.create(Schema.Type.STRING)),
-                ScalarType.createDefaultExternalTableString());
+                ScalarType.createDefaultCatalogString());
         Assert.assertEquals(ColumnTypeConverter.fromHudiType(
                 Schema.createArray(Schema.create(Schema.Type.INT))),
                 new ArrayType(ScalarType.createType(PrimitiveType.INT)));
@@ -195,7 +195,7 @@ public class HudiTableTest {
                 ScalarType.createType(PrimitiveType.VARCHAR));
         Assert.assertEquals(ColumnTypeConverter.fromHudiType(
                         Schema.createMap(Schema.create(Schema.Type.INT))),
-                new MapType(ScalarType.createDefaultExternalTableString(), ScalarType.createType(PrimitiveType.INT)));
+                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.createType(PrimitiveType.INT)));
         Assert.assertEquals(ColumnTypeConverter.fromHudiType(
                         Schema.createUnion(Schema.create(Schema.Type.INT))),
                 ScalarType.createType(PrimitiveType.INT));

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/StructTypeTest.java
@@ -71,7 +71,7 @@ public class StructTypeTest {
         // "struct<struct_test:int,c1:struct<c1:int,cc1:string>>"
         StructType c1 = new StructType(Lists.newArrayList(
                 new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+                new StructField("cc1", ScalarType.createDefaultCatalogString())
         ));
         StructType root = new StructType(Lists.newArrayList(
                 new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
@@ -111,7 +111,7 @@ public class StructTypeTest {
         // matched
         StructType mc1 = new StructType(Lists.newArrayList(
                 new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+                new StructField("cc1", ScalarType.createDefaultCatalogString())
         ));
         StructType matched = new StructType(Lists.newArrayList(
                 new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
@@ -121,7 +121,7 @@ public class StructTypeTest {
 
         // Won't match with different subfield order
         StructType mc2 = new StructType(Lists.newArrayList(
-                new StructField("cc1", ScalarType.createDefaultExternalTableString()),
+                new StructField("cc1", ScalarType.createDefaultCatalogString()),
                 new StructField("c1", ScalarType.createType(PrimitiveType.INT))
         ));
         StructType matchedDiffOrder = new StructType(Lists.newArrayList(

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TypeTest.java
@@ -244,7 +244,7 @@ public class TypeTest {
         // map<int,struct<c1:int,cc1:string>>
         StructType c1 = new StructType(Lists.newArrayList(
                 new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+                new StructField("cc1", ScalarType.createDefaultCatalogString())
         ));
         MapType mapType =
                 new MapType(ScalarType.createType(PrimitiveType.INT), c1);
@@ -262,7 +262,7 @@ public class TypeTest {
         // "struct<struct_test:int,c1:struct<c1:int,cc1:string>>"
         StructType c1 = new StructType(Lists.newArrayList(
                 new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                new StructField("cc1", ScalarType.createDefaultExternalTableString())
+                new StructField("cc1", ScalarType.createDefaultCatalogString())
         ));
         StructType root = new StructType(Lists.newArrayList(
                 new StructField("struct_test", ScalarType.createType(PrimitiveType.INT), "comment test"),

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ColumnTypeConverterTest.java
@@ -34,7 +34,7 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import static com.starrocks.catalog.ScalarType.MAX_VARCHAR_LENGTH;
+import static com.starrocks.catalog.ScalarType.OLAP_MAX_VARCHAR_LENGTH;
 import static com.starrocks.catalog.Type.UNKNOWN_TYPE;
 import static com.starrocks.connector.ColumnTypeConverter.columnEquals;
 import static com.starrocks.connector.ColumnTypeConverter.fromHiveTypeToArrayType;
@@ -111,7 +111,7 @@ public class ColumnTypeConverterTest {
         Type resType = fromHiveTypeToArrayType(typeStr);
         Assert.assertEquals(arrayType, resType);
 
-        itemType = ScalarType.createDefaultExternalTableString();
+        itemType = ScalarType.createDefaultCatalogString();
         arrayType = new ArrayType(itemType);
         typeStr = "Array<string>";
         resType = fromHiveTypeToArrayType(typeStr);
@@ -165,7 +165,7 @@ public class ColumnTypeConverterTest {
         Assert.assertEquals(mapType, resType);
 
         keyType = ScalarType.createType(PrimitiveType.DATE);
-        valueType = ScalarType.createDefaultExternalTableString();
+        valueType = ScalarType.createDefaultCatalogString();
         mapType = new MapType(keyType, valueType);
         typeStr = "map<date,string>";
         resType = fromHiveTypeToMapType(typeStr);
@@ -236,7 +236,7 @@ public class ColumnTypeConverterTest {
             String typeStr = "struct<struct_test:int,c1:struct<c1:int,cc1:string>>";
             StructType c1 = new StructType(Lists.newArrayList(
                     new StructField("c1", ScalarType.createType(PrimitiveType.INT)),
-                    new StructField("cc1", ScalarType.createDefaultExternalTableString())
+                    new StructField("cc1", ScalarType.createDefaultCatalogString())
             ));
             StructType root = new StructType(Lists.newArrayList(
                     new StructField("struct_test", ScalarType.createType(PrimitiveType.INT)),
@@ -296,7 +296,7 @@ public class ColumnTypeConverterTest {
         resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assert.assertEquals(resType, varcharType);
 
-        Type stringType = ScalarType.createDefaultExternalTableString();
+        Type stringType = ScalarType.createDefaultCatalogString();
         typeStr = "string";
         resType = ColumnTypeConverter.fromHiveType(typeStr);
         Assert.assertEquals(resType, stringType);
@@ -321,7 +321,7 @@ public class ColumnTypeConverterTest {
 
         unionSchema = Schema.createUnion(Schema.create(Schema.Type.STRING));
         arraySchema = Schema.createArray(unionSchema);
-        Assert.assertEquals(fromHudiType(arraySchema), new ArrayType(ScalarType.createDefaultExternalTableString()));
+        Assert.assertEquals(fromHudiType(arraySchema), new ArrayType(ScalarType.createDefaultCatalogString()));
 
         unionSchema = Schema.createUnion(Schema.create(Schema.Type.BYTES));
         arraySchema = Schema.createArray(unionSchema);
@@ -338,7 +338,7 @@ public class ColumnTypeConverterTest {
         Schema structSchema = Schema.createRecord(fields);
 
         StructField structField1 = new StructField("field1", ScalarType.createType(PrimitiveType.INT));
-        StructField structField2 = new StructField("field2", ScalarType.createDefaultExternalTableString());
+        StructField structField2 = new StructField("field2", ScalarType.createDefaultCatalogString());
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(structField1);
         structFields.add(structField2);
@@ -362,13 +362,13 @@ public class ColumnTypeConverterTest {
         Schema mapSchema = Schema.createMap(structSchema);
 
         StructField structField1 = new StructField("field1", ScalarType.createType(PrimitiveType.INT));
-        StructField structField2 = new StructField("field2", ScalarType.createDefaultExternalTableString());
+        StructField structField2 = new StructField("field2", ScalarType.createDefaultCatalogString());
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(structField1);
         structFields.add(structField2);
         StructType structType = new StructType(structFields);
 
-        MapType mapType = new MapType(ScalarType.createDefaultExternalTableString(), structType);
+        MapType mapType = new MapType(ScalarType.createDefaultCatalogString(), structType);
 
         Assert.assertEquals(mapType, fromHudiType(mapSchema));
 
@@ -426,7 +426,7 @@ public class ColumnTypeConverterTest {
                 "Unsupported Hive type: VARCHAR(200000). Supported VARCHAR types: VARCHAR(<=65535)",
                 () -> toHiveType(ScalarType.createVarcharType(200000)));
 
-        Assert.assertEquals("string", toHiveType(ScalarType.createVarchar(MAX_VARCHAR_LENGTH)));
+        Assert.assertEquals("string", toHiveType(ScalarType.createVarchar(OLAP_MAX_VARCHAR_LENGTH)));
 
         ScalarType itemType = ScalarType.createType(PrimitiveType.DATE);
         ArrayType arrayType = new ArrayType(new ArrayType(itemType));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergApiConverterTest.java
@@ -69,7 +69,7 @@ public class IcebergApiConverterTest {
 
     @Test
     public void testString() {
-        Type stringType = ScalarType.createDefaultExternalTableString();
+        Type stringType = ScalarType.createDefaultCatalogString();
         org.apache.iceberg.types.Type icebergType = Types.StringType.get();
         Type resType = fromIcebergType(icebergType);
         Assert.assertEquals(resType, stringType);
@@ -115,7 +115,7 @@ public class IcebergApiConverterTest {
                 Types.StringType.get(), Types.IntegerType.get());
         Type resType = fromIcebergType(icebergType);
         Assert.assertEquals(resType,
-                new MapType(ScalarType.createDefaultExternalTableString(), ScalarType.createType(PrimitiveType.INT)));
+                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.createType(PrimitiveType.INT)));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -62,7 +62,7 @@ public class PaimonColumnConverterTest {
     public void testConvertVarchar() {
         VarCharType paimonType = new VarCharType();
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
-        Type srType = ScalarType.createDefaultExternalTableString();
+        Type srType = ScalarType.createDefaultCatalogString();
         Assert.assertEquals(result, srType);
     }
 
@@ -154,7 +154,7 @@ public class PaimonColumnConverterTest {
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
         Assert.assertTrue(result instanceof com.starrocks.catalog.MapType);
         com.starrocks.catalog.MapType srType = (com.starrocks.catalog.MapType) result;
-        Assert.assertEquals(ScalarType.createDefaultExternalTableString(), srType.getKeyType());
+        Assert.assertEquals(ScalarType.createDefaultCatalogString(), srType.getKeyType());
         Assert.assertEquals(Type.DATETIME, srType.getValueType());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/trino/TrinoViewTest.java
@@ -85,7 +85,7 @@ public class TrinoViewTest {
         Assert.assertEquals(hiveView.getFullSchema().get(2).getName(), "salary");
         Assert.assertEquals(hiveView.getFullSchema().get(2).getType(), ScalarType.DOUBLE);
         Assert.assertEquals(hiveView.getFullSchema().get(3).getName(), "new_col");
-        Assert.assertEquals(hiveView.getFullSchema().get(3).getType(), ScalarType.createDefaultExternalTableString());
+        Assert.assertEquals(hiveView.getFullSchema().get(3).getType(), ScalarType.createDefaultCatalogString());
     }
 
     @Test
@@ -134,11 +134,11 @@ public class TrinoViewTest {
         Assert.assertEquals(hiveView.getFullSchema().get(14).getType(), ScalarType.ARRAY_INT);
         Assert.assertEquals(hiveView.getFullSchema().get(15).getName(), "map_col");
         Assert.assertEquals(hiveView.getFullSchema().get(15).getType(),
-                new MapType(ScalarType.createDefaultExternalTableString(), ScalarType.INT));
+                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.INT));
         Assert.assertEquals(hiveView.getFullSchema().get(16).getName(), "struct_col");
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(new StructField("field1", ScalarType.INT));
-        structFields.add(new StructField("field2", ScalarType.createDefaultExternalTableString()));
+        structFields.add(new StructField("field2", ScalarType.createDefaultCatalogString()));
         Assert.assertEquals(hiveView.getFullSchema().get(16).getType(), new StructType(structFields));
     }
 
@@ -174,15 +174,15 @@ public class TrinoViewTest {
         Assert.assertEquals(columnList.get(6).getType(), ScalarType.createDecimalV3NarrowestType(10, 2));
         Assert.assertEquals(columnList.get(7).getType(), ScalarType.createVarcharType(20));
         Assert.assertEquals(columnList.get(8).getType(), ScalarType.createCharType(10));
-        Assert.assertEquals(columnList.get(9).getType(), ScalarType.createDefaultExternalTableString());
+        Assert.assertEquals(columnList.get(9).getType(), ScalarType.createDefaultCatalogString());
         Assert.assertEquals(columnList.get(10).getType(), ScalarType.BOOLEAN);
         Assert.assertEquals(columnList.get(11).getType(), ScalarType.DATETIME);
         Assert.assertEquals(columnList.get(12).getType(), ScalarType.ARRAY_INT);
         Assert.assertEquals(columnList.get(13).getType(),
-                new MapType(ScalarType.createDefaultExternalTableString(), ScalarType.INT));
+                new MapType(ScalarType.createDefaultCatalogString(), ScalarType.INT));
         ArrayList<StructField> structFields = new ArrayList<>();
         structFields.add(new StructField("field1", ScalarType.INT));
-        structFields.add(new StructField("field2", ScalarType.createDefaultExternalTableString()));
+        structFields.add(new StructField("field2", ScalarType.createDefaultCatalogString()));
         Assert.assertEquals(columnList.get(14).getType(), new StructType(structFields));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzerUtilsTest.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.analyzer;
 
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.StringLiteral;
+import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
@@ -75,6 +76,13 @@ public class AnalyzerUtilsTest {
         Assert.assertTrue(success);
         Expr shouldReplaceExpr = expr.getChild(0).getChild(0);
         Assert.assertTrue(shouldReplaceExpr instanceof StringLiteral);
+    }
+
+    @Test
+    public void testConvertCatalogMaxStringToOlapMaxString() {
+        ScalarType catalogString = ScalarType.createDefaultCatalogString();
+        ScalarType convertedString = (ScalarType) AnalyzerUtils.transformTableColumnType(catalogString);
+        Assert.assertEquals(ScalarType.OLAP_MAX_VARCHAR_LENGTH, convertedString.getLength());
     }
 
 }


### PR DESCRIPTION
Fixes error msg: `Getting analyzing error. Detail message: Varchar size must be <= 1048576: 1073741824.` in CTAS.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
