### PR TITLE
[BugFix] Fix mv rewrite bug for count agg func with rollup

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -684,7 +684,6 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
                 Type[] argTypes = {targetColumn.getType()};
                 Function sumFn = findArithmeticFunction(argTypes, FunctionSet.SUM);
-
                 return new CallOperator(FunctionSet.SUM, aggCall.getFunction().getReturnType(),
                         Lists.newArrayList(targetColumn), sumFn);
             } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.MaterializedView;
@@ -40,12 +41,14 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.BitSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -54,6 +57,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.starrocks.catalog.Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF;
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVRewrite;
 import static com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorUtil.findArithmeticFunction;
 
@@ -377,16 +381,20 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                     newAggColumnRef, newAggColumnRef.getType(), newAggColumnRef.isNullable());
             queryColumnRefToScalarMap.put(entry.getKey(), rewriteAggColumnRef);
         }
+
         // generate new agg exprs(rollup functions)
+        final Map<ColumnRefOperator, ScalarOperator> newProjection = new HashMap<>();
         Map<ColumnRefOperator, CallOperator> newAggregations = rewriteAggregates(
                 queryAggregation, equationRewriter, rewriteContext.getOutputMapping(),
-                new ColumnRefSet(rewriteContext.getQueryColumnSet()), queryColumnRefToScalarMap);
+                new ColumnRefSet(rewriteContext.getQueryColumnSet()), queryColumnRefToScalarMap,
+                newProjection);
         if (newAggregations == null) {
             logMVRewrite(mvRewriteContext, "Rewrite rollup aggregate failed: cannot rewrite aggregate functions");
             return null;
         }
 
-        return createNewAggregate(rewriteContext, rewrittenQueryAggOp, newAggregations, queryColumnRefToScalarMap, mvOptExpr);
+        return createNewAggregate(rewriteContext, rewrittenQueryAggOp, newAggregations,
+                queryColumnRefToScalarMap, mvOptExpr, newProjection);
     }
 
     @Override
@@ -461,13 +469,15 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             aggregateMapping.put(entry.getKey(), mapped);
         }
 
+        final Map<ColumnRefOperator, ScalarOperator> newProjection = new HashMap<>();
         Map<ColumnRefOperator, CallOperator> newAggregations = rewriteAggregatesForUnion(
-                queryAgg.getAggregations(), columnMapping, aggregateMapping);
+                queryAgg.getAggregations(), columnMapping, aggregateMapping, newProjection);
         if (newAggregations == null) {
             logMVRewrite(mvRewriteContext, "Rewrite aggregate with union failed: rewrite aggregate for union failed");
             return null;
         }
-        return createNewAggregate(rewriteContext, queryAgg, newAggregations, aggregateMapping, unionExpr);
+        return createNewAggregate(rewriteContext, queryAgg, newAggregations, aggregateMapping,
+                unionExpr, newProjection);
     }
 
     private OptExpression createNewAggregate(
@@ -475,7 +485,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             LogicalAggregationOperator queryAgg,
             Map<ColumnRefOperator, CallOperator> newAggregations,
             Map<ColumnRefOperator, ScalarOperator> queryColumnRefToScalarMap,
-            OptExpression mvOptExpr) {
+            OptExpression mvOptExpr,
+            Map<ColumnRefOperator, ScalarOperator> newProjection) {
         // newGroupKeys may have duplicate because of EquivalenceClasses
         // remove duplicate here as new grouping keys
         List<ColumnRefOperator> originalGroupKeys = queryAgg.getGroupingKeys();
@@ -532,7 +543,6 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         }
 
         // add projection to make sure that the output columns keep the same with the origin query
