### PR TITLE
[Enhancement] Optimize the performance of bitmap_xor using native roaring_bitmap function

### DIFF
--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -464,10 +464,7 @@ BitmapValue& BitmapValue::operator^=(const BitmapValue& rhs) {
             _type = BITMAP;
             break;
         case BITMAP: {
-            BitmapValue rhs_bitmap(rhs);
-            *rhs_bitmap._bitmap -= *_bitmap;
-            *_bitmap -= *rhs._bitmap;
-            *_bitmap |= *rhs_bitmap._bitmap;
+            *_bitmap ^= *rhs._bitmap;
             break;
         }
         case SET: {


### PR DESCRIPTION
Optimize the performance of bitmap_xor using native roaring_bitmap function

```
mysql> select count(bitmap_xor(c2, c3)) from t1;                                                                                            
+---------------------------+                                                                                                               
| count(bitmap_xor(c2, c3)) |                                                                                                               
+---------------------------+                                                                                                               
|                     38496 |                                                                                                               
+---------------------------+
```

Before optimization:
```
ExprComputeTime: 2s731ms
```
After optimization
```
ExprComputeTime: 2s154ms
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
