### PR TITLE
[BugFix] Fix query may hang in right outer join

### DIFF
--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -378,7 +378,7 @@ StatusOr<ChunkPtr> SpillableHashJoinProbeOperator::pull_chunk(RuntimeState* stat
     }
 
     // restore chunk from spilled partition then push it to hash join prober
-    if (!_current_reader.empty() && probe_has_no_output) {
+    if (!_current_reader.empty() && all_probe_partition_is_empty()) {
         RETURN_IF_ERROR(_restore_probe_partition(state));
     }
 

--- a/test/sql/test_spill/R/test_spill_hash_join
+++ b/test/sql/test_spill/R/test_spill_hash_join
@@ -175,3 +175,40 @@ select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is
 -- result:
 404095
 -- !result
+set spill_operator_max_bytes=0;
+-- result:
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0;
+-- result:
+2	4096.0	2	2	4098
+-- !result
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [shuffle] t1 r on l.c0 = r.c0;
+-- result:
+2	4096.0	2	2	4098
+-- !result
+select count(*), count(r.c0), avg(r.c0), count(r.c1) from empty_t l right outer join [bucket] t1 r on l.c0 = r.c0;
+-- result:
+4097	4097	6144.0	4097
+-- !result
+create table tstring (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into tstring SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into tstring select * from tstring;
+-- result:
+-- !result
+select count(*) from tstring;
+-- result:
+8192
+-- !result
+select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l join tstring r on l.c0 = r.c0; 
+select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l left join tstring r on l.c0 = r.c0; 
+select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l right join tstring r on l.c0 = r.c0;
+-- result:
+16384	61108	61096
+-- !result

--- a/test/sql/test_spill/T/test_spill_hash_join
+++ b/test/sql/test_spill/T/test_spill_hash_join
@@ -66,3 +66,23 @@ create table t2 like t0;
 insert into t2 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  409600));
 select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 > 400000;
 select count(*) from t0 l right join [shuffle]t2 r on l.c0=r.c0 where if(l.c0 is null, 0, l.c0) + r.c0 < 400000;
+
+-- make sure each time we only load one partition
+set spill_operator_max_bytes=0;
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [bucket] t1 r on l.c0 = r.c0;
+select count(l.c0), avg(l.c0), count(l.c1), count(l.c0), count(r.c1) from t0 l right join [shuffle] t1 r on l.c0 = r.c0;
+select count(*), count(r.c0), avg(r.c0), count(r.c1) from empty_t l right outer join [bucket] t1 r on l.c0 = r.c0;
+
+-- all string column
+create table tstring (
+    c0 STRING,
+    c1 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into tstring SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+insert into tstring select * from tstring;
+select count(*) from tstring;
+
+select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l join tstring r on l.c0 = r.c0; 
+select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l left join tstring r on l.c0 = r.c0; 
+select count(l.c0),sum(length(l.c0)), sum(length(l.c1)) from tstring l right join tstring r on l.c0 = r.c0;
+


### PR DESCRIPTION
when SpillableHashJoinProbe::_current_reader has output data. but _has_probe_remain is true. at this time current reader prober status is not EOS. SpillableHashJoinProbe pull_chunk will do nothing. which will cause query hang

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
