### PR TITLE
[BugFix] Fix special partition error with NULL predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
@@ -48,7 +48,6 @@ import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -121,17 +120,16 @@ public class RangePartitionPruner implements PartitionPruner {
                     && lowerBound != null && upperBound != null
                     && 0 == lowerBound.compareLiteral(upperBound)) {
 
-                LiteralExpr lowerBoundExpr = filter.getLowerBound(isConvertToDate);
-                LiteralExpr upperBoundExpr = filter.getUpperBound(isConvertToDate);
-
                 // eg: [10, 10], [null, null]
-                if (lowerBoundExpr instanceof NullLiteral && upperBoundExpr instanceof NullLiteral) {
+                if (lowerBound instanceof NullLiteral && upperBound instanceof NullLiteral) {
                     // replace Null with min value
                     LiteralExpr minKeyValue = LiteralExpr.createInfinity(
                             Type.fromPrimitiveType(keyColumn.getPrimitiveType()), false);
                     minKey.pushColumn(minKeyValue, keyColumn.getPrimitiveType());
                     maxKey.pushColumn(minKeyValue, keyColumn.getPrimitiveType());
                 } else {
+                    LiteralExpr lowerBoundExpr = filter.getLowerBound(isConvertToDate);
+                    LiteralExpr upperBoundExpr = filter.getUpperBound(isConvertToDate);
                     minKey.pushColumn(lowerBoundExpr, keyColumn.getPrimitiveType());
                     maxKey.pushColumn(upperBoundExpr, keyColumn.getPrimitiveType());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -319,7 +319,7 @@ public class OptOlapPartitionPruner {
         } catch (AnalysisException e) {
             LOG.warn("PartitionPrune Failed. ", e);
         }
-        return null;
+        return specifyPartitionIds;
     }
 
     private static List<Long> rangePartitionPrune(OlapTable olapTable, RangePartitionInfo partitionInfo,
@@ -344,7 +344,7 @@ public class OptOlapPartitionPruner {
         } catch (Exception e) {
             LOG.warn("PartitionPrune Failed. ", e);
         }
-        return null;
+        return Lists.newArrayList(keyRangeById.keySet());
     }
 
     private static boolean isNeedFurtherPrune(List<Long> candidatePartitions, LogicalOlapScanOperator olapScanOperator,

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PartitionPruneTest.java
@@ -166,4 +166,11 @@ public class PartitionPruneTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: 1: k1 = CAST('  -111 2  ' AS INT)");
     }
+
+    @Test
+    public void testNullException() throws Exception {
+        String sql = "select * from ptest partition(p202007) where d2 is null";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "partitions=0/4");
+    }
 }


### PR DESCRIPTION
Fixes https://github.com/StarRocks/starrocks/pull/33897

```
select * from ptest partition(p202007) where d2 is null
```

cast d2(date) to lowBound will throw Exception and return null partition, not sepecial partition(p202007)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
