### PR TITLE
[BugFix] Update tablet schema and compaction have writer/read conflict

### DIFF
--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1723,6 +1723,7 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
 }
 
 void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
+    std::lock_guard wrlock(_meta_lock);
     std::lock_guard wrlock(_schema_lock);
     // Double Check for concurrent update
     if (!_max_version_schema || tablet_schema->schema_version() > _max_version_schema->schema_version()) {
@@ -1732,6 +1733,7 @@ void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
             _max_version_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_schema).first;
         }
     }
+
     _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
 }
 

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1723,8 +1723,8 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
 }
 
 void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
-    std::lock_guard wrlock(_meta_lock);
-    std::lock_guard wrlock(_schema_lock);
+    std::lock_guard l0(_meta_lock);
+    std::lock_guard l1(_schema_lock);
     // Double Check for concurrent update
     if (!_max_version_schema || tablet_schema->schema_version() > _max_version_schema->schema_version()) {
         if (tablet_schema->id() == TabletSchema::invalid_id()) {


### PR DESCRIPTION
After we support fast schema evolution, we may update tablet schema during data ingestion, so we need to access tablet meta. And during compaction, we will modify the tablet meta and there are write/read conflict.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
