### PR TITLE
[BugFix] Fix inconsistency crash when generated column backuped after base compaction(#34323)

### DIFF
--- a/be/src/runtime/snapshot_loader.cpp
+++ b/be/src/runtime/snapshot_loader.cpp
@@ -701,6 +701,7 @@ Status SnapshotLoader::move(const std::string& snapshot_path, const TabletShared
                             DeltaColumnGroupListSerializer::deserialize_delta_column_group_list(dcg_list_pb, &dcgs));
 
                     if (dcgs.size() == 0) {
+                        ++idx;
                         continue;
                     }
 

--- a/be/src/storage/task/engine_clone_task.cpp
+++ b/be/src/storage/task/engine_clone_task.cpp
@@ -288,6 +288,7 @@ Status EngineCloneTask::_do_clone(Tablet* tablet) {
                             DeltaColumnGroupListSerializer::deserialize_delta_column_group_list(dcg_list_pb, &dcgs));
 
                     if (dcgs.size() == 0) {
+                        ++idx;
                         continue;
                     }
 
@@ -769,6 +770,7 @@ Status EngineCloneTask::_finish_clone(Tablet* tablet, const string& clone_dir, i
                             DeltaColumnGroupListSerializer::deserialize_delta_column_group_list(dcg_list_pb, &dcgs));
 
                     if (dcgs.size() == 0) {
+                        ++idx;
                         continue;
                     }
 

--- a/be/src/storage/task/engine_storage_migration_task.cpp
+++ b/be/src/storage/task/engine_storage_migration_task.cpp
@@ -416,6 +416,7 @@ Status EngineStorageMigrationTask::_finish_migration(const TabletSharedPtr& tabl
                 }
 
                 if (dcgs.size() == 0) {
+                    ++idx;
                     continue;
                 }
 


### PR DESCRIPTION
Problem:
For a non-primary key table with a generated column added by ALTER STMT, concurrent operations between base-compaction and backup/restore
will trigger this problem. Here is an example:

Suppose we have four rowsets in the table and each rowsets has the following files:
rowset 1: segment1<->cols1
rowset 2: segment2<->cols2
rowset 3: segment3<->cols3
rowset 4: segment4<->cols4

Then, the base compaction happens and merges rowset1 and rowset2 into rowset1-2:
rowset 1-2: segment1-2 (cols file will be eliminated by compaction)

At this time, we backup the snapshot for the table, and the snapshot will contain the following files:
rowset 1-2: segment1-2
rowset 3: segment3<->cols3
rowset 4: segment4<->cols4

The bug is that we can not handle this kind of snapshot correctly. For such a snapshot, after the restore
process, we will get the following result:
rowset 1-2: segment1-2
rowset 3: segment3
rowset 4: segment4<->cols3

It means that we set the wrong connection between cols files and segment files and caused the assert on
row to check in the chunk. This is because we wrongly handled the index of the snapshot list for dcg metadata

This problem will only affect the non-primary key table

Fixes #34324

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
