### PR TITLE
[UT] improve performance of rollup test case

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterHandler.java
@@ -162,6 +162,7 @@ public abstract class AlterHandler extends FrontendDaemon {
     @Override
     protected void runAfterCatalogReady() {
         clearExpireFinishedOrCancelledAlterJobsV2();
+        setInterval(Config.alter_scheduler_interval_millisecond);
     }
 
     @Override

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -911,10 +911,10 @@ class StarrocksSQLApiLib(object):
             res = self.execute_sql(show_sql, True)
             status = res["result"][-1][8]
             if status != "FINISHED":
-                time.sleep(5)
+                time.sleep(1)
             else:
                 # sleep another 5s to avoid FE's async action.
-                time.sleep(5)
+                time.sleep(1)
                 break
             count += 1
         tools.assert_equal("FINISHED", status, "wait alter table finish error")

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view1
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view1
@@ -1,5 +1,7 @@
 -- name: test_sync_materialized_view
 
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 insert into user_tags values('2023-04-13', 1, 'a', 1), ('2023-04-13', 1, 'b', 2), ('2023-04-13', 1, 'c', 3), ('2023-04-13', 1, 'd', 4), ('2023-04-13', 1, 'e', 5), ('2023-04-13', 2, 'e', 5), ('2023-04-13', 3, 'e', 6);
 

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view2
@@ -1,5 +1,7 @@
 -- name: test_sync_materialized_view2
 
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 insert into user_tags values('2023-04-13', 1, 'a', 1), ('2023-04-13', 1, 'b', 2), ('2023-04-13', 1, 'c', 3), ('2023-04-13', 1, 'd', 4), ('2023-04-13', 1, 'e', 5), ('2023-04-13', 2, 'e', 5), ('2023-04-13', 3, 'e', 6);
 

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_rewrite
@@ -1,4 +1,7 @@
 -- name: test_sync_materialized_view_rewrite
+
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
 CREATE TABLE `duplicate_tbl` (
     `k1` date NULL COMMENT "",   
     `k2` datetime NULL COMMENT "",   

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_with_colocate
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_with_colocate
@@ -1,5 +1,7 @@
 -- name: test_sync_materialized_view_with_colocate @sequential
 
+admin set frontend config('alter_scheduler_interval_millisecond' = '100');
+
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('colocate_with' = 'colocate_gorup1', 'replication_num' = '3', 'replicated_storage' = 'true');
 insert into user_tags values('2023-04-13', 1, 'a', 1), ('2023-04-13', 1, 'b', 2), ('2023-04-13', 1, 'c', 3), ('2023-04-13', 1, 'd', 4), ('2023-04-13', 1, 'e', 5), ('2023-04-13', 2, 'e', 5), ('2023-04-13', 3, 'e', 6);
 


### PR DESCRIPTION
Fixes #issue

1. Make the `alter_scheduler_interval_millisecond` dynamic 
2. Change default config in rollup test

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
