### PR TITLE
[BugFix] Fix creating jdbc resource blocks with lock acquired

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCResource.java
@@ -79,7 +79,7 @@ public class JDBCResource extends Resource {
 
     private void computeDriverChecksum() throws DdlException {
         if (FeConstants.runningUnitTest) {
-            // skip checking checksun when running ut
+            // skip checking checksum when running ut
             return;
         }
         try {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceMgr.java
@@ -117,11 +117,11 @@ public class ResourceMgr implements Writable {
     }
 
     public void createResource(CreateResourceStmt stmt) throws DdlException {
+        Resource resource = Resource.fromStmt(stmt);
+
         this.writeLock();
         try {
-            Resource resource = Resource.fromStmt(stmt);
             String resourceName = stmt.getResourceName();
-
             String typeName = resource.getType().name().toLowerCase(Locale.ROOT);
             if (resource.needMappingCatalog()) {
                 try {


### PR DESCRIPTION
1. creating jdbc resource involves network request (see JDBCResource#computeDriverChecksum)
2. moves this part of code out of critical section

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
