### PR TITLE
[Refactor] Remove the TabletSchema member variable from Segment

### DIFF
--- a/be/src/exec/pipeline/scan/morsel.h
+++ b/be/src/exec/pipeline/scan/morsel.h
@@ -368,8 +368,9 @@ public:
     std::string name() const override { return "physical_split_morsel_queue"; }
 
 private:
-    rowid_t _lower_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower) const;
-    rowid_t _upper_bound_ordinal(Segment* segment, const SeekTuple& key, bool lower, rowid_t end) const;
+    rowid_t _lower_bound_ordinal(size_t short_keys, Segment* segment, const SeekTuple& key, bool lower) const;
+    rowid_t _upper_bound_ordinal(size_t short_keys, Segment* segment, const SeekTuple& key, bool lower,
+                                 rowid_t end) const;
     bool _is_last_split_of_current_morsel();
 
     Rowset* _cur_rowset();

--- a/be/src/storage/binlog_reader.cpp
+++ b/be/src/storage/binlog_reader.cpp
@@ -264,6 +264,7 @@ Status BinlogReader::_init_segment_iterator() {
     ASSIGN_OR_RETURN(seg_options.fs, FileSystem::CreateSharedFromString(_rowset->rowset_path()))
     seg_options.chunk_size = _reader_params.chunk_size;
     seg_options.stats = &_stats;
+    seg_options.tablet_schema = _rowset->schema();
     // set start row to read if next change event is not the first row in the segment
     if (log_entry_info->start_seq_id < _next_seq_id) {
         // for duplicate key, LogEntryInfo#start_row_id is 0

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -122,12 +122,8 @@ StatusOr<int32_t> HorizontalCompactionTask::calculate_chunk_size() {
         total_num_rows += rowset->num_rows();
         total_input_segs += rowset->is_overlapped() ? rowset->num_segments() : 1;
         ASSIGN_OR_RETURN(auto segments, rowset->segments(false));
-        for (auto& segment : segments) {
-            for (size_t i = 0; i < segment->num_columns(); ++i) {
-                const auto* column_reader = segment->column(i);
-                if (column_reader == nullptr) {
-                    continue;
-                }
+        for (auto&& segment : segments) {
+            for (auto&& [_, column_reader] : segment->column_readers()) {
                 total_mem_footprint += column_reader->total_mem_footprint();
             }
         }

--- a/be/src/storage/lake/lake_local_persistent_index.cpp
+++ b/be/src/storage/lake/lake_local_persistent_index.cpp
@@ -221,7 +221,8 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
         total_data_size += rowset->data_size();
         total_segments += rowset->num_segments();
 
-        auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
+        auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats,
+                                                                 tablet_schema);
         if (!res.ok()) {
             return res.status();
         }

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -127,7 +127,8 @@ Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& met
     // NOTICE: primary index will be builded by segment files in metadata, and delvecs.
     // The delvecs we need are stored in delvec file by base_version and current MetaFileBuilder's cache.
     for (auto& rowset : *rowsets) {
-        auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
+        auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats,
+                                                                 tablet_schema);
         if (!res.ok()) {
             return res.status();
         }

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -43,8 +43,9 @@ public:
     // |stats| used for iterator read stats
     // return iterator list, an iterator for each segment,
     // if the segment is empty, it wouln't add this iterator to iterator list
-    [[nodiscard]] StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator(const Schema& schema,
-                                                                                    OlapReaderStatistics* stats);
+    [[nodiscard]] StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator(
+            const Schema& schema, OlapReaderStatistics* stats,
+            const std::shared_ptr<const TabletSchema>& tablet_schema);
 
     // used for primary index load, it will get segment iterator by specifice version and it's delvec,
     // without complex options like predicates
@@ -54,7 +55,8 @@ public:
     // return iterator list, an iterator for each segment,
     // if the segment is empty, it wouln't add this iterator to iterator list
     [[nodiscard]] StatusOr<std::vector<ChunkIteratorPtr>> get_each_segment_iterator_with_delvec(
-            const Schema& schema, int64_t version, const MetaFileBuilder* builder, OlapReaderStatistics* stats);
+            const Schema& schema, int64_t version, const MetaFileBuilder* builder, OlapReaderStatistics* stats,
+            const std::shared_ptr<const TabletSchema>& tablet_schema);
 
     [[nodiscard]] bool is_overlapped() const { return metadata().overlapped(); }
 

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -194,7 +194,7 @@ Status RowsetUpdateState::_do_load_upserts_deletes(const TxnLogPB_OpWrite& op_wr
     }
 
     OlapReaderStatistics stats;
-    auto res = rowset_ptr->get_each_segment_iterator(pkey_schema, &stats);
+    auto res = rowset_ptr->get_each_segment_iterator(pkey_schema, &stats, tablet_schema);
     if (!res.ok()) {
         return res.status();
     }

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -132,9 +132,8 @@ StatusOr<SegmentPtr> Tablet::load_segment(std::string_view segment_name, int seg
     auto segment_path = segment_location(segment_name);
     auto segment = _mgr->metacache()->lookup_segment(segment_path);
     if (segment == nullptr) {
-        ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_path));
-        segment = std::make_shared<Segment>(std::move(fs), segment_path, seg_id, std::move(tablet_schema), _mgr);
+        segment = std::make_shared<Segment>(std::move(fs), segment_path, seg_id, _mgr);
         if (fill_metadata_cache) {
             // NOTE: the returned segment may be not the same as the parameter passed in
             // Use the one in cache if the same key already exists

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -65,7 +65,7 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
 
     OlapReaderStatistics stats;
     if (_segment_iters.empty()) {
-        ASSIGN_OR_RETURN(_segment_iters, rowset->get_each_segment_iterator(pkey_schema, &stats));
+        ASSIGN_OR_RETURN(_segment_iters, rowset->get_each_segment_iterator(pkey_schema, &stats, tablet_schema));
     }
     CHECK_EQ(_segment_iters.size(), rowset->num_segments());
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -407,7 +407,7 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
                                          const TabletSchemaCSPtr& tablet_schema,
                                          const std::vector<uint32_t>& rowids) -> Status {
         std::string path = tablet->segment_location(segment_name);
-        auto segment = Segment::open(fs, path, segment_id, tablet_schema);
+        auto segment = Segment::open(fs, path, segment_id);
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open rssid: " << segment_id << " path: " << path << " : " << segment.status();
             return segment.status();

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -119,7 +119,8 @@ StatusOr<int32_t> VerticalCompactionTask::calculate_chunk_size_for_column_group(
         ASSIGN_OR_RETURN(auto segments, rowset->segments(false, true));
         for (auto& segment : segments) {
             for (auto column_index : column_group) {
-                const auto* column_reader = segment->column(column_index);
+                ColumnUID uid = _tablet_schema->column(column_index).unique_id();
+                const auto* column_reader = segment->column_with_uid(uid);
                 if (column_reader == nullptr) {
                     continue;
                 }

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -275,7 +275,8 @@ Status SegmentMetaCollecter::__collect_max_or_min(ColumnId cid, Column* column, 
     if (cid >= _segment->num_columns()) {
         return Status::NotFound("");
     }
-    const ColumnReader* col_reader = _segment->column(cid);
+    ColumnUID uid = _params->tablet_schema->column(cid).unique_id();
+    const ColumnReader* col_reader = _segment->column_with_uid(uid);
     if (col_reader == nullptr || col_reader->segment_zone_map() == nullptr) {
         return Status::NotFound("");
     }

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -153,7 +153,6 @@ public:
     // reload this rowset after the underlying segment file is changed
     Status reload();
     Status reload_segment(int32_t segment_id);
-    Status reload_segment_with_schema(int32_t segment_id, TabletSchemaCSPtr& schema);
     int64_t total_segment_data_size();
 
     const TabletSchema& schema_ref() const { return *_schema; }

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -657,6 +657,7 @@ Status HorizontalRowsetWriter::_final_merge() {
 
     OlapReaderStatistics stats;
     seg_options.stats = &stats;
+    seg_options.tablet_schema = _context.tablet_schema;
 
     for (int seg_id = 0; seg_id < _num_segment; ++seg_id) {
         if (_num_rows_of_tmp_segment_files[seg_id] == 0) {
@@ -664,7 +665,7 @@ Status HorizontalRowsetWriter::_final_merge() {
         }
         std::string tmp_segment_file =
                 Rowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-        auto segment_ptr = Segment::open(_fs, tmp_segment_file, seg_id, _context.tablet_schema);
+        auto segment_ptr = Segment::open(_fs, tmp_segment_file, seg_id);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();

--- a/be/src/storage/rowset/segment_group.cpp
+++ b/be/src/storage/rowset/segment_group.cpp
@@ -99,7 +99,7 @@ void ShortKeyIndexDecoderGroup::_find_position(ssize_t ordinal, ssize_t* decoder
 }
 
 /// SegmentGroup
-SegmentGroup::SegmentGroup(std::vector<SegmentSharedPtr>&& segments)
-        : _segments(std::move(segments)), _decoder_group(_segments) {}
+SegmentGroup::SegmentGroup(std::vector<SegmentSharedPtr>&& segments, size_t num_short_keys)
+        : _segments(std::move(segments)), _decoder_group(_segments), _num_short_keys(num_short_keys) {}
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_group.h
+++ b/be/src/storage/rowset/segment_group.h
@@ -109,7 +109,7 @@ private:
 // It is used to perform binary search on the short keys of all the segments.
 class SegmentGroup {
 public:
-    SegmentGroup(std::vector<SegmentSharedPtr>&& segments);
+    explicit SegmentGroup(std::vector<SegmentSharedPtr>&& segments, size_t num_short_keys);
 
     ShortKeyIndexGroupIterator lower_bound(const Slice& key) const { return _decoder_group.lower_bound(key); }
 
@@ -130,16 +130,12 @@ public:
         return _segments[0]->num_rows_per_block();
     }
 
-    size_t num_short_keys() const {
-        if (_segments.empty()) {
-            return 0;
-        }
-        return _segments[0]->num_short_keys();
-    }
+    size_t num_short_keys() const { return _num_short_keys; }
 
 private:
     std::vector<SegmentSharedPtr> _segments;
     ShortKeyIndexDecoderGroup _decoder_group;
+    size_t _num_short_keys;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -111,6 +111,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
     seg_options.fs = fs;
     seg_options.stats = &stats;
     seg_options.chunk_size = num_rows;
+    seg_options.tablet_schema = rowset->schema();
 
     auto res = rowset->segments()[segment_id]->new_iterator(src_schema, seg_options);
     auto& itr = res.value();
@@ -203,6 +204,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
     seg_options.fs = fs;
     seg_options.stats = &stats;
     seg_options.chunk_size = num_rows;
+    seg_options.tablet_schema = tschema;
 
     auto res = segments[segment_id]->new_iterator(src_schema, seg_options);
     auto& itr = res.value();

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -299,7 +299,7 @@ static StatusOr<ChunkPtr> read_from_source_segment(Rowset* rowset, const Schema&
                                                    OlapReaderStatistics* stats, int64_t version,
                                                    RowsetSegmentId rowset_seg_id, const std::string& path) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(rowset->rowset_path()));
-    auto segment = Segment::open(fs, path, rowset_seg_id.segment_id, rowset->schema());
+    auto segment = Segment::open(fs, path, rowset_seg_id.segment_id);
     if (!segment.ok()) {
         LOG(WARNING) << "Fail to open " << path << ": " << segment.status();
         return segment.status();
@@ -316,6 +316,7 @@ static StatusOr<ChunkPtr> read_from_source_segment(Rowset* rowset, const Schema&
     seg_options.version = version;
     // not use delvec loader
     seg_options.dcg_loader = std::make_shared<LocalDeltaColumnGroupLoader>(tablet->data_dir()->get_meta());
+    seg_options.tablet_schema = rowset->schema();
     ASSIGN_OR_RETURN(auto seg_iter, (*segment)->new_iterator(schema, seg_options));
     auto source_chunk_ptr = ChunkHelper::new_chunk(schema, (*segment)->num_rows());
     auto tmp_chunk_ptr = ChunkHelper::new_chunk(schema, 1024);

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -786,7 +786,7 @@ Status RowsetUpdateState::apply(Tablet* tablet, const TabletSchemaCSPtr& tablet_
     // segment[segment_id] of partial rowset
     if (FileSystem::Default()->path_exists(dest_path).ok()) {
         RETURN_IF_ERROR(FileSystem::Default()->rename_file(dest_path, src_path));
-        RETURN_IF_ERROR(rowset->reload_segment_with_schema(segment_id, _tablet_schema));
+        RETURN_IF_ERROR(rowset->reload_segment(segment_id));
     }
 
     if (!txn_meta.partial_update_column_ids().empty()) {

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -697,7 +697,7 @@ Status SegmentDump::_init() {
 
     // open segment
     size_t footer_length = 16 * 1024 * 1024;
-    auto segment_res = Segment::open(_fs, _path, 0, _tablet_schema, &footer_length, nullptr);
+    auto segment_res = Segment::open(_fs, _path, 0, &footer_length, nullptr);
     if (!segment_res.ok()) {
         std::cout << "open segment failed: " << segment_res.status() << std::endl;
         return Status::InternalError("");
@@ -822,6 +822,7 @@ Status SegmentDump::calc_checksum() {
     seg_opts.use_page_cache = false;
     OlapReaderStatistics stats;
     seg_opts.stats = &stats;
+    seg_opts.tablet_schema = _tablet_schema;
     auto seg_res = _segment->new_iterator(schema, seg_opts);
     if (!seg_res.ok()) {
         std::cout << "new segment iterator failed: " << seg_res.status().message() << std::endl;
@@ -905,6 +906,7 @@ Status SegmentDump::dump_segment_data() {
     seg_opts.use_page_cache = false;
     OlapReaderStatistics stats;
     seg_opts.stats = &stats;
+    seg_opts.tablet_schema = _tablet_schema;
     auto seg_res = _segment->new_iterator(*schema, seg_opts);
     if (!seg_res.ok()) {
         std::cout << "new segment iterator failed: " << seg_res.status() << std::endl;
@@ -952,6 +954,7 @@ Status SegmentDump::dump_column_size() {
         seg_opts.use_page_cache = false;
         OlapReaderStatistics stats;
         seg_opts.stats = &stats;
+        seg_opts.tablet_schema = _tablet_schema;
         auto seg_res = _segment->new_iterator(*schema, seg_opts);
         if (!seg_res.ok()) {
             std::cout << "new segment iterator failed: " << seg_res.status() << std::endl;

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -213,7 +213,7 @@ protected:
         auto path = _location_provider->segment_location(tablet_id, filename);
         std::cerr << path << '\n';
 
-        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, path, 0, _tablet_schema));
+        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, path, 0));
 
         OlapReaderStatistics statistics;
         SegmentReadOptions opts;
@@ -221,6 +221,7 @@ protected:
         opts.tablet_id = tablet_id;
         opts.stats = &statistics;
         opts.chunk_size = 1024;
+        opts.tablet_schema = _tablet_schema;
 
         ASSIGN_OR_ABORT(auto seg_iter, seg->new_iterator(*_schema, opts));
         auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -206,7 +206,7 @@ protected:
         ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
         auto path = _location_provider->segment_location(tablet_id, filename);
 
-        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, path, 0, _tablet_schema));
+        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, path, 0));
 
         OlapReaderStatistics statistics;
         SegmentReadOptions opts;
@@ -214,6 +214,7 @@ protected:
         opts.tablet_id = tablet_id;
         opts.stats = &statistics;
         opts.chunk_size = 1024;
+        opts.tablet_schema = _tablet_schema;
 
         ASSIGN_OR_ABORT(auto seg_iter, seg->new_iterator(*_schema, opts));
         auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -234,7 +234,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
     auto path0 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -242,6 +242,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write) {
     opts.tablet_id = tablet_id;
     opts.stats = &statistics;
     opts.chunk_size = 1024;
+    opts.tablet_schema = _tablet_schema;
 
     auto check_segment = [&](const SegmentSharedPtr& segment) {
         ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(*_schema, opts));
@@ -336,7 +337,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write_concurrently) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
     auto path0 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -344,6 +345,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write_concurrently) {
     opts.tablet_id = tablet_id;
     opts.stats = &statistics;
     opts.chunk_size = kNumThreads * kChunksPerThread * kChunkSize;
+    opts.tablet_schema = _tablet_schema;
 
     auto check_segment = [&](const SegmentSharedPtr& segment) {
         ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(*_schema, opts));

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -240,8 +240,8 @@ TEST_F(LakeDeltaWriterTest, test_write) {
     auto path0 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
     auto path1 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(1));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, path1, 1, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0));
+    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, path1, 1));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -249,6 +249,7 @@ TEST_F(LakeDeltaWriterTest, test_write) {
     opts.tablet_id = tablet_id;
     opts.stats = &statistics;
     opts.chunk_size = 1024;
+    opts.tablet_schema = _tablet_schema;
 
     auto check_segment = [&](const SegmentSharedPtr& segment) {
         ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(*_schema, opts));

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -283,7 +283,7 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent) {
     std::string segment_path("test_cache_segment_if_absent.dat");
 
     EXPECT_EQ(nullptr, metacache->lookup_segment(segment_path));
-    auto seg1 = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+    auto seg1 = std::make_shared<Segment>(fs, segment_path, segment_id, _tablet_mgr.get());
 
     {
         // cache seg1, since there is no segment cached before, cache_segment_if_absent will cache the seg1 and return it.
@@ -293,7 +293,7 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent) {
         EXPECT_EQ(seg1, metacache->lookup_segment(segment_path));
     }
 
-    auto seg2 = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+    auto seg2 = std::make_shared<Segment>(fs, segment_path, segment_id, _tablet_mgr.get());
     {
         auto seg = metacache->cache_segment_if_absent(segment_path, seg2);
         EXPECT_TRUE(seg != nullptr);
@@ -342,7 +342,7 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent_concurrency) {
     for (int i = 0; i < kConcurrency; ++i) {
         TestCacheSegmentConcurrency ctx;
         ctx.pending_count = &pending_count;
-        ctx.segment = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+        ctx.segment = std::make_shared<Segment>(fs, segment_path, segment_id, _tablet_mgr.get());
         ctx.mutex = &m;
         ctx.cv = &cv;
         ctx.cache = metacache;

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -182,7 +182,6 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
     auto sample_segment = segments[0];
     std::string path = sample_segment->file_name();
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(path));
-    auto schema = sample_segment->tablet_schema_share_ptr();
 
     // create a dummy segment with the same path to cache ahead in metacache,
     // the later segment open operation will not update the mem_usage due to instance mismatch.
@@ -190,12 +189,12 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
         // clean the cache
         cache->prune();
         //create the dummy segment and put it into metacache
-        auto dummy_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto dummy_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), _tablet_mgr.get());
         cache->cache_segment(path, dummy_segment);
         EXPECT_EQ(dummy_segment, cache->lookup_segment(path));
         auto sz1 = cache->memory_usage();
 
-        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), _tablet_mgr.get());
         auto st = mirror_segment->open(nullptr, nullptr, true);
         EXPECT_TRUE(st.ok());
         auto sz2 = cache->memory_usage();
@@ -208,7 +207,7 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
         // clean the cache
         cache->prune();
         //create the dummy segment and put it into metacache
-        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), _tablet_mgr.get());
         cache->cache_segment(path, mirror_segment);
         auto sz1 = cache->memory_usage();
         auto ssz1 = mirror_segment->mem_usage();

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -133,10 +133,8 @@ TEST_P(LakeTabletWriterTest, test_write_success) {
     writer->close();
 
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[0]), 0,
-                                             _tablet_schema));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[1]), 1,
-                                             _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[0]), 0));
+    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[1]), 1));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -144,6 +142,7 @@ TEST_P(LakeTabletWriterTest, test_write_success) {
     opts.tablet_id = _tablet_metadata->id();
     opts.stats = &statistics;
     opts.chunk_size = 1024;
+    opts.tablet_schema = _tablet_schema;
 
     auto check_segment = [&](const SegmentSharedPtr& segment) {
         ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(*_schema, opts));
@@ -219,10 +218,8 @@ TEST_P(LakeTabletWriterTest, test_vertical_write_success) {
     writer->close();
 
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[0]), 0,
-                                             _tablet_schema));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[1]), 1,
-                                             _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[0]), 0));
+    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[1]), 1));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -230,6 +227,7 @@ TEST_P(LakeTabletWriterTest, test_vertical_write_success) {
     opts.tablet_id = _tablet_metadata->id();
     opts.stats = &statistics;
     opts.chunk_size = 1024;
+    opts.tablet_schema = _tablet_schema;
 
     auto check_segment = [&](const SegmentSharedPtr& segment) {
         ASSIGN_OR_ABORT(auto seg_iter, segment->new_iterator(*_schema, opts));

--- a/be/test/storage/meta_reader_test.cpp
+++ b/be/test/storage/meta_reader_test.cpp
@@ -45,7 +45,7 @@ public:
         uint64_t file_size, index_size, footer_pos;
         EXPECT_OK(writer.finalize(&file_size, &index_size, &footer_pos));
 
-        ASSIGN_OR_ABORT(_segment, Segment::open(fs, segment_name, 0, _tablet_schema));
+        ASSIGN_OR_ABORT(_segment, Segment::open(fs, segment_name, 0));
     }
 
 protected:

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -99,7 +99,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, fname, 1, nullptr);
     }
 
     template <LogicalType type, EncodingTypePB encoding, uint32_t version>

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -48,7 +48,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, fname, 1, nullptr);
     }
 
     void test_int_map() {

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -331,9 +331,10 @@ void RowsetTest::test_final_merge(bool has_merge_condition = false) {
             SegmentReadOptions seg_options;
             ASSIGN_OR_ABORT(seg_options.fs, FileSystem::CreateSharedFromString("posix://"));
             seg_options.stats = &_stats;
+            seg_options.tablet_schema = tablet->tablet_schema();
             std::string segment_file =
                     Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, seg_id);
-            auto segment = *Segment::open(seg_options.fs, segment_file, 0, tablet->tablet_schema());
+            auto segment = *Segment::open(seg_options.fs, segment_file, 0);
             ASSERT_NE(segment->num_rows(), 0);
             auto res = segment->new_iterator(schema, seg_options);
             ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
@@ -490,10 +491,11 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
             SegmentReadOptions seg_options;
             ASSIGN_OR_ABORT(seg_options.fs, FileSystem::CreateSharedFromString("posix://"));
             seg_options.stats = &_stats;
+            seg_options.tablet_schema = tablet->tablet_schema();
 
             std::string segment_file =
                     Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, seg_id);
