### PR TITLE
[BugFix] Build curl without brotli

### DIFF
--- a/thirdparty/build-thirdparty.sh
+++ b/thirdparty/build-thirdparty.sh
@@ -499,7 +499,7 @@ build_curl() {
 
     LDFLAGS="-L${TP_LIB_DIR}" LIBS="-lssl -lcrypto -ldl" \
     ./configure --prefix=$TP_INSTALL_DIR --disable-shared --enable-static \
-    --without-librtmp --with-ssl=${TP_INSTALL_DIR} --without-libidn2 --without-libgsasl --disable-ldap --enable-ipv6
+    --without-librtmp --with-ssl=${TP_INSTALL_DIR} --without-libidn2 --without-libgsasl --disable-ldap --enable-ipv6 --without-brotli
     make -j$PARALLEL
     make install
 }


### PR DESCRIPTION
Fix the compilation error with thirdparty building:

```
../lib/.libs/libcurl.a(libcurl_la-version.o): In function `brotli_version':
/root/starrocks/thirdparty/src/curl-8.4.0/lib/version.c:91: undefined reference to `BrotliDecoderVersion'
../lib/.libs/libcurl.a(libcurl_la-version.o): In function `curl_version_info':
/root/starrocks/thirdparty/src/curl-8.4.0/lib/version.c:619: undefined reference to `BrotliDecoderVersion'
../lib/.libs/libcurl.a(libcurl_la-version.o): In function `brotli_version':
/root/starrocks/thirdparty/src/curl-8.4.0/lib/version.c:91: undefined reference to `BrotliDecoderVersion'
../lib/.libs/libcurl.a(libcurl_la-content_encoding.o): In function `brotli_close_writer':
/root/starrocks/thirdparty/src/curl-8.4.0/lib/content_encoding.c:704: undefined reference to `BrotliDecoderDestroyInstance'
../lib/.libs/libcurl.a(libcurl_la-content_encoding.o): In function `brotli_init_writer':
/root/starrocks/thirdparty/src/curl-8.4.0/lib/content_encoding.c:644: undefined reference to `BrotliDecoderCreateInstance'
../lib/.libs/libcurl.a(libcurl_la-content_encoding.o): In function `brotli_unencode_write':
/root/starrocks/thirdparty/src/curl-8.4.0/lib/content_encoding.c:671: undefined reference to `BrotliDecoderDecompressStream'
/root/starrocks/thirdparty/src/curl-8.4.0/lib/content_encoding.c:682: undefined reference to `BrotliDecoderDestroyInstance'
/root/starrocks/thirdparty/src/curl-8.4.0/lib/content_encoding.c:688: undefined reference to `BrotliDecoderGetErrorCode'
collect2: error: ld returned 1 exit status
make[2]: *** [curl] Error 1
make[2]: Leaving directory `/root/starrocks/thirdparty/src/curl-8.4.0/src'
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory `/root/starrocks/thirdparty/src/curl-8.4.0/src'
make: *** [all-recursive] Error 1
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
