### PR TITLE
[Feature] Support scalar udf with dynamic return types

### DIFF
--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -181,6 +181,13 @@ StatusOr<std::shared_ptr<JavaUDFContext>> JavaFunctionCallExpr::_build_udf_func_
             (*res)->name = std::move(method_name);
             (*res)->signature = std::move(signature);
             (*res)->method_desc = std::move(mtdesc);
+            if (_fn.scalar_fn.has_dynamic_return_type) {
+                for (int i = 0; i < (*res)->method_desc.size(); ++i) {
+                    if ((*res)->method_desc.at(i).type == TYPE_UNKNOWN) {
+                        (*res)->method_desc.at(i).type = _type.type;
+                    }
+                }
+            }
             ASSIGN_OR_RETURN((*res)->method, desc->analyzer->get_method_object(desc->udf_class.clazz(), name));
         }
         return Status::OK();

--- a/be/src/formats/csv/csv_builder_options.h
+++ b/be/src/formats/csv/csv_builder_options.h
@@ -1,0 +1,26 @@
+
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace starrocks::csv {
+
+struct CsvBuilderOptions {
+    std::string column_separator;
+    std::string row_delimiter;
+    bool print_header;
+};
+
+}

--- a/be/src/udf/java/java_udf.cpp
+++ b/be/src/udf/java/java_udf.cpp
@@ -577,7 +577,7 @@ StatusOr<JVMClass> ClassLoader::getClass(const std::string& className) {
     LOCAL_REF_GUARD(loaded_clazz);
 
     // check exception
-    RETURN_ERROR_IF_EXCEPTION(env, "exception happened when get class: {}");
+    RETURN_ERROR_IF_EXCEPTION(env, "exception happened when get class " + className + ": {}");
     // no exception happened, class exists
     DCHECK(loaded_clazz != nullptr);
 

--- a/fe/fe-common/pom.xml
+++ b/fe/fe-common/pom.xml
@@ -31,7 +31,7 @@ under the License.
     </parent>
 
     <artifactId>fe-common</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/fe/fe-common/src/main/java/com/starrocks/common/type/StarrocksType.java
+++ b/fe/fe-common/src/main/java/com/starrocks/common/type/StarrocksType.java
@@ -1,0 +1,28 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.type;
+
+public enum StarrocksType {
+    BOOLEAN,
+    TINYINT,
+    SMALLINT,
+    INT,
+    BIGINT,
+    FLOAT,
+    DOUBLE,
+    STRING,
+    VARCHAR,
+    UNKNOWN
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -821,12 +821,12 @@ public class Database extends MetaObject implements Writable {
         }
     }
 
-    public synchronized Function getFunction(Function desc, Function.CompareMode mode) {
+    public synchronized Function getFunction(Function desc, Object [] argValues, Function.CompareMode mode) {
         List<Function> fns = name2Function.get(desc.getFunctionName().getFunction());
         if (fns == null) {
             return null;
         }
-        return Function.getFunction(fns, desc, mode);
+        return Function.getFunction(fns, desc, argValues, mode);
     }
 
     public synchronized List<Function> getFunctions() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DynamicScalarFunction.java
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/main/java/org/apache/doris/catalog/ScalarFunction.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+package com.starrocks.catalog;
+
+import com.starrocks.analysis.FunctionName;
+import com.starrocks.thrift.TFunction;
+import com.starrocks.thrift.TScalarFunction;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class DynamicScalarFunction extends ScalarFunction {
+
+    public DynamicScalarFunction(
+            FunctionName fnName, Type[] argTypes, Type retType, boolean hasVarArgs) {
+        super(fnName, argTypes, retType, hasVarArgs);
+    }
+
+    public DynamicScalarFunction(DynamicScalarFunction other) {
+        super(other);
+    }
+
+    public DynamicScalarFunction() {
+        super();
+    }
+
+    @Override
+    public String toSql(boolean ifNotExists) {
+        StringBuilder sb = new StringBuilder("CREATE FUNCTION ");
+        if (ifNotExists) {
+            sb.append("IF NOT EXISTS ");
+        }
+        sb.append(dbName() + "." + signatureString() + "\n")
+                .append(" LOCATION '" + getLocation() + "'\n")
+                .append(" SYMBOL='" + getSymbolName() + "'\n");
+        return sb.toString();
+    }
+
+    @Override
+    public TFunction toThrift() {
+        TFunction fn = super.toThrift();
+        TScalarFunction scalarFunction = new TScalarFunction();
+        scalarFunction.setSymbol(getSymbolName());
+        if (getPrepareFnSymbol() != null) {
+            scalarFunction.setPrepare_fn_symbol(getPrepareFnSymbol());
+        }
+        if (getCloseFnSymbol() != null) {
+            scalarFunction.setClose_fn_symbol(getCloseFnSymbol());
+        }
+        scalarFunction.setHas_dynamic_return_type(true);
+        fn.setScalar_fn(scalarFunction);
+        return fn;
+    }
+
+    @Override
+    public void write(DataOutput output) throws IOException {
+        // 1. type
+        FunctionType.DYNAMIC_SCALAR.write(output);
+        // 2. parent
+        super.writeFields(output);
+    }
+
+    @Override
+    public Function copy() {
+        return new DynamicScalarFunction(this);
+    }
+
+    @Override
+    public void readFields(DataInput input) throws IOException {
+        super.readFields(input);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -43,6 +43,7 @@ import com.starrocks.analysis.FunctionName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.sql.ast.HdfsURI;
+import com.starrocks.sql.optimizer.rewrite.ScalarFunctionInitializer;
 import com.starrocks.thrift.TFunction;
 import com.starrocks.thrift.TFunctionBinaryType;
 import org.apache.commons.lang.ArrayUtils;
@@ -590,11 +591,25 @@ public class Function implements Writable {
         return null;
     }
 
+    public static Function getFunction(List<Function> fns, Function desc, Object [] argValues, CompareMode mode) {
+        Function fn = getFunction(fns, desc, mode);
+        if (fn != null && argValues != null && fn instanceof DynamicScalarFunction) {
+            DynamicScalarFunction dfn = (DynamicScalarFunction) fn;
+            Type retType = ScalarFunctionInitializer.initialize(dfn, argValues);
+            Function candidate = new DynamicScalarFunction(dfn);
+            candidate.setRetType(retType);
+            return candidate;
+        }
+
+        return fn;
+    }
+
     enum FunctionType {
         ORIGIN(0),
         SCALAR(1),
         AGGREGATE(2),
         TABLE(3),
+        DYNAMIC_SCALAR(4),
         UNSUPPORTED(-1);
 
         private int code;
@@ -686,6 +701,9 @@ public class Function implements Writable {
         switch (functionType) {
             case SCALAR:
                 function = new ScalarFunction();
+                break;
+            case DYNAMIC_SCALAR:
+                function = new DynamicScalarFunction();
                 break;
             case AGGREGATE:
                 function = new AggregateFunction();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/GlobalFunctionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/GlobalFunctionMgr.java
@@ -52,12 +52,12 @@ public class GlobalFunctionMgr {
         return functions;
     }
 
-    public synchronized Function getFunction(Function desc, Function.CompareMode mode) {
+    public synchronized Function getFunction(Function desc, Object[] argValues, Function.CompareMode mode) {
         List<Function> fns = name2Function.get(desc.getFunctionName().getFunction());
         if (fns == null) {
             return null;
         }
-        return Function.getFunction(fns, desc, mode);
+        return Function.getFunction(fns, desc, argValues, mode);
     }
 
     public synchronized Function getFunction(FunctionSearchDesc function) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -147,8 +147,14 @@ public class ScalarFunction extends Function {
             FunctionName name, Type[] args,
             Type returnType, boolean isVariadic,
             TFunctionBinaryType binaryType,
-            String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol, boolean isolationType) {
-        ScalarFunction fn = new ScalarFunction(name, args, returnType, isVariadic);
+            String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol, boolean isolationType,
+            boolean hasDynamicReturnType) {
+        ScalarFunction fn;
+        if (hasDynamicReturnType) {
+            fn = new DynamicScalarFunction(name, args, returnType, isVariadic);
+        } else {
+            fn = new ScalarFunction(name, args, returnType, isVariadic);
+        }
         fn.setBinaryType(binaryType);
         fn.setUserVisible(true);
         fn.symbolName = symbol;
@@ -165,7 +171,7 @@ public class ScalarFunction extends Function {
             TFunctionBinaryType binaryType,
             String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol) {
         return createUdf(name, args, returnType, isVariadic, binaryType, objectFile,
-                symbol, prepareFnSymbol, closeFnSymbol, true);
+                symbol, prepareFnSymbol, closeFnSymbol, true, false);
     }
 
     public void setSymbolName(String s) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/StarrocksTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/StarrocksTypeConverter.java
@@ -1,0 +1,70 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.catalog;
+
+import com.starrocks.common.type.StarrocksType;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class StarrocksTypeConverter {
+
+    private static Map<Type, StarrocksType> typeMapper = new HashMap<>();
+    private static Map<StarrocksType, Type> starrocksTypeMapper = new HashMap<>();
+
+    static {
+        typeMapper.put(Type.BOOLEAN, StarrocksType.BOOLEAN);
+        typeMapper.put(Type.TINYINT, StarrocksType.TINYINT);
+        typeMapper.put(Type.SMALLINT, StarrocksType.SMALLINT);
+        typeMapper.put(Type.INT, StarrocksType.INT);
+        typeMapper.put(Type.BIGINT, StarrocksType.BIGINT);
+        typeMapper.put(Type.FLOAT, StarrocksType.FLOAT);
+        typeMapper.put(Type.DOUBLE, StarrocksType.DOUBLE);
+        typeMapper.put(Type.DEFAULT_STRING, StarrocksType.STRING);
+        typeMapper.put(Type.VARCHAR, StarrocksType.VARCHAR);
+
+        starrocksTypeMapper.put(StarrocksType.BOOLEAN, Type.BOOLEAN);
+        starrocksTypeMapper.put(StarrocksType.TINYINT, Type.TINYINT);
+        starrocksTypeMapper.put(StarrocksType.SMALLINT, Type.SMALLINT);
+        starrocksTypeMapper.put(StarrocksType.INT, Type.INT);
+        starrocksTypeMapper.put(StarrocksType.BIGINT, Type.BIGINT);
+        starrocksTypeMapper.put(StarrocksType.FLOAT, Type.FLOAT);
+        starrocksTypeMapper.put(StarrocksType.DOUBLE, Type.DOUBLE);
+        starrocksTypeMapper.put(StarrocksType.STRING, Type.DEFAULT_STRING);
+        starrocksTypeMapper.put(StarrocksType.VARCHAR, Type.VARCHAR);
+    }
+
+    public static StarrocksType getSRType(Type type) {
+        if (typeMapper.containsKey(type)) {
+            return typeMapper.get(type);
+        }
+        throw new RuntimeException("Unsupported type " + type + " for UDF");
+    }
+
+    public static StarrocksType[] getSRTypes(Type[] types) {
+        StarrocksType[] res = new StarrocksType[types.length];
+        for (int i = 0; i < types.length; i++) {
+            res[i] = getSRType(types[i]);
+        }
+        return res;
+    }
+
+    public static Type getTypeFromSR(StarrocksType type) {
+        if (starrocksTypeMapper.containsKey(type)) {
+            return starrocksTypeMapper.get(type);
+        }
+        throw new RuntimeException("Unsupported type " + type + " for UDF");
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/common/UDFException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/UDFException.java
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common;
+
+public class UDFException extends RuntimeException {
+    public UDFException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
+
+    public UDFException(String msg) {
+        super(msg);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -79,6 +79,7 @@ import com.starrocks.catalog.AnyElementType;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.CatalogRecycleBin;
 import com.starrocks.catalog.DistributionInfo;
+import com.starrocks.catalog.DynamicScalarFunction;
 import com.starrocks.catalog.EsTable;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
@@ -365,6 +366,7 @@ public class GsonUtils {
     public static final RuntimeTypeAdapterFactory<Function> FUNCTION_TYPE_RUNTIME_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory.of(Function.class, "clazz")
                     .registerSubtype(ScalarFunction.class, "ScalarFunction")
+                    .registerSubtype(DynamicScalarFunction.class, "DynamicScalarFunction")
                     .registerSubtype(AggregateFunction.class, "AggregateFunction")
                     .registerSubtype(TableFunction.class, "TableFunction");
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -182,7 +182,7 @@ public class AnalyzerUtils {
     }
 
     public static Function getDBUdfFunction(ConnectContext context, FunctionName fnName,
-                                            Type[] argTypes) {
+                                            Type[] argTypes, Object[] argValues) {
         String dbName = fnName.getDb();
         if (StringUtils.isEmpty(dbName)) {
             dbName = context.getDatabase();
@@ -197,7 +197,7 @@ public class AnalyzerUtils {
         try {
             locker.lockDatabase(db, LockType.READ);
             Function search = new Function(fnName, argTypes, Type.INVALID, false);
-            Function fn = db.getFunction(search, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+            Function fn = db.getFunction(search, argValues, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
             if (fn != null) {
                 try {
@@ -217,10 +217,11 @@ public class AnalyzerUtils {
         }
     }
 
-    private static Function getGlobalUdfFunction(ConnectContext context, FunctionName fnName, Type[] argTypes) {
+    private static Function getGlobalUdfFunction(ConnectContext context, FunctionName fnName, Type[] argTypes,
+                                                 Object[] argValues) {
         Function search = new Function(fnName, argTypes, Type.INVALID, false);
         Function fn = context.getGlobalStateMgr().getGlobalFunctionMgr()
-                .getFunction(search, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
+                .getFunction(search, argValues, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
         if (fn != null) {
             try {
                 Authorizer.checkGlobalFunctionAction(context.getCurrentUserIdentity(), context.getCurrentRoleIds(),
@@ -236,10 +237,10 @@ public class AnalyzerUtils {
         return fn;
     }
 
-    public static Function getUdfFunction(ConnectContext context, FunctionName fnName, Type[] argTypes) {
-        Function fn = getDBUdfFunction(context, fnName, argTypes);
+    public static Function getUdfFunction(ConnectContext context, FunctionName fnName, Type[] argTypes, Object[] argValues) {
+        Function fn = getDBUdfFunction(context, fnName, argTypes, argValues);
         if (fn == null && context.getGlobalStateMgr() != null) {
-            fn = getGlobalUdfFunction(context, fnName, argTypes);
+            fn = getGlobalUdfFunction(context, fnName, argTypes, argValues);
         }
         if (fn != null) {
             if (!Config.enable_udf) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/DecimalV3FunctionAnalyzer.java
@@ -345,7 +345,7 @@ public class DecimalV3FunctionAnalyzer {
         Function fn = Expr.getBuiltinFunction(fnName, argumentTypes, Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
         if (fn == null) {
-            fn = AnalyzerUtils.getUdfFunction(session, node.getFnName(), argumentTypes);
+            fn = AnalyzerUtils.getUdfFunction(session, node.getFnName(), argumentTypes, null);
         }
 
         if (fn == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -1133,7 +1133,9 @@ public class ExpressionAnalyzer {
             }
 
             if (fn == null) {
-                fn = AnalyzerUtils.getUdfFunction(session, node.getFnName(), argumentTypes);
+                Object[] argValues = node.getChildren().stream().map(
+                        e -> e instanceof LiteralExpr ? ((LiteralExpr) e).getRealObjectValue() : null).toArray(Object []::new);
+                fn = AnalyzerUtils.getUdfFunction(session, node.getFnName(), argumentTypes, argValues);
             }
             if (fn == null) {
                 fn = ScalarOperatorEvaluator.INSTANCE.getMetaFunction(node.getFnName(), argumentTypes);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -845,7 +845,7 @@ public class QueryAnalyzer {
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
             if (fn == null) {
-                fn = AnalyzerUtils.getUdfFunction(session, node.getFunctionName(), argTypes);
+                fn = AnalyzerUtils.getUdfFunction(session, node.getFunctionName(), argTypes, null);
             }
 
             if (fn == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -34,6 +34,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.parser.NodePosition;
+import com.starrocks.sql.parser.ParsingException;
 import com.starrocks.thrift.TFunctionBinaryType;
 import org.apache.commons.codec.binary.Hex;
 
@@ -54,6 +55,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.starrocks.sql.common.ErrorMsgProxy.PARSER_ERROR_MSG;
+
 // create a user define function
 public class CreateFunctionStmt extends DdlStmt {
     public static final String FILE_KEY = "file";
@@ -63,6 +66,8 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String ISOLATION_KEY = "isolation";
     public static final String TYPE_STARROCKS_JAR = "StarrocksJar";
     public static final String EVAL_METHOD_NAME = "evaluate";
+
+    public static final String INITIAL_METHOD_NAME = "initialize";
     public static final String CREATE_METHOD_NAME = "create";
     public static final String DESTROY_METHOD_NAME = "destroy";
     public static final String SERIALIZE_METHOD_NAME = "serialize";
@@ -189,6 +194,10 @@ public class CreateFunctionStmt extends DdlStmt {
             checkUdfType(method, expType, method.getReturnType(), RETURN_FIELD_NAME);
         }
 
+        private boolean checkDynamicReturnUdfType(Method method) {
+            return method.getReturnType() == Object.class;
+        }
+
         private void checkUdfType(Method method, Type expType, Class ptype, String pname)
                 throws AnalysisException {
             if (!(expType instanceof ScalarType)) {
@@ -268,6 +277,9 @@ public class CreateFunctionStmt extends DdlStmt {
         this.isAggregate = functionType.equalsIgnoreCase("AGGREGATE");
         this.isTable = functionType.equalsIgnoreCase("TABLE");
         this.argsDef = argsDef;
+        if ((isAggregate || isTable) && returnType == null) {
+            throw new ParsingException(PARSER_ERROR_MSG.missingFunctionReturnType(functionName.toString()));
+        }
         this.returnType = returnType;
         this.intermediateType = intermediateType;
         if (properties == null) {
@@ -321,7 +333,9 @@ public class CreateFunctionStmt extends DdlStmt {
 
         // check argument
         argsDef.analyze();
-        returnType.analyze();
+        if (returnType != null) {
+            returnType.analyze();
+        }
 
         intermediateType = TypeDef.createVarchar(ScalarType.OLAP_MAX_VARCHAR_LENGTH);
 
@@ -406,26 +420,41 @@ public class CreateFunctionStmt extends DdlStmt {
         checksum = Hex.encodeHexString(digest.digest());
     }
 
-    private void checkStarrocksJarUdfClass() throws AnalysisException {
+    private boolean checkInitializeMethod() throws AnalysisException {
+        Method method = mainClass.getMethod(INITIAL_METHOD_NAME, false);
+        return method != null;
+    }
+
+    private boolean checkStarrocksJarUdfClass() throws AnalysisException {
         {
             // RETURN_TYPE evaluate(...)
             Method method = mainClass.getMethod(EVAL_METHOD_NAME, true);
             mainClass.checkMethodNonStaticAndPublic(method);
             mainClass.checkArgumentCount(method, argsDef.getArgTypes().length);
-            mainClass.checkReturnUdfType(method, returnType.getType());
+            boolean hasDynamicReturnType = checkInitializeMethod() && mainClass.checkDynamicReturnUdfType(method);
+            if (!hasDynamicReturnType) {
+                if (returnType == null) {
+                    throw new AnalysisException(
+                            String.format("UDF '%s' should have return type", mainClass.getCanonicalName()));
+                }
+                mainClass.checkReturnUdfType(method, returnType.getType());
+            }
+
             for (int i = 0; i < method.getParameters().length; i++) {
                 Parameter p = method.getParameters()[i];
                 mainClass.checkUdfType(method, argsDef.getArgTypes()[i], p.getType(), p.getName());
             }
+            return hasDynamicReturnType;
         }
     }
 
     private void analyzeStarrocksJarUdf() throws AnalysisException {
-        checkStarrocksJarUdfClass();
+        boolean hasDynamicReturnType = checkStarrocksJarUdfClass();
         function = ScalarFunction.createUdf(
                 functionName, argsDef.getArgTypes(),
-                returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
-                objectFile, mainClass.getCanonicalName(), "", "", !"shared".equalsIgnoreCase(isolation));
+                returnType != null ? returnType.getType() : Type.UNKNOWN_TYPE, argsDef.isVariadic(),
+                TFunctionBinaryType.SRJAR, objectFile, mainClass.getCanonicalName(), "", "",
+                !"shared".equalsIgnoreCase(isolation), true);
         function.setChecksum(checksum);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ParserErrorMsg.java
@@ -64,6 +64,9 @@ public interface ParserErrorMsg {
     @BaseMessage("Invalid UDF function name ''{0}''")
     String invalidUDFName(String a0);
 
+    @BaseMessage("Missing return type for UDAF or UDTF function ''{0}''")
+    String missingFunctionReturnType(String a0);
+
     @BaseMessage("Unsupported type specification: ''{0}''")
     String unsupportedType(String a0);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarFunctionInitializer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarFunctionInitializer.java
@@ -1,0 +1,65 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rewrite;
+
+import com.starrocks.catalog.DynamicScalarFunction;
+import com.starrocks.catalog.StarrocksTypeConverter;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.UDFException;
+import com.starrocks.common.type.StarrocksType;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+public class ScalarFunctionInitializer {
+    public static Type initialize(DynamicScalarFunction f, Object[] argsValues) {
+        try {
+            URL[] urls = {new URL("jar:" + f.getLocation() + "!/")};
+            try (URLClassLoader classLoader = URLClassLoader.newInstance(urls)) {
+                Class c = classLoader.loadClass(f.getSymbolName());
+
+                for (Method m : c.getMethods()) {
+                    if (!m.getDeclaringClass().equals(c)) {
+                        continue;
+                    }
+                    String name = m.getName();
+                    if (name.equalsIgnoreCase("initialize")) {
+                        Object fnInstance = c.newInstance();
+                        return StarrocksTypeConverter.getTypeFromSR((StarrocksType) m.invoke(fnInstance,
+                                StarrocksTypeConverter.getSRTypes(f.getArgs()), argsValues));
+                    }
+                }
+            } catch (IOException e) {
+                throw new UDFException("Failed to load object_file: " + f.getLocation());
+            } catch (ClassNotFoundException e) {
+                throw new UDFException("Class '" + f.getSymbolName() + "' not found in object_file :"
+                        + f.getLocation());
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new UDFException("Failed to create function " + f.getFunctionName().getFunction()
+                        + ": " + f.getLocation(), e);
+            } catch (InvocationTargetException e) {
+                throw new UDFException("Failed to initialize function " + f.getFunctionName().getFunction()
+                        + ": " + f.getLocation(), e);
+            }
+        } catch (MalformedURLException e) {
+            throw new UDFException("Object file is invalid: " + f.getLocation(), e);
+        }
+
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4689,7 +4689,10 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         QualifiedName qualifiedName = getQualifiedName(context.qualifiedName());
         String functionName = qualifiedName.toString();
 
-        TypeDef returnTypeDef = new TypeDef(getType(context.returnType), createPos(context.returnType));
+        TypeDef returnTypeDef = null;
+        if (context.returnType != null) {
+            returnTypeDef = new TypeDef(getType(context.returnType), createPos(context.returnType));
+        }
         TypeDef intermediateType = null;
         if (context.intermediateType != null) {
             intermediateType = new TypeDef(getType(context.intermediateType), createPos(context.intermediateType));

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1248,7 +1248,7 @@ dropFunctionStatement
     ;
 
 createFunctionStatement
-    : CREATE GLOBAL? functionType=(TABLE | AGGREGATE)? FUNCTION qualifiedName '(' typeList ')' RETURNS returnType=type (INTERMEDIATE intermediateType =  type)? properties?
+    : CREATE GLOBAL? functionType=(TABLE | AGGREGATE)? FUNCTION qualifiedName '(' typeList ')' (RETURNS returnType=type)? (INTERMEDIATE intermediateType =  type)? properties?
     ;
 
 typeList

--- a/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/ast/CreateFunctionStmtTest.java
@@ -71,10 +71,10 @@ public class CreateFunctionStmtTest {
             FunctionName mock = FunctionName.createFnName("mock");
             new Expectations(AnalyzerUtils.class) {
                 {
-                    AnalyzerUtils.getDBUdfFunction(ctx, mock, new Type[0]);
+                    AnalyzerUtils.getDBUdfFunction(ctx, mock, new Type[0], new Object[0]);
                 }
             };
-            AnalyzerUtils.getUdfFunction(ctx, mock, new Type[0]);
+            AnalyzerUtils.getUdfFunction(ctx, mock, new Type[0], new Object[0]);
 
         } finally {
             Config.enable_udf = val;

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -154,7 +154,7 @@ under the License.
             <dependency>
                 <groupId>com.starrocks</groupId>
                 <artifactId>fe-common</artifactId>
-                <version>1.0.0</version>
+                <version>1.0.1</version>
             </dependency>
 
             <dependency>

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -292,6 +292,7 @@ struct TScalarFunction {
     1: required string symbol
     2: optional string prepare_fn_symbol
     3: optional string close_fn_symbol
+    4: optional bool has_dynamic_return_type 
 }
 
 struct TAggregateFunction {

--- a/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
+++ b/java-extensions/udf-extensions/src/main/java/com/starrocks/udf/UDFHelper.java
@@ -54,6 +54,14 @@ public class UDFHelper {
             ThreadLocal.withInitial(() -> new SimpleDateFormat("yyyy-MM-dd HH:mm:ss"));
     private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
+    private static void getBooleanBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        Boolean [] boolArr = new Boolean[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            boolArr[i] = (Boolean) boxedArr[i];
+        }
+        getBooleanBoxedResult(numRows, boolArr, columnAddr);
+    }  
+
     private static void getBooleanBoxedResult(int numRows, Boolean[] boxedArr, long columnAddr) {
         byte[] nulls = new byte[numRows];
         byte[] dataArr = new byte[numRows];
@@ -72,6 +80,14 @@ public class UDFHelper {
         Platform.copyMemory(dataArr, Platform.BYTE_ARRAY_OFFSET, null, addrs[1], numRows);
     }
 
+    private static void getByteBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        Byte [] byteArr = new Byte[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            byteArr[i] = (Byte) boxedArr[i];
+        }
+        getByteBoxedResult(numRows, byteArr, columnAddr);
+    }
+
     private static void getByteBoxedResult(int numRows, Byte[] boxedArr, long columnAddr) {
         byte[] nulls = new byte[numRows];
         byte[] dataArr = new byte[numRows];
@@ -88,6 +104,14 @@ public class UDFHelper {
         Platform.copyMemory(nulls, Platform.BYTE_ARRAY_OFFSET, null, addrs[0], numRows);
         // memcpy to int array
         Platform.copyMemory(dataArr, Platform.BYTE_ARRAY_OFFSET, null, addrs[1], numRows);
+    }
+
+    private static void getShortBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        Short [] shortArr = new Short[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            shortArr[i] = (Short) boxedArr[i];
+        }
+        getShortBoxedResult(numRows, shortArr, columnAddr);
     }
 
     private static void getShortBoxedResult(int numRows, Short[] boxedArr, long columnAddr) {
@@ -109,6 +133,14 @@ public class UDFHelper {
     }
 
     // getIntBoxedResult
+    private static void getIntBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        Integer [] intArr = new Integer[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            intArr[i] = (Integer) boxedArr[i];
+        }
+        getIntBoxedResult(numRows, intArr, columnAddr);
+    }                      
+
     private static void getIntBoxedResult(int numRows, Integer[] boxedArr, long columnAddr) {
         byte[] nulls = new byte[numRows];
         int[] dataArr = new int[numRows];
@@ -128,6 +160,14 @@ public class UDFHelper {
     }
 
     // getIntBoxedResult
+    private static void getBigIntBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        Long [] longArr = new Long[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            longArr[i] = (Long) boxedArr[i];
+        }
+        getBigIntBoxedResult(numRows, longArr, columnAddr);
+    }   
+
     private static void getBigIntBoxedResult(int numRows, Long[] boxedArr, long columnAddr) {
         byte[] nulls = new byte[numRows];
         long[] dataArr = new long[numRows];
@@ -156,6 +196,14 @@ public class UDFHelper {
         getStringBoxedResult(numRows, results, columnAddr);
     }
 
+    private static void getFloatBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        Float [] floatArr = new Float[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            floatArr[i] = (Float) boxedArr[i];
+        }
+        getFloatBoxedResult(numRows, floatArr, columnAddr);
+    }   
+
     private static void getFloatBoxedResult(int numRows, Float[] boxedArr, long columnAddr) {
         byte[] nulls = new byte[numRows];
         float[] dataArr = new float[numRows];
@@ -172,6 +220,14 @@ public class UDFHelper {
         Platform.copyMemory(nulls, Platform.BYTE_ARRAY_OFFSET, null, addrs[0], numRows);
         // memcpy to int array
         Platform.copyMemory(dataArr, Platform.FLOAT_ARRAY_OFFSET, null, addrs[1], numRows * 4L);
+    }
+
+    private static void getDoubleBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        Double [] doubleArr = new Double[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            doubleArr[i] = (Double) boxedArr[i];
+        }
+        getDoubleBoxedResult(numRows, doubleArr, columnAddr);
     }
 
     private static void getDoubleBoxedResult(int numRows, Double[] boxedArr, long columnAddr) {
@@ -235,6 +291,14 @@ public class UDFHelper {
         getStringBoxedResult(numRows, results, columnAddr);
     }
 
+    private static void getStringBoxedResult(int numRows, Object[] boxedArr, long columnAddr) {
+        String [] strArr = new String[boxedArr.length];
+        for (int i = 0;i < boxedArr.length;i++) {
+            strArr[i] = (String) boxedArr[i];
+        }
+        getStringBoxedResult(numRows, strArr, columnAddr);
+    }
+
     private static void getStringBoxedResult(int numRows, String[] column, long columnAddr) {
         byte[] nulls = new byte[numRows];
         int[] offsets = new int[numRows];
@@ -269,31 +333,59 @@ public class UDFHelper {
     public static void getResultFromBoxedArray(int type, int numRows, Object boxedResult, long columnAddr) {
         switch (type) {
             case TYPE_BOOLEAN: {
-                getBooleanBoxedResult(numRows, (Boolean[]) boxedResult, columnAddr);
+                if (boxedResult instanceof Object[]) {
+                    getBooleanBoxedResult(numRows, (Object[]) boxedResult, columnAddr);
+                } else {
+                    getBooleanBoxedResult(numRows, (Boolean[]) boxedResult, columnAddr);
+                }
                 break;
             }
             case TYPE_TINYINT: {
-                getByteBoxedResult(numRows, (Byte[]) boxedResult, columnAddr);
+                if (boxedResult instanceof Object[]) {
+                    getByteBoxedResult(numRows, (Object[]) boxedResult, columnAddr);
+                } else {
+                    getByteBoxedResult(numRows, (Byte[]) boxedResult, columnAddr);
+                }
                 break;
             }
             case TYPE_SMALLINT: {
-                getShortBoxedResult(numRows, (Short[]) boxedResult, columnAddr);
+                if (boxedResult instanceof Object[]) {
+                    getShortBoxedResult(numRows, (Object[]) boxedResult, columnAddr);
+                } else {
+                    getShortBoxedResult(numRows, (Short[]) boxedResult, columnAddr);
+                }
                 break;
             }
             case TYPE_INT: {
-                getIntBoxedResult(numRows, (Integer[]) boxedResult, columnAddr);
+                if (boxedResult instanceof Object[]) {
+                    getIntBoxedResult(numRows, (Object[]) boxedResult, columnAddr);
+                } else {
+                    getIntBoxedResult(numRows, (Integer[]) boxedResult, columnAddr);
+                }
                 break;
             }
             case TYPE_FLOAT: {
-                getFloatBoxedResult(numRows, (Float[]) boxedResult, columnAddr);
+                if (boxedResult instanceof Object[]) {
+                    getFloatBoxedResult(numRows, (Object[]) boxedResult, columnAddr); 
+                } else {
+                    getFloatBoxedResult(numRows, (Float[]) boxedResult, columnAddr);
+                }
                 break;
             }
             case TYPE_DOUBLE: {
-                getDoubleBoxedResult(numRows, (Double[]) boxedResult, columnAddr);
+                if (boxedResult instanceof Object[]) {
+                    getDoubleBoxedResult(numRows, (Object[]) boxedResult, columnAddr);
+                } else {
+                    getDoubleBoxedResult(numRows, (Double[]) boxedResult, columnAddr);
+                }
                 break;
             }
             case TYPE_BIGINT: {
-                getBigIntBoxedResult(numRows, (Long[]) boxedResult, columnAddr);
+                if (boxedResult instanceof Object[]) {
+                    getBigIntBoxedResult(numRows, (Object[]) boxedResult, columnAddr);
+                } else {
+                    getBigIntBoxedResult(numRows, (Long[]) boxedResult, columnAddr);
+                }
                 break;
             }
             case TYPE_VARCHAR: {
@@ -309,8 +401,10 @@ public class UDFHelper {
                     getStringLargeIntResult(numRows, (BigInteger[]) boxedResult, columnAddr);
                 } else if (boxedResult instanceof String[]) {
                     getStringBoxedResult(numRows, (String[]) boxedResult, columnAddr);
+                } else if (boxedResult instanceof Object[]) {
+                    getStringBoxedResult(numRows, (Object[]) boxedResult, columnAddr);
                 } else {
-                    throw new UnsupportedOperationException("unsupported type:" + boxedResult);
+                    throw new UnsupportedOperationException("unsupported java return type:" + boxedResult);
                 }
                 break;
             }


### PR DESCRIPTION
Fixes #issue
Now we are not allowed to have java udfs with the same name and input type but different output types. In Hive, the output type of UDF is obtained through the initialize method, which allows the same UDF to return different types of return values.

How to create scalar function :
`
CREATE GLOBAL FUNCTION xxx(xxx, xxx)
properties (
xxx
);
`

Dynamic return type UDF must implement an initialize method. Return type of evaluate function must be Object. e.g.

`public class TestDynamic {

    private StarrocksType functionType = StarrocksType.UNKNOWN;

    public StarrocksType getFunctionType(String type) {
        if (type.equalsIgnoreCase("string"))
            return StarrocksType.STRING;
        else if (type.equalsIgnoreCase("int"))
            return StarrocksType.INT;
        else if (type.equalsIgnoreCase("double"))
            return StarrocksType.DOUBLE;
        return StarrocksType.UNKNOWN;
    }

    public final StarrocksType initialize(StarrocksType[] argsTypes, Object [] argValues) {
        if (argsTypes.length != 2) {
            throw new RuntimeException("Test must has 2 args");
        }
        if (argsTypes[0] != StarrocksType.STRING && argsTypes[0] != StarrocksType.VARCHAR) {
            throw new RuntimeException("First param of test must be string, but got " + argsTypes[0]);
        }
        if (argsTypes[1] != StarrocksType.STRING && argsTypes[0] != StarrocksType.VARCHAR) {
            throw new RuntimeException("Second param of test must be string, but got " + argsTypes[1]);
        }

        String typeStr = (String) argValues[0];
        if (typeStr != null) {
            StarrocksType type = getFunctionType(typeStr);
            if (type == StarrocksType.UNKNOWN) {
                throw new RuntimeException("Unsupported type " + typeStr + " for TestDynamic.");
            }
            return type;
        }
        throw new RuntimeException("First parameter for TestDynamic must be const string.");
    }

    public final Object evaluate(String type, String value) {
        if (functionType == StarrocksType.UNKNOWN)
            functionType = getFunctionType(type);
        switch (functionType) {
            case STRING:
                return "String: " + value;
            case INT:
                return Integer.parseInt(value);
            case DOUBLE:
                return Double.parseDouble(value);
            default:
                return "Unsupported type: " + type;
        }
    }
}`

1 When registering a UDF, fe will check whether the udf is legal. If there is a legal initialize function, there is no need to provide a return value.
2 When the UDF is called, the fe end will generate the return value type based on the input parameter type, and the be will collect the results based on the return value type determined by the fe.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5