-            auto segment = *Segment::open(seg_options.fs, segment_file, 0, tablet->tablet_schema());
+            auto segment = *Segment::open(seg_options.fs, segment_file, 0);
 
             ASSERT_NE(segment->num_rows(), 0);
             auto res = segment->new_iterator(schema, seg_options);
@@ -937,7 +939,7 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
     std::shared_ptr<FileSystem> fs = FileSystem::CreateSharedFromString(rowset->rowset_path()).value();
     std::string file_name = Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), 0);
 
-    auto partial_segment = *Segment::open(fs, file_name, 0, partial_tablet_schema);
+    auto partial_segment = *Segment::open(fs, file_name, 0);
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
     std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
@@ -964,7 +966,7 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
     ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, tablet_schema, auto_increment_partial_update_state,
                                        column_ids, &write_columns));
 
-    auto segment = *Segment::open(fs, dst_file_name, 0, tablet_schema);
+    auto segment = *Segment::open(fs, dst_file_name, 0);
     ASSERT_EQ(segment->num_rows(), num_rows);
 }
 

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -189,13 +189,9 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSetWithUnusedColumn) {
     ASSERT_OK(segment_data_builder.finalize_footer());
 
     //
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, file_name, 0);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
-    SegmentReadOptions seg_options;
-    OlapReaderStatistics stats;
-    seg_options.fs = _fs;
-    seg_options.stats = &stats;
     VecSchemaBuilder schema_builder;
     schema_builder.add(0, "c0", TYPE_INT)
             .add(1, "c1", TYPE_VARCHAR)
