### PR TITLE
[Enhancement] Implement append_selective_shallow_copy for NullableColumn

### DIFF
--- a/be/src/column/adaptive_nullable_column.cpp
+++ b/be/src/column/adaptive_nullable_column.cpp
@@ -107,6 +107,12 @@ void AdaptiveNullableColumn::append_selective(const Column& src, const uint32_t*
     NullableColumn::append_selective(src, indexes, from, size);
 }
 
+void AdaptiveNullableColumn::append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
+                                                           uint32_t size) {
+    materialized_nullable();
+    NullableColumn::append_selective_shallow_copy(src, indexes, from, size);
+}
+
 void AdaptiveNullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size,
                                                          bool deep_copy) {
     materialized_nullable();

--- a/be/src/column/adaptive_nullable_column.h
+++ b/be/src/column/adaptive_nullable_column.h
@@ -272,6 +272,9 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
+    void append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
+                                       uint32_t size) override;
+
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     bool append_nulls(size_t count) override;

--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -109,6 +109,28 @@ void NullableColumn::append_selective(const Column& src, const uint32_t* indexes
     DCHECK_EQ(_null_column->size(), _data_column->size());
 }
 
+void NullableColumn::append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
+                                                   uint32_t size) {
+    DCHECK_EQ(_null_column->size(), _data_column->size());
+    size_t orig_size = _null_column->size();
+    if (src.only_null()) {
+        append_nulls(size);
+    } else if (src.is_nullable()) {
+        const auto& src_column = down_cast<const NullableColumn&>(src);
+
+        DCHECK_EQ(src_column._null_column->size(), src_column._data_column->size());
+
+        _null_column->append_selective(*src_column._null_column, indexes, from, size);
+        _data_column->append_selective_shallow_copy(*src_column._data_column, indexes, from, size);
+        _has_null = _has_null || SIMD::contain_nonzero(_null_column->get_data(), orig_size, size);
+    } else {
+        _null_column->resize(orig_size + size);
+        _data_column->append_selective_shallow_copy(src, indexes, from, size);
+    }
+
+    DCHECK_EQ(_null_column->size(), _data_column->size());
+}
+
 void NullableColumn::append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) {
     DCHECK_EQ(_null_column->size(), _data_column->size());
     size_t orig_size = _null_column->size();

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -140,6 +140,9 @@ public:
 
     void append_selective(const Column& src, const uint32_t* indexes, uint32_t from, uint32_t size) override;
 
+    void append_selective_shallow_copy(const Column& src, const uint32_t* indexes, uint32_t from,
+                                       uint32_t size) override;
+
     void append_value_multiple_times(const Column& src, uint32_t index, uint32_t size, bool deep_copy) override;
 
     void append_shallow_copy(const Column& src, size_t offset, size_t count) override;


### PR DESCRIPTION
Implement append_selective_shallow_copy for NullableColumn, to optimize the performance of hash join with bitmap

```
mysql> select count(*) from lineorder;
+-----------+
| count(*)  |
+-----------+
| 143999468 |
+-----------+

mysql> select c1, bitmap_count(c2) from t1;
+------+------------------+
| c1   | bitmap_count(c2) |
+------+------------------+
|    1 |         30000000 |
+------+------------------+
1 row in set (0.03 sec)



select count(*) from lineorder join t1 on lo_partkey=c1 and bitmap_contains(c2, lo_orderkey);
````

Before optimization:

Time: 2.054s
PeakMemUsage: 3.168G


After optimization:

Time: 0.069s
PeakMemUsage: 30M

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
