### PR TITLE
[Enhancement] Optimize the performance of BitmapValue::add()

### DIFF
--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -1026,7 +1026,7 @@ int64_t BitmapValue::bitmap_subset_limit_internal(const int64_t& range_start, co
             auto end = _bitmap->begin();
 
             int64_t offset = 0;
-            for (; end != _bitmap->end() && offset < abs_limit && * end <= range_start;) {
+            for (; end != _bitmap->end() && offset < abs_limit && *end <= range_start;) {
                 ++end;
                 ++offset;
             }

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -103,11 +103,7 @@ BitmapValue::BitmapValue(const BitmapValue& other)
 
 BitmapValue& BitmapValue::operator=(const BitmapValue& other) {
     if (this != &other) {
-        if (other._type == BITMAP) {
-            _bitmap = other._bitmap;
-        } else {
-            _bitmap = nullptr;
-        }
+        this->_bitmap = other._bitmap;
         this->_set = other._set == nullptr ? nullptr : std::make_unique<phmap::flat_hash_set<uint64_t>>(*other._set);
         this->_sv = other._sv;
         this->_type = other._type;


### PR DESCRIPTION
Replace _is_shared with use_count of std::shared_ptr, It has no impact on performance and can make the code more concise.

Move BitmapValue::add() to bitmap_value.h to improve the performance of optimize the performance of high-frequency calls function such as bitmap_agg(bigint)

lo_orderkey is bigint type

```
 select bitmap_count(bitmap_agg(lo_orderkey)) from lineorder_bigint;
```

TotalTime: 5.22s -> 4.76s
AggFuncComputeTime: 5.066s -> 4.594s

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
