### PR TITLE
[BugFix] Alter table add column error cause by generated column(#34095)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -989,6 +989,13 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("Column[" + columnPos.getLastCol() + "] does not found");
         }
 
+        if (hasPos && modIndexSchema.get(posIndex) != null) {
+            Column posColumn = modIndexSchema.get(posIndex);
+            if (posColumn.isGeneratedColumn()) {
+                throw new DdlException("Can not add column after Generated Column");
+            }
+        }
+
         // check if add to first
         if (columnPos != null && columnPos.isFirst()) {
             posIndex = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableClauseVisitor.java
@@ -488,12 +488,6 @@ public class AlterTableClauseVisitor extends AstVisitor<Void, ConnectContext> {
                 throw new SemanticException(PARSER_ERROR_MSG.invalidColumnPos(e.getMessage()), colPos.getPos());
             }
         }
-        if (colPos != null && table instanceof OlapTable && colPos.getLastCol() != null) {
-            Column afterColumn = table.getColumn(colPos.getLastCol());
-            if (afterColumn.isGeneratedColumn()) {
-                throw new SemanticException("Can not add column after Generated Column");
-            }
-        }
 
         if (!columnDef.isAllowNull() && columnDef.defaultValueIsNull()) {
             throw new SemanticException(PARSER_ERROR_MSG.withOutDefaultVal(columnDef.getName()), columnDef.getPos());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -3605,7 +3605,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
             if (columnPosition != null) {
                 throw new ParsingException(
-                        PARSER_ERROR_MSG.generatedColumnLimit("columnPosition", "ADD GENERATED COLUMN"),
+                        PARSER_ERROR_MSG.generatedColumnLimit("AFTER", "ADD GENERATED COLUMN"),
                         columnDef.getPos());
             }
 

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -938,11 +938,11 @@ E: (1064, 'Unexpected exception: Column[xxx] does not found')
 -- !result
 alter table t0 add column testcol1 BIGINT as v1 + 10 after xxx, add column testcol2 BIGINT after xxx;
 -- result:
-E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Detail message: columnPosition can not be set when ADD GENERATED COLUMN.')
+E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Detail message: AFTER can not be set when ADD GENERATED COLUMN.')
 -- !result
 alter table t0 add column testcol1 BIGINT as v1 + 10 after v1, add column testcol2 BIGINT after v1;
 -- result:
-E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Detail message: columnPosition can not be set when ADD GENERATED COLUMN.')
+E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Detail message: AFTER can not be set when ADD GENERATED COLUMN.')
 -- !result
 alter table t0 add column testcol1 BIGINT as v1 + 10, add column testcol2 BIGINT after testcol1;
 -- result:

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -914,3 +914,127 @@ DROP TABLE t;
 DROP DATABASE test_schema_change_for_constant_expression;
 -- result:
 -- !result
+-- name: test_schema_change_for_after
+CREATE DATABASE test_schema_change_for_after;
+-- result:
+-- !result
+USE test_schema_change_for_after;
+-- result:
+-- !result
+CREATE TABLE t0 ( v1 BIGINT NOT NULL, v2 BIGINT NOT NULL, v3 BIGINT NOT NULL) DUPLICATE KEY (v1) DISTRIBUTED BY HASH(v1) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+alter table t0 add column testcol1 BIGINT after xxx, add column testcol2 BIGINT after testcol1;
+-- result:
+E: (1064, 'Unexpected exception: Column[xxx] does not found')
+-- !result
+alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after xxx;
+-- result:
+E: (1064, 'Unexpected exception: Column[xxx] does not found')
+-- !result
+alter table t0 add column testcol1 BIGINT after xxx, add column testcol2 BIGINT after xxx;
+-- result:
+E: (1064, 'Unexpected exception: Column[xxx] does not found')
+-- !result
+alter table t0 add column testcol1 BIGINT as v1 + 10 after xxx, add column testcol2 BIGINT after xxx;
+-- result:
+E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Detail message: columnPosition can not be set when ADD GENERATED COLUMN.')
+-- !result
+alter table t0 add column testcol1 BIGINT as v1 + 10 after v1, add column testcol2 BIGINT after v1;
+-- result:
+E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Detail message: columnPosition can not be set when ADD GENERATED COLUMN.')
+-- !result
+alter table t0 add column testcol1 BIGINT as v1 + 10, add column testcol2 BIGINT after testcol1;
+-- result:
+E: (1064, 'Unexpected exception: Can not add column after Generated Column')
+-- !result
+alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after testcol1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SHOW CREATE TABLE t0;
+-- result:
+t0	CREATE TABLE `t0` (
+  `v1` bigint(20) NOT NULL COMMENT "",
+  `testcol1` bigint(20) NULL COMMENT "",
+  `testcol2` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NOT NULL COMMENT "",
+  `v3` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- !result
+alter table t0 add column testcol3 BIGINT after v1, add column testcol4 BIGINT after v1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SHOW CREATE TABLE t0;
+-- result:
+t0	CREATE TABLE `t0` (
+  `v1` bigint(20) NOT NULL COMMENT "",
+  `testcol4` bigint(20) NULL COMMENT "",
+  `testcol3` bigint(20) NULL COMMENT "",
+  `testcol1` bigint(20) NULL COMMENT "",
+  `testcol2` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NOT NULL COMMENT "",
+  `v3` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- !result
+alter table t0 add column testcol5 BIGINT, add column testcol6 BIGINT as v1 * 10;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+SHOW CREATE TABLE t0;
+-- result:
+t0	CREATE TABLE `t0` (
+  `v1` bigint(20) NOT NULL COMMENT "",
+  `testcol4` bigint(20) NULL COMMENT "",
+  `testcol3` bigint(20) NULL COMMENT "",
+  `testcol1` bigint(20) NULL COMMENT "",
+  `testcol2` bigint(20) NULL COMMENT "",
+  `v2` bigint(20) NOT NULL COMMENT "",
+  `v3` bigint(20) NOT NULL COMMENT "",
+  `testcol5` bigint(20) NULL COMMENT "",
+  `testcol6` bigint(20) NULL AS v1 * 10 COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+DISTRIBUTED BY HASH(`v1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- !result
+DROP DATABASE test_schema_change_for_after;
+-- result:
+-- !result

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -946,7 +946,7 @@ E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Det
 -- !result
 alter table t0 add column testcol1 BIGINT as v1 + 10, add column testcol2 BIGINT after testcol1;
 -- result:
-E: (1064, 'Unexpected exception: Can not add column after Generated Column')
+E: (1064, 'Getting analyzing error. Detail message: Can not add column after Generated Column.')
 -- !result
 alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after testcol1;
 -- result:

--- a/test/sql/test_materialized_column/R/test_materialized_column
+++ b/test/sql/test_materialized_column/R/test_materialized_column
@@ -431,7 +431,7 @@ CREATE TABLE t ( id BIGINT NOT NULL, name BIGINT NOT NULL, job INT NOT NULL, mc 
 -- !result
 ALTER TABLE t ADD COLUMN newcol INT DEFAULT "0" AFTER mc;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Can not add column after Generated Column.')
+E: (1064, 'Unexpected exception: Can not add column after Generated Column')
 -- !result
 ALTER TABLE t MODIFY COLUMN job BIGINT;
 -- result:
@@ -946,7 +946,7 @@ E: (1064, 'Getting syntax error from line 1, column 26 to line 1, column 50. Det
 -- !result
 alter table t0 add column testcol1 BIGINT as v1 + 10, add column testcol2 BIGINT after testcol1;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Can not add column after Generated Column.')
+E: (1064, 'Unexpected exception: Can not add column after Generated Column')
 -- !result
 alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after testcol1;
 -- result:

--- a/test/sql/test_materialized_column/T/test_materialized_column
+++ b/test/sql/test_materialized_column/T/test_materialized_column
@@ -354,3 +354,30 @@ SELECT * FROM t ORDER BY id;
 DROP TABLE t;
 
 DROP DATABASE test_schema_change_for_constant_expression;
+
+-- name: test_schema_change_for_after
+CREATE DATABASE test_schema_change_for_after;
+USE test_schema_change_for_after;
+
+CREATE TABLE t0 ( v1 BIGINT NOT NULL, v2 BIGINT NOT NULL, v3 BIGINT NOT NULL) DUPLICATE KEY (v1) DISTRIBUTED BY HASH(v1) BUCKETS 1 PROPERTIES("replication_num" = "1");
+
+alter table t0 add column testcol1 BIGINT after xxx, add column testcol2 BIGINT after testcol1;
+alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after xxx;
+alter table t0 add column testcol1 BIGINT after xxx, add column testcol2 BIGINT after xxx;
+alter table t0 add column testcol1 BIGINT as v1 + 10 after xxx, add column testcol2 BIGINT after xxx;
+alter table t0 add column testcol1 BIGINT as v1 + 10 after v1, add column testcol2 BIGINT after v1;
+alter table t0 add column testcol1 BIGINT as v1 + 10, add column testcol2 BIGINT after testcol1;
+
+alter table t0 add column testcol1 BIGINT after v1, add column testcol2 BIGINT after testcol1;
+function: wait_alter_table_finish()
+SHOW CREATE TABLE t0;
+
+alter table t0 add column testcol3 BIGINT after v1, add column testcol4 BIGINT after v1;
+function: wait_alter_table_finish()
+SHOW CREATE TABLE t0;
+
+alter table t0 add column testcol5 BIGINT, add column testcol6 BIGINT as v1 * 10;
+function: wait_alter_table_finish()
+SHOW CREATE TABLE t0;
+
+DROP DATABASE test_schema_change_for_after;


### PR DESCRIPTION
Problem:
AlterTableClauseVisitor.visitAddColumnClause will crash when check the pos column is generated column or not if the pos column is a new column or a non-exist column.

Solution:
we should check this in schema change handler

Fixes #34095

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
