### PR TITLE
[Enhancement] BitmapValue support copy on write

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -96,27 +96,15 @@ void AdaptiveNullableColumn::append(const Column& src, size_t offset, size_t cou
     NullableColumn::append(src, offset, count);
 }
 
-void AdaptiveNullableColumn::append_shallow_copy(const Column& src, size_t offset, size_t count) {
-    materialized_nullable();
-    NullableColumn::append_shallow_copy(src, offset, count);
-}
-
 void AdaptiveNullableColumn::append_selective(const Column& src, const uint32_t* indexes, uint32_t from,
                                               uint32_t size) {
     materialized_nullable();
     NullableColumn::append_selective(src, indexes, from, size);
 }
 
-void AdaptiveNullableColumn::append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
-                                                           uint32_t size) {
+void AdaptiveNullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     materialized_nullable();
-    NullableColumn::append_selective_shallow_copy(src, indexes, from, size);
-}
-
-void AdaptiveNullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
-                                                         bool deep_copy) {
-    materialized_nullable();
-    NullableColumn::append_value_multiple_times(src, index, size, deep_copy);
+    NullableColumn::append_value_multiple_times(src, index, size);
 }
 
 bool AdaptiveNullableColumn::append_nulls(size_t count) {

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -268,14 +268,9 @@ public:
 
     void append(const Column& src, size_t offset, size_t count) override;
 
-    void append_shallow_copy(const Column& src, size_t offset, size_t count) override;
-
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
-                                       uint32_t size) override;
-
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/array_column.cpp
+++ b/be/src/column/array_column.cpp
@@ -125,7 +125,7 @@ void ArrayColumn::append_selective(const Column& src, const uint32_t* indexes, u
 }
 
 // TODO(fzh): directly copy elements for un-nested arrays
-void ArrayColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
+void ArrayColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     for (uint32_t i = 0; i < size; i++) {
         append(src, index, 1);
     }

--- a/be/src/column/array_column.h
+++ b/be/src/column/array_column.h
@@ -83,7 +83,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -90,8 +90,7 @@ void BinaryColumnBase<T>::append_selective(const Column& src, const uint32_t* in
 }
 
 template <typename T>
-void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
-                                                      bool deep_copy) {
+void BinaryColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     auto& src_column = down_cast<const BinaryColumnBase<T>&>(src);
     auto& src_offsets = src_column.get_offset();
     auto& src_bytes = src_column.get_bytes();

--- a/be/src/column/binary_column.h
+++ b/be/src/column/binary_column.h
@@ -188,7 +188,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     bool append_nulls(size_t count) override { return false; }
 

--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -159,11 +159,7 @@ public:
     // The type of |src| and |this| must be exactly matched.
     virtual void append(const Column& src, size_t offset, size_t count) = 0;
 
-    virtual void append_shallow_copy(const Column& src, size_t offset, size_t count) { append(src, offset, count); }
-
     virtual void append(const Column& src) { append(src, 0, src.size()); }
-
-    virtual void append_shallow_copy(const Column& src) { append_shallow_copy(src, 0, src.size()); }
 
     // replicate a column to align with an array's offset, used for captured columns in lambda functions
     // for example: column(1,2)->replicate({0,2,5}) = column(1,1,2,2,2)
@@ -175,7 +171,7 @@ public:
         DCHECK(this->size() >= dest_size) << "The size of the source column is less when duplicating it.";
         dest->reserve(offsets.back());
         for (int i = 0; i < dest_size; ++i) {
-            dest->append_value_multiple_times(*this, i, offsets[i + 1] - offsets[i], true);
+            dest->append_value_multiple_times(*this, i, offsets[i + 1] - offsets[i]);
         }
         return dest;
     }
@@ -203,22 +199,13 @@ public:
     // This function will copy the [3, 2] row of src to this column.
     virtual void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) = 0;
 
-    virtual void append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
-                                               uint32_t size) {
-        return append_selective(src, indexes, from, size);
-    }
-
     void append_selective(const Column& src, const Buffer<uint32_t>& indexes) {
         return append_selective(src, indexes.data(), 0, static_cast<uint32_t>(indexes.size()));
     }
 
-    void append_selective_shallow_copy(const Column& src, const Buffer<uint32_t>& indexes) {
-        return append_selective_shallow_copy(src, indexes.data(), 0, static_cast<uint32_t>(indexes.size()));
-    }
-
     // This function will get row through 'from' index from src, and copy size elements to this column.
     // Currently only `ObjectColumn<BitmapValue>` support shallow copy
-    virtual void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) = 0;
+    virtual void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) = 0;
 
     // Append multiple `null` values into this column.
     // Return false if this is a non-nullable column, i.e, if `is_nullable` return false.

--- a/be/src/column/const_column.cpp
+++ b/be/src/column/const_column.cpp
@@ -48,7 +48,7 @@ void ConstColumn::append_selective(const Column& src, const uint32_t* indexes, u
     append(src, indexes[from], size);
 }
 
-void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
+void ConstColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     append(src, index, size);
 }
 

--- a/be/src/column/const_column.h
+++ b/be/src/column/const_column.h
@@ -106,7 +106,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     ColumnPtr replicate(const std::vector<uint32_t>& offsets) override;
 

--- a/be/src/column/fixed_length_column_base.cpp
+++ b/be/src/column/fixed_length_column_base.cpp
@@ -54,8 +54,7 @@ void FixedLengthColumnBase<T>::append_selective(const Column& src, const uint32_
 }
 
 template <typename T>
-void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
-                                                           bool deep_copy) {
+void FixedLengthColumnBase<T>::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     const T* src_data = reinterpret_cast<const T*>(src.raw_data());
     size_t orig_size = _data.size();
     _data.resize(orig_size + size);

--- a/be/src/column/fixed_length_column_base.h
+++ b/be/src/column/fixed_length_column_base.h
@@ -119,7 +119,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     [[nodiscard]] bool append_nulls(size_t count __attribute__((unused))) override { return false; }
 

--- a/be/src/column/map_column.cpp
+++ b/be/src/column/map_column.cpp
@@ -133,7 +133,7 @@ void MapColumn::append_selective(const Column& src, const uint32_t* indexes, uin
     }
 }
 
-void MapColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
+void MapColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     for (uint32_t i = 0; i < size; i++) {
         append(src, index, 1);
     }

--- a/be/src/column/map_column.h
+++ b/be/src/column/map_column.h
@@ -82,7 +82,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -109,8 +109,7 @@ void NullableColumn::append_selective(const Column& src, const uint32_t* indexes
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
-void NullableColumn::append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
-                                                   uint32_t size) {
+void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     size_t orig_size = _null_column->size();
     if (src.only_null()) {
@@ -120,52 +119,12 @@ void NullableColumn::append_selective_shallow_copy(const Column& src, const uint
 
         DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
 
-        _null_column->append_selective(*src_column._null_column, indexes, from, size);
-        _data_column->append_selective_shallow_copy(*src_column._data_column, indexes, from, size);
+        _null_column->append_value_multiple_times(*src_column._null_column, index, size);
+        _data_column->append_value_multiple_times(*src_column._data_column, index, size);
         _has_null = _has_null || SIMD::contain_nonzero(_null_column->get_data(), orig_size, size);
     } else {
         _null_column->resize(orig_size + size);
-        _data_column->append_selective_shallow_copy(src, indexes, from, size);
-    }
-
-    DCHECK_EQ(_null_column->size(), _data_column->size());
-}
-
-void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
-    DCHECK_EQ(_null_column->size(), _data_column->size());
-    size_t orig_size = _null_column->size();
-    if (src.only_null()) {
-        append_nulls(size);
-    } else if (src.is_nullable()) {
-        const auto& src_column = down_cast<const NullableColumn&>(src);
-
-        DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
-
-        _null_column->append_value_multiple_times(*src_column._null_column, index, size, deep_copy);
-        _data_column->append_value_multiple_times(*src_column._data_column, index, size, deep_copy);
-        _has_null = _has_null || SIMD::contain_nonzero(_null_column->get_data(), orig_size, size);
-    } else {
-        _null_column->resize(orig_size + size);
-        _data_column->append_value_multiple_times(src, index, size, deep_copy);
-    }
-
-    DCHECK_EQ(_null_column->size(), _data_column->size());
-}
-
-void NullableColumn::append_shallow_copy(const Column& src, size_t offset, size_t count) {
-    if (src.only_null()) {
-        append_nulls(count);
-    } else if (src.is_nullable()) {
-        const auto& c = down_cast<const NullableColumn&>(src);
-
-        DCHECK_EQ(c._null_column->size(), c._data_column->size());
-
-        _null_column->append(*c._null_column, offset, count);
-        _data_column->append_shallow_copy(*c._data_column, offset, count);
-        _has_null = _has_null || SIMD::contain_nonzero(c._null_column->get_data(), offset, count);
-    } else {
-        _null_column->resize(_null_column->size() + count);
-        _data_column->append_shallow_copy(src, offset, count);
+        _data_column->append_value_multiple_times(src, index, size);
     }
 
     DCHECK_EQ(_null_column->size(), _data_column->size());

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -140,12 +140,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
-                                       uint32_t size) override;
-
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
-
-    void append_shallow_copy(const Column& src, size_t offset, size_t count) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     bool append_nulls(size_t count) override;
 

--- a/be/src/column/object_column.cpp
+++ b/be/src/column/object_column.cpp
@@ -94,20 +94,6 @@ void ObjectColumn<T>::append(const Column& src, size_t offset, size_t count) {
 }
 
 template <typename T>
