### PR TITLE
[BugFix] fix clang build error

### DIFF
--- a/be/src/util/bthreads/util.h
+++ b/be/src/util/bthreads/util.h
@@ -25,13 +25,11 @@
 namespace starrocks::bthreads {
 
 namespace {
-struct FunctorArg {
-    std::function<void()> func;
-};
+typedef std::function<void()> FunctorArg;
 
 static void* bthread_func(void* arg) {
     auto func_arg = static_cast<FunctorArg*>(arg);
-    func_arg->func();
+    func_arg->operator()();
     delete func_arg;
     return nullptr;
 }


### PR DESCRIPTION
* clang will complain the `FunctorArg` has no default contructor and the std::function is not a trivial member, std::make_unique<FunctorArg> will refuse to initialize the object.
* define the `FunctorArg` by typedef instead of a struct.

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
