### PR TITLE
[BugFix] Expr prepare() should do only once

### DIFF
--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -28,11 +28,11 @@ namespace starrocks {
 LambdaFunction::LambdaFunction(const TExprNode& node) : Expr(node, false), _common_sub_expr_num(node.output_column) {}
 
 Status LambdaFunction::prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) {
+    RETURN_IF_ERROR(Expr::prepare(state, context));
     if (_is_prepared) {
         return Status::OK();
     }
     _is_prepared = true;
-    RETURN_IF_ERROR(Expr::prepare(state, context));
     // common sub expressions include 2 parts in a pair: (slot id, expression)
     const int child_num = get_num_children() - 2 * _common_sub_expr_num;
     // collect the slot ids of lambda arguments

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -28,6 +28,11 @@ namespace starrocks {
 LambdaFunction::LambdaFunction(const TExprNode& node) : Expr(node, false), _common_sub_expr_num(node.output_column) {}
 
 Status LambdaFunction::prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) {
+    if (UNLIKELY(!_captured_slot_ids.empty() || !_arguments_ids.empty() || !_common_sub_expr_ids.empty() ||
+                 !_common_sub_expr.empty())) {
+        LOG(WARNING) << "Lambda function's prepare() again";
+        return Status::OK();
+    }
     RETURN_IF_ERROR(Expr::prepare(state, context));
     // common sub expressions include 2 parts in a pair: (slot id, expression)
     const int child_num = get_num_children() - 2 * _common_sub_expr_num;

--- a/be/src/exprs/lambda_function.cpp
+++ b/be/src/exprs/lambda_function.cpp
@@ -28,11 +28,10 @@ namespace starrocks {
 LambdaFunction::LambdaFunction(const TExprNode& node) : Expr(node, false), _common_sub_expr_num(node.output_column) {}
 
 Status LambdaFunction::prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) {
-    if (UNLIKELY(!_captured_slot_ids.empty() || !_arguments_ids.empty() || !_common_sub_expr_ids.empty() ||
-                 !_common_sub_expr.empty())) {
-        LOG(WARNING) << "Lambda function's prepare() again";
+    if (_is_prepared) {
         return Status::OK();
     }
+    _is_prepared = true;
     RETURN_IF_ERROR(Expr::prepare(state, context));
     // common sub expressions include 2 parts in a pair: (slot id, expression)
     const int child_num = get_num_children() - 2 * _common_sub_expr_num;

--- a/be/src/exprs/lambda_function.h
+++ b/be/src/exprs/lambda_function.h
@@ -65,5 +65,6 @@ private:
     std::vector<SlotId> _common_sub_expr_ids;
     std::vector<Expr*> _common_sub_expr;
     int _common_sub_expr_num;
+    bool _is_prepared = false;
 };
 } // namespace starrocks

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -39,11 +39,11 @@ MapApplyExpr::MapApplyExpr(const TExprNode& node) : Expr(node, false) {}
 MapApplyExpr::MapApplyExpr(TypeDescriptor type) : Expr(std::move(type), false), _maybe_duplicated_keys(true) {}
 
 Status MapApplyExpr::prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) {
+    RETURN_IF_ERROR(Expr::prepare(state, context));
     if (_is_prepared) {
         return Status::OK();
     }
     _is_prepared = true;
-    RETURN_IF_ERROR(Expr::prepare(state, context));
     if (_children.size() < 2) {
         return Status::InternalError("map expression's children size should not less than 2");
     }

--- a/be/src/exprs/map_apply_expr.cpp
+++ b/be/src/exprs/map_apply_expr.cpp
@@ -39,10 +39,10 @@ MapApplyExpr::MapApplyExpr(const TExprNode& node) : Expr(node, false) {}
 MapApplyExpr::MapApplyExpr(TypeDescriptor type) : Expr(std::move(type), false), _maybe_duplicated_keys(true) {}
 
 Status MapApplyExpr::prepare(starrocks::RuntimeState* state, starrocks::ExprContext* context) {
-    if (UNLIKELY(!_arguments_ids.empty())) {
-        LOG(WARNING) << "map_apply()' prepare() again";
+    if (_is_prepared) {
         return Status::OK();
     }
+    _is_prepared = true;
     RETURN_IF_ERROR(Expr::prepare(state, context));
     if (_children.size() < 2) {
         return Status::InternalError("map expression's children size should not less than 2");

--- a/be/src/exprs/map_apply_expr.h
+++ b/be/src/exprs/map_apply_expr.h
@@ -41,5 +41,6 @@ public:
 private:
     bool _maybe_duplicated_keys;
     std::vector<SlotId> _arguments_ids;
+    bool _is_prepared = false;
 };
 } // namespace starrocks

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -311,8 +311,7 @@ void RuntimeFilterProbeDescriptor::replace_probe_expr_ctx(RuntimeState* state, c
     // close old probe expr
     _probe_expr_ctx->close(state);
     // create new probe expr and open it.
-    _probe_expr_ctx =
-            state->obj_pool()->add(new ExprContext(Expr::copy(state->obj_pool(), new_probe_expr_ctx->root())));
+    _probe_expr_ctx = state->obj_pool()->add(new ExprContext(new_probe_expr_ctx->root()));
     WARN_IF_ERROR(_probe_expr_ctx->prepare(state), "prepare probe expr failed");
     WARN_IF_ERROR(_probe_expr_ctx->open(state), "open probe expr failed");
 }

--- a/be/src/exprs/runtime_filter_bank.cpp
+++ b/be/src/exprs/runtime_filter_bank.cpp
@@ -311,7 +311,8 @@ void RuntimeFilterProbeDescriptor::replace_probe_expr_ctx(RuntimeState* state, c
     // close old probe expr
     _probe_expr_ctx->close(state);
     // create new probe expr and open it.
-    _probe_expr_ctx = state->obj_pool()->add(new ExprContext(new_probe_expr_ctx->root()));
+    _probe_expr_ctx =
+            state->obj_pool()->add(new ExprContext(Expr::copy(state->obj_pool(), new_probe_expr_ctx->root())));
     WARN_IF_ERROR(_probe_expr_ctx->prepare(state), "prepare probe expr failed");
     WARN_IF_ERROR(_probe_expr_ctx->open(state), "open probe expr failed");
 }

--- a/test/sql/test_join/R/test_join_array
+++ b/test/sql/test_join/R/test_join_array
@@ -1199,3 +1199,9 @@ None	None
 [[["10"],["20"],["30"]],[["60"],["5"],["4"]],[["-100","-2"],["-20","10"],["100","23"]]]	[[["1",null],["3"],null],[["50","2","6","4"]]]
 [[["10"],["20"],["30"]],[["60"],["5"],["4"]],[["-100","-2"],["-20","10"],["100","23"]]]	[[["1","2"],["3"]],[["50","2","6","4"]]]
 -- !result
+select s.i_1, t.d_1 from array_test s join array_test t on array_map(x -> x*3, s.i_1) = array_map(x-> x*3 + 1, t.d_1) order by 1, 2;
+-- result:
+-- !result
+select s.i_1, t.d_1 from array_test s join array_test t on array_map(x -> x*3, s.i_1)[0] = array_map(x-> x*3 + 1, t.d_1)[0] order by 1, 2;
+-- result:
+-- !result

--- a/test/sql/test_join/R/test_join_map
+++ b/test/sql/test_join/R/test_join_map
@@ -164,84 +164,84 @@ select t.map3, s.map4 from map_test t join map_test s where s.map3 <= t.map4 ord
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 60 to line 1, column 72. Detail message: Column type map<varchar(65533),map<int(11),varchar(30)>> does not support binary predicate operation with type map<int(11),json>.')
 -- !result
-select map0 from map_test t where exists (select 1 from map_test s where t.map0 = s.map3);
+select map0 from map_test t where exists (select 1 from map_test s where t.map0 = s.map3) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 73 to line 1, column 84. Detail message: Column type map<int(11),varchar(65533)> does not support binary predicate operation with type map<varchar(65533),map<int(11),varchar(30)>>.')
 -- !result
-select map1 from map_test t where exists (select 1 from map_test s where t.map1 = s.map3);
+select map1 from map_test t where exists (select 1 from map_test s where t.map1 = s.map3) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 73 to line 1, column 84. Detail message: Column type map<decimal64(16, 3),varchar(30)> does not support binary predicate operation with type map<varchar(65533),map<int(11),varchar(30)>>.')
 -- !result
-select map2 from map_test t where exists (select 1 from map_test s where t.map2 = s.map3);
+select map2 from map_test t where exists (select 1 from map_test s where t.map2 = s.map3) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 73 to line 1, column 84. Detail message: Column type map<int(11),array<varchar(65533)>> does not support binary predicate operation with type map<varchar(65533),map<int(11),varchar(30)>>.')
 -- !result
-select map3 from map_test t where exists (select 1 from map_test s where t.map3 = s.map3);
+select map3 from map_test t where exists (select 1 from map_test s where t.map3 = s.map3) order by t.pk;
 -- result:
-{"11":{1:"abc"},"":{2:null}}
 {"1":{1:"abc"}}
+{"11":{1:"abc"},"":{2:null}}
 {null:{null:null}}
 {"3":{3:"a33c"},null:null}
 -- !result
-select map5 from map_test t where exists (select 1 from map_test s where t.map5 < s.map3);
+select map5 from map_test t where exists (select 1 from map_test s where t.map5 < s.map3) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 73 to line 1, column 84. Detail message: Column type map<int(11),struct<c int(11), b varchar(65533)>> does not support binary predicate operation with type map<varchar(65533),map<int(11),varchar(30)>>.')
 -- !result
-select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map0);
+select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map0) order by t.pk;
 -- result:
 None
 -- !result
-select map1 from map_test t where not exists (select 1 from map_test s where t.map1 = s.map0);
+select map1 from map_test t where not exists (select 1 from map_test s where t.map1 = s.map0) order by t.pk;
 -- result:
-None
 {null:""}
+None
 -- !result
-select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map5);
+select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type map<int(11),varchar(65533)> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
 -- !result
