### PR TITLE
[BugFix] Fix chunk columns and schema fields check in memtable::insert

### DIFF
--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -170,7 +170,7 @@ bool MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from
     if (_keys_type == PRIMARY_KEYS) {
         std::unique_ptr<Schema> schema_without_full_row_column;
         if (_vectorized_schema->field_names().back() == "__row") {
-            DCHECK_EQ(chunk.num_columns(), _vectorized_schema->num_fields() - 1);
+            DCHECK_GE(chunk.num_columns(), _vectorized_schema->num_fields() - 1);
             std::vector<ColumnId> cids(_vectorized_schema->num_fields() - 1);
             for (int i = 0; i < _vectorized_schema->num_fields() - 1; i++) {
                 cids[i] = i;
@@ -182,7 +182,9 @@ bool MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uint32_t from
             (void)row_encoder->encode_chunk_to_full_row_column(*schema_without_full_row_column, chunk,
                                                                full_row_col.get());
         } else {
-            DCHECK_EQ(chunk.num_columns(), _vectorized_schema->num_fields());
+            // when doing schema change, the chunk has shadow columns,
+            // so the columns in the chunk will be more than the fields in the schema.
+            DCHECK_GE(chunk.num_columns(), _vectorized_schema->num_fields());
         }
     }
 


### PR DESCRIPTION
when doing schema change, the chunk has shadow columns, so the columns in the chunk will be more than the fields in the schema.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
