### PR TITLE
[BugFix] Check column exist in vertical compaction

### DIFF
--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -256,7 +256,11 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
             total_num_rows += rowset->num_rows();
             for (auto& segment : rowset->segments()) {
                 for (uint32_t column_index : _column_groups[i]) {
-                    const auto* column_reader = segment->column(column_index);
+                    auto uid = tablet_schema->column(column_index).unique_id();
+                    if (!segment->is_valid_column(uid)) {
+                        continue;
+                    }
+                    const auto* column_reader = segment->column_with_uid(uid);
                     if (column_reader == nullptr) {
                         continue;
                     }

--- a/be/src/storage/compaction.cpp
+++ b/be/src/storage/compaction.cpp
@@ -257,9 +257,6 @@ Status Compaction::_merge_rowsets_vertically(size_t segment_iterator_num, Statis
             for (auto& segment : rowset->segments()) {
                 for (uint32_t column_index : _column_groups[i]) {
                     auto uid = tablet_schema->column(column_index).unique_id();
-                    if (!segment->is_valid_column(uid)) {
-                        continue;
-                    }
                     const auto* column_reader = segment->column_with_uid(uid);
                     if (column_reader == nullptr) {
                         continue;

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -337,6 +337,10 @@ bool Segment::has_loaded_index() const {
     return invoked(_load_index_once);
 }
 
+bool Segment::is_valid_column(uint32_t column_unique_id) const  {
+    return _column_readers.count(column_unique_id) > 0;
+}
+
 Status Segment::_create_column_readers(SegmentFooterPB* footer) {
     std::unordered_map<uint32_t, uint32_t> column_id_to_footer_ordinal;
     for (uint32_t ordinal = 0, sz = footer->columns().size(); ordinal < sz; ++ordinal) {

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -337,7 +337,7 @@ bool Segment::has_loaded_index() const {
     return invoked(_load_index_once);
 }
 
-bool Segment::is_valid_column(uint32_t column_unique_id) const  {
+bool Segment::is_valid_column(uint32_t column_unique_id) const {
     return _column_readers.count(column_unique_id) > 0;
 }
 

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -337,10 +337,6 @@ bool Segment::has_loaded_index() const {
     return invoked(_load_index_once);
 }
 
-bool Segment::is_valid_column(uint32_t column_unique_id) const {
-    return _column_readers.count(column_unique_id) > 0;
-}
-
 Status Segment::_create_column_readers(SegmentFooterPB* footer) {
     std::unordered_map<uint32_t, uint32_t> column_id_to_footer_ordinal;
     for (uint32_t ordinal = 0, sz = footer->columns().size(); ordinal < sz; ++ordinal) {

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -148,7 +148,7 @@ public:
         return _column_readers.count(unique_id) > 0 ? _column_readers.at(unique_id).get() : nullptr;
     }
 
-    const ColumnReader* column_with_uid(size_t uid) const { 
+    const ColumnReader* column_with_uid(size_t uid) const {
         return _column_readers.count(uid) > 0 ? _column_readers.at(uid).get() : nullptr;
     }
 

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -148,6 +148,10 @@ public:
         return _column_readers.count(unique_id) > 0 ? _column_readers.at(unique_id).get() : nullptr;
     }
 
+    const ColumnReader* column_with_uid(size_t uid) const {
+        return _column_readers.at(uid).get();
+    }
+
     FileSystem* file_system() const { return _fs.get(); }
 
     const TabletSchema& tablet_schema() const { return *_tablet_schema; }
@@ -168,6 +172,8 @@ public:
     size_t mem_usage() const {
         return _basic_info_mem_usage() + _short_key_index_mem_usage() + _column_index_mem_usage();
     }
+
+    bool is_valid_column(uint32_t column_unique_id) const;
 
     int64_t get_data_size() {
         auto res = _fs->get_file_size(_fname);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -148,7 +148,9 @@ public:
         return _column_readers.count(unique_id) > 0 ? _column_readers.at(unique_id).get() : nullptr;
     }
 
-    const ColumnReader* column_with_uid(size_t uid) const { return _column_readers.at(uid).get(); }
+    const ColumnReader* column_with_uid(size_t uid) const { 
+        return _column_readers.count(uid) > 0 ? _column_readers.at(uid).get() : nullptr;
+    }
 
     FileSystem* file_system() const { return _fs.get(); }
 
@@ -170,8 +172,6 @@ public:
     size_t mem_usage() const {
         return _basic_info_mem_usage() + _short_key_index_mem_usage() + _column_index_mem_usage();
     }
-
-    bool is_valid_column(uint32_t column_unique_id) const;
 
     int64_t get_data_size() {
         auto res = _fs->get_file_size(_fname);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -148,9 +148,7 @@ public:
         return _column_readers.count(unique_id) > 0 ? _column_readers.at(unique_id).get() : nullptr;
     }
 
-    const ColumnReader* column_with_uid(size_t uid) const {
-        return _column_readers.at(uid).get();
-    }
+    const ColumnReader* column_with_uid(size_t uid) const { return _column_readers.at(uid).get(); }
 
     FileSystem* file_system() const { return _fs.get(); }
 

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -171,9 +171,6 @@ StatusOr<int32_t> VerticalCompactionTask::_calculate_chunk_size_for_column_group
         for (auto& segment : rowset->segments()) {
             for (uint32_t column_index : column_group) {
                 auto uid = _tablet_schema->column(column_index).unique_id();
-                if (!segment->is_valid_column(uid)) {
-                    continue;
-                }
                 const auto* column_reader = segment->column_with_uid(uid);
                 if (column_reader == nullptr) {
                     continue;

--- a/be/src/storage/vertical_compaction_task.cpp
+++ b/be/src/storage/vertical_compaction_task.cpp
@@ -170,7 +170,11 @@ StatusOr<int32_t> VerticalCompactionTask::_calculate_chunk_size_for_column_group
         total_num_rows += rowset->num_rows();
         for (auto& segment : rowset->segments()) {
             for (uint32_t column_index : column_group) {
-                const auto* column_reader = segment->column(column_index);
+                auto uid = _tablet_schema->column(column_index).unique_id();
+                if (!segment->is_valid_column(uid)) {
+                    continue;
+                }
+                const auto* column_reader = segment->column_with_uid(uid);
                 if (column_reader == nullptr) {
                     continue;
                 }


### PR DESCRIPTION
Fixes #issue
Output rowset tablet schema after compaction maybe different with the tablet schema of input rowset, so we need to check column exist when getting column reader from segment.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
