### PR TITLE
[BugFix] Remove the db lock when releasing schedule resource

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -42,6 +42,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.clone.TabletSchedCtx;
 import com.starrocks.clone.TabletSchedCtx.Priority;
+import com.starrocks.common.CloseableLock;
 import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
 import com.starrocks.persist.gson.GsonPostProcessable;
@@ -60,6 +61,8 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
 
 /**
@@ -102,6 +105,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
 
     private long lastFullCloneFinishedTimeMs = -1;
 
+    private final ReadWriteLock rwLock = new ReentrantReadWriteLock();
+
     public LocalTablet() {
         this(0L, new ArrayList<>());
     }
@@ -142,23 +147,24 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     private boolean deleteRedundantReplica(long backendId, long version) {
         boolean delete = false;
         boolean hasBackend = false;
-        Iterator<Replica> iterator = replicas.iterator();
-        while (iterator.hasNext()) {
-            Replica replica = iterator.next();
-            if (replica.getBackendId() == backendId) {
-                hasBackend = true;
-                if (replica.getVersion() <= version) {
-                    iterator.remove();
-                    delete = true;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.writeLock())) {
+            Iterator<Replica> iterator = replicas.iterator();
+            while (iterator.hasNext()) {
+                Replica replica = iterator.next();
+                if (replica.getBackendId() == backendId) {
+                    hasBackend = true;
+                    if (replica.getVersion() <= version) {
+                        iterator.remove();
+                        delete = true;
+                    }
                 }
             }
         }
-
         return delete || !hasBackend;
     }
 
     public void addReplica(Replica replica, boolean updateInvertedIndex) {
-        synchronized (replicas) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.writeLock())) {
             if (deleteRedundantReplica(replica.getBackendId(), replica.getVersion())) {
                 replicas.add(replica);
                 if (updateInvertedIndex) {
@@ -174,11 +180,11 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
 
     public int getErrorStateReplicaNum() {
         int num = 0;
-        Iterator<Replica> iterator = replicas.iterator();
-        while (iterator.hasNext()) {
-            Replica replica = iterator.next();
-            if (replica.isErrorState()) {
-                num++;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.isErrorState()) {
+                    num++;
+                }
             }
         }
         return num;
@@ -193,14 +199,18 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     }
 
     public Replica getSingleReplica() {
-        return replicas.get(0);
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            return replicas.get(0);
+        }
     }
 
     @Override
     public Set<Long> getBackendIds() {
         Set<Long> beIds = Sets.newHashSet();
-        for (Replica replica : replicas) {
-            beIds.add(replica.getBackendId());
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                beIds.add(replica.getBackendId());
+            }
         }
         return beIds;
     }
@@ -208,12 +218,14 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     public List<String> getBackends() {
         List<String> backends = new ArrayList<String>();
         SystemInfoService infoService = GlobalStateMgr.getCurrentSystemInfo();
-        for (Replica replica : replicas) {
-            Backend backend = infoService.getBackend(replica.getBackendId());
-            if (backend == null) {
-                continue;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                Backend backend = infoService.getBackend(replica.getBackendId());
+                if (backend == null) {
+                    continue;
+                }
+                backends.add(backend.getHost());
             }
-            backends.add(backend.getHost());
         }
         return backends;
     }
@@ -222,14 +234,16 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     public List<Long> getNormalReplicaBackendIds() {
         List<Long> beIds = Lists.newArrayList();
         SystemInfoService infoService = GlobalStateMgr.getCurrentSystemInfo();
-        for (Replica replica : replicas) {
-            if (replica.isBad()) {
-                continue;
-            }
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.isBad()) {
+                    continue;
+                }
 
-            ReplicaState state = replica.getState();
-            if (infoService.checkBackendAlive(replica.getBackendId()) && state.canLoad()) {
-                beIds.add(replica.getBackendId());
+                ReplicaState state = replica.getState();
+                if (infoService.checkBackendAlive(replica.getBackendId()) && state.canLoad()) {
+                    beIds.add(replica.getBackendId());
+                }
             }
         }
         return beIds;
@@ -238,16 +252,18 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     // return map of (BE id -> path hash) of normal replicas
     public Multimap<Replica, Long> getNormalReplicaBackendPathMap(int clusterId) {
         Multimap<Replica, Long> map = LinkedHashMultimap.create();
-        SystemInfoService infoService = GlobalStateMgr.getCurrentState().getOrCreateSystemInfo(clusterId);
-        for (Replica replica : replicas) {
-            if (replica.isBad()) {
-                continue;
-            }
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            SystemInfoService infoService = GlobalStateMgr.getCurrentState().getOrCreateSystemInfo(clusterId);
+            for (Replica replica : replicas) {
+                if (replica.isBad()) {
+                    continue;
+                }
 
-            ReplicaState state = replica.getState();
-            if (infoService.checkBackendAlive(replica.getBackendId())
-                    && (state == ReplicaState.NORMAL || state == ReplicaState.ALTER)) {
-                map.put(replica, replica.getPathHash());
+                ReplicaState state = replica.getState();
+                if (infoService.checkBackendAlive(replica.getBackendId())
+                        && (state == ReplicaState.NORMAL || state == ReplicaState.ALTER)) {
+                    map.put(replica, replica.getPathHash());
+                }
             }
         }
         return map;
@@ -257,25 +273,27 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     @Override
     public void getQueryableReplicas(List<Replica> allQueryableReplicas, List<Replica> localReplicas,
                                      long visibleVersion, long localBeId, int schemaHash) {
-        for (Replica replica : replicas) {
-            if (replica.isBad()) {
-                continue;
-            }
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.isBad()) {
+                    continue;
+                }
 
-            // Skip the missing version replica
-            if (replica.getLastFailedVersion() > 0) {
-                continue;
-            }
+                // Skip the missing version replica
+                if (replica.getLastFailedVersion() > 0) {
+                    continue;
+                }
 
-            ReplicaState state = replica.getState();
-            if (state.canQuery()) {
-                // replica.getSchemaHash() == -1 is for compatibility
-                if (replica.checkVersionCatchUp(visibleVersion, false)
-                        && replica.getMinReadableVersion() <= visibleVersion
-                        && (replica.getSchemaHash() == -1 || replica.getSchemaHash() == schemaHash)) {
-                    allQueryableReplicas.add(replica);
-                    if (localBeId != -1 && replica.getBackendId() == localBeId) {
-                        localReplicas.add(replica);
+                ReplicaState state = replica.getState();
+                if (state.canQuery()) {
+                    // replica.getSchemaHash() == -1 is for compatibility
+                    if (replica.checkVersionCatchUp(visibleVersion, false)
+                            && replica.getMinReadableVersion() <= visibleVersion
+                            && (replica.getSchemaHash() == -1 || replica.getSchemaHash() == schemaHash)) {
+                        allQueryableReplicas.add(replica);
+                        if (localBeId != -1 && replica.getBackendId() == localBeId) {
+                            localReplicas.add(replica);
+                        }
                     }
                 }
             }
@@ -284,23 +302,25 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
 
     public int getQueryableReplicasSize(long visibleVersion, int schemaHash) {
         int size = 0;
-        for (Replica replica : replicas) {
-            if (replica.isBad()) {
-                continue;
-            }
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.isBad()) {
+                    continue;
+                }
 
-            // Skip the missing version replica
-            if (replica.getLastFailedVersion() > 0) {
-                continue;
-            }
+                // Skip the missing version replica
+                if (replica.getLastFailedVersion() > 0) {
+                    continue;
+                }
 
-            ReplicaState state = replica.getState();
-            if (state.canQuery()) {
-                // replica.getSchemaHash() == -1 is for compatibility
-                if (replica.checkVersionCatchUp(visibleVersion, false)
-                        && replica.getMinReadableVersion() <= visibleVersion
-                        && (replica.getSchemaHash() == -1 || replica.getSchemaHash() == schemaHash)) {
-                    size++;
+                ReplicaState state = replica.getState();
+                if (state.canQuery()) {
+                    // replica.getSchemaHash() == -1 is for compatibility
+                    if (replica.checkVersionCatchUp(visibleVersion, false)
+                            && replica.getMinReadableVersion() <= visibleVersion
+                            && (replica.getSchemaHash() == -1 || replica.getSchemaHash() == schemaHash)) {
+                        size++;
+                    }
                 }
             }
         }
@@ -308,36 +328,40 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     }
 
     public Replica getReplicaById(long replicaId) {
-        for (Replica replica : replicas) {
-            if (replica.getId() == replicaId) {
-                return replica;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.getId() == replicaId) {
+                    return replica;
+                }
             }
         }
         return null;
     }
 
     public Replica getReplicaByBackendId(long backendId) {
-        for (Replica replica : replicas) {
-            if (replica.getBackendId() == backendId) {
-                return replica;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.getBackendId() == backendId) {
+                    return replica;
+                }
             }
         }
         return null;
     }
 
     public boolean deleteReplica(Replica replica) {
-        synchronized (replicas) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.writeLock())) {
             if (replicas.contains(replica)) {
                 replicas.remove(replica);
                 GlobalStateMgr.getCurrentInvertedIndex().deleteReplica(id, replica.getBackendId());
                 return true;
             }
-            return false;
         }
+        return false;
     }
 
     public boolean deleteReplicaByBackendId(long backendId) {
-        synchronized (replicas) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.writeLock())) {
             Iterator<Replica> iterator = replicas.iterator();
             while (iterator.hasNext()) {
                 Replica replica = iterator.next();
@@ -347,14 +371,14 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                     return true;
                 }
             }
-            return false;
         }
+        return false;
     }
 
     // for test,
     // and for some replay cases
     public void clearReplica() {
-        synchronized (replicas) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.writeLock())) {
             this.replicas.clear();
         }
     }
@@ -442,15 +466,17 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     @Override
     public long getDataSize(boolean singleReplica) {
         long dataSize = 0;
-        for (Replica replica : getImmutableReplicas()) {
-            if (replica.getState() == ReplicaState.NORMAL || replica.getState() == ReplicaState.SCHEMA_CHANGE) {
-                if (singleReplica) {
-                    long replicaDataSize = replica.getDataSize();
-                    if (replicaDataSize > dataSize) {
-                        dataSize = replicaDataSize;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.getState() == ReplicaState.NORMAL || replica.getState() == ReplicaState.SCHEMA_CHANGE) {
+                    if (singleReplica) {
+                        long replicaDataSize = replica.getDataSize();
+                        if (replicaDataSize > dataSize) {
+                            dataSize = replicaDataSize;
+                        }
+                    } else {
+                        dataSize += replica.getDataSize();
                     }
-                } else {
-                    dataSize += replica.getDataSize();
                 }
             }
         }
@@ -461,9 +487,11 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     @Override
     public long getRowCount(long version) {
         long tabletRowCount = 0L;
-        for (Replica replica : getImmutableReplicas()) {
-            if (replica.checkVersionCatchUp(version, false) && replica.getRowCount() > tabletRowCount) {
-                tabletRowCount = replica.getRowCount();
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                if (replica.checkVersionCatchUp(version, false) && replica.getRowCount() > tabletRowCount) {
+                    tabletRowCount = replica.getRowCount();
+                }
             }
         }
         return tabletRowCount;
@@ -513,21 +541,33 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     }
 
     private boolean needRecoverWithEmptyTablet(SystemInfoService systemInfoService) {
-        if (Config.recover_with_empty_tablet && replicas.size() > 1) {
-            int numReplicaLostForever = 0;
-            int numReplicaRecoverable = 0;
-            for (Replica replica : replicas) {
-                if (replica.isBad() || systemInfoService.getBackend(replica.getBackendId()) == null) {
-                    numReplicaLostForever++;
-                } else {
-                    numReplicaRecoverable++;
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            if (Config.recover_with_empty_tablet && replicas.size() > 1) {
+                int numReplicaLostForever = 0;
+                int numReplicaRecoverable = 0;
+                for (Replica replica : replicas) {
+                    if (replica.isBad() || systemInfoService.getBackend(replica.getBackendId()) == null) {
+                        numReplicaLostForever++;
+                    } else {
+                        numReplicaRecoverable++;
+                    }
                 }
-            }
 
-            return numReplicaLostForever > 0 && numReplicaRecoverable == 0;
+                return numReplicaLostForever > 0 && numReplicaRecoverable == 0;
+            }
         }
 
         return false;
+    }
+
+    public Pair<TabletStatus, TabletSchedCtx.Priority> getHealthStatusWithPriority(
+            SystemInfoService systemInfoService,
+            long visibleVersion, int replicationNum,
+            List<Long> aliveBeIdsInCluster) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            return getHealthStatusWithPriorityUnlocked(systemInfoService, visibleVersion,
+                    replicationNum, aliveBeIdsInCluster);
+        }
     }
 
     /**
@@ -539,7 +579,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
      * 1. healthy replica num is equal to replicationNum
      * 2. all healthy replicas are in right cluster
      */
