### PR TITLE
[Enhancement] support refresh mv in reversed order

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2546,6 +2546,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long mv_active_checker_interval_seconds = 60;
 
+    // TODO: change the default value to true
+    @ConfField(mutable = true)
+    public static boolean default_mv_partition_refresh_reverse = false;
+
     /**
      * To prevent the external catalog from displaying too many entries in the grantsTo system table,
      * you can use this variable to ignore the entries in the external catalog

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -20,6 +20,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
+import com.starrocks.common.Config;
 import com.starrocks.sql.plan.ExecPlan;
 
 import java.util.List;
@@ -53,6 +54,7 @@ public class MvTaskRunContext extends TaskRunContext {
     private ExecPlan execPlan = null;
 
     private int partitionTTLNumber = TableProperty.INVALID;
+    private boolean partitionRefreshReverse = false;
 
     public MvTaskRunContext(TaskRunContext context) {
         this.ctx = context.ctx;
@@ -61,6 +63,7 @@ public class MvTaskRunContext extends TaskRunContext {
         this.properties = context.properties;
         this.type = context.type;
         this.status = context.status;
+        this.partitionRefreshReverse = Config.default_mv_partition_refresh_reverse;
     }
 
     public Map<String, Set<String>> getRefBaseTableMVIntersectedPartitions() {
@@ -159,5 +162,13 @@ public class MvTaskRunContext extends TaskRunContext {
     public void setRefBaseTablePartitionColumn(Column refBaseTablePartitionColumn) {
         Preconditions.checkNotNull(refBaseTablePartitionColumn);
         this.refBaseTablePartitionColumn = refBaseTablePartitionColumn;
+    }
+
+    public boolean isPartitionRefreshReverse() {
+        return partitionRefreshReverse;
+    }
+
+    public void setPartitionRefreshReverse(boolean partitionRefreshReverse) {
+        this.partitionRefreshReverse = partitionRefreshReverse;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -380,13 +380,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 .collect(Collectors.toList());
 
         // Skip first N partitions, which will be refreshed in this round
-        List<String> residualPartitions = sortedPartition.subList(partitionRefreshNumber, sortedPartition.size());
-
-        if (residualPartitions.isEmpty()) {
+        if (partitionRefreshNumber >= sortedPartition.size()) {
             mvContext.setNextPartitionStart(null);
             mvContext.setNextPartitionEnd(null);
             return;
         }
+        List<String> residualPartitions = sortedPartition.subList(partitionRefreshNumber, sortedPartition.size());
         String startPartitionName = residualPartitions.get(0);
         String endPartitionName = residualPartitions.get(residualPartitions.size() - 1);
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -359,6 +359,11 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         if (partitionRefreshNumber <= 0) {
             return;
         }
+        if (CollectionUtils.isEmpty(partitionsToRefresh)) {
+            mvContext.setNextPartitionStart(null);
+            mvContext.setNextPartitionEnd(null);
+            return;
+        }
         Map<String, Range<PartitionKey>> rangePartitionMap = materializedView.getRangePartitionMap();
         if (partitionRefreshNumber >= rangePartitionMap.size()) {
             return;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -2162,6 +2162,18 @@ public class PartitionBasedMvRefreshProcessorTest {
             processor.filterPartitionByRefreshNumber(toRefresh, materializedView);
             Assert.assertEquals(ImmutableSet.of("p2"), toRefresh);
             refreshedPartitions.addAll(toRefresh);
+
+            // round 4
+            toRefresh = new HashSet<>(SetUtils.disjunction(allPartitions, refreshedPartitions));
+            processor.filterPartitionByRefreshNumber(toRefresh, materializedView);
+            Assert.assertEquals(ImmutableSet.of("p1"), toRefresh);
+            refreshedPartitions.addAll(toRefresh);
+
+            // round 5
+            toRefresh = new HashSet<>(SetUtils.disjunction(allPartitions, refreshedPartitions));
+            processor.filterPartitionByRefreshNumber(toRefresh, materializedView);
+            Assert.assertEquals(ImmutableSet.of("p0"), toRefresh);
+            refreshedPartitions.addAll(toRefresh);
         }
     }
 


### PR DESCRIPTION
Fixes #issue

1. Support refresh partitions in reversed order, which is more reasonable when there're a lot of partitions
2. The default behavior has not been changed, but could be changed by `admin set frontend config('default_mv_partition_refresh_reverse'='true')`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
