### PR TITLE
[BugFix] fix show mv npe after dropping table and upgrading from 3.1 to 3.2 for 3.2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -183,6 +183,10 @@ public class BaseTableInfo {
             LOG.warn("catalog {} not exist", catalogName);
             return null;
         }
+        // upgrade from 3.1 to 3.2, dbName/tableName maybe null after dbs or tables are dropped
+        if (dbName == null || tableName == null) {
+            return null;
+        }
         Table table = GlobalStateMgr.getCurrentState().getMetadataMgr().getTable(catalogName, dbName, tableName);
         if (table == null) {
             LOG.warn("table {}.{}.{} not exist", catalogName, dbName, tableName);

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -31,6 +31,7 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.FastByteArrayOutputStream;
+import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.ShowExecutor;
@@ -40,6 +41,7 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterTableStmt;
 import com.starrocks.sql.ast.PartitionKeyDesc;
@@ -65,6 +67,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
 
@@ -992,5 +995,39 @@ public class MaterializedViewTest {
         Assert.assertThrows("Duplicate column name 'k2' in index",
                 UserException.class,
                 () -> starRocksAssert.withMaterializedView(mvSql2));
+    }
+
+    @Test
+    public void testBaseTableInfo(@Mocked GlobalStateMgr globalStateMgr,
+                                  @Mocked MetadataMgr metadataMgr,
+                                  @Mocked ConnectorMetadata connectorMetadata,
+                                  @Mocked Database database) {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                result = globalStateMgr;
+
+                globalStateMgr.getMetadataMgr();
+                result = metadataMgr;
+
+                metadataMgr.getOptionalMetadata(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
+                result = Optional.of(connectorMetadata);
+
+                connectorMetadata.getDb(100L);
+                result = database;
+
+                connectorMetadata.getDb(200L);
+                result = null;
+
+                database.getTable(10L);
+                result = null;
+            }
+        };
+        BaseTableInfo baseTableInfo = new BaseTableInfo(100L, 10L);
+        Assert.assertNull(baseTableInfo.getTable());
+        Assert.assertNull(baseTableInfo.getTableByName());
+        BaseTableInfo baseTableInfo2 = new BaseTableInfo(200L, 10L);
+        Assert.assertNull(baseTableInfo2.getTable());
+        Assert.assertNull(baseTableInfo2.getTableByName());
     }
 }


### PR DESCRIPTION
fix #34503

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