@@ -204,6 +200,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSetWithUnusedColumn) {
             .add(4, "c4", TYPE_VARCHAR);
     auto vec_schema = schema_builder.build();
     ObjectPool pool;
+    OlapReaderStatistics stats;
     SegmentReadOptions seg_opts;
     seg_opts.fs = _fs;
     seg_opts.stats = &stats;
@@ -291,15 +288,10 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDictWithUnusedColumn) {
     ASSERT_OK(segment_data_builder.append(1, slice_provider));
     ASSERT_OK(segment_data_builder.finalize_footer());
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, file_name, 0);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
-    SegmentReadOptions seg_options;
     OlapReaderStatistics stats;
-    seg_options.fs = _fs;
-    seg_options.stats = &stats;
-    seg_options.tablet_schema = tablet_schema;
-
     ColumnIteratorOptions iter_opts;
     ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(segment->file_name()));
     iter_opts.stats = &stats;
@@ -385,7 +377,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     ASSERT_OK(segment_data_builder.append(1, slice_provider));
     ASSERT_OK(segment_data_builder.finalize_footer());
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, file_name, 0);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
@@ -401,6 +393,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     SegmentReadOptions seg_opts;
     seg_opts.fs = _fs;
     seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
 
     auto* con = pool.add(new ConjunctivePredicates());
     auto type_varchar = get_type_info(TYPE_VARCHAR);
