### PR TITLE
[BugFix] Fix forward compatibility for newly added PEntryObject type (2/2)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/AuthorizationMgr.java
@@ -564,7 +564,14 @@ public class AuthorizationMgr {
                 }
 
                 collection.addParentRole(parentRoleId);
-                rolePrivCollectionModified.put(parentRoleId, parentCollection);
+
+                if (PrivilegeBuiltinConstants.IMMUTABLE_BUILT_IN_ROLE_IDS.contains(parentRoleId)) {
+                    RolePrivilegeCollectionV2 clone = parentCollection.cloneSelf();
+                    clone.typeToPrivilegeEntryList = new HashMap<>();
+                    rolePrivCollectionModified.put(parentRoleId, clone);
+                } else {
+                    rolePrivCollectionModified.put(parentRoleId, parentCollection);
+                }
             }
 
             invalidateRolesInCacheRoleUnlocked(roleId);
@@ -648,7 +655,13 @@ public class AuthorizationMgr {
                 RolePrivilegeCollectionV2 parentCollection =
                         getRolePrivilegeCollectionUnlocked(parentRoleId, true);
                 parentRoleIdList.add(parentRoleId);
-                rolePrivCollectionModified.put(parentRoleId, parentCollection);
+                if (PrivilegeBuiltinConstants.IMMUTABLE_BUILT_IN_ROLE_IDS.contains(parentRoleId)) {
+                    RolePrivilegeCollectionV2 clone = parentCollection.cloneSelf();
+                    clone.typeToPrivilegeEntryList = new HashMap<>();
+                    rolePrivCollectionModified.put(parentRoleId, clone);
+                } else {
+                    rolePrivCollectionModified.put(parentRoleId, parentCollection);
+                }
             }
 
             // write journal to update privilege collections of both role & parent role
@@ -1206,7 +1219,13 @@ public class AuthorizationMgr {
                 if (!PrivilegeBuiltinConstants.IMMUTABLE_BUILT_IN_ROLE_IDS.contains(roleId)) {
                     provider.upgradePrivilegeCollection(privilegeCollection, info.getPluginId(), info.getPluginVersion());
                 }
+
+                if (PrivilegeBuiltinConstants.IMMUTABLE_BUILT_IN_ROLE_IDS.contains(roleId)) {
+                    RolePrivilegeCollectionV2 builtInRolePrivilegeCollection = this.roleIdToPrivilegeCollection.get(roleId);
+                    privilegeCollection.typeToPrivilegeEntryList = builtInRolePrivilegeCollection.typeToPrivilegeEntryList;
+                }
                 roleIdToPrivilegeCollection.put(roleId, privilegeCollection);
+
                 if (!roleNameToId.containsKey(privilegeCollection.getName())) {
                     roleNameToId.put(privilegeCollection.getName(), roleId);
                 }


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
