### PR TITLE
[BugFix] fix the error where the Delta Lake data path contains special char

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DeltaLakeScanNode.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -138,7 +139,8 @@ public class DeltaLakeScanNode extends ScanNode {
         }
         // use current snapshot now
         Snapshot snapshot = deltaLog.snapshot();
-        preProcessConjuncts(snapshot.getMetadata().getSchema());
+        Metadata metadata = snapshot.getMetadata();
+        preProcessConjuncts(metadata.getSchema());
         List<String> partitionColumnNames = snapshot.getMetadata().getPartitionColumns();
         // PartitionKey -> partition id
         Map<PartitionKey, Long> partitionKeys = Maps.newHashMap();
@@ -151,7 +153,6 @@ public class DeltaLakeScanNode extends ScanNode {
             List<String> partitionValues = partitionColumnNames.stream().map(partitionValueMap::get).collect(
                     Collectors.toList());
 
-            Metadata metadata = snapshot.getMetadata();
             PartitionKey partitionKey =
                     PartitionUtil.createPartitionKey(partitionValues, deltaLakeTable.getPartitionColumns(),
                             deltaLakeTable.getType());
@@ -167,7 +168,8 @@ public class DeltaLakeScanNode extends ScanNode {
         if (!partitionKeys.containsKey(partitionKey)) {
             partitionId = nextPartitionId();
             String tableLocation = deltaLakeTable.getTableLocation();
-            Path filePath = new Path(tableLocation, file.getPath());
+            Path p = new Path(URI.create(file.getPath()));
+            Path filePath = new Path(tableLocation, p);
 
             DescriptorTable.ReferencedPartitionInfo referencedPartitionInfo =
                     new DescriptorTable.ReferencedPartitionInfo(partitionId, partitionKey,
@@ -186,7 +188,7 @@ public class DeltaLakeScanNode extends ScanNode {
 
         THdfsScanRange hdfsScanRange = new THdfsScanRange();
 
-        hdfsScanRange.setRelative_path(new Path(file.getPath()).getName());
+        hdfsScanRange.setRelative_path(new Path(URI.create(file.getPath())).getName());
         hdfsScanRange.setOffset(0);
         hdfsScanRange.setLength(file.getSize());
         hdfsScanRange.setPartition_id(partitionId);


### PR DESCRIPTION
Fixes #issue

`select count(1) cnt from delta_catalog.dwd.delta_table_1 where dt>='2023-10-28' and `#event_name`='login' ;`
Execute error message：
`ERROR 1064 (HY000): code=404(SdkErrorType:133), message=The specified key does not exist.:file = oss://testbucket/dwd/delta_table_1/dt=2023-10-29/%2523event_name=login/part-00000-d0b6da22-f3fd-42dc-b4a3-277ba7970c0e.c000.snappy.parquet`

The actual path of the file is decoded by URL：
`oss://testbucket/dwd/delta_table_1/dt=2023-10-29/%23event_name=login/part-00000-d0b6da22-f3fd-42dc-b4a3-277ba7970c0e.c000.snappy.parquet`

The address of the delta lake metadata store is encoded by uri
![image](https://github.com/StarRocks/starrocks/assets/13195083/fdeff29d-c500-4b2e-8ade-c3979fd8710b)
data file path:
![image](https://github.com/StarRocks/starrocks/assets/13195083/ab6e3cb0-b4b7-4e8f-a374-35c1dbe5acc8)



## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5