### PR TITLE
[BugFix] Fix bug of pushing down Iceberg table In-List predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -227,6 +227,9 @@ public class ScalarOperatorToIcebergExpr {
                         return literalValue;
                     }).collect(Collectors.toList());
 
+            // It should not be pushed down if there is an implicit cast
+            // TODO: Some functions within ScalarOperatorFunctions could be computed on frontends.
+            // Maybe we can obtain the result first and then convert it into an Iceberg expression.
             if (literalValues.stream().anyMatch(Objects::isNull)) {
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/ScalarOperatorToIcebergExpr.java
@@ -45,6 +45,7 @@ import org.apache.logging.log4j.Logger;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
@@ -225,6 +226,10 @@ public class ScalarOperatorToIcebergExpr {
                         }
                         return literalValue;
                     }).collect(Collectors.toList());
+
+            if (literalValues.stream().anyMatch(Objects::isNull)) {
+                return null;
+            }
 
             if (operator.isNotIn()) {
                 return notIn(columnName, literalValues);

--- a/test/sql/test_iceberg/R/test_iceberg_in_list_predicate
+++ b/test/sql/test_iceberg/R/test_iceberg_in_list_predicate
@@ -16,9 +16,11 @@ create table ice_tbl_${uuid0} (
 insert into ice_tbl_${uuid0} values ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000),
   ('3e82e36e56718dc4abc1168d21ec91ab', 2000),
   ('abc', 2000),
+  (NULL, 2000),
   ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001),
   ('3e82e36e56718dc4abc1168d21ec91ab', 2001),
-  ('abc', 2001);
+  ('abc', 2001),
+  (NULL, 2001);
 -- result:
 -- !result
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc');
@@ -48,6 +50,18 @@ select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in ('1d8cf2a
 -- result:
 1d8cf2a2c0e14fa89d8117792be6eb6f
 -- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and (col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc') or col_str is null);
+-- result:
+1d8cf2a2c0e14fa89d8117792be6eb6f
+None
+-- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and (col_str in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc')) or col_str is null);
+-- result:
+1d8cf2a2c0e14fa89d8117792be6eb6f
+None
+-- !result
+drop table ice_tbl_${uuid0};
+drop database ice_db_${uuid0};
 drop catalog ice_cat_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_iceberg/R/test_iceberg_in_list_predicate
+++ b/test/sql/test_iceberg/R/test_iceberg_in_list_predicate
@@ -60,7 +60,7 @@ select col_str from ice_tbl_${uuid0} where col_int=2000 and (col_str in ('1d8cf2
 1d8cf2a2c0e14fa89d8117792be6eb6f
 None
 -- !result
-drop table ice_tbl_${uuid0};
+drop table ice_tbl_${uuid0} force;
 drop database ice_db_${uuid0};
 drop catalog ice_cat_${uuid0};
 -- result:

--- a/test/sql/test_iceberg/R/test_iceberg_in_list_predicate
+++ b/test/sql/test_iceberg/R/test_iceberg_in_list_predicate
@@ -1,0 +1,53 @@
+-- name: test_iceberg_in_list_predicate
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+create table ice_tbl_${uuid0} (
+  col_str string,
+  col_int int
+);
+insert into ice_tbl_${uuid0} values ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000),
+  ('abc', 2000),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001),
+  ('abc', 2001);
+-- result:
+-- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc');
+-- result:
+1d8cf2a2c0e14fa89d8117792be6eb6f
+-- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), md5('abc')) order by 1;
+-- result:
+1d8cf2a2c0e14fa89d8117792be6eb6f
+abc
+-- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc')) order by 1;
+-- result:
+3e82e36e56718dc4abc1168d21ec91ab
+abc
+-- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc') order by 1;
+-- result:
+3e82e36e56718dc4abc1168d21ec91ab
+abc
+-- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), md5('abc'));
+-- result:
+3e82e36e56718dc4abc1168d21ec91ab
+-- !result
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc'));
+-- result:
+1d8cf2a2c0e14fa89d8117792be6eb6f
+-- !result
+drop catalog ice_cat_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_iceberg/T/test_iceberg_in_list_predicate
+++ b/test/sql/test_iceberg/T/test_iceberg_in_list_predicate
@@ -29,6 +29,6 @@ select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in (md5('1d8
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc'));
 select col_str from ice_tbl_${uuid0} where col_int=2000 and (col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc') or col_str is null);
 select col_str from ice_tbl_${uuid0} where col_int=2000 and (col_str in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc')) or col_str is null);
-drop table ice_tbl_${uuid0};
+drop table ice_tbl_${uuid0} force;
 drop database ice_db_${uuid0};
 drop catalog ice_cat_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_in_list_predicate
+++ b/test/sql/test_iceberg/T/test_iceberg_in_list_predicate
@@ -1,0 +1,28 @@
+-- name: test_iceberg_in_list_predicate
+create external catalog ice_cat_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog ice_cat_${uuid0};
+create database ice_db_${uuid0};
+use ice_db_${uuid0};
+create table ice_tbl_${uuid0} (
+  col_str string,
+  col_int int
+);
+insert into ice_tbl_${uuid0} values ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000),
+  ('abc', 2000),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001),
+  ('abc', 2001);
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc');
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), md5('abc')) order by 1;
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc')) order by 1;
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc') order by 1;
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), md5('abc'));
+select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc'));
+drop catalog ice_cat_${uuid0};

--- a/test/sql/test_iceberg/T/test_iceberg_in_list_predicate
+++ b/test/sql/test_iceberg/T/test_iceberg_in_list_predicate
@@ -16,13 +16,19 @@ create table ice_tbl_${uuid0} (
 insert into ice_tbl_${uuid0} values ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000),
   ('3e82e36e56718dc4abc1168d21ec91ab', 2000),
   ('abc', 2000),
+  (NULL, 2000),
   ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001),
   ('3e82e36e56718dc4abc1168d21ec91ab', 2001),
-  ('abc', 2001);
+  ('abc', 2001),
+  (NULL, 2001);
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc');
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), md5('abc')) order by 1;
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str not in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc')) order by 1;
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc') order by 1;
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), md5('abc'));
 select col_str from ice_tbl_${uuid0} where col_int=2000 and col_str in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc'));
+select col_str from ice_tbl_${uuid0} where col_int=2000 and (col_str not in (md5('1d8cf2a2c0e14fa89d8117792be6eb6f'), 'abc') or col_str is null);
+select col_str from ice_tbl_${uuid0} where col_int=2000 and (col_str in ('1d8cf2a2c0e14fa89d8117792be6eb6f', md5('abc')) or col_str is null);
+drop table ice_tbl_${uuid0};
+drop database ice_db_${uuid0};
 drop catalog ice_cat_${uuid0};


### PR DESCRIPTION
"ERROR : Cannot create expression literal from null",  when
there is an implicit conversion in the predicate In-List
e.g col_str in ('abc', md5('abc')). For Iceberg tables, if there
is implicit conversion in the predicate In-List, it should not be 
pushed down.

testing:
 - add end_2_end tests

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