-void ObjectColumn<T>::append_shallow_copy(const Column& src, size_t offset, size_t count) {
-    const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
-    if constexpr (std::is_same_v<T, BitmapValue>) {
-        for (size_t i = offset; i < count + offset; ++i) {
-            append({*obj_col.get_object(i), false});
-        }
-    } else {
-        for (size_t i = offset; i < count + offset; ++i) {
-            append(obj_col.get_object(i));
-        }
-    }
-}
-
-template <typename T>
 void ObjectColumn<T>::append_selective(const starrocks::Column& src, const uint32_t* indexes, uint32_t from,
                                        uint32_t size) {
     const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
@@ -117,32 +103,10 @@ void ObjectColumn<T>::append_selective(const starrocks::Column& src, const uint3
 }
 
 template <typename T>
-void ObjectColumn<T>::append_selective_shallow_copy(const starrocks::Column& src, const uint32_t* indexes,
-                                                    uint32_t from, uint32_t size) {
+void ObjectColumn<T>::append_value_multiple_times(const starrocks::Column& src, uint32_t index, uint32_t size) {
     const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
-    if constexpr (std::is_same_v<T, BitmapValue>) {
-        for (uint32_t j = 0; j < size; ++j) {
-            append({*obj_col.get_object(indexes[from + j]), false});
-        }
-    } else {
-        for (uint32_t j = 0; j < size; ++j) {
-            append(obj_col.get_object(indexes[from + j]));
-        }
-    }
-}
-
-template <typename T>
-void ObjectColumn<T>::append_value_multiple_times(const starrocks::Column& src, uint32_t index, uint32_t size,
-                                                  bool deep_copy) {
-    const auto& obj_col = down_cast<const ObjectColumn<T>&>(src);
-    if constexpr (std::is_same_v<T, BitmapValue>) {
-        for (uint32_t i = 0; i < size; i++) {
-            append({*obj_col.get_object(index), deep_copy});
-        }
-    } else {
-        for (uint32_t i = 0; i < size; i++) {
-            append(obj_col.get_object(index));
-        }
+    for (uint32_t i = 0; i < size; i++) {
+        append(obj_col.get_object(index));
     }
 }
 

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -104,14 +104,9 @@ public:
 
     void append(const Column& src, size_t offset, size_t count) override;
 
-    void append_shallow_copy(const Column& src, size_t offset, size_t count) override;
-
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
-                                       uint32_t size) override;
-
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     bool append_nulls(size_t count) override { return false; }
 

--- a/be/src/column/struct_column.cpp
+++ b/be/src/column/struct_column.cpp
@@ -169,12 +169,12 @@ void StructColumn::append_selective(const Column& src, const uint32_t* indexes, 
     }
 }
 
-void StructColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
+void StructColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) {
     DCHECK(src.is_struct());
     const auto& src_column = down_cast<const StructColumn&>(src);
     DCHECK_EQ(_fields.size(), src_column._fields.size());
     for (size_t i = 0; i < _fields.size(); i++) {
-        _fields[i]->append_value_multiple_times(*src_column._fields[i], index, size, deep_copy);
+        _fields[i]->append_value_multiple_times(*src_column._fields[i], index, size);
     }
 }
 

--- a/be/src/column/struct_column.h
+++ b/be/src/column/struct_column.h
@@ -108,7 +108,7 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
-    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
+    void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size) override;
 
     [[nodiscard]] bool append_nulls(size_t count) override;
 

--- a/be/src/exec/cross_join_node.cpp
+++ b/be/src/exec/cross_join_node.cpp
@@ -186,7 +186,7 @@ void CrossJoinNode::_copy_probe_rows_with_index_base_probe(ColumnPtr& dest_col, 
             dest_col->append_nulls(copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
         }
     } else {
         if (src_col->is_constant()) {
@@ -197,7 +197,7 @@ void CrossJoinNode::_copy_probe_rows_with_index_base_probe(ColumnPtr& dest_col, 
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, copy_number);
         } else {
             // repeat the value from probe table for copy_number times
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number, false);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, copy_number);
         }
     }
 }
@@ -258,14 +258,14 @@ void CrossJoinNode::_copy_build_rows_with_index_base_build(ColumnPtr& dest_col, 
             _buf_selective.assign(row_count, 0);
             dest_col->append_selective(*const_col->data_column(), &_buf_selective[0], 0, row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
         }
     } else {
         if (src_col->is_constant()) {
             // current can't reach here
             dest_col->append_nulls(row_count);
         } else {
-            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count, false);
+            dest_col->append_value_multiple_times(*src_col.get(), start_row, row_count);
         }
     }
 }

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -615,12 +615,11 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& 
                                                                const SlotDescriptor* slot, bool to_nullable) {
     if (to_nullable) {
         auto data_column = src_column->clone_empty();
-        data_column->append_selective_shallow_copy(*src_column, _probe_state->build_index.data(), 0,
-                                                   _probe_state->count);
+        data_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
 
         // When left outer join is executed,
         // build_index[i] Equal to 0 means it is not found in the hash table,
-        // but append_selective_shallow_copy() has set item of NullColumn to not null
+        // but append_selective() has set item of NullColumn to not null
         // so NullColumn needs to be set back to null
         auto null_column = NullColumn::create(_probe_state->count, 0);
         size_t end = _probe_state->count;
@@ -633,8 +632,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_column(const ColumnPtr& 
         (*chunk)->append_column(std::move(dest_column), slot->id());
     } else {
         auto dest_column = src_column->clone_empty();
-        dest_column->append_selective_shallow_copy(*src_column, _probe_state->build_index.data(), 0,
-                                                   _probe_state->count);
+        dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
         (*chunk)->append_column(std::move(dest_column), slot->id());
     }
 }
@@ -644,11 +642,11 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::_copy_build_nullable_column(const Co
                                                                         const SlotDescriptor* slot) {
     ColumnPtr dest_column = src_column->clone_empty();
 
-    dest_column->append_selective_shallow_copy(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
+    dest_column->append_selective(*src_column, _probe_state->build_index.data(), 0, _probe_state->count);
 
     // When left outer join is executed,
     // build_index[i] Equal to 0 means it is not found in the hash table,
-    // but append_selective_shallow_copy() has set item of NullColumn to not null
+    // but append_selective() has set item of NullColumn to not null
     // so NullColumn needs to be set back to null
     auto* null_column = ColumnHelper::as_raw_column<NullableColumn>(dest_column);
     size_t end = _probe_state->count;

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -420,10 +420,10 @@ void NLJoinProbeOperator::_permute_probe_row(RuntimeState* state, const ChunkPtr
         ColumnPtr& dst_col = chunk->get_column_by_slot_id(slot->id());
         if (is_probe) {
             ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot->id());
-            dst_col->append_value_multiple_times(*src_col, _probe_row_current, cur_build_chunk_rows, true);
+            dst_col->append_value_multiple_times(*src_col, _probe_row_current, cur_build_chunk_rows);
         } else {
             ColumnPtr& src_col = _curr_build_chunk->get_column_by_slot_id(slot->id());
-            dst_col->append_shallow_copy(*src_col);
+            dst_col->append(*src_col);
         }
     }
 }

--- a/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/spillable_nljoin_probe_operator.cpp
@@ -103,10 +103,10 @@ void NLJoinProber::_permute_probe_row(Chunk* dst, const ChunkPtr& build_chunk) {
         ColumnPtr& dst_col = dst->get_column_by_slot_id(slot->id());
         if (is_probe) {
             ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot->id());
-            dst_col->append_value_multiple_times(*src_col, _probe_row_current, cur_build_chunk_rows, true);
+            dst_col->append_value_multiple_times(*src_col, _probe_row_current, cur_build_chunk_rows);
         } else {
             ColumnPtr& src_col = build_chunk->get_column_by_slot_id(slot->id());
-            dst_col->append_shallow_copy(*src_col);
+            dst_col->append(*src_col);
         }
     }
 }

