### PR TITLE
[BugFix] fix segment mem_usage race condition

### DIFF
--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string_view>
 #include <variant>
 
@@ -63,6 +64,9 @@ public:
 
     void cache_segment(std::string_view key, std::shared_ptr<Segment> segment);
 
+    // cache the segment if the given key not exists in the cache, returns the segment shared_ptr stored in the cache.
+    std::shared_ptr<Segment> cache_segment_if_absent(std::string_view key, std::shared_ptr<Segment> segment);
+
     void cache_delvec(std::string_view key, std::shared_ptr<const DelVector> delvec);
 
     void erase(std::string_view key);
@@ -78,9 +82,14 @@ public:
 private:
     static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
 
+    std::shared_ptr<Segment> _lookup_segment_no_lock(std::string_view key);
+    void _cache_segment_no_lock(std::string_view key, std::shared_ptr<Segment> segment);
+
     void insert(std::string_view key, CacheValue* ptr, size_t size);
 
     std::unique_ptr<Cache> _cache;
+
+    std::mutex _mutex;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -141,7 +141,11 @@ public:
     // only for TEST purpose
     void TEST_set_global_schema_cache(int64_t index_id, TabletSchemaPtr schema);
 
-    void update_segment_cache_size(std::string_view key);
+    // update cache size of the segment with the given key, optionally provide the segment address hint.
+    // If segment_addr_hint is provided and it's non-zero, the cache size will be only updated when the
+    // instance address matches the address provided by the segment_addr_hint. This is used to prevent
+    // updating the cache size where the cached object is not the one as expected.
+    void update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint = 0);
 
 private:
     static std::string global_schema_cache_key(int64_t index_id);

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -193,13 +193,14 @@ Status Segment::open(size_t* footer_length_hint, const FooterPointerPB* partial_
         return Status::OK();
     }
 
-    auto res = success_once(_open_once, [&] {
-        Status st = _open(footer_length_hint, partial_rowset_footer, skip_fill_local_cache);
-        if (st.ok()) {
-            update_cache_size();
-        }
-        return st;
-    });
+    auto res = success_once(_open_once,
+                            [&] { return _open(footer_length_hint, partial_rowset_footer, skip_fill_local_cache); });
+
+    // move the cache size update out of the `success_once`,
+    // so that the onceflag `_open_once` can be set before the cache_size is updated.
+    if (res.ok() && *res) {
+        update_cache_size();
+    }
     return res.status();
 }
 
