### PR TITLE
[BugFix] exception when migrate empty tablet for primary key table (#34061)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -1053,6 +1053,10 @@ public class ReportHandler extends Daemon {
             long maxRowsetCreationTime = -1L;
             for (Replica replica : tablet.getImmutableReplicas()) {
                 maxRowsetCreationTime = Math.max(maxRowsetCreationTime, replica.getMaxRowsetCreationTime());
+                if (replica.getLastReportVersion() <= 1) {
+                    // unmigratable if it is a empty tablet
+                    return false;
+                }
             }
 
             // get negative max rowset creation time or too close to the max rowset creation time, unmigratable

--- a/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/leader/ReportHandlerTest.java
@@ -353,6 +353,7 @@ public class ReportHandlerTest {
                 replica.setMaxRowsetCreationTime(System.currentTimeMillis() / 1000);
             }
         }
+        Config.tablet_sched_max_migration_task_sent_once = 1000000;
         Config.primary_key_disk_schedule_time = 0;
         ReportHandler.handleMigration(tabletMetaMigrationMap, 10001);
     }


### PR DESCRIPTION
Problem:
If migrate empty tablet for primary key table will get error. This is because empty tablet for primary key table can not get any rowset to be migrated and cause this problem. Non-primary key tablets has no problem in this case because it can always get rowset(even empty) for empty tablet.

Solution:
Do not migrate the empty tablet for primary key table.

Fixes #34061

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
