### PR TITLE
[BugFix] fix FragmentMgr dead lock in close()

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -452,6 +452,10 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, co
             // Duplicated
             return Status::InternalError("Double execute");
         }
+        // check if shutting down in progress under the lock
+        if (_closed) {
+            return Status::Cancelled("FragmentManager shutdown in progress.");
+        }
         // register exec_state before starting exec thread
         _fragment_map.insert(std::make_pair(fragment_instance_id, exec_state));
     }
@@ -537,10 +541,21 @@ void FragmentMgr::receive_runtime_filter(const PTransmitRuntimeFilterParams& par
 }
 
 void FragmentMgr::close() {
-    std::lock_guard<std::mutex> lock(_lock);
-    for (auto& it : _fragment_map) {
-        WARN_IF_ERROR(cancel(it.second->fragment_instance_id(), PPlanFragmentCancelReason::USER_CANCEL),
-                      strings::Substitute("Fail to cancel fragment $0", print_id(it.first)));
+    std::vector<TUniqueId> frag_instance_ids;
+    {
+        std::lock_guard<std::mutex> lock(_lock);
+        // reject all fragments from now on.
+        // expect no fragment can be added into `_fragment_map` after the lock is released.
+        _closed = true;
+        frag_instance_ids.reserve(_fragment_map.size());
+        for (auto& it : _fragment_map) {
+            frag_instance_ids.push_back(it.first);
+        }
+    }
+    // cancel all the fragments without lock.
+    for (auto& id : frag_instance_ids) {
+        WARN_IF_ERROR(cancel(id, PPlanFragmentCancelReason::USER_CANCEL),
+                      strings::Substitute("Fail to cancel fragment $0", print_id(id)));
     }
 }
 

--- a/be/src/runtime/fragment_mgr.h
+++ b/be/src/runtime/fragment_mgr.h
@@ -132,6 +132,7 @@ private:
     std::thread _cancel_thread;
     // every job is a pool
     std::unique_ptr<ThreadPool> _thread_pool;
+    bool _closed = false;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
* close() holds lock and call the cancel() interface which will acquire the lock again.
* fixes #34152 (introduced in #27828)

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
