### PR TITLE
[Enhancement] Refactor the create table logic to reduce the I/O usage.

### DIFF
--- a/be/src/agent/agent_server.h
+++ b/be/src/agent/agent_server.h
@@ -47,6 +47,7 @@ class Status;
 class TAgentTaskRequest;
 class TAgentResult;
 class TAgentPublishRequest;
+class TReq;
 class TSnapshotRequest;
 class ThreadPool;
 
@@ -62,6 +63,7 @@ public:
     void stop();
 
     void submit_tasks(TAgentResult& agent_result, const std::vector<TAgentTaskRequest>& tasks);
+    void submit_req(TAgentResult& agent_result, const TReq& req);
 
     void make_snapshot(TAgentResult& agent_result, const TSnapshotRequest& snapshot_request);
 

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -264,9 +264,9 @@ void run_create_table_req(const TCreateTableReq& create_table_req, long txn_id, 
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;
     if (!status.ok()) {
-        LOG(WARNING) << "create table failed. error_msg:" << status.get_error_msg() << ", txn_id: " << txn_id;
+        LOG(WARNING) << "create table failed. error_msg:" << status.to_string() << ", txn_id: " << txn_id;
         status_code = TStatusCode::RUNTIME_ERROR;
-        error_msgs.emplace_back("create table failed. error_msg: " + status.get_error_msg() +
+        error_msgs.emplace_back("create table failed. error_msg: " + status.to_string() +
                                 ", txn_id: " + std::to_string(txn_id));
     }
 

--- a/be/src/agent/agent_task.h
+++ b/be/src/agent/agent_task.h
@@ -23,7 +23,9 @@ namespace starrocks {
 
 void run_drop_tablet_task(const std::shared_ptr<DropTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env);
 void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env);
+void run_create_table_req(const TCreateTableReq& create_table_req, long txn_id, ExecEnv* exec_env);
 void run_alter_tablet_task(const std::shared_ptr<AlterTabletAgentTaskRequest>& agent_task_req, ExecEnv* exec_env);
+void run_abort_req(const TAbortTxnReq& abort_req, long txn_id, ExecEnv* exec_env);
 void run_clear_transaction_task(const std::shared_ptr<ClearTransactionAgentTaskRequest>& agent_task_req,
                                 ExecEnv* exec_env);
 void run_clone_task(const std::shared_ptr<CloneAgentTaskRequest>& agent_task_req, ExecEnv* exec_env);

--- a/be/src/agent/finish_task.cpp
+++ b/be/src/agent/finish_task.cpp
@@ -65,7 +65,7 @@ void finish_req(const TFinishRequest& finish_request) {
     int32_t sleep_seconds = 1;
     int32_t max_retry_times = TASK_FINISH_MAX_RETRY;
 
-    MasterServerClient client(&g_frontend_service_client_cache);
+    MasterServerClient client(ExecEnv::GetInstance()->frontend_client_cache());
 
     while (try_time < max_retry_times) {
         AgentStatus client_status = client.finish_req(finish_request, &result);

--- a/be/src/agent/finish_task.h
+++ b/be/src/agent/finish_task.h
@@ -3,6 +3,8 @@
 namespace starrocks {
 
 class TFinishTaskRequest;
+class TFinishRequest;
 
 void finish_task(const TFinishTaskRequest& finish_task_request);
+void finish_req(const TFinishRequest& finish_request);
 } // namespace starrocks

--- a/be/src/agent/utils.h
+++ b/be/src/agent/utils.h
@@ -55,6 +55,7 @@ public:
     // Output parameters:
     // * result: The result of report task
     virtual AgentStatus finish_task(const TFinishTaskRequest& request, TMasterResult* result);
+    virtual AgentStatus finish_req(const TFinishRequest& finish_request, TMasterResult* result);
 
     // Report tasks/olap tablet/disk state to the master server
     //

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -507,7 +507,7 @@ CONF_mInt32(result_buffer_cancelled_interval_time, "300");
 CONF_mInt32(priority_queue_remaining_tasks_increased_frequency, "512");
 
 // Sync tablet_meta when modifing meta.
-CONF_mBool(sync_tablet_meta, "false");
+CONF_mBool(sync_tablet_meta, "true");
 
 // Default thrift rpc timeout ms.
 CONF_mInt32(thrift_rpc_timeout_ms, "5000");

--- a/be/src/service/service_be/backend_service.cpp
+++ b/be/src/service/service_be/backend_service.cpp
@@ -53,6 +53,10 @@ void BackendService::submit_tasks(TAgentResult& return_value, const std::vector<
     _agent_server->submit_tasks(return_value, tasks);
 }
 
+void BackendService::submit_req(TAgentResult& return_value, const TReq& req) {
+    _agent_server->submit_req(return_value, req);
+}
+
 void BackendService::make_snapshot(TAgentResult& return_value, const TSnapshotRequest& snapshot_request) {
     _agent_server->make_snapshot(return_value, snapshot_request);
 }

--- a/be/src/service/service_be/backend_service.h
+++ b/be/src/service/service_be/backend_service.h
@@ -49,6 +49,7 @@ public:
     ~BackendService() override;
 
     void submit_tasks(TAgentResult& return_value, const std::vector<TAgentTaskRequest>& tasks) override;
+    void submit_req(TAgentResult& return_value, const TReq& req) override;
 
     void make_snapshot(TAgentResult& return_value, const TSnapshotRequest& snapshot_request) override;
 

--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -564,6 +564,10 @@ void DataDir::perform_path_gc_by_tablet() {
             LOG(WARNING) << "could not find data dir for tablet path " << path;
             continue;
         }
+
+        if (_txn_manager->check_tablet_in_txn(tablet_id)) {
+            continue;
+        }
         _tablet_manager->try_delete_unused_tablet_path(data_dir, tablet_id, schema_hash, tablet_id_path.string());
     }
     _all_tablet_schemahash_paths.clear();

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -52,6 +52,7 @@
 
 namespace starrocks {
 
+struct CreateTableTxn;
 class Tablet;
 class TabletManager;
 class TxnManager;
@@ -157,6 +158,10 @@ public:
 
     // for test
     size_t get_all_check_dcg_files_cnt() const { return _all_check_dcg_files.size(); }
+
+    Status load_create_table_txn();
+    bool decode_create_table_txn(std::string_view key, std::string_view value, int64_t* txn_id,
+                                 CreateTableTxn* create_table_txn);
 
 private:
     Status _init_data_dir();

--- a/be/src/storage/kv_store.cpp
+++ b/be/src/storage/kv_store.cpp
@@ -100,7 +100,9 @@ Status KVStore::init(bool read_only) {
     cf_descs[2].options = meta_cf_options;
     cf_descs[2].options.prefix_extractor.reset(NewFixedPrefixTransform(PREFIX_LENGTH));
     cf_descs[2].options.compression = rocksdb::kSnappyCompression;
-    static_assert(NUM_COLUMN_FAMILY_INDEX == 3);
+    cf_descs[3].name = TXN_COLUMN_FAMILY;
+    cf_descs[3].options.compression = rocksdb::kSnappyCompression;
+    static_assert(NUM_COLUMN_FAMILY_INDEX == 4);
 
     rocksdb::Status s;
     if (read_only) {

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -83,8 +83,9 @@ static const double BLOOM_FILTER_DEFAULT_FPP = 0.05;
 
 enum ColumnFamilyIndex {
     DEFAULT_COLUMN_FAMILY_INDEX = 0,
-    STARROCKS_COLUMN_FAMILY_INDEX,
-    META_COLUMN_FAMILY_INDEX,
+    STARROCKS_COLUMN_FAMILY_INDEX = 1,
+    META_COLUMN_FAMILY_INDEX = 2,
+    TXN_COLUMN_FAMILY_INDEX = 3,
     // Newly-added item should be placed above this item.
     NUM_COLUMN_FAMILY_INDEX,
 };
@@ -92,6 +93,7 @@ enum ColumnFamilyIndex {
 static const std::string DEFAULT_COLUMN_FAMILY = "default"; // NOLINT
 static const std::string STARROCKS_COLUMN_FAMILY = "doris"; // NOLINT
 static const std::string META_COLUMN_FAMILY = "meta";       // NOLINT
+static const std::string TXN_COLUMN_FAMILY = "txn";         // NOLINT
 const std::string TABLET_ID_KEY = "tablet_id";              // NOLINT
 
 #define DECLARE_SINGLETON(classname) \

--- a/be/src/storage/tablet_manager.h
+++ b/be/src/storage/tablet_manager.h
@@ -196,6 +196,14 @@ public:
 
     std::vector<TabletAndScore> pick_tablets_to_do_pk_index_major_compaction();
 
+    Status add_tablets(const std::vector<TabletSharedPtr>& new_tablets);
+
+    Status create_tablet_meta_unlocked(const TCreateTabletReq& request, DataDir* store, uint64_t shard_id,
+                                       TabletMetaSharedPtr* tablet_meta);
+
+    Status create_inital_rowset_unlocked(const TCreateTabletReq& request, TabletMetaSharedPtr tablet_meta,
+                                         const string& path_prefix);
+
 private:
     using TabletMap = std::unordered_map<int64_t, TabletSharedPtr>;
     using TabletSet = std::unordered_set<int64_t>;
@@ -235,7 +243,7 @@ private:
 
     Status _update_tablet_map_and_partition_info(const TabletSharedPtr& tablet);
 
-    static Status _create_inital_rowset_unlocked(const TCreateTabletReq& request, Tablet* tablet);
+    Status _create_inital_rowset_unlocked(const TCreateTabletReq& request, Tablet* tablet);
 
     Status _drop_tablet_unlocked(TTabletId tablet_id, TabletDropFlag flag);
 

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -201,7 +201,7 @@ Status TabletMeta::save_meta(DataDir* data_dir) {
 void TabletMeta::save_tablet_schema(const TabletSchemaCSPtr& tablet_schema, DataDir* data_dir) {
     std::unique_lock wrlock(_meta_lock);
     _schema = tablet_schema;
-    (void)_save_meta(data_dir);
+    Status st = _save_meta(data_dir);
 }
 
 Status TabletMeta::_save_meta(DataDir* data_dir) {

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -108,6 +108,7 @@ public:
                                      rocksdb::WriteBatch& batch);
 
     static Status save(DataDir* store, const TabletMetaPB& meta_pb);
+    static Status save(DataDir* store, const std::vector<TabletMetaSharedPtr>& tablet_metas);
 
     static Status remove(DataDir* store, TTabletId tablet_id, TSchemaHash schema_hash);
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -104,6 +104,9 @@ void repeated_field_add(::google::protobuf::RepeatedField<T>* array, Itr begin, 
 }
 
 Status TabletUpdates::init() {
+    if (max_version() == 0) {
+        return Status::OK();
+    }
     std::unique_ptr<TabletUpdatesPB> updates(_tablet.tablet_meta()->release_updates(this));
     if (!updates) {
         string msg = strings::Substitute("updatable tablet do not have updates meta tablet:$0", _tablet.tablet_id());

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -315,6 +315,7 @@ set(EXEC_FILES_PART2
         ./io/seekable_input_stream_test.cpp
         ./io/shared_buffered_input_stream_test.cpp
         ./io/spill_test.cpp
+        ./storage/create_tablet_test.cpp
         ./storage/decimal12_test.cpp
         ./storage/disjunctive_predicates_test.cpp
         ./storage/utils_test.cpp

--- a/be/test/storage/create_tablet_test.cpp
+++ b/be/test/storage/create_tablet_test.cpp
@@ -1,0 +1,268 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "fs/fs_util.h"
+#include "storage/storage_engine.h"
+#include "storage/txn_manager.h"
+#include "testutil/parallel_test.h"
+
+namespace starrocks {
+
+class CreateTableTest : public testing::Test {
+public:
+    ~CreateTableTest() override {
+        if (_engine) {
+            _engine->stop();
+            delete _engine;
+            _engine = nullptr;
+        }
+    }
+    void SetUp() override {
+        _default_storage_root_path = config::storage_root_path;
+        config::storage_root_path = std::filesystem::current_path().string() + "/create_table";
+        fs::remove_all(config::storage_root_path);
+        std::vector<StorePath> paths;
+        paths.emplace_back(config::storage_root_path);
+
+        starrocks::EngineOptions options;
+        options.store_paths = paths;
+        if (_engine == nullptr) {
+            Status s = starrocks::StorageEngine::open(options, &_engine);
+            ASSERT_TRUE(s.ok()) << s.to_string();
+        }
+    }
+
+    void TearDown() override {
+        if (fs::path_exist(config::storage_root_path)) {
+            ASSERT_TRUE(fs::remove_all(config::storage_root_path).ok());
+        }
+        config::storage_root_path = _default_storage_root_path;
+    }
+
+protected:
+    StorageEngine* _engine = nullptr;
+    std::string _default_storage_root_path;
+};
+
+PARALLEL_TEST(CreateTableTest, create_table_test_primary_key) {
+    std::vector<int64_t> tablet_ids;
+    std::vector<int32_t> schema_hashs;
+    tablet_ids.push_back(10000);
+    tablet_ids.push_back(10001);
+    tablet_ids.push_back(10002);
+    schema_hashs.push_back(20000);
+    schema_hashs.push_back(20001);
+    schema_hashs.push_back(20002);
+    long txn_id = 30000;
+    TCreateTableReq request;
+    for (int i = 0; i < tablet_ids.size(); ++i) {
+        TCreateTabletReq tablet_request;
+        tablet_request.tablet_id = tablet_ids[i];
+        tablet_request.__set_version(1);
+        tablet_request.__set_version_hash(0);
+        tablet_request.tablet_schema.schema_hash = schema_hashs[i];
+        tablet_request.tablet_schema.short_key_column_count = 1;
+        tablet_request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        tablet_request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn pk1;
+        pk1.column_name = "pk1_bigint";
+        pk1.__set_is_key(true);
+        pk1.column_type.type = TPrimitiveType::BIGINT;
+        tablet_request.tablet_schema.columns.push_back(pk1);
+        TColumn pk2;
+        pk2.column_name = "pk2_varchar";
+        pk2.__set_is_key(true);
+        pk2.column_type.type = TPrimitiveType::VARCHAR;
+        pk2.column_type.len = 128;
+        tablet_request.tablet_schema.columns.push_back(pk2);
+        TColumn pk3;
+        pk3.column_name = "pk3_int";
+        pk3.__set_is_key(true);
+        pk3.column_type.type = TPrimitiveType::INT;
+        tablet_request.tablet_schema.columns.push_back(pk3);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        tablet_request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        tablet_request.tablet_schema.columns.push_back(k3);
+        request.create_tablet_reqs.push_back(tablet_request);
+    }
+    Status st = StorageEngine::instance()->create_table(request, txn_id);
+    CHECK(st.ok()) << st.to_string();
+}
+
+PARALLEL_TEST(CreateTableTest, create_table_test_primary_key_with_sort_key) {
+    std::vector<int64_t> tablet_ids;
+    std::vector<int32_t> schema_hashs;
+    tablet_ids.push_back(100000);
+    tablet_ids.push_back(100001);
+    tablet_ids.push_back(100002);
+    schema_hashs.push_back(200000);
+    schema_hashs.push_back(200001);
+    schema_hashs.push_back(200002);
+    long txn_id = 300000;
+    TCreateTableReq request;
+    for (int i = 0; i < tablet_ids.size(); ++i) {
+        TCreateTabletReq tablet_request;
+        tablet_request.tablet_id = tablet_ids[i];
+        tablet_request.__set_version(1);
+        tablet_request.tablet_schema.schema_hash = schema_hashs[i];
+        tablet_request.tablet_schema.short_key_column_count = 1;
+        tablet_request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        tablet_request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        tablet_request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        tablet_request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        tablet_request.tablet_schema.columns.push_back(k3);
+        request.create_tablet_reqs.push_back(tablet_request);
+    }
+    auto st = StorageEngine::instance()->create_table(request, txn_id);
+    CHECK(st.ok()) << st.to_string();
+}
+
+PARALLEL_TEST(CreateTableTest, create_table_test_duplicate_key) {
+    std::vector<int64_t> tablet_ids;
+    std::vector<int32_t> schema_hashs;
+    tablet_ids.push_back(1000000);
+    tablet_ids.push_back(1000001);
+    tablet_ids.push_back(1000002);
+    schema_hashs.push_back(2000000);
+    schema_hashs.push_back(2000001);
+    schema_hashs.push_back(2000002);
+    long txn_id = 3000000;
+    TCreateTableReq request;
+    for (int i = 0; i < tablet_ids.size(); ++i) {
+        TCreateTabletReq tablet_request;
+        tablet_request.tablet_id = tablet_ids[i];
+        tablet_request.__set_version(1);
+        tablet_request.tablet_schema.schema_hash = schema_hashs[i];
+        tablet_request.tablet_schema.short_key_column_count = 1;
+        tablet_request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        tablet_request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        tablet_request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.__set_is_allow_null(true);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        tablet_request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.__set_is_allow_null(true);
+        k3.column_type.type = TPrimitiveType::INT;
+        tablet_request.tablet_schema.columns.push_back(k3);
+        request.create_tablet_reqs.push_back(tablet_request);
+    }
+    auto st = StorageEngine::instance()->create_table(request, txn_id);
+    CHECK(st.ok()) << st.to_string();
+}
+
+PARALLEL_TEST(CreateTableTest, create_table_test_failed) {
+    std::vector<int64_t> tablet_ids;
+    std::vector<int32_t> schema_hashs;
+    tablet_ids.push_back(10000000);
+    tablet_ids.push_back(10000001);
+    tablet_ids.push_back(10000002);
+    schema_hashs.push_back(20000000);
+    schema_hashs.push_back(20000001);
+    schema_hashs.push_back(20000002);
+    long txn_id = 30000000;
+
+    TCreateTableReq request;
+
+    for (int i = 0; i < tablet_ids.size(); ++i) {
+        TCreateTabletReq tablet_request;
+        tablet_request.tablet_id = tablet_ids[i];
+        tablet_request.__set_version(1);
+        tablet_request.__set_version_hash(0);
+        tablet_request.tablet_schema.schema_hash = schema_hashs[i];
+        tablet_request.tablet_schema.short_key_column_count = 1;
+        tablet_request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        tablet_request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        tablet_request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        tablet_request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        tablet_request.tablet_schema.columns.push_back(k3);
+
+        TColumn k4;
+        k4.column_name = "v3";
+        k4.__set_is_key(false);
+        k4.column_type.type = TPrimitiveType::INT;
+        k4.__set_default_value("1");
+        tablet_request.tablet_schema.columns.push_back(k4);
+        request.create_tablet_reqs.push_back(tablet_request);
+    }
+    auto st = StorageEngine::instance()->create_table(request, txn_id);
+    CHECK(st.ok()) << st.to_string();
+    TxnManager* txn_manager = StorageEngine::instance()->txn_manager();
+    StatusOr<CreateTableTxn*> get_st = txn_manager->get_create_txn(txn_id);
+    CHECK_EQ(get_st.value()->txn_state, TxnState::TXN_COMMITTED);
+
+    // retry the create table request
+    st = StorageEngine::instance()->create_table(request, txn_id);
+    ASSERT_TRUE(st.is_already_exist());
+}
+
+} // namespace starrocks

--- a/build.sh
+++ b/build.sh
@@ -38,6 +38,7 @@ ROOT=`cd "$ROOT"; pwd`
 MACHINE_TYPE=$(uname -m)
 
 export STARROCKS_HOME=${ROOT}
+export BUILD_TYPE=DEBUG
 
 if [ -z $BUILD_TYPE ]; then
     export BUILD_TYPE=Release

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -788,6 +788,12 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int tablet_create_timeout_second = 10;
 
+    @ConfField(mutable = true)
+    public static int create_table_timeout_second = 60;
+
+    @ConfField(mutable = true)
+    public static boolean enable_create_table_txn = true;
+
     /**
      * minimal intervals between two publish version action
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -788,6 +788,11 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int tablet_create_timeout_second = 10;
 
+    // time config for create table
+    // create_table_timeout_second and tablet_create_timeout_second
+    // are all both used in the create table. There are for different
+    // mechanism. After new mechanism stable, tablet_create_timeout_second
+    // will be deprecated.
     @ConfField(mutable = true)
     public static int create_table_timeout_second = 60;
 

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -183,6 +183,7 @@ import com.starrocks.thrift.TFeLocksReq;
 import com.starrocks.thrift.TFeLocksRes;
 import com.starrocks.thrift.TFeResult;
 import com.starrocks.thrift.TFetchResourceResult;
+import com.starrocks.thrift.TFinishRequest;
 import com.starrocks.thrift.TFinishSlotRequirementRequest;
 import com.starrocks.thrift.TFinishSlotRequirementResponse;
 import com.starrocks.thrift.TFinishTaskRequest;
@@ -1207,6 +1208,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
     @Override
     public TBatchReportExecStatusResult batchReportExecStatus(TBatchReportExecStatusParams params) throws TException {
         return QeProcessorImpl.INSTANCE.batchReportExecStatus(params, getClientAddr());
+    }
+
+    @Override
+    public TMasterResult finishReq(TFinishRequest request) throws TException {
+        return leaderImpl.finishReq(request);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/task/AbortCreateTableTxnTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AbortCreateTableTxnTask.java
@@ -1,0 +1,83 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.task;
+
+import com.starrocks.common.ClientPool;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.BackendService;
+import com.starrocks.thrift.TAbortTxnReq;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TReq;
+import com.starrocks.thrift.TTaskType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class AbortCreateTableTxnTask implements Runnable {
+    private static final Logger LOG = LogManager.getLogger(AbortCreateTableTxnTask.class);
+
+    private long txnId;
+
+    private long backendId;
+
+    public AbortCreateTableTxnTask(long txnId, long backendId) {
+        this.txnId = txnId;
+        this.backendId = backendId;
+    }
+
+    @Override
+    public void run() {
+        BackendService.Client client = null;
+        TNetworkAddress address = null;
+        boolean ok = false;
+        try {
+            ComputeNode computeNode = GlobalStateMgr.getCurrentSystemInfo().getBackend(backendId);
+            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA && computeNode == null) {
+                computeNode = GlobalStateMgr.getCurrentSystemInfo().getComputeNode(backendId);
+            }
+
+            if (computeNode == null || !computeNode.isAlive()) {
+                return;
+            }
+
+            address = new TNetworkAddress(computeNode.getHost(), computeNode.getBePort());
+            client = ClientPool.backendPool.borrowObject(address);
+
+            TAbortTxnReq abortTxnReq = new TAbortTxnReq();
+            abortTxnReq.setTxn_id(txnId);
+
+            TReq req = new TReq();
+            req.setTxn_id(txnId);
+            req.setTask_type(TTaskType.CLEAR_TRANSACTION_TASK);
+            req.setAbort_req(abortTxnReq);
+            client.submit_req(req);
+            LOG.info("Req type: {}, backend: {}, txnId: {}", req.getTask_type(), address, req.getTxn_id());
+            ok = true;
+        } catch (Exception e) {
+            LOG.warn("task exec error. backend[{}]", address, e);
+        } finally {
+            if (ok) {
+                ClientPool.backendPool.returnObject(address, client);
+            } else {
+                // TODO: notify tasks rpc failed in trace
+                ClientPool.backendPool.invalidateObject(address, client);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskExecutor.java
@@ -31,11 +31,24 @@ public class AgentTaskExecutor {
 
     }
 
-    public static void submit(AgentBatchTask task) {
+    public static void submit(CreateTableTask task) {
         if (task == null) {
             return;
         }
         EXECUTOR.submit(task);
     }
 
+    public static void submit(AbortCreateTableTxnTask task) {
+        if (task == null) {
+            return;
+        }
+        EXECUTOR.submit(task);
+    }
+
+    public static void submit(AgentBatchTask task) {
+        if (task == null) {
+            return;
+        }
+        EXECUTOR.submit(task);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentTaskQueue.java
@@ -46,6 +46,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -62,10 +63,19 @@ public class AgentTaskQueue {
     private static Table<Long, TTaskType, Map<Long, AgentTask>> tasks = HashBasedTable.create();
     private static int taskNum = 0;
 
+    private static Map<Long, Map<Long, List<AgentTask>>> create_tablet_tasks = new HashMap<>();
+
     public static synchronized void addBatchTask(AgentBatchTask batchTask) {
         for (AgentTask task : batchTask.getAllTasks()) {
             addTask(task);
         }
+    }
+
+    public static synchronized boolean addCreateTabletTask(AgentTask task, long txnId) {
+        long backendId = task.getBackendId();
+        Map<Long, List<AgentTask>> txnTasks = create_tablet_tasks.get(backendId);
+        txnTasks.get(txnId).add(task);
+        return true;
     }
 
     public static synchronized boolean addTask(AgentTask task) {

--- a/fe/fe-core/src/main/java/com/starrocks/task/CreateTableTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/CreateTableTask.java
@@ -1,0 +1,136 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.task;
+
+import com.starrocks.common.ClientPool;
+import com.starrocks.common.Config;
+import com.starrocks.common.Status;
+import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
+import com.starrocks.system.ComputeNode;
+import com.starrocks.thrift.BackendService;
+import com.starrocks.thrift.TCreateTableReq;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TReq;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTaskType;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class CreateTableTask implements Runnable {
+    private static final Logger LOG = LogManager.getLogger(CreateReplicaTask.class);
+
+    private List<CreateReplicaTask> tasks = new ArrayList<>();
+
+    private long backendId;
+
+    private long txnId;
+
+    private MarkedCountDownLatch<Long, Long> latch;
+
+    public void addReplicaTask(CreateReplicaTask task) {
+        tasks.add(task);
+    }
+
+    public void setBackendId(long backendId) {
+        this.backendId = backendId;
+    }
+
+    public long getBackendId() {
+        return backendId;
+    }
+
+    public void setTxnId(long txnId) {
+        this.txnId = txnId;
+    }
+
+    public long getTxnId() {
+        return txnId;
+    }
+
+    public List<CreateReplicaTask> getTasks() {
+        return tasks;
+    }
+
+    public void countDownLatch(long backendId, long txnId) {
+        if (this.latch != null) {
+            if (latch.markedCountDown(backendId, txnId)) {
+                LOG.info("CreateReplicaTask current latch count: {}, backend: {}, tablet:{}",
+                        latch.getCount(), backendId, txnId);
+            }
+        }
+        LOG.info("count: {}", this.latch.getCount());
+    }
+
+    // call this always means one of tasks is failed. count down to zero to finish entire task
+    public void countDownToZero(String errMsg) {
+        if (this.latch != null) {
+            latch.countDownToZero(new Status(TStatusCode.CANCELLED, errMsg));
+            LOG.info("CreateReplicaTask download to zero. error msg: {}", errMsg);
+        }
+    }
+
+    public void setLatch(MarkedCountDownLatch<Long, Long> latch) {
+        this.latch = latch;
+    }
+
+    @Override
+    public void run() {
+        BackendService.Client client = null;
+        TNetworkAddress address = null;
+        boolean ok = false;
+        try {
+            ComputeNode computeNode = GlobalStateMgr.getCurrentSystemInfo().getBackend(backendId);
+            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA && computeNode == null) {
+                computeNode = GlobalStateMgr.getCurrentSystemInfo().getComputeNode(backendId);
+            }
+
+            if (computeNode == null || !computeNode.isAlive()) {
+                return;
+            }
+
+            address = new TNetworkAddress(computeNode.getHost(), computeNode.getBePort());
+            client = ClientPool.backendPool.borrowObject(address);
+
+            TCreateTableReq createTableReq = new TCreateTableReq();
+            createTableReq.setTimeout(Config.create_table_timeout_second);
+            for (CreateReplicaTask task : tasks) {
+                createTableReq.addToCreate_tablet_reqs(task.toThrift());
+                LOG.info("tablet_id: {}", task.getTabletId());
+            }
+
+            TReq req = new TReq();
+            req.setTxn_id(txnId);
+            req.setTask_type(TTaskType.CREATE);
+            req.setCreate_table_req(createTableReq);
+            client.submit_req(req);
+            LOG.info("Req type: {}, backend: {}, txnId: {}", req.getTask_type(), backendId, req.getTxn_id());
+            ok = true;
+        } catch (Exception e) {
+            LOG.warn("task exec error. backend[{}]", backendId, e);
+        } finally {
+            if (ok) {
+                ClientPool.backendPool.returnObject(address, client);
+            } else {
+                // TODO: notify tasks rpc failed in trace
+                ClientPool.backendPool.invalidateObject(address, client);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/task/TaskQueue.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/TaskQueue.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.task;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Task queue
+ */
+public class TaskQueue {
+    private static final Logger LOG = LogManager.getLogger(TaskQueue.class);
+
+    private static int taskNum = 0;
+
+    // backendId -> (txnId -> create table task)
+    private static Table<Long, Long, CreateTableTask> create_table_tasks = HashBasedTable.create();
+
+    public static synchronized boolean addCreateTableTask(CreateTableTask task, long txnId) {
+        long backendId = task.getBackendId();
+        create_table_tasks.put(backendId, txnId, task);
+        taskNum++;
+        return true;
+    }
+
+    public static synchronized boolean removeCreateTableTask(CreateTableTask task, long txnId) {
+        long backendId = task.getBackendId();
+        create_table_tasks.remove(backendId, txnId);
+        return true;
+    }
+
+    public static synchronized CreateTableTask getTask(long backendId, long txnId) {
+        return create_table_tasks.get(backendId, txnId);
+    }
+
+    // only for test now
+    public static synchronized void clearAllTasks() {
+        create_table_tasks.clear();
+        taskNum = 0;
+    }
+
+    public static synchronized int getTaskNum() {
+        return taskNum;
+    }
+}
+

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/CreateTableTxnState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/CreateTableTxnState.java
@@ -1,0 +1,89 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/transaction/TransactionState.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.transaction;
+
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.task.AbortCreateTableTxnTask;
+import com.starrocks.task.AgentTaskExecutor;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+
+public class CreateTableTxnState {
+    private static final Logger LOG = LogManager.getLogger(CreateTableTxnState.class);
+
+    public enum TxnState {
+        INITIAL,
+        PREPARED,
+        COMMITTED,
+        ABORTED
+    }
+
+    private Long txnId;
+
+    // the transaction timeout, the unit is second
+    private int txnTimeOut;
+
+    private Long txnStartTime;
+
+    private TxnState txnState;
+
+    public Long getTxnId() {
+        return txnId;
+    }
+
+    public CreateTableTxnState(Long txnId, int txnTimeOut) {
+        this.txnId = txnId;
+        this.txnState = TxnState.INITIAL;
+        this.txnStartTime = System.currentTimeMillis() / 1000;
+    }
+
+    public boolean isTimeout(Long currentTime) {
+        return (currentTime - txnStartTime) > txnTimeOut;
+    }
+
+    public void abort() {
+        if (txnState != TxnState.PREPARED) {
+            return;
+        }
+        // for aborted transaction, we don't know which backends are involved, so we have to send clear task to all backends.
+        List<Long> allBeIds = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(false);
+        for (Long beId : allBeIds) {
+            AbortCreateTableTxnTask task = new AbortCreateTableTxnTask(txnId, beId);
+            AgentTaskExecutor.submit(task);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/common/GenericPoolTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/GenericPoolTest.java
@@ -35,6 +35,7 @@ import com.starrocks.thrift.TMiniLoadEtlStatusRequest;
 import com.starrocks.thrift.TMiniLoadEtlStatusResult;
 import com.starrocks.thrift.TMiniLoadEtlTaskRequest;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TReq;
 import com.starrocks.thrift.TResultBatch;
 import com.starrocks.thrift.TRoutineLoadTask;
 import com.starrocks.thrift.TScanBatchResult;
@@ -140,6 +141,11 @@ public class GenericPoolTest {
 
         @Override
         public TAgentResult submit_tasks(List<TAgentTaskRequest> tasks) throws TException {
+            return null;
+        }
+
+        @Override
+        public TAgentResult submit_req(TReq req) throws TException {
             return null;
         }
 

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -128,7 +128,7 @@ struct TCreateTableReq {
 }
 
 struct TAbortTxnReq {
-    1: required Types.TTransactionId txn_id;
+    1: optional Types.TTransactionId txn_id;
 }
 
 struct TReq {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -122,6 +122,22 @@ struct TCreateTabletReq {
     20: optional bool create_schema_file = true;
 }
 
+struct TCreateTableReq {
+    1: optional list<TCreateTabletReq> create_tablet_reqs;
+    2: optional i32 timeout = 0; // unit: second
+}
+
+struct TAbortTxnReq {
+    1: required Types.TTransactionId txn_id;
+}
+
+struct TReq {
+    1: optional i64 txn_id;
+    2: optional Types.TTaskType task_type;
+    3: optional TCreateTableReq create_table_req;
+    4: optional TAbortTxnReq abort_req;
+}
+
 struct TDropTabletReq {
     1: required Types.TTabletId tablet_id
     2: optional Types.TSchemaHash schema_hash

--- a/gensrc/thrift/BackendService.thrift
+++ b/gensrc/thrift/BackendService.thrift
@@ -171,4 +171,6 @@ service BackendService {
     // release the context resource associated with the context_id
     StarrocksExternalService.TScanCloseResult close_scanner(1: StarrocksExternalService.TScanCloseParams params);
 
+    AgentService.TAgentResult submit_req(AgentService.TReq req);
+
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1682,6 +1682,7 @@ service FrontendService {
     TBatchReportExecStatusResult batchReportExecStatus(1:TBatchReportExecStatusParams params)
 
     MasterService.TMasterResult finishTask(1:MasterService.TFinishTaskRequest request)
+    MasterService.TMasterResult finishReq(1:MasterService.TFinishRequest request)
     MasterService.TMasterResult report(1:MasterService.TReportRequest request)
     
     // Deprecated

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -97,8 +97,8 @@ struct TFinishTaskRequest {
 struct TFinishRequest {
     1: optional i64 txn_id
     2: optional Types.TBackend backend
-    3: required Types.TTaskType task_type
-    4: required Status.TStatus task_status
+    3: optional Types.TTaskType task_type
+    4: optional Status.TStatus task_status
 }
 
 struct TTablet {

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -94,6 +94,13 @@ struct TFinishTaskRequest {
     19: optional bool incremental_snapshot
 }
 
+struct TFinishRequest {
+    1: optional i64 txn_id
+    2: optional Types.TBackend backend
+    3: required Types.TTaskType task_type
+    4: required Status.TStatus task_status
+}
+
 struct TTablet {
     1: required list<TTabletInfo> tablet_infos
 }


### PR DESCRIPTION
Currently, the create table will be splited multiple create_tablet tasks. Every create_tablet task will need two I/O operations, and always hold the lock, per RPC per tablet.
The procedure is as followes.
```
1. hold the tablet_shard lock      (hold the lock always)
2. create the tablet dir           (First I/O)
3. create tablet meta              (Second I/O)
4. add the tablet to the tablet_map
5. report the status to FE
```

If the concurrency of create table is high, the number of create_tablet tasks may be very high. It will be stuck on the disk I/O and the lock. So I batch the I/O operation for table granularity. Every table will cost constant four I/O operations. As well the I/O opeartions is moved out of the lock. Finally, it only have one RPC to response the status. The new operation is as follows.
```
1. generate tablet dirs
2. save_create_txn(TXN_PREPARED)  (First I/O)
3. mkdir tablet dirs
4. sync tablet dirs               (Second I/O)
5. create tablet meta             (Third I/O)
6. save_create_txn(TXN_COMMITTED) (Four I/O)
7. hold the tablet_shard lock     (hold lock only for a while)
8. add the tablet to the tablet_map
9. report the status to FE
```

To complete the optimization, FE/BE use transaction mechanism to guarantee the exactly-once for create table.
The transaction is only one-phase, not two-phases. When the BE succeed to create the table, the tablets will be added to the map. So we need to remove the tablet when FE failed, partial BEs succeed.
```
1. FE send an abort request to BEs at best effort.
2. BE remove the timeout transactions through an daemon thread.
3. BE report the tablets list to FE, FE send an request to remove the extra tablets.
```

If the transaction failed or timeout, the FE side remove the transaction and send abort request to BE. The BE side will remove the

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