-        Map<ColumnRefOperator, ScalarOperator> newProjection = Maps.newHashMap();
         if (queryAgg.getProjection() == null) {
             for (int i = 0; i < originalGroupKeys.size(); i++) {
                 newProjection.put(originalGroupKeys.get(i), newGroupByKeyColumnRefs.get(i));
@@ -588,9 +598,11 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                                                                    EquationRewriter equationRewriter,
                                                                    Map<ColumnRefOperator, ColumnRefOperator> mapping,
                                                                    ColumnRefSet queryColumnSet,
-                                                                   Map<ColumnRefOperator, ScalarOperator> aggregateMapping) {
-        Map<ColumnRefOperator, CallOperator> newAggregations = Maps.newHashMap();
+                                                                   Map<ColumnRefOperator, ScalarOperator> aggregateMapping,
+                                                                   Map<ColumnRefOperator, ScalarOperator> newProjection) {
+        final Map<ColumnRefOperator, CallOperator> newAggregations = Maps.newHashMap();
         equationRewriter.setOutputMapping(mapping);
+
         for (Map.Entry<ColumnRefOperator, ScalarOperator> entry : aggregates.entrySet()) {
             Preconditions.checkState(entry.getValue() instanceof CallOperator);
             CallOperator aggCall = (CallOperator) entry.getValue();
@@ -615,6 +627,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             }
             ColumnRefOperator oldColRef = (ColumnRefOperator) aggregateMapping.get(entry.getKey());
             newAggregations.put(oldColRef, newAggregate);
+            newProjection.put(oldColRef, genRollupProject(aggCall, oldColRef));
         }
 
         return newAggregations;
@@ -623,7 +636,8 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
     private Map<ColumnRefOperator, CallOperator> rewriteAggregatesForUnion(
             Map<ColumnRefOperator, CallOperator> aggregates,
             Map<ColumnRefOperator, ColumnRefOperator> mapping,
-            Map<ColumnRefOperator, ScalarOperator> aggregateMapping) {
+            Map<ColumnRefOperator, ScalarOperator> aggregateMapping,
+            Map<ColumnRefOperator, ScalarOperator> newProjection) {
         Map<ColumnRefOperator, CallOperator> rewrittens = Maps.newHashMap();
         for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregates.entrySet()) {
             Preconditions.checkState(entry.getValue() != null);
@@ -641,10 +655,23 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
                         aggCall.toString());
                 return null;
             }
-            rewrittens.put((ColumnRefOperator) aggregateMapping.get(entry.getKey()), newAggregate);
+            ColumnRefOperator oldColRef = (ColumnRefOperator) aggregateMapping.get(entry.getKey());
+            rewrittens.put(oldColRef, newAggregate);
+            newProjection.put(oldColRef, genRollupProject(aggCall, oldColRef));
         }
 
         return rewrittens;
+    }
+
+    private ScalarOperator genRollupProject(CallOperator aggCall, ColumnRefOperator oldColRef) {
+        if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
+            List<ScalarOperator> args = Arrays.asList(oldColRef, ConstantOperator.createBigint(0L));
+            Type[] argTypes = args.stream().map(a -> a.getType()).toArray(Type[]::new);
+            return new CallOperator(FunctionSet.COALESCE, aggCall.getType(), args,
+                    Expr.getBuiltinFunction(FunctionSet.COALESCE, argTypes, IS_NONSTRICT_SUPERTYPE_OF));
+        } else {
+            return oldColRef;
+        }
     }
 
     // generate new aggregates for rollup
@@ -657,6 +684,7 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
             if (aggCall.getFnName().equals(FunctionSet.COUNT)) {
                 Type[] argTypes = {targetColumn.getType()};
                 Function sumFn = findArithmeticFunction(argTypes, FunctionSet.SUM);
+
                 return new CallOperator(FunctionSet.SUM, aggCall.getFunction().getReturnType(),
                         Lists.newArrayList(targetColumn), sumFn);
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2694,21 +2694,15 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv2, "select user_id, avg(tag_id % 10) from user_tags group by user_id;");
     }
 
