### PR TITLE
[Enhancement] Reuse ColumnAccessPath logic in DLA's complex type subfield prune

### DIFF
--- a/be/src/column/column_access_path.cpp
+++ b/be/src/column/column_access_path.cpp
@@ -136,4 +136,139 @@ const std::string ColumnAccessPath::to_string() const {
     return ss.str();
 }
 
+void ColumnAccessPathUtil::rewrite_struct_type_descriptor(TypeDescriptor& original_type,
+                                                          const ColumnAccessPathPtr& access_path) {
+    DCHECK(original_type.is_struct_type());
+
+    if (is_select_all_subfields(access_path)) {
+        return;
+    }
+
+    // build child access path mapping
+    std::unordered_map<std::string, const ColumnAccessPathPtr&> subfield_mapping{};
+    for (const auto& child : access_path->children()) {
+        subfield_mapping.emplace(child->path(), child);
+    }
+
+    std::vector<std::string> new_subfield_names{};
+    std::vector<TypeDescriptor> new_subfield_types{};
+
+    for (size_t i = 0; i < original_type.children.size(); i++) {
+        TypeDescriptor& subfield_type = original_type.children[i];
+        const auto& subfield_name = original_type.field_names[i];
+
+        const auto& it = subfield_mapping.find(subfield_name);
+        if (it == subfield_mapping.end()) {
+            continue;
+        }
+
+        if (subfield_type.is_complex_type()) {
+            const ColumnAccessPathPtr& child_path = it->second;
+            DCHECK(child_path->is_field());
+            rewrite_complex_type_descriptor(subfield_type, child_path);
+        }
+
+        new_subfield_names.emplace_back(subfield_name);
+        new_subfield_types.emplace_back(subfield_type);
+    }
+
+    original_type.children = new_subfield_types;
+    original_type.field_names = new_subfield_names;
+}
+
+void ColumnAccessPathUtil::rewrite_map_type_descriptor(TypeDescriptor& original_type,
+                                                       const ColumnAccessPathPtr& access_path) {
+    DCHECK(original_type.is_map_type());
+    if (is_select_all_subfields(access_path)) {
+        return;
+    }
+
+    DCHECK_EQ(1, access_path->children().size());
+    ColumnAccessPathPtr& value_path = access_path->children()[0];
+
+    bool access_key = false;
+    bool access_value = false;
+
+    // TODO(SmithCruise) Not support to read offset column only
+    if (value_path->is_key() || value_path->is_offset()) {
+        access_key = true;
+    } else if (value_path->is_value()) {
+        access_value = true;
+    } else if (value_path->is_index() || value_path->is_all()) {
+        access_key = true;
+        access_value = true;
+    } else {
+        DCHECK(false) << "Error ColumnAccessPaths for MapType";
+        // Defense code, just select all
+        access_key = true;
+        access_value = true;
+    }
+
+    TypeDescriptor& key_type = original_type.children[0];
+    TypeDescriptor& value_type = original_type.children[1];
+
+    if (!access_key) {
+        key_type.type = TYPE_UNKNOWN;
+    }
+    if (!access_value) {
+        value_type.type = TYPE_UNKNOWN;
+        value_type.children.resize(0);
+        value_type.field_names.resize(0);
+    } else {
+        // Map value column may contains complex type, rewrite it either
+        if (value_type.is_complex_type()) {
+            // Consider for [/col2/VALUE/INDEX/a], we need to advance one level if it has child
+            // If is_value()=true, means it's map_values() function,
+            if (!value_path->children().empty()) {
+                DCHECK_EQ(1, value_path->children().size());
+                const ColumnAccessPathPtr& value_child_path = value_path->children()[0];
+                DCHECK(value_child_path->is_index());
+                rewrite_complex_type_descriptor(value_type, value_child_path);
+            }
+        }
+    }
+}
+
+void ColumnAccessPathUtil::rewrite_array_type_descriptor(TypeDescriptor& original_type,
+                                                         const ColumnAccessPathPtr& access_path) {
+    DCHECK(original_type.is_array_type());
+
+    TypeDescriptor& element_type = original_type.children[0];
+
+    if (!element_type.is_complex_type()) {
+        return;
+    }
+
+    if (is_select_all_subfields(access_path)) {
+        return;
+    }
+
+    DCHECK_EQ(1, access_path->children().size());
+    const ColumnAccessPathPtr& element_path = access_path->children()[0];
+    DCHECK(element_path->is_index());
+
+    rewrite_complex_type_descriptor(element_type, element_path);
+}
+
+void ColumnAccessPathUtil::rewrite_complex_type_descriptor(TypeDescriptor& original_type,
+                                                           const ColumnAccessPathPtr& access_path) {
+    if (original_type.is_struct_type()) {
+        rewrite_struct_type_descriptor(original_type, access_path);
+    } else if (original_type.is_map_type()) {
+        rewrite_map_type_descriptor(original_type, access_path);
+    } else if (original_type.is_array_type()) {
+        rewrite_array_type_descriptor(original_type, access_path);
+    } else {
+        DCHECK(false);
+    }
+}
+
+bool ColumnAccessPathUtil::is_select_all_subfields(const ColumnAccessPathPtr& path) {
+    if (path == nullptr || path->is_all() || path->children().empty()) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 } // namespace starrocks

--- a/be/src/column/column_access_path.h
+++ b/be/src/column/column_access_path.h
@@ -19,6 +19,7 @@
 
 #include "common/status.h"
 #include "gen_cpp/PlanNodes_types.h"
