### PR TITLE
[BugFix] fix date_format expr partition prune bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -32,7 +32,6 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.StringLiteral;
-import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
 import com.starrocks.catalog.FunctionSet;
@@ -417,11 +416,11 @@ public class ColumnFilterConverter {
         }
     }
 
-    public static LiteralExpr convertLiteral(Column partitionColumn, ConstantOperator operator) throws AnalysisException {
-        return convertLiteral(partitionColumn.getType(), operator);
+    public static LiteralExpr convertLiteral(ConstantOperator operator) throws AnalysisException {
+        return convertLiteral(operator.getType(), operator);
     }
 
-    public static LiteralExpr convertLiteral(Type partitionType, ConstantOperator operator) throws AnalysisException {
+    public static LiteralExpr convertLiteral(Type definedType, ConstantOperator operator) throws AnalysisException {
         Preconditions.checkArgument(!operator.getType().isInvalid());
 
         if (operator.isNull()) {
@@ -464,7 +463,7 @@ public class ColumnFilterConverter {
             case CHAR:
             case VARCHAR:
             case HLL:
-                boolean isConvertToDate = PartitionUtil.isConvertToDate(partitionType, operator.getType());
+                boolean isConvertToDate = PartitionUtil.isConvertToDate(definedType, operator.getType());
                 literalExpr = new StringLiteral(operator.getVarchar());
                 if (isConvertToDate) {
                     literalExpr = PartitionUtil.convertToDateLiteral(literalExpr);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ConstantFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ConstantFunction.java
@@ -37,11 +37,12 @@ public @interface ConstantFunction {
     boolean isMetaFunction() default false;
 
     /**
-     * When a function is a monotonic function, which means for any value within a range,
-     * the first and last endpoints yield the new extreme points after the function mapping.
-     * This helps us to determine the result range according the only first and last endpoints
-     * of the input of a function.
-     * For example, date_trunc() is a monotonic function while abs() is not.
+     * When a function is a possible monotonic function, which means for any value within a range,
+     * the first and last endpoints yield the new extreme points after the function mapping with
+     * other specific arguments. This helps us to determine the result range according the only
+     * first and last endpoints of the input of a function.
+     * For example, date_trunc() is a monotonic function while abs() is not. date_format(arg1, pattern)
+     * is a monotonic function when pattern is special values.
      */
     boolean isMonotonic() default false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/PartitionColPredicateEvaluator.java
@@ -172,7 +172,7 @@ public class PartitionColPredicateEvaluator {
                 if (constantOperator.isNull()) {
                     literalExpr = LiteralExpr.createInfinity(childType, false);
                 } else {
-                    literalExpr = ColumnFilterConverter.convertLiteral(partitionColumn, constantOperator);
+                    literalExpr = ColumnFilterConverter.convertLiteral(constantOperator);
                 }
             } catch (AnalysisException e) {
                 return createAllTrueBitSet();
@@ -239,7 +239,7 @@ public class PartitionColPredicateEvaluator {
             if (IN_OPERANDS_LIMIT >= constList.size()) {
                 for (ConstantOperator constantOperator : constList) {
                     try {
-                        LiteralExpr literalExpr = ColumnFilterConverter.convertLiteral(partitionColumn, constantOperator);
+                        LiteralExpr literalExpr = ColumnFilterConverter.convertLiteral(constantOperator);
                         PartitionKey conditionKey = new PartitionKey();
                         conditionKey.pushColumn(literalExpr, childType);
                         Range<PartitionKey> predicateRange = Range.closed(conditionKey, conditionKey);
@@ -251,8 +251,8 @@ public class PartitionColPredicateEvaluator {
                 }
             } else {
                 try {
-                    LiteralExpr min = ColumnFilterConverter.convertLiteral(partitionColumn, constList.get(0));
-                    LiteralExpr max = ColumnFilterConverter.convertLiteral(partitionColumn, constList.get(constList.size() - 1));
+                    LiteralExpr min = ColumnFilterConverter.convertLiteral(constList.get(0));
+                    LiteralExpr max = ColumnFilterConverter.convertLiteral(constList.get(constList.size() - 1));
                     PartitionKey minKey = new PartitionKey();
                     minKey.pushColumn(min, childType);
                     PartitionKey maxKey = new PartitionKey();
@@ -358,7 +358,7 @@ public class PartitionColPredicateEvaluator {
             if (result.isConstantRef()) {
                 LiteralExpr newLiteralExpr;
                 try {
-                    newLiteralExpr = ColumnFilterConverter.convertLiteral(partitionColumn, (ConstantOperator) result);
+                    newLiteralExpr = ColumnFilterConverter.convertLiteral((ConstantOperator) result);
                 } catch (Exception e) {
                     return Optional.empty();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -45,8 +45,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions.SUPPORT_JAVA_STYLE_DATETIME_FORMATTER;
 
 /**
  * Use for execute constant functions
@@ -170,13 +173,13 @@ public enum ScalarOperatorEvaluator {
         FunctionSignature signature =
                 new FunctionSignature(fn.functionName().toUpperCase(), argTypes, fn.getReturnType());
 
-        if (!functions.containsKey(signature)) {
+        FunctionInvoker invoker = functions.get(signature);
+
+        if (invoker == null) {
             return root;
         }
 
-        FunctionInvoker invoker = functions.get(signature);
-
-        if (needMonotonic && !invoker.isMonotonic) {
+        if (needMonotonic && !isMonotonicFunc(invoker, root)) {
             return root;
         }
 
@@ -198,6 +201,77 @@ public enum ScalarOperatorEvaluator {
             }
         }
         return root;
+    }
+
+
+    private boolean isMonotonicFunc(FunctionInvoker invoker, CallOperator operator) {
+        if (!invoker.isMonotonic) {
+            return false;
+        }
+
+        if (FunctionSet.DATE_FORMAT.equalsIgnoreCase(invoker.getSignature().getName())) {
+            String pattern = operator.getChild(1).toString();
+            if (pattern.isEmpty()) {
+                return true;
+            }
+
+            if (SUPPORT_JAVA_STYLE_DATETIME_FORMATTER.contains(pattern.trim())) {
+                return true;
+            }
+            Optional<String> stripedPattern = stripFormatValue(pattern);
+            // "YmdHiSf" or "YmdHisf" ensure the format string value reserve the original date order
+            // like date_format('2021-01-01', '%Y-%m-%d') is qualified but date_format('2021-01-01', '%m-%Y-%d') is not
+            return stripedPattern.map(e -> "YmdHiSf".startsWith(e) || "YmdHisf".startsWith(e)).orElse(false);
+        }
+
+        return true;
+    }
+    private Optional<String> stripFormatValue(String pattern) {
+        StringBuilder builder = new StringBuilder();
+        boolean unsupportedFormat = false;
+        for (char c : pattern.toCharArray()) {
+            switch (c) {
+                case 'Y':
+                case 'm':
+                case 'd':
+                case 'H':
+                case 'i':
+                case 'S':
+                case 's':
+                case 'f':
+                    builder.append(c);
+                    break;
+                case 'a':
+                case 'b':
+                case 'c':
+                case 'D':
+                case 'e':
+                case 'h':
+                case 'I':
+                case 'j':
+                case 'k':
+                case 'l':
+                case 'M':
+                case 'p':
+                case 'r':
+                case 'T':
+                case 'U':
+                case 'u':
+                case 'V':
+                case 'v':
+                case 'W':
+                case 'w':
+                case 'X':
+                case 'x':
+                case 'y':
+                    unsupportedFormat = true;
+                    break;
+                default:
+                    // do nothing
+            }
+        }
+
+        return unsupportedFormat ? Optional.empty() : Optional.of(builder.toString());
     }
 
     private static class FunctionInvoker {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -127,7 +127,7 @@ import static com.starrocks.catalog.PrimitiveType.VARCHAR;
  * Constant Functions List
  */
 public class ScalarOperatorFunctions {
-    private static final Set<String> SUPPORT_JAVA_STYLE_DATETIME_FORMATTER =
+    public static final Set<String> SUPPORT_JAVA_STYLE_DATETIME_FORMATTER =
             ImmutableSet.<String>builder().add("yyyy-MM-dd").add("yyyy-MM-dd HH:mm:ss").add("yyyyMMdd").build();
 
     private static final Pattern HAS_TIME_PART = Pattern.compile("^.*[HhIiklrSsT]+.*$");
@@ -373,8 +373,8 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
-            @ConstantFunction(name = "year", argTypes = {DATETIME}, returnType = SMALLINT),
-            @ConstantFunction(name = "year", argTypes = {DATE}, returnType = SMALLINT)
+            @ConstantFunction(name = "year", argTypes = {DATETIME}, returnType = SMALLINT, isMonotonic = true),
+            @ConstantFunction(name = "year", argTypes = {DATE}, returnType = SMALLINT, isMonotonic = true)
     })
     public static ConstantOperator year(ConstantOperator arg) {
         return ConstantOperator.createSmallInt((short) arg.getDatetime().getYear());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -452,7 +452,10 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         sqlList.add("select * from ptest where date_trunc('year', d2) = '2020-01-01'");
         sqlList.add("select * from less_than_tbl where date_trunc('year', k1) < '2020-08-01'");
         sqlList.add("select * from less_than_tbl where datediff('2020-08-01', k1) = 1");
-
+        sqlList.add("select * from less_than_tbl where date_format(k1, '%m月%Y年') = '06月-2020年'");
+        sqlList.add("select * from less_than_tbl where date_format(k1, '%a-%Y') = 'Wed-2020'");
+        sqlList.add("select * from less_than_tbl where date_format(k1, '') is null");
+        sqlList.add("select * from less_than_tbl where date_format(k1, '%abcdDdehIjklMprTUvWXxy') = 'Wed-2020'");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 
@@ -493,6 +496,9 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         sqlList.add("select * from less_than_tbl where previous_day(k1, 'Monday') in ('2020-07-01', '2020-08-01', " +
                 "'2020-08-06') and k3 = 'a'");
         sqlList.add("select * from less_than_tbl where datediff('2020-08-01', k1) < 0");
+        sqlList.add("select * from less_than_tbl where date_format(k1, '%Y年%m月') = '2020年06月'");
+        sqlList.add("select * from less_than_tbl where date_format(k1, '%Y年%m月') < '2020年08月'");
+        sqlList.add("select * from less_than_tbl where date_format(k1, '%Y-%m-%d %H-%i-%S') < '2020-08-02 12:00:00'");
         return sqlList.stream().map(e -> Arguments.of(e));
     }
 }


### PR DESCRIPTION
Fix [benchmark] Query performance degradation in 20231105

Two problems:
1. `create materialized view mv1 partition by str2date(d,'%Y-%m-%d') distributed by hash(a) ...` yields a `ExpressionRangePartitionInfo` but with `PartitionType.RANGE` not `PartitionType.EXPR_RANGE`. This leads an unsupported scene go into the expr partition prune logic.
2. `date_format()` is a possible monotic fucntion. Like `date_format('2021-01-01', '%Y-%m-%d')` is qualified but `date_format('2021-01-01', '%m-%Y-%d')` is not.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