-
     @Test
     public void testCountWithRollup() {
         String mv = "select user_id, count(tag_id) from user_tags group by user_id, time;";
         testRewriteOK(mv, "select user_id, count(tag_id) from user_tags group by user_id, time;")
                 .notContain("coalesce");
         testRewriteOK(mv, "select user_id, count(tag_id) from user_tags group by user_id;")
-                .contains(" 2:Project\n" +
-                        "  |  <slot 2> : 6: user_id\n" +
-                        "  |  <slot 5> : 8: count\n" +
-                        "  |  <slot 8> : coalesce(8: count, 0)\n" +
-                        "  |  \n" +
-                        "  1:AGGREGATE (update finalize)\n" +
-                        "  |  output: sum(7: count(tag_id))\n" +
-                        "  |  group by: 6: user_id");
+                .notContain("coalesce");
+        testRewriteOK(mv, "select count(tag_id) from user_tags;")
+                .contains("coalesce");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -2694,6 +2694,23 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
         testRewriteOK(mv2, "select user_id, avg(tag_id % 10) from user_tags group by user_id;");
     }
 
+
+    @Test
+    public void testCountWithRollup() {
+        String mv = "select user_id, count(tag_id) from user_tags group by user_id, time;";
+        testRewriteOK(mv, "select user_id, count(tag_id) from user_tags group by user_id, time;")
+                .notContain("coalesce");
+        testRewriteOK(mv, "select user_id, count(tag_id) from user_tags group by user_id;")
+                .contains(" 2:Project\n" +
+                        "  |  <slot 2> : 6: user_id\n" +
+                        "  |  <slot 5> : 8: count\n" +
+                        "  |  <slot 8> : coalesce(8: count, 0)\n" +
+                        "  |  \n" +
+                        "  1:AGGREGATE (update finalize)\n" +
+                        "  |  output: sum(7: count(tag_id))\n" +
+                        "  |  group by: 6: user_id");
+    }
+
     @Test
     public void testCountDistinctToBitmapCount1() {
         String mv = "select user_id, bitmap_union(to_bitmap(tag_id)) from user_tags group by user_id;";

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -255,7 +255,6 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 }
 
                 this.rewritePlan = getFragmentPlan(query);
-                System.out.println(rewritePlan);
             } catch (Exception e) {
                 LOG.warn("test rewrite failed:", e);
                 this.exception = e;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -255,6 +255,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 }
 
                 this.rewritePlan = getFragmentPlan(query);
