### PR TITLE
[Enhancement] Upgrade AWS S3 SDK to 1.10.36 (#24129)

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -205,6 +205,9 @@ set_target_properties(mysql PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/m
 add_library(hdfs STATIC IMPORTED)
 set_target_properties(hdfs PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libhdfs.a)
 
+# Allow FindOpenSSL() to find correct static libraries
+set(OPENSSL_ROOT_DIR ${THIRDPARTY_DIR} CACHE STRING "root directory of an OpenSSL installation")
+message(STATUS "Using OpenSSL Root Dir: ${OPENSSL_ROOT_DIR}")
 add_library(crypto STATIC IMPORTED)
 set_target_properties(crypto PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libcrypto.a)
 

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -208,6 +208,8 @@ set_target_properties(hdfs PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/li
 add_library(crypto STATIC IMPORTED)
 set_target_properties(crypto PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libcrypto.a)
 
+add_library(AWS::crypto STATIC IMPORTED)
+set_target_properties(AWS::crypto PROPERTIES IMPORTED_LOCATION ${THIRDPARTY_DIR}/lib/libcrypto.a)
 set(AWSSDK_ROOT_DIR ${THIRDPARTY_DIR})
 set(AWSSDK_COMMON_RUNTIME_LIBS "aws-crt-cpp;aws-c-auth;aws-c-cal;aws-c-common;aws-c-compression;aws-c-event-stream;aws-c-http;aws-c-io;aws-c-mqtt;aws-c-s3;aws-checksums;s2n;aws-c-sdkutils")
 foreach(lib IN ITEMS ${AWSSDK_COMMON_RUNTIME_LIBS})

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -805,6 +805,13 @@ CONF_Double(connector_scan_use_query_mem_ratio, "0.3");
 // https://docs.aws.amazon.com/zh_cn/sdk-for-cpp/v1/developer-guide/logging.html
 CONF_mBool(aws_sdk_logging_trace_enabled, "false");
 
+// Enable RFC-3986 encoding.
+// When Querying data on Google Cloud Storage, if the objects key contain special characters like '=', '$', it will fail
+// to Authenticate because the request URL does not translate these special characters.
+// This is critical for Hive partitioned tables. The object key usually contains '=' like 'dt=20230101'.
+// Enabling RFC-3986 encoding will make sure these characters are properly encoded.
+CONF_mBool(aws_sdk_enable_compliant_rfc3986_encoding, "false");
+
 // default: 16MB
 CONF_mInt64(experimental_s3_max_single_part_size, "16777216");
 // default: 16MB

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -203,6 +203,9 @@ int main(int argc, char** argv) {
     if (starrocks::config::aws_sdk_logging_trace_enabled) {
         aws_sdk_options.loggingOptions.logLevel = Aws::Utils::Logging::LogLevel::Trace;
     }
+    if (starrocks::config::aws_sdk_enable_compliant_rfc3986_encoding) {
+        aws_sdk_options.httpOptions.compliantRfc3986Encoding = true;
+    }
     Aws::InitAPI(aws_sdk_options);
 
     std::vector<starrocks::StorePath> paths;

--- a/be/test/io/s3_input_stream_test.cpp
+++ b/be/test/io/s3_input_stream_test.cpp
@@ -65,7 +65,8 @@ void init_s3client() {
     const char* ak = config::object_storage_access_key_id.c_str();
     const char* sk = config::object_storage_secret_access_key.c_str();
     auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
-    g_s3client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config));
+    g_s3client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
+                                                     Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
 }
 
 void init_bucket() {

--- a/be/test/io/s3_output_stream_test.cpp
+++ b/be/test/io/s3_output_stream_test.cpp
@@ -59,7 +59,8 @@ void init_s3client() {
     const char* ak = config::object_storage_access_key_id.c_str();
     const char* sk = config::object_storage_secret_access_key.c_str();
     auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
-    g_s3client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config));
+    g_s3client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
+                                                     Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
 }
 
 void init_bucket() {

--- a/thirdparty/download-thirdparty.sh
+++ b/thirdparty/download-thirdparty.sh
@@ -406,6 +406,18 @@ else
     echo "$AWS_SDK_CPP_SOURCE not patched"
 fi
 
+cd $TP_SOURCE_DIR/$AWS_SDK_CPP_SOURCE
+if [ ! -f $PATCHED_MARK ] && [ $AWS_SDK_CPP_SOURCE = "aws-sdk-cpp-1.10.36" ]; then
+    if [ ! -f prefetch_crt_dep_ok ]; then
+        bash ./prefetch_crt_dependency.sh
+        touch prefetch_crt_dep_ok
+    fi
+    touch $PATCHED_MARK
+    echo "Finished patching $AWS_SDK_CPP_SOURCE"
+else
+    echo "$AWS_SDK_CPP_SOURCE not patched"
+fi
+
 # patch jemalloc_hook
 cd $TP_SOURCE_DIR/$JEMALLOC_SOURCE
 if [ ! -f $PATCHED_MARK ] && [ $JEMALLOC_SOURCE = "jemalloc-5.2.1" ]; then

--- a/thirdparty/vars.sh
+++ b/thirdparty/vars.sh
@@ -300,10 +300,10 @@ JINDOSDK_SOURCE="jindosdk-4.6.2"
 JINDOSDK_MD5SUM="7288ffb8f2fbdde6b907d15041a0f79c"
 
 # aws-sdk-cpp
-AWS_SDK_CPP_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.9.179.tar.gz"
-AWS_SDK_CPP_NAME="aws-sdk-cpp-1.9.179.tar.gz"
-AWS_SDK_CPP_SOURCE="aws-sdk-cpp-1.9.179"
-AWS_SDK_CPP_MD5SUM="3a4e2703eaeeded588814ee9e61a3342"
+AWS_SDK_CPP_DOWNLOAD="https://github.com/aws/aws-sdk-cpp/archive/refs/tags/1.10.36.tar.gz"
+AWS_SDK_CPP_NAME="aws-sdk-cpp-1.10.36.tar.gz"
+AWS_SDK_CPP_SOURCE="aws-sdk-cpp-1.10.36"
+AWS_SDK_CPP_MD5SUM="8fed635c5ac98b448bc1a98cf7c97c70"
 
 # velocypack: A fast and compact format for serialization and storage
 VPACK_DOWNLOAD="https://github.com/arangodb/velocypack/archive/refs/tags/XYZ1.0.tar.gz"


### PR DESCRIPTION
The reason that needs to upgrade aws-sdk-cpp is already described in https://github.com/StarRocks/starrocks/issues/18912

Consider cloud storage like KS3, OBS, if the request path contains '=', will face 403 problems. So we need to upgrade s3 sdk, to enable `compliantRfc3986Encoding`.

And we are using the same version as
[ClickHouse](https://github.com/ClickHouse/ClickHouse/tree/a9d5b68946bd8076c7e4517a8c3b50966fad51ed/contrib), it will be more stable.

Previous pr about this problem: #18912 #19000 #19229 #19228

**We need to change BE's CMakeFiles also, otherwise ci will be failed.**

## IMPORTANT
Introduce a new parameter `aws_sdk_enable_compliant_rfc3986_encoding` in be.conf, if you are using OBS/KS3 cloud storage, you should set `aws_sdk_enable_compliant_rfc3986_encoding=true`.

---------

Signed-off-by: Smith Cruise <chendingchao1@126.com>
(cherry picked from commit 8be2372adfcdc5602313861be64a1d9a5bf87bb7)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