--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -611,6 +611,7 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_subset_limit(FunctionContext* contex
         auto range_start = range_start_viewer.value(row);
         auto limit = limit_viewer.value(row);
 
+        // TODO: the result of bitmap_subset_limit(bitmap, -1, -1) maybe invalid
         if (range_start < 0) {
             range_start = 0;
         }

--- a/be/src/exprs/struct_functions.cpp
+++ b/be/src/exprs/struct_functions.cpp
@@ -33,7 +33,7 @@ StatusOr<ColumnPtr> StructFunctions::new_struct(FunctionContext* context, const 
             fields[i]->append_nulls(column->size());
         } else if (column->is_constant()) {
             auto* cc = ColumnHelper::get_data_column(column.get());
-            fields[i]->append_value_multiple_times(*cc, 0, column->size(), true);
+            fields[i]->append_value_multiple_times(*cc, 0, column->size());
         } else {
             fields[i]->append(*column, 0, column->size());
         }

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -34,9 +34,9 @@
 
 #include "types/bitmap_value.h"
 
-#include "gutil/strings/split.h"
 #include "gutil/strings/substitute.h"
 #include "types/bitmap_value_detail.h"
+#include "util/defer_op.h"
 #include "util/phmap/phmap.h"
 
 namespace starrocks {
@@ -61,9 +61,14 @@ static void get_only_value_to_set_and_common_value_to_bitmap(const phmap::flat_h
 BitmapValue::BitmapValue() = default;
 
 BitmapValue::BitmapValue(BitmapValue&& other) noexcept
-        : _bitmap(std::move(other._bitmap)), _set(std::move(other._set)), _sv(other._sv), _type(other._type) {
+        : _bitmap(std::move(other._bitmap)),
+          _set(std::move(other._set)),
+          _sv(other._sv),
+          _type(other._type),
+          _shared(other._shared) {
     other._sv = 0;
     other._type = EMPTY;
+    other._shared = false;
 }
 
 BitmapValue& BitmapValue::operator=(BitmapValue&& other) noexcept {
@@ -72,8 +77,10 @@ BitmapValue& BitmapValue::operator=(BitmapValue&& other) noexcept {
         this->_set = std::move(other._set);
         this->_sv = other._sv;
         this->_type = other._type;
+        this->_shared = other._shared;
         other._sv = 0;
         other._type = EMPTY;
+        other._shared = false;
     }
     return *this;
 }
@@ -88,25 +95,35 @@ BitmapValue::BitmapValue(const char* src) {
 }
 
 BitmapValue::BitmapValue(const Slice& src) {
-    deserialize(src.data);
+    bool res = deserialize(src.data);
+    DCHECK(res);
 }
 
-BitmapValue::BitmapValue(const BitmapValue& other, bool deep_copy)
+BitmapValue::BitmapValue(const BitmapValue& other)
         : _set(other._set == nullptr ? nullptr : std::make_unique<phmap::flat_hash_set<uint64_t>>(*other._set)),
           _sv(other._sv),
           _type(other._type) {
     // TODO: _set is usually relatively small, and it needs system performance testing to decide
     //  whether to change std::unique_ptr to std::shared_ptr and support shallow copy
-    if (deep_copy) {
-        _bitmap = (other._bitmap == nullptr) ? nullptr : std::make_shared<detail::Roaring64Map>(*other._bitmap);
+    if (other._type == BITMAP) {
+        _bitmap = other._bitmap;
+        _shared = true;
+        other._shared = true;
     } else {
-        _bitmap = (other._bitmap == nullptr) ? nullptr : other._bitmap;
+        _shared = false;
     }
 }
 
 BitmapValue& BitmapValue::operator=(const BitmapValue& other) {
     if (this != &other) {
-        this->_bitmap = (other._bitmap == nullptr ? nullptr : std::make_shared<detail::Roaring64Map>(*other._bitmap));
+        if (other._type == BITMAP) {
+            _bitmap = other._bitmap;
+            _shared = true;
+            other._shared = true;
+        } else {
+            _bitmap = nullptr;
+            _shared = false;
+        }
         this->_set = other._set == nullptr ? nullptr : std::make_unique<phmap::flat_hash_set<uint64_t>>(*other._set);
         this->_sv = other._sv;
         this->_type = other._type;
@@ -116,6 +133,8 @@ BitmapValue& BitmapValue::operator=(const BitmapValue& other) {
 
 // Construct a bitmap from given elements.
 BitmapValue::BitmapValue(const std::vector<uint64_t>& bits) {
+    _shared = false;
+    // TODO: why not use SET ?
     switch (bits.size()) {
     case 0:
         _type = EMPTY;
@@ -133,6 +152,7 @@ BitmapValue::BitmapValue(const std::vector<uint64_t>& bits) {
 
 void BitmapValue::_from_set_to_bitmap() {
     _bitmap = std::make_shared<detail::Roaring64Map>();
+    _shared = false;
     for (auto x : *_set) {
         _bitmap->add(x);
     }
@@ -156,20 +176,24 @@ BitmapValue& BitmapValue::operator|=(const BitmapValue& rhs) {
     case BITMAP:
         switch (_type) {
         case EMPTY:
-            // TODO: Reduce memory copy.
-            _bitmap = std::make_shared<detail::Roaring64Map>(*rhs._bitmap);
+            _bitmap = rhs._bitmap;
+            _shared = true;
+            rhs._shared = true;
             _type = BITMAP;
             break;
         case SINGLE:
             _bitmap = std::make_shared<detail::Roaring64Map>(*rhs._bitmap);
+            _shared = false;
             _bitmap->add(_sv);
             _type = BITMAP;
             break;
         case BITMAP:
+            _copy_on_write();
             *_bitmap |= *rhs._bitmap;
             break;
         case SET:
             _bitmap = std::make_shared<detail::Roaring64Map>(*rhs._bitmap);
+            _shared = false;
             for (auto x : *_set) {
                 _bitmap->add(x);
             }
@@ -199,10 +223,10 @@ BitmapValue& BitmapValue::operator|=(const BitmapValue& rhs) {
             }
             break;
         case BITMAP:
+            _copy_on_write();
             for (auto x : *rhs._set) {
                 _bitmap->add(x);
             }
-            _type = BITMAP;
             break;
         }
     }
@@ -237,6 +261,7 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
                 _sv = rhs._sv;
             }
             _bitmap.reset();
+            _shared = false;
             break;
         case SET:
             if (!_set->contains(rhs._sv)) {
@@ -259,6 +284,7 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
             }
             break;
         case BITMAP:
+            _copy_on_write();
             *_bitmap &= *rhs._bitmap;
             _from_bitmap_to_smaller_type();
             break;
@@ -292,6 +318,7 @@ BitmapValue& BitmapValue::operator&=(const BitmapValue& rhs) {
             }
             _set = std::move(set);
             _bitmap.reset();
+            _shared = false;
             _type = SET;
             break;
         }
@@ -321,6 +348,7 @@ void BitmapValue::remove(uint64_t rhs) {
         }
         break;
     case BITMAP:
+        _copy_on_write();
         _bitmap->remove(rhs);
         break;
     case SET:
@@ -343,6 +371,7 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
             }
             break;
         case BITMAP:
+            _copy_on_write();
             _bitmap->remove(rhs._sv);
             break;
         case SET:
@@ -360,6 +389,7 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
             }
             break;
         case BITMAP:
+            _copy_on_write();
             *_bitmap -= *rhs._bitmap;
             _from_bitmap_to_smaller_type();
             break;
@@ -385,6 +415,7 @@ BitmapValue& BitmapValue::operator-=(const BitmapValue& rhs) {
             }
             break;
         case BITMAP: {
+            _copy_on_write();
             for (auto x : *rhs._set) {
                 _bitmap->remove(x);
             }
@@ -424,6 +455,7 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
             }
             break;
         case BITMAP:
+            _copy_on_write();
             if (_bitmap->contains(rhs._sv)) {
                 _bitmap->remove(rhs._sv);
             } else {
@@ -442,11 +474,14 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
     case BITMAP:
         switch (_type) {
         case EMPTY:
-            _bitmap = std::make_shared<detail::Roaring64Map>(*rhs._bitmap);
+            _bitmap = rhs._bitmap;
+            _shared = true;
+            rhs._shared = true;
             _type = BITMAP;
             break;
         case SINGLE:
             _bitmap = std::make_shared<detail::Roaring64Map>(*rhs._bitmap);
+            _shared = false;
             if (_bitmap->contains(_sv)) {
                 _bitmap->remove(_sv);
             } else {
@@ -455,6 +490,7 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
             _type = BITMAP;
             break;
         case BITMAP: {
+            _copy_on_write();
             *_bitmap ^= *rhs._bitmap;
             break;
         }
@@ -466,6 +502,7 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
 
             // obtain values only in right bitmap
             _bitmap = std::make_shared<detail::Roaring64Map>(*rhs._bitmap);
+            _shared = false;
             *_bitmap -= bitmap;
 
             // collect all values that only in left set or only in right bitmap.
@@ -502,6 +539,7 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
 
             // obtain values only in left bitmap
             *_bitmap -= bitmap;
+            _shared = false;
 
             // collect all values that only in right set or only in left bitmap.
             for (auto x : set) {
@@ -538,7 +576,7 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
 }
 
 // check if value x is present
-bool BitmapValue::contains(uint64_t x) {
+bool BitmapValue::contains(uint64_t x) const {
     switch (_type) {
     case EMPTY:
         return false;
@@ -658,7 +696,6 @@ void BitmapValue::write(char* dst) const {
         _bitmap->write(dst, config::bitmap_serialize_version);
         break;
     case SET:
-
         *dst = BitmapTypeCode::SET;
         dst += 1;
         uint32_t size = _set->size();
@@ -674,6 +711,7 @@ void BitmapValue::write(char* dst) const {
 // Deserialize a bitmap value from `src`.
 // Return false if `src` begins with unknown type code, true otherwise.
 bool BitmapValue::deserialize(const char* src) {
+    _shared = false;
     if (src == nullptr) {
         _type = EMPTY;
         return true;
@@ -690,6 +728,7 @@ bool BitmapValue::deserialize(const char* src) {
         break;
     case BitmapTypeCode::SINGLE64:
         _type = SINGLE;
+        _shared = false;
         _sv = decode_fixed64_le(reinterpret_cast<const uint8_t*>(src + 1));
         break;
     case BitmapTypeCode::BITMAP32:
@@ -730,6 +769,7 @@ bool BitmapValue::valid_and_deserialize(const char* src, size_t max_bytes) {
 
     if (src == nullptr) {
         _type = EMPTY;
+        _shared = false;
         return true;
     }
 
@@ -794,6 +834,7 @@ bool BitmapValue::valid_and_deserialize(const char* src, size_t max_bytes) {
         default:
             return false;
         }
+        _shared = false;
         return true;
     }
 }
@@ -880,6 +921,7 @@ size_t BitmapValue::serialize(uint8_t* dst) const {
 // This method should be called before `serialize_size`.
 void BitmapValue::compress() const {
     if (_type == BITMAP) {
+        // no need to copy on write
         _bitmap->runOptimize();
         _bitmap->shrinkToFit();
     }
@@ -887,13 +929,18 @@ void BitmapValue::compress() const {
 
 void BitmapValue::clear() {
     if (_bitmap != nullptr) {
-        _bitmap->clear();
+        if (!_shared || _bitmap.use_count() <= 1) {
+            _bitmap->clear();
+        } else {
+            _bitmap.reset();
+        }
     }
     if (_set != nullptr) {
         _set->clear();
     }
     _sv = 0;
     _type = EMPTY;
+    _shared = false;
 }
 
 void BitmapValue::reset() {
@@ -901,6 +948,7 @@ void BitmapValue::reset() {
     _set.reset();
     _sv = 0;
     _type = EMPTY;
+    _shared = false;
 }
 
 void BitmapValue::_from_bitmap_to_smaller_type() {
@@ -915,9 +963,10 @@ void BitmapValue::_from_bitmap_to_smaller_type() {
         _sv = min_value.value();
     }
     _bitmap.reset();
+    _shared = false;
 }
 
-int64_t BitmapValue::sub_bitmap_internal(const int64_t& offset, const int64_t& len, BitmapValue* ret_bitmap) {
+int64_t BitmapValue::sub_bitmap_internal(const int64_t& offset, const int64_t& len, BitmapValue* ret_bitmap) const {
     switch (_type) {
     case EMPTY:
         return 0;
@@ -973,7 +1022,7 @@ int64_t BitmapValue::sub_bitmap_internal(const int64_t& offset, const int64_t& l
 }
 
 int64_t BitmapValue::bitmap_subset_limit_internal(const int64_t& range_start, const int64_t& limit,
-                                                  BitmapValue* ret_bitmap) {
+                                                  BitmapValue* ret_bitmap) const {
     switch (_type) {
     case EMPTY:
         return 0;
@@ -1042,7 +1091,8 @@ int64_t BitmapValue::bitmap_subset_limit_internal(const int64_t& range_start, co
 }
 
 int64_t BitmapValue::bitmap_subset_in_range_internal(const int64_t& range_start, const int64_t& range_end,
-                                                     BitmapValue* ret_bitmap) {
+                                                     BitmapValue* ret_bitmap) const {
+    // range_end < range_start already checked in BitmapFunctions::bitmap_subset_in_range
     switch (_type) {
     case EMPTY:
         return 0;
@@ -1084,8 +1134,26 @@ void BitmapValue::add_many(size_t n_args, const uint32_t* vals) {
             add(vals[i]);
         }
     } else {
+        _copy_on_write();
         _bitmap->addMany(n_args, vals);
     }
+}
+
+void BitmapValue::_copy_on_write() {
+    if (_bitmap == nullptr) {
+        _bitmap = std::make_shared<detail::Roaring64Map>();
+        _shared = false;
+        return;
+    }
+
+    if (!_shared) {
+        return;
+    }
+
+    if (_bitmap.use_count() > 1) {
+        _bitmap = std::make_shared<detail::Roaring64Map>(*_bitmap);
+    }
+    _shared = false;
 }
 
 void BitmapValue::add(uint64_t value) {
@@ -1106,6 +1174,7 @@ void BitmapValue::add(uint64_t value) {
         _type = SET;
         break;
     case BITMAP:
+        _copy_on_write();
         _bitmap->add(value);
         break;
     case SET:

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -161,7 +161,8 @@ public:
 
     int64_t sub_bitmap_internal(const int64_t& offset, const int64_t& len, BitmapValue* ret_bitmap) const;
 
-    int64_t bitmap_subset_limit_internal(const int64_t& range_start, const int64_t& limit, BitmapValue* ret_bitmap) const;
+    int64_t bitmap_subset_limit_internal(const int64_t& range_start, const int64_t& limit,
+                                         BitmapValue* ret_bitmap) const;
 
     int64_t bitmap_subset_in_range_internal(const int64_t& range_start, const int64_t& range_end,
                                             BitmapValue* ret_bitmap) const;

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -75,7 +75,7 @@ public:
     // Construct an empty bitmap.
     BitmapValue();
 
-    BitmapValue(const BitmapValue& other, bool deep_copy = true);
+    BitmapValue(const BitmapValue& other);
     BitmapValue& operator=(const BitmapValue& other);
 
     BitmapValue(BitmapValue&& other) noexcept;
@@ -119,7 +119,7 @@ public:
     BitmapValue& operator^=(const BitmapValue& rhs);
 
     // check if value x is present
-    bool contains(uint64_t x);
+    bool contains(uint64_t x) const;
 
     // TODO should the return type be uint64_t?
     int64_t cardinality() const;
@@ -159,23 +159,26 @@ public:
     void clear();
     void reset();
 
-    int64_t sub_bitmap_internal(const int64_t& offset, const int64_t& len, BitmapValue* ret_bitmap);
+    int64_t sub_bitmap_internal(const int64_t& offset, const int64_t& len, BitmapValue* ret_bitmap) const;
 
-    int64_t bitmap_subset_limit_internal(const int64_t& range_start, const int64_t& limit, BitmapValue* ret_bitmap);
+    int64_t bitmap_subset_limit_internal(const int64_t& range_start, const int64_t& limit, BitmapValue* ret_bitmap) const;
 
     int64_t bitmap_subset_in_range_internal(const int64_t& range_start, const int64_t& range_end,
-                                            BitmapValue* ret_bitmap);
+                                            BitmapValue* ret_bitmap) const;
 
     BitmapDataType type() const { return _type; }
+    bool is_shared() const { return _shared; }
 
 private:
     void _from_bitmap_to_smaller_type();
     void _from_set_to_bitmap();
+    void _copy_on_write();
 
     // Use shared_ptr, not unique_ptr, because we want to avoid unnecessary copy
     std::shared_ptr<detail::Roaring64Map> _bitmap = nullptr;
     std::unique_ptr<phmap::flat_hash_set<uint64_t>> _set;
     uint64_t _sv = 0; // store the single value when _type == SINGLE
     BitmapDataType _type{EMPTY};
+    mutable bool _shared = false;
 };
 } // namespace starrocks

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -23,7 +23,6 @@
 #include "runtime/types.h"
 #include "types/hll.h"
 #include "util/percentile_value.h"
-#include "util/phmap/phmap.h"
 
 namespace starrocks {
 
@@ -164,8 +163,8 @@ TEST(ObjectColumnTest, test_append_value_multiple_times) {
     }
     src_col->append(&bitmap);
 
-    deep_copy_col->append_value_multiple_times(*src_col, 0, 4, true);
-    shallow_copy_col->append_value_multiple_times(*src_col, 0, 4, false);
+    deep_copy_col->append_value_multiple_times(*src_col, 0, 4);
+    shallow_copy_col->append_value_multiple_times(*src_col, 0, 4);
     src_col->get_object(0)->add(64);
 
     for (size_t i = 0; i < 4; i++) {

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -154,8 +154,7 @@ TEST(ObjectColumnTest, test_object_column_upgrade_if_overflow) {
 // NOLINTNEXTLINE
 TEST(ObjectColumnTest, test_append_value_multiple_times) {
     auto src_col = BitmapColumn::create();
-    auto deep_copy_col = BitmapColumn::create();
-    auto shallow_copy_col = BitmapColumn::create();
+    auto copy_col = BitmapColumn::create();
 
     BitmapValue bitmap;
     for (size_t i = 0; i < 64; i++) {
@@ -163,13 +162,12 @@ TEST(ObjectColumnTest, test_append_value_multiple_times) {
     }
     src_col->append(&bitmap);
 
-    deep_copy_col->append_value_multiple_times(*src_col, 0, 4);
-    shallow_copy_col->append_value_multiple_times(*src_col, 0, 4);
+    copy_col->append_value_multiple_times(*src_col, 0, 4);
     src_col->get_object(0)->add(64);
 
     for (size_t i = 0; i < 4; i++) {
-        ASSERT_EQ(deep_copy_col->get_object(0)->cardinality(), 64);
-        ASSERT_EQ(shallow_copy_col->get_object(0)->cardinality(), 65);
+        ASSERT_EQ(copy_col->get_object(0)->cardinality(), 64);
+        ASSERT_EQ(src_col->get_object(0)->cardinality(), 65);
     }
 }
 

--- a/be/test/column/object_column_test.cpp
+++ b/be/test/column/object_column_test.cpp
@@ -165,9 +165,9 @@ TEST(ObjectColumnTest, test_append_value_multiple_times) {
     copy_col->append_value_multiple_times(*src_col, 0, 4);
     src_col->get_object(0)->add(64);
 
+    ASSERT_EQ(src_col->get_object(0)->cardinality(), 65);
     for (size_t i = 0; i < 4; i++) {
         ASSERT_EQ(copy_col->get_object(0)->cardinality(), 64);
-        ASSERT_EQ(src_col->get_object(0)->cardinality(), 65);
     }
 }
 

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -20,121 +20,857 @@
 #include <string>
 
 #include "column/vectorized_fwd.h"
-#include "exprs/bitmap_functions.h"
-#include "exprs/function_context.h"
 #include "types/bitmap_value_detail.h"
 #include "util/coding.h"
 
 namespace starrocks {
 
-TEST(BitmapValueTest, constructor) {
-    BitmapValue bitmap;
+using BitmapDataType = BitmapValue::BitmapDataType;
+
+class BitmapValueTest : public ::testing::Test {
+public:
+    void SetUp() override;
+    BitmapValue gen_bitmap(uint64_t start, uint64_t end);
+    void check_bitmap(BitmapDataType type, const BitmapValue& bitmap, uint64_t start, uint64_t end);
+    void check_bitmap(BitmapDataType type, const BitmapValue& bitmap, uint64_t start_1, uint64_t end_1,
+                      uint64_t start_2, uint64_t end_2);
+
+protected:
+    BitmapValue _large_bitmap;
+    BitmapValue _medium_bitmap;
+    BitmapValue _single_bitmap;
+    BitmapValue _empty_bitmap;
+};
+
+void BitmapValueTest::SetUp() {
     for (size_t i = 0; i < 64; i++) {
+        _large_bitmap.add(i);
+    }
+    for (size_t i = 0; i < 14; i++) {
+        _medium_bitmap.add(i);
+    }
+    _single_bitmap.add(0);
+}
+
+BitmapValue BitmapValueTest::gen_bitmap(uint64_t start, uint64_t end) {
+    BitmapValue bitmap;
+    for (auto i = start; i < end; i++) {
+        bitmap.add(i);
+    }
+    return bitmap;
+}
+
+void BitmapValueTest::check_bitmap(BitmapDataType type, const BitmapValue& bitmap, uint64_t start, uint64_t end) {
+    ASSERT_EQ(bitmap.type(), type);
+    ASSERT_EQ(bitmap.cardinality(), end - start);
+    for (auto i = start; i < end; i++) {
+        ASSERT_TRUE(bitmap.contains(i));
+    }
+}
+
+void BitmapValueTest::check_bitmap(BitmapDataType type, const BitmapValue& bitmap, uint64_t start_1, uint64_t end_1,
+                                   uint64_t start_2, uint64_t end_2) {
+    ASSERT_EQ(bitmap.type(), type);
+    ASSERT_EQ(bitmap.cardinality(), end_1 - start_1 + end_2 - start_2);
+    for (auto i = start_1; i < end_1; i++) {
+        ASSERT_TRUE(bitmap.contains(i));
+    }
+    for (auto i = start_2; i < end_2; i++) {
+        ASSERT_TRUE(bitmap.contains(i));
+    }
+}
+
+TEST_F(BitmapValueTest, copy_construct) {
+    BitmapValue bitmap_1(_large_bitmap);
+    bitmap_1.add(64);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 65);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_2(_medium_bitmap);
+    bitmap_2.add(14);
+    check_bitmap(BitmapDataType::SET, bitmap_2, 0, 15);
+}
+
+TEST_F(BitmapValueTest, assign_operator) {
+    BitmapValue bitmap_1 = _large_bitmap;
+    bitmap_1.add(64);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 65);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_2 = _medium_bitmap;
+    bitmap_2.add(14);
+    check_bitmap(BitmapDataType::SET, bitmap_2, 0, 15);
+
+    BitmapValue* bitmap_3 = &_large_bitmap;
+    *bitmap_3 = _large_bitmap;
+    bitmap_3->add(64);
+    check_bitmap(BitmapDataType::BITMAP, *bitmap_3, 0, 65);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 65);
+}
+
+TEST_F(BitmapValueTest, move_construct) {
+    BitmapValue bitmap_1(std::move(_large_bitmap));
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 64);
+    check_bitmap(BitmapDataType::EMPTY, _large_bitmap, 0, 0);
+
+    BitmapValue bitmap_2(std::move(_medium_bitmap));
+    check_bitmap(BitmapDataType::SET, bitmap_2, 0, 14);
+    check_bitmap(BitmapDataType::EMPTY, _medium_bitmap, 0, 0);
+}
+
+TEST_F(BitmapValueTest, move_assign_operator) {
+    BitmapValue* bitmap_1 = &_large_bitmap;
+    *bitmap_1 = std::move(_large_bitmap);
+    bitmap_1->add(64);
+    check_bitmap(BitmapDataType::BITMAP, *bitmap_1, 0, 65);
+
+    BitmapValue bitmap_2 = std::move(_large_bitmap);
+    bitmap_2.add(64);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_2, 0, 65);
+    check_bitmap(BitmapDataType::EMPTY, _large_bitmap, 0, 0);
+
+    BitmapValue bitmap_3 = std::move(_medium_bitmap);
+    bitmap_3.add(14);
+    check_bitmap(BitmapDataType::SET, bitmap_3, 0, 15);
+    check_bitmap(BitmapDataType::EMPTY, _medium_bitmap, 0, 0);
+}
+
+TEST_F(BitmapValueTest, single_construct) {
+    BitmapValue bitmap(1);
+    check_bitmap(BitmapDataType::SINGLE, bitmap, 1, 2);
+}
+
+TEST_F(BitmapValueTest, construct_from_deserialize) {
+    size_t size = _large_bitmap.serialize_size();
+    uint8_t buf[size];
+    _large_bitmap.serialize(buf);
+
+    BitmapValue bitmap_1((char*)buf);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 64);
+
+    Slice slice{(char*)&buf, size};
+    BitmapValue bitmap_2(slice);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_2, 0, 64);
+}
+
+TEST_F(BitmapValueTest, construct_from_vector) {
+    std::vector<uint64_t> v1{};
+    std::vector<uint64_t> v2{0};
+    std::vector<uint64_t> v3{1, 2, 3};
+    std::vector<uint64_t> v4;
+    for (size_t i = 0; i < 64; i++) {
+        v4.emplace_back(i);
+    }
+
+    BitmapValue bitmap_1(v1);
+    check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
+
+    BitmapValue bitmap_2(v2);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
+
+    BitmapValue bitmap_3(v3);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_3, 1, 4);
+
+    BitmapValue bitmap_4(v4);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_4, 0, 64);
+}
+
+TEST_F(BitmapValueTest, add) {
+    BitmapValue bitmap_1;
+    bitmap_1.add(0);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_1, 0, 1);
+
+    bitmap_1.add(0);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_1, 0, 1);
+
+    bitmap_1.add(1);
+    check_bitmap(BitmapDataType::SET, bitmap_1, 0, 2);
+
+    bitmap_1.add(2);
+    check_bitmap(BitmapDataType::SET, bitmap_1, 0, 3);
+
+    for (size_t i = 0; i < 33; i++) {
+        bitmap_1.add(i);
+    }
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 33);
+
+    for (size_t i = 0; i < 64; i++) {
+        bitmap_1.add(i);
+    }
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 64);
+
+    BitmapValue bitmap_2(bitmap_1);
+    bitmap_2.add(64);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_2, 0, 65);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 64);
+}
+
+TEST_F(BitmapValueTest, add_many) {
+    BitmapValue bitmap_1(_single_bitmap);
+    std::vector<uint32_t> v1{1, 2, 3};
+    bitmap_1.add_many(3, v1.data());
+    check_bitmap(BitmapDataType::SET, bitmap_1, 0, 4);
+
+    BitmapValue bitmap_2(_large_bitmap);
+    std::vector<uint32_t> v2{64, 65, 66};
+    bitmap_2.add_many(3, v2.data());
+    check_bitmap(BitmapDataType::BITMAP, bitmap_2, 0, 67);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+}
+
+TEST_F(BitmapValueTest, bitmap_union) {
+    auto bitmap_1 = gen_bitmap(0, 64);
+    bitmap_1 |= _empty_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 64);
+
+    auto bitmap_2 = gen_bitmap(1, 2);
+    bitmap_2 |= _single_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_2, 0, 2);
+
+    BitmapValue bitmap_3;
+    bitmap_3 |= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_3, 0, 14);
+
+    BitmapValue bitmap_4(14);
+    bitmap_4 |= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_4, 0, 15);
+
+    auto bitmap_5 = gen_bitmap(0, 32);
+    auto bitmap_6 = gen_bitmap(32, 33);
+    bitmap_6 |= bitmap_5;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_6, 0, 33);
+
+    auto bitmap_7 = gen_bitmap(14, 34);
+    bitmap_7 |= _medium_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_7, 0, 34);
+
+    BitmapValue bitmap_8(_large_bitmap);
+    auto bitmap_9 = gen_bitmap(64, 84);
+    bitmap_8 |= bitmap_9;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_8, 0, 84);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_10;
+    bitmap_10 |= _large_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_10, 0, 64);
+
+    BitmapValue bitmap_11(64);
+    bitmap_11 |= _large_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_11, 0, 65);
+
+    BitmapValue bitmap_12(_large_bitmap);
+    auto bitmap_13 = gen_bitmap(64, 164);
+    bitmap_12 |= bitmap_13;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_12, 0, 164);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_14(_medium_bitmap);
+    auto bitmap_15 = gen_bitmap(14, 132);
+    bitmap_14 |= bitmap_15;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_14, 0, 132);
+}
+
+TEST_F(BitmapValueTest, bitmap_intersect) {
+    auto bitmap_1 = gen_bitmap(0, 100);
+    bitmap_1 &= _empty_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
+
+    BitmapValue bitmap_2;
+    bitmap_2 &= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_2, 0, 0);
+
+    BitmapValue bitmap_3((uint64_t)0);
+    bitmap_3 &= _single_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_3, 0, 1);
+
+    BitmapValue bitmap_4(1);
+    bitmap_4 &= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_4, 0, 0);
+
+    auto bitmap_5 = gen_bitmap(0, 40);
+    bitmap_5 &= _single_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_5, 0, 1);
+
+    auto bitmap_6 = gen_bitmap(1, 40);
+    bitmap_6 &= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_6, 0, 0);
+
+    auto bitmap_7 = gen_bitmap(0, 10);
+    bitmap_7 &= _single_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_7, 0, 1);
+
+    auto bitmap_8 = gen_bitmap(1, 10);
+    bitmap_8 &= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_8, 0, 0);
+
+    auto bitmap_9 = gen_bitmap(0, 64);
+    bitmap_9 &= _empty_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_9, 0, 0);
+
+    auto bitmap_10 = gen_bitmap(0, 64);
+    bitmap_10 &= _single_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_10, 0, 1);
+
+    auto bitmap_11 = gen_bitmap(1, 65);
+    bitmap_11 &= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_11, 0, 0);
+
+    auto bitmap_13 = gen_bitmap(0, 100);
+    BitmapValue bitmap_14(bitmap_13);
+    auto bitmap_15 = gen_bitmap(80, 180);
+    bitmap_14 &= bitmap_15;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_14, 80, 100);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_13, 0, 100);
+    auto bitmap_16 = gen_bitmap(100, 200);
+    bitmap_16 &= bitmap_13;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_16, 0, 0);
+    auto bitmap_17 = gen_bitmap(99, 299);
+    bitmap_17 &= bitmap_13;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_17, 99, 100);
+
+    auto bitmap_18 = gen_bitmap(60, 80);
+    bitmap_18 &= _large_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_18, 60, 64);
+
+    BitmapValue bitmap_19;
+    bitmap_19 &= _medium_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_19, 0, 0);
+
+    BitmapValue bitmap_20((uint64_t)0);
+    bitmap_20 &= _medium_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_20, 0, 1);
+
+    BitmapValue bitmap_21(100);
+    bitmap_21 &= _medium_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_21, 0, 0);
+
+    auto bitmap_22 = gen_bitmap(10, 160);
+    bitmap_22 &= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_22, 10, 14);
+
+    auto bitmap_23 = gen_bitmap(10, 20);
+    bitmap_23 &= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_23, 10, 14);
+}
+
+TEST_F(BitmapValueTest, test_remove) {
+    BitmapValue bitmap_1;
+    bitmap_1.remove(1);
+    check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
+
+    BitmapValue bitmap_2(1);
+    bitmap_2.remove(1);
+    check_bitmap(BitmapDataType::EMPTY, bitmap_2, 0, 0);
+
+    BitmapValue bitmap_3(1);
+    bitmap_3.remove(2);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_3, 1, 2);
+
+    BitmapValue bitmap_4(_large_bitmap);
+    bitmap_4.remove(0);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_4, 1, 64);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_5(_medium_bitmap);
+    bitmap_5.remove(0);
+    check_bitmap(BitmapDataType::SET, bitmap_5, 1, 14);
+}
+
+TEST_F(BitmapValueTest, bitmap_sub) {
+    BitmapValue bitmap_1(_large_bitmap);
+    bitmap_1 -= _empty_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 64);
+
+    BitmapValue bitmap_2;
+    bitmap_2 -= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_2, 0, 0);
+
+    BitmapValue bitmap_3((uint64_t)0);
+    bitmap_3 -= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_3, 0, 0);
+
+    BitmapValue bitmap_4(1);
+    bitmap_4 -= _single_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_4, 1, 2);
+
+    BitmapValue bitmap_5(_large_bitmap);
+    bitmap_5 -= _single_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_5, 1, 64);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_6(_medium_bitmap);
+    bitmap_6 -= _single_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_6, 1, 14);
+
+    BitmapValue bitmap_7;
+    bitmap_7 -= _large_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_7, 0, 0);
+
+    BitmapValue bitmap_8((uint64_t)0);
+    bitmap_8 -= _large_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_8, 0, 0);
+
+    BitmapValue bitmap_9(128);
+    bitmap_9 -= _large_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_9, 128, 129);
+
+    auto bitmap_10 = gen_bitmap(30, 200);
+    BitmapValue bitmap_11(bitmap_10);
+    bitmap_11 -= _large_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_11, 64, 200);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    auto bitmap_12 = gen_bitmap(50, 120);
+    bitmap_12 -= _large_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_12, 64, 120);
+
+    auto bitmap_13 = gen_bitmap(50, 70);
+    bitmap_13 -= _large_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_13, 64, 70);
+
+    BitmapValue bitmap_14;
+    bitmap_14 -= _medium_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_14, 0, 0);
+
+    BitmapValue bitmap_15((uint64_t)0);
+    bitmap_15 -= _medium_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_15, 0, 0);
+
+    BitmapValue bitmap_16(100);
+    bitmap_16 -= _medium_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_16, 100, 101);
+
+    BitmapValue bitmap_17(_large_bitmap);
+    bitmap_17 -= _medium_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_17, 14, 64);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    auto bitmap_18 = gen_bitmap(1, 65);
+    bitmap_18 -= _large_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_18, 64, 65);
+
+    auto bitmap_19 = gen_bitmap(3, 16);
+    bitmap_19 -= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_19, 14, 16);
+}
+
+TEST_F(BitmapValueTest, bitmap_xor) {
+    BitmapValue bitmap_1(_large_bitmap);
+    bitmap_1 ^= _empty_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_1, 0, 64);
+
+    BitmapValue bitmap_2;
+    bitmap_2 ^= _single_bitmap;
+    check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
+
+    BitmapValue bitmap_3(1);
+    bitmap_3 ^= _single_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_3, 0, 2);
+
+    BitmapValue bitmap_4((uint64_t)0);
+    bitmap_4 ^= _single_bitmap;
+    check_bitmap(BitmapDataType::EMPTY, bitmap_4, 0, 0);
+
+    BitmapValue bitmap_5(_large_bitmap);
+    bitmap_5 ^= _single_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_5, 1, 64);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_6(_large_bitmap);
+    auto bitmap_7 = gen_bitmap(64, 65);
+    bitmap_6 ^= bitmap_7;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_6, 0, 65);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    BitmapValue bitmap_8(_medium_bitmap);
+    bitmap_8 ^= _single_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_8, 1, 14);
+
+    BitmapValue bitmap_9(_medium_bitmap);
+    auto bitmap_10 = gen_bitmap(14, 15);
+    bitmap_9 ^= bitmap_10;
+    check_bitmap(BitmapDataType::SET, bitmap_9, 0, 15);
+
+    BitmapValue bitmap_11(_large_bitmap);
+    bitmap_11 ^= _empty_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_11, 0, 64);
+
+    BitmapValue bitmap_12((uint64_t)0);
+    bitmap_12 ^= _large_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_12, 1, 64);
+
+    BitmapValue bitmap_13(64);
+    bitmap_13 ^= _large_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_13, 0, 65);
+
+    // BITMAP ^= SET
+    auto bitmap_14 = gen_bitmap(20, 80);
+    BitmapValue bitmap_15(_large_bitmap);
+    bitmap_15 ^= bitmap_14;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_15, 0, 20, 64, 80);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+
+    auto bitmap_16 = gen_bitmap(60, 80);
+    bitmap_16 ^= _large_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_16, 0, 60, 64, 80);
+
+    // EMPTY ^= SET
+    BitmapValue bitmap_17;
+    bitmap_17 ^= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_17, 0, 14);
+
+    BitmapValue bitmap_18((uint64_t)0);
+    bitmap_18 ^= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_18, 1, 14);
+
+    // SINGLE ^= SET
+    BitmapValue bitmap_19(100);
+    bitmap_19 ^= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_19, 0, 14, 100, 101);
+
+    // BITMAP ^= SET -> BITMAP
+    auto bitmap_20 = gen_bitmap(10, 80);
+    bitmap_20 ^= _medium_bitmap;
+    check_bitmap(BitmapDataType::BITMAP, bitmap_20, 0, 10, 14, 80);
+
+    // SET ^= SET -> SET
+    auto bitmap_21 = gen_bitmap(10, 20);
+    bitmap_21 ^= _medium_bitmap;
+    check_bitmap(BitmapDataType::SET, bitmap_21, 0, 10, 14, 20);
+}
+
+TEST_F(BitmapValueTest, bitmap_contains) {
+    ASSERT_FALSE(_empty_bitmap.contains(5));
+    ASSERT_TRUE(_single_bitmap.contains(0));
+    ASSERT_FALSE(_single_bitmap.contains(1));
+    ASSERT_TRUE(_large_bitmap.contains(5));
+    ASSERT_FALSE(_large_bitmap.contains(100));
+    ASSERT_TRUE(_medium_bitmap.contains(5));
+    ASSERT_FALSE(_large_bitmap.contains(100));
+}
+
+TEST_F(BitmapValueTest, bitmap_cardinality) {
+    ASSERT_EQ(_empty_bitmap.cardinality(), 0);
+    ASSERT_EQ(_single_bitmap.cardinality(), 1);
+    ASSERT_EQ(_medium_bitmap.cardinality(), 14);
+    ASSERT_EQ(_large_bitmap.cardinality(), 64);
+}
+
+TEST_F(BitmapValueTest, bitmap_max) {
+    ASSERT_FALSE(_empty_bitmap.max().has_value());
+    ASSERT_EQ(_single_bitmap.max().value(), 0);
+    ASSERT_EQ(_medium_bitmap.max().value(), 13);
+    ASSERT_EQ(_large_bitmap.max().value(), 63);
+}
+
+TEST_F(BitmapValueTest, bitmap_min) {
+    ASSERT_FALSE(_empty_bitmap.min().has_value());
+    ASSERT_EQ(_single_bitmap.min().value(), 0);
+    ASSERT_EQ(_medium_bitmap.min().value(), 0);
+    ASSERT_EQ(_large_bitmap.min().value(), 0);
+}
+
+TEST_F(BitmapValueTest, bitmap_serialize_deserialize) {
+    // empty bitmap
+    size_t size = _empty_bitmap.getSizeInBytes();
+    char buf_1[size];
+    _empty_bitmap.write(buf_1);
+    BitmapValue bitmap_1;
+    bool ret = bitmap_1.deserialize(buf_1);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
+
+    // single bitmap
+    size = _single_bitmap.getSizeInBytes();
+    char buf_2[size];
+    _single_bitmap.write(buf_2);
+    BitmapValue bitmap_2;
+    ret = bitmap_2.deserialize(buf_2);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
+
+    // medium bitmap
+    size = _medium_bitmap.getSizeInBytes();
+    char buf_3[size];
+    _medium_bitmap.write(buf_3);
+    BitmapValue bitmap_3;
+    ret = bitmap_3.deserialize(buf_3);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::SET, bitmap_3, 0, 14);
+
+    // large bitmap
+    size = _large_bitmap.getSizeInBytes();
+    char buf_4[size];
+    _large_bitmap.write(buf_4);
+    BitmapValue bitmap_4;
+    ret = bitmap_4.deserialize(buf_4);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_4, 0, 64);
+}
+
+TEST_F(BitmapValueTest, test_valid_and_deserialize) {
+    // empty bitmap
+    size_t size = _empty_bitmap.getSizeInBytes();
+    char buf_1[size];
+    _empty_bitmap.write(buf_1);
+    BitmapValue bitmap_1;
+    bool ret = bitmap_1.valid_and_deserialize(buf_1, size);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
+
+    // single bitmap
+    size = _single_bitmap.getSizeInBytes();
+    char buf_2[size];
+    _single_bitmap.write(buf_2);
+    BitmapValue bitmap_2;
+    ret = bitmap_2.valid_and_deserialize(buf_2, size);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
+
+    // medium bitmap
+    size = _medium_bitmap.getSizeInBytes();
+    char buf_3[size];
+    _medium_bitmap.write(buf_3);
+    BitmapValue bitmap_3;
+    ret = bitmap_3.valid_and_deserialize(buf_3, size);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::SET, bitmap_3, 0, 14);
+
+    // large bitmap
+    size = _large_bitmap.getSizeInBytes();
+    char buf_4[size];
+    _large_bitmap.write(buf_4);
+    BitmapValue bitmap_4(_large_bitmap);
+    ret = bitmap_4.valid_and_deserialize(buf_4, size);
+    ASSERT_TRUE(ret);
+    check_bitmap(BitmapDataType::BITMAP, bitmap_4, 0, 64);
+    ASSERT_FALSE(bitmap_4.is_shared());
+
+    // invalid bitmap (invalid size)
+    BitmapValue bitmap_5;
+    ret = bitmap_5.valid_and_deserialize(buf_4, 0);
+    ASSERT_FALSE(ret);
+
+    // invalid bitmap (nullptr)
+    BitmapValue bitmap_6;
+    ret = bitmap_6.valid_and_deserialize(nullptr, 10);
+    ASSERT_TRUE(ret);
+
+    // invalid bitmap (invalid string)
+    BitmapValue bitmap_7;
+    char buf_5[5] = "1234";
+    ret = bitmap_7.valid_and_deserialize(buf_5, 5);
+    ASSERT_FALSE(ret);
+}
+
+TEST_F(BitmapValueTest, bitmap_to_string) {
+    ASSERT_STREQ("", _empty_bitmap.to_string().c_str());
+    ASSERT_STREQ("0", _single_bitmap.to_string().c_str());
+    ASSERT_STREQ("0,1,2,3,4,5,6,7,8,9,10,11,12,13", _medium_bitmap.to_string().c_str());
+    ASSERT_STREQ(
+            "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,"
+            "37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63",
+            _large_bitmap.to_string().c_str());
+}
+
+TEST_F(BitmapValueTest, bitmap_to_array) {
+    std::vector<int64_t> array_1;
+    _empty_bitmap.to_array(&array_1);
+    ASSERT_EQ(array_1.size(), 0);
+
+    std::vector<int64_t> array_2;
+    _single_bitmap.to_array(&array_2);
+    ASSERT_EQ(array_2.size(), 1);
+    ASSERT_EQ(array_2[0], 0);
+
+    std::vector<int64_t> array_3;
+    _medium_bitmap.to_array(&array_3);
+    ASSERT_EQ(array_3.size(), 14);
+    for (size_t i = 0; i < 14; i++) {
+        ASSERT_EQ(array_3[i], i);
+    }
+
+    std::vector<int64_t> array_4;
+    _large_bitmap.to_array(&array_4);
+    ASSERT_EQ(array_4.size(), 64);
+    for (size_t i = 0; i < 64; i++) {
+        ASSERT_EQ(array_4[i], i);
+    }
+}
+
+TEST_F(BitmapValueTest, bitmap_compress) {
+    BitmapValue bitmap;
+    for (size_t i = 0; i < 1000; i++) {
         bitmap.add(i);
     }
 
-    BitmapValue shallow_bitmap(bitmap, false);
-    shallow_bitmap.add(64);
-    ASSERT_EQ(bitmap.cardinality(), 65);
+    size_t size_1 = bitmap.serialize_size();
+    bitmap.compress();
+    size_t size_2 = bitmap.serialize_size();
+    ASSERT_LT(size_2, size_1);
 }
 
