### PR TITLE
[BugFix] conflict between light schema change and migration (#34542)

### DIFF
--- a/be/src/storage/data_dir.cpp
+++ b/be/src/storage/data_dir.cpp
@@ -330,7 +330,15 @@ Status DataDir::load() {
 
     for (int64_t tablet_id : tablet_ids) {
         TabletSharedPtr tablet = _tablet_manager->get_tablet(tablet_id);
-        if (tablet && tablet->set_tablet_schema_into_rowset_meta()) {
+        /*
+         * check path here, in migration case, it is possible that
+         * there are two different tablets with the same tablet id
+         * in two different paths. And one of them is shutdown.
+         * For the path with shutdown tablet, should skip the
+         * tablet meta save here. (tablet get from manager is not the shutdown one)
+        */
+        if (tablet && tablet->data_dir()->path_hash() == this->path_hash() &&
+            tablet->set_tablet_schema_into_rowset_meta()) {
             TabletMetaPB tablet_meta_pb;
             tablet->tablet_meta()->to_meta_pb(&tablet_meta_pb);
             Status s = TabletMetaManager::save(this, tablet_meta_pb);


### PR DESCRIPTION
Problem:
Suppose there are two path: old_path and new_path. In v3.1, a tablet with id 100 migrate from old_path to new_path The tablet meta in old_path will be set shutdown.

If the shutdown tablet meta does not been gced and upgrade in v3.2 It is possible that the tablet meta in old_path will be replaced by the one in new_path which is running state.

This will cause problem because there are two tablet with the same id 100 in two different path and both of them are running state.

Fixes #34542

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
