### PR TITLE
[Enhancement] Avoid checking group concurrency_limit when enabling group level queue (#34398)

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -185,7 +185,16 @@ Status FragmentExecutor::_prepare_workgroup(const UnifiedExecPlanFragmentParams&
         wg = WorkGroupManager::instance()->add_workgroup(wg);
     }
     DCHECK(wg != nullptr);
-    RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get()));
+
+    const auto& query_options = request.common().query_options;
+    bool enable_group_level_query_queue = false;
+    if (query_options.__isset.query_queue_options) {
+        const auto& queue_options = query_options.query_queue_options;
+        enable_group_level_query_queue =
+                queue_options.__isset.enable_group_level_query_queue && queue_options.enable_group_level_query_queue;
+    }
+    RETURN_IF_ERROR(_query_ctx->init_query_once(wg.get(), enable_group_level_query_queue));
+
     _fragment_ctx->set_workgroup(wg);
     _wg = wg;
 

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -139,12 +139,12 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
     });
 }
 
-Status QueryContext::init_query_once(workgroup::WorkGroup* wg) {
+Status QueryContext::init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue) {
     Status st = Status::OK();
     if (wg != nullptr) {
-        std::call_once(_init_query_once, [this, &st, wg]() {
+        std::call_once(_init_query_once, [this, &st, wg, enable_group_level_query_queue]() {
             this->init_query_begin_time();
-            auto maybe_token = wg->acquire_running_query_token();
+            auto maybe_token = wg->acquire_running_query_token(enable_group_level_query_queue);
             if (maybe_token.ok()) {
                 _wg_running_query_token_ptr = std::move(maybe_token.value());
                 _wg_running_query_token_atomic_ptr = _wg_running_query_token_ptr.get();

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -125,7 +125,7 @@ public:
                           workgroup::WorkGroup* wg = nullptr);
     std::shared_ptr<MemTracker> mem_tracker() { return _mem_tracker; }
 
-    Status init_query_once(workgroup::WorkGroup* wg);
+    Status init_query_once(workgroup::WorkGroup* wg, bool enable_group_level_query_queue);
     /// Release the workgroup token only once to avoid double-free.
     /// This method should only be invoked while the QueryContext is still valid,
     /// to avoid double-free between the destruction and this method.

--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -196,9 +196,10 @@ void WorkGroup::decr_num_running_drivers() {
     }
 }
 
-StatusOr<RunningQueryTokenPtr> WorkGroup::acquire_running_query_token() {
+StatusOr<RunningQueryTokenPtr> WorkGroup::acquire_running_query_token(bool enable_group_level_query_queue) {
     int64_t old = _num_running_queries.fetch_add(1);
-    if (_concurrency_limit != ABSENT_CONCURRENCY_LIMIT && old >= _concurrency_limit) {
+    if (!enable_group_level_query_queue && _concurrency_limit != ABSENT_CONCURRENCY_LIMIT &&
+        old >= _concurrency_limit) {
         _num_running_queries.fetch_sub(1);
         _concurrency_overflow_count++;
         return Status::TooManyTasks(fmt::format("Exceed concurrency limit: {}", _concurrency_limit));

--- a/be/src/exec/workgroup/work_group.h
+++ b/be/src/exec/workgroup/work_group.h
@@ -187,7 +187,7 @@ public:
     static int128_t create_unique_id(int64_t id, int64_t version) { return (((int128_t)version) << 64) | id; }
 
     Status check_big_query(const QueryContext& query_context);
-    StatusOr<RunningQueryTokenPtr> acquire_running_query_token();
+    StatusOr<RunningQueryTokenPtr> acquire_running_query_token(bool enable_group_level_query_queue);
     void decr_num_queries();
     int64_t num_running_queries() const { return _num_running_queries; }
     int64_t num_total_queries() const { return _num_total_queries; }

--- a/be/test/exec/pipeline/query_context_manger_test.cpp
+++ b/be/test/exec/pipeline/query_context_manger_test.cpp
@@ -253,9 +253,9 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
     const auto query_id1 = query_ctx1->query_id();
 
     /// Case 1: When all the fragments have come and finished, wg.num_running_queries should become to zero.
-    ASSERT_OK(query_ctx1->init_query_once(wg.get()));
-    ASSERT_OK(query_ctx1->init_query_once(wg.get()));              // None-first invocations have no side-effects.
-    ASSERT_ERROR(query_ctx_overloaded->init_query_once(wg.get())); // Exceed concurrency_limit.
+    ASSERT_OK(query_ctx1->init_query_once(wg.get(), false));
+    ASSERT_OK(query_ctx1->init_query_once(wg.get(), false)); // None-first invocations have no side-effects.
+    ASSERT_ERROR(query_ctx_overloaded->init_query_once(wg.get(), false)); // Exceed concurrency_limit.
     ASSERT_EQ(1, wg->num_running_queries());
     ASSERT_EQ(1, wg->concurrency_overflow_count());
     // All the fragments comes.
@@ -276,8 +276,8 @@ TEST(QueryContextManagerTest, testSetWorkgroup) {
     auto* query_ctx2 =
             gen_query_ctx(parent_mem_tracker.get(), query_ctx_mgr.get(), 3, 4, 3, 0 /* delivery_timeout */, 300);
     const auto query_id2 = query_ctx2->query_id();
-    ASSERT_OK(query_ctx2->init_query_once(wg.get()));
-    ASSERT_OK(query_ctx2->init_query_once(wg.get())); // None-first invocations have no side-effects.
+    ASSERT_OK(query_ctx2->init_query_once(wg.get(), false));
+    ASSERT_OK(query_ctx2->init_query_once(wg.get(), false)); // None-first invocations have no side-effects.
     ASSERT_EQ(1, wg->num_running_queries());
     for (int i = 2; i < query_ctx2->total_fragments(); ++i) {
         auto* cur_query_ctx = query_ctx_mgr->get_or_register(query_id2);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -175,6 +175,10 @@ public class CoordinatorPreprocessor {
     // Resource group
     private final TWorkGroup resourceGroup;
 
+    private boolean enableQueue = false;
+    private boolean needCheckQueued = false;
+    private boolean enableGroupLevelQueue = false;
+
     public CoordinatorPreprocessor(TUniqueId queryId, ConnectContext context, List<PlanFragment> fragments,
                                    List<ScanNode> scanNodes, TDescriptorTable descriptorTable,
                                    TQueryGlobals queryGlobals, TQueryOptions queryOptions) {
@@ -377,6 +381,30 @@ public class CoordinatorPreprocessor {
 
     public TWorkGroup getResourceGroup() {
         return resourceGroup;
+    }
+
+    public boolean isEnableQueue() {
+        return enableQueue;
+    }
+
+    public void setEnableQueue(boolean enableQueue) {
+        this.enableQueue = enableQueue;
+    }
+
+    public boolean isNeedCheckQueued() {
+        return needCheckQueued;
+    }
+
+    public void setNeedCheckQueued(boolean needCheckQueued) {
+        this.needCheckQueued = needCheckQueued;
+    }
+
+    public boolean isEnableGroupLevelQueue() {
+        return enableGroupLevelQueue;
+    }
+
+    public void setEnableGroupLevelQueue(boolean enableGroupLevelQueue) {
+        this.enableGroupLevelQueue = enableGroupLevelQueue;
     }
 
     public Map<TNetworkAddress, Integer> getHostToNumbers() {
@@ -1699,6 +1727,14 @@ public class CoordinatorPreprocessor {
                                 sessionVariable.getAdaptiveDopMaxBlockRowsPerDriverSeq());
                         commonParams.adaptive_dop_param.setMax_output_amplification_factor(
                                 sessionVariable.getAdaptiveDopMaxOutputAmplificationFactor());
+                    }
+                    if (isEnableQueue()) {
+                        TQueryQueueOptions queryQueueOptions = new TQueryQueueOptions();
+                        queryQueueOptions.setEnable_global_query_queue(isEnableQueue());
+                        queryQueueOptions.setEnable_group_level_query_queue(isEnableGroupLevelQueue());
+
+                        TQueryOptions queryOptions = commonParams.getQuery_options();
+                        queryOptions.setQuery_queue_options(queryQueueOptions);
                     }
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -82,6 +82,7 @@ import com.starrocks.thrift.TPlanFragmentDestination;
 import com.starrocks.thrift.TPlanFragmentExecParams;
 import com.starrocks.thrift.TQueryGlobals;
 import com.starrocks.thrift.TQueryOptions;
+import com.starrocks.thrift.TQueryQueueOptions;
 import com.starrocks.thrift.TQueryType;
 import com.starrocks.thrift.TRuntimeFilterParams;
 import com.starrocks.thrift.TScanRangeLocation;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QueryQueueManager.java
@@ -51,7 +51,12 @@ public class QueryQueueManager {
     }
 
     public void maybeWait(ConnectContext context, Coordinator coord) throws UserException, InterruptedException {
-        if (!needCheckQueue(coord) || !isEnableQueue(coord)) {
+        CoordinatorPreprocessor coordPrepare = coord.getPrepareInfo();
+        coordPrepare.setNeedCheckQueued(needCheckQueue(coord));
+        coordPrepare.setEnableQueue(isEnableQueue(coord));
+        coordPrepare.setEnableGroupLevelQueue(coordPrepare.isEnableQueue() && GlobalVariable.isEnableGroupLevelQueryQueue());
+
+        if (!coordPrepare.isNeedCheckQueued() || !coordPrepare.isEnableQueue()) {
             return;
         }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -122,6 +122,11 @@ enum TOverflowMode {
   REPORT_ERROR = 1;
 }
 
+struct TQueryQueueOptions {
+  1: optional bool enable_global_query_queue;
+  2: optional bool enable_group_level_query_queue;
+}
+
 // Query options with their respective defaults
 struct TQueryOptions {
   2: optional i32 max_errors = 0
@@ -227,6 +232,8 @@ struct TQueryOptions {
 
   // Whether use hdfs file metacache
   107: optional bool enable_hdfs_file_metacache;
+
+  110: optional TQueryQueueOptions query_queue_options;
 }
 
 


### PR DESCRIPTION
CP from #34398.

---

When enabling group level query queue,
1. The `concurrency_limit` is checked in both FE and BE 
    a. FE will **queue** the coming queries, when `num_running_queries` == `concurrency_limit`.
    b. BE will **fail** the coming queries, when `num_running_queries` == `concurrency_limit`.
2. The order between decreasing `num_running_queries` in FE and BE are uncertain.
    a. FE decreases `num_running_queries`, when it **receives EOS** RPC from BE.
    b. BE decreases `num_running_queries`, when it **finalizes the query context** (after sending EOS RPC to FE asynchronously).

Therefore, `num_running_queries` in BE may be greater than that in FE. This results in that the query is admitted by FE but still failed by exceeding the concurrency limit in BE, even though the group level query queue is enabled. This is not intuitive.


Thus, to make the judgement of exceeding the concurrency limit in FE and BE consistent, when enabling group level query queue, BE doesn't check it anymore.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

