### PR TITLE
[BugFix] fix segment mem_usage race condition (#34283)

### DIFF
--- a/be/src/storage/lake/metacache.h
+++ b/be/src/storage/lake/metacache.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <memory>
+#include <mutex>
 #include <string_view>
 #include <variant>
 
@@ -63,6 +64,9 @@ public:
 
     void cache_segment(std::string_view key, std::shared_ptr<Segment> segment);
 
+    // cache the segment if the given key not exists in the cache, returns the segment shared_ptr stored in the cache.
+    std::shared_ptr<Segment> cache_segment_if_absent(std::string_view key, std::shared_ptr<Segment> segment);
+
     void cache_delvec(std::string_view key, std::shared_ptr<const DelVector> delvec);
 
     void erase(std::string_view key);
@@ -78,9 +82,14 @@ public:
 private:
     static void cache_value_deleter(const CacheKey& /*key*/, void* value) { delete static_cast<CacheValue*>(value); }
 
+    std::shared_ptr<Segment> _lookup_segment_no_lock(std::string_view key);
+    void _cache_segment_no_lock(std::string_view key, std::shared_ptr<Segment> segment);
+
     void insert(std::string_view key, CacheValue* ptr, size_t size);
 
     std::unique_ptr<Cache> _cache;
+
+    std::mutex _mutex;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -151,7 +151,12 @@ StatusOr<SegmentPtr> Tablet::load_segment(std::string_view segment_name, int seg
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_path));
         segment = std::make_shared<Segment>(std::move(fs), segment_path, seg_id, std::move(tablet_schema), _mgr);
         if (fill_metadata_cache) {
-            _mgr->metacache()->cache_segment(segment_path, segment);
+            // NOTE: the returned segment may be not the same as the parameter passed in
+            // Use the one in cache if the same key already exists
+            if (auto cached_segment = _mgr->metacache()->cache_segment_if_absent(segment_path, segment);
+                cached_segment != nullptr) {
+                segment = cached_segment;
+            }
         }
     }
     // segment->open will read the footer, and it is time-consuming.

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -121,11 +121,15 @@ std::string TabletManager::tablet_latest_metadata_cache_key(int64_t tablet_id) {
 }
 
 // current lru cache does not support updating value size, so use refill to update.
-void TabletManager::update_segment_cache_size(std::string_view key) {
+void TabletManager::update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint) {
     // use write lock to protect parallel segment size update
     std::unique_lock wrlock(_meta_lock);
     auto segment = _metacache->lookup_segment(key);
     if (segment == nullptr) {
+        return;
+    }
+    if (segment_addr_hint != 0 && segment_addr_hint != reinterpret_cast<intptr_t>(segment.get())) {
+        // the segment in cache is not the one as expected, skip the cache update
         return;
     }
     _metacache->cache_segment(key, std::move(segment));

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -146,7 +146,11 @@ public:
     // only for TEST purpose
     void TEST_set_global_schema_cache(int64_t index_id, TabletSchemaPtr schema);
 
-    void update_segment_cache_size(std::string_view key);
+    // update cache size of the segment with the given key, optionally provide the segment address hint.
+    // If segment_addr_hint is provided and it's non-zero, the cache size will be only updated when the
+    // instance address matches the address provided by the segment_addr_hint. This is used to prevent
+    // updating the cache size where the cached object is not the one as expected.
+    void update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint = 0);
 
 private:
     static std::string global_schema_cache_key(int64_t index_id);

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -169,9 +169,7 @@ public:
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
 
