### PR TITLE
[BugFix] Schema change ignoring PREPARED transaction may lead to data loss

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -387,7 +387,8 @@ public class TransactionState implements Writable {
     }
 
     public boolean isRunning() {
-        return transactionStatus == TransactionStatus.PREPARE || transactionStatus == TransactionStatus.COMMITTED;
+        return transactionStatus == TransactionStatus.PREPARE || transactionStatus == TransactionStatus.PREPARED ||
+                transactionStatus == TransactionStatus.COMMITTED;
     }
 
     public void setTabletCommitInfos(List<TabletCommitInfo> infos) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -42,6 +42,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 public class TransactionStateTest {
@@ -149,5 +150,23 @@ public class TransactionStateTest {
             e.printStackTrace();
         }
         Assert.assertTrue(readTransactionState.isNewFinish());
+    }
+
+    @Test
+    public void testIsRunning() {
+        Set<TransactionStatus> nonRunningStatus = new HashSet<>();
+        nonRunningStatus.add(TransactionStatus.UNKNOWN);
+        nonRunningStatus.add(TransactionStatus.VISIBLE);
+        nonRunningStatus.add(TransactionStatus.ABORTED);
+
+        UUID uuid = UUID.randomUUID();
+        for (TransactionStatus status : TransactionStatus.values()) {
+            TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
+                    3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                    LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
+                    60 * 1000L);
+            transactionState.setTransactionStatus(status);
+            Assert.assertEquals(nonRunningStatus.contains(status), !transactionState.isRunning());
+        }
     }
 }


### PR DESCRIPTION
Fixes #34377

Schema change should wait if there are previous loads running, and it uses `TransactionStatus` to see whether a load is running. Now it only considers `PREPARE` and `COMMITTED` transactions to be running, but ignores the `PREPARED` transactions, and this may lead to data loss for transaction stream load while doing schema change concurrently.

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [X] 3.0
  - [X] 2.5
