### PR TITLE
[Enhancement] Avoid checking group concurrency_limit when enabling group level queue

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -197,9 +197,8 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
     bool enable_group_level_query_queue = false;
     if (query_options.__isset.query_queue_options) {
         const auto& queue_options = query_options.query_queue_options;
-        enable_group_level_query_queue = queue_options.__isset.enable_query_queue && queue_options.enable_query_queue &&
-                                         queue_options.__isset.enable_group_level_query_queue &&
-                                         queue_options.enable_group_level_query_queue;
+        enable_group_level_query_queue =
+                queue_options.__isset.enable_group_level_query_queue && queue_options.enable_group_level_query_queue;
     }
     RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get(), enable_group_level_query_queue));
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -201,7 +201,7 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
                                          queue_options.__isset.enable_group_level_query_queue &&
                                          queue_options.enable_group_level_query_queue;
     }
-    RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get()), enable_group_level_query_queue);
+    RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get(), enable_group_level_query_queue));
 
     _fragment_ctx->set_workgroup(wg);
     _wg = wg;

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -197,7 +197,7 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
     bool enable_group_level_query_queue = false;
     if (query_options.__isset.query_queue_options) {
         const auto& queue_options = query_options.query_queue_options;
-        enable_group_level_query_queue = query_options.__isset.enable_query_queue && query_options.enable_query_queue &&
+        enable_group_level_query_queue = queue_options.__isset.enable_query_queue && queue_options.enable_query_queue &&
                                          queue_options.__isset.enable_group_level_query_queue &&
                                          queue_options.enable_group_level_query_queue;
     }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -192,7 +192,17 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
         wg = WorkGroupManager::instance()->add_workgroup(wg);
     }
     DCHECK(wg != nullptr);
-    RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get()));
+
+    const auto& query_options = request.common().query_options;
+    bool enable_group_level_query_queue = false;
+    if (query_options.__isset.query_queue_options) {
+        const auto& queue_options = query_options.query_queue_options;
+        enable_group_level_query_queue = query_options.__isset.enable_query_queue && query_options.enable_query_queue &&
+                                         queue_options.__isset.enable_group_level_query_queue &&
+                                         queue_options.enable_group_level_query_queue
+    }
+    RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get()), enable_group_level_query_queue);
+
     _fragment_ctx->set_workgroup(wg);
     _wg = wg;
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -199,7 +199,7 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
         const auto& queue_options = query_options.query_queue_options;
         enable_group_level_query_queue = query_options.__isset.enable_query_queue && query_options.enable_query_queue &&
                                          queue_options.__isset.enable_group_level_query_queue &&
-                                         queue_options.enable_group_level_query_queue
+                                         queue_options.enable_group_level_query_queue;
     }
     RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get()), enable_group_level_query_queue);
 

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -140,12 +140,12 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
     });
 }
 