-    public Pair<TabletStatus, TabletSchedCtx.Priority> getHealthStatusWithPriority(
+    private Pair<TabletStatus, TabletSchedCtx.Priority> getHealthStatusWithPriorityUnlocked(
             SystemInfoService systemInfoService,
             long visibleVersion, int replicationNum,
             List<Long> aliveBeIdsInCluster) {
@@ -664,6 +704,13 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         return Pair.create(TabletStatus.HEALTHY, TabletSchedCtx.Priority.NORMAL);
     }
 
+    public TabletStatus getColocateHealthStatus(long visibleVersion,
+                                                int replicationNum, Set<Long> backendsSet) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            return getColocateHealthStatusUnlocked(visibleVersion, replicationNum, backendsSet);
+        }
+    }
+
     /**
      * Check colocate table's tablet health
      * <p>
@@ -694,7 +741,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
      * No need to check if backend is available. We consider all backends in 'backendsSet' are available,
      * If not, unavailable backends will be relocated by ColocateTableBalancer first.
      */
-    public TabletStatus getColocateHealthStatus(long visibleVersion,
+    private TabletStatus getColocateHealthStatusUnlocked(long visibleVersion,
                                                 int replicationNum, Set<Long> backendsSet) {
         // 1. check if replicas' backends are mismatch
         Set<Long> replicaBackendIds = getBackendIds();
@@ -808,10 +855,12 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
 
     public String getReplicaInfos() {
         StringBuilder sb = new StringBuilder();
-        for (Replica replica : replicas) {
-            sb.append(String.format("%d:%d/%d/%d/%d:%s:%s,", replica.getBackendId(), replica.getVersion(),
-                    replica.getLastFailedVersion(), replica.getLastSuccessVersion(), replica.getMinReadableVersion(),
-                    replica.getState(), getReplicaBackendState(replica.getBackendId())));
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
+            for (Replica replica : replicas) {
+                sb.append(String.format("%d:%d/%d/%d/%d:%s:%s,", replica.getBackendId(), replica.getVersion(),
+                        replica.getLastFailedVersion(), replica.getLastSuccessVersion(), replica.getMinReadableVersion(),
+                        replica.getState(), getReplicaBackendState(replica.getBackendId())));
+            }
         }
         return sb.toString();
     }
@@ -819,7 +868,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     // Note: this method does not require db lock to be held
     public boolean quorumReachVersion(long version, long quorum, TxnFinishState finishState) {
         long valid = 0;
-        synchronized (replicas) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
             for (Replica replica : replicas) {
                 long replicaId = replica.getId();
                 long replicaVersion = replica.getVersion();
@@ -844,7 +893,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
     }
 
     public void getAbnormalReplicaInfos(long version, long quorum, StringBuilder sb) {
-        synchronized (replicas) {
+        try (CloseableLock ignored = CloseableLock.lock(this.rwLock.readLock())) {
             boolean empty = true;
             for (Replica replica : replicas) {
                 long replicaVersion = replica.getVersion();

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -707,22 +707,12 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
         if (cloneTask != null) {
             AgentTaskQueue.removeTask(cloneTask.getBackendId(), TTaskType.CLONE, cloneTask.getSignature());
 
-            // clear all CLONE replicas
-            Database db = GlobalStateMgr.getCurrentState().getDbIncludeRecycleBin(dbId);
-            if (db != null) {
-                db.writeLock();
-                try {
-                    List<Replica> cloneReplicas = Lists.newArrayList();
-                    tablet.getImmutableReplicas().stream().filter(r -> r.getState() == ReplicaState.CLONE).forEach(
-                            cloneReplicas::add);
+            List<Replica> cloneReplicas = Lists.newArrayList();
+            tablet.getImmutableReplicas().stream().filter(r -> r.getState() == ReplicaState.CLONE).forEach(
+                    cloneReplicas::add);
 
-                    for (Replica cloneReplica : cloneReplicas) {
-                        tablet.deleteReplica(cloneReplica);
-                    }
-
-                } finally {
-                    db.writeUnlock();
-                }
+            for (Replica cloneReplica : cloneReplicas) {
+                tablet.deleteReplica(cloneReplica);
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/CloseableLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/CloseableLock.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+import java.util.concurrent.locks.Lock;
+
+public class CloseableLock implements AutoCloseable {
+    private final Lock lock;
+
+    private CloseableLock(Lock lock) {
+        this.lock = lock;
+    }
+
+    private CloseableLock lock() {
+        this.lock.lock();
+        return this;
+    }
+
+    @Override
+    public void close() {
+        this.lock.unlock();
+    }
+
+    public static CloseableLock lock(Lock lock) {
+        return new CloseableLock(lock).lock();
+    }
+}


### PR DESCRIPTION
Fixes dead lock
```
"tablet scheduler" #30 daemon prio=5 os_prio=0 tid=0x00007f3a7c018800 nid=0x3019 waiting on condition [0x00007f3a1b374000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00000001ef1946a0> (a java.util.concurrent.locks.ReentrantReadWriteLock$FairSync)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireQueued(AbstractQueuedSynchronizer.java:870)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquire(AbstractQueuedSynchronizer.java:1199)
	at java.util.concurrent.locks.ReentrantReadWriteLock$WriteLock.lock(ReentrantReadWriteLock.java:943)
	at com.starrocks.catalog.Database.writeLock(Database.java:224)
	at com.starrocks.clone.TabletSchedCtx.releaseResource(TabletSchedCtx.java:698)
	at com.starrocks.clone.TabletSchedCtx.releaseResource(TabletSchedCtx.java:665)
	at com.starrocks.clone.TabletScheduler.scheduleTablet(TabletScheduler.java:776)
	at com.starrocks.clone.TabletScheduler.schedulePendingTablets(TabletScheduler.java:570)
	at com.starrocks.clone.TabletScheduler.runAfterCatalogReady(TabletScheduler.java:436)
	at com.starrocks.common.util.LeaderDaemon.runOneCycle(LeaderDaemon.java:60)
	at com.starrocks.common.util.Daemon.run(Daemon.java:115)

   Locked ownable synchronizers:
	- None
```
If there are unhealthy replicas, when scheduling a balance task, the task state will be changed to repair, and the related resource will be released. The db write lock should be hold to remove the CLONE state replcias in releaseResource function, but db read lock has been seized by this thread, which will cause dead lock.
To fix this bug, remove the lock in releaseResource.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
