### PR TITLE
[BugFix] fix concurrency modify propertyInfo in empty PhysicalPropertySet

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OutputPropertyDeriver.java
@@ -166,6 +166,10 @@ public class OutputPropertyDeriver extends PropertyDeriverBase<PhysicalPropertyS
                                                                         PhysicalPropertySet physicalPropertySet,
                                                                         List<DistributionCol> leftOnPredicateColumns,
                                                                         List<DistributionCol> rightOnPredicateColumns) {
+        // only update propertyInfo in HashDistributionSpec
+        if (!physicalPropertySet.getDistributionProperty().isShuffle()) {
+            return physicalPropertySet;
+        }
         DistributionSpec.PropertyInfo propertyInfo =
                 physicalPropertySet.getDistributionProperty().getSpec().getPropertyInfo();
 


### PR DESCRIPTION
Fixes #issue
Fix stack like this
```
java.util.ConcurrentModificationException: null
        at java.util.HashMap.computeIfAbsent(HashMap.java:1134) ~[?:?]
        at com.starrocks.sql.optimizer.base.DistributionDisjointSet.find(DistributionDisjointSet.java:55) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.base.DistributionDisjointSet.union(DistributionDisjointSet.java:74) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.optimizer.base.DistributionSpec$PropertyInfo.unionDistributionCols(DistributionSpec.java:93) ~[starrocks-fe.jar:?]
        
```

The root cause is 
```
private PhysicalPropertySet computeShuffleJoinOutputProperty(JoinOperator joinType,
                                                                 List<DistributionCol> leftShuffleColumns,
                                                                 List<DistributionCol> rightShuffleColumns) {
        Optional<HashDistributionDesc> requiredShuffleDesc = getRequiredShuffleDesc();
        if (!requiredShuffleDesc.isPresent()) {
            return PhysicalPropertySet.EMPTY;
        }
}
```
may return PhysicalPropertySet.EMPTY and we may update the PropertyInfo in `DistributionProperty.EMPTY` in the next `computeHashJoinDistributionPropertyInfo()` step which may concurrent modify a static object at the same time.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
