### PR TITLE
[Enhancement] don't copy iceberg file scan task when disable column statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -421,7 +421,10 @@ public class IcebergMetadata implements ConnectorMetadata {
             statisticProvider.updateIcebergFileStats(
                     icebergTable, scanTask, idToTypeMapping, nonPartitionPrimitiveColumns, key);
 
-            IcebergSplitScanTask icebergSplitScanTask = buildIcebergSplitScanTask(scanTask, icebergPredicate);
+            FileScanTask icebergSplitScanTask = scanTask;
+            if (enableCollectColumnStatistics()) {
+                icebergSplitScanTask = buildIcebergSplitScanTask(scanTask, icebergPredicate);
+            }
             icebergScanTasks.add(icebergSplitScanTask);
 
             String filePath = icebergSplitScanTask.file().path().toString();


### PR DESCRIPTION


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