-TEST(BitmapValueTest, bitmap_union) {
-    BitmapValue empty;
-    BitmapValue single(1024);
-    BitmapValue bitmap({1024, 1025, 1026});
+TEST_F(BitmapValueTest, bitmap_clear) {
+    BitmapValue bitmap_1(_large_bitmap);
+    bitmap_1.clear();
+    check_bitmap(BitmapDataType::EMPTY, bitmap_1, 0, 0);
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
 
-    ASSERT_EQ(0, empty.cardinality());
-    ASSERT_EQ(1, single.cardinality());
-    ASSERT_EQ(3, bitmap.cardinality());
-
-    BitmapValue empty2;
-    empty2 |= empty;
-    ASSERT_EQ(0, empty2.cardinality());
-    empty2 |= single;
-    ASSERT_EQ(1, empty2.cardinality());
-    BitmapValue empty3;
-    empty3 |= bitmap;
-    ASSERT_EQ(3, empty3.cardinality());
-
-    BitmapValue single2(1025);
-    single2 |= empty;
-    ASSERT_EQ(1, single2.cardinality());
-    single2 |= single;
-    ASSERT_EQ(2, single2.cardinality());
-
-    BitmapValue bitmap2;
-    bitmap2.add(1024);
-    bitmap2.add(2048);
-    bitmap2.add(4096);
-    bitmap2 |= empty;
-    ASSERT_EQ(3, bitmap2.cardinality());
-    bitmap2 |= single;
-    ASSERT_EQ(3, bitmap2.cardinality());
-    bitmap2 |= bitmap;
-    ASSERT_EQ(5, bitmap2.cardinality());
+    auto bitmap_2 = gen_bitmap(0, 64);
+    bitmap_2.clear();
+    check_bitmap(BitmapDataType::EMPTY, bitmap_2, 0, 0);
 }
 
-TEST(BitmapValueTest, bitmap_intersect) {
-    BitmapValue empty;
-    BitmapValue single(1024);
-    BitmapValue bitmap({1024, 1025, 1026});
+TEST_F(BitmapValueTest, bitmap_reset) {
+    BitmapValue bitmap_1(_large_bitmap);
+    bitmap_1.reset();
+    ASSERT_EQ(BitmapDataType::EMPTY, bitmap_1.type());
+    check_bitmap(BitmapDataType::BITMAP, _large_bitmap, 0, 64);
+}
 
-    BitmapValue empty2;
-    empty2 &= empty;
-    ASSERT_EQ(0, empty2.cardinality());
-    empty2 &= single;
-    ASSERT_EQ(0, empty2.cardinality());
-    empty2 &= bitmap;
-    ASSERT_EQ(0, empty2.cardinality());
+TEST_F(BitmapValueTest, sub_bitmap_internal) {
+    // empty
+    BitmapValue bitmap_1;
+    int64_t ret = _empty_bitmap.sub_bitmap_internal(0, 1, &bitmap_1);
+    ASSERT_EQ(ret, 0);
 
-    BitmapValue single2(1025);
-    single2 &= empty;
-    ASSERT_EQ(0, single2.cardinality());
+    // single
+    BitmapValue bitmap_2;
+    ret = _single_bitmap.sub_bitmap_internal(0, 1, &bitmap_2);
+    ASSERT_EQ(ret, 1);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
 
-    BitmapValue single4(1025);
-    single4 &= single;
-    ASSERT_EQ(0, single4.cardinality());
+    // set (offset > 0)
+    BitmapValue bitmap_3;
+    ret = _medium_bitmap.sub_bitmap_internal(3, 5, &bitmap_3);
+    ASSERT_EQ(ret, 5);
+    check_bitmap(BitmapDataType::SET, bitmap_3, 3, 8);
 
-    BitmapValue single3(1024);
-    single3 &= single;
-    ASSERT_EQ(1, single3.cardinality());
+    // set (offset < 0)
+    BitmapValue bitmap_4;
+    ret = _medium_bitmap.sub_bitmap_internal(-5, 2, &bitmap_4);
+    ASSERT_EQ(ret, 2);
+    check_bitmap(BitmapDataType::SET, bitmap_4, 9, 11);
 
-    single3 &= bitmap;
-    ASSERT_EQ(1, single3.cardinality());
+    // bitmap (offset > 0)
+    BitmapValue bitmap_5;
+    ret = _large_bitmap.sub_bitmap_internal(3, 5, &bitmap_5);
+    ASSERT_EQ(ret, 5);
+    check_bitmap(BitmapDataType::SET, bitmap_5, 3, 8);
 
-    BitmapValue single5(2048);
-    single5 &= bitmap;
-    ASSERT_EQ(0, single5.cardinality());
+    // bitmap (offset < 0)
+    BitmapValue bitmap_6;
+    ret = _large_bitmap.sub_bitmap_internal(-5, 2, &bitmap_6);
+    ASSERT_EQ(ret, 2);
+    check_bitmap(BitmapDataType::SET, bitmap_6, 59, 61);
 
-    BitmapValue bitmap2;
-    bitmap2.add(1024);
-    bitmap2.add(2048);
-    bitmap2 &= empty;
-    ASSERT_EQ(0, bitmap2.cardinality());
+    // set (offset > 0 && invalid offset)
+    BitmapValue bitmap_7;
+    ret = _medium_bitmap.sub_bitmap_internal(100, 2, &bitmap_7);
+    ASSERT_EQ(ret, 0);
 
-    BitmapValue bitmap3;
-    bitmap3.add(1024);
-    bitmap3.add(2048);
-    bitmap3 &= single;
-    ASSERT_EQ(1, bitmap3.cardinality());
+    // set (offset < 0 && invalid offset)
+    BitmapValue bitmap_8;
+    ret = _medium_bitmap.sub_bitmap_internal(-100, 2, &bitmap_8);
+    ASSERT_EQ(ret, 0);
 
-    BitmapValue bitmap4;
-    bitmap4.add(2049);
-    bitmap4.add(2048);
-    bitmap4 &= single;
-    ASSERT_EQ(0, bitmap4.cardinality());
+    // bitmap (offset > 0 && invalid offset)
+    BitmapValue bitmap_9;
+    ret = _large_bitmap.sub_bitmap_internal(100, 2, &bitmap_9);
+    ASSERT_EQ(ret, 0);
 
-    BitmapValue bitmap5;
-    bitmap5.add(2049);
-    bitmap5.add(2048);
-    bitmap5 &= bitmap;
-    ASSERT_EQ(0, bitmap5.cardinality());
+    // bitmap (offset < 0 && invalid offset)
+    BitmapValue bitmap_10;
+    ret = _large_bitmap.sub_bitmap_internal(100, 2, &bitmap_10);
+    ASSERT_EQ(ret, 0);
+}
 
-    BitmapValue bitmap6;
-    bitmap6.add(1024);
-    bitmap6.add(1025);
-    bitmap6 &= bitmap;
-    ASSERT_EQ(2, bitmap6.cardinality());
+TEST_F(BitmapValueTest, subset_limit) {
+    // empty
+    BitmapValue bitmap_1;
+    int64_t ret = _empty_bitmap.bitmap_subset_limit_internal(0, 1, &bitmap_1);
+    ASSERT_EQ(ret, 0);
+
+    // single
+    BitmapValue bitmap_2;
+    ret = _single_bitmap.bitmap_subset_limit_internal(0, 1, &bitmap_2);
+    ASSERT_EQ(ret, 1);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
+
+    // set
+    BitmapValue bitmap_3;
+    ret = _medium_bitmap.bitmap_subset_limit_internal(5, 2, &bitmap_3);
+    ASSERT_EQ(ret, 2);
+    check_bitmap(BitmapDataType::SET, bitmap_3, 5, 7);
+
+    // bitmap
+    BitmapValue bitmap_4;
+    ret = _large_bitmap.bitmap_subset_limit_internal(5, 2, &bitmap_4);
+    ASSERT_EQ(ret, 2);
+    check_bitmap(BitmapDataType::SET, bitmap_4, 5, 7);
+
+    // single (invalid)
+    BitmapValue bitmap_5;
+    ret = _single_bitmap.bitmap_subset_limit_internal(0, 0, &bitmap_5);
+    ASSERT_EQ(ret, 0);
+    ret = _single_bitmap.bitmap_subset_limit_internal(2, 1, &bitmap_5);
+    ASSERT_EQ(ret, 0);
+
+    // set (invalid)
+    BitmapValue bitmap_6;
+    ret = _medium_bitmap.bitmap_subset_limit_internal(3, 0, &bitmap_6);
+    ASSERT_EQ(ret, 0);
+    ret = _medium_bitmap.bitmap_subset_limit_internal(15, 1, &bitmap_6);
+    ASSERT_EQ(ret, 0);
+
+    // bitmap (invalid)
+    BitmapValue bitmap_7;
+    ret = _large_bitmap.bitmap_subset_limit_internal(3, 0, &bitmap_7);
+    ASSERT_EQ(ret, 0);
+    ret = _large_bitmap.bitmap_subset_limit_internal(68, 1, &bitmap_7);
+    ASSERT_EQ(ret, 0);
+}
+
+TEST_F(BitmapValueTest, subset_in_range) {
+    // empty
+    BitmapValue bitmap_1;
+    int64_t ret = _empty_bitmap.bitmap_subset_in_range_internal(0, 1, &bitmap_1);
+    ASSERT_EQ(ret, 0);
+
+    // single
+    BitmapValue bitmap_2;
+    ret = _single_bitmap.bitmap_subset_in_range_internal(0, 1, &bitmap_2);
+    ASSERT_EQ(ret, 1);
+    check_bitmap(BitmapDataType::SINGLE, bitmap_2, 0, 1);
+
+    // set
+    BitmapValue bitmap_3;
+    ret = _medium_bitmap.bitmap_subset_in_range_internal(5, 7, &bitmap_3);
+    ASSERT_EQ(ret, 2);
+    check_bitmap(BitmapDataType::SET, bitmap_3, 5, 7);
+
+    // bitmap
+    BitmapValue bitmap_4;
+    ret = _large_bitmap.bitmap_subset_in_range_internal(5, 7, &bitmap_4);
+    ASSERT_EQ(ret, 2);
+    check_bitmap(BitmapDataType::SET, bitmap_4, 5, 7);
+
+    // single (invalid)
+    BitmapValue bitmap_5;
+    ret = _single_bitmap.bitmap_subset_in_range_internal(0, 0, &bitmap_5);
+    ASSERT_EQ(ret, 0);
+    ret = _single_bitmap.bitmap_subset_in_range_internal(2, 3, &bitmap_5);
+    ASSERT_EQ(ret, 0);
+
+    // set (invalid)
+    BitmapValue bitmap_6;
+    ret = _medium_bitmap.bitmap_subset_limit_internal(15, 16, &bitmap_6);
+    ASSERT_EQ(ret, 0);
+
+    // bitmap (invalid)
+    BitmapValue bitmap_7;
+    ret = _medium_bitmap.bitmap_subset_limit_internal(68, 69, &bitmap_7);
+    ASSERT_EQ(ret, 0);
 }
 
 std::string convert_bitmap_to_string(BitmapValue& bitmap) {
@@ -144,7 +880,7 @@ std::string convert_bitmap_to_string(BitmapValue& bitmap) {
     return buf;
 }
 
-TEST(BitmapValueTest, bitmap_serde) {
+TEST(BitmapValueTest1, bitmap_serde) {
     bool use_v1 = config::bitmap_serialize_version == 1;
     BitmapTypeCode::type type_bitmap32 = BitmapTypeCode::BITMAP32_SERIV2;
     BitmapTypeCode::type type_bitmap64 = BitmapTypeCode::BITMAP64_SERIV2;
@@ -228,7 +964,7 @@ TEST(BitmapValueTest, bitmap_serde) {
 }
 
 // Forked from CRoaring's UT of Roaring64Map
-TEST(BitmapValueTest, Roaring64Map) {
+TEST(BitmapValueTest1, Roaring64Map) {
     using starrocks::detail::Roaring64Map;
     // create a new empty bitmap
     Roaring64Map r1;
@@ -310,103 +1046,6 @@ TEST(BitmapValueTest, Roaring64Map) {
         sum += i;
     }
     ASSERT_EQ(r1_sum, sum);
-}
-
-TEST(BitmapValueTest, bitmap_to_string) {
-    BitmapValue empty;
-    ASSERT_STREQ("", empty.to_string().c_str());
-    empty.add(1);
-    ASSERT_STREQ("1", empty.to_string().c_str());
-    empty.add(2);
-    ASSERT_STREQ("1,2", empty.to_string().c_str());
-}
-
-TEST(BitmapValueTest, bitmap_single_convert) {
-    BitmapValue bitmap;
-    ASSERT_STREQ("", bitmap.to_string().c_str());
-    bitmap.add(1);
-    ASSERT_STREQ("1", bitmap.to_string().c_str());
-    bitmap.add(1);
-    ASSERT_STREQ("1", bitmap.to_string().c_str());
-    ASSERT_EQ(BitmapValue::SINGLE, bitmap.type());
-
-    BitmapValue bitmap_u;
-    bitmap_u.add(1);
-    bitmap |= bitmap_u;
-    ASSERT_EQ(BitmapValue::SINGLE, bitmap.type());
-
-    bitmap_u.add(2);
-    ASSERT_EQ(BitmapValue::SET, bitmap_u.type());
-
-    bitmap |= bitmap_u;
-    ASSERT_EQ(BitmapValue::SET, bitmap.type());
-}
-
-TEST(BitmapValueTest, bitmap_max) {
-    std::unique_ptr<FunctionContext> ctx_ptr;
-    FunctionContext* ctx;
-    ctx_ptr.reset(FunctionContext::create_test_context());
-    ctx = ctx_ptr.get();
-
-    BitmapValue bitmap;
-    Columns columns;
-    auto s = BitmapColumn::create();
-    s->append(&bitmap);
-    columns.push_back(s);
-    auto column = BitmapFunctions::bitmap_max(ctx, columns).value();
-    ASSERT_TRUE(column->is_null(0));
-
-    bitmap.add(0);
-    ASSERT_EQ(bitmap.max(), 0);
-    bitmap.add(1);
-    ASSERT_EQ(bitmap.max(), 1);
-    bitmap.add(std::numeric_limits<uint64_t>::max());
-    ASSERT_EQ(bitmap.max(), std::numeric_limits<uint64_t>::max());
-    bitmap.add(std::numeric_limits<uint64_t>::lowest());
-    ASSERT_EQ(bitmap.max(), std::numeric_limits<uint64_t>::max());
-}
-
-TEST(BitmapValueTest, bitmap_min) {
-    std::unique_ptr<FunctionContext> ctx_ptr;
-    FunctionContext* ctx;
-    ctx_ptr.reset(FunctionContext::create_test_context());
-    ctx = ctx_ptr.get();
-
-    BitmapValue bitmap;
-    Columns columns;
-    auto s = BitmapColumn::create();
-    s->append(&bitmap);
-    columns.push_back(s);
-    auto column = BitmapFunctions::bitmap_min(ctx, columns).value();
-    ASSERT_TRUE(column->is_null(0));
-
-    bitmap.add(std::numeric_limits<uint64_t>::max());
-    ASSERT_EQ(bitmap.min(), std::numeric_limits<uint64_t>::max());
-    bitmap.add(1);
-    ASSERT_EQ(bitmap.min(), 1);
-    bitmap.add(5);
-    ASSERT_EQ(bitmap.min(), 1);
-    bitmap.add(0);
-    ASSERT_EQ(bitmap.min(), 0);
-}
-
-TEST(BitmapValueTest, bitmap_xor) {
-    // {3} ^ {1,2} = {1,2,3}
-    {
-        BitmapValue bm1;
-        bm1.add(3);
-        BitmapValue bm2;
-        bm2.add(1);
-        bm2.add(2);
-
-        bm1 ^= bm2;
-        ASSERT_EQ(3, bm1.cardinality());
-        ASSERT_EQ(3, bm1.max());
-        ASSERT_EQ(1, bm1.min());
-
-        // and b2 should not be changed
-        ASSERT_EQ(2, bm2.cardinality());
-    }
 }
 
 } // namespace starrocks


### PR DESCRIPTION
BitmapValue support copy on write.

```
CREATE TABLE `t1` (
  `c1` int(11) NULL COMMENT "",
  `c2` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"light_schema_change" = "true",
"compression" = "LZ4"
); 

CREATE TABLE `lineorder` (
  `lo_orderkey` int(11) NOT NULL COMMENT "",
  `lo_linenumber` int(11) NOT NULL COMMENT "",
  `lo_custkey` int(11) NOT NULL COMMENT "",
  `lo_partkey` int(11) NOT NULL COMMENT "",
  `lo_suppkey` int(11) NOT NULL COMMENT "",
  `lo_orderdate` int(11) NOT NULL COMMENT "",
  `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
  `lo_shippriority` int(11) NOT NULL COMMENT "",
  `lo_quantity` int(11) NOT NULL COMMENT "",
  `lo_extendedprice` int(11) NOT NULL COMMENT "",
  `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
  `lo_discount` int(11) NOT NULL COMMENT "",
  `lo_revenue` int(11) NOT NULL COMMENT "",
  `lo_supplycost` int(11) NOT NULL COMMENT "",
  `lo_tax` int(11) NOT NULL COMMENT "",
  `lo_commitdate` int(11) NOT NULL COMMENT "",
  `lo_shipmode` varchar(11) NOT NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`lo_orderkey`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 192 
PROPERTIES (
"replication_num" = "1",
"colocate_with" = "groupa1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"compression" = "LZ4"
); 

CREATE TABLE `t2` (
  `c1` int(11) NULL COMMENT "",
  `c2` bitmap BITMAP_UNION NULL COMMENT "",
  `c3` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"light_schema_change" = "true",
"compression" = "LZ4"
); 

mysql> select c1, bitmap_count(c2) from t1;
+------+------------------+
| c1   | bitmap_count(c2) |
+------+------------------+
|    1 |         30000000 |
+------+------------------+
1 row in set (0.02 sec)

mysql> select count(*) from lineorder;
+-----------+
| count(*)  |
+-----------+
| 143999468 |
+-----------+
1 row in set (0.19 sec)

select count(*) from t2;
+----------+
| count(*) |
+----------+
|       64 |
+----------+
1 row in set (0.01 sec)
```

Time:  5.020s -> 0.043s
Mem: 7.372G -> 0.015G

```
select count(*) from lineorder join [broadcast] t1 on bitmap_contains(c2, lo_orderkey) where lo_orderkey<100;
```

Time: 10.684s  -> 0.048s
Mem: 14.73sG -> 0.014G

```
select count(*) from t1 join [broadcast] lineorder on bitmap_contains(c2, lo_orderkey) where lo_orderkey<100;
```

Time: 4.251s -> 3.679s
Mem: 29M    ->  19M

```
select count(*) from lineorder join [broadcast] t1 on lo_linenumber=c1 and bitmap_contains(c2, lo_orderkey);
```

Time: 7.618s  -> 5.045s
Mem: 6.792G -> 3.640G

```
select count(*) from t1 join [broadcast] lineorder on lo_partkey=c1 and bitmap_contains(c2, lo_orderkey);
```


Time: 2.365s    -> 2.316s
Mem: 29.358m -> 17.758m

```
select bitmap_count(bitmap_agg(lo_orderkey)) from lineorder;
```

Time: 4.5s  -> 2.1s
Mem: 2.7G -> 2.7G

```
select count(bitmap_or(c2, c3)) from t2;
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