-select map5 from map_test t where not exists (select 1 from map_test s where t.map5 < s.map5);
+select map5 from map_test t where not exists (select 1 from map_test s where t.map5 < s.map5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type map<int(11),struct<c int(11), b varchar(65533)>> does not support binary predicate operation with type map<int(11),struct<c int(11), b varchar(65533)>>.')
 -- !result
-select map3 from map_test t where map3 in (select map3 from map_test s);
+select map3 from map_test t where map3 in (select map3 from map_test s) order by t.pk;
 -- result:
-{null:{null:null}}
 {"1":{1:"abc"}}
-{"3":{3:"a33c"},null:null}
 {"11":{1:"abc"},"":{2:null}}
+{null:{null:null}}
+{"3":{3:"a33c"},null:null}
 -- !result
-select map4 from map_test t where map4 in (select map5 from map_test s);
+select map4 from map_test t where map4 in (select map5 from map_test s) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 39 to line 1, column 70. Detail message: The input types (map<int(11),json>,map<int(11),struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
 -- !result
-select map5 from map_test t where map5 in (select map5 from map_test s);
+select map5 from map_test t where map5 in (select map5 from map_test s) order by t.pk;
 -- result:
 {0:{"c":1,"b":"a"}}
+{null:{"c":null,"b":null}}
+{null:{"c":null,"b":null}}
 {null:null,3:{"c":3,"b":"a"}}
-{null:{"c":null,"b":null}}
-{null:{"c":null,"b":null}}
 -- !result
-select map3 from map_test t where map3 not in (select map2 from map_test s);
+select map3 from map_test t where map3 not in (select map2 from map_test s) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 39 to line 1, column 74. Detail message: The input types (map<varchar(65533),map<int(11),varchar(30)>>,map<int(11),array<varchar(65533)>>) of in predict are not compatible.')
 -- !result
-select map5 from map_test t where map5 not in (select map5 from map_test s);
+select map5 from map_test t where map5 not in (select map5 from map_test s) order by t.pk;
 -- result:
 -- !result
-select map0 in (select map0 from map_test s) from map_test;
+select map0 in (select map0 from map_test s) from map_test order by 1;
 -- result:
-1
 None
 1
 1
 1
+1
 -- !result
-select map3 in (select map5 from map_test s) from map_test;
+select map3 in (select map5 from map_test s) from map_test order by 1;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 43. Detail message: The input types (map<varchar(65533),map<int(11),varchar(30)>>,map<int(11),struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
 -- !result
-select map5 in (select map5 from map_test s) from map_test;
+select map5 in (select map5 from map_test s) from map_test order by 1;
 -- result:
 None
 1
@@ -249,7 +249,7 @@ None
 1
 1
 -- !result
-select map0 not in (select map0 from map_test s) from map_test;
+select map0 not in (select map0 from map_test s) from map_test order by 1;
 -- result:
 None
 0
@@ -257,19 +257,19 @@ None
 0
 0
 -- !result
-select map1 not in (select map0 from map_test s) from map_test;
+select map1 not in (select map0 from map_test s) from map_test order by 1;
 -- result:
-0
+None
 None
 0
 0
-None
+0
 -- !result
-select map4 not in (select map5 from map_test s) from map_test;
+select map4 not in (select map5 from map_test s) from map_test order by 1;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 12 to line 1, column 47. Detail message: The input types (map<int(11),json>,map<int(11),struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
 -- !result
-select map5 not in (select map5 from map_test s) from map_test;
+select map5 not in (select map5 from map_test s) from map_test order by 1;
 -- result:
 None
 0
@@ -360,4 +360,18 @@ E: (1064, "Getting syntax error at line 1, column 59. Detail message: Unexpected
 select t.map5, s.map5 from map_test t full join map_test s where s.map5 = t.map5 order by t.pk;
 -- result:
 E: (1064, "Getting syntax error at line 1, column 59. Detail message: Unexpected input 'where', the most similar input is {'ON', 'USING'}.")
+-- !result
+select t.map2, s.map2 from map_test t join map_test s on map_apply((k,v)->(k+1,array_length(v)),s.map2) = map_apply((k,v)->(k+1,array_length(v)),t.map2) order by t.pk;
+-- result:
+{0:["1","2"]}	{0:["1","2"]}
+{1:[]}	{1:[]}
+{null:null}	{null:null}
+{3:["3",null],null:null}	{3:["3",null],null:null}
+-- !result
+select t.map2, s.map2 from map_test t join map_test s on map_apply((k,v)->(k+1,v),s.map2) = map_apply((k,v)->(k+1,v),t.map2) order by t.pk;
+-- result:
+{0:["1","2"]}	{0:["1","2"]}
+{1:[]}	{1:[]}
+{null:null}	{null:null}
+{3:["3",null],null:null}	{3:["3",null],null:null}
 -- !result

--- a/test/sql/test_join/R/test_join_struct
+++ b/test/sql/test_join/R/test_join_struct
@@ -175,118 +175,102 @@ select t.s4, s.s5 from struct_test t join struct_test s where s.s4 >= t.s5 order
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 72. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
 -- !result
-select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 = s.s5);
+select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 = s.s5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 varchar(65533)> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
 -- !result
-select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 = s.s5);
+select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 = s.s5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 decimal64(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
 -- !result
-select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 = s.s5);
+select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 = s.s5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 array<varchar(65533)>> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
 -- !result
-select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 <=> s.s2);
+select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 <=> s.s2) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Not support exists correlation subquery with Non-EQ predicate.')
 -- !result
-select s3 from struct_test t where exists (select 1 from struct_test s where t.s3 <=> s.s2);
+select s3 from struct_test t where exists (select 1 from struct_test s where t.s3 <=> s.s2) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
 -- !result
-select s4 from struct_test t where exists (select 1 from struct_test s where t.s4 <=> s.s2);
+select s4 from struct_test t where exists (select 1 from struct_test s where t.s4 <=> s.s2) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
 -- !result
-select s5 from struct_test t where exists (select 1 from struct_test s where t.s5 <=> s.s2);
+select s5 from struct_test t where exists (select 1 from struct_test s where t.s5 <=> s.s2) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 88. Detail message: Column type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>> does not support binary predicate operation with type struct<c0 int(11), c1 array<varchar(65533)>>.')
 -- !result
-select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 < s.s1);
+select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 < s.s1) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 varchar(65533)> does not support binary predicate operation with type struct<c0 decimal64(16, 3), c1 varchar(30)>.')
 -- !result
