### PR TITLE
[Enhancement] Read dcg segment without column index

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -397,7 +397,8 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
         ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(path));
         iter_opts.read_file = read_file.get();
         for (auto i = 0; i < column_ids.size(); ++i) {
-            ASSIGN_OR_RETURN(auto col_iter, (*segment)->new_column_iterator(column_ids[i]));
+            const TabletColumn& col = tablet_schema->column(column_ids[i]);
+            ASSIGN_OR_RETURN(auto col_iter, (*segment)->new_column_iterator_or_default(col, nullptr));
             RETURN_IF_ERROR(col_iter->init(iter_opts));
             RETURN_IF_ERROR(col_iter->fetch_values_by_rowid(rowids.data(), rowids.size(), (*columns)[i].get()));
         }

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -51,7 +51,6 @@ Status LakeMetaReader::init(const LakeMetaReaderParams& read_params) {
 Status LakeMetaReader::_build_collect_context(const lake::VersionedTablet& tablet,
                                               const LakeMetaReaderParams& read_params) {
     auto tablet_schema = tablet.get_schema();
-    _collect_context.seg_collecter_params.max_cid = 0;
     for (const auto& it : *(read_params.id_to_names)) {
         std::string col_name = "";
         std::string collect_field = "";
@@ -74,7 +73,6 @@ Status LakeMetaReader::_build_collect_context(const lake::VersionedTablet& table
 
         // get column id
         _collect_context.seg_collecter_params.cids.emplace_back(index);
-        _collect_context.seg_collecter_params.max_cid = std::max(_collect_context.seg_collecter_params.max_cid, index);
 
         // get result slot id
         _collect_context.result_slot_ids.emplace_back(it.first);
@@ -88,6 +86,7 @@ Status LakeMetaReader::_build_collect_context(const lake::VersionedTablet& table
         }
         _has_count_agg |= (collect_field == "count");
     }
+    _collect_context.seg_collecter_params.tablet_schema = tablet_schema;
     return Status::OK();
 }
 

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -116,7 +116,7 @@ Status MetaReader::_fill_result_chunk(Chunk* chunk) {
             TypeDescriptor desc;
             desc.type = TYPE_ARRAY;
             desc.children.emplace_back(item_desc);
-            ColumnPtr column = ColumnHelper::create_column(desc, _has_count_agg ? true : false);
+            ColumnPtr column = ColumnHelper::create_column(desc, _has_count_agg);
             chunk->append_column(std::move(column), slot->id());
         } else if (field == "count") {
             TypeDescriptor item_desc;
@@ -127,7 +127,7 @@ Status MetaReader::_fill_result_chunk(Chunk* chunk) {
             ColumnPtr column = ColumnHelper::create_column(desc, false);
             chunk->append_column(std::move(column), slot->id());
         } else {
-            ColumnPtr column = ColumnHelper::create_column(slot->type(), _has_count_agg ? true : false);
+            ColumnPtr column = ColumnHelper::create_column(slot->type(), _has_count_agg);
             chunk->append_column(std::move(column), slot->id());
         }
     }
@@ -139,23 +139,42 @@ SegmentMetaCollecter::SegmentMetaCollecter(SegmentSharedPtr segment) : _segment(
 SegmentMetaCollecter::~SegmentMetaCollecter() = default;
 
 Status SegmentMetaCollecter::init(const SegmentMetaCollecterParams* params) {
+    if (UNLIKELY(params == nullptr)) {
+        return Status::InvalidArgument("params is nullptr");
+    }
+    if (UNLIKELY(params->fields.size() != params->field_type.size())) {
+        return Status::InvalidArgument(fmt::format("unmatched field name count({}) and field type count({})",
+                                                   params->fields.size(), params->field_type.size()));
+    }
+    if (UNLIKELY(params->fields.size() != params->cids.size())) {
+        return Status::InvalidArgument(fmt::format("unmatched field name count({}) and column id count({})",
+                                                   params->fields.size(), params->cids.size()));
+    }
+    if (UNLIKELY(params->fields.size() != params->read_page.size())) {
+        return Status::InvalidArgument(fmt::format("unmatched field name count({}) and read page flags count({})",
+                                                   params->fields.size(), params->read_page.size()));
+    }
+    if (UNLIKELY(params->tablet_schema == nullptr)) {
+        return Status::InvalidArgument("tablet schema is nullptr");
+    }
     _params = params;
     return Status::OK();
 }
 
 Status SegmentMetaCollecter::open() {
+    if (UNLIKELY(_params == nullptr)) {
+        return Status::InternalError("SegmentMetaCollecter::init() has not been called");
+    }
     RETURN_IF_ERROR(_init_return_column_iterators());
     return Status::OK();
 }
 
 Status SegmentMetaCollecter::_init_return_column_iterators() {
-    DCHECK_EQ(_params->fields.size(), _params->cids.size());
-    DCHECK_EQ(_params->fields.size(), _params->read_page.size());
-
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_segment->file_name()));
     ASSIGN_OR_RETURN(_read_file, fs->new_random_access_file(_segment->file_name()));
 
-    _column_iterators.resize(_params->max_cid + 1);
+    auto max_cid = _params->cids.empty() ? 0 : *std::max(_params->cids.begin(), _params->cids.end());
+    _column_iterators.resize(max_cid + 1);
     for (int i = 0; i < _params->fields.size(); i++) {
         if (_params->read_page[i]) {
             auto cid = _params->cids[i];
@@ -175,7 +194,10 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
 }
 
 Status SegmentMetaCollecter::collect(std::vector<Column*>* dsts) {
-    DCHECK_EQ(dsts->size(), _params->fields.size());
+    if (UNLIKELY(dsts->size() != _params->fields.size())) {
+        return Status::InvalidArgument(
+                fmt::format("invalid column count. expect: {} real: {}", _params->fields.size(), dsts->size()));
+    }
 
     for (size_t i = 0; i < _params->fields.size(); i++) {
         RETURN_IF_ERROR(_collect(_params->fields[i], _params->cids[i], (*dsts)[i], _params->field_type[i]));

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -173,7 +173,7 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_segment->file_name()));
     ASSIGN_OR_RETURN(_read_file, fs->new_random_access_file(_segment->file_name()));
 
-    auto max_cid = _params->cids.empty() ? 0 : *std::max(_params->cids.begin(), _params->cids.end());
+    auto max_cid = _params->cids.empty() ? 0 : *std::max_element(_params->cids.begin(), _params->cids.end());
     _column_iterators.resize(max_cid + 1);
     for (int i = 0; i < _params->fields.size(); i++) {
         if (_params->read_page[i]) {

--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -160,8 +160,8 @@ Status SegmentMetaCollecter::_init_return_column_iterators() {
         if (_params->read_page[i]) {
             auto cid = _params->cids[i];
             if (_column_iterators[cid] == nullptr) {
-                ASSIGN_OR_RETURN(_column_iterators[cid],
-                                 _segment->new_column_iterator(cid, nullptr, _params->tablet_schema));
+                const TabletColumn& col = _params->tablet_schema->column(cid);
+                ASSIGN_OR_RETURN(_column_iterators[cid], _segment->new_column_iterator_or_default(col, nullptr));
 
                 ColumnIteratorOptions iter_opts;
                 iter_opts.check_dict_encoding = true;

--- a/be/src/storage/meta_reader.h
+++ b/be/src/storage/meta_reader.h
@@ -56,7 +56,6 @@ struct SegmentMetaCollecterParams {
     std::vector<ColumnId> cids;
     std::vector<bool> read_page;
     std::vector<LogicalType> field_type;
-    int32_t max_cid;
     bool use_page_cache;
     TabletSchemaCSPtr tablet_schema;
 };

--- a/be/src/storage/olap_meta_reader.cpp
+++ b/be/src/storage/olap_meta_reader.cpp
@@ -55,7 +55,6 @@ Status OlapMetaReader::init(const OlapMetaReaderParams& read_params) {
 }
 
 Status OlapMetaReader::_build_collect_context(const OlapMetaReaderParams& read_params) {
-    _collect_context.seg_collecter_params.max_cid = 0;
     auto tablet_schema = read_params.tablet_schema;
     for (const auto& it : *(read_params.id_to_names)) {
         std::string col_name = "";
@@ -79,7 +78,6 @@ Status OlapMetaReader::_build_collect_context(const OlapMetaReaderParams& read_p
 
         // get column id
         _collect_context.seg_collecter_params.cids.emplace_back(index);
-        _collect_context.seg_collecter_params.max_cid = std::max(_collect_context.seg_collecter_params.max_cid, index);
 
         // get result slot id
         _collect_context.result_slot_ids.emplace_back(it.first);

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -343,32 +343,35 @@ Status Segment::_create_column_readers(SegmentFooterPB* footer) {
     return Status::OK();
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(uint32_t cid, ColumnAccessPath* path,
-                                                                       const TabletSchemaCSPtr& read_tablet_schema) {
-    auto const& current_tablet_schema = !read_tablet_schema ? _tablet_schema.schema() : read_tablet_schema;
-    const TabletColumn& tablet_column = current_tablet_schema->column(cid);
-    auto column_unique_id = tablet_column.unique_id();
-    if ((_column_readers.count(column_unique_id) < 1)) {
-        if (!tablet_column.has_default_value() && !tablet_column.is_nullable()) {
-            return Status::InternalError(
-                    fmt::format("invalid nonexistent column({}) without default value.", tablet_column.name()));
-        }
-        const TypeInfoPtr& type_info = get_type_info(tablet_column);
-        std::unique_ptr<DefaultValueColumnIterator> default_value_iter(new DefaultValueColumnIterator(
-                tablet_column.has_default_value(), tablet_column.default_value(), tablet_column.is_nullable(),
-                type_info, tablet_column.length(), num_rows()));
+StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator_or_default(const TabletColumn& column,
+                                                                                  ColumnAccessPath* path) {
+    auto id = column.unique_id();
+    if (_column_readers.contains(id)) {
+        return _column_readers.at(id)->new_iterator(path);
+    } else if (!column.has_default_value() && !column.is_nullable()) {
+        return Status::InternalError(
+                fmt::format("invalid nonexistent column({}) without default value.", column.name()));
+    } else {
+        const TypeInfoPtr& type_info = get_type_info(column);
+        auto default_value_iter = std::make_unique<DefaultValueColumnIterator>(
+                column.has_default_value(), column.default_value(), column.is_nullable(), type_info, column.length(),
+                num_rows());
         ColumnIteratorOptions iter_opts;
         RETURN_IF_ERROR(default_value_iter->init(iter_opts));
         return default_value_iter;
     }
-    return _column_readers.at(column_unique_id)->new_iterator(path);
 }
 
-Status Segment::new_bitmap_index_iterator(uint32_t cid, const IndexReadOptions& options, BitmapIndexIterator** iter,
-                                          const TabletSchemaCSPtr& tablet_schema) {
-    auto column_id = tablet_schema->column(cid).unique_id();
-    if (_column_readers.count(column_id) > 0 && _column_readers.at(column_id)->has_bitmap_index()) {
-        return _column_readers.at(column_id)->new_bitmap_index_iterator(options, iter);
+StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(ColumnUID id, ColumnAccessPath* path) {
+    if (_column_readers.count(id) < 1) {
+        return Status::NotFound(fmt::format("{} does not contain column of id {}", _fname, id));
+    }
+    return _column_readers.at(id)->new_iterator(path);
+}
+
+Status Segment::new_bitmap_index_iterator(ColumnUID id, const IndexReadOptions& options, BitmapIndexIterator** iter) {
+    if (_column_readers.count(id) > 0 && _column_readers.at(id)->has_bitmap_index()) {
+        return _column_readers.at(id)->new_bitmap_index_iterator(options, iter);
     }
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -108,12 +108,34 @@ public:
 
     uint64_t id() const { return _segment_id; }
 
-    // TODO: remove this method, create `ColumnIterator` via `ColumnReader`.
-    StatusOr<std::unique_ptr<ColumnIterator>> new_column_iterator(uint32_t id, ColumnAccessPath* path = nullptr,
-                                                                  const TabletSchemaCSPtr& tablet_schema = nullptr);
+    // Creates a new iterator for a specific column in a segment.
+    //
+    // This function initializes a new iterator object that can be used to traverse
+    // the elements in a column of a segment. The iterator starts from the beginning
+    // of the column.
+    //
+    // @param id The unique identifier of the column.
+    // @param path A pointer to the access path of the column.
+    // @return A new iterator object for the specified column, or NotFound if the segment does not have the column.
+    StatusOr<std::unique_ptr<ColumnIterator>> new_column_iterator(ColumnUID id, ColumnAccessPath* path);
 
-    [[nodiscard]] Status new_bitmap_index_iterator(uint32_t cid, const IndexReadOptions& options,
-                                                   BitmapIndexIterator** iter, const TabletSchemaCSPtr& tablet_schema);
+    // Creates a new iterator for a specific column in a segment.
+    //
+    // The main difference from `new_iterator` is, if the segment does not have the
+    // column, `new_column_iterator_or_default` will return an iterator that can read
+    // the default value of the column, if there is one.
+    //
+    // Note: If this column does not have a default value defined, but is nullable, then
+    // NULL will be used as the default value.
+    //
+    // @param id The unique identifier of the column.
+    // @param path A pointer to the access path of the column.
+    // @return A new iterator object for the specified column. If the segment does not have the column and the
+    // column does not hava a default value, an error will be returned.
+    StatusOr<std::unique_ptr<ColumnIterator>> new_column_iterator_or_default(const TabletColumn& column,
+                                                                             ColumnAccessPath* path);
+
+    Status new_bitmap_index_iterator(ColumnUID id, const IndexReadOptions& options, BitmapIndexIterator** iter);
 
     size_t num_short_keys() const { return _tablet_schema->num_short_key_columns(); }
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -4390,7 +4390,7 @@ static StatusOr<std::unique_ptr<ColumnIterator>> new_dcg_column_iterator(GetDelt
             ctx.dcg_read_files[dcg_segment->file_name()] = std::move(read_file);
         }
         iter_opts.read_file = ctx.dcg_read_files[dcg_segment->file_name()].get();
-        return dcg_segment->new_column_iterator(col_index);
+        return dcg_segment->new_column_iterator(ucid, nullptr);
     }
     return nullptr;
 }
@@ -4484,8 +4484,8 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
         if (full_row_column) {
             full_row_column->reset_column();
             full_row_column->reserve(rowids.size());
-            ASSIGN_OR_RETURN(auto col_iter,
-                             (*segment)->new_column_iterator(_tablet.tablet_schema()->num_columns() - 1));
+            const auto& column = _tablet.tablet_schema()->column(_tablet.tablet_schema()->num_columns() - 1);
+            ASSIGN_OR_RETURN(auto col_iter, (*segment)->new_column_iterator_or_default(column, nullptr));
             RETURN_IF_ERROR(col_iter->init(iter_opts));
             RETURN_IF_ERROR(col_iter->fetch_values_by_rowid(rowids.data(), rowids.size(), full_row_column.get()));
             auto row_encoder = RowStoreEncoderFactory::instance()->get_or_create_encoder(SIMPLE);
@@ -4498,8 +4498,8 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
                                  new_dcg_column_iterator(ctx, fs, iter_opts, unique_column_ids[i], read_tablet_schema));
                 if (col_iter == nullptr) {
                     // not found in delta column file, build iterator from main segment
-                    ASSIGN_OR_RETURN(col_iter,
-                                     (*segment)->new_column_iterator(column_ids[i], nullptr, read_tablet_schema));
+                    const auto& column = read_tablet_schema->column(column_ids[i]);
+                    ASSIGN_OR_RETURN(col_iter, (*segment)->new_column_iterator_or_default(column, nullptr));
                     iter_opts.read_file = read_file.get();
                 }
                 RETURN_IF_ERROR(col_iter->init(iter_opts));
@@ -4545,7 +4545,8 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
                              new_dcg_column_iterator(ctx, fs, iter_opts, unique_column_ids[i], read_tablet_schema));
             if (col_iter == nullptr) {
                 // not found in delta column file, build iterator from main segment
-                ASSIGN_OR_RETURN(col_iter, (*segment)->new_column_iterator(auto_increment_column_idx));
+                const TabletColumn& col = auto_increment_state->schema->column(auto_increment_column_idx);
+                ASSIGN_OR_RETURN(col_iter, (*segment)->new_column_iterator_or_default(col, nullptr));
                 iter_opts.read_file = read_file.get();
             }
             RETURN_IF_ERROR(col_iter->init(iter_opts));

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -291,6 +291,7 @@ set(EXEC_FILES
         ./storage/publish_version_task_test.cpp
         ./storage/publish_version_manager_test.cpp
         ./storage/get_use_pk_index_test.cpp
+        ./storage/meta_reader_test.cpp
         ./runtime/buffer_control_block_test.cpp
         ./runtime/datetime_value_test.cpp
         ./runtime/decimalv2_value_test.cpp

--- a/be/test/storage/meta_reader_test.cpp
+++ b/be/test/storage/meta_reader_test.cpp
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/meta_reader.h"
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "column/fixed_length_column.h"
+#include "fs/fs_util.h"
+#include "storage/rowset/segment_writer.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class SegmentMetaCollecterTest : public ::testing::Test {
+public:
+    SegmentMetaCollecterTest() {
+        TabletSchemaPB schema_pb;
+        auto col = schema_pb.add_column();
+        col->set_name("c0");
+        col->set_type("INT");
+        col->set_is_key(true);
+        col->set_is_nullable(false);
+        _tablet_schema = TabletSchema::create(schema_pb);
+
+        std::string segment_name = "segment_meta_collector_test.dat";
+        ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(segment_name));
+        WritableFileOptions options{.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_ABORT(auto wf, fs->new_writable_file(options, segment_name));
+        SegmentWriter writer(std::move(wf), 0, _tablet_schema, SegmentWriterOptions());
+        EXPECT_OK(writer.init());
+        uint64_t file_size, index_size, footer_pos;
+        EXPECT_OK(writer.finalize(&file_size, &index_size, &footer_pos));
+
+        ASSIGN_OR_ABORT(_segment, Segment::open(fs, segment_name, 0, _tablet_schema));
+    }
+
+protected:
+    TabletSchemaCSPtr _tablet_schema;
+    SegmentSharedPtr _segment;
+};
+
+TEST_F(SegmentMetaCollecterTest, test_init) {
+    SegmentMetaCollecter collecter(_segment);
+    EXPECT_FALSE(collecter.init(nullptr).ok());
+
+    SegmentMetaCollecterParams params;
+    EXPECT_FALSE(collecter.init(&params).ok());
+
+    params.fields.emplace_back("count");
+    EXPECT_FALSE(collecter.init(&params).ok());
+
+    params.field_type.emplace_back(LogicalType::TYPE_INT);
+    EXPECT_FALSE(collecter.init(&params).ok());
+
+    params.cids.emplace_back(0);
+    EXPECT_FALSE(collecter.init(&params).ok());
+
+    params.read_page.emplace_back(false);
+    EXPECT_FALSE(collecter.init(&params).ok());
+
+    params.tablet_schema = _tablet_schema;
+    EXPECT_OK(collecter.init(&params));
+}
+
+TEST_F(SegmentMetaCollecterTest, test_open_and_collect) {
+    SegmentMetaCollecter collecter(_segment);
+
+    // init() has not been called
+    EXPECT_FALSE(collecter.open().ok());
+
+    SegmentMetaCollecterParams params;
+    params.fields.emplace_back("count");
+    params.field_type.emplace_back(LogicalType::TYPE_INT);
+    params.cids.emplace_back(0);
+    params.read_page.emplace_back(false);
+    params.tablet_schema = _tablet_schema;
+    EXPECT_OK(collecter.init(&params));
+
+    std::vector<Column*> columns;
+    EXPECT_FALSE(collecter.collect(&columns).ok());
+
+    auto col = Int64Column::create();
+    columns.emplace_back(col.get());
+
+    EXPECT_OK(collecter.collect(&columns));
+    EXPECT_EQ(1, col->size());
+    EXPECT_EQ(0, col->get(0).get_int64());
+}
+
+} // namespace starrocks

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -308,7 +308,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDictWithUnusedColumn) {
     iter_opts.check_dict_encoding = true;
     iter_opts.reader_type = READER_QUERY;
 
-    ASSIGN_OR_ABORT(auto scalar_iter, segment->new_column_iterator(1));
+    ASSIGN_OR_ABORT(auto scalar_iter, segment->new_column_iterator(1, nullptr));
     ASSERT_OK(scalar_iter->init(iter_opts));
     ASSERT_FALSE(scalar_iter->all_page_dict_encoded());
 
@@ -494,7 +494,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     iter_opts.read_file = read_file.get();
     iter_opts.check_dict_encoding = true;
     iter_opts.reader_type = READER_QUERY;
-    ASSIGN_OR_ABORT(auto scalar_iter, segment->new_column_iterator(1));
+    ASSIGN_OR_ABORT(auto scalar_iter, segment->new_column_iterator(1, nullptr));
     ASSERT_OK(scalar_iter->init(iter_opts));
     ASSERT_FALSE(scalar_iter->all_page_dict_encoded());
 

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -243,6 +243,32 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
         }
     }
     EXPECT_EQ(count, num_rows);
+
+    // Test new_column_iterator
+    {
+        auto r = segment->new_column_iterator(5 /* nonexist column id*/, nullptr);
+        ASSERT_FALSE(r.ok());
+        ASSERT_TRUE(r.status().is_not_found()) << r.status();
+    }
+    // Test new_column_iterator_or_default
+    {
+        TabletColumn column;
+        column.set_unique_id(5);
+        column.set_type(LogicalType::TYPE_BIGINT);
+        column.set_is_nullable(false);
+
+        auto r = segment->new_column_iterator_or_default(column, nullptr);
+        ASSERT_FALSE(r.ok());
+
+        column.set_is_nullable(true);
+        r = segment->new_column_iterator_or_default(column, nullptr);
+        ASSERT_TRUE(r.ok()) << r.status();
+
+        column.set_is_nullable(false);
+        column.set_default_value("10");
+        r = segment->new_column_iterator_or_default(column, nullptr);
+        ASSERT_TRUE(r.ok()) << r.status();
+    }
 }
 
 // NOLINTNEXTLINE


### PR DESCRIPTION
Create column iterator from column unique id, reduce the dependency of the segment interfaces on TabletSchema.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