@@ -444,8 +445,15 @@ size_t Segment::_column_index_mem_usage() const {
 
 void Segment::update_cache_size() {
     if (_tablet_manager != nullptr) {
-        _tablet_manager->update_segment_cache_size(file_name());
+        _tablet_manager->update_segment_cache_size(file_name(), reinterpret_cast<intptr_t>(this));
     }
 }
 
+size_t Segment::mem_usage() const {
+    if (!invoked(_open_once)) {
+        // just report the basic info memory usage if not opened yet
+        return _basic_info_mem_usage();
+    }
+    return _basic_info_mem_usage() + _short_key_index_mem_usage() + _column_index_mem_usage();
+}
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -165,9 +165,7 @@ public:
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
 
-    size_t mem_usage() const {
-        return _basic_info_mem_usage() + _short_key_index_mem_usage() + _column_index_mem_usage();
-    }
+    size_t mem_usage() const;
 
     int64_t get_data_size() {
         auto res = _fs->get_file_size(_fname);

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <future>
+
 #include "column/chunk.h"
 #include "column/datum_tuple.h"
 #include "column/fixed_length_column.h"
@@ -238,7 +240,7 @@ TEST_F(LakeMetacacheTest, test_segment_cache) {
 
     // load segment with indexes, and remove index meta (index meta is larger than index)
     auto sz2 = metacache->memory_usage();
-    std::cout << "metadata cache memory usage: " << sz0 << "-" << sz1 << "-" << sz2;
+    LOG(INFO) << "metadata cache memory usage: " << sz0 << "-" << sz1 << "-" << sz2;
     ASSERT_GT(sz1, sz0);
     ASSERT_LT(sz2, sz1);
 }
@@ -267,6 +269,106 @@ TEST_F(LakeMetacacheTest, test_prune) {
 
     auto meta3 = metacache->lookup_tablet_metadata("meta1");
     ASSERT_TRUE(meta3 == nullptr);
+}
+
+TEST_F(LakeMetacacheTest, test_cache_segment_if_absent) {
+    // intend empty value for the following two variables
+    std::shared_ptr<FileSystem> fs;
+    TabletSchemaCSPtr schema;
+
+    auto* metacache = _tablet_mgr->metacache();
+    metacache->prune();
+
+    uint32_t segment_id = 1000;
+    std::string segment_path("test_cache_segment_if_absent.dat");
+
+    EXPECT_EQ(nullptr, metacache->lookup_segment(segment_path));
+    auto seg1 = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+
+    {
+        // cache seg1, since there is no segment cached before, cache_segment_if_absent will cache the seg1 and return it.
+        auto seg = metacache->cache_segment_if_absent(segment_path, seg1);
+        EXPECT_TRUE(seg != nullptr);
+        EXPECT_EQ(seg1, seg);
+        EXPECT_EQ(seg1, metacache->lookup_segment(segment_path));
+    }
+
+    auto seg2 = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+    {
+        auto seg = metacache->cache_segment_if_absent(segment_path, seg2);
+        EXPECT_TRUE(seg != nullptr);
+        EXPECT_NE(seg1, seg2);
+        // still returns seg1
+        EXPECT_EQ(seg1, seg);
+        EXPECT_EQ(seg1, metacache->lookup_segment(segment_path));
+    }
+}
+
+struct TestCacheSegmentConcurrency {
+    std::shared_ptr<Segment> segment;
+    std::promise<std::shared_ptr<Segment>> seg_promise;
+    std::mutex* mutex;
+    std::condition_variable* cv;
+    starrocks::lake::Metacache* cache;
+    std::unique_ptr<std::thread> thread;
+    std::atomic<int>* pending_count;
+};
+
+static void run_single(TestCacheSegmentConcurrency* ctx) {
+    std::unique_lock lk(*(ctx->mutex));
+    ctx->cv->wait(lk);
+    ctx->pending_count->fetch_sub(1);
+    auto seg = ctx->cache->cache_segment_if_absent(ctx->segment->file_name(), ctx->segment);
+    ctx->seg_promise.set_value(seg);
+}
+
+TEST_F(LakeMetacacheTest, test_cache_segment_if_absent_concurrency) {
+    std::mutex m;
+    std::condition_variable cv;
+
+    auto* metacache = _tablet_mgr->metacache();
+    metacache->prune();
+
+    std::shared_ptr<FileSystem> fs;
+    TabletSchemaCSPtr schema;
+
+    uint32_t segment_id = 10001;
+    std::string segment_path("test_cache_segment_if_absent_concurrent.dat");
+
+    int kConcurrency = 128;
+    std::atomic<int> pending_count = kConcurrency;
+    std::vector<TestCacheSegmentConcurrency> ctx_arr;
+    ctx_arr.reserve(kConcurrency);
+    for (int i = 0; i < kConcurrency; ++i) {
+        TestCacheSegmentConcurrency ctx;
+        ctx.pending_count = &pending_count;
+        ctx.segment = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+        ctx.mutex = &m;
+        ctx.cv = &cv;
+        ctx.cache = metacache;
+        ctx_arr.push_back(std::move(ctx));
+        ctx_arr.back().thread = std::make_unique<std::thread>(&run_single, &(ctx_arr.back()));
+    }
+
+    using namespace std::chrono_literals;
+    // sleep for a while, so that all the threads can be ready as much as possible
+    std::this_thread::sleep_for(500ms);
+    while (pending_count.load() > 0) {
+        cv.notify_all();
+    }
+    std::shared_ptr<Segment> final_result;
+    bool first = true;
+    for (auto& ctx : ctx_arr) {
+        ctx.thread->join();
+        auto res = ctx.seg_promise.get_future().get();
+        if (first) {
+            final_result = res;
+            first = false;
+        } else {
+            // expect all threads' cache_segment_if_absent() call to the same segment path, returns the same result
+            EXPECT_EQ(final_result, res);
+        }
+    }
 }
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -76,6 +76,64 @@ public:
 
     void TearDown() override { remove_test_dir_ignore_error(); }
 
+    void create_rowsets_for_testing() {
+        std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+        std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+        std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+        std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int32Column::create();
+        auto c3 = Int32Column::create();
+        c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+        c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+        c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+        Chunk chunk0({c0, c1}, _schema);
+        Chunk chunk1({c2, c3}, _schema);
+
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+
+        {
+            int64_t txn_id = next_id();
+            // write rowset 1 with 2 segments
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+            ASSERT_OK(writer->open());
+
+            // write rowset data
+            // segment #1
+            ASSERT_OK(writer->write(chunk0));
+            ASSERT_OK(writer->write(chunk1));
+            ASSERT_OK(writer->finish());
+
+            // segment #2
+            ASSERT_OK(writer->write(chunk0));
+            ASSERT_OK(writer->write(chunk1));
+            ASSERT_OK(writer->finish());
+
+            auto files = writer->files();
+            ASSERT_EQ(2, files.size());
+
+            // add rowset metadata
+            auto* rowset = _tablet_metadata->add_rowsets();
+            rowset->set_overlapped(true);
+            rowset->set_id(1);
+            auto* segs = rowset->mutable_segments();
+            for (auto& file : writer->files()) {
+                segs->Add(std::move(file));
+            }
+
+            writer->close();
+        }
+
+        // write tablet metadata
+        _tablet_metadata->set_version(2);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
 protected:
     constexpr static const char* const kTestDirectory = "test_lake_rowset";
 
@@ -85,62 +143,9 @@ protected:
 };
 
 TEST_F(LakeRowsetTest, test_load_segments) {
-    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
-    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
-
-    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
-    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-
-    auto c0 = Int32Column::create();
-    auto c1 = Int32Column::create();
-    auto c2 = Int32Column::create();
-    auto c3 = Int32Column::create();
-    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
-    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
-    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
-    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
-
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    create_rowsets_for_testing();
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-
-    {
-        int64_t txn_id = next_id();
-        // write rowset 1 with 2 segments
-        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
-        ASSERT_OK(writer->open());
-
-        // write rowset data
-        // segment #1
-        ASSERT_OK(writer->write(chunk0));
-        ASSERT_OK(writer->write(chunk1));
-        ASSERT_OK(writer->finish());
-
-        // segment #2
-        ASSERT_OK(writer->write(chunk0));
-        ASSERT_OK(writer->write(chunk1));
-        ASSERT_OK(writer->finish());
-
-        auto files = writer->files();
-        ASSERT_EQ(2, files.size());
-
-        // add rowset metadata
-        auto* rowset = _tablet_metadata->add_rowsets();
-        rowset->set_overlapped(true);
-        rowset->set_id(1);
-        auto* segs = rowset->mutable_segments();
-        for (auto& file : writer->files()) {
-            segs->Add(std::move(file));
-        }
-
-        writer->close();
-    }
-
-    // write tablet metadata
-    _tablet_metadata->set_version(2);
-    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
-
     auto* cache = _tablet_mgr->metacache();
 
     ASSIGN_OR_ABORT(auto rowsets, tablet.get_rowsets(2));
@@ -161,6 +166,60 @@ TEST_F(LakeRowsetTest, test_load_segments) {
     for (const auto& seg : segments2) {
         auto segment = cache->lookup_segment(seg->file_name());
         ASSERT_TRUE(segment != nullptr);
+    }
+}
+
+TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
+    create_rowsets_for_testing();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto rowsets, tablet.get_rowsets(2));
+    ASSIGN_OR_ABORT(auto segments, rowsets[0]->segments(false));
+
+    auto* cache = _tablet_mgr->metacache();
+
+    // get the same segments from the rowset
+    auto sample_segment = segments[0];
+    std::string path = sample_segment->file_name();
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(path));
+    auto schema = sample_segment->tablet_schema_share_ptr();
+
+    // create a dummy segment with the same path to cache ahead in metacache,
+    // the later segment open operation will not update the mem_usage due to instance mismatch.
+    {
+        // clean the cache
+        cache->prune();
+        //create the dummy segment and put it into metacache
+        auto dummy_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        cache->cache_segment(path, dummy_segment);
+        EXPECT_EQ(dummy_segment, cache->lookup_segment(path));
+        auto sz1 = cache->memory_usage();
+
+        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto st = mirror_segment->open(nullptr, nullptr, true);
+        EXPECT_TRUE(st.ok());
+        auto sz2 = cache->memory_usage();
+        // no memory_usage change, because the instance in metacache is different from this mirror_segment
+        EXPECT_EQ(sz1, sz2);
+    }
+    // create the mirror_segment without open, and put it into metacache, get the cache memory_usage,
+    // open the segment (during the open, the cache size will be updated), get the cache memory_usage again.
+    {
+        // clean the cache
+        cache->prune();
+        //create the dummy segment and put it into metacache
+        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        cache->cache_segment(path, mirror_segment);
+        auto sz1 = cache->memory_usage();
+        auto ssz1 = mirror_segment->mem_usage();
+
+        auto st = mirror_segment->open(nullptr, nullptr, true);
+        EXPECT_TRUE(st.ok());
+        auto sz2 = cache->memory_usage();
+        auto ssz2 = mirror_segment->mem_usage();
+        // mem usage updated after the segment is opened.
+        EXPECT_LT(sz1, sz2);
+        EXPECT_EQ(ssz2 - ssz1, sz2 - sz1);
     }
 }
 


### PR DESCRIPTION
* protect the Segment::mem_usage() with open_once flag
* TabletManager is able to skip the cache size update if the segment in the cache is not the same as expected one.
* MetaCache support `cache_segment_if_absent` interface.

Fixes #34273

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
