### PR TITLE
[BugFix] Fix hive partition not in no eval conjuncts with OR predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ListPartitionPruner.java
@@ -22,6 +22,7 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Pair;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.planner.PartitionPruner;
 import com.starrocks.sql.optimizer.Utils;
@@ -151,13 +152,18 @@ public class ListPartitionPruner implements PartitionPruner {
                 continue;
             }
 
-            Set<Long> conjunctMatches = evalPartitionPruneFilter(operator);
+            Pair<Set<Long>, Boolean> matchesPair = evalPartitionPruneFilter(operator);
+            Set<Long> conjunctMatches = matchesPair.first;
+            Boolean existNoEvalConjuncts = matchesPair.second;
             LOG.debug("prune by expr: {}, partitions: {}", operator.toString(), conjunctMatches);
             if (conjunctMatches != null) {
                 if (matches == null) {
                     matches = Sets.newHashSet(conjunctMatches);
                 } else {
                     matches.retainAll(conjunctMatches);
+                }
+                if (existNoEvalConjuncts) {
+                    noEvalConjuncts.add(operator);
                 }
             } else {
                 noEvalConjuncts.add(operator);
@@ -183,17 +189,21 @@ public class ListPartitionPruner implements PartitionPruner {
         }
     }
 
-    private Set<Long> evalPartitionPruneFilter(ScalarOperator operator) {
+    private Pair<Set<Long>, Boolean> evalPartitionPruneFilter(ScalarOperator operator) {
+        Set<Long> matches = null;
+        Boolean existNoEval = false;
         if (operator instanceof BinaryPredicateOperator) {
-            return evalBinaryPredicate((BinaryPredicateOperator) operator);
+            matches = evalBinaryPredicate((BinaryPredicateOperator) operator);
         } else if (operator instanceof InPredicateOperator) {
-            return evalInPredicate((InPredicateOperator) operator);
+            matches = evalInPredicate((InPredicateOperator) operator);
         } else if (operator instanceof IsNullPredicateOperator) {
-            return evalIsNullPredicate((IsNullPredicateOperator) operator);
+            matches = evalIsNullPredicate((IsNullPredicateOperator) operator);
         } else if (operator instanceof CompoundPredicateOperator) {
-            return evalCompoundPredicate((CompoundPredicateOperator) operator);
+            Pair<Set<Long>, Boolean> matchesPair = evalCompoundPredicate((CompoundPredicateOperator) operator);
+            matches = matchesPair.first;
+            existNoEval = matchesPair.second;
         }
-        return null;
+        return matches == null ? Pair.create(null, true) : Pair.create(matches, existNoEval);
     }
 
     private boolean isSinglePartitionColumn(ScalarOperator predicate) {
@@ -464,33 +474,39 @@ public class ListPartitionPruner implements PartitionPruner {
         return matches;
     }
 
-    private Set<Long> evalCompoundPredicate(CompoundPredicateOperator compoundPredicate) {
+    private Pair<Set<Long>, Boolean> evalCompoundPredicate(CompoundPredicateOperator compoundPredicate) {
         Preconditions.checkNotNull(compoundPredicate);
         if (compoundPredicate.getCompoundType() == CompoundPredicateOperator.CompoundType.NOT) {
-            return null;
+            return Pair.create(null, true);
         }
 
-        Set<Long> lefts = evalPartitionPruneFilter(compoundPredicate.getChild(0));
-        Set<Long> rights = evalPartitionPruneFilter(compoundPredicate.getChild(1));
+        Pair<Set<Long>, Boolean> leftPair = evalPartitionPruneFilter(compoundPredicate.getChild(0));
+        Set<Long> lefts = leftPair.first;
+
+        Pair<Set<Long>, Boolean> rightPair = evalPartitionPruneFilter(compoundPredicate.getChild(1));
+        Set<Long> rights = rightPair.first;
+
+        Boolean existNoEval = leftPair.second || rightPair.second;
+
         if (lefts == null && rights == null) {
-            return null;
+            return Pair.create(null, existNoEval);
         }
 
         if (compoundPredicate.getCompoundType() == CompoundPredicateOperator.CompoundType.AND) {
             if (lefts == null) {
-                return rights;
+                return Pair.create(rights, existNoEval);
             } else if (rights == null) {
-                return lefts;
+                return Pair.create(lefts, existNoEval);
             } else {
                 lefts.retainAll(rights);
             }
         } else if (compoundPredicate.getCompoundType() == CompoundPredicateOperator.CompoundType.OR) {
             if (lefts == null || rights == null) {
-                return null;
+                return Pair.create(null, existNoEval);
             } else {
                 lefts.addAll(rights);
             }
         }
-        return lefts;
+        return Pair.create(lefts, existNoEval);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -78,18 +78,24 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "PARTITION PREDICATES: ((4: par_col = 0) AND (abs(4: par_col) = 3)) " +
                 "OR (4: par_col = 5), 4: par_col IN (0, 5)\n" +
+                "     NO EVAL-PARTITION PREDICATES: ((4: par_col = 0) AND (abs(4: par_col) = 3)) " +
+                "OR (4: par_col = 5)\n" +
                 "     partitions=1/3");
 
         sql = "select * from t1 where abs(par_col) = 3 and par_col = 0 or par_col = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 0)) " +
                 "OR (4: par_col = 2), 4: par_col IN (0, 2)\n" +
+                "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 0)) " +
+                "OR (4: par_col = 2)\n" +
                 "     partitions=2/3");
 
         sql = "select * from t1 where abs(par_col) = 3 and par_col = 10 or par_col = 2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 10)) " +
                 "OR (4: par_col = 2), 4: par_col IN (10, 2)\n" +
+                "     NO EVAL-PARTITION PREDICATES: ((abs(4: par_col) = 3) AND (4: par_col = 10)) " +
+                "OR (4: par_col = 2)\n" +
                 "     partitions=1/3");
 
         sql = "select * from t1 where abs(par_col) = 1 and abs(par_col) = 3 or par_col = 10";
@@ -122,6 +128,14 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         assertContains(plan, "PARTITION PREDICATES: (abs(4: par_col) = 1) OR (abs(4: par_col) = 2)\n" +
                 "     NO EVAL-PARTITION PREDICATES: (abs(4: par_col) = 1) OR (abs(4: par_col) = 2)\n" +
                 "     partitions=3/3");
+
+        sql = "select * from t1 where par_col = 0 or (par_col = 1 and abs(par_col) = 2);";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PARTITION PREDICATES: (4: par_col = 0) OR ((4: par_col = 1) " +
+                "AND (abs(4: par_col) = 2)), 4: par_col IN (0, 1)\n" +
+                "     NO EVAL-PARTITION PREDICATES: (4: par_col = 0) OR ((4: par_col = 1) " +
+                "AND (abs(4: par_col) = 2))\n" +
+                "     partitions=2/3");
     }
 
     @Test


