### PR TITLE
[Feature] support sync cloud table meta by http api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -84,6 +84,7 @@ import com.starrocks.http.rest.ShowProcAction;
 import com.starrocks.http.rest.ShowRuntimeInfoAction;
 import com.starrocks.http.rest.StopFeAction;
 import com.starrocks.http.rest.StorageTypeCheckAction;
+import com.starrocks.http.rest.SyncCloudTableMetaAction;
 import com.starrocks.http.rest.TableQueryPlanAction;
 import com.starrocks.http.rest.TableRowCountAction;
 import com.starrocks.http.rest.TableSchemaAction;
@@ -183,6 +184,7 @@ public class HttpServer {
         ConnectionAction.registerAction(controller);
         ShowDataAction.registerAction(controller);
         QueryDumpAction.registerAction(controller);
+        SyncCloudTableMetaAction.registerAction(controller);
         // for stop FE
         StopFeAction.registerAction(controller);
         ExecuteSqlAction.registerAction(controller);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/SyncCloudTableMetaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/SyncCloudTableMetaAction.java
@@ -1,0 +1,81 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.google.common.base.Strings;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.StarRocksHttpException;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.lake.StarMgrMetaSyncer;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.UserIdentity;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+
+// This class is responsible for sync cloud table's tablet and shard meta between fe and starmgr
+public class SyncCloudTableMetaAction extends RestBaseAction {
+    private static final String FORCE = "force";
+
+    public SyncCloudTableMetaAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller)
+            throws IllegalArgException {
+        SyncCloudTableMetaAction action = new SyncCloudTableMetaAction(controller);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/{" + DB_KEY + "}/{" + TABLE_KEY + "}/_sync_meta", action);
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response)
+            throws DdlException, AccessDeniedException {
+        UserIdentity currentUser = ConnectContext.get().getCurrentUserIdentity();
+        checkUserOwnsAdminRole(currentUser);
+
+        if (redirectToLeader(request, response)) {
+            return;
+        }
+
+        boolean force = true;
+        String forceStr = request.getSingleParameter(FORCE);
+        if (!Strings.isNullOrEmpty(forceStr)) {
+            if (forceStr.equalsIgnoreCase("true")) {
+                force = true;
+            } else if (forceStr.equalsIgnoreCase("false")) {
+                force = false;
+            } else {
+                response.appendContent("Bad force parameter");
+                sendResult(request, response);
+                return;
+            }
+        }
+
+        String dbName = request.getSingleParameter(DB_KEY);
+        String tableName = request.getSingleParameter(TABLE_KEY);
+        if (Strings.isNullOrEmpty(dbName) || Strings.isNullOrEmpty(tableName)) {
+            throw new StarRocksHttpException(HttpResponseStatus.BAD_REQUEST,
+                    "both database and table should be provided.");
+        }
+
+        StarMgrMetaSyncer.syncTableMeta(dbName, tableName, force);
+        response.appendContent("OK");
+        sendResult(request, response);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -20,10 +20,12 @@ import autovalue.shaded.com.google.common.common.collect.Sets;
 import com.google.common.base.Preconditions;
 import com.staros.proto.ShardGroupInfo;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
@@ -40,6 +42,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -234,5 +237,67 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
     protected void runAfterCatalogReady() {
         deleteUnusedShardAndShardGroup();
         deleteUnusedWorker();
+    }
+
+    // do a one time sync, delete all shards from this table that exist in starmgr but not in fe
+    public static void syncTableMeta(String dbName, String tableName, boolean forceDeleteData) throws DdlException {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        if (db == null) {
+            throw new DdlException(String.format("db %s does not exist.", dbName));
+        }
+
+        HashMap<Long, List<Long>> feGroupToShards = new HashMap<>();
+        db.readLock();
+        try {
+            Table table = db.getTable(tableName);
+            if (table == null) {
+                throw new DdlException(String.format("table %s does not exist.", tableName));
+            }
+            if (!table.isCloudNativeTableOrMaterializedView()) {
+                throw new DdlException("only support cloud table or cloud mv.");
+            }
+
+            OlapTable olapTable = (OlapTable) table;
+            for (Partition partition : olapTable.getAllPartitions()) {
+                for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
+                    long groupId = physicalPartition.getShardGroupId();
+                    List<Long> feShardIds = new ArrayList<>();
+                    for (MaterializedIndex materializedIndex :
+                            physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                        for (Tablet tablet : materializedIndex.getTablets()) {
+                            feShardIds.add(tablet.getId());
+                        }
+                    }
+                    if (!feShardIds.isEmpty()) {
+                        feGroupToShards.put(groupId, feShardIds);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new DdlException(e.getMessage());
+        } finally {
+            db.readUnlock();
+        }
+
+        // delete tablet meta and data, outside db lock
+        StarOSAgent starOSAgent = GlobalStateMgr.getCurrentStarOSAgent();
+        Set<Long> shardToDelete = new HashSet<>();
+        for (Map.Entry<Long, List<Long>> entry : feGroupToShards.entrySet()) {
+            List<Long> starmgrShardIds = starOSAgent.listShard(entry.getKey());
+            starmgrShardIds.removeAll(entry.getValue());
+            if (forceDeleteData) {
+                try {
+                    // delete shard in starmgr but not in fe
+                    dropTabletAndDeleteShard(starmgrShardIds, starOSAgent);
+                } catch (Exception e) {
+                    // ignore exception
+                    LOG.info(e.getMessage());
+                }
+            }
+            shardToDelete.addAll(starmgrShardIds);
+        }
+
+        // do final meta delete, regardless whether above tablet deleted or not
+        starOSAgent.deleteShards(shardToDelete);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -472,7 +472,7 @@ public class StarOSAgent {
         try {
             shardInfo = client.listShard(serviceId, Arrays.asList(groupId));
         } catch (StarClientException e) {
-            throw new DdlException("Failed to list shards. error: " + e.getMessage());
+            throw new DdlException(String.format("Failed to list shards in group %d. error:%s", groupId, e.getMessage()));
         }
         return shardInfo.get(0).stream().map(ShardInfo::getShardId).collect(Collectors.toList());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/http/SyncCloudTableMetaTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/SyncCloudTableMetaTest.java
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.lake.StarMgrMetaSyncer;
+import mockit.Mock;
+import mockit.MockUp;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertTrue;
+
+public class SyncCloudTableMetaTest extends StarRocksHttpTestCase {
+    @Test
+    public void testSyncCloudTableMeta() throws IOException {
+        new MockUp<StarMgrMetaSyncer>() {
+            @Mock
+            public void syncTableMeta(String dbName, String tableName, boolean force) throws DdlException {
+            }
+        };
+
+        Request request = new Request.Builder()
+                .get()
+                .addHeader("Authorization", rootAuth)
+                .url(BASE_URL + "/api/test_db/test_table/_sync_meta?force=true")
+                .build();
+        Response response = networkClient.newCall(request).execute();
+        assertTrue(response.isSuccessful());
+        Assert.assertNotNull(response.body());
+        String respStr = response.body().string();
+        Assert.assertNotNull(respStr);
+        Assert.assertEquals("OK", respStr);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -29,7 +29,9 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
+import com.starrocks.common.DdlException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
@@ -41,6 +43,7 @@ import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -104,6 +107,11 @@ public class StarMgrMetaSyncerTest {
                 MaterializedIndex baseIndex = new MaterializedIndex();
                 DistributionInfo distributionInfo = new HashDistributionInfo();
                 return Lists.newArrayList(new Partition(partitionId, "p1", baseIndex, distributionInfo, shardGroupId));
+            }
+
+            @Mock
+            public Database getDb(String dbName) {
+                return new Database(dbId, dbName);
             }
         };
 
@@ -192,5 +200,111 @@ public class StarMgrMetaSyncerTest {
         };
 
         Assert.assertEquals(2, starMgrMetaSyncer.deleteUnusedWorker());
+    }
+
+    @Test
+    public void testSyncTabletMetaDbNotExist() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return null;
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(DdlException.class, () -> {
+            starMgrMetaSyncer.syncTableMeta("db", "table", true);
+        });
+    }
+
+    @Test
+    public void testSyncTabletMetaTableNotExist() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return new Database(100, dbName);
+            }
+        };
+
+        new MockUp<Database>() {
+            @Mock
+            public Table getTable(String tableName) {
+                return null;
+            }
+        };
+
+        Exception exception = Assertions.assertThrows(DdlException.class, () -> {
+            starMgrMetaSyncer.syncTableMeta("db", "table", true);
+        });
+    }
+
+    @Test
+    public void testSyncTabletMeta() throws Exception {
+        List<Long> shards = new ArrayList<>();
+        shards.add(111L);
+        shards.add(222L);
+        shards.add(333L);
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public Database getDb(String dbName) {
+                return new Database(100, dbName);
+            }
+        };
+
+        new MockUp<Database>() {
+            @Mock
+            public Table getTable(String tableName) {
+                List<Column> baseSchema = new ArrayList<>();
+                KeysType keysType = KeysType.AGG_KEYS;
+                PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
+                DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
+                Table table = new LakeTable(1000, tableName, baseSchema, keysType, partitionInfo, defaultDistributionInfo);
+                return table;
+            }
+        };
+
+        new MockUp<OlapTable>() {
+            @Mock
+            public Collection<Partition> getAllPartitions() {
+                List<Partition> partitions = new ArrayList<>();
+                DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
+                MaterializedIndex baseIndex = new MaterializedIndex();
+                partitions.add(new Partition(2000, "aaa", baseIndex, defaultDistributionInfo));
+                return partitions;
+            }
+        };
+
+        new MockUp<MaterializedIndex>() {
+            @Mock
+            public List<Tablet> getTablets() {
+                List<Tablet> tablets = new ArrayList<>();
+                tablets.add(new LakeTablet(111));
+                tablets.add(new LakeTablet(222));
+                tablets.add(new LakeTablet(333));
+                return tablets;
+            }
+        };
+
+        new MockUp<Partition>() {
+            @Mock
+            public long getShardGroupId() {
+                return 444;
+            }
+        };
+
+        new MockUp<StarOSAgent>() {
+            @Mock
+            public List<Long> listShard(long groupId) {
+                return shards;
+            }
+
+            @Mock
+            public void deleteShards(List<Long> shardIds) {
+                shards.removeAll(shardIds);
+            }
+        };
+
+        starMgrMetaSyncer.syncTableMeta("db", "table", true);
+        Assert.assertEquals(0, shards.size());
     }
 }


### PR DESCRIPTION
current meta sync does not delete cloud schema change's old tablet, supports an http api to support tablet delete and shard delete, so this problem does not affect table colocation.
also fix the wrong order of delete old tablet/shard and update colocation info after schema change.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