+#include "runtime/types.h"
 
 namespace starrocks {
 
@@ -50,6 +51,8 @@ public:
     std::vector<std::unique_ptr<ColumnAccessPath>>& children() { return _children; }
 
     bool is_key() const { return _type == TAccessPathType::type::KEY; }
+
+    bool is_value() const { return _type == TAccessPathType::type::VALUE; }
 
     bool is_offset() const { return _type == TAccessPathType::type::OFFSET; }
 
@@ -89,5 +92,16 @@ inline std::ostream& operator<<(std::ostream& out, const ColumnAccessPath& val) 
     out << val.to_string();
     return out;
 }
+
+class ColumnAccessPathUtil {
+public:
+    static void rewrite_complex_type_descriptor(TypeDescriptor& original_type, const ColumnAccessPathPtr& access_path);
+
+private:
+    static void rewrite_struct_type_descriptor(TypeDescriptor& original_type, const ColumnAccessPathPtr& access_path);
+    static void rewrite_map_type_descriptor(TypeDescriptor& original_type, const ColumnAccessPathPtr& access_path);
+    static void rewrite_array_type_descriptor(TypeDescriptor& original_type, const ColumnAccessPathPtr& access_path);
+    static bool is_select_all_subfields(const ColumnAccessPathPtr& path);
+};
 
 } // namespace starrocks

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -68,6 +68,46 @@ std::string HiveDataSource::name() const {
     return "HiveDataSource";
 }
 