-select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 < s.s1);
+select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 < s.s1) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 decimal64(16, 3), c1 varchar(30)> does not support binary predicate operation with type struct<c0 decimal64(16, 3), c1 varchar(30)>.')
 -- !result
-select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 < s.s1);
+select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 < s.s1) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 77 to line 1, column 86. Detail message: Column type struct<c0 int(11), c1 array<varchar(65533)>> does not support binary predicate operation with type struct<c0 decimal64(16, 3), c1 varchar(30)>.')
 -- !result
-select s2 from struct_test t where not exists (select 1 from struct_test s where t.s2 <=> s.s5);
+select s2 from struct_test t where not exists (select 1 from struct_test s where t.s2 <=> s.s5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<c0 int(11), c1 array<varchar(65533)>> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
 -- !result
-select s3 from struct_test t where not exists (select 1 from struct_test s where t.s3 <=> s.s5);
+select s3 from struct_test t where not exists (select 1 from struct_test s where t.s3 <=> s.s5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<c0 varchar(65533), c1 map<int(11),varchar(30)>> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
 -- !result
-select s4 from struct_test t where not exists (select 1 from struct_test s where t.s4 <=> s.s5);
+select s4 from struct_test t where not exists (select 1 from struct_test s where t.s4 <=> s.s5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 81 to line 1, column 92. Detail message: Column type struct<c0 int(11), c1 json> does not support binary predicate operation with type struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>.')
 -- !result
-select s5 from struct_test t where not exists (select 1 from struct_test s where t.s5 <=> s.s5);
+select s5 from struct_test t where not exists (select 1 from struct_test s where t.s5 <=> s.s5) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error. Detail message: Not support exists correlation subquery with Non-EQ predicate.')
 -- !result
-select s2 from struct_test t where s2 in (select s0 from struct_test s);
+select s2 from struct_test t where s2 in (select s0 from struct_test s) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 70. Detail message: The input types (struct<c0 int(11), c1 array<varchar(65533)>>,struct<c0 int(11), c1 varchar(65533)>) of in predict are not compatible.')
 -- !result
-select s4 from struct_test t where s4 in (select s1 from struct_test s);
+select s4 from struct_test t where s4 in (select s1 from struct_test s) order by t.pk;
 -- result:
 {"c0":null,"c1":null}
 -- !result
-select s0 from struct_test t where s0 in (select s5 from struct_test s);
+select s0 from struct_test t where s0 in (select s5 from struct_test s) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 70. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
 -- !result
-select s5 from struct_test t where s5 not in (select s5 from struct_test s);
+select s5 from struct_test t where s5 not in (select s5 from struct_test s) order by t.pk;
 -- result:
 -- !result
-select s0 from struct_test t where s0 not in (select s5 from struct_test s);
+select s0 from struct_test t where s0 not in (select s5 from struct_test s) order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 38 to line 1, column 74. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
 -- !result
-select s0 in (select s0 from struct_test s) from struct_test;
+select s0 in (select s0 from struct_test s) from struct_test order by t.pk;
 -- result:
-1
-1
-1
-1
-None
+E: (1064, "Getting analyzing error. Detail message: Column '`t`.`pk`' cannot be resolved.")
 -- !result
-select s0 in (select s1 from struct_test s) from struct_test;
+select s0 in (select s1 from struct_test s) from struct_test order by t.pk;
 -- result:
-None
-1
-1
-1
-None
+E: (1064, "Getting analyzing error. Detail message: Column '`t`.`pk`' cannot be resolved.")
 -- !result
-select s5 in (select s5 from struct_test s) from struct_test;
+select s5 in (select s5 from struct_test s) from struct_test order by t.pk;
 -- result:
-1
-None
-1
-1
-1
+E: (1064, "Getting analyzing error. Detail message: Column '`t`.`pk`' cannot be resolved.")
 -- !result
-select s0 not in (select s0 from struct_test s) from struct_test;
+select s0 not in (select s0 from struct_test s) from struct_test order by t.pk;
 -- result:
-0
-None
-0
-0
-0
+E: (1064, "Getting analyzing error. Detail message: Column '`t`.`pk`' cannot be resolved.")
 -- !result
-select s0 not in (select s2 from struct_test s) from struct_test;
+select s0 not in (select s2 from struct_test s) from struct_test order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 10 to line 1, column 46. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 array<varchar(65533)>>) of in predict are not compatible.')
 -- !result
-select s0 not in (select s5 from struct_test s) from struct_test;
+select s0 not in (select s5 from struct_test s) from struct_test order by t.pk;
 -- result:
 E: (1064, 'Getting analyzing error from line 1, column 10 to line 1, column 46. Detail message: The input types (struct<c0 int(11), c1 varchar(65533)>,struct<c0 int(11), c1 struct<c int(11), b varchar(65533)>>) of in predict are not compatible.')
 -- !result

--- a/test/sql/test_join/T/test_join_array
+++ b/test/sql/test_join/T/test_join_array
@@ -179,3 +179,6 @@ select s.aas_1, t.aas_1 from array_test s full join array_test t on s.aas_1 <=> 
 select s.aad_1, t.aad_1 from array_test s full join array_test t on s.aad_1 != t.aad_1 order by 1, 2;
 select s.aas_1, t.aas_1 from array_test s full join array_test t on s.aas_1 != t.aas_1 order by 1, 2;
 
+select s.i_1, t.d_1 from array_test s join array_test t on array_map(x -> x*3, s.i_1) = array_map(x-> x*3 + 1, t.d_1) order by 1, 2;
+
+select s.i_1, t.d_1 from array_test s join array_test t on array_map(x -> x*3, s.i_1)[0] = array_map(x-> x*3 + 1, t.d_1)[0] order by 1, 2;

--- a/test/sql/test_join/T/test_join_map
+++ b/test/sql/test_join/T/test_join_map
@@ -53,29 +53,29 @@ select t.map0, s.map0 from map_test t join map_test s on s.map0 < t.map0 order b
 select t.map0, s.map0 from map_test t join map_test s on s.map0 <= t.map0 order by t.pk;
 select t.map3, s.map4 from map_test t join map_test s where s.map3 <= t.map4 order by t.pk;
 
-select map0 from map_test t where exists (select 1 from map_test s where t.map0 = s.map3);
-select map1 from map_test t where exists (select 1 from map_test s where t.map1 = s.map3);
-select map2 from map_test t where exists (select 1 from map_test s where t.map2 = s.map3);
-select map3 from map_test t where exists (select 1 from map_test s where t.map3 = s.map3);
-select map5 from map_test t where exists (select 1 from map_test s where t.map5 < s.map3);
+select map0 from map_test t where exists (select 1 from map_test s where t.map0 = s.map3) order by t.pk;
+select map1 from map_test t where exists (select 1 from map_test s where t.map1 = s.map3) order by t.pk;
+select map2 from map_test t where exists (select 1 from map_test s where t.map2 = s.map3) order by t.pk;
+select map3 from map_test t where exists (select 1 from map_test s where t.map3 = s.map3) order by t.pk;
+select map5 from map_test t where exists (select 1 from map_test s where t.map5 < s.map3) order by t.pk;
 
-select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map0);
-select map1 from map_test t where not exists (select 1 from map_test s where t.map1 = s.map0);
-select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map5);
-select map5 from map_test t where not exists (select 1 from map_test s where t.map5 < s.map5);
+select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map0) order by t.pk;
+select map1 from map_test t where not exists (select 1 from map_test s where t.map1 = s.map0) order by t.pk;
+select map0 from map_test t where not exists (select 1 from map_test s where t.map0 = s.map5) order by t.pk;
+select map5 from map_test t where not exists (select 1 from map_test s where t.map5 < s.map5) order by t.pk;
 
