### PR TITLE
[BugFix] Make 'start_bthread' and 'start_bthread_and_join' inline

### DIFF
--- a/be/src/util/bthreads/util.h
+++ b/be/src/util/bthreads/util.h
@@ -37,7 +37,7 @@ static void* bthread_func(void* arg) {
 
 // Starts a new bthread that runs the specified function.
 // Note: The function provided must not throw any exceptions.
-StatusOr<bthread_t> start_bthread(std::function<void()> func) {
+inline StatusOr<bthread_t> start_bthread(std::function<void()> func) {
     auto arg = std::make_unique<FunctorArg>(std::move(func));
     bthread_t bid;
     int rc = bthread_start_background(&bid, nullptr, bthread_func, arg.get());
@@ -51,7 +51,7 @@ StatusOr<bthread_t> start_bthread(std::function<void()> func) {
 // Starts a new bthread that runs the specified function, then waits for the new bthread
 // to complete before returning to the caller.
 // Note: The function provided must not throw any exceptions.
-Status start_bthread_and_join(std::function<void()> func) {
+inline Status start_bthread_and_join(std::function<void()> func) {
     ASSIGN_OR_RETURN(auto bid, start_bthread(std::move(func)));
     int rc = bthread_join(bid, nullptr);
     if (rc != 0) {


### PR DESCRIPTION
Modified two function declarations in the bthread utility header to be inline functions to prevent 'multiple definition' error.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