+Status HiveDataSource::_try_to_rewrite_tuple_desc_type() {
+    // Init complex type ColumnAccessPaths
+    std::vector<ColumnAccessPathPtr> column_access_paths;
+    if (_provider->_hdfs_scan_node.__isset.column_access_paths) {
+        for (int i = 0; i < _provider->_hdfs_scan_node.column_access_paths.size(); ++i) {
+            auto path = std::make_unique<ColumnAccessPath>();
+            RETURN_IF_ERROR(path->init(_provider->_hdfs_scan_node.column_access_paths[i], _runtime_state, &_pool));
+            column_access_paths.emplace_back(std::move(path));
+        }
+    }
+
+    std::unordered_map<std::string, ColumnAccessPathPtr> column_name_2_column_access_path_mapping;
+
+    for (auto& column_access_path : column_access_paths) {
+        if (column_access_path->is_from_predicate()) {
+            // TODO(SmithCruise) We don't support complex type late materialize in catalog now,
+            // so ignore ColumnAccessPath from predicates
+            continue;
+        }
+        column_name_2_column_access_path_mapping.emplace(column_access_path->path(), std::move(column_access_path));
+    }
+
+    const std::vector<SlotDescriptor*>& slots = _tuple_desc->slots();
+
+    for (SlotDescriptor* slot : slots) {
+        const auto it = column_name_2_column_access_path_mapping.find(slot->col_name());
+        if (it == column_name_2_column_access_path_mapping.end()) {
+            continue;
+        }
+        TypeDescriptor& type = slot->type();
+        if (!type.is_complex_type()) {
+            continue;
+        }
+        ColumnAccessPathUtil::rewrite_complex_type_descriptor(type, it->second);
+        std::cout << "name: " << slot->col_name() << ", type: " << type.debug_string() << std::endl;
+    }
+
+    return Status::OK();
+}
+
 Status HiveDataSource::open(RuntimeState* state) {
     // right now we don't force user to set JAVA_HOME.
     // but when we access hdfs via JNI, we have to make sure JAVA_HOME is set,
@@ -84,6 +124,8 @@ Status HiveDataSource::open(RuntimeState* state) {
 
     _runtime_state = state;
     _tuple_desc = state->desc_tbl().get_tuple_descriptor(hdfs_scan_node.tuple_id);
+    // rewrite tuple desc type
+    RETURN_IF_ERROR(_try_to_rewrite_tuple_desc_type());
     _hive_table = dynamic_cast<const HiveTableDescriptor*>(_tuple_desc->table_desc());
     if (_hive_table == nullptr) {
         return Status::RuntimeError(

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "column/column_access_path.h"
 #include "column/vectorized_fwd.h"
 #include "connector/connector.h"
 #include "exec/connector_scan_node.h"
@@ -74,6 +75,8 @@ private:
     const THdfsScanRange _scan_range;
 
     // ============= init func =============
+    // Try to rewrite TypeDescriptor based on ColumnAccessPath
+    Status _try_to_rewrite_tuple_desc_type();
     Status _init_conjunct_ctxs(RuntimeState* state);
     void _update_has_any_predicate();
     Status _decompose_conjunct_ctxs(RuntimeState* state);

--- a/be/src/storage/rowset/map_column_iterator.cpp
+++ b/be/src/storage/rowset/map_column_iterator.cpp
@@ -57,6 +57,10 @@ Status MapColumnIterator::init(const ColumnIteratorOptions& opts) {
             _access_keys |= true;
         }
 
+        if (p->is_value()) {
+            _access_values |= true;
+        }
+
         if (p->is_all() || p->is_index()) {
             _access_values |= true;
             _access_keys |= true;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(EXEC_FILES
         ./column/object_column_test.cpp
         ./column/timestamp_value_test.cpp
         ./column/schema_test.cpp
+        ./column/column_access_path_test.cpp
         ./common/config_test.cpp
         ./common/status_test.cpp
         ./common/tracer_test.cpp

--- a/be/test/column/column_access_path_test.cpp
+++ b/be/test/column/column_access_path_test.cpp
@@ -1,0 +1,180 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "column/column_access_path.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+class ColumnAccessPathTest : public testing::Test {
+public:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+TEST_F(ColumnAccessPathTest, test_struct) {
+    ColumnAccessPathPtr root = std::make_unique<ColumnAccessPath>();
+    Status st = root->init(TAccessPathType::ROOT, "c1", -1);
+    ASSERT_TRUE(st.ok());
+
+    ColumnAccessPathPtr subfield1 = std::make_unique<ColumnAccessPath>();
+    st = subfield1->init(TAccessPathType::FIELD, "subfield1", -1);
+    ASSERT_TRUE(st.ok());
+    root->children().emplace_back(std::move(subfield1));
+
+    {
+        TypeDescriptor struct_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        struct_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        struct_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        struct_type.field_names.emplace_back("subfield1");
+        struct_type.field_names.emplace_back("subfield2");
+
+        ColumnAccessPathUtil::rewrite_complex_type_descriptor(struct_type, nullptr);
+        ASSERT_EQ("STRUCT{subfield1 INT, subfield2 INT}", struct_type.debug_string());
+
+        ColumnAccessPathUtil::rewrite_complex_type_descriptor(struct_type, root);
+        ASSERT_EQ("STRUCT{subfield1 INT}", struct_type.debug_string());
+    }
+
+    {
+        TypeDescriptor struct_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+        TypeDescriptor struct_struct_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+
+        struct_struct_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        struct_struct_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+        struct_struct_type.field_names.emplace_back("subfield1");
+        struct_struct_type.field_names.emplace_back("subfield2");
+
+        struct_type.children.emplace_back(struct_struct_type);
+        struct_type.field_names.emplace_back("subfield1");
+
+        ColumnAccessPathPtr subfield1_subfield1 = std::make_unique<ColumnAccessPath>();
+        st = subfield1_subfield1->init(TAccessPathType::FIELD, "subfield1", -1);
+        ASSERT_TRUE(st.ok());
+        root->children()[0]->children().emplace_back(std::move(subfield1_subfield1));
+
+        ColumnAccessPathUtil::rewrite_complex_type_descriptor(struct_type, root);
+        ASSERT_EQ("STRUCT{subfield1 STRUCT{subfield1 INT}}", struct_type.debug_string());
+    }
+}
+
+TEST_F(ColumnAccessPathTest, test_map_keys) {
+    ColumnAccessPathPtr root = std::make_unique<ColumnAccessPath>();
+    Status st = root->init(TAccessPathType::ROOT, "c1", -1);
+    ASSERT_TRUE(st.ok());
+
+    ColumnAccessPathPtr keys = std::make_unique<ColumnAccessPath>();
+    st = keys->init(TAccessPathType::KEY, "P", -1);
+    ASSERT_TRUE(st.ok());
+    root->children().emplace_back(std::move(keys));
+
+    TypeDescriptor map_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_MAP);
+    map_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+    map_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+
+    ColumnAccessPathUtil::rewrite_complex_type_descriptor(map_type, root);
+    ASSERT_EQ("MAP<INT, INVALID>", map_type.debug_string());
+}
+
+TEST_F(ColumnAccessPathTest, test_map_values) {
+    ColumnAccessPathPtr root = std::make_unique<ColumnAccessPath>();
+    Status st = root->init(TAccessPathType::ROOT, "c1", -1);
+    ASSERT_TRUE(st.ok());
+
+    ColumnAccessPathPtr keys = std::make_unique<ColumnAccessPath>();
+    st = keys->init(TAccessPathType::VALUE, "P", -1);
+    ASSERT_TRUE(st.ok());
+    root->children().emplace_back(std::move(keys));
+
+    TypeDescriptor map_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_MAP);
+    map_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+    map_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+
+    ColumnAccessPathUtil::rewrite_complex_type_descriptor(map_type, nullptr);
+    ASSERT_EQ("MAP<INT, INT>", map_type.debug_string());
+
+    ColumnAccessPathUtil::rewrite_complex_type_descriptor(map_type, root);
+    ASSERT_EQ("MAP<INVALID, INT>", map_type.debug_string());
+}
+
+TEST_F(ColumnAccessPathTest, test_map_values_struct) {
+    ColumnAccessPathPtr root = std::make_unique<ColumnAccessPath>();
+    Status st = root->init(TAccessPathType::ROOT, "c1", -1);
+    ASSERT_TRUE(st.ok());
+
+    ColumnAccessPathPtr keys = std::make_unique<ColumnAccessPath>();
+    st = keys->init(TAccessPathType::VALUE, "P", -1);
+    ASSERT_TRUE(st.ok());
+    root->children().emplace_back(std::move(keys));
+
+    ColumnAccessPathPtr keys_index = std::make_unique<ColumnAccessPath>();
+    st = keys_index->init(TAccessPathType::INDEX, "P", -1);
+    ASSERT_TRUE(st.ok());
+    root->children()[0]->children().emplace_back(std::move(keys_index));
+
+    ColumnAccessPathPtr keys_index_field = std::make_unique<ColumnAccessPath>();
+    st = keys_index_field->init(TAccessPathType::FIELD, "subfield1", -1);
+    ASSERT_TRUE(st.ok());
+    root->children()[0]->children()[0]->children().emplace_back(std::move(keys_index_field));
+
+    TypeDescriptor map_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_MAP);
+    map_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+
+    TypeDescriptor map_value_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+    map_value_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+    map_value_type.children.emplace_back(TypeDescriptor::from_logical_type(LogicalType::TYPE_INT));
+    map_value_type.field_names.emplace_back("subfield1");
+    map_value_type.field_names.emplace_back("subfield2");
+
+    map_type.children.emplace_back(map_value_type);
+
+    ColumnAccessPathUtil::rewrite_complex_type_descriptor(map_type, nullptr);
+    ASSERT_EQ("MAP<INT, STRUCT{subfield1 INT, subfield2 INT}>", map_type.debug_string());
+
+    ColumnAccessPathUtil::rewrite_complex_type_descriptor(map_type, root);
+    ASSERT_EQ("MAP<INVALID, STRUCT{subfield1 INT}>", map_type.debug_string());
+}
+
+TEST_F(ColumnAccessPathTest, test_array_struct) {
+    ColumnAccessPathPtr root = std::make_unique<ColumnAccessPath>();
+    Status st = root->init(TAccessPathType::ROOT, "c1", -1);
+    ASSERT_TRUE(st.ok());
+
+    ColumnAccessPathPtr elements = std::make_unique<ColumnAccessPath>();
+    st = elements->init(TAccessPathType::INDEX, "P", -1);
+    ASSERT_TRUE(st.ok());
+    root->children().emplace_back(std::move(elements));
+
+    ColumnAccessPathPtr elements_struct = std::make_unique<ColumnAccessPath>();
+    st = elements_struct->init(TAccessPathType::FIELD, "subfield1", -1);
+    ASSERT_TRUE(st.ok());
+    root->children()[0]->children().emplace_back(std::move(elements_struct));
+
+    TypeDescriptor array_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_ARRAY);
+    TypeDescriptor array_struct_type = TypeDescriptor::from_logical_type(LogicalType::TYPE_STRUCT);
+    array_struct_type.children.emplace_back(TypeDescriptor::from_logical_type(TYPE_INT));
+    array_struct_type.children.emplace_back(TypeDescriptor::from_logical_type(TYPE_INT));
+    array_struct_type.field_names.emplace_back("subfield1");
+    array_struct_type.field_names.emplace_back("subfield2");
+    array_type.children.emplace_back(array_struct_type);
+
+    ColumnAccessPathUtil::rewrite_complex_type_descriptor(array_type, nullptr);
+    ASSERT_EQ("ARRAY<STRUCT{subfield1 INT, subfield2 INT}>", array_type.debug_string());
+
+    ColumnAccessPathUtil::rewrite_complex_type_descriptor(array_type, root);
+    ASSERT_EQ("ARRAY<STRUCT{subfield1 INT}>", array_type.debug_string());
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/planner/CatalogScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/CatalogScanNode.java
@@ -1,0 +1,96 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.base.Preconditions;
+import com.starrocks.analysis.SlotDescriptor;
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.catalog.ColumnAccessPath;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Type;
+import com.starrocks.connector.CatalogConnector;
+import com.starrocks.credential.CloudConfiguration;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.plan.HDFSScanNodePredicates;
+import com.starrocks.thrift.TCloudConfiguration;
+import com.starrocks.thrift.THdfsScanNode;
+import org.apache.commons.collections4.CollectionUtils;
+
+import java.util.List;
+
+public abstract class CatalogScanNode extends ScanNode {
+
+    protected CloudConfiguration cloudConfiguration = null;
+    // isEnableOriginalPruneComplexTypes means is use the original catalog's subfield prune rule
+    private boolean isEnableOriginalPruneComplexTypes = false;
+
+    public CatalogScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
+        super(id, desc, planNodeName);
+        setupCloudCredential(desc.getTable());
+    }
+
+    protected void setupCloudCredential(Table table) {
+        String catalogName = table.getCatalogName();
+        if (catalogName == null) {
+            return;
+        }
+        CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);
+        Preconditions.checkState(connector != null,
+                String.format("connector of catalog %s should not be null", catalogName));
+        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
+        Preconditions.checkState(cloudConfiguration != null,
+                String.format("cloudConfiguration of catalog %s should not be null", catalogName));
+    }
+
+    public void setColumnAccessPaths(boolean isEnableOriginalPruneComplexTypes,
+                                     List<ColumnAccessPath> columnAccessPaths) {
+        this.isEnableOriginalPruneComplexTypes = isEnableOriginalPruneComplexTypes;
+        this.columnAccessPaths = columnAccessPaths;
+    }
+
+    protected String explainCatalogComplexTypePrune(String prefix) {
+        StringBuilder output = new StringBuilder();
+        if (isEnableOriginalPruneComplexTypes) {
+            for (SlotDescriptor slotDescriptor : desc.getSlots()) {
+                Type type = slotDescriptor.getOriginType();
+                if (type.isComplexType()) {
+                    output.append(prefix)
+                            .append(String.format("Pruned type: %d [%s] <-> [%s]\n", slotDescriptor.getId().asInt(), slotDescriptor.getColumn().getName(), type));
+                }
+            }
+        } else {
+            output.append(explainColumnAccessPath(prefix));
+        }
+        return output.toString();
+    }
+
+    protected void setColumnAccessPathToThrift(THdfsScanNode tHdfsScanNode) {
+        if (isEnableOriginalPruneComplexTypes) {
+            // We've already pruned SlotDescriptor's type, don't need to pass ColumnAccessPath anymore
+            return;
+        }
+        if (CollectionUtils.isNotEmpty(columnAccessPaths)) {
+            tHdfsScanNode.setColumn_access_paths(columnAccessPathToThrift());
+        }
+    }
+
+    protected void setCloudConfigurationToThrift(THdfsScanNode tHdfsScanNode) {
+        if (cloudConfiguration != null) {
+            TCloudConfiguration tCloudConfiguration = new TCloudConfiguration();
+            cloudConfiguration.toThrift(tCloudConfiguration);
+            tHdfsScanNode.setCloud_configuration(tCloudConfiguration);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -766,14 +766,6 @@ public class OlapScanNode extends ScanNode {
         }
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            for (SlotDescriptor slotDescriptor : desc.getSlots()) {
-                Type type = slotDescriptor.getOriginType();
-                if (type.isComplexType()) {
-                    output.append(prefix)
-                            .append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
-                }
-            }
-
             if (!bucketColumns.isEmpty() && FeConstants.showScanNodeLocalShuffleColumnsInExplain) {
                 output.append(prefix).append("LocalShuffleColumns:\n");
                 for (ColumnRefOperator col : bucketColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PaimonScanNode.java
@@ -38,6 +38,7 @@ import com.starrocks.thrift.TPlanNodeType;
 import com.starrocks.thrift.TScanRange;
 import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.paimon.data.BinaryRow;
@@ -56,18 +57,16 @@ import java.util.stream.Collectors;
 import static com.starrocks.thrift.TExplainLevel.VERBOSE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-public class PaimonScanNode extends ScanNode {
+public class PaimonScanNode extends CatalogScanNode {
     private static final Logger LOG = LogManager.getLogger(PaimonScanNode.class);
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
     private final PaimonTable paimonTable;
     private final HDFSScanNodePredicates scanNodePredicates = new HDFSScanNodePredicates();
     private final List<TScanRangeLocations> scanRangeLocationsList = new ArrayList<>();
-    private CloudConfiguration cloudConfiguration = null;
 
     public PaimonScanNode(PlanNodeId id, TupleDescriptor desc, String planNodeName) {
         super(id, desc, planNodeName);
         this.paimonTable = (PaimonTable) desc.getTable();
-        setupCloudCredential();
     }
 
     public HDFSScanNodePredicates getScanNodePredicates() {
@@ -76,19 +75,6 @@ public class PaimonScanNode extends ScanNode {
 
     public PaimonTable getPaimonTable() {
         return paimonTable;
-    }
-
-    private void setupCloudCredential() {
-        String catalog = paimonTable.getCatalogName();
-        if (catalog == null) {
-            return;
-        }
-        CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalog);
-        Preconditions.checkState(connector != null,
-                String.format("connector of catalog %s should not be null", catalog));
-        cloudConfiguration = connector.getMetadata().getCloudConfiguration();
-        Preconditions.checkState(cloudConfiguration != null,
-                String.format("cloudConfiguration of catalog %s should not be null", catalog));
     }
 
     @Override
@@ -204,13 +190,7 @@ public class PaimonScanNode extends ScanNode {
         output.append(prefix).append(String.format("avgRowSize=%s\n", avgRowSize));
 
         if (detailLevel == TExplainLevel.VERBOSE) {
-            for (SlotDescriptor slotDescriptor : desc.getSlots()) {
-                Type type = slotDescriptor.getOriginType();
-                if (type.isComplexType()) {
-                    output.append(prefix)
-                            .append(String.format("Pruned type: %d <-> [%s]\n", slotDescriptor.getId().asInt(), type));
-                }
-            }
+            output.append(explainCatalogComplexTypePrune(prefix));
         }
 
         return output.toString();
@@ -235,8 +215,9 @@ public class PaimonScanNode extends ScanNode {
             msg.hdfs_scan_node.setTable_name(paimonTable.getName());
         }
 
+        setColumnAccessPathToThrift(tHdfsScanNode);
+        setCloudConfigurationToThrift(tHdfsScanNode);
         HdfsScanNode.setScanOptimizeOptionToThrift(tHdfsScanNode, this);
-        HdfsScanNode.setCloudConfigurationToThrift(tHdfsScanNode, cloudConfiguration);
         HdfsScanNode.setMinMaxConjunctsToThrift(tHdfsScanNode, this, this.getScanNodePredicates());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1384,7 +1384,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int cboReorderThresholdUseExhaustive = 6;
 
     @VarAttr(name = ENABLE_PRUNE_COMPLEX_TYPES)
-    private boolean enablePruneComplexTypes = true;
+    private boolean enablePruneComplexTypes = false;
 
     @VarAttr(name = ENABLE_SUBFIELD_NO_COPY)
     private boolean enableSubfieldNoCopy = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/DeltaLakeScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/DeltaLakeScanImplementationRule.java
@@ -36,6 +36,7 @@ public class DeltaLakeScanImplementationRule extends ImplementationRule {
         LogicalDeltaLakeScanOperator logicalDeltaLakeScanOperator = (LogicalDeltaLakeScanOperator) input.getOp();
         PhysicalDeltaLakeScanOperator physicalDeltaLakeScan =
                 new PhysicalDeltaLakeScanOperator(logicalDeltaLakeScanOperator);
+        physicalDeltaLakeScan.setColumnAccessPaths(logicalDeltaLakeScanOperator.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalDeltaLakeScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/FileScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/FileScanImplementationRule.java
@@ -35,6 +35,7 @@ public class FileScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalFileScanOperator scan = (LogicalFileScanOperator) input.getOp();
         PhysicalFileScanOperator physicalFileScan = new PhysicalFileScanOperator(scan);
+        physicalFileScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalFileScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HiveScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HiveScanImplementationRule.java
@@ -35,6 +35,7 @@ public class HiveScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalHiveScanOperator scan = (LogicalHiveScanOperator) input.getOp();
         PhysicalHiveScanOperator physicalHiveScan = new PhysicalHiveScanOperator(scan);
+        physicalHiveScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalHiveScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HudiScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HudiScanImplementationRule.java
@@ -34,6 +34,7 @@ public class HudiScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalHudiScanOperator scan = (LogicalHudiScanOperator) input.getOp();
         PhysicalHudiScanOperator physicalHudiScan = new PhysicalHudiScanOperator(scan);
+        physicalHudiScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalHudiScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/IcebergScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/IcebergScanImplementationRule.java
@@ -36,6 +36,7 @@ public class IcebergScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalIcebergScanOperator scan = (LogicalIcebergScanOperator) input.getOp();
         PhysicalIcebergScanOperator physicalIcebergScan = new PhysicalIcebergScanOperator(scan);
+        physicalIcebergScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalIcebergScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PaimonScanImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/PaimonScanImplementationRule.java
@@ -35,6 +35,7 @@ public class PaimonScanImplementationRule extends ImplementationRule {
     public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
         LogicalPaimonScanOperator scan = (LogicalPaimonScanOperator) input.getOp();
         PhysicalPaimonScanOperator physicalPaimonScan = new PhysicalPaimonScanOperator(scan);
+        physicalPaimonScan.setColumnAccessPaths(scan.getColumnAccessPaths());
         OptExpression result = new OptExpression(physicalPaimonScan);
         return Lists.newArrayList(result);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneSubfieldsForComplexType.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.optimizer.rule.tree;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ComplexTypeAccessGroup;
 import com.starrocks.catalog.Type;
-import com.starrocks.common.FeConstants;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.operator.OperatorType;
@@ -170,7 +169,7 @@ public class PruneSubfieldsForComplexType implements TreeRewriteRule {
         public Void visitPhysicalScan(OptExpression optExpression, PruneComplexTypeUtil.Context context) {
             PhysicalScanOperator physicalScanOperator = (PhysicalScanOperator) optExpression.getOp();
 
-            if (OperatorType.PHYSICAL_OLAP_SCAN.equals(physicalScanOperator.getOpType()) && !FeConstants.runningUnitTest) {
+            if (OperatorType.PHYSICAL_OLAP_SCAN.equals(physicalScanOperator.getOpType())) {
                 // olap scan operator prune column not in this rule
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -35,7 +35,7 @@ import java.util.List;
 
 public class PruneSubfieldRule extends TransformationRule {
     public static final List<String> SUPPORT_FUNCTIONS = ImmutableList.<String>builder()
-            .add(FunctionSet.MAP_KEYS, FunctionSet.MAP_SIZE)
+            .add(FunctionSet.MAP_KEYS, FunctionSet.MAP_VALUES, FunctionSet.MAP_SIZE)
             .add(FunctionSet.ARRAY_LENGTH)
             .add(FunctionSet.CARDINALITY)
             .build();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -146,14 +146,18 @@ public class SubfieldAccessPathNormalizer {
                 return Optional.empty();
             }
 
-            if (call.getFnName().equals(FunctionSet.MAP_KEYS)) {
-                return childrenAccessPaths.get(0)
-                        .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.KEY));
-            } else if (FunctionSet.MAP_SIZE.equals(call.getFnName())
-                    || FunctionSet.CARDINALITY.equals(call.getFnName())
-                    || FunctionSet.ARRAY_LENGTH.equals(call.getFnName())) {
-                return childrenAccessPaths.get(0)
-                        .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.OFFSET));
+            switch (call.getFnName()) {
+                case FunctionSet.MAP_KEYS:
+                    return childrenAccessPaths.get(0)
+                            .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.KEY));
+                case FunctionSet.MAP_VALUES:
+                    return childrenAccessPaths.get(0)
+                            .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.VALUE));
+                case FunctionSet.MAP_SIZE:
+                case FunctionSet.CARDINALITY:
+                case FunctionSet.ARRAY_LENGTH:
+                    return childrenAccessPaths.get(0)
+                            .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.OFFSET));
             }
 
             return Optional.empty();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -970,6 +970,10 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
+            // set column access path
+            hudiScanNode.setColumnAccessPaths(
+                    context.getConnectContext().getSessionVariable().getEnablePruneComplexTypes(),
+                    computeAllColumnAccessPath(node, context));
             hudiScanNode.setLimit(node.getLimit());
 
             tupleDescriptor.computeMemLayout();
@@ -1011,6 +1015,10 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
+            // set column access path
+            hdfsScanNode.setColumnAccessPaths(
+                    context.getConnectContext().getSessionVariable().getEnablePruneComplexTypes(),
+                    computeAllColumnAccessPath(node, context));
             hdfsScanNode.setLimit(node.getLimit());
 
             tupleDescriptor.computeMemLayout();
@@ -1050,6 +1058,10 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
+            // set column access path
+            fileTableScanNode.setColumnAccessPaths(
+                    context.getConnectContext().getSessionVariable().getEnablePruneComplexTypes(),
+                    computeAllColumnAccessPath(node, context));
             fileTableScanNode.setLimit(node.getLimit());
 
             tupleDescriptor.computeMemLayout();
@@ -1101,6 +1113,10 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
+            // set column access path
+            deltaLakeScanNode.setColumnAccessPaths(
+                    context.getConnectContext().getSessionVariable().getEnablePruneComplexTypes(),
+                    computeAllColumnAccessPath(node, context));
             deltaLakeScanNode.setLimit(node.getLimit());
 
             tupleDescriptor.computeMemLayout();
@@ -1144,6 +1160,10 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
+            // set column access path
+            paimonScanNode.setColumnAccessPaths(
+                    context.getConnectContext().getSessionVariable().getEnablePruneComplexTypes(),
+                    computeAllColumnAccessPath(node, context));
             paimonScanNode.setLimit(node.getLimit());
 
             tupleDescriptor.computeMemLayout();
@@ -1193,6 +1213,10 @@ public class PlanFragmentBuilder {
                 throw new StarRocksPlannerException(e.getMessage(), INTERNAL_ERROR);
             }
 
+            // set column access path
+            icebergScanNode.setColumnAccessPaths(
+                    context.getConnectContext().getSessionVariable().getEnablePruneComplexTypes(),
+                    computeAllColumnAccessPath(node, context));
             icebergScanNode.setLimit(node.getLimit());
 
             tupleDescriptor.computeMemLayout();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -353,24 +353,31 @@ public class MockedHiveMetadata implements ConnectorMetadata {
         MOCK_TABLE_MAP.putIfAbsent(MOCKED_SUBFIELD_DB, new CaseInsensitiveMap<>());
         Map<String, HiveTableInfo> mockTables = MOCK_TABLE_MAP.get(MOCKED_SUBFIELD_DB);
 
-        // Mock table region
         List<FieldSchema> cols = Lists.newArrayList();
         cols.add(new FieldSchema("col_int", "int", null));
         cols.add(new FieldSchema("col_struct", "struct<c0: int, c1: struct<c11: int>>", null));
+        cols.add(new FieldSchema("c1", "int", null));
+        cols.add(new FieldSchema("c2", "array<struct<c2_sub1: int, c2_sub2: int>>", null));
+        cols.add(new FieldSchema("c3",
+                "struct<c3_sub1: array<struct<c3_sub1_sub1: int, c3_sub1_sub2: int>>, c3_sub2: int>", null));
         StorageDescriptor sd =
                 new StorageDescriptor(cols, "", MAPRED_PARQUET_INPUT_FORMAT_CLASS, "", false,
                         -1, null, Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap());
 
-        CaseInsensitiveMap<String, ColumnStatistic> regionStats = new CaseInsensitiveMap<>();
-        regionStats.put("col_int", ColumnStatistic.unknown());
-        regionStats.put("col_struct", ColumnStatistic.unknown());
+        CaseInsensitiveMap<String, ColumnStatistic> subfieldStats = new CaseInsensitiveMap<>();
+        subfieldStats.put("col_int", ColumnStatistic.unknown());
+        subfieldStats.put("col_struct", ColumnStatistic.unknown());
+        subfieldStats.put("c1", ColumnStatistic.unknown());
+        subfieldStats.put("c2", ColumnStatistic.unknown());
+        subfieldStats.put("c3", ColumnStatistic.unknown());
 
         Table tbl =
                 new Table("subfield", MOCKED_SUBFIELD_DB, null, 0, 0, 0, sd, Lists.newArrayList(), Maps.newHashMap(), null, null,
                         "EXTERNAL_TABLE");
         mockTables.put(tbl.getTableName(),
                 new HiveTableInfo(HiveMetastoreApiConverter.toHiveTable(tbl, MOCKED_HIVE_CATALOG_NAME),
-                        ImmutableList.of(), 5, regionStats, MOCKED_FILES));
+                        ImmutableList.of(), 5, subfieldStats, MOCKED_FILES));
+
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ComplexTypePrunePlanTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.FeConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -43,6 +44,13 @@ public class ComplexTypePrunePlanTest extends PlanTestBase {
     @Before
     public void setup() throws Exception {
         connectContext.getSessionVariable().setCboPruneSubfield(true);
+    }
+
+    @Test
+    public void testNamedStruct() throws Exception {
+        String sql = "select q.t.c0 from (select named_struct('c0', c0, 'c1', c0) as t from test)q";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveComplexTypePrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveComplexTypePrunePlanTest.java
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class HiveComplexTypePrunePlanTest extends PlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+    }
+
+    @After
+    public void resetSessionVariable() {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
+    }
+
+    @Test
+    public void testAggCTE() throws Exception {
+        String sql = "with stream as (select array_agg(col_struct.c0) as t1 from hive0.subfield_db.subfield group by " +
+                "col_int) select t1 from stream";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "[/col_struct/c0]");
+
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "Pruned type: 9 [col_struct] <-> [struct<c0 int(11)>]");
+    }
+
+    @Test
+    public void testNoProjectOnTF() throws Exception {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        // no project on input, and no project on tf, no prune
+        String sql = "select c2_struct from hive0.subfield_db.subfield, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        sql = "select c2 from hive0.subfield_db.subfield, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        sql = "select c2, c2_struct from hive0.subfield_db.subfield, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        // project on input, no project on tf, prune
+        sql = "select c3_struct from hive0.subfield_db.subfield, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        // output contains the complete column, no prune
+        sql = "select c3 from hive0.subfield_db.subfield, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), " +
+                "c3_sub1_sub2 int(11)>>, c3_sub2 int(11)>]");
+        sql = "select c3, c3_struct from hive0.subfield_db.subfield, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), " +
+                "c3_sub1_sub2 int(11)>>, c3_sub2 int(11)>]");
+    }
+
+    @Test
+    public void testProjectOnTF() throws Exception {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        // no project on input, and project on tf, prune
+        String sql = "select c2_struct.c2_sub1 from hive0.subfield_db.subfield, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        // no project on input, and project on tf all subfiled, no prune
+        sql =
+                "select c2_struct.c2_sub1, c2_struct.c2_sub2 from hive0.subfield_db.subfield, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        sql = "select c2_struct, c2_struct.c2_sub2 from hive0.subfield_db.subfield, unnest(c2) as t(c2_struct);";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11), c2_sub2 int(11)>>]");
+        // project on input, project on tf, prune
+        sql = "select c3_struct.c3_sub1_sub1 from hive0.subfield_db.subfield, unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+        // project on input, project on tf but all subfiled, prune
+        sql = "select c3_struct.c3_sub1_sub1, c3_struct.c3_sub1_sub2 from hive0.subfield_db.subfield, " +
+                "unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+        sql = "select c3_struct.c3_sub1_sub1, c3_struct from hive0.subfield_db.subfield, " +
+                "unnest(c3.c3_sub1) as t(c3_struct);";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11), c3_sub1_sub2 int(11)>>>]");
+    }
+
+    @Test
+    public void testNoOutputOnTF() throws Exception {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        String sql =
+                "select c1 from hive0.subfield_db.subfield, unnest(c2) as t(c2_struct) where c2_struct.c2_sub1 > 0;";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        sql =
+                "select c1 from hive0.subfield_db.subfield, unnest(c3.c3_sub1) as t(c3_struct) where c3_struct.c3_sub1_sub1 > 0;";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+    }
+
+    @Test
+    public void testUnnestComplex() throws Exception {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        String sql = "select c3_struct.c3_sub1_sub1 from hive0.subfield_db.subfield, unnest(c2) as t(c_struct), " +
+                "unnest(c3.c3_sub1) as tt(c3_struct) where c_struct.c2_sub1 > 10";
+        assertVerbosePlanContains(sql, "[ARRAY<struct<c2_sub1 int(11)>>]");
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+    }
+
+    @Test
+    public void testUnnestCrossJoin() throws Exception {
+        connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
+        String sql = "select c3_struct.c3_sub1_sub1 from hive0.subfield_db.subfield cross join " +
+                "unnest(c3.c3_sub1) as t(c3_struct) where c1 > 0;";
+        assertVerbosePlanContains(sql, "[struct<c3_sub1 array<struct<c3_sub1_sub1 int(11)>>>]");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.plan;
 
-import com.starrocks.server.GlobalStateMgr;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -24,7 +23,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         PlanTestNoneDBBase.beforeClass();
-        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
         String dbName = "prune_column_test";
         starRocksAssert.withDatabase(dbName).useDatabase(dbName);
 
@@ -169,7 +167,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
 
         sql = "select map_values(map2) from pc0";
         plan = getVerboseExplain(sql);
-        assertNotContains(plan, "ColumnAccessPath");
+        assertContains(plan, "[/map2/VALUE]");
 
         sql = "select map_keys(map3[1][2]) from pc0";
         plan = getVerboseExplain(sql);
@@ -261,7 +259,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     public void testPruneMapValues() throws Exception {
         String sql = "select map_keys(map1), map_values(map1) from pc0";
         String plan = getVerboseExplain(sql);
-        assertNotContains(plan, "ColumnAccessPath");
+        assertContains(plan, "[/map1/ALL]");
 
         sql = "select map_keys(map1), map_size(map1) from pc0";
         plan = getVerboseExplain(sql);
@@ -650,7 +648,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                     "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
                     "     tabletList=\n" +
                     "     actualRows=0, avgRowSize=1.0\n" +
-                    "     Pruned type: 7 <-> [ARRAY<INT>]\n" +
                     "     cardinality: 1");
 
         }
@@ -664,7 +661,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                     "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
                     "     tabletList=\n" +
                     "     actualRows=0, avgRowSize=3.0\n" +
-                    "     Pruned type: 4 <-> [struct<s1 int(11), s2 int(11), sa3 array<int(11)>>]\n" +
                     "     ColumnAccessPath: [/st3/sa3]\n" +
                     "     cardinality: 1\n");
         }