-select map3 from map_test t where map3 in (select map3 from map_test s);
-select map4 from map_test t where map4 in (select map5 from map_test s);
-select map5 from map_test t where map5 in (select map5 from map_test s);
-select map3 from map_test t where map3 not in (select map2 from map_test s);
-select map5 from map_test t where map5 not in (select map5 from map_test s);
-select map0 in (select map0 from map_test s) from map_test;
-select map3 in (select map5 from map_test s) from map_test;
-select map5 in (select map5 from map_test s) from map_test;
-select map0 not in (select map0 from map_test s) from map_test;
-select map1 not in (select map0 from map_test s) from map_test;
-select map4 not in (select map5 from map_test s) from map_test;
-select map5 not in (select map5 from map_test s) from map_test;
+select map3 from map_test t where map3 in (select map3 from map_test s) order by t.pk;
+select map4 from map_test t where map4 in (select map5 from map_test s) order by t.pk;
+select map5 from map_test t where map5 in (select map5 from map_test s) order by t.pk;
+select map3 from map_test t where map3 not in (select map2 from map_test s) order by t.pk;
+select map5 from map_test t where map5 not in (select map5 from map_test s) order by t.pk;
+select map0 in (select map0 from map_test s) from map_test order by 1;
+select map3 in (select map5 from map_test s) from map_test order by 1;
+select map5 in (select map5 from map_test s) from map_test order by 1;
+select map0 not in (select map0 from map_test s) from map_test order by 1;
+select map1 not in (select map0 from map_test s) from map_test order by 1;
+select map4 not in (select map5 from map_test s) from map_test order by 1;
+select map5 not in (select map5 from map_test s) from map_test order by 1;
 
 select t.map4, s.map4 from map_test t left join map_test s on s.map4 = t.map4 order by t.pk;
 select t.map2, s.map4 from map_test t left join map_test s where s.map2 = t.map4 order by t.pk;