@@ -479,14 +472,10 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     ASSERT_OK(segment_data_builder.append(1, slice_provider));
     ASSERT_OK(segment_data_builder.finalize_footer());
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, file_name, 0);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
-    SegmentReadOptions seg_options;
     OlapReaderStatistics stats;
-    seg_options.fs = _fs;
-    seg_options.stats = &stats;
-
     ColumnIteratorOptions iter_opts;
     ASSIGN_OR_ABORT(auto read_file, _fs->new_random_access_file(segment->file_name()));
     iter_opts.stats = &stats;
@@ -506,6 +495,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     SegmentReadOptions seg_opts;
     seg_opts.fs = _fs;
     seg_opts.stats = &stats;
+    seg_opts.tablet_schema = tablet_schema;
 
     ColumnIdToGlobalDictMap dict_map;
     GlobalDictMap g_dict;

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -99,7 +99,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     partial_rowset_footer.set_position(footer_position);
     partial_rowset_footer.set_size(file_size - footer_position);
 
-    auto partial_segment = *Segment::open(_fs, file_name, 0, partial_tablet_schema);
+    auto partial_segment = *Segment::open(_fs, file_name, 0);
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
     std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
@@ -121,13 +121,14 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 
-    auto segment = *Segment::open(_fs, dst_file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, dst_file_name, 0);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
     seg_options.fs = _fs;
     OlapReaderStatistics stats;
     seg_options.stats = &stats;
