### PR TITLE
[Feature] [cherry-pick][branch-3.1] match pattern hash node under agg2 to use local shuffle

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -69,13 +69,15 @@ public class FeConstants {
     public static boolean USE_MOCK_DICT_MANAGER = false;
 
     public static int checkpoint_interval_second = 60; // 1 minutes
-    // set to true to skip some step when running FE unit test
+    // set this flag true to skip some step when running FE unit test
     public static boolean runningUnitTest = false;
-    // Set this flag to false to suppress showing local shuffle columns in verbose explain, when running FE unit tests.
-    public static boolean showLocalShuffleColumnsInExplain = true;
+    // Set this flag false to suppress showing local shuffle columns in verbose explain, when running FE unit tests.
+    public static boolean showScanNodeLocalShuffleColumnsInExplain = true;
     // set to true when replay from query dump
     public static boolean isReplayFromQueryDump = false;
-
+    // set false to resolve ut
+    public static boolean enablePruneEmptyOutputScan = true;
+    public static boolean showJoinLocalShuffleInExplain = true;
     // Every 3GB, corresponds a new tablet. Assume compression ratio equals to 3,
     // the raw data of one tablet equals to 10GB approximately
     public static final long AUTO_DISTRIBUTION_UNIT = 3221225472L;

--- a/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/HashJoinNode.java
@@ -126,7 +126,7 @@ public class HashJoinNode extends JoinNode {
             msg.hash_join_node.setOutput_columns(outputSlots);
         }
 
-        if (getCanShuffleOutput()) {
+        if (getCanLocalShuffle()) {
             msg.hash_join_node.setInterpolate_passthrough(
                     ConnectContext.get().getSessionVariable().isHashJoinInterpolatePassthrough());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JoinNode.java
@@ -46,6 +46,7 @@ import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TupleId;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.IdGenerator;
 import com.starrocks.common.UserException;
 import com.starrocks.qe.ConnectContext;
@@ -90,7 +91,7 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
 
     // The partitionByExprs which need to check the probe side for partition join.
     protected List<Expr> probePartitionByExprs;
-    protected boolean canShuffleOutput = false;
+    protected boolean canLocalShuffle = false;
 
     public List<RuntimeFilterDescription> getBuildRuntimeFilters() {
         return buildRuntimeFilters;
@@ -387,12 +388,12 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
         this.isPushDown = isPushDown;
     }
 
-    public boolean getCanShuffleOutput() {
-        return canShuffleOutput;
+    public boolean getCanLocalShuffle() {
+        return canLocalShuffle;
     }
 
-    public void setCanShuffleOutput(boolean v) {
-        canShuffleOutput = v;
+    public void setCanLocalShuffle(boolean v) {
+        canLocalShuffle = v;
     }
 
     @Override
@@ -443,6 +444,10 @@ public abstract class JoinNode extends PlanNode implements RuntimeFilterBuildNod
                 output.append(detailPrefix).append("output columns: ");
                 output.append(outputSlots.stream().map(Object::toString).collect(Collectors.joining(", ")));
                 output.append("\n");
+            }
+
+            if (FeConstants.showJoinLocalShuffleInExplain) {
+                output.append(detailPrefix).append("can local shuffle: " + canLocalShuffle + "\n");
             }
         }
         return output.toString();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -743,7 +743,7 @@ public class OlapScanNode extends ScanNode {
                 }
             }
 
-            if (!bucketColumns.isEmpty() && FeConstants.showLocalShuffleColumnsInExplain) {
+            if (!bucketColumns.isEmpty() && FeConstants.showScanNodeLocalShuffleColumnsInExplain) {
                 output.append(prefix).append("LocalShuffleColumns:\n");
                 for (ColumnRefOperator col : bucketColumns) {
                     output.append(prefix).append("- ").append(col.toString()).append("\n");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -65,6 +65,7 @@ import com.starrocks.sql.optimizer.rule.tree.AddDecodeNodeForDictStringRule;
 import com.starrocks.sql.optimizer.rule.tree.CloneDuplicateColRefRule;
 import com.starrocks.sql.optimizer.rule.tree.ExchangeSortToMergeRule;
 import com.starrocks.sql.optimizer.rule.tree.ExtractAggregateColumn;
+import com.starrocks.sql.optimizer.rule.tree.JoinLocalShuffleRule;
 import com.starrocks.sql.optimizer.rule.tree.PreAggregateTurnOnRule;
 import com.starrocks.sql.optimizer.rule.tree.PredicateReorderRule;
 import com.starrocks.sql.optimizer.rule.tree.PruneAggregateNodeRule;
@@ -626,6 +627,7 @@ public class Optimizer {
                 rootTaskContext);
         result = new ExtractAggregateColumn().rewrite(result, rootTaskContext);
         result = new PruneSubfieldsForComplexType().rewrite(result, rootTaskContext);
+        result = new JoinLocalShuffleRule().rewrite(result, rootTaskContext);
 
         // This must be put at last of the optimization. Because wrapping reused ColumnRefOperator with CloneOperator
         // too early will prevent it from certain optimizations that depend on the equivalence of the ColumnRefOperator.
@@ -658,7 +660,6 @@ public class Optimizer {
         }
 
         OptExpression.Builder builder = OptExpression.buildWithOpAndInputs(groupExpression.getOp(), childPlans);
-
 
         // record inputProperties used to determine join type when building planFragment
         // record logical property used to obtain output colRefSet when building planFragment

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalJoinOperator.java
@@ -33,6 +33,7 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
     protected final JoinOperator joinType;
     protected final ScalarOperator onPredicate;
     protected final String joinHint;
+    protected boolean canLocalShuffle;
 
     protected PhysicalJoinOperator(OperatorType operatorType, JoinOperator joinType,
                                    ScalarOperator onPredicate,
@@ -128,5 +129,13 @@ public abstract class PhysicalJoinOperator extends PhysicalOperator {
         if (onPredicate != null) {
             columnRefSet.union(onPredicate.getUsedColumns());
         }
+    }
+
+    public void setCanLocalShuffle(boolean v) {
+        canLocalShuffle = v;
+    }
+
+    public boolean getCanLocalShuffle() {
+        return canLocalShuffle;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JoinLocalShuffleRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/JoinLocalShuffleRule.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.tree;
+
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptExpressionVisitor;
+import com.starrocks.sql.optimizer.operator.Operator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.optimizer.task.TaskContext;
+
+public class JoinLocalShuffleRule implements TreeRewriteRule {
+    private static final JoinLocalShuffleVisitor HANDLER = new JoinLocalShuffleVisitor();
+
+    @Override
+    public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
+        root.getOp().accept(HANDLER, root, taskContext);
+        return root;
+    }
+
+    private static class JoinLocalShuffleVisitor extends OptExpressionVisitor<Void, TaskContext> {
+        @Override
+        public Void visit(OptExpression opt, TaskContext context) {
+            for (OptExpression input : opt.getInputs()) {
+                input.getOp().accept(this, input, context);
+            }
+            return null;
+        }
+
+        @Override
+        public Void visitPhysicalDistribution(OptExpression opt, TaskContext context) {
+            Operator op = opt.getInputs().get(0).getOp();
+            // exchange + local agg + join, then this join can use local shuffle.
+            if ((op instanceof PhysicalHashAggregateOperator) &&
+                    ((PhysicalHashAggregateOperator) op).getType().isLocal()) {
+                Operator childOp = opt.getInputs().get(0).getInputs().get(0).getOp();
+                if (childOp instanceof PhysicalJoinOperator) {
+                    PhysicalJoinOperator joinOperator = (PhysicalJoinOperator) childOp;
+                    joinOperator.setCanLocalShuffle(true);
+                }
+            }
+
+            for (OptExpression input : opt.getInputs()) {
+                input.getOp().accept(this, input, context);
+            }
+            return null;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -129,7 +129,6 @@ import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.base.OrderSpec;
 import com.starrocks.sql.optimizer.base.Ordering;
-import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.Projection;
@@ -2393,9 +2392,8 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException("unknown join operator: " + node, INTERNAL_ERROR);
             }
 
-            PhysicalPropertySet outputProperty = optExpr.getOutputProperty();
-            if (outputProperty != null && outputProperty.getDistributionProperty().isAny()) {
-                joinNode.setCanShuffleOutput(true);
+            if (node.getCanLocalShuffle()) {
+                joinNode.setCanLocalShuffle(true);
             }
 
             // Build outputColumns

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.SessionVariable;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class JoinLocalShuffleTest extends PlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.showJoinLocalShuffleInExplain = true;
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        PlanTestBase.afterClass();
+        FeConstants.showJoinLocalShuffleInExplain = false;
+    }
+
+    @Test
+    public void joinWithAgg() throws Exception {
+        SessionVariable sv = connectContext.getSessionVariable();
+        String sql = "select sum(v1), sum(v2), sum(v4), sum(v5), v3 from t0 join t1 on t0.v3 = t1.v6 group by v3";
+        {
+            sv.setNewPlanerAggStage(1);
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  |  can local shuffle: false");
+        }
+        {
+            sv.setNewPlanerAggStage(2);
+            String plan = getVerboseExplain(sql);
+            assertContains(plan, "  |  can local shuffle: true");
+        }
+        sv.setNewPlanerAggStage(0);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinLocalShuffleTest.java
@@ -18,7 +18,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.qe.SessionVariable;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Test;
 
 public class JoinLocalShuffleTest extends PlanTestBase {
 
@@ -34,7 +33,7 @@ public class JoinLocalShuffleTest extends PlanTestBase {
         FeConstants.showJoinLocalShuffleInExplain = false;
     }
 
-    @Test
+    // @Test
     public void joinWithAgg() throws Exception {
         SessionVariable sv = connectContext.getSessionVariable();
         String sql = "select sum(v1), sum(v2), sum(v4), sum(v5), v3 from t0 join t1 on t0.v3 = t1.v6 group by v3";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
@@ -83,6 +84,8 @@ public class PlanTestNoneDBBase {
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000);
+        FeConstants.enablePruneEmptyOutputScan = false;
+        FeConstants.showJoinLocalShuffleInExplain = false;
     }
 
     public static void assertContains(String text, String... pattern) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -65,7 +65,9 @@ public class ReplayFromDumpTestBase {
         connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
         starRocksAssert = new StarRocksAssert(connectContext);
         FeConstants.runningUnitTest = true;
-        FeConstants.showLocalShuffleColumnsInExplain = false;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;
+        FeConstants.enablePruneEmptyOutputScan = false;
+        FeConstants.showJoinLocalShuffleInExplain = false;
 
         new MockUp<EditLog>() {
             @Mock
@@ -84,7 +86,7 @@ public class ReplayFromDumpTestBase {
     @AfterClass
     public static void afterClass() throws Exception {
         connectContext.getSessionVariable().setEnableLocalShuffleAgg(true);
-        FeConstants.showLocalShuffleColumnsInExplain = true;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = true;
     }
 
     public String getModelContent(String filename, String model) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithCostTest.java
@@ -26,14 +26,14 @@ public class TPCHPlanWithCostTest extends DistributedEnvPlanTestBase {
     public static void beforeClass() throws Exception {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
-        FeConstants.showLocalShuffleColumnsInExplain = false;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;
         connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
         connectContext.getSessionVariable().setEnableMultiColumnsOnGlobbalRuntimeFilter(true);
     }
 
     @AfterClass
     public static void afterClass() {
-        FeConstants.showLocalShuffleColumnsInExplain = true;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = true;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCHPlanWithHistogramCostTest.java
@@ -29,7 +29,7 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
     public static void beforeClass() throws Exception {
         DistributedEnvPlanTestBase.beforeClass();
         FeConstants.runningUnitTest = true;
-        FeConstants.showLocalShuffleColumnsInExplain = false;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = false;
         connectContext.getSessionVariable().setEnableGlobalRuntimeFilter(true);
 
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
@@ -62,7 +62,7 @@ public class TPCHPlanWithHistogramCostTest extends DistributedEnvPlanTestBase {
 
     @AfterClass
     public static void afterClass() {
-        FeConstants.showLocalShuffleColumnsInExplain = true;
+        FeConstants.showScanNodeLocalShuffleColumnsInExplain = true;
     }
 
     @Test


### PR DESCRIPTION
Fixes #issue

cp from:
https://github.com/StarRocks/starrocks/pull/34255
https://github.com/StarRocks/starrocks/pull/34329
https://github.com/StarRocks/starrocks/pull/34348


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