-Status QueryContext::init_query_once(workgroup::WorkGroup* wg) {
+Status QueryContext::init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue) {
     Status st = Status::OK();
     if (wg != nullptr) {
-        std::call_once(_init_query_once, [this, &st, wg]() {
+        std::call_once(_init_query_once, [this, &st, wg, enable_group_level_query_queue]() {
             this->init_query_begin_time();
-            auto maybe_token = wg->acquire_running_query_token();
+            auto maybe_token = wg->acquire_running_query_token(enable_group_level_query_queue);
             if (maybe_token.ok()) {
                 _wg_running_query_token_ptr = std::move(maybe_token.value());
                 _wg_running_query_token_atomic_ptr = _wg_running_query_token_ptr.get();

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -136,7 +136,7 @@ public:
                           workgroup::WorkGroup* wg = nullptr);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
 
-    Status init_query_once(workgroup::WorkGroup* wg);
+    Status init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue);
     /// Release the workgroup token only once to avoid double-free.
     /// This method should only be invoked while the QueryContext is still valid,
     /// to avoid double-free between the destruction and this method.

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -196,9 +196,10 @@ void WorkGroup::decr_num_running_drivers() {
     }
 }
 
-StatusOr<RunningQueryTokenPtr> WorkGroup::acquire_running_query_token() {
+StatusOr<RunningQueryTokenPtr> WorkGroup::acquire_running_query_token(bool enable_group_level_query_queue) {
     int64_t old = _num_running_queries.fetch_add(1);
-    if (_concurrency_limit != ABSENT_CONCURRENCY_LIMIT && old >= _concurrency_limit) {
+    if (!enable_group_level_query_queue && _concurrency_limit != ABSENT_CONCURRENCY_LIMIT &&
+        old >= _concurrency_limit) {
         _num_running_queries.fetch_sub(1);
         _concurrency_overflow_count++;
         return Status::TooManyTasks(fmt::format("Exceed concurrency limit: {}", _concurrency_limit));

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -187,7 +187,7 @@ public:
     static int128_t create_unique_id(int64_t id, int64_t version) { return (((int128_t)version) << 64) | id; }
 
     Status check_big_query(const QueryContext& query_context);
-    StatusOr<RunningQueryTokenPtr> acquire_running_query_token();
+    StatusOr<RunningQueryTokenPtr> acquire_running_query_token(bool enable_group_level_query_queue);
     void decr_num_queries();
     int64_t num_running_queries() const { return _num_running_queries; }
     int64_t num_total_queries() const { return _num_total_queries; }

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -253,9 +253,9 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
     const auto query_id1 = query_ctx1->query_id();
 
     /// Case 1: When all the fragments have come and finished, wg.num_running_queries should become to zero.
-    ASSERT_OK(query_ctx1->init_query_once(wg.get()));
-    ASSERT_OK(query_ctx1->init_query_once(wg.get()));              // None-first invocations have no side-effects.
-    ASSERT_ERROR(query_ctx_overloaded->init_query_once(wg.get())); // Exceed concurrency_limit.
+    ASSERT_OK(query_ctx1->init_query_once(wg.get(), false));
+    ASSERT_OK(query_ctx1->init_query_once(wg.get(), false)); // None-first invocations have no side-effects.
+    ASSERT_ERROR(query_ctx_overloaded->init_query_once(wg.get(), false)); // Exceed concurrency_limit.
     ASSERT_EQ(1, wg->num_running_queries());
     ASSERT_EQ(1, wg->concurrency_overflow_count());
     // All the fragments comes.
@@ -276,8 +276,8 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
     auto* query_ctx2 =
             gen_query_ctx(parent_mem_tracker.get(), query_ctx_mgr.get(), 3, 4, 3, 0 /* delivery_timeout */, 300);
     const auto query_id2 = query_ctx2->query_id();
-    ASSERT_OK(query_ctx2->init_query_once(wg.get()));
-    ASSERT_OK(query_ctx2->init_query_once(wg.get())); // None-first invocations have no side-effects.
+    ASSERT_OK(query_ctx2->init_query_once(wg.get(), false));
+    ASSERT_OK(query_ctx2->init_query_once(wg.get(), false)); // None-first invocations have no side-effects.
     ASSERT_EQ(1, wg->num_running_queries());
     for (int i = 2; i < query_ctx2->total_fragments(); ++i) {
         auto* cur_query_ctx = query_ctx_mgr->get_or_register(query_id2);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -153,7 +153,7 @@ public class TFragmentInstanceFactory {
                 }
                 if (jobSpec.isEnableQueue()) {
                     TQueryQueueOptions queryQueueOptions = new TQueryQueueOptions();
-                    queryQueueOptions.setEnable_query_queue(jobSpec.isEnableQueue());
+                    queryQueueOptions.setEnable_global_query_queue(jobSpec.isEnableQueue());
                     queryQueueOptions.setEnable_group_level_query_queue(jobSpec.isEnableGroupLevelQueue());
 
                     TQueryOptions queryOptions = result.getQuery_options();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -34,6 +34,7 @@ import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPlanFragmentDestination;
 import com.starrocks.thrift.TPlanFragmentExecParams;
 import com.starrocks.thrift.TQueryOptions;
+import com.starrocks.thrift.TQueryQueueOptions;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -149,6 +150,14 @@ public class TFragmentInstanceFactory {
                             sessionVariable.getAdaptiveDopMaxBlockRowsPerDriverSeq());
                     result.adaptive_dop_param.setMax_output_amplification_factor(
                             sessionVariable.getAdaptiveDopMaxOutputAmplificationFactor());
+                }
+                if (jobSpec.isEnableQueue() && jobSpec.isNeedQueued()) {
+                    TQueryQueueOptions queryQueueOptions = new TQueryQueueOptions();
+                    queryQueueOptions.setEnable_query_queue(jobSpec.isEnableQueue());
+                    queryQueueOptions.setEnable_group_level_query_queue(jobSpec.isEnableGroupLevelQueue());
+
+                    TQueryOptions queryOptions = result.getQuery_options();
+                    queryOptions.setQuery_queue_options(queryQueueOptions);
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/TFragmentInstanceFactory.java
@@ -151,7 +151,7 @@ public class TFragmentInstanceFactory {
                     result.adaptive_dop_param.setMax_output_amplification_factor(
                             sessionVariable.getAdaptiveDopMaxOutputAmplificationFactor());
                 }
-                if (jobSpec.isEnableQueue() && jobSpec.isNeedQueued()) {
+                if (jobSpec.isEnableQueue()) {
                     TQueryQueueOptions queryQueueOptions = new TQueryQueueOptions();
                     queryQueueOptions.setEnable_query_queue(jobSpec.isEnableQueue());
                     queryQueueOptions.setEnable_group_level_query_queue(jobSpec.isEnableGroupLevelQueue());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -22,8 +22,10 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.load.loadv2.BulkLoadJob;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
+import com.starrocks.planner.SchemaScanNode;
 import com.starrocks.planner.StreamLoadPlanner;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.GlobalVariable;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.thrift.TCompressionType;
@@ -47,23 +49,23 @@ import static com.starrocks.qe.CoordinatorPreprocessor.prepareResourceGroup;
 public class JobSpec {
 
     private static final long UNINITIALIZED_LOAD_JOB_ID = -1;
-    private long loadJobId;
+    private long loadJobId = UNINITIALIZED_LOAD_JOB_ID;
 
     private TUniqueId queryId;
 
-    private final List<PlanFragment> fragments;
-    private final List<ScanNode> scanNodes;
+    private List<PlanFragment> fragments;
+    private List<ScanNode> scanNodes;
     /**
      * copied from TQueryExecRequest; constant across all fragments
      */
-    private final TDescriptorTable descTable;
+    private TDescriptorTable descTable;
 
-    private final ConnectContext connectContext;
-    private final boolean enablePipeline;
-    private final boolean enableStreamPipeline;
-    private final boolean isBlockQuery;
+    private ConnectContext connectContext;
+    private boolean enablePipeline;
+    private boolean enableStreamPipeline;
+    private boolean isBlockQuery;
 
-    private final boolean needReport;
+    private boolean needReport;
 
     /**
      * Why we use query global?
@@ -71,11 +73,15 @@ public class JobSpec {
      * but, we execute `NOW()` distributed.
      * So we make a query global value here to make one `now()` value in one query process.
      */
-    private final TQueryGlobals queryGlobals;
-    private final TQueryOptions queryOptions;
-    private final TWorkGroup resourceGroup;
+    private TQueryGlobals queryGlobals;
+    private TQueryOptions queryOptions;
+    private TWorkGroup resourceGroup;
 
-    private final String planProtocol;
+    private String planProtocol;
+
+    private boolean enableQueue = false;
+    private boolean needQueued = false;
+    private boolean enableGroupLevelQueue = false;
 
     public static class Factory {
         private Factory() {
@@ -323,25 +329,7 @@ public class JobSpec {
         }
     }
 
-    private JobSpec(Builder builder) {
-        this.loadJobId = builder.loadJobId;
-
-        this.queryId = builder.queryId;
-
-        this.fragments = builder.fragments;
-        this.scanNodes = builder.scanNodes;
-        this.descTable = builder.descTable;
-
-        this.enablePipeline = builder.enablePipeline;
-        this.enableStreamPipeline = builder.enableStreamPipeline;
-        this.isBlockQuery = builder.isBlockQuery;
-        this.needReport = builder.needReport;
-        this.connectContext = builder.connectContext;
-
-        this.queryGlobals = builder.queryGlobals;
-        this.queryOptions = builder.queryOptions;
-        this.resourceGroup = builder.resourceGroup;
-        this.planProtocol = builder.planProtocol;
+    private JobSpec() {
     }
 
     @Override
@@ -436,8 +424,16 @@ public class JobSpec {
         return connectContext.isStatisticsJob();
     }
 
+    public boolean isEnableQueue() {
+        return enableQueue;
+    }
+
     public boolean isNeedQueued() {
-        return connectContext.isNeedQueued();
+        return needQueued;
+    }
+
+    public boolean isEnableGroupLevelQueue() {
+        return enableGroupLevelQueue;
     }
 
     public boolean isStreamLoad() {
@@ -453,56 +449,44 @@ public class JobSpec {
     }
 
     public static class Builder {
-        private long loadJobId = UNINITIALIZED_LOAD_JOB_ID;
-
-        private TUniqueId queryId;
-        private List<PlanFragment> fragments;
-        private List<ScanNode> scanNodes;
-        private TDescriptorTable descTable;
-
-        private boolean enablePipeline;
-        private boolean enableStreamPipeline;
-        private boolean isBlockQuery;
-        private boolean needReport;
-        private ConnectContext connectContext;
-
-        private TQueryGlobals queryGlobals;
-        private TQueryOptions queryOptions;
-        private TWorkGroup resourceGroup;
-        private String planProtocol;
+        private final JobSpec instance = new JobSpec();
 
         public JobSpec build() {
-            return new JobSpec(this);
+            return instance;
         }
 
         public Builder commonProperties(ConnectContext context) {
             TWorkGroup newResourceGroup = prepareResourceGroup(
-                    context, ResourceGroupClassifier.QueryType.fromTQueryType(queryOptions.getQuery_type()));
+                    context, ResourceGroupClassifier.QueryType.fromTQueryType(instance.queryOptions.getQuery_type()));
             this.resourceGroup(newResourceGroup);
 
-            this.enablePipeline(isEnablePipeline(context, fragments));
-            this.connectContext = context;
+            this.enablePipeline(isEnablePipeline(context, instance.fragments));
+            instance.connectContext = context;
+
+            instance.enableQueue = isEnableQueue();
+            instance.needQueued = needCheckQueue();
+            instance.enableGroupLevelQueue = GlobalVariable.isEnableGroupLevelQueryQueue();
 
             return this;
         }
 
         public Builder loadJobId(long loadJobId) {
-            this.loadJobId = loadJobId;
+            instance.loadJobId = loadJobId;
             return this;
         }
 
         public Builder queryId(TUniqueId queryId) {
-            this.queryId = Preconditions.checkNotNull(queryId);
+            instance.queryId = Preconditions.checkNotNull(queryId);
             return this;
         }
 
         public Builder fragments(List<PlanFragment> fragments) {
-            this.fragments = fragments;
+            instance.fragments = fragments;
             return this;
         }
 
         public Builder scanNodes(List<ScanNode> scanNodes) {
-            this.scanNodes = scanNodes;
+            instance.scanNodes = scanNodes;
             return this;
         }
 
@@ -510,47 +494,47 @@ public class JobSpec {
             if (descTable != null) {
                 descTable.setIs_cached(false);
             }
-            this.descTable = descTable;
+            instance.descTable = descTable;
             return this;
         }
 
         public Builder enableStreamPipeline(boolean enableStreamPipeline) {
-            this.enableStreamPipeline = enableStreamPipeline;
+            instance.enableStreamPipeline = enableStreamPipeline;
             return this;
         }
 
         public Builder isBlockQuery(boolean isBlockQuery) {
-            this.isBlockQuery = isBlockQuery;
+            instance.isBlockQuery = isBlockQuery;
             return this;
         }
 
         public Builder queryGlobals(TQueryGlobals queryGlobals) {
-            this.queryGlobals = queryGlobals;
+            instance.queryGlobals = queryGlobals;
             return this;
         }
 
         public Builder queryOptions(TQueryOptions queryOptions) {
-            this.queryOptions = queryOptions;
+            instance.queryOptions = queryOptions;
             return this;
         }
 
         private Builder enablePipeline(boolean enablePipeline) {
-            this.enablePipeline = enablePipeline;
+            instance.enablePipeline = enablePipeline;
             return this;
         }
 
         private Builder resourceGroup(TWorkGroup resourceGroup) {
-            this.resourceGroup = resourceGroup;
+            instance.resourceGroup = resourceGroup;
             return this;
         }
 
         private Builder needReport(boolean needReport) {
-            this.needReport = needReport;
+            instance.needReport = needReport;
             return this;
         }
 
         private Builder setPlanProtocol(String planProtocol) {
-            this.planProtocol = StringUtils.lowerCase(planProtocol);
+            instance.planProtocol = StringUtils.lowerCase(planProtocol);
             return this;
         }
 
@@ -566,6 +550,30 @@ public class JobSpec {
             return connectContext != null &&
                     connectContext.getSessionVariable().isEnablePipelineEngine() &&
                     fragments.stream().allMatch(PlanFragment::canUsePipeline);
+        }
+
+        private boolean isEnableQueue() {
+            if (instance.isStatisticsJob()) {
+                return GlobalVariable.isEnableQueryQueueStatistic();
+            }
+
+            if (instance.isLoadType()) {
+                return GlobalVariable.isEnableQueryQueueLoad();
+            }
+
+            return GlobalVariable.isEnableQueryQueueSelect();
+        }
+
+        private boolean needCheckQueue() {
+            if (!instance.connectContext.isNeedQueued()) {
+                return false;
+            }
+
+            // The queries only using schema meta will never been queued, because a MySQL client will
+            // query schema meta after the connection is established.
+            boolean notNeed =
+                    instance.scanNodes.isEmpty() || instance.scanNodes.stream().allMatch(SchemaScanNode.class::isInstance);
+            return !notNeed;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/JobSpec.java
@@ -465,7 +465,7 @@ public class JobSpec {
 
             instance.enableQueue = isEnableQueue();
             instance.needQueued = needCheckQueue();
-            instance.enableGroupLevelQueue = GlobalVariable.isEnableGroupLevelQueryQueue();
+            instance.enableGroupLevelQueue = instance.enableQueue && GlobalVariable.isEnableGroupLevelQueryQueue();
 
             return this;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -58,7 +58,6 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.utframe.MockGenericPool;
 import com.starrocks.utframe.UtFrameUtils;
-import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.thrift.TApplicationException;
@@ -192,20 +191,20 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
         {
             // 1. ScanNodes is empty.
             DefaultCoordinator coordinator = getSchedulerWithQueryId("select 1");
-            Assert.assertFalse(manager.needCheckQueue(coordinator));
+            Assert.assertFalse(coordinator.getJobSpec().isNeedQueued());
         }
 
         {
             // 2. ScanNodes only contain SchemaNode.
             DefaultCoordinator coordinator = getSchedulerWithQueryId("select TABLE_CATALOG from information_schema.tables");
-            Assert.assertFalse(manager.needCheckQueue(coordinator));
+            Assert.assertFalse(coordinator.getJobSpec().isNeedQueued());
         }
 
         {
             // 3. ScanNodes include non-SchemaNode.
             DefaultCoordinator coordinator = getSchedulerWithQueryId(
                     "select TABLE_CATALOG from information_schema.tables UNION ALL select count(1) from lineitem");
-            Assert.assertTrue(manager.needCheckQueue(coordinator));
+            Assert.assertTrue(coordinator.getJobSpec().isNeedQueued());
         }
 
         {
@@ -213,7 +212,7 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             connectContext.setNeedQueued(false);
             DefaultCoordinator coordinator = getSchedulerWithQueryId(
                     "select TABLE_CATALOG from information_schema.tables UNION ALL select count(1) from lineitem");
-            Assert.assertFalse(manager.needCheckQueue(coordinator));
+            Assert.assertFalse(coordinator.getJobSpec().isNeedQueued());
             connectContext.setNeedQueued(true);
         }
     }
@@ -222,21 +221,25 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
     public void testEnableQueue() throws Exception {
         {
             // 1. Load type.
-            DefaultCoordinator coordinator = getSchedulerWithQueryId("insert into lineitem select * from lineitem");
             GlobalVariable.setEnableQueryQueueLoad(false);
-            Assert.assertFalse(manager.isEnableQueue(coordinator));
+            DefaultCoordinator coordinator = getSchedulerWithQueryId("insert into lineitem select * from lineitem");
+            Assert.assertFalse(coordinator.getJobSpec().isEnableQueue());
+
             GlobalVariable.setEnableQueryQueueLoad(true);
-            Assert.assertTrue(manager.isEnableQueue(coordinator));
+            coordinator = getSchedulerWithQueryId("insert into lineitem select * from lineitem");
+            Assert.assertTrue(coordinator.getJobSpec().isEnableQueue());
             GlobalVariable.setEnableQueryQueueLoad(false);
         }
 
         {
             // 2. Query for select.
-            DefaultCoordinator coordinator = getSchedulerWithQueryId("select * from lineitem");
             GlobalVariable.setEnableQueryQueueSelect(false);
-            Assert.assertFalse(manager.isEnableQueue(coordinator));
+            DefaultCoordinator coordinator = getSchedulerWithQueryId("select * from lineitem");
+            Assert.assertFalse(coordinator.getJobSpec().isEnableQueue());
+
             GlobalVariable.setEnableQueryQueueSelect(true);
-            Assert.assertTrue(manager.isEnableQueue(coordinator));
+            coordinator = getSchedulerWithQueryId("select * from lineitem");
+            Assert.assertTrue(coordinator.getJobSpec().isEnableQueue());
             GlobalVariable.setEnableQueryQueueSelect(false);
         }
 
@@ -244,21 +247,27 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
             // 3. Query for statistic.
             connectContext.setStatisticsContext(false);
             connectContext.setStatisticsJob(true); // Mock statistics job.
-            DefaultCoordinator coordinator = getSchedulerWithQueryId("select * from lineitem");
             GlobalVariable.setEnableQueryQueueStatistic(false);
-            Assert.assertFalse(manager.isEnableQueue(coordinator));
+            DefaultCoordinator coordinator = getSchedulerWithQueryId("select * from lineitem");
+            Assert.assertFalse(coordinator.getJobSpec().isEnableQueue());
+
             GlobalVariable.setEnableQueryQueueStatistic(true);
-            Assert.assertTrue(manager.isEnableQueue(coordinator));
+            coordinator = getSchedulerWithQueryId("select * from lineitem");
+            Assert.assertTrue(coordinator.getJobSpec().isEnableQueue());
 
             connectContext.setStatisticsJob(false);
             GlobalVariable.setEnableQueryQueueStatistic(true);
-            Assert.assertFalse(manager.isEnableQueue(coordinator));
+            coordinator = getSchedulerWithQueryId("select * from lineitem");
+            Assert.assertFalse(coordinator.getJobSpec().isEnableQueue());
 
             connectContext.setStatisticsContext(true);
             GlobalVariable.setEnableQueryQueueStatistic(false);
-            Assert.assertFalse(manager.isEnableQueue(coordinator));
+            coordinator = getSchedulerWithQueryId("select * from lineitem");
+            Assert.assertFalse(coordinator.getJobSpec().isEnableQueue());
+
             GlobalVariable.setEnableQueryQueueStatistic(true);
-            Assert.assertTrue(manager.isEnableQueue(coordinator));
+            coordinator = getSchedulerWithQueryId("select * from lineitem");
+            Assert.assertTrue(coordinator.getJobSpec().isEnableQueue());
             connectContext.setStatisticsContext(false);
             GlobalVariable.setEnableQueryQueueStatistic(false);
         }
@@ -1518,42 +1527,6 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
                     "wg2|12|be1-host|1.22|27|26\n" +
                     "wg3|13|be1-host|0.23|0|0");
         }
-    }
-
-    private void mockNeedCheckQueue() {
-        new Expectations(manager) {
-            {
-                manager.needCheckQueue((DefaultCoordinator) any);
-                result = true;
-            }
-        };
-    }
-
-    private void mockNotNeedCheckQueue() {
-        new Expectations(manager) {
-            {
-                manager.needCheckQueue((DefaultCoordinator) any);
-                result = false;
-            }
-        };
-    }
-
-    private void mockEnableQueue() {
-        new Expectations(manager) {
-            {
-                manager.isEnableQueue((DefaultCoordinator) any);
-                result = true;
-            }
-        };
-    }
-
-    private void mockNotEnableCheckQueue() {
-        new Expectations(manager) {
-            {
-                manager.isEnableQueue((DefaultCoordinator) any);
-                result = false;
-            }
-        };
     }
 
     private static class MockFrontendServiceClient extends FrontendService.Client {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -123,6 +123,11 @@ enum TOverflowMode {
   REPORT_ERROR = 1;
 }
 
+struct TQueryQueueOptions {
+  1: optional bool enable_query_queue;
+  2: optional bool enable_group_level_query_queue;
+}
+
 // Query options with their respective defaults
 struct TQueryOptions {
   2: optional i32 max_errors = 0
@@ -234,6 +239,8 @@ struct TQueryOptions {
   108: optional i64 runtime_filter_rpc_http_min_size;
 
   109: optional i64 big_query_profile_second_threshold;
+
+  110: optional TQueryQueueOptions query_queue_options;
 }
 
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -124,7 +124,7 @@ enum TOverflowMode {
 }
 
 struct TQueryQueueOptions {
-  1: optional bool enable_query_queue;
+  1: optional bool enable_global_query_queue;
   2: optional bool enable_group_level_query_queue;
 }
 


### PR DESCRIPTION
When enabling group level query queue,
1. The `concurrency_limit` is checked in both FE and BE 
    a. FE will **queue** the coming queries, when `num_running_queries` == `concurrency_limit`.
    b. BE will **fail** the coming queries, when `num_running_queries` == `concurrency_limit`.
2. The order between decreasing `num_running_queries` in FE and BE are uncertain.
    a. FE decreases `num_running_queries`, when it **receives EOS** RPC from BE.
    b. BE decreases `num_running_queries`, when it **finalizes the query context** (after sending EOS RPC to FE asynchronously).

Therefore, `num_running_queries` in BE may be greater than that in FE. This results in that the query is admitted by FE but still failed by exceeding the concurrency limit in BE, even though the group level query queue is enabled. This is not intuitive.


Thus, to make the judgement of exceeding the concurrency limit in FE and BE consistent, when enabling group level query queue, BE doesn't check it anymore.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
