### PR TITLE
[BugFix] Fix full outer join rewrite and nested mv refresh bug for 3.1-mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -27,6 +27,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IsNullPredicate;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
@@ -1101,6 +1102,23 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 sourceTablePartitionRange.add(refBaseTableRangePartitionMap.get(partitionName));
             }
             sourceTablePartitionRange = MvUtils.mergeRanges(sourceTablePartitionRange);
+            // for nested mv, the base table may be another mv, which is partition by str2date(dt, '%Y%m%d')
+            // here we should convert date into '%Y%m%d' format
+            Expr partitionExpr = materializedView.getFirstPartitionRefTableExpr();
+            Pair<Table, Column> partitionTableAndColumn = materializedView.getBaseTableAndPartitionColumn();
+            boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionExpr, partitionTableAndColumn.second);
+            if (isConvertToDate && partitionExpr instanceof FunctionCallExpr
+                    && !sourceTablePartitionRange.isEmpty() && MvUtils.isDateRange(sourceTablePartitionRange.get(0))) {
+                FunctionCallExpr functionCallExpr = (FunctionCallExpr) partitionExpr;
+                Preconditions.checkState(functionCallExpr.getFnName().getFunction().equalsIgnoreCase(FunctionSet.STR2DATE));
+                String dateFormat = ((StringLiteral) functionCallExpr.getChild(1)).getStringValue();
+                List<Range<PartitionKey>> converted = Lists.newArrayList();
+                for (Range<PartitionKey> range : sourceTablePartitionRange) {
+                    Range<PartitionKey> varcharPartitionKey = MvUtils.convertToVarcharRange(range, dateFormat);
+                    converted.add(varcharPartitionKey);
+                }
+                sourceTablePartitionRange = converted;
+            }
             List<Expr> partitionPredicates =
                     MvUtils.convertRange(outputPartitionSlot, sourceTablePartitionRange);
             // range contains the min value could be null value
@@ -1272,6 +1290,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
         ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
