### PR TITLE
[Feature] match pattern hash node under agg2 to use local shuffle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -77,7 +77,7 @@ public class FeConstants {
     public static boolean isReplayFromQueryDump = false;
     // set false to resolve ut
     public static boolean enablePruneEmptyOutputScan = true;
-    public static boolean showJoinLocalShuffleInExplain = false;
+    public static boolean showJoinLocalShuffleInExplain = true;
 
     // Every 3GB, corresponds a new tablet. Assume compression ratio equals to 3,
     // the raw data of one tablet equals to 10GB approximately

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -69,14 +69,15 @@ public class FeConstants {
     public static boolean USE_MOCK_DICT_MANAGER = false;
 
     public static int checkpoint_interval_second = 60; // 1 minutes
-    // set to true to skip some step when running FE unit test
+    // set this flag true to skip some step when running FE unit test
     public static boolean runningUnitTest = false;
-    // Set this flag to false to suppress showing local shuffle columns in verbose explain, when running FE unit tests.
-    public static boolean showLocalShuffleColumnsInExplain = true;
+    // Set this flag false to suppress showing local shuffle columns in verbose explain, when running FE unit tests.
+    public static boolean showScanNodeLocalShuffleColumnsInExplain = true;
     // set to true when replay from query dump
     public static boolean isReplayFromQueryDump = false;
     // set false to resolve ut
     public static boolean enablePruneEmptyOutputScan = true;
+    public static boolean showJoinLocalShuffleInExplain = false;
 
     // Every 3GB, corresponds a new tablet. Assume compression ratio equals to 3,
     // the raw data of one tablet equals to 10GB approximately

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -126,7 +126,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setOutput_columns(outputSlots);
         }
 
-        if (getCanLocalShuffleOutput()) {
+        if (getCanLocalShuffle()) {
             msg.hash_join_node.setInterpolate_passthrough(
                     ConnectContext.get().getSessionVariable().isHashJoinInterpolatePassthrough());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -126,7 +126,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setOutput_columns(outputSlots);
         }
 
-        if (getCanShuffleOutput()) {
+        if (getCanLocalShuffleOutput()) {
             msg.hash_join_node.setInterpolate_passthrough(
                     ConnectContext.get().getSessionVariable().isHashJoinInterpolatePassthrough());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -90,7 +90,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
 
     // The partitionByExprs which need to check the probe side for partition join.
     protected List<Expr> probePartitionByExprs;
-    protected boolean canShuffleOutput = false;
+    protected boolean canLocalShuffleOutput = false;
 
     public List<RuntimeFilterDescription> getBuildRuntimeFilters() {
         return buildRuntimeFilters;
@@ -387,12 +387,12 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         this.isPushDown = isPushDown;
     }
 
-    public boolean getCanShuffleOutput() {
-        return canShuffleOutput;
+    public boolean getCanLocalShuffleOutput() {
+        return canLocalShuffleOutput;
     }
 
-    public void setCanShuffleOutput(boolean v) {
-        canShuffleOutput = v;
+    public void setCanLocalShuffleOutput(boolean v) {
+        canLocalShuffleOutput = v;
     }
 
     @Override
@@ -444,6 +444,8 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
                 output.append(outputSlots.stream().map(Object::toString).collect(Collectors.joining(", ")));
                 output.append("\n");
             }
+
+            output.append(detailPrefix).append("can local shuffle output: " + canLocalShuffleOutput + "\n");
         }
         return output.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -46,6 +46,7 @@ import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
@@ -90,7 +91,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
 
     // The partitionByExprs which need to check the probe side for partition join.
     protected List<Expr> probePartitionByExprs;
-    protected boolean canLocalShuffleOutput = false;
+    protected boolean canLocalShuffle = false;
 
     public List<RuntimeFilterDescription> getBuildRuntimeFilters() {
         return buildRuntimeFilters;
@@ -387,12 +388,12 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         this.isPushDown = isPushDown;
     }
 
-    public boolean getCanLocalShuffleOutput() {
-        return canLocalShuffleOutput;
+    public boolean getCanLocalShuffle() {
+        return canLocalShuffle;
     }
 
-    public void setCanLocalShuffleOutput(boolean v) {
-        canLocalShuffleOutput = v;
+    public void setCanLocalShuffle(boolean v) {
+        canLocalShuffle = v;
     }
 
     @Override
@@ -445,7 +446,9 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
                 output.append("\n");
             }
 
-            output.append(detailPrefix).append("can local shuffle output: " + canLocalShuffleOutput + "\n");
+            if (!FeConstants.runningUnitTest || FeConstants.showJoinLocalShuffleInExplain) {
+                output.append(detailPrefix).append("can local shuffle: " + canLocalShuffle + "\n");
+            }
         }
         return output.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -446,7 +446,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
                 output.append("\n");
             }
 
-            if (!FeConstants.runningUnitTest || FeConstants.showJoinLocalShuffleInExplain) {
+            if (FeConstants.showJoinLocalShuffleInExplain) {
                 output.append(detailPrefix).append("can local shuffle: " + canLocalShuffle + "\n");
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -770,7 +770,7 @@ public class OlapScanNode extends ScanNode {
                 }
             }
 
-            if (!bucketColumns.isEmpty() && FeConstants.showLocalShuffleColumnsInExplain) {
+            if (!bucketColumns.isEmpty() && FeConstants.showScanNodeLocalShuffleColumnsInExplain) {
                 output.append(prefix).append("LocalShuffleColumns:\n");
                 for (ColumnRefOperator col : bucketColumns) {
                     output.append(prefix).append("- ").append(col.toString()).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -69,6 +69,7 @@ import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rule.tree.CloneDuplicateColRefRule;
 import com.starrocks.sql.optimizer.rule.tree.ExchangeSortToMergeRule;
 import com.starrocks.sql.optimizer.rule.tree.ExtractAggregateColumn;
+import com.starrocks.sql.optimizer.rule.tree.JoinLocalShuffleRule;
 import com.starrocks.sql.optimizer.rule.tree.PhysicalDistributionAggOptRule;
 import com.starrocks.sql.optimizer.rule.tree.PreAggregateTurnOnRule;
 import com.starrocks.sql.optimizer.rule.tree.PredicateReorderRule;
@@ -634,8 +635,7 @@ public class Optimizer {
                 rootTaskContext);
         result = new ExtractAggregateColumn().rewrite(result, rootTaskContext);
         result = new PruneSubfieldsForComplexType().rewrite(result, rootTaskContext);
-
-        SessionVariable sessionVariable = rootTaskContext.getOptimizerContext().getSessionVariable();
+        result = new JoinLocalShuffleRule().rewrite(result, rootTaskContext);
 
         // This must be put at last of the optimization. Because wrapping reused ColumnRefOperator with CloneOperator
         // too early will prevent it from certain optimizations that depend on the equivalence of the ColumnRefOperator.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
@@ -33,6 +33,7 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
     protected final JoinOperator joinType;
     protected final ScalarOperator onPredicate;
     protected final String joinHint;
+    protected boolean canUseLocalShuffle;
 
     protected PhysicalJoinOperator(OperatorType operatorType, JoinOperator joinType,
                                    ScalarOperator onPredicate,
@@ -128,5 +129,13 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
         if (onPredicate != null) {
             columnRefSet.union(onPredicate.getUsedColumns());
         }
+    }
+
+    public void setCanUseLocalShuffle(boolean v) {
+        canUseLocalShuffle = v;
+    }
+
+    public boolean getCanUseLocalShuffle() {
+        return canUseLocalShuffle;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
@@ -33,7 +33,7 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
     protected final JoinOperator joinType;
     protected final ScalarOperator onPredicate;
     protected final String joinHint;
-    protected boolean canUseLocalShuffle;
+    protected boolean canLocalShuffle;
 
     protected PhysicalJoinOperator(OperatorType operatorType, JoinOperator joinType,
                                    ScalarOperator onPredicate,
@@ -131,11 +131,11 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
         }
     }
 
-    public void setCanUseLocalShuffle(boolean v) {
-        canUseLocalShuffle = v;
+    public void setCanLocalShuffle(boolean v) {
+        canLocalShuffle = v;
     }
 
-    public boolean getCanUseLocalShuffle() {
-        return canUseLocalShuffle;
+    public boolean getCanLocalShuffle() {
+        return canLocalShuffle;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JoinLocalShuffleRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JoinLocalShuffleRule.java
@@ -47,7 +47,7 @@ public class JoinLocalShuffleRule implements TreeRewriteRule {
                 Operator childOp = opt.getInputs().get(0).getOp();
                 if (childOp instanceof PhysicalJoinOperator) {
                     PhysicalJoinOperator joinOperator = (PhysicalJoinOperator) childOp;
-                    joinOperator.setCanUseLocalShuffle(true);
+                    joinOperator.setCanLocalShuffle(true);
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JoinLocalShuffleRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JoinLocalShuffleRule.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+public class JoinLocalShuffleRule implements TreeRewriteRule {
+    private static final JoinLocalShuffleVisitor HANDLER = new JoinLocalShuffleVisitor();
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        root.getOp().accept(HANDLER, root, taskContext);
+        return root;
+    }
+
+    private static class JoinLocalShuffleVisitor extends OptExpressionVisitor<Void, TaskContext> {
+        @Override
+        public Void visit(OptExpression opt, TaskContext context) {
+            for (OptExpression input : opt.getInputs()) {
+                input.getOp().accept(this, input, context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitPhysicalHashAggregate(OptExpression opt, TaskContext context) {
+            PhysicalHashAggregateOperator op = (PhysicalHashAggregateOperator) opt.getOp();
+            // local agg + join, then this join can use local shuffle.
+            if (op.getType().isLocal()) {
+                Operator childOp = opt.getInputs().get(0).getOp();
+                if (childOp instanceof PhysicalJoinOperator) {
+                    PhysicalJoinOperator joinOperator = (PhysicalJoinOperator) childOp;
+                    joinOperator.setCanUseLocalShuffle(true);
+                }
+            }
+
+            for (OptExpression input : opt.getInputs()) {
+                input.getOp().accept(this, input, context);
+            }
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -131,7 +131,6 @@ import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.OrderSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
-import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2337,10 +2337,6 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException("unknown join operator: " + node, INTERNAL_ERROR);
             }
 
-            PhysicalPropertySet outputProperty = optExpr.getOutputProperty();
-            if (outputProperty != null && outputProperty.getDistributionProperty().isAny()) {
-                joinNode.setCanLocalShuffle(true);
-            }
             if (node.getCanLocalShuffle()) {
                 joinNode.setCanLocalShuffle(true);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2339,7 +2339,10 @@ public class PlanFragmentBuilder {
 
             PhysicalPropertySet outputProperty = optExpr.getOutputProperty();
             if (outputProperty != null && outputProperty.getDistributionProperty().isAny()) {
-                joinNode.setCanShuffleOutput(true);
+                joinNode.setCanLocalShuffleOutput(true);
+            }
+            if (node.getCanUseLocalShuffle()) {
+                joinNode.setCanLocalShuffleOutput(true);
             }
 
             // Build outputColumns

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2339,10 +2339,10 @@ public class PlanFragmentBuilder {
 
             PhysicalPropertySet outputProperty = optExpr.getOutputProperty();
             if (outputProperty != null && outputProperty.getDistributionProperty().isAny()) {
-                joinNode.setCanLocalShuffleOutput(true);
+                joinNode.setCanLocalShuffle(true);
             }
-            if (node.getCanUseLocalShuffle()) {
-                joinNode.setCanLocalShuffleOutput(true);
+            if (node.getCanLocalShuffle()) {
+                joinNode.setCanLocalShuffle(true);
             }
 
             // Build outputColumns

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
@@ -25,7 +25,6 @@ public class JoinLocalShuffleTest extends PlanTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
-        FeConstants.runningUnitTest = true;
         FeConstants.showJoinLocalShuffleInExplain = true;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
@@ -1,0 +1,37 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.qe.SessionVariable;
+import org.junit.Test;
+
+public class JoinLocalShuffleTest extends PlanTestBase {
+    @Test
+    public void joinWithAgg() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        int agg = sv.getNewPlannerAggStage();
+        String sql = "select sum(v1), sum(v2), sum(v4), sum(v5), v3 from t0 join t1 on t0.v3 = t1.v6 group by v3";
+        {
+            sv.setNewPlanerAggStage(1);
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  |  can local shuffle output: false");
+        }
+        {
+            sv.setNewPlanerAggStage(2);
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  |  can local shuffle output: true");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
@@ -16,25 +16,23 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SessionVariable;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class JoinLocalShuffleTest extends PlanTestBase {
-    int aggState = 0;
 
-    @Before
-    public void setup() {
-        SessionVariable sv = connectContext.getSessionVariable();
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
         FeConstants.showJoinLocalShuffleInExplain = true;
-        aggState = sv.getNewPlannerAggStage();
     }
 
-    @After
-    public void teardown() {
-        SessionVariable sv = connectContext.getSessionVariable();
+    @AfterClass
+    public static void afterClass() {
+        PlanTestBase.afterClass();
         FeConstants.showJoinLocalShuffleInExplain = false;
-        sv.setNewPlanerAggStage(aggState);
     }
 
     @Test
@@ -51,5 +49,6 @@ public class JoinLocalShuffleTest extends PlanTestBase {
             String plan = getVerboseExplain(sql);
             assertContains(plan, "  |  can local shuffle: true");
         }
+        sv.setNewPlanerAggStage(0);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -89,6 +89,7 @@ public class PlanTestNoneDBBase {
         starRocksAssert = new StarRocksAssert(connectContext);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);
         FeConstants.enablePruneEmptyOutputScan = false;
+        FeConstants.showJoinLocalShuffleInExplain = false;
     }
 
     public static void assertContains(String text, String... pattern) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -67,6 +67,7 @@ public class ReplayFromDumpTestBase {
         FeConstants.runningUnitTest = true;
         FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;
         FeConstants.enablePruneEmptyOutputScan = false;
+        FeConstants.showJoinLocalShuffleInExplain = false;
 
         new MockUp<EditLog>() {
             @Mock

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -65,7 +65,7 @@ public class ReplayFromDumpTestBase {
         connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
         starRocksAssert = new StarRocksAssert(connectContext);
         FeConstants.runningUnitTest = true;
-        FeConstants.showLocalShuffleColumnsInExplain = false;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;
         FeConstants.enablePruneEmptyOutputScan = false;
 
         new MockUp<EditLog>() {
@@ -85,7 +85,7 @@ public class ReplayFromDumpTestBase {
     @AfterClass
     public static void afterClass() throws Exception {
         connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
-        FeConstants.showLocalShuffleColumnsInExplain = true;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = true;
     }
 
     public String getModelContent(String filename, String model) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithCostTest.java
@@ -26,14 +26,14 @@ public class TPCHPlanWithCostTest extends DistributedEnvPlanTestBase {
     public static void beforeClass() throws Exception {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
-        FeConstants.showLocalShuffleColumnsInExplain = false;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;
         connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
         connectContext.getSessionVariable().setEnableMultiColumnsOnGlobbalRuntimeFilter(true);
     }
 
     @AfterClass
     public static void afterClass() {
-        FeConstants.showLocalShuffleColumnsInExplain = true;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = true;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
@@ -29,7 +29,7 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
     public static void beforeClass() throws Exception {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
-        FeConstants.showLocalShuffleColumnsInExplain = false;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;
         connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
@@ -62,7 +62,7 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
 
     @AfterClass
     public static void afterClass() {
-        FeConstants.showLocalShuffleColumnsInExplain = true;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = true;
     }
 
     @Test


### PR DESCRIPTION
Fixes #issue

PR https://github.com/StarRocks/starrocks/pull/33453 does  not work as expected. 

I expect requiredProperty of hash join would be ANY, but in our CBO implementation the hash join requiredProperty is actually it's outputProperty.

It's hard to change CBO implementation. So I add a pattern match during physical plan rewrite stage:
- local agg + join
- then this join can use local shuffle.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