-    size_t mem_usage() const {
-        return _basic_info_mem_usage() + _short_key_index_mem_usage() + _column_index_mem_usage();
-    }
+    size_t mem_usage() const;
 
     int64_t get_data_size() {
         auto res = _fs->get_file_size(_fname);

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -76,6 +76,64 @@ public:
 
     void TearDown() override { remove_test_dir_ignore_error(); }
 
+    void create_rowsets_for_testing() {
+        std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+        std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+        std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+        std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+        auto c0 = Int32Column::create();
+        auto c1 = Int32Column::create();
+        auto c2 = Int32Column::create();
+        auto c3 = Int32Column::create();
+        c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+        c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+        c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+        c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+        Chunk chunk0({c0, c1}, _schema);
+        Chunk chunk1({c2, c3}, _schema);
+
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+
+        {
+            int64_t txn_id = next_id();
+            // write rowset 1 with 2 segments
+            ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+            ASSERT_OK(writer->open());
+
+            // write rowset data
+            // segment #1
+            ASSERT_OK(writer->write(chunk0));
+            ASSERT_OK(writer->write(chunk1));
+            ASSERT_OK(writer->finish());
+
+            // segment #2
+            ASSERT_OK(writer->write(chunk0));
+            ASSERT_OK(writer->write(chunk1));
+            ASSERT_OK(writer->finish());
+
+            auto files = writer->files();
+            ASSERT_EQ(2, files.size());
+
+            // add rowset metadata
+            auto* rowset = _tablet_metadata->add_rowsets();
+            rowset->set_overlapped(true);
+            rowset->set_id(1);
+            auto* segs = rowset->mutable_segments();
+            for (auto& file : writer->files()) {
+                segs->Add(std::move(file));
+            }
+
+            writer->close();
+        }
+
+        // write tablet metadata
+        _tablet_metadata->set_version(2);
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
 protected:
     constexpr static const char* const kTestDirectory = "test_lake_rowset";
 
@@ -85,62 +143,9 @@ protected:
 };
 
 TEST_F(LakeRowsetTest, test_load_segments) {
-    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
-    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
-
-    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
-    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
-
-    auto c0 = Int32Column::create();
-    auto c1 = Int32Column::create();
-    auto c2 = Int32Column::create();
-    auto c3 = Int32Column::create();
-    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
-    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
-    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
-    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
-
-    Chunk chunk0({c0, c1}, _schema);
-    Chunk chunk1({c2, c3}, _schema);
+    create_rowsets_for_testing();
 
     ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-
-    {
-        int64_t txn_id = next_id();
-        // write rowset 1 with 2 segments
-        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
-        ASSERT_OK(writer->open());
-
-        // write rowset data
-        // segment #1
-        ASSERT_OK(writer->write(chunk0));
-        ASSERT_OK(writer->write(chunk1));
-        ASSERT_OK(writer->finish());
-
-        // segment #2
-        ASSERT_OK(writer->write(chunk0));
-        ASSERT_OK(writer->write(chunk1));
-        ASSERT_OK(writer->finish());
-
-        auto files = writer->files();
-        ASSERT_EQ(2, files.size());
-
-        // add rowset metadata
-        auto* rowset = _tablet_metadata->add_rowsets();
-        rowset->set_overlapped(true);
-        rowset->set_id(1);
-        auto* segs = rowset->mutable_segments();
-        for (auto& file : writer->files()) {
-            segs->Add(std::move(file));
-        }
-
-        writer->close();
-    }
-
-    // write tablet metadata
-    _tablet_metadata->set_version(2);
-    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
-
     auto* cache = _tablet_mgr->metacache();
 
     ASSIGN_OR_ABORT(auto rowsets, tablet.get_rowsets(2));
@@ -161,6 +166,60 @@ TEST_F(LakeRowsetTest, test_load_segments) {
     for (const auto& seg : segments2) {
         auto segment = cache->lookup_segment(seg->file_name());
         ASSERT_TRUE(segment != nullptr);
+    }
+}
+
+TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
+    create_rowsets_for_testing();
+
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto rowsets, tablet.get_rowsets(2));
+    ASSIGN_OR_ABORT(auto segments, rowsets[0]->segments(false));
+
+    auto* cache = _tablet_mgr->metacache();
+
+    // get the same segments from the rowset
+    auto sample_segment = segments[0];
+    std::string path = sample_segment->file_name();
+    ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(path));
+    auto schema = _tablet_schema;
+
+    // create a dummy segment with the same path to cache ahead in metacache,
+    // the later segment open operation will not update the mem_usage due to instance mismatch.
+    {
+        // clean the cache
+        cache->prune();
+        //create the dummy segment and put it into metacache
+        auto dummy_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        cache->cache_segment(path, dummy_segment);
+        EXPECT_EQ(dummy_segment, cache->lookup_segment(path));
+        auto sz1 = cache->memory_usage();
+
+        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto st = mirror_segment->open(nullptr, nullptr, true);
+        EXPECT_TRUE(st.ok());
+        auto sz2 = cache->memory_usage();
+        // no memory_usage change, because the instance in metacache is different from this mirror_segment
+        EXPECT_EQ(sz1, sz2);
+    }
+    // create the mirror_segment without open, and put it into metacache, get the cache memory_usage,
+    // open the segment (during the open, the cache size will be updated), get the cache memory_usage again.
+    {
+        // clean the cache
+        cache->prune();
+        //create the dummy segment and put it into metacache
+        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        cache->cache_segment(path, mirror_segment);
+        auto sz1 = cache->memory_usage();
+        auto ssz1 = mirror_segment->mem_usage();
+
+        auto st = mirror_segment->open(nullptr, nullptr, true);
+        EXPECT_TRUE(st.ok());
+        auto sz2 = cache->memory_usage();
+        auto ssz2 = mirror_segment->mem_usage();
+        // mem usage updated after the segment is opened.
+        EXPECT_LT(sz1, sz2);
+        EXPECT_EQ(ssz2 - ssz1, sz2 - sz1);
     }
 }
 


### PR DESCRIPTION
* protect the Segment::mem_usage() with open_once flag
* TabletManager is able to skip the cache size update if the segment in the cache is not the same as expected one.
* MetaCache support `cache_segment_if_absent` interface.

Fixes #34273


(cherry picked from commit ef1a2a8d97b8828fc84c8cf0fd5ceb8a45579937)

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