+        ctx.getSessionVariable().setEnableInsertStrict(false);
         try {
             executor.handleDMLStmtWithProfile(execPlan, insertStmt, beginTimeInNanoSecond);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -34,6 +34,9 @@ public class MvPlanContextBuilder {
             optimizerConfig.disableRule(RuleType.TF_MATERIALIZED_VIEW);
         }
         optimizerConfig.setMVRewritePlan(true);
-        return mvOptimizer.optimize(mv, new ConnectContext(), optimizerConfig);
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(
+                ConnectContext.get().getSessionVariable().getOptimizerExecuteTimeout());
+        return mvOptimizer.optimize(mv, connectContext, optimizerConfig);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -47,7 +47,7 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
             } else if (o2 == null) {
                 return 1;
             } else {
-                return o1.toString().compareTo(o2.toString());
+                return o1.toString().toLowerCase().compareTo(o2.toString().toLowerCase());
             }
         }
     };

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -65,12 +65,16 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
                     } else if (o2 == null) {
                         return 1;
                     } else {
-                        String s1 = o1.toString();
-                        String s2 = o2.toString();
+                        String s1 = o1.toString().toLowerCase();
+                        String s2 = o2.toString().toLowerCase();
                         String n1 = s1.replaceAll("\\d+: ", "");
                         String n2 = s2.replaceAll("\\d+: ", "");
-                        int ret = n1.compareTo(n2);
-                        return ret == 0 ? s1.compareTo(s2) : ret;
+                        int ret = Integer.compare(n1.length(), n2.length());
+                        if (ret != 0) {
+                            return ret;
+                        }
+                        ret = n1.compareTo(n2);
+                        return (ret == 0) ? s1.compareTo(s2) : ret;
                     }
                 }
             };

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/JoinDeriveContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/JoinDeriveContext.java
@@ -25,6 +25,8 @@ public class JoinDeriveContext {
     private final JoinOperator mvJoinType;
     // join columns for left and right join tables
     private final List<List<ColumnRefOperator>> joinColumns;
+    // join columns for left and right join tables
+    private final List<List<ColumnRefOperator>> childOutputColumns;
 
     private final List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns;
 
@@ -32,11 +34,13 @@ public class JoinDeriveContext {
             JoinOperator queryJoinType,
             JoinOperator mvJoinType,
             List<List<ColumnRefOperator>> joinColumns,
-            List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns) {
+            List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns,
+            List<List<ColumnRefOperator>> childOutputColumns) {
         this.queryJoinType = queryJoinType;
         this.mvJoinType = mvJoinType;
         this.joinColumns = joinColumns;
         this.compensatedEquivalenceColumns = compensatedEquivalenceColumns;
+        this.childOutputColumns = childOutputColumns;
     }
 
     public JoinOperator getQueryJoinType() {
@@ -57,5 +61,13 @@ public class JoinDeriveContext {
 
     public List<Pair<ColumnRefOperator, ColumnRefOperator>> getCompensatedEquivalenceColumns() {
         return compensatedEquivalenceColumns;
+    }
+
+    public List<ColumnRefOperator> getLeftChildOutputColumns() {
+        return childOutputColumns.get(0);
+    }
+
+    public List<ColumnRefOperator> getRightChildOutputColumns() {
+        return childOutputColumns.get(1);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -376,9 +376,11 @@ public class MaterializedViewRewriter {
             ScalarOperator queryOnPredicate = queryJoin.getOnPredicate();
             // relationId -> join on predicate used columns
             Map<Integer, ColumnRefSet> tableToJoinColumns = Maps.newHashMap();
+            // first is from left, second is from right
             List<Pair<ColumnRefOperator, ColumnRefOperator>> joinColumnPairs = Lists.newArrayList();
-            boolean isSupported = isSupportedPredicate(queryOnPredicate,
-                    materializationContext.getQueryRefFactory(), tableToJoinColumns, joinColumnPairs);
+            ColumnRefSet leftColumns = queryExpr.inputAt(0).getOutputColumns();
+            boolean isSupported = isSupportedPredicate(queryOnPredicate, materializationContext.getQueryRefFactory(),
+                    leftColumns, tableToJoinColumns, joinColumnPairs);
             if (!isSupported) {
                 logMVRewrite(mvRewriteContext, "join predicate is not supported {}", queryOnPredicate);
                 return false;
@@ -389,19 +391,33 @@ public class MaterializedViewRewriter {
                 Table table = materializationContext.getQueryRefFactory().getTableForColumn(entry.getValue().getFirstId());
                 usedColumnsToTable.put(entry.getValue(), table);
             }
-            ColumnRefSet leftColumns = queryExpr.inputAt(0).getOutputColumns();
-            ColumnRefSet rightColumns = queryExpr.inputAt(1).getOutputColumns();
+
+            ColumnRefSet leftJoinColumns = new ColumnRefSet();
+            ColumnRefSet rightJoinColumns = new ColumnRefSet();
+            for (Pair<ColumnRefOperator, ColumnRefOperator> pair : joinColumnPairs) {
+                leftJoinColumns.union(pair.first);
+                rightJoinColumns.union(pair.second);
+            }
             List<List<ColumnRefOperator>> joinColumnRefs = Lists.newArrayList(Lists.newArrayList(), Lists.newArrayList());
             // query based join columns pair
             List<Pair<ColumnRefOperator, ColumnRefOperator>> compensatedEquivalenceColumns = Lists.newArrayList();
             boolean isCompatible = isJoinCompatible(usedColumnsToTable, queryJoinType, mvJoinType,
-                    leftColumns, rightColumns, joinColumnPairs, joinColumnRefs, compensatedEquivalenceColumns);
+                    leftJoinColumns, rightJoinColumns, joinColumnPairs, joinColumnRefs, compensatedEquivalenceColumns);
             if (!isCompatible) {
-                logMVRewrite(mvRewriteContext, "join columns not compatible {} != {}", leftColumns, rightColumns);
+                logMVRewrite(mvRewriteContext, "join columns not compatible {} != {}, query join type: {}, mv join type: {}",
+                        leftJoinColumns, rightJoinColumns, queryJoinType, mvJoinType);
                 return false;
             }
-            JoinDeriveContext joinDeriveContext =
-                    new JoinDeriveContext(queryJoinType, mvJoinType, joinColumnRefs, compensatedEquivalenceColumns);
+            // here collect output columns to compensate the derived predicates if necessary.
+            // use mv output columns because the output is decided by mv.
+            // if the column is not in mv's output, it can not be used as compensated predicate.
+            List<List<ColumnRefOperator>> childOutputColumns = Lists.newArrayList();
+            childOutputColumns.add(mvExpr.getChildOutputColumns(0)
+                    .getColumnRefOperators(materializationContext.getMvColumnRefFactory()));
+            childOutputColumns.add(mvExpr.getChildOutputColumns(1)
+                    .getColumnRefOperators(materializationContext.getMvColumnRefFactory()));
+            JoinDeriveContext joinDeriveContext = new JoinDeriveContext(
+                    queryJoinType, mvJoinType, joinColumnRefs, compensatedEquivalenceColumns, childOutputColumns);
             mvRewriteContext.addJoinDeriveContext(joinDeriveContext);
             return true;
         } else if (queryOp instanceof LogicalScanOperator) {
@@ -507,87 +523,35 @@ public class MaterializedViewRewriter {
             Preconditions.checkNotNull(leftTable);
             isCompatible = isUniqueColumns(leftTable, columnNames);
         } else if (mvJoinType.isLeftOuterJoin() && (queryJoinType.isInnerJoin() || queryJoinType.isLeftAntiJoin())) {
-            Optional<ColumnRefSet> rightColumnRefSet = usedColumnsToTable.keySet()
-                    .stream().filter(columnSet -> rightColumns.containsAll(columnSet)).findFirst();
-            if (!rightColumnRefSet.isPresent()) {
-                return false;
-            }
             List<ColumnRefOperator> rightJoinColumnRefs =
-                    rightColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
+                    rightColumns.getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(1, rightJoinColumnRefs);
             if (queryJoinType.isInnerJoin()) {
                 // for inner join, we should add the join columns into equivalence
                 compensatedEquivalenceColumns.addAll(joinColumnPairs);
             }
         } else if (mvJoinType.isRightOuterJoin() && (queryJoinType.isInnerJoin() || queryJoinType.isRightAntiJoin())) {
-            Optional<ColumnRefSet> leftColumnRefSet = usedColumnsToTable.keySet()
-                    .stream().filter(columnSet -> leftColumns.containsAll(columnSet)).findFirst();
-            if (!leftColumnRefSet.isPresent()) {
-                return false;
-            }
             List<ColumnRefOperator> leftJoinColumnRefs =
-                    leftColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
+                    leftColumns.getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(0, leftJoinColumnRefs);
             if (queryJoinType.isInnerJoin()) {
                 // for inner join, we should add the join columns into equivalence
                 compensatedEquivalenceColumns.addAll(joinColumnPairs);
             }
         } else if (mvJoinType.isFullOuterJoin() && queryJoinType.isLeftOuterJoin()) {
-            Optional<ColumnRefSet> leftColumnRefSet = usedColumnsToTable.keySet()
-                    .stream().filter(columnSet -> leftColumns.containsAll(columnSet)).findFirst();
-            if (!leftColumnRefSet.isPresent()) {
-                return false;
-            }
-            Table leftTable = usedColumnsToTable.get(leftColumnRefSet.get());
-            if (leftTable.getColumns().stream().allMatch(column -> column.isAllowNull())) {
-                // should have at least one nullable column
-                return  false;
-            }
-
             List<ColumnRefOperator> leftJoinColumnRefs =
-                    leftColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
+                    leftColumns.getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(0, leftJoinColumnRefs);
         } else if (mvJoinType.isFullOuterJoin() && queryJoinType.isRightOuterJoin()) {
-            Optional<ColumnRefSet> rightColumnRefSet = usedColumnsToTable.keySet()
-                    .stream().filter(columnSet -> rightColumns.containsAll(columnSet)).findFirst();
-            if (!rightColumnRefSet.isPresent()) {
-                return false;
-            }
-            Table rightTable = usedColumnsToTable.get(rightColumnRefSet.get());
-            if (rightTable.getColumns().stream().allMatch(column -> column.isAllowNull())) {
-                // should have at least one nullable column
-                return  false;
-            }
             List<ColumnRefOperator> rightJoinColumnRefs =
-                    rightColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
+                    rightColumns.getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(1, rightJoinColumnRefs);
         } else if (mvJoinType.isFullOuterJoin() && queryJoinType.isInnerJoin()) {
-            Optional<ColumnRefSet> leftColumnRefSet = usedColumnsToTable.keySet()
-                    .stream().filter(columnSet -> leftColumns.containsAll(columnSet)).findFirst();
-            if (!leftColumnRefSet.isPresent()) {
-                return false;
-            }
-            Table leftTable = usedColumnsToTable.get(leftColumnRefSet.get());
-            if (leftTable.getColumns().stream().allMatch(column -> column.isAllowNull())) {
-                // should have at least one nullable column
-                return  false;
-            }
             List<ColumnRefOperator> leftJoinColumnRefs =
-                    leftColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
+                    leftColumns.getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(0, leftJoinColumnRefs);
-
-            Optional<ColumnRefSet> rightColumnRefSet = usedColumnsToTable.keySet()
-                    .stream().filter(columnSet -> rightColumns.containsAll(columnSet)).findFirst();
-            if (!rightColumnRefSet.isPresent()) {
-                return false;
-            }
-            Table rightTable = usedColumnsToTable.get(rightColumnRefSet.get());
-            if (rightTable.getColumns().stream().allMatch(column -> column.isAllowNull())) {
-                // should have at least one nullable column
-                return  false;
-            }
             List<ColumnRefOperator> rightJoinColumnRefs =
-                    rightColumnRefSet.get().getColumnRefOperators(materializationContext.getQueryRefFactory());
+                    rightColumns.getColumnRefOperators(materializationContext.getQueryRefFactory());
             joinColumnRefs.set(1, rightJoinColumnRefs);
             // for inner join, we should add the join columns into equivalence
             compensatedEquivalenceColumns.addAll(joinColumnPairs);
@@ -609,8 +573,8 @@ public class MaterializedViewRewriter {
     }
 
     private boolean isSupportedPredicate(
-            ScalarOperator onPredicate, ColumnRefFactory columnRefFactory, Map<Integer, ColumnRefSet> tableToJoinColumns,
-            List<Pair<ColumnRefOperator, ColumnRefOperator>> joinColumnPairs) {
+            ScalarOperator onPredicate, ColumnRefFactory columnRefFactory, ColumnRefSet leftColumns,
+            Map<Integer, ColumnRefSet> tableToJoinColumns, List<Pair<ColumnRefOperator, ColumnRefOperator>> joinColumnPairs) {
         List<ScalarOperator> conjuncts = Utils.extractConjuncts(onPredicate);
         List<ScalarOperator> binaryPredicates = conjuncts.stream()
                 .filter(conjunct -> ScalarOperator.isColumnEqualBinaryPredicate(conjunct)).collect(Collectors.toList());
@@ -619,7 +583,11 @@ public class MaterializedViewRewriter {
         }
 
         for (ScalarOperator scalarOperator : binaryPredicates) {
-            joinColumnPairs.add(Pair.create(scalarOperator.getChild(0).cast(), scalarOperator.getChild(1).cast()));
+            if (leftColumns.containsAll(scalarOperator.getChild(0).getUsedColumns())) {
+                joinColumnPairs.add(Pair.create(scalarOperator.getChild(0).cast(), scalarOperator.getChild(1).cast()));
+            } else {
+                joinColumnPairs.add(Pair.create(scalarOperator.getChild(1).cast(), scalarOperator.getChild(0).cast()));
+            }
         }
 
         ColumnRefSet usedColumns = Utils.compoundAnd(binaryPredicates).getUsedColumns();
@@ -627,14 +595,10 @@ public class MaterializedViewRewriter {
             int relationId = columnRefFactory.getRelationId(columnId);
             if (relationId == -1) {
                 // not use the column from table scan, unsupported
-                return false;
+                continue;
             }
             ColumnRefSet refColumns = tableToJoinColumns.computeIfAbsent(relationId, k -> new ColumnRefSet());
             refColumns.union(columnId);
-        }
-        if (tableToJoinColumns.size() != 2) {
-            // join predicate refs more than two tables, unsupported
-            return false;
         }
         return true;
     }
@@ -788,7 +752,7 @@ public class MaterializedViewRewriter {
                 .filter(columnRef -> !scanMvOutputColumns.contains(columnRef))
                 .collect(Collectors.toSet());
         final EquivalenceClasses queryEc = createEquivalenceClasses(
-                queryPredicateSplit.getEqualPredicates(), queryExpression, null);
+                queryPredicateSplit.getEqualPredicates(), queryExpression, mvRewriteContext.getQueryColumnRefRewriter(), null);
         if (queryEc == null) {
             logMVRewrite(mvRewriteContext, "Cannot construct query equivalence classes");
             return null;
@@ -829,14 +793,19 @@ public class MaterializedViewRewriter {
 
             // construct query based view EC
             final EquivalenceClasses queryBasedViewEqualPredicate =
-                    createEquivalenceClasses(mvEqualPredicate, mvExpression, columnRewriter);
+                    createEquivalenceClasses(mvEqualPredicate, mvExpression, mvColumnRefRewriter, columnRewriter);
             if (queryBasedViewEqualPredicate == null) {
                 logMVRewrite(mvRewriteContext, "Rewrite complete failed: cannot construct query based equivalence classes");
                 return null;
             }
             for (JoinDeriveContext deriveContext : mvRewriteContext.getJoinDeriveContexts()) {
                 for (Pair<ColumnRefOperator, ColumnRefOperator> pair : deriveContext.getCompensatedEquivalenceColumns()) {
-                    queryBasedViewEqualPredicate.addEquivalence(pair.first, pair.second);
+                    ScalarOperator first = mvRewriteContext.getQueryColumnRefRewriter().rewrite(pair.first);
+                    ScalarOperator second = mvRewriteContext.getQueryColumnRefRewriter().rewrite(pair.second);
+                    // now only support this pattern ec
+                    if (first.isColumnRef() && second.isColumnRef()) {
+                        queryBasedViewEqualPredicate.addEquivalence(first.cast(), second.cast());
+                    }
                 }
             }
             rewriteContext.setQueryBasedViewEquivalenceClasses(queryBasedViewEqualPredicate);
@@ -1265,8 +1234,7 @@ public class MaterializedViewRewriter {
             final ScalarOperator equalPredicates = MvUtils.canonizePredicate(compensationPredicates.getEqualPredicates());
             final ScalarOperator otherPredicates = MvUtils.canonizePredicate(Utils.compoundAnd(
                     compensationPredicates.getRangePredicates(), compensationPredicates.getResidualPredicates()));
-
-            final ScalarOperator compensationPredicate = getMVCompensationPredicate(rewriteContext,
+            ScalarOperator compensationPredicate = getMVCompensationPredicate(rewriteContext,
                     columnRewriter, mvColumnRefToScalarOp, equalPredicates, otherPredicates);
             if (compensationPredicate == null) {
                 logMVRewrite(mvRewriteContext, "Rewrite query failed: success to convert query compensation predicates to MV " +
@@ -1352,38 +1320,45 @@ public class MaterializedViewRewriter {
             Optional<ScalarOperator> derivedPredicateOpt = Optional.empty();
             if (joinDeriveContext.getMvJoinType().isLeftOuterJoin() && joinDeriveContext.getQueryJoinType().isInnerJoin()) {
                 List<ColumnRefOperator> rightJoinColumns = joinDeriveContext.getRightJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, rightJoinColumns, predicates, true, true, false);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, rightJoinColumns, joinDeriveContext.getRightChildOutputColumns(),
+                        predicates, true, true, false);
             } else if (joinDeriveContext.getMvJoinType().isLeftOuterJoin()
                     && joinDeriveContext.getQueryJoinType().isLeftAntiJoin()) {
                 List<ColumnRefOperator> rightJoinColumns = joinDeriveContext.getRightJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, rightJoinColumns, predicates, false, true, false);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, rightJoinColumns, joinDeriveContext.getRightChildOutputColumns(),
+                        predicates, false, true, false);
             } else if (joinDeriveContext.getMvJoinType().isRightOuterJoin()
                     && joinDeriveContext.getQueryJoinType().isInnerJoin()) {
                 List<ColumnRefOperator> leftJoinColumns = joinDeriveContext.getLeftJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, leftJoinColumns, predicates, true, true, false);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, leftJoinColumns, joinDeriveContext.getLeftChildOutputColumns(),
+                        predicates, true, true, false);
             } else if (joinDeriveContext.getMvJoinType().isRightOuterJoin()
                     && joinDeriveContext.getQueryJoinType().isRightAntiJoin()) {
                 List<ColumnRefOperator> leftJoinColumns = joinDeriveContext.getLeftJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, leftJoinColumns, predicates, false, true, false);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, leftJoinColumns, joinDeriveContext.getLeftChildOutputColumns(),
+                        predicates, false, true, false);
             } else if (joinDeriveContext.getMvJoinType().isFullOuterJoin()
                     && joinDeriveContext.getQueryJoinType().isLeftOuterJoin()) {
                 List<ColumnRefOperator> leftJoinColumns = joinDeriveContext.getLeftJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, leftJoinColumns, predicates, true, false, true);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, leftJoinColumns, joinDeriveContext.getLeftChildOutputColumns(),
+                        predicates, true, false, true);
             } else if (joinDeriveContext.getMvJoinType().isFullOuterJoin()
                     && joinDeriveContext.getQueryJoinType().isRightOuterJoin()) {
                 List<ColumnRefOperator> rightJoinColumns = joinDeriveContext.getRightJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, rightJoinColumns, predicates, true, false, true);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, rightJoinColumns, joinDeriveContext.getRightChildOutputColumns(),
+                        predicates, true, false, true);
             } else if (joinDeriveContext.getMvJoinType().isFullOuterJoin()
                     && joinDeriveContext.getQueryJoinType().isInnerJoin()) {
                 List<ColumnRefOperator> rightJoinColumns = joinDeriveContext.getRightJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, rightJoinColumns, predicates, true, false, true);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, rightJoinColumns, joinDeriveContext.getRightChildOutputColumns(),
+                        predicates, true, false, true);
                 if (!derivedPredicateOpt.isPresent()) {
                     // can not get derived predicates
                     return null;
@@ -1393,8 +1368,9 @@ public class MaterializedViewRewriter {
                     derivedPredicates.add(derivedPredicate);
                 }
                 List<ColumnRefOperator> leftJoinColumns = joinDeriveContext.getLeftJoinColumns();
-                derivedPredicateOpt = getDerivedPredicate(rewriteContext,
-                        rewriter, mvColumnRefToScalarOp, leftJoinColumns, predicates, true, false, true);
+                derivedPredicateOpt = getDerivedPredicate(rewriteContext, rewriter,
+                        mvColumnRefToScalarOp, leftJoinColumns, joinDeriveContext.getLeftChildOutputColumns(),
+                        predicates, true, false, true);
             }
             if (!derivedPredicateOpt.isPresent()) {
                 // can not get derived predicates
@@ -1413,43 +1389,57 @@ public class MaterializedViewRewriter {
             ColumnRewriter rewriter,
             Map<ColumnRefOperator, ScalarOperator> mvColumnRefToScalarOp,
             List<ColumnRefOperator> joinColumns,
+            List<ColumnRefOperator> outputColumns,
             List<ScalarOperator> compensationPredicates,
             boolean isNotNull, boolean onlyJoinColumns, boolean onlyNotNullColumns) {
-        Integer relationId = materializationContext.getQueryRefFactory().getRelationId(joinColumns.get(0).getId());
-        List<ColumnRefOperator> relationColumns = Lists.newArrayList();
-        Map<Integer, Integer> columnToRelationId = materializationContext.getQueryRefFactory().getColumnToRelationIds();
-        for (Map.Entry<Integer, Integer> entry : columnToRelationId.entrySet()) {
-            if (entry.getValue().equals(relationId)) {
-                relationColumns.add(materializationContext.getQueryRefFactory().getColumnRef(entry.getKey()));
+        // output column to target mv expr
+        Map<ColumnRefOperator, ScalarOperator> compensatedColumnsInMv = Maps.newHashMap();
+        // output column to query based expr
+        Map<ColumnRefOperator, ScalarOperator> outputExprMap = Maps.newHashMap();
+        Set<ColumnRefOperator> relatedColumns = Sets.newHashSet();
+        // outputColumns are mv based, should be rewritten by MvColumnRefRewriter first to base tables
+        // and then rewritten to mv to construct the derived predicates
+        for (ColumnRefOperator outputColumn : outputColumns) {
+            ScalarOperator rewrittenColumnRef = rewriteContext.getMvColumnRefRewriter().rewrite(outputColumn);
+            rewrittenColumnRef = rewriter.rewriteViewToQuery(rewrittenColumnRef);
+            ScalarOperator targetExpr = rewriteMVCompensationExpression(rewriteContext, rewriter,
+                    mvColumnRefToScalarOp, rewrittenColumnRef, false, false);
+            if (targetExpr != null) {
+                relatedColumns.addAll(targetExpr.getColumnRefs());
+                compensatedColumnsInMv.put(outputColumn, targetExpr);
+                outputExprMap.put(outputColumn, rewrittenColumnRef);
             }
-        }
-        Map<ColumnRefOperator, ColumnRefOperator> compensatedColumnsInMv = Maps.newHashMap();
-        for (ColumnRefOperator relationColumnRef : relationColumns) {
-            if (onlyNotNullColumns && relationColumnRef.isNullable()) {
-                continue;
-            }
-            ScalarOperator rewrittenColumnRef = rewriteMVCompensationExpression(rewriteContext, rewriter,
-                    mvColumnRefToScalarOp, relationColumnRef, false, false);
-            if (rewrittenColumnRef != null) {
-                compensatedColumnsInMv.put(relationColumnRef, (ColumnRefOperator) rewrittenColumnRef);
-            }
-        }
-        if (compensatedColumnsInMv.isEmpty()) {
-            // there is no output of compensation table
-            return Optional.empty();
         }
 
-        Collection<ColumnRefOperator> relatedColumns = compensatedColumnsInMv.values();
         List<ScalarOperator> relatedPredicates = compensationPredicates.stream().filter(
                 predicate -> predicate.getUsedColumns().containsAny(relatedColumns)).collect(Collectors.toList());
         if (relatedPredicates.isEmpty() || relatedPredicates.stream().allMatch(
-                relatedPredicate -> !Utils.canEliminateNull(Sets.newHashSet(relatedColumns), relatedPredicate))) {
+                relatedPredicate -> !Utils.canEliminateNull(relatedColumns, relatedPredicate))) {
+            if (compensatedColumnsInMv.isEmpty()) {
+                // there is no output of compensation table
+                return Optional.empty();
+            }
             final List<ColumnRefOperator> candidateColumns = Lists.newArrayList();
             if (onlyJoinColumns) {
-                compensatedColumnsInMv.keySet().stream().filter(key -> joinColumns.contains(key))
-                        .forEach(key -> candidateColumns.add(compensatedColumnsInMv.get(key)));
+                List<ScalarOperator> joinExprs = Lists.newArrayList();
+                for (ColumnRefOperator joinColumn : joinColumns) {
+                    joinExprs.add(rewriteContext.getQueryColumnRefRewriter().rewrite(joinColumn));
+                }
+                for (ColumnRefOperator outputColumn : compensatedColumnsInMv.keySet()) {
+                    if (joinExprs.contains(outputExprMap.get(outputColumn))) {
+                        candidateColumns.addAll(compensatedColumnsInMv.get(outputColumn).getColumnRefs());
+                    }
+                }
             } else {
-                candidateColumns.addAll(compensatedColumnsInMv.values());
+                candidateColumns.addAll(relatedColumns);
+            }
+            if (onlyNotNullColumns) {
+                for (ColumnRefOperator columnRef : compensatedColumnsInMv.keySet()) {
+                    // remove nullable columns
+                    if (columnRef.isNullable()) {
+                        candidateColumns.remove(compensatedColumnsInMv.get(columnRef));
+                    }
+                }
             }
             if (candidateColumns.isEmpty()) {
                 return Optional.empty();
@@ -1968,10 +1958,13 @@ public class MaterializedViewRewriter {
     }
 
     private EquivalenceClasses createEquivalenceClasses(
-            ScalarOperator equalPredicate, OptExpression expression, ColumnRewriter columnRewriter) {
+            ScalarOperator equalPredicate, OptExpression expression,
+            ReplaceColumnRefRewriter refRewriter, ColumnRewriter columnRewriter) {
         List<ScalarOperator> outerJoinOnPredicate = MvUtils.collectOuterAntiJoinOnPredicate(expression);
         final PredicateSplit outerJoinPredicateSplit = PredicateSplit.splitPredicate(Utils.compoundAnd(outerJoinOnPredicate));
-        return createEquivalenceClasses(equalPredicate, outerJoinPredicateSplit.getEqualPredicates(), columnRewriter);
+        // should use ReplaceColumnRefRewriter to rewrite outerJoinPredicateSplit to base tables
+        return createEquivalenceClasses(equalPredicate,
+                refRewriter.rewrite(outerJoinPredicateSplit.getEqualPredicates()), columnRewriter);
     }
 
     // equalPredicates eg: t1.a = t2.b and t1.c = t2.d
@@ -2000,47 +1993,6 @@ public class MaterializedViewRewriter {
             if (leftTarget == null || rightTarget == null) {
                 return null;
             }
-            ec.addEquivalence(leftTarget, rightTarget);
-        }
-        return ec;
-    }
-
-    // equalPredicates eg: t1.a = t2.b and t1.c = t2.d
-    private EquivalenceClasses createEquivalenceClasses(ScalarOperator equalPredicates) {
-        EquivalenceClasses ec = new EquivalenceClasses();
-        if (equalPredicates == null) {
-            return ec;
-        }
-        for (ScalarOperator equalPredicate : Utils.extractConjuncts(equalPredicates)) {
-            Preconditions.checkState(equalPredicate.getChild(0).isColumnRef());
-            ColumnRefOperator left = (ColumnRefOperator) equalPredicate.getChild(0);
-            Preconditions.checkState(equalPredicate.getChild(1).isColumnRef());
-            ColumnRefOperator right = (ColumnRefOperator) equalPredicate.getChild(1);
-            ec.addEquivalence(left, right);
-        }
-        return ec;
-    }
-
-    private EquivalenceClasses createQueryBasedEquivalenceClasses(ColumnRewriter columnRewriter,
-                                                                  ScalarOperator equalPredicates) {
-        EquivalenceClasses ec = new EquivalenceClasses();
-        if (equalPredicates == null) {
-            return ec;
-        }
-
-        for (ScalarOperator equalPredicate : Utils.extractConjuncts(equalPredicates)) {
-            Preconditions.checkState(equalPredicate.getChild(0).isColumnRef());
-            ColumnRefOperator left = (ColumnRefOperator) equalPredicate.getChild(0);
-            Preconditions.checkState(equalPredicate.getChild(1).isColumnRef());
-            ColumnRefOperator right = (ColumnRefOperator) equalPredicate.getChild(1);
-            ScalarOperator leftScalar = columnRewriter.rewriteViewToQuery(left);
-            ScalarOperator rightScalar = columnRewriter.rewriteViewToQuery(right);
-            if (leftScalar == null || rightScalar == null) {
-                return ec;
-            }
-
-            ColumnRefOperator leftTarget = leftScalar.cast();
-            ColumnRefOperator rightTarget = rightScalar.cast();
             ec.addEquivalence(leftTarget, rightTarget);
         }
         return ec;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -95,6 +95,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -1071,12 +1072,12 @@ public class MvUtils {
             LocalDateTime lowerDateTime = DateUtils.parseDatTimeString(lowerString.getStringValue());
             PartitionKey lowerPartitionKey = PartitionKey.ofDate(lowerDateTime.toLocalDate());
 
-            StringLiteral upperString = (StringLiteral) from.lowerEndpoint().getKeys().get(0);
+            StringLiteral upperString = (StringLiteral) from.upperEndpoint().getKeys().get(0);
             LocalDateTime upperDateTime = DateUtils.parseDatTimeString(upperString.getStringValue());
             PartitionKey upperPartitionKey = PartitionKey.ofDate(upperDateTime.toLocalDate());
             return Range.range(lowerPartitionKey, from.lowerBoundType(), upperPartitionKey, from.upperBoundType());
         } else if (from.hasUpperBound()) {
-            StringLiteral upperString = (StringLiteral) from.lowerEndpoint().getKeys().get(0);
+            StringLiteral upperString = (StringLiteral) from.upperEndpoint().getKeys().get(0);
             LocalDateTime upperDateTime = DateUtils.parseDatTimeString(upperString.getStringValue());
             PartitionKey upperPartitionKey = PartitionKey.ofDate(upperDateTime.toLocalDate());
             return Range.upTo(upperPartitionKey, from.upperBoundType());
@@ -1084,6 +1085,44 @@ public class MvUtils {
             StringLiteral lowerString = (StringLiteral) from.lowerEndpoint().getKeys().get(0);
             LocalDateTime lowerDateTime = DateUtils.parseDatTimeString(lowerString.getStringValue());
             PartitionKey lowerPartitionKey = PartitionKey.ofDate(lowerDateTime.toLocalDate());
+            return Range.downTo(lowerPartitionKey, from.lowerBoundType());
+        }
+        return Range.all();
+    }
+
+    public static boolean isDateRange(Range<PartitionKey> range) {
+        if (range.hasUpperBound()) {
+            PartitionKey partitionKey = range.upperEndpoint();
+            return partitionKey.getKeys().get(0) instanceof DateLiteral;
+        } else if (range.hasLowerBound()) {
+            PartitionKey partitionKey = range.lowerEndpoint();
+            return partitionKey.getKeys().get(0) instanceof DateLiteral;
+        }
+        return false;
+    }
+
+    // convert date to varchar type
+    public static Range<PartitionKey> convertToVarcharRange(
+            Range<PartitionKey> from, String dateFormat) throws AnalysisException {
+        DateTimeFormatter formatter = DateUtils.unixDatetimeFormatter(dateFormat);
+        if (from.hasLowerBound() && from.hasUpperBound()) {
+            DateLiteral lowerDate = (DateLiteral) from.lowerEndpoint().getKeys().get(0);
+            String lowerDateString = lowerDate.toLocalDateTime().toLocalDate().format(formatter);
+            PartitionKey lowerPartitionKey = PartitionKey.ofString(lowerDateString);
+
+            DateLiteral upperDate = (DateLiteral) from.upperEndpoint().getKeys().get(0);
+            String upperDateString = upperDate.toLocalDateTime().toLocalDate().format(formatter);
+            PartitionKey upperPartitionKey = PartitionKey.ofString(upperDateString);
+            return Range.range(lowerPartitionKey, from.lowerBoundType(), upperPartitionKey, from.upperBoundType());
+        } else if (from.hasUpperBound()) {
+            DateLiteral upperDate = (DateLiteral) from.upperEndpoint().getKeys().get(0);
+            String upperDateString = upperDate.toLocalDateTime().toLocalDate().format(formatter);
+            PartitionKey upperPartitionKey = PartitionKey.ofString(upperDateString);
+            return Range.upTo(upperPartitionKey, from.upperBoundType());
+        } else if (from.hasLowerBound()) {
+            DateLiteral lowerDate = (DateLiteral) from.lowerEndpoint().getKeys().get(0);
+            String lowerDateString = lowerDate.toLocalDateTime().toLocalDate().format(formatter);
+            PartitionKey lowerPartitionKey = PartitionKey.ofString(lowerDateString);
             return Range.downTo(lowerPartitionKey, from.lowerBoundType());
         }
         return Range.all();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -538,7 +538,7 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv, "select empid as col2, emps.locationid from " +
                 "emps left join locations on emps.locationid = locations.locationid " +
                 "where emps.locationid > 10");
-        // TODO: Query's left outer join will be converted to Inner Join.
+        // no locations.locationid in mv
         testRewriteFail(mv, "select empid as col2, locations.locationid from " +
                 "emps left join locations on emps.locationid = locations.locationid " +
                 "where locations.locationid > 10");
@@ -3224,7 +3224,8 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     " from lineorder left outer join customer" +
                     " on lo_custkey = c_custkey where c_name = 'name' and c_custkey = 100";
             MVRewriteChecker checker = testRewriteOK(mv, query);
-            checker.contains("TABLE: mv0\n" +
+            checker.contains("0:OlapScanNode\n" +
+                    "     TABLE: mv0\n" +
                     "     PREAGGREGATION: ON\n" +
                     "     PREDICATES: 30: c_custkey = 100, 31: c_name = 'name'\n" +
                     "     partitions=1/1");
@@ -3336,6 +3337,8 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                     "     PREDICATES: 30: lo_custkey IS NOT NULL\n" +
                     "     partitions=1/1");
         }
+
+
 
         {
             String mv = "select lo_orderkey, lo_linenumber, lo_quantity, lo_revenue, c_custkey, lo_custkey, c_name" +
@@ -4663,5 +4666,316 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         starRocksAssert.dropTable("table_d");
         starRocksAssert.dropTable("table_e");
         starRocksAssert.dropMaterializedView("mv_view_delta_1");
+    }
+
+    @Test
+    public void testJoinDeriveRewriteOnNestedMv() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `IDX_BASE_DIM_TRACEID` (\n" +
+                "  `trace_id` varchar(65533) DEFAULT NULL,\n" +
+                "  `strategy_id_pdl` varchar(65533) DEFAULT NULL,\n" +
+                "  `dt` date DEFAULT NULL\n" +
+                ") PARTITION BY range(dt) (\n" +
+                "PARTITION p1 VALUES [ (\"20230702\"),(\"20230703\")),\n" +
+                "PARTITION p2 VALUES [ (\"20230703\"),(\"20230704\")),\n" +
+                "PARTITION p3 VALUES [ (\"20230704\"),(\"20230705\")),\n" +
+                "PARTITION p4 VALUES [ (\"20230705\"),(\"20230706\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(trace_id)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n" +
+                "\n");
+
+        starRocksAssert.withTable("CREATE TABLE `IDX_BASE_OBJ_STRATEGY` (\n" +
+                "  `strategy_id` varchar(65533) DEFAULT NULL,\n" +
+                "  `strategy_type` varchar(65533) DEFAULT NULL,\n" +
+                "  `cust_group_name` varchar(65533) DEFAULT NULL,\n" +
+                "  `dt` date DEFAULT NULL\n" +
+                ") PARTITION BY range(dt) (\n" +
+                "PARTITION p1 VALUES [ (\"20230702\"),(\"20230703\")),\n" +
+                "PARTITION p2 VALUES [ (\"20230703\"),(\"20230704\")),\n" +
+                "PARTITION p3 VALUES [ (\"20230704\"),(\"20230705\")),\n" +
+                "PARTITION p4 VALUES [ (\"20230705\"),(\"20230706\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(strategy_id)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n" +
+                "\n");
+
+        starRocksAssert.withTable("CREATE TABLE `IDX_COMMON_EV_BANKAPP_EXP_CLICK_INFO` (\n" +
+                "  `strategy_id_pdl` varchar(65533) DEFAULT NULL,\n" +
+                "  `becif_no` varchar(65533) DEFAULT NULL,\n" +
+                "  `trace_id` varchar(65533) DEFAULT NULL,\n" +
+                "  `pv` int(11) DEFAULT NULL,\n" +
+                "  `dt` date DEFAULT NULL\n" +
+                ") PARTITION BY range(dt) (\n" +
+                "PARTITION p1 VALUES [ (\"20230702\"),(\"20230703\")),\n" +
+                "PARTITION p2 VALUES [ (\"20230703\"),(\"20230704\")),\n" +
+                "PARTITION p3 VALUES [ (\"20230704\"),(\"20230705\")),\n" +
+                "PARTITION p4 VALUES [ (\"20230705\"),(\"20230706\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(trace_id)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n" +
+                "\n");
+
+        starRocksAssert.withTable("CREATE TABLE `IDX_COMMON_EV_BANKAPP_CLICK_INFO` (\n" +
+                "  `strategy_id_pdl` varchar(65533) DEFAULT NULL,\n" +
+                "  `becif_no` varchar(65533) DEFAULT NULL,\n" +
+                "  `trace_id` varchar(65533) DEFAULT NULL,\n" +
+                "  `pv` int(11) DEFAULT NULL,\n" +
+                "  `dt` date DEFAULT NULL\n" +
+                ") PARTITION BY range(dt) (\n" +
+                "PARTITION p1 VALUES [ (\"20230702\"),(\"20230703\")),\n" +
+                "PARTITION p2 VALUES [ (\"20230703\"),(\"20230704\")),\n" +
+                "PARTITION p3 VALUES [ (\"20230704\"),(\"20230705\")),\n" +
+                "PARTITION p4 VALUES [ (\"20230705\"),(\"20230706\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(trace_id)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n" +
+                "\n");
+
+        starRocksAssert.withTable("CREATE TABLE `IDX_CUST_COMMON_DIM` (\n" +
+                "  `sales_new_cust` varchar(65533) DEFAULT NULL,\n" +
+                "  `payroll_flag` varchar(65533) DEFAULT NULL,\n" +
+                "  `becif_no` varchar(65533) DEFAULT NULL,\n" +
+                "  `dt` date DEFAULT NULL\n" +
+                ") PARTITION BY range(dt) (\n" +
+                "PARTITION p1 VALUES [ (\"20230702\"),(\"20230703\")),\n" +
+                "PARTITION p2 VALUES [ (\"20230703\"),(\"20230704\")),\n" +
+                "PARTITION p3 VALUES [ (\"20230704\"),(\"20230705\")),\n" +
+                "PARTITION p4 VALUES [ (\"20230705\"),(\"20230706\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(becif_no)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n" +
+                "\n");
+
+        starRocksAssert.withTable("CREATE TABLE `D_OPERATION_ORDER_CUST_DETAIL_PDL_ID3` (\n" +
+                "  `strategy_id_pdl` varchar(65533) DEFAULT NULL,\n" +
+                "  `trace_id` varchar(65533) DEFAULT NULL,\n" +
+                "  `page_name_gy` varchar(65533) DEFAULT NULL,\n" +
+                "  `becif_no` varchar(65533) DEFAULT NULL,\n" +
+                "  `dt` date DEFAULT NULL\n" +
+                ") PARTITION BY range(dt) (\n" +
+                "PARTITION p1 VALUES [ (\"20230702\"),(\"20230703\")),\n" +
+                "PARTITION p2 VALUES [ (\"20230703\"),(\"20230704\")),\n" +
+                "PARTITION p3 VALUES [ (\"20230704\"),(\"20230705\")),\n" +
+                "PARTITION p4 VALUES [ (\"20230705\"),(\"20230706\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(trace_id)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");\n" +
+                "\n");
+
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_perf_mv_pv1`\n" +
+                "PARTITION BY dt\n" +
+                "DISTRIBUTED BY HASH(`TRACE_ID`) BUCKETS 8\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ")\n" +
+                "AS\n" +
+                " SELECT\n" +
+                "                 f.DT,\n" +
+                "                f.TRACE_ID AS TRACE_ID,\n" +
+                "                f.BECIF_NO AS BECIF_NO,\n" +
+                "                SUM(f.PV) AS pv1\n" +
+                "            FROM\n" +
+                "                IDX_COMMON_EV_BANKAPP_CLICK_INFO f\n" +
+                "            GROUP BY\n" +
+                "                f.DT,\n" +
+                "                f.BECIF_NO,\n" +
+                "                f.TRACE_ID;");
+
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_perf_mv_pv2`\n" +
+                "PARTITION BY dt\n" +
+                "DISTRIBUTED BY HASH(`BECIF_NO`) BUCKETS 8\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ")\n" +
+                "AS\n" +
+                " SELECT\n" +
+                "                 f.DT,\n" +
+                "                dim0.STRATEGY_ID_PDL AS STRATEGY_ID_PDL,\n" +
+                "                f.BECIF_NO AS BECIF_NO,\n" +
+                "                SUM(f.PV) AS pv2\n" +
+                "            FROM\n" +
+                "                IDX_COMMON_EV_BANKAPP_EXP_CLICK_INFO f\n" +
+                "            LEFT JOIN IDX_BASE_DIM_TRACEID dim0 ON\n" +
+                "                f.TRACE_ID = dim0.TRACE_ID\n" +
+                "                AND f.DT = dim0.DT\n" +
+                "            GROUP BY\n" +
+                "                f.DT,\n" +
+                "                f.BECIF_NO,\n" +
+                "                dim0.STRATEGY_ID_PDL;");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `test_perf_mv_pv3`\n" +
+                "PARTITION BY dt \n" +
+                "DISTRIBUTED BY HASH(`BECIF_NO`) BUCKETS 8\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ")\n" +
+                "AS\n" +
+                " SELECT\n" +
+                "                 f.DT,\n" +
+                "                dim0.STRATEGY_ID_PDL AS STRATEGY_ID_PDL,\n" +
+                "                f.BECIF_NO AS BECIF_NO,\n" +
+                "                                COUNT(f.PAGE_NAME_GY) AS cnt1\n" +
+                "            FROM\n" +
+                "                D_OPERATION_ORDER_CUST_DETAIL_PDL_ID3 f\n" +
+                "            LEFT JOIN IDX_BASE_DIM_TRACEID dim0 ON\n" +
+                "                f.TRACE_ID = dim0.TRACE_ID\n" +
+                "                AND f.DT = dim0.DT\n" +
+                "            GROUP BY\n" +
+                "                f.DT,\n" +
+                "                f.BECIF_NO,\n" +
+                "                dim0.STRATEGY_ID_PDL;");
+        starRocksAssert.withMaterializedView("\n" +
+                "CREATE MATERIALIZED VIEW `test_perf_mv_pv4`\n" +
+                "PARTITION BY dt\n" +
+                "DISTRIBUTED BY HASH(DT, SALES_NEW_CUST, PAYROLL_FLAG, STRATEGY_TYPE, CUST_GROUP_NAME)\n" +
+                "REFRESH DEFERRED MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"force_external_table_query_rewrite\" = \"true\"\n" +
+                ")\n" +
+                "AS\n" +
+                "SELECT q.DT, f1.SALES_NEW_CUST AS SALES_NEW_CUST, f1.PAYROLL_FLAG AS PAYROLL_FLAG," +
+                " f7.STRATEGY_TYPE AS STRATEGY_TYPE, f7.CUST_GROUP_NAME AS CUST_GROUP_NAME\n" +
+                "        , SUM(q.cnt1) AS cnt1, SUM(q.pv1) AS pv1\n" +
+                "        , SUM(q.pv2) AS pv2\n" +
+                "FROM (\n" +
+                "        SELECT t0.pv1 AS pv1, t1.pv2 AS pv2, t2.cnt1 AS cnt1\n" +
+                "                , t0.DT AS DT\n" +
+                "                , COALESCE(t0.BECIF_NO, t1.BECIF_NO, t2.BECIF_NO) AS pk1\n" +
+                "                , COALESCE(t0.TRACE_ID, t1.STRATEGY_ID_PDL, t2.STRATEGY_ID_PDL) AS pk7\n" +
+                "        FROM (\n" +
+                "                SELECT f.pv1, f.TRACE_ID, f.BECIF_NO, f.DT\n" +
+                "                FROM test_perf_mv_pv1 f\n" +
+                "        ) t0\n" +
+                "                FULL JOIN (\n" +
+                "                        SELECT f.STRATEGY_ID_PDL, f.BECIF_NO, f.pv2, f.DT\n" +
+                "                        FROM test_perf_mv_pv2 f\n" +
+                "                ) t1\n" +
+                "                ON t1.DT = t0.DT\n" +
+                "                        AND t1.BECIF_NO = t0.BECIF_NO\n" +
+                "                        AND t1.STRATEGY_ID_PDL = t0.TRACE_ID\n" +
+                "                FULL JOIN (\n" +
+                "                        SELECT f.STRATEGY_ID_PDL, f.cnt1, f.BECIF_NO, f.DT\n" +
+                "                        FROM test_perf_mv_pv3 f\n" +
+                "                ) t2\n" +
+                "                ON t2.DT = COALESCE(t0.DT , t1.DT)\n" +
+                "                        AND t2.BECIF_NO = COALESCE(t0.BECIF_NO, t1.BECIF_NO)\n" +
+                "                        AND t2.STRATEGY_ID_PDL = COALESCE(t0.TRACE_ID, t1.STRATEGY_ID_PDL)\n" +
+                ") q\n" +
+                "        LEFT JOIN (\n" +
+                "                SELECT f.SALES_NEW_CUST AS SALES_NEW_CUST," +
+                " f.PAYROLL_FLAG AS PAYROLL_FLAG, f.BECIF_NO AS BECIF_NO, f.DT\n" +
+                "                FROM IDX_CUST_COMMON_DIM f\n" +
+                "        ) f1\n" +
+                "        ON f1.BECIF_NO = q.pk1\n" +
+                "                AND f1.DT = q.DT\n" +
+                "        LEFT JOIN (\n" +
+                "                SELECT f.STRATEGY_ID AS STRATEGY_ID, f.STRATEGY_TYPE AS STRATEGY_TYPE," +
+                " f.CUST_GROUP_NAME AS CUST_GROUP_NAME, f.DT\n" +
+                "                FROM IDX_BASE_OBJ_STRATEGY f\n" +
+                "        ) f7\n" +
+                "        ON f7.STRATEGY_ID = q.pk7\n" +
+                "                AND f7.DT = q.DT\n" +
+                "GROUP BY q.DT, f1.PAYROLL_FLAG, f7.CUST_GROUP_NAME, f7.STRATEGY_TYPE, f1.SALES_NEW_CUST;");
+        String query = "SELECT SUM(q.pv1) AS pv1,\n" +
+                "       f1.SALES_NEW_CUST AS SALES_NEW_CUST,\n" +
+                "       SUM(q.cnt1) AS cnt1,\n" +
+                "       f1.PAYROLL_FLAG AS PAYROLL_FLAG,\n" +
+                "       f7.STRATEGY_TYPE AS STRATEGY_TYPE,\n" +
+                "       f7.CUST_GROUP_NAME AS CUST_GROUP_NAME,\n" +
+                "       SUM(q.pv2) AS pv2\n" +
+                "FROM\n" +
+                "  ( SELECT t0.pv1 AS pv1,\n" +
+                "           t1.pv2 AS pv2,\n" +
+                "           t2.cnt1 AS cnt1,\n" +
+                "           t0.DT AS DT ,\n" +
+                "           COALESCE(t0.BECIF_NO , t1.BECIF_NO , t2.BECIF_NO) AS pk1 ,\n" +
+                "           COALESCE(t0.TRACE_ID , t1.STRATEGY_ID_PDL , t2.STRATEGY_ID_PDL) AS pk7\n" +
+                "   FROM\n" +
+                "     ( SELECT SUM(f.PV) AS pv1,\n" +
+                "              f.TRACE_ID AS TRACE_ID,\n" +
+                "              f.BECIF_NO AS BECIF_NO,\n" +
+                "              f.DT\n" +
+                "      FROM IDX_COMMON_EV_BANKAPP_CLICK_INFO f\n" +
+                "      GROUP BY f.DT,\n" +
+                "               f.BECIF_NO,\n" +
+                "               f.TRACE_ID) AS t0\n" +
+                "   FULL JOIN\n" +
+                "     ( SELECT dim0.STRATEGY_ID_PDL AS STRATEGY_ID_PDL,\n" +
+                "              f.BECIF_NO AS BECIF_NO,\n" +
+                "              SUM(f.PV) AS pv2,\n" +
+                "              f.DT\n" +
+                "      FROM IDX_COMMON_EV_BANKAPP_EXP_CLICK_INFO f\n" +
+                "      LEFT JOIN IDX_BASE_DIM_TRACEID dim0 ON f.TRACE_ID = dim0.TRACE_ID\n" +
+                "      AND f.DT = dim0.DT\n" +
+                "      GROUP BY f.DT,\n" +
+                "               f.BECIF_NO,\n" +
+                "               dim0.STRATEGY_ID_PDL) AS t1 \n" +
+                "   ON t1.DT = t0.DT\n" +
+                "   AND t1.BECIF_NO = t0.BECIF_NO\n" +
+                "   AND t1.STRATEGY_ID_PDL = t0.TRACE_ID\n" +
+                "   FULL JOIN\n" +
+                "     ( SELECT dim0.STRATEGY_ID_PDL AS STRATEGY_ID_PDL,\n" +
+                "              COUNT(f.PAGE_NAME_GY) AS cnt1,\n" +
+                "              f.BECIF_NO AS BECIF_NO,\n" +
+                "              f.DT\n" +
+                "      FROM D_OPERATION_ORDER_CUST_DETAIL_PDL_ID3 f\n" +
+                "      LEFT JOIN IDX_BASE_DIM_TRACEID dim0 ON f.TRACE_ID = dim0.TRACE_ID\n" +
+                "      AND f.DT = dim0.DT\n" +
+                "      GROUP BY f.DT,\n" +
+                "               f.BECIF_NO,\n" +
+                "               dim0.STRATEGY_ID_PDL) AS t2\n" +
+                "   ON t2.DT = COALESCE(t0.DT , t1.DT)\n" +
+                "   AND t2.BECIF_NO = COALESCE(t0.BECIF_NO , t1.BECIF_NO)\n" +
+                "   AND t2.STRATEGY_ID_PDL = COALESCE(t0.TRACE_ID , t1.STRATEGY_ID_PDL)) AS q\n" +
+                "LEFT JOIN\n" +
+                "  ( SELECT f.SALES_NEW_CUST AS SALES_NEW_CUST,\n" +
+                "           f.PAYROLL_FLAG AS PAYROLL_FLAG,\n" +
+                "           f.BECIF_NO AS BECIF_NO,\n" +
+                "           f.DT\n" +
+                "   FROM IDX_CUST_COMMON_DIM f) AS f1 ON f1.BECIF_NO = q.pk1\n" +
+                "AND f1.DT = q.DT\n" +
+                "LEFT JOIN\n" +
+                "  ( SELECT f.STRATEGY_ID AS STRATEGY_ID,\n" +
+                "           f.STRATEGY_TYPE AS STRATEGY_TYPE,\n" +
+                "           f.CUST_GROUP_NAME AS CUST_GROUP_NAME,\n" +
+                "           f.DT\n" +
+                "   FROM IDX_BASE_OBJ_STRATEGY f) AS f7 ON f7.STRATEGY_ID = q.pk7\n" +
+                "AND f7.DT = q.DT\n" +
+                "WHERE q.DT IN ('20230924')\n" +
+                "  AND f1.PAYROLL_FLAG IN ('Y')\n" +
+                "GROUP BY f1.PAYROLL_FLAG,\n" +
+                "         f7.CUST_GROUP_NAME,\n" +
+                "         f7.STRATEGY_TYPE,\n" +
+                "         f1.SALES_NEW_CUST";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "test_perf_mv_pv4");
+        starRocksAssert.dropMaterializedView("test_perf_mv_pv1");
+        starRocksAssert.dropMaterializedView("test_perf_mv_pv2");
+        starRocksAssert.dropMaterializedView("test_perf_mv_pv3");
+        starRocksAssert.dropMaterializedView("test_perf_mv_pv4");
+        starRocksAssert.dropTable("IDX_BASE_DIM_TRACEID");
+        starRocksAssert.dropTable("IDX_BASE_OBJ_STRATEGY");
+        starRocksAssert.dropTable("IDX_COMMON_EV_BANKAPP_EXP_CLICK_INFO");
+        starRocksAssert.dropTable("IDX_COMMON_EV_BANKAPP_CLICK_INFO");
+        starRocksAssert.dropTable("IDX_CUST_COMMON_DIM");
+        starRocksAssert.dropTable("D_OPERATION_ORDER_CUST_DETAIL_PDL_ID3");
     }
 }

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q12.sql
@@ -33,6 +33,6 @@ TOP-N (order by [[24: l_shipmode ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(28: sum), 29: sum=sum(29: sum)}] group by [[24: l_shipmode]] having [null]
             EXCHANGE SHUFFLE[24]
                 AGGREGATE ([LOCAL] aggregate [{28: sum=sum(26: case), 29: sum=sum(27: case)}] group by [[24: l_shipmode]] having [null]
-                    SCAN (mv[lineitem_mv] columns[73: l_commitdate, 79: l_receiptdate, 81: l_shipdate, 83: l_shipmode, 87: o_orderpriority] predicate[79: l_receiptdate >= 1997-01-01 AND 79: l_receiptdate < 1998-01-01 AND 83: l_shipmode IN (MAIL, REG AIR) AND 73: l_commitdate < 79: l_receiptdate AND 73: l_commitdate > 81: l_shipdate])
+                    SCAN (mv[lineitem_mv] columns[73: l_commitdate, 79: l_receiptdate, 81: l_shipdate, 83: l_shipmode, 87: o_orderpriority] predicate[79: l_receiptdate >= 1997-01-01 AND 79: l_receiptdate < 1998-01-01 AND 83: l_shipmode IN (MAIL, REG AIR) AND 81: l_shipdate < 73: l_commitdate AND 73: l_commitdate < 79: l_receiptdate])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q12.sql
@@ -33,6 +33,6 @@ TOP-N (order by [[24: l_shipmode ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{28: sum=sum(28: sum), 29: sum=sum(29: sum)}] group by [[24: l_shipmode]] having [null]
             EXCHANGE SHUFFLE[24]
                 AGGREGATE ([LOCAL] aggregate [{28: sum=sum(26: case), 29: sum=sum(27: case)}] group by [[24: l_shipmode]] having [null]
-                    SCAN (mv[lineitem_mv] columns[41: l_commitdate, 47: l_receiptdate, 49: l_shipdate, 51: l_shipmode, 55: o_orderpriority] predicate[47: l_receiptdate >= 1997-01-01 AND 47: l_receiptdate < 1998-01-01 AND 51: l_shipmode IN (MAIL, REG AIR) AND 41: l_commitdate < 47: l_receiptdate AND 41: l_commitdate > 49: l_shipdate])
+                    SCAN (mv[lineitem_mv] columns[41: l_commitdate, 47: l_receiptdate, 49: l_shipdate, 51: l_shipmode, 55: o_orderpriority] predicate[47: l_receiptdate >= 1997-01-01 AND 47: l_receiptdate < 1998-01-01 AND 51: l_shipmode IN (MAIL, REG AIR) AND 49: l_shipdate < 41: l_commitdate AND 41: l_commitdate < 47: l_receiptdate])
 [end]
 


### PR DESCRIPTION
For rewrite:
1. fix join derivibility rewrite bug for multi joins query
2. fix equivalence class construction bugs to exclude outer join on predicate, which should be rewritten by ReplaceColumnRefRewriter
3. optimize predicate normalization to process column name's case
4. set mv plan timeout to new_planner_optimize_timeout

For refresh:
1. fix refresh on nested mv bug to process date format like %Y%m%d
2. set strict mode to false for mv refresh

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
