### PR TITLE
[Enhancement] make Pattern.scanTypes static 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
@@ -15,9 +15,8 @@ import java.util.List;
  * Pattern is used in rules as a placeholder for group
  */
 public class Pattern {
-    private final OperatorType opType;
-    private final List<Pattern> children;
-    private final ImmutableList<OperatorType> scanTypes = ImmutableList.<OperatorType>builder()
+
+    private static final ImmutableList<OperatorType> SCAN_TYPES = ImmutableList.<OperatorType>builder()
             .add(OperatorType.LOGICAL_OLAP_SCAN)
             .add(OperatorType.LOGICAL_HIVE_SCAN)
             .add(OperatorType.LOGICAL_ICEBERG_SCAN)
@@ -28,6 +27,9 @@ public class Pattern {
             .add(OperatorType.LOGICAL_META_SCAN)
             .add(OperatorType.LOGICAL_JDBC_SCAN)
             .build();
+
+    private final OperatorType opType;
+    private final List<Pattern> children;
 
     protected Pattern(OperatorType opType) {
         this.opType = opType;
@@ -93,7 +95,7 @@ public class Pattern {
             return true;
         }
 
-        if (isPatternScan() && scanTypes.contains(expression.getOp().getOpType())) {
+        if (isPatternScan() && SCAN_TYPES.contains(expression.getOp().getOpType())) {
             return true;
         }
 
@@ -118,7 +120,7 @@ public class Pattern {
             return true;
         }
 
-        if (isPatternScan() && scanTypes.contains(expression.getOp().getOpType())) {
+        if (isPatternScan() && SCAN_TYPES.contains(expression.getOp().getOpType())) {
             return true;
         }
 
@@ -126,7 +128,7 @@ public class Pattern {
     }
 
     private boolean isMultiJoin(OperatorType operatorType, int level) {
-        if (scanTypes.contains(operatorType) && level != 0) {
+        if (SCAN_TYPES.contains(operatorType) && level != 0) {
             return true;
         } else if (operatorType.equals(OperatorType.LOGICAL_JOIN)) {
             return true;


### PR DESCRIPTION
Fixes #issue


Make the Pattern.scanTypes static, which could speedup 300% performance improvement for complex join.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