@@ -97,3 +97,6 @@ select t.map2, s.map5 from map_test t full join map_test s on s.map2 = t.map5 or
 select t.map3, s.map4 from map_test t full join map_test s on s.map3 <=> t.map4 order by t.pk;
 select t.map3, s.map5 from map_test t full join map_test s where s.map3 => t.map5 order by t.pk;
 select t.map5, s.map5 from map_test t full join map_test s where s.map5 = t.map5 order by t.pk;
+
+select t.map2, s.map2 from map_test t join map_test s on map_apply((k,v)->(k+1,array_length(v)),s.map2) = map_apply((k,v)->(k+1,array_length(v)),t.map2) order by t.pk;
+select t.map2, s.map2 from map_test t join map_test s on map_apply((k,v)->(k+1,v),s.map2) = map_apply((k,v)->(k+1,v),t.map2) order by t.pk;

--- a/test/sql/test_join/T/test_join_struct
+++ b/test/sql/test_join/T/test_join_struct
@@ -47,34 +47,34 @@ select t.s4, s.s4 from struct_test t join struct_test s where s.s4 > t.s4 order 
 select t.s0, s.s0 from struct_test t join struct_test s on s.s0 >= t.s0 order by t.pk;
 select t.s4, s.s5 from struct_test t join struct_test s where s.s4 >= t.s5 order by t.pk;
 