### PR DESCRIPTION
Fixes #issue

When the partition predicate has `or`, and its child has a partition predicate `and` a noEvalPartitionConjunct, the predicate cannot be added to noEvalPartitionConjuncts, resulting in an error in the returned result.

For example Q1:
```sql
select *
from xxx
where dtm='20230323' or (dtm = abs(dtm))
```
The query plan is as follows, which contains `NO EVAL-PARTITION PREDICATES`

> | PARTITION PREDICATES: (6: dtm = '20230323') OR (CAST(6: dtm AS DOUBLE) = abs(CAST(6: dtm AS DOUBLE))) |
> | NO EVAL-PARTITION PREDICATES: (6: dtm = '20230323') OR (CAST(6: dtm AS DOUBLE) = abs(CAST(6: dtm AS DOUBLE))) |
> | partitions=681/681

Q2:
```sql
select *
from xxx
where dtm='20230323' or (dtm >= '20220101' and dtm<'20230323' and dtm = abs(dtm))
```
The query plan is as follows, **there is no NO EVAL-PARTITION PREDICATES, resulting in incorrect query results.**

> | PARTITION PREDICATES: (6: dtm = '20230323') OR (((6: dtm >= '20220101') AND (6: dtm < '20230323')) AND (CAST(6: dtm AS DOUBLE) = abs( CAST(6: dtm AS DOUBLE)))) |
> | partitions=447/681


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
