### PR TITLE
[Enhancement] Choose 4 stage aggregate as default when group by columns has low ndv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SplitAggregateRule.java
@@ -180,14 +180,39 @@ public class SplitAggregateRule extends TransformationRule {
                 && aggOutputRow > aggOp.getLimit();
     }
 
-
-    private boolean isThreeStageMoreEfficient(OptExpression input, List<ColumnRefOperator> groupKeys) {
+    private boolean isThreeStageMoreEfficient(OptExpression input, List<ColumnRefOperator> groupKeys,
+                                              List<ColumnRefOperator> partitionByColumns) {
         if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == FOUR_STAGE) {
             return false;
+        }
+        if (ConnectContext.get().getSessionVariable().getNewPlannerAggStage() == THREE_STAGE) {
+            return true;
         }
 
         Statistics inputStatistics = input.getGroupExpression().inputAt(0).getStatistics();
         Collection<ColumnStatistic> inputsColumnStatistics = inputStatistics.getColumnStatistics().values();
+
+        // Estimate the NDV when use partitionBy columns to shuffle, if the NDV is small,
+        // this may result in only a few nodes participating in subsequent calculations.
+        // To take full advantage of all compute nodes, should select the four stages
+        List<ColumnStatistic> partitionByColumnStatistics = partitionByColumns.stream().
+                map(inputStatistics::getColumnStatistic).collect(Collectors.toList());
+        if (partitionByColumnStatistics.stream().noneMatch(ColumnStatistic::isUnknown)) {
+            Statistics statistics = inputStatistics;
+            if (inputStatistics.getOutputRowCount() <= 1) {
+                double rowCount = 1.0;
+                for (ColumnStatistic columnStatistic : partitionByColumnStatistics) {
+                    rowCount *= columnStatistic.getDistinctValuesCount();
+                }
+                statistics = Statistics.buildFrom(inputStatistics).setOutputRowCount(rowCount).build();
+            }
+            double aggOutputRow = StatisticsCalculator.computeGroupByStatistics(partitionByColumns, statistics,
+                    Maps.newHashMap());
+            if (aggOutputRow <= LOW_AGGREGATE_EFFECT_COEFFICIENT) {
+                return false;
+            }
+        }
+
         if (inputsColumnStatistics.stream().anyMatch(ColumnStatistic::isUnknown)) {
             return true;
         }
@@ -389,7 +414,7 @@ public class SplitAggregateRule extends TransformationRule {
         List<ColumnRefOperator> partitionByCols;
 
         boolean shouldFurtherSplit = false;
-        if (isThreeStageMoreEfficient(input, distinctGlobal.getGroupingKeys())
+        if (isThreeStageMoreEfficient(input, distinctGlobal.getGroupingKeys(), local.getPartitionByColumns())
                 || oldAgg.getGroupingKeys().containsAll(distinctGlobal.getGroupingKeys())) {
             partitionByCols = oldAgg.getGroupingKeys();
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -332,7 +332,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/multi_count_distinct"), null, TExplainLevel.NORMAL);
         String plan = replayPair.second;
-        Assert.assertTrue(plan, plan.contains("33:AGGREGATE (update serialize)\n" +
+        Assert.assertTrue(plan, plan.contains("35:AGGREGATE (update serialize)\n" +
                 "  |  STREAMING\n" +
                 "  |  output: multi_distinct_count(6: order_id), multi_distinct_count(11: delivery_phone)," +
                 " multi_distinct_count(128: case), max(103: count)\n" +


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