-select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 = s.s5);
-select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 = s.s5);
-select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 = s.s5);
-select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 <=> s.s2);
-select s3 from struct_test t where exists (select 1 from struct_test s where t.s3 <=> s.s2);
-select s4 from struct_test t where exists (select 1 from struct_test s where t.s4 <=> s.s2);
-select s5 from struct_test t where exists (select 1 from struct_test s where t.s5 <=> s.s2);
+select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 = s.s5) order by t.pk;
+select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 = s.s5) order by t.pk;
+select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 = s.s5) order by t.pk;
+select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 <=> s.s2) order by t.pk;
+select s3 from struct_test t where exists (select 1 from struct_test s where t.s3 <=> s.s2) order by t.pk;
+select s4 from struct_test t where exists (select 1 from struct_test s where t.s4 <=> s.s2) order by t.pk;
+select s5 from struct_test t where exists (select 1 from struct_test s where t.s5 <=> s.s2) order by t.pk;
 
-select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 < s.s1);
-select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 < s.s1);
-select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 < s.s1);
-select s2 from struct_test t where not exists (select 1 from struct_test s where t.s2 <=> s.s5);
-select s3 from struct_test t where not exists (select 1 from struct_test s where t.s3 <=> s.s5);
-select s4 from struct_test t where not exists (select 1 from struct_test s where t.s4 <=> s.s5);
-select s5 from struct_test t where not exists (select 1 from struct_test s where t.s5 <=> s.s5);
+select s0 from struct_test t where exists (select 1 from struct_test s where t.s0 < s.s1) order by t.pk;
+select s1 from struct_test t where exists (select 1 from struct_test s where t.s1 < s.s1) order by t.pk;
+select s2 from struct_test t where exists (select 1 from struct_test s where t.s2 < s.s1) order by t.pk;
+select s2 from struct_test t where not exists (select 1 from struct_test s where t.s2 <=> s.s5) order by t.pk;
+select s3 from struct_test t where not exists (select 1 from struct_test s where t.s3 <=> s.s5) order by t.pk;
+select s4 from struct_test t where not exists (select 1 from struct_test s where t.s4 <=> s.s5) order by t.pk;
+select s5 from struct_test t where not exists (select 1 from struct_test s where t.s5 <=> s.s5) order by t.pk;
 