@@ -682,7 +678,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                     "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
                     "     tabletList=\n" +
                     "     actualRows=0, avgRowSize=3.0\n" +
-                    "     Pruned type: 7 <-> [ARRAY<INT>]\n" +
                     "     ColumnAccessPath: [/a1/INDEX]\n" +
                     "     cardinality: 1");
         }
@@ -696,7 +691,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                     "     partitionsRatio=0/1, tabletsRatio=0/0\n" +
                     "     tabletList=\n" +
                     "     actualRows=0, avgRowSize=3.0\n" +
-                    "     Pruned type: 4 <-> [struct<s1 int(11), s2 int(11), sa3 array<int(11)>>]\n" +
                     "     ColumnAccessPath: [/st3/sa3/ALL]\n" +
                     "     cardinality: 1\n");
         }

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -481,6 +481,7 @@ enum TAccessPathType {
     FIELD,      // STRUCT FIELD
     INDEX,      // ARRAY/MAP INDEX-AT POSITION DATA
     ALL,        // ARRAY/MAP ALL DATA
+    VALUE,      // MAP VALUE
 }
 
 struct TColumnAccessPath {
@@ -1047,6 +1048,8 @@ struct THdfsScanNode {
     15: optional bool can_use_min_max_count_opt;
 
     16: optional bool use_partition_column_value_only;
+
+    17: optional list<TColumnAccessPath> column_access_paths;
 }
 
 struct TProjectNode {


### PR DESCRIPTION
We should maintain one complex type prune framework in starrocks.

Not support prune unnest() now

If you `set enable_prune_complex_types=true`, we will reuse the original prune rule in the catalog.

Since creating a const column to replace an unselected subfield will bring non-negligible overhead, on the BE side, the TypeDescriptor should be pruned based on ColumnAccessPath.

For example, `SELECT col.a FROM tbl`, FE will send complete struct type `col: struct<a int, b int>` to BE, then BE will according to ColumnAccessPath to prune TypeDescriptor, we will rewrite col's type to `struct<a int>` before `fill_chunk()`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
