### PR TITLE
[BugFix] Fix forward compatibility for newly added PEntryObject type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
@@ -1950,7 +1950,10 @@ public class AuthorizationMgr {
                 // But to keep the correct relationship with roles inherited from them, we still need to persist
                 // an empty role for them, just for the role id.
                 if (PrivilegeBuiltinConstants.IMMUTABLE_BUILT_IN_ROLE_IDS.contains(entry.getKey())) {
-                    value = new RolePrivilegeCollectionV2();
+                    // clone to avoid race condition
+                    RolePrivilegeCollectionV2 clone = value.cloneSelf();
+                    clone.typeToPrivilegeEntryList = new HashMap<>();
+                    value = clone;
                 }
                 writer.writeJson(entry.getKey());
                 writer.writeJson(value);

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
@@ -1944,8 +1944,16 @@ public class AuthorizationMgr {
                     roleIdToPrivilegeCollection.entrySet().iterator();
             while (roleIter.hasNext()) {
                 Map.Entry<Long, RolePrivilegeCollectionV2> entry = roleIter.next();
+                RolePrivilegeCollectionV2 value = entry.getValue();
+                // Avoid newly added PEntryObject type corrupt forward compatibility,
+                // since built-in roles are always initialized on startup, we don't need to persist them.
+                // But to keep the correct relationship with roles inherited from them, we still need to persist
+                // an empty role for them, just for the role id.
+                if (PrivilegeBuiltinConstants.IMMUTABLE_BUILT_IN_ROLE_IDS.contains(entry.getKey())) {
+                    value = new RolePrivilegeCollectionV2();
+                }
                 writer.writeJson(entry.getKey());
-                writer.writeJson(entry.getValue());
+                writer.writeJson(value);
             }
             writer.close();
         } catch (SRMetaBlockException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollectionV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/RolePrivilegeCollectionV2.java
@@ -16,6 +16,7 @@
 package com.starrocks.privilege;
 
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.persist.gson.GsonUtils;
 
 import java.util.HashSet;
 import java.util.List;
@@ -141,5 +142,9 @@ public class RolePrivilegeCollectionV2 extends PrivilegeCollectionV2 {
             throws PrivilegeException {
         assertMutable();
         super.revoke(type, privilegeTypes, objects);
+    }
+
+    public RolePrivilegeCollectionV2 cloneSelf() {
+        return GsonUtils.GSON.fromJson(GsonUtils.GSON.toJson(this), RolePrivilegeCollectionV2.class);
     }
 }


### PR DESCRIPTION
Avoid newly added PEntryObject type corrupt forward compatibility,
since built-in roles are always initialized on startup, we don't need to persist them.
But to keep the correct relationship with roles inherited from them, we still need to persist
an empty role for them, just for the role id.

Only need to backport to 3.2.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
