### PR TITLE
[Feature] meta tool supports dump each column size (backport #31992)

### DIFF
--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -128,6 +128,7 @@ std::string get_usage(const std::string& progname) {
     ss << "./meta_tool --operation=show_meta --pb_meta_path=path\n";
     ss << "./meta_tool --operation=show_segment_footer --file=/path/to/segment/file\n";
     ss << "./meta_tool --operation=dump_segment_data --file=/path/to/segment/file\n";
+    ss << "./meta_tool --operation=dump_column_size --file=/path/to/segment/file\n";
     ss << "./meta_tool --operation=dump_short_key_index --file=/path/to/segment/file --key_column_count=2\n";
     ss << "./meta_tool --operation=check_table_meta_consistency --root_path=/path/to/storage/path "
           "--table_id=tableid\n";
@@ -588,6 +589,7 @@ public:
 
     Status dump_segment_data();
     Status dump_short_key_index(size_t key_column_count);
+    Status dump_column_size();
 
 private:
     struct ColItem {
@@ -599,6 +601,8 @@ private:
     Status _init();
     void _convert_column_meta(const ColumnMetaPB& src_col, ColumnPB* dest_col);
     std::shared_ptr<Schema> _init_query_schema(const std::shared_ptr<TabletSchema>& tablet_schema);
+    std::shared_ptr<Schema> _init_query_schema_by_column_id(const std::shared_ptr<TabletSchema>& tablet_schema,
+                                                            ColumnId id);
     std::shared_ptr<TabletSchema> _init_search_schema_from_footer(const SegmentFooterPB& footer);
     void _analyze_short_key_columns(size_t key_column_count, std::vector<ColItem>* cols);
     Status _output_short_key_string(const std::vector<ColItem>& cols, size_t idx, Slice& key, std::string* result);
@@ -616,6 +620,13 @@ private:
 
 std::shared_ptr<Schema> SegmentDump::_init_query_schema(const std::shared_ptr<TabletSchema>& tablet_schema) {
     return std::make_shared<Schema>(tablet_schema->schema());
+}
+
+std::shared_ptr<Schema> SegmentDump::_init_query_schema_by_column_id(const std::shared_ptr<TabletSchema>& tablet_schema,
+                                                                     ColumnId id) {
+    std::vector<ColumnId> cids;
+    cids.push_back(id);
+    return std::make_shared<Schema>(tablet_schema->schema(), cids);
 }
 
 void SegmentDump::_convert_column_meta(const ColumnMetaPB& src_col, ColumnPB* dest_col) {
@@ -839,6 +850,59 @@ Status SegmentDump::dump_segment_data() {
     return Status::OK();
 }
 
+Status SegmentDump::dump_column_size() {
+    Status st = _init();
+    if (!st.ok()) {
+        std::cout << "SegmentDump init failed: " << st << std::endl;
+        return st;
+    }
+
+    std::string result = "";
+    // for each column
+    for (ColumnId id = 0; id < _tablet_schema->num_columns(); id++) {
+        // read column one by one
+        auto schema = _init_query_schema_by_column_id(_tablet_schema, id);
+        SegmentReadOptions seg_opts;
+        seg_opts.fs = _fs;
+        seg_opts.use_page_cache = false;
+        OlapReaderStatistics stats;
+        seg_opts.stats = &stats;
+        auto seg_res = _segment->new_iterator(*schema, seg_opts);
+        if (!seg_res.ok()) {
+            std::cout << "new segment iterator failed: " << seg_res.status() << std::endl;
+            return seg_res.status();
+        }
+        auto seg_iter = std::move(seg_res.value());
+
+        // iter chunk
+        auto chunk = ChunkHelper::new_chunk(*schema, 4096);
+        do {
+            st = seg_iter->get_next(chunk.get());
+            if (!st.ok()) {
+                if (st.is_end_of_file()) {
+                    break;
+                }
+                std::cout << "iter chunk failed: " << st.to_string() << std::endl;
+                return st;
+            }
+            chunk->reset();
+        } while (true);
+        const ColumnMetaPB& column_meta = _footer.columns(id);
+        const google::protobuf::EnumValueDescriptor* compession_desc =
+                CompressionTypePB_descriptor()->FindValueByNumber(column_meta.compression());
+        const google::protobuf::EnumValueDescriptor* encoding_desc =
+                EncodingTypePB_descriptor()->FindValueByNumber(column_meta.encoding());
+
+        result += fmt::format(
+                "[ column id: {} compression: {} encoding: {} compressed bytes: {} uncompressed bytes: {}]\n", id,
+                compession_desc->name(), encoding_desc->name(), stats.compressed_bytes_read_request,
+                column_meta.total_mem_footprint());
+    }
+    std::cout << result;
+
+    return Status::OK();
+}
+
 } // namespace starrocks
 
 int meta_tool_main(int argc, char** argv) {
@@ -874,6 +938,17 @@ int meta_tool_main(int argc, char** argv) {
         Status st = segment_dump.dump_segment_data();
         if (!st.ok()) {
             std::cout << "dump segment data failed: " << st << std::endl;
+            return -1;
+        }
+    } else if (FLAGS_operation == "dump_column_size") {
+        if (FLAGS_file == "") {
+            std::cout << "no file flag for dump segment file" << std::endl;
+            return -1;
+        }
+        starrocks::SegmentDump segment_dump(FLAGS_file);
+        Status st = segment_dump.dump_column_size();
+        if (!st.ok()) {
+            std::cout << "dump column size failed: " << st << std::endl;
             return -1;
         }
     } else if (FLAGS_operation == "dump_short_key_index") {


### PR DESCRIPTION
Support dump each column's size in meta_tool, e.g
```
./meta_tool.sh --operation=dump_column_size --file=/path/to/segment/file/xxx.dat
```
And result:
```
[ column id: 0 compression: LZ4_FRAME encoding: BIT_SHUFFLE compressed bytes: 85 ]
[ column id: 1 compression: LZ4_FRAME encoding: BIT_SHUFFLE compressed bytes: 85 ]
[ column id: 2 compression: LZ4_FRAME encoding: BIT_SHUFFLE compressed bytes: 63 ]
[ column id: 3 compression: LZ4_FRAME encoding: DICT_ENCODING compressed bytes: 111 ]
...
```

Fixes #31992

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