+                System.out.println(rewritePlan);
             } catch (Exception e) {
                 LOG.warn("test rewrite failed:", e);
                 this.exception = e;

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite
@@ -584,42 +584,46 @@ from emps right anti join depts using (deptno);
 -- result:
 2
 -- !result
-
-
 -- name: test_single_table_mv_rewrite
 create table user_tags (time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+-- result:
+-- !result
 insert into user_tags values('2023-04-13', 1, 'a', 1);
+-- result:
+-- !result
 insert into user_tags values('2023-04-13', 1, 'b', 2);
+-- result:
+-- !result
 insert into user_tags values('2023-04-13', 1, 'c', 3);
+-- result:
+-- !result
 insert into user_tags values('2023-04-13', 1, 'd', 4);
+-- result:
+-- !result
 insert into user_tags values('2023-04-13', 1, 'e', 5);
-
+-- result:
+-- !result
 create materialized view agg_count_mv1
 distributed by hash(user_id)
 as
 select user_id, count(1) as cnt
 from user_tags
 group by user_id;
-
+-- result:
+-- !result
 refresh materialized view agg_count_mv1 with sync mode;
-analyze table agg_count_mv1 with sync mode;
-
 create materialized view agg_count_mv2
 distributed by hash(user_id)
 as
 select user_id, user_name, count(1) as cnt
 from user_tags
 group by user_id, user_name;
-
+-- result:
+-- !result
 refresh materialized view agg_count_mv2 with sync mode;
-analyze table agg_count_mv2 with sync mode;
-
 explain select user_id, count(1) as cnt
 from user_tags
 group by user_id;
--- result:
-[REGEX]agg_count_mv1
-
 CREATE TABLE `user_tags_2` (
   `time` date NULL COMMENT "",
   `user_id` int(11) NULL COMMENT "",
@@ -638,49 +642,120 @@ PROPERTIES (
 "light_schema_change" = "true",
 "compression" = "LZ4"
 );
-
+-- result:
+-- !result
 insert into user_tags_2 values('2023-04-13', 1, 'a', 1);
+-- result:
+-- !result
 insert into user_tags_2 values('2023-04-13', 2, 'b', 2);
+-- result:
+-- !result
 insert into user_tags_2 values('2023-04-13', 3, 'c', 3);
+-- result:
+-- !result
 insert into user_tags_2 values('2023-04-13', 4, 'd', 4);
+-- result:
+-- !result
 insert into user_tags_2 values('2023-04-13', 5, 'e', 5);
-
+-- result:
+-- !result
 create materialized view agg_count_mv3
 distributed by hash(user_id)
 as
 select user_id, count(1) as cnt
 from user_tags_2
 group by user_id;
-
+-- result:
+-- !result
 refresh materialized view agg_count_mv3 with sync mode;
-
 create materialized view agg_count_mv4
 distributed by hash(user_id)
 as
 select user_id, user_name, count(1) as cnt
 from user_tags_2
 group by user_id, user_name;
-
+-- result:
+-- !result
 refresh materialized view agg_count_mv4 with sync mode;
-
-
 explain select user_id, count(1) as cnt
 from user_tags_2
 group by user_id;
--- result:
-[REGEX]agg_count_mv3
-
 create materialized view agg_count_mv5
 distributed by hash(user_id)
 as
 select user_id, user_name, count(1) as cnt, sum(tag_id) as total
 from user_tags_2
 group by user_id, user_name;
-
+-- result:
+-- !result
 refresh materialized view agg_count_mv5 with sync mode;
-
 explain select user_id, user_name, count(1) as cnt
 from user_tags_2
 group by user_id, user_name;
+-- name: test_count_rollup_with_empty_table
+create table empty_tbl(time date, user_id int, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
 -- result:
-[REGEX]agg_count_mv4
+-- !result
+create materialized view empty_tbl_with_mv distributed by hash(user_id) 
+as select user_id, count(tag_id) from empty_tbl group by user_id, time;
+-- result:
+-- !result
+select user_id, count(tag_id) from empty_tbl group by user_id, time;
+-- result:
+-- !result
+select user_id, count(tag_id) from empty_tbl group by user_id;
+-- result:
+-- !result
+drop table empty_tbl;
+-- result:
+-- !result
+drop materialized view empty_tbl_with_mv;
+-- result:
+-- !result
+CREATE TABLE orders (
+    dt date NOT NULL,
+    order_id bigint NOT NULL,
+    user_id int NOT NULL,
+    merchant_id int NOT NULL,
+    good_id int NOT NULL,
+    good_name string NOT NULL,
+    price int NOT NULL,
+    cnt int NOT NULL,
+    revenue int NOT NULL,
+    state tinyint NOT NULL
+)
+PRIMARY KEY (dt, order_id)
+PARTITION BY RANGE(dt) (
+    PARTITION p20210820 VALUES [('2021-08-20'), ('2021-08-21')),
+    PARTITION p20210821 VALUES [('2021-08-21'), ('2021-08-22'))
+)
+DISTRIBUTED BY HASH(order_id) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1",
+    "enable_persistent_index" = "true"
+);
+-- result:
+-- !result
+            
+CREATE MATERIALIZED VIEW order_mv2
+PARTITION BY date_trunc('MONTH', dt)
+DISTRIBUTED BY HASH(order_id) BUCKETS 10
+REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
+AS
+select
+    dt,
+    order_id,
+    user_id,
+    sum(cnt) as total_cnt,
+    sum(revenue) as total_revenue,
+    count(state) as state_count
+from orders group by dt, order_id, user_id;
+-- result:
+-- !result
+select count() from orders;
+-- result:
+0
+-- !result
+drop materialized view order_mv2;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite
@@ -357,3 +357,63 @@ refresh materialized view agg_count_mv5 with sync mode;
 explain select user_id, user_name, count(1) as cnt
 from user_tags_2
 group by user_id, user_name;
+
+-- name: test_count_rollup_with_empty_table
+create table empty_tbl(time date, user_id int not null, user_name varchar(20), tag_id int) partition by range (time)  (partition p1 values less than MAXVALUE) distributed by hash(time) buckets 3 properties('replication_num' = '1');
+create materialized view empty_tbl_with_mv distributed by hash(user_id) 
+as select user_id, time, count(tag_id) from empty_tbl group by user_id, time;
+select count() from empty_tbl;
+select user_id, count(tag_id) from empty_tbl group by user_id, time;
+select user_id, count(tag_id) from empty_tbl group by user_id;
+
+insert into empty_tbl values('2023-04-13', 1, 'a', 1);
+refresh materialized view empty_tbl_with_mv with sync mode;
+select count() from empty_tbl where user_id > 2;
+select user_id, count(tag_id) from empty_tbl where user_id = 2 group by user_id, time;
+select user_id, count(tag_id) from empty_tbl where user_id > 2 group by user_id;
+select user_id, count(tag_id) from empty_tbl group by user_id;
+select count(user_id) from empty_tbl where user_id > 2 group by user_id;
+select count(user_id) from empty_tbl where user_id > 2;
+
+drop table empty_tbl;
+drop materialized view empty_tbl_with_mv;
+
+
+CREATE TABLE orders (
+    dt date NOT NULL,
+    order_id bigint NOT NULL,
+    user_id int NOT NULL,
+    merchant_id int NOT NULL,
+    good_id int NOT NULL,
+    good_name string NOT NULL,
+    price int NOT NULL,
+    cnt int NOT NULL,
+    revenue int NOT NULL,
+    state tinyint NOT NULL
+)
+PRIMARY KEY (dt, order_id)
+PARTITION BY RANGE(dt) (
+    PARTITION p20210820 VALUES [('2021-08-20'), ('2021-08-21')),
+    PARTITION p20210821 VALUES [('2021-08-21'), ('2021-08-22'))
+)
+DISTRIBUTED BY HASH(order_id) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1",
+    "enable_persistent_index" = "true"
+);
+            
+CREATE MATERIALIZED VIEW order_mv2
+PARTITION BY date_trunc('MONTH', dt)
+DISTRIBUTED BY HASH(order_id) BUCKETS 10
+REFRESH ASYNC START('2023-07-01 10:00:00') EVERY (interval 1 day)
+AS
+select
+    dt,
+    order_id,
+    user_id,
+    sum(cnt) as total_cnt,
+    sum(revenue) as total_revenue,
+    count(state) as state_count
+from orders group by dt, order_id, user_id;
+select count() from orders;
+drop materialized view order_mv2;


### PR DESCRIPTION
Fixes [#issue](https://starrocks.atlassian.net/browse/SR-21350)

- Rewrite to count(*) to coalese(sum(mv_cnt), 0) for rollup.


Before, result should be 0 rather than NULL.
```
mysql> explain select count() from orders;
+-----------------------------------+
| Explain String                    |
+-----------------------------------+
| PLAN FRAGMENT 0                   |
|  OUTPUT EXPRS:11: count           |
|   PARTITION: RANDOM               |
|                                   |
|   RESULT SINK                     |
|                                   |
|   2:Project                       |
|   |  <slot 11> : 20: count        |
|   |                               |
|   1:AGGREGATE (update finalize)   |
|   |  output: sum(17: state_count) |
|   |  group by:                    |
|   |                               |
|   0:OlapScanNode                  |
|      TABLE: order_mv2             |
|      PREAGGREGATION: ON           |
|      partitions=0/1               |
|      rollup: order_mv2            |
|      tabletRatio=0/0              |
|      tabletList=                  |
|      cardinality=1                |
|      avgRowSize=1.0               |
|      numNodes=0                   |
|      MaterializedView: true       |
+-----------------------------------+
24 rows in set (0.04 sec)

mysql> select count() from orders;
+---------+
| count() |
+---------+
|    NULL |
+---------+
1 row in set (0.01 sec)
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