-select s2 from struct_test t where s2 in (select s0 from struct_test s);
-select s4 from struct_test t where s4 in (select s1 from struct_test s);
-select s0 from struct_test t where s0 in (select s5 from struct_test s);
-select s5 from struct_test t where s5 not in (select s5 from struct_test s);
-select s0 from struct_test t where s0 not in (select s5 from struct_test s);
+select s2 from struct_test t where s2 in (select s0 from struct_test s) order by t.pk;
+select s4 from struct_test t where s4 in (select s1 from struct_test s) order by t.pk;
+select s0 from struct_test t where s0 in (select s5 from struct_test s) order by t.pk;
+select s5 from struct_test t where s5 not in (select s5 from struct_test s) order by t.pk;
+select s0 from struct_test t where s0 not in (select s5 from struct_test s) order by t.pk;
 
-select s0 in (select s0 from struct_test s) from struct_test;
-select s0 in (select s1 from struct_test s) from struct_test;
-select s5 in (select s5 from struct_test s) from struct_test;
-select s0 not in (select s0 from struct_test s) from struct_test;
-select s0 not in (select s2 from struct_test s) from struct_test;
-select s0 not in (select s5 from struct_test s) from struct_test;
+select s0 in (select s0 from struct_test s) from struct_test order by t.pk;
+select s0 in (select s1 from struct_test s) from struct_test order by t.pk;
+select s5 in (select s5 from struct_test s) from struct_test order by t.pk;
+select s0 not in (select s0 from struct_test s) from struct_test order by t.pk;
+select s0 not in (select s2 from struct_test s) from struct_test order by t.pk;
+select s0 not in (select s5 from struct_test s) from struct_test order by t.pk;
 
 select t.s4, s.s5 from struct_test t left join struct_test s where s.s4 <=> t.s5 order by t.pk;
 select t.s0, s.s0 from struct_test t left join struct_test s on s.s0 = t.s0 order by t.pk;


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/issues/33852

rf clone the expr that was prepared, then prepare again, result into crashing. To fix it,  prepared state of expressions are safely reenterable.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
