### PR TITLE
[BugFix] fix `PrintableMap` bug when properties contains quotation mark

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -18,6 +18,8 @@
 package com.starrocks.common.util;
 
 import com.google.common.collect.Sets;
+import com.google.common.escape.Escaper;
+import com.google.common.escape.Escapers;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -83,6 +85,11 @@ public class PrintableMap<K, V> {
     public String toString() {
         StringBuilder sb = new StringBuilder();
         Iterator<Map.Entry<K, V>> iter = map.entrySet().iterator();
+
+        Escapers.Builder builder = Escapers.builder();
+        builder.addEscape('"', "\\\"");
+        Escaper escaper = builder.build();
+
         while (iter.hasNext()) {
             Map.Entry<K, V> entry = iter.next();
             if (withQuotation) {
@@ -99,7 +106,11 @@ public class PrintableMap<K, V> {
             if (hidePassword && SENSITIVE_KEY.contains(entry.getKey())) {
                 sb.append("***");
             } else {
-                sb.append(entry.getValue());
+                String text = entry.getValue().toString();
+                if (withQuotation) {
+                    text = escaper.escape(text);
+                }
+                sb.append(text);
             }
             if (withQuotation) {
                 sb.append("\"");


### PR DESCRIPTION
Fixes #issue

If hive table definition properties contains quotation mark, then we can not handle table definition correctly.

```
CREATE EXTERNAL TABLE `ex_hive_tbl` (
  `col_tinyint` tinyint(4) NULL COMMENT "column tinyint",
) ENGINE=HIVE 
PROPERTIES (
"COLUMN_STATS_ACCURATE"  =  "{"BASIC_STATS":"true"}",
);
```

And if we use `create table like`, then we will get error message like 

```
Unexpected input 'BASIC_STATS', the most similar input is {',', ')'}.
```

And to fix this problem, we have to escape quotation mark in property value.  And for compatibility, we only escape quotation mark when `withQuotation = true`

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
