### PR TITLE
[Refactor] disable column pool by default

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -268,7 +268,7 @@ CONF_mBool(enable_zonemap_index_memory_page_cache, "false");
 // whether to enable the ordinal index memory cache
 CONF_mBool(enable_ordinal_index_memory_page_cache, "false");
 // whether to disable column pool
-CONF_Bool(disable_column_pool, "false");
+CONF_Bool(disable_column_pool, "true");
 
 CONF_mInt32(base_compaction_check_interval_seconds, "60");
 CONF_mInt64(min_base_compaction_num_singleton_deltas, "5");

--- a/docs/administration/Configuration.md
+++ b/docs/administration/Configuration.md
@@ -2132,7 +2132,7 @@ BE static parameters are as follows.
 | dictionary_encoding_ratio | 0.7 | N/A | |
 | dictionary_speculate_min_chunk_size | 10000 | N/A | |
 | directory_of_inject |  | N/A | |
-| disable_column_pool | 0 | N/A | |
+| disable_column_pool | 1 | N/A | |
 | disable_mem_pools | 0 | N/A | |
 | download_worker_count | 1 | N/A | |
 | enable_check_string_lengths | 1 | N/A | |


### PR DESCRIPTION
Fixes #issue

after using jemalloc, column pool seems no effects, so disable it by default.

https://starrocks.feishu.cn/sheets/K4T3sEvPAh83uCtJH1TcWkB5nXd?sheet=MQru4d


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
