### PR TITLE
[BugFix] Fix be crash when execute show proc '/current_queries'

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -691,6 +691,7 @@ Status FragmentExecutor::prepare(ExecEnv* exec_env, const TExecPlanFragmentParam
     }
 
     RETURN_IF_ERROR(_query_ctx->fragment_mgr()->register_ctx(request.fragment_instance_id(), _fragment_ctx));
+    _query_ctx->mark_prepared();
     prepare_success = true;
 
     return Status::OK();

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -143,8 +143,8 @@ public:
     void release_workgroup_token_once();
 
     // Some statistic about the query, including cpu, scan_rows, scan_bytes
-    int64_t mem_cost_bytes() const { return _mem_tracker->peak_consumption(); }
-    int64_t current_mem_usage_bytes() const { return _mem_tracker->consumption(); }
+    int64_t mem_cost_bytes() const { return _mem_tracker == nullptr ? 0 : _mem_tracker->peak_consumption(); }
+    int64_t current_mem_usage_bytes() const { return _mem_tracker == nullptr ? 0 : _mem_tracker->consumption(); }
     void incr_cpu_cost(int64_t cost) {
         _total_cpu_cost_ns += cost;
         _delta_cpu_cost_ns += cost;

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -143,14 +143,8 @@ public:
     void release_workgroup_token_once();
 
     // Some statistic about the query, including cpu, scan_rows, scan_bytes
-    int64_t mem_cost_bytes() const {
-        // mem_tracker may be nullptr when the query is in prepare stage.
-        return _mem_tracker == nullptr ? 0 : _mem_tracker->peak_consumption();
-    }
-    int64_t current_mem_usage_bytes() const {
-        // mem_tracker may be nullptr when the query is in prepare stage.
-        return _mem_tracker == nullptr ? 0 : _mem_tracker->consumption();
-    }
+    int64_t mem_cost_bytes() const { return _mem_tracker->peak_consumption(); }
+    int64_t current_mem_usage_bytes() const { return _mem_tracker->consumption(); }
     void incr_cpu_cost(int64_t cost) {
         _total_cpu_cost_ns += cost;
         _delta_cpu_cost_ns += cost;
@@ -200,6 +194,9 @@ public:
 
     spill::QuerySpillManager* spill_manager() { return _spill_manager.get(); }
 
+    void mark_prepared() { _is_prepared = true; }
+    bool is_prepared() { return _is_prepared; }
+
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
 
@@ -227,6 +224,7 @@ private:
     DescriptorTbl* _desc_tbl = nullptr;
     std::once_flag _query_trace_init_flag;
     std::shared_ptr<starrocks::debug::QueryTrace> _query_trace;
+    std::atomic_bool _is_prepared = false;
 
     std::once_flag _init_query_once;
     int64_t _query_begin_time = 0;
@@ -270,7 +268,7 @@ public:
     ~QueryContextManager();
     Status init();
     QueryContext* get_or_register(const TUniqueId& query_id);
-    QueryContextPtr get(const TUniqueId& query_id);
+    QueryContextPtr get(const TUniqueId& query_id, bool need_prepared = false);
     size_t size();
     bool remove(const TUniqueId& query_id);
     // used for graceful exit

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -143,8 +143,14 @@ public:
     void release_workgroup_token_once();
 
     // Some statistic about the query, including cpu, scan_rows, scan_bytes
-    int64_t mem_cost_bytes() const { return _mem_tracker == nullptr ? 0 : _mem_tracker->peak_consumption(); }
-    int64_t current_mem_usage_bytes() const { return _mem_tracker == nullptr ? 0 : _mem_tracker->consumption(); }
+    int64_t mem_cost_bytes() const {
+        // mem_tracker may be nullptr when the query is in prepare stage.
+        return _mem_tracker == nullptr ? 0 : _mem_tracker->peak_consumption();
+    }
+    int64_t current_mem_usage_bytes() const {
+        // mem_tracker may be nullptr when the query is in prepare stage.
+        return _mem_tracker == nullptr ? 0 : _mem_tracker->consumption();
+    }
     void incr_cpu_cost(int64_t cost) {
         _total_cpu_cost_ns += cost;
         _delta_cpu_cost_ns += cost;


### PR DESCRIPTION
## Why this may cause be to crash

When a query is about to execute, it may stay in the prepare stage. Some of the resources are not properly initialized, such as MemTracker. And if `show proc '/current_queries'` is issued, it may use the half initialized queryContext. So NPE occurs.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
