### PR TITLE
[Enhancement] remove db lock in MetricRepo

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/MetricsAction.java
@@ -70,8 +70,7 @@ public class MetricsAction extends RestBaseAction {
         super(controller);
     }
 
-
-    public final class RequestParams {
+    public static final class RequestParams {
         // Whether to collect per table metrics
         private final boolean collectTableMetrics;
         // Whether to collect per table metrics in minified mode, Ignore some heavy metrics if true
@@ -80,7 +79,8 @@ public class MetricsAction extends RestBaseAction {
         private final boolean collectMVMetrics;
         // Whether to collect per materialized view metrics in minified mode, Ignore some heavy metrics if true
         private final boolean minifyMVMetrics;
-        RequestParams(boolean collectTableMetrics, boolean minifyTableMetrics,
+
+        public RequestParams(boolean collectTableMetrics, boolean minifyTableMetrics,
                       boolean collectMVMetrics, boolean minifyMVMetrics) {
             this.collectTableMetrics = collectTableMetrics;
             this.minifyTableMetrics = minifyTableMetrics;

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -424,10 +424,10 @@ public final class MetricRepo {
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_ROUTINE_LOAD_ERROR_ROWS);
 
         COUNTER_UNFINISHED_BACKUP_JOB = new LongCounterMetric("unfinished_backup_job", MetricUnit.REQUESTS,
-        "current unfinished backup job");
+                "current unfinished backup job");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_UNFINISHED_BACKUP_JOB);
         COUNTER_UNFINISHED_RESTORE_JOB = new LongCounterMetric("unfinished_restore_job", MetricUnit.REQUESTS,
-        "current unfinished restore job");
+                "current unfinished restore job");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_UNFINISHED_RESTORE_JOB);
         List<Database> dbs = Lists.newArrayList();
         if (GlobalStateMgr.getCurrentState().getIdToDb() != null) {
@@ -793,8 +793,8 @@ public final class MetricRepo {
     public static void updateRoutineLoadProcessMetrics() {
         List<RoutineLoadJob> jobs = GlobalStateMgr.getCurrentState().getRoutineLoadMgr().getRoutineLoadJobByState(
                 Sets.newHashSet(RoutineLoadJob.JobState.NEED_SCHEDULE,
-                                RoutineLoadJob.JobState.PAUSED,
-                                RoutineLoadJob.JobState.RUNNING));
+                        RoutineLoadJob.JobState.PAUSED,
+                        RoutineLoadJob.JobState.RUNNING));
 
         List<RoutineLoadJob> kafkaJobs = jobs.stream()
                 .filter(job -> (job instanceof KafkaRoutineLoadJob)
@@ -929,23 +929,22 @@ public final class MetricRepo {
             if (null == db) {
                 continue;
             }
-            db.readLock();
-            try {
-                for (Table table : db.getTables()) {
-                    TableMetricsEntity entity = TableMetricsRegistry.getInstance().getMetricsEntity(table.getId());
-                    for (Metric m : entity.getMetrics()) {
-                        if (minifyTableMetrics && (null == m.getValue() ||
-                                (MetricType.COUNTER == m.type && ((Long) m.getValue()).longValue() == 0L))) {
-                            continue;
-                        }
-                        m.addLabel(new MetricLabel("db_name", dbName))
-                                .addLabel(new MetricLabel("tbl_name", table.getName()))
-                                .addLabel(new MetricLabel("tbl_id", String.valueOf(table.getId())));
-                        visitor.visit(m);
+
+            // NOTE: avoid holding database lock here, since we only read all tables, and immutable fields of table
+            for (Table table : db.getTables()) {
+                long tableId = table.getId();
+                String tableName = table.getName();
+                TableMetricsEntity entity = TableMetricsRegistry.getInstance().getMetricsEntity(tableId);
+                for (Metric m : entity.getMetrics()) {
+                    if (minifyTableMetrics && (null == m.getValue() ||
+                            (MetricType.COUNTER == m.type && (Long) m.getValue() == 0L))) {
+                        continue;
                     }
+                    m.addLabel(new MetricLabel("db_name", dbName))
+                            .addLabel(new MetricLabel("tbl_name", tableName))
+                            .addLabel(new MetricLabel("tbl_id", String.valueOf(tableId)));
+                    visitor.visit(m);
                 }
-            } finally {
-                db.readUnlock();
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/TableMetricsRegistry.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/TableMetricsRegistry.java
@@ -30,7 +30,7 @@ public final class TableMetricsRegistry {
     private static final TableMetricsRegistry INSTANCE = new TableMetricsRegistry();
 
     private TableMetricsRegistry() {
-        idToTableMetrics = Maps.newHashMap();
+        idToTableMetrics = Maps.newConcurrentMap();
         // clear all metrics everyday
         timer = ThreadPoolManager.newDaemonScheduledThreadPool(1, "Table-Metrics-Cleaner", true);
         timer.scheduleAtFixedRate(new MetricsCleaner(), 0, 1L, TimeUnit.DAYS);
@@ -40,7 +40,7 @@ public final class TableMetricsRegistry {
         return INSTANCE;
     }
 
-    public synchronized TableMetricsEntity getMetricsEntity(long tableId) {
+    public TableMetricsEntity getMetricsEntity(long tableId) {
         return idToTableMetrics.computeIfAbsent(tableId, k -> new TableMetricsEntity());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricRepoTest.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.metric;
+
+import com.starrocks.catalog.Table;
+import com.starrocks.http.rest.MetricsAction;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MetricRepoTest extends PlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+
+        starRocksAssert.withDatabase("test_metric");
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        PlanTestBase.afterClass();
+        try {
+            starRocksAssert.dropDatabase("test_metric");
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGetMetric() throws Exception {
+        starRocksAssert.useDatabase("test_metric")
+                .withTable("create table t1 (c1 int, c2 string)" +
+                        " distributed by hash(c1) " +
+                        " properties('replication_num'='1') ");
+        Table t1 = starRocksAssert.getTable("test_metric", "t1");
+
+        // update metric
+        TableMetricsEntity entity = TableMetricsRegistry.getInstance().getMetricsEntity(t1.getId());
+        entity.counterScanBytesTotal.increase(1024L);
+
+        // verify metric
+        JsonMetricVisitor visitor = new JsonMetricVisitor("m");
+        MetricsAction.RequestParams params = new MetricsAction.RequestParams(true, true, true, true);
+        MetricRepo.getMetric(visitor, params);
+        String json = visitor.build();
+        Assert.assertTrue(StringUtils.isNotEmpty(json));
+        Assert.assertTrue(json.contains("test_metric"));
+    }
+
+}


### PR DESCRIPTION
Fixes #issue

Why? 
- There's a lot contention on the db lock, metric should not be affected by it
- The metric procedure only needs to read the immutable fields(TableName and TableId) for all tables, it's not necessary to hold the database lock

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