+    seg_options.tablet_schema = tablet_schema;
     auto schema = ChunkHelper::convert_schema(tablet_schema);
     auto res = segment->new_iterator(schema, seg_options);
     ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
@@ -172,7 +173,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     }
     ASSERT_OK(SegmentRewriter::rewrite(file_name, tablet_schema, read_column_ids, new_write_columns,
                                        partial_segment->id(), partial_rowset_footer));
-    auto rewrite_segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto rewrite_segment = *Segment::open(_fs, file_name, 0);
 
     ASSERT_EQ(rewrite_segment->num_rows(), num_rows);
     res = rewrite_segment->new_iterator(schema, seg_options);

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -50,7 +50,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, fname, 1, nullptr);
     }
 
     void test_int_struct() {

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -233,7 +233,7 @@ static bool check_until_eof(const ChunkIteratorPtr& iter, int64_t check_rows_cnt
             }
             chunk->reset();
         } else {
-            LOG(WARNING) << "read error: " << st.to_string();
+            DCHECK(false) << "read error: " << st.to_string();
             return false;
         }
     }


### PR DESCRIPTION
- Removed TabletSchema member variable from Segment class
- Require TabletSchema to be passed in SegmentReadOptions
- Follow up patches needed to remove TabletSchema from SegmentReadOptions

This change removes the storage of schema information from Segment.
TabletSchema will now need to be provided externally when reading Segments.

The existence of a TabletSchema member introduces confusion around which
schema should be used - the external one passed in or the internal one stored
in Segment. This leads to complex conditional logic choosing between the two.

It violates the single responsibility principle - the Segment class now has dual
responsibilities of storing data as well as schema. These concerns should be
separated.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
