### PR TITLE
[BugFix] Make sure isForwardToLeader immutable in the StmtExecutor's lifecycle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/AuditEvent.java
@@ -135,6 +135,8 @@ public class AuditEvent {
     @AuditField(value = "HitMvs", ignore_zero = true)
     public String hitMVs;
 
+    @AuditField(value = "IsForwardToLeader")
+    public boolean isForwardToLeader = false;
 
     public static class AuditEventBuilder {
 
@@ -307,6 +309,11 @@ public class AuditEvent {
 
         public String getHitMvs() {
             return this.auditEvent.hitMVs;
+        }
+
+        public AuditEventBuilder setIsForwardToLeader(boolean isForwardToLeader) {
+            auditEvent.isForwardToLeader = isForwardToLeader;
+            return this;
         }
 
         public AuditEvent build() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -441,7 +441,7 @@ public class ConnectContext {
         return returnRows;
     }
 
-    public void resetRetureRows() {
+    public void resetReturnRows() {
         returnRows = 0;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -176,10 +176,12 @@ public class ConnectProcessor {
         long endTime = System.currentTimeMillis();
         long elapseMs = endTime - ctx.getStartTime();
 
+        boolean isForwardToLeader = (executor != null) ? executor.getIsForwardToLeaderOrInit(false) : false;
         ctx.getAuditEventBuilder().setEventType(EventType.AFTER_QUERY)
                 .setState(ctx.getState().toString()).setErrorCode(ctx.getErrorCode()).setQueryTime(elapseMs)
                 .setReturnRows(ctx.getReturnRows())
                 .setStmtId(ctx.getStmtId())
+                .setIsForwardToLeader(isForwardToLeader)
                 .setQueryId(ctx.getQueryId() == null ? "NaN" : ctx.getQueryId().toString());
         if (statistics != null) {
             ctx.getAuditEventBuilder().setScanBytes(statistics.scanBytes);
@@ -187,6 +189,7 @@ public class ConnectProcessor {
             ctx.getAuditEventBuilder().setCpuCostNs(statistics.cpuCostNs == null ? -1 : statistics.cpuCostNs);
             ctx.getAuditEventBuilder().setMemCostBytes(statistics.memCostBytes == null ? -1 : statistics.memCostBytes);
             ctx.getAuditEventBuilder().setSpilledBytes(statistics.spillBytes == null ? -1 : statistics.spillBytes);
+            ctx.getAuditEventBuilder().setReturnRows(statistics.returnedRows == null ? 0 : statistics.returnedRows);
         }
 
         if (ctx.getState().isQuery()) {
@@ -354,7 +357,7 @@ public class ConnectProcessor {
             for (int i = 0; i < stmts.size(); ++i) {
                 ctx.getState().reset();
                 if (i > 0) {
-                    ctx.resetRetureRows();
+                    ctx.resetReturnRows();
                     ctx.setQueryId(UUIDUtil.genUUID());
                 }
                 parsedStmt = stmts.get(i);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.qe;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.reflect.TypeToken;
@@ -65,6 +66,7 @@ import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 // System variable
 @SuppressWarnings("FieldMayBeFinal")
@@ -422,6 +424,16 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_ICEBERG_IDENTITY_COLUMN_OPTIMIZE = "enable_iceberg_identity_column_optimize";
 
     public static final String ENABLE_PLAN_SERIALIZE_CONCURRENTLY = "enable_plan_serialize_concurrently";
+
+    // Add the flag to control whether to proxy follower's query statement to leader which can be
+    // used for testing.
+    public enum FollowerQueryForwardMode {
+        DEFAULT,
+        FOLLOWER,
+        LEADER
+    }
+
+    public static final String FOLLOWER_QUERY_FORWARD_MODE = "follower_query_forward_mode";
 
     public enum MaterializedViewRewriteMode {
         DISABLE,            // disable materialized view rewrite
@@ -1509,6 +1521,17 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_PLAN_SERIALIZE_CONCURRENTLY)
     private boolean enablePlanSerializeConcurrently = true;
+
+    @VarAttr(name = FOLLOWER_QUERY_FORWARD_MODE, flag = VariableMgr.INVISIBLE | VariableMgr.DISABLE_FORWARD_TO_LEADER)
+    private String followerForwardMode = "";
+
+    public Optional<Boolean> isFollowerForwardToLeaderOpt() {
+        if (Strings.isNullOrEmpty(this.followerForwardMode) ||
+                followerForwardMode.equalsIgnoreCase(FollowerQueryForwardMode.DEFAULT.toString())) {
+            return Optional.empty();
+        }
+        return Optional.of(followerForwardMode.equalsIgnoreCase(FollowerQueryForwardMode.LEADER.toString()));
+    }
 
     public int getExprChildrenLimit() {
         return exprChildrenLimit;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1523,6 +1523,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = FOLLOWER_QUERY_FORWARD_MODE, flag = VariableMgr.INVISIBLE | VariableMgr.DISABLE_FORWARD_TO_LEADER)
     private String followerForwardMode = "";
 
+    public void setFollowerQueryForwardMode(String mode) {
+        this.followerForwardMode = mode;
+    }
+
     public Optional<Boolean> isFollowerForwardToLeaderOpt() {
         if (Strings.isNullOrEmpty(this.followerForwardMode) ||
                 followerForwardMode.equalsIgnoreCase(FollowerQueryForwardMode.DEFAULT.toString())) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -425,14 +425,12 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PLAN_SERIALIZE_CONCURRENTLY = "enable_plan_serialize_concurrently";
 
-    // Add the flag to control whether to proxy follower's query statement to leader which can be
-    // used for testing.
+    // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
-        DEFAULT,
-        FOLLOWER,
-        LEADER
+        DEFAULT,    // proxy queries by the follower's replay progress (default)
+        FOLLOWER,   // proxy queries to follower no matter the follower's replay progress
+        LEADER      // proxy queries to leader no matter the follower's replay progress
     }
-
     public static final String FOLLOWER_QUERY_FORWARD_MODE = "follower_query_forward_mode";
 
     public enum MaterializedViewRewriteMode {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -351,12 +351,12 @@ public class StmtExecutor {
             if (!isInitIfNoPresent) {
                 return false;
             }
-            isForwardToLeaderOpt = Optional.of(getIsForwardToLeaderState());
+            isForwardToLeaderOpt = Optional.of(initForwardToLeaderState());
         }
         return isForwardToLeaderOpt.get();
     }
 
-    private boolean getIsForwardToLeaderState() {
+    private boolean initForwardToLeaderState() {
         if (GlobalStateMgr.getCurrentState().isLeader()) {
             return false;
         }
@@ -369,7 +369,7 @@ public class StmtExecutor {
                 return context.getSessionVariable().isFollowerForwardToLeaderOpt().get();
             }
 
-            if (!GlobalStateMgr.getCurrentState().isLeader() && !GlobalStateMgr.getCurrentState().canRead()) {
+            if (!GlobalStateMgr.getCurrentState().canRead()) {
                 return true;
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -211,6 +211,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
@@ -244,6 +245,7 @@ public class StmtExecutor {
     private ShowResultSet proxyResultSet = null;
     private PQueryStatistics statisticsForAuditLog;
     private List<StmtExecutor> subStmtExecutors;
+    private Optional<Boolean> isForwardToLeaderOpt = Optional.empty();
 
     private HttpResultSender httpResultSender;
 
@@ -337,15 +339,39 @@ public class StmtExecutor {
         return profile;
     }
 
+    /**
+     * Whether to forward to leader from follower which should be the same in the StmtExecutor's lifecycle.
+     */
     public boolean isForwardToLeader() {
+        return getIsForwardToLeaderOrInit(true);
+    }
+
+    public boolean getIsForwardToLeaderOrInit(boolean isInitIfNoPresent) {
+        if (!isForwardToLeaderOpt.isPresent()) {
+            if (!isInitIfNoPresent) {
+                return false;
+            }
+            isForwardToLeaderOpt = Optional.of(getIsForwardToLeaderState());
+        }
+        return isForwardToLeaderOpt.get();
+    }
+
+    private boolean getIsForwardToLeaderState() {
         if (GlobalStateMgr.getCurrentState().isLeader()) {
             return false;
         }
 
         // this is a query stmt, but this non-master FE can not read, forward it to master
-        if (parsedStmt instanceof QueryStatement && !GlobalStateMgr.getCurrentState().isLeader()
-                && !GlobalStateMgr.getCurrentState().canRead()) {
-            return true;
+        if (parsedStmt instanceof QueryStatement) {
+            // When FollowerQueryForwardMode is not default, forward it to leader or follower by default.
+            if (context != null && context.getSessionVariable() != null &&
+                    context.getSessionVariable().isFollowerForwardToLeaderOpt().isPresent()) {
+                return context.getSessionVariable().isFollowerForwardToLeaderOpt().get();
+            }
+
+            if (!GlobalStateMgr.getCurrentState().isLeader() && !GlobalStateMgr.getCurrentState().canRead()) {
+                return true;
+            }
         }
 
         if (redirectStatus == null) {
@@ -408,6 +434,12 @@ public class StmtExecutor {
         try {
             // parsedStmt may already by set when constructing this StmtExecutor();
             resolveParseStmtForForward();
+
+            if (parsedStmt != null) {
+                boolean isQuery = parsedStmt instanceof QueryStatement;
+                // set isQuery before `forwardToLeader` to make it right for audit log.
+                context.getState().setIsQuery(isQuery);
+            }
 
             processVarHint(sessionVariableBackup);
 
@@ -489,7 +521,6 @@ public class StmtExecutor {
             }
 
             if (parsedStmt instanceof QueryStatement) {
-                context.getState().setIsQuery(true);
                 final boolean isStatisticsJob = AnalyzerUtils.isStatisticsJob(context, parsedStmt);
                 context.setStatisticsJob(isStatisticsJob);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -211,6 +211,17 @@ public class SetStmtAnalyzer {
             }
         }
 
+        // follower_query_forward_mode
+        if (variable.equalsIgnoreCase(SessionVariable.FOLLOWER_QUERY_FORWARD_MODE)) {
+            String queryFollowerForwardMode = resolvedExpression.getStringValue();
+            if (!EnumUtils.isValidEnumIgnoreCase(SessionVariable.FollowerQueryForwardMode.class, queryFollowerForwardMode)) {
+                String supportedList = StringUtils.join(
+                        EnumUtils.getEnumList(SessionVariable.FollowerQueryForwardMode.class), ",");
+                throw new SemanticException(String.format("Unsupported follower query forward mode: %s, " +
+                        "supported list is %s", queryFollowerForwardMode, supportedList));
+            }
+        }
+
         var.setResolvedExpression(resolvedExpression);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
@@ -211,4 +211,51 @@ public class SetStmtTest {
             }
         }
     }
+
+    @Test
+    public void testFollowerQueryForwardMode() throws AnalysisException {
+        // normal
+        {
+            for (SessionVariable.FollowerQueryForwardMode mode :
+                    EnumUtils.getEnumList(SessionVariable.FollowerQueryForwardMode.class)) {
+                try {
+                    SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.FOLLOWER_QUERY_FORWARD_MODE,
+                            new StringLiteral(mode.toString()));
+                    SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                } catch (Exception e) {
+                    Assert.fail();;
+                }
+            }
+
+        }
+
+        // empty
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.FOLLOWER_QUERY_FORWARD_MODE,
+                    new StringLiteral(""));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assert.fail();
+            } catch (Exception e) {
+                e.printStackTrace();
+                Assert.assertEquals("Getting analyzing error. Detail message: Unsupported follower " +
+                                "query forward mode: , supported list is DEFAULT,FOLLOWER,LEADER.",
+                        e.getMessage());
+            }
+        }
+
+        // bad case
+        {
+            SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.FOLLOWER_QUERY_FORWARD_MODE,
+                    new StringLiteral("bad_case"));
+            try {
+                SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                Assert.fail("should fail");
+            } catch (SemanticException e) {
+                Assert.assertEquals("Getting analyzing error. Detail message: " +
+                        "Unsupported follower query forward mode: bad_case, " +
+                        "supported list is DEFAULT,FOLLOWER,LEADER.", e.getMessage());;
+            }
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/QueryPlannerTest.java
@@ -34,19 +34,23 @@
 
 package com.starrocks.planner;
 
-import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.meta.BlackListSql;
 import com.starrocks.meta.SqlBlackList;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.CreateDbStmt;
 import com.starrocks.sql.ast.DropDbStmt;
 import com.starrocks.sql.ast.ShowCreateDbStmt;
+import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -238,5 +242,46 @@ public class QueryPlannerTest {
         StmtExecutor stmtExecutor3 = new StmtExecutor(connectContext, deleteBlackListSql);
         stmtExecutor3.execute();
         Assert.assertEquals(0, SqlBlackList.getInstance().sqlBlackListMap.entrySet().size());
+    }
+
+    @Test
+    public void testFollowerProxyQuery() throws Exception {
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public FrontendNodeType getFeType() {
+                return FrontendNodeType.FOLLOWER;
+            }
+            @Mock
+            public boolean isLeader() {
+                return false;
+            }
+        };
+
+        String sql = "select k1 from test.baseall";
+        StatementBase statement = SqlParser.parse(sql, connectContext.getSessionVariable().getSqlMode()).get(0);
+
+        {
+            StmtExecutor executor = new StmtExecutor(connectContext, statement);
+            Assert.assertTrue(executor.isForwardToLeader() == true);
+        }
+        {
+            connectContext.getSessionVariable().setFollowerQueryForwardMode("default");
+            StmtExecutor executor = new StmtExecutor(connectContext, statement);
+            Assert.assertTrue(executor.isForwardToLeader() == true);
+        }
+        {
+            connectContext.getSessionVariable().setFollowerQueryForwardMode("follower");
+            StmtExecutor executor = new StmtExecutor(connectContext, statement);
+            Assert.assertTrue(executor.isForwardToLeader() == false);
+            connectContext.getSessionVariable().setFollowerQueryForwardMode("leader");
+            Assert.assertTrue(executor.isForwardToLeader() == false);
+        }
+        {
+            connectContext.getSessionVariable().setFollowerQueryForwardMode("leader");
+            StmtExecutor executor = new StmtExecutor(connectContext, statement);
+            Assert.assertTrue(executor.isForwardToLeader() == true);
+            connectContext.getSessionVariable().setFollowerQueryForwardMode("follower");
+            Assert.assertTrue(executor.isForwardToLeader() == true);
+        }
     }
 }


### PR DESCRIPTION
Fix https://starrocks.atlassian.net/browse/SR-21632


- Add an invisible flag `follower_query_forward_mode` which can be used to proxy query for follower/leader;
- Make sure isForwardToLeader is always the same in the StmtExecutor's lifecycle.
- Fix `IsQuery` and `ReturnRows` audit log bugs when it's forward to leader.
- Add audit log `IsForwardToLeader ` to mark whether this query is forward to leader or not.

```
set follower_query_forward_mode='leader';

Before
2023-11-10 10:57:08,220 [query] |Client=172.26.92.227:47776|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=test|State=EOF|ErrorCode=|Time=2243|ScanBytes=370|ScanRows=5|ReturnRows=0|CpuCostNs=3830128|MemCostBytes=1758728|StmtId=7|QueryId=7d6982c6-7f72-11ee-baa1-00163e2774a9|IsQuery=false|feIp=172.26.95.216|Stmt=SELECT dtstatdate as dteventtime, sum(imoney) as count FROM dws_cosgame_revenue_min_income_v2 GROUP BY dtstatdate ORDER BY dtstatdate|Digest=

After:
2023-11-10 11:08:58,090 [query] |Client=172.26.92.227:47810|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=test|State=EOF|ErrorCode=|Time=36|ScanBytes=370|ScanRows=5|ReturnRows=3|CpuCostNs=3927442|MemCostBytes=1582208|StmtId=8|QueryId=7d533eba-7f76-11ee-adcf-00163e2774a9|IsQuery=true|feIp=172.26.95.216|Stmt=SELECT dtstatdate as dteventtime, sum(imoney) as count FROM dws_cosgame_revenue_min_income_v2 GROUP BY dtstatdate ORDER BY dtstatdate|Digest=|IsForwardToLeader=true
```

```
set follower_query_forward_mode='follower';

2023-11-10 11:10:25,121 [query] |Client=172.26.92.227:47810|User=root|AuthorizedUser='root'@'%'|ResourceGroup=default_wg|Catalog=default_catalog|Db=test|State=EOF|ErrorCode=|Time=31|ScanBytes=370|ScanRows=5|ReturnRows=3|CpuCostNs=3703618|MemCostBytes=775968|StmtId=10|QueryId=b133bb6c-7f76-11ee-adcf-00163e2774a9|IsQuery=true|feIp=172.26.95.216|Stmt=SELECT dtstatdate as dteventtime, sum(imoney) as count FROM dws_cosgame_revenue_min_income_v2 GROUP BY dtstatdate ORDER BY dtstatdate|Digest=|PlanCpuCost=152.0|PlanMemCost=99.2|IsForwardToLeader=false
```

```
mysql> set follower_query_forward_mode='';
ERROR 1064 (HY000): Getting analyzing error. Detail message: Unsupported follower query forward mode: , supported list is DEFAULT,FOLLOWER,LEADER.
mysql> set follower_query_forward_mode='d';
ERROR 1064 (HY000): Getting analyzing error. Detail message: Unsupported follower query forward mode: d, supported list is DEFAULT,FOLLOWER,LEADER.
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
