### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] PersistentIndex may keep unused delete operations (backport #34352)

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3598,6 +3598,10 @@ Status merge_shard_kvs_fixed_len(std::vector<KVRef>& l0_kvs, std::vector<std::ve
     kvs_set.reserve(estimated_size);
     DCHECK(!l1_kvs.empty());
     for (const auto& kv : l1_kvs[0]) {
+        const auto v = UNALIGNED_LOAD64(kv.kv_pos + KeySize);
+        if (v == NullIndexValue) {
+            continue;
+        }
         const auto [_, inserted] = kvs_set.emplace(kv);
         DCHECK(inserted) << "duplicate key found when in l1 index";
         if (!inserted) {
@@ -3648,6 +3652,10 @@ Status merge_shard_kvs_var_len(std::vector<KVRef>& l0_kvs, std::vector<std::vect
     kvs_set.reserve(estimate_size);
     DCHECK(!l1_kvs.empty());
     for (const auto& kv : l1_kvs[0]) {
+        const auto v = UNALIGNED_LOAD64(kv.kv_pos + kv.size - kIndexValueSize);
+        if (v == NullIndexValue) {
+            continue;
+        }
         const auto [_, inserted] = kvs_set.emplace(kv);
         DCHECK(inserted) << "duplicate key found when in l1 index";
         if (!inserted) {
@@ -4041,15 +4049,6 @@ Status PersistentIndex::_merge_compaction() {
     if (_l1_vec.empty()) {
         return Status::InternalError("cannot do merge_compaction without l1");
     }
-    // if _l0 is empty() and _l1_vec only has one _l1, we can rename it directly
-    if (_l0->size() == 0) {
-        if (!_has_l1 && _l1_vec.size() == 1) {
-            const std::string idx_file_path =
-                    strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
-            const std::string idx_file_path_tmp = _l1_vec[0]->_file->filename();
-            return FileSystem::Default()->rename_file(idx_file_path_tmp, idx_file_path);
-        }
-    }
     auto writer = std::make_unique<ImmutableIndexWriter>();
     const std::string idx_file_path =
             strings::Substitute("$0/index.l1.$1.$2", _path, _version.major(), _version.minor());
@@ -4061,6 +4060,13 @@ Status PersistentIndex::_merge_compaction() {
     // so we use total_kv_size to correct the _usage.
     if (_usage != writer->total_kv_size()) {
         _usage = writer->total_kv_size();
+    }
+    if (_size != writer->total_kv_num()) {
+        std::string msg =
+                strings::Substitute("inconsistent kv num after merge compaction, actual:$0, expect:$1, index_file:$2",
+                                    writer->total_kv_num(), _size, writer->index_file());
+        LOG(ERROR) << msg;
+        return Status::InternalError(msg);
     }
     return writer->finish();
 }

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -493,6 +493,10 @@ public:
 
     size_t file_size() { return _total_bytes; }
 
+    size_t total_kv_num() { return _total; }
+
+    std::string index_file() { return _idx_file_path; }
+
 private:
     EditVersion _version;
     string _idx_file_path_tmp;
@@ -641,6 +645,18 @@ public:
     double get_write_amp_score() const;
 
     static double major_compaction_score(size_t l1_count, size_t l2_count);
+
+    // not thread safe, just for unit test
+    size_t kv_num_in_immutable_index() {
+        size_t res = 0;
+        for (int i = 0; i < _l1_vec.size(); i++) {
+            res += _l1_vec[i]->total_size();
+        }
+        for (int i = 0; i < _l2_vec.size(); i++) {
+            res += _l2_vec[i]->total_size();
+        }
+        return res;
+    }
 
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -2206,4 +2206,80 @@ PARALLEL_TEST(PersistentIndexTest, test_l2_versions) {
     ASSERT_TRUE(m10 < m9);
 }
 
+PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
+    config::l0_max_mem_usage = 1024;
+    config::enable_pindex_minor_compaction = false;
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_index_keep_delete";
+    const std::string kIndexFile = "./PersistentIndexTest_test_index_keep_delete/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    using Key = std::string;
+    PersistentIndexMetaPB index_meta;
+    const int N = 10000;
+    const int DEL_N = 90000;
+    int64_t cur_version = 0;
+
+    // insert
+    vector<Key> keys(N);
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = "test_varlen_" + std::to_string(i);
+        values.emplace_back(i);
+        key_slices.emplace_back(keys[i]);
+    }
+    // erase
+    vector<Key> erase_keys(DEL_N);
+    vector<Slice> erase_key_slices;
+    erase_key_slices.reserve(DEL_N);
+    for (int i = 0; i < DEL_N; i++) {
+        erase_keys[i] = "test_varlen_" + std::to_string(i);
+        erase_key_slices.emplace_back(erase_keys[i]);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    {
+        EditVersion version(cur_version++, 0);
+        index_meta.set_key_size(0);
+        index_meta.set_size(0);
+        version.to_pb(index_meta.mutable_version());
+        MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+        l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+        version.to_pb(snapshot_meta->mutable_version());
+
+        PersistentIndex index(kPersistentIndexDir);
+
+        ASSERT_OK(index.load(index_meta));
+        ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), N));
+        // erase non-exist keys
+        // flush advance
+        vector<IndexValue> erase_old_values(erase_keys.size());
+        ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
+        ASSERT_TRUE(index.commit(&index_meta).ok());
+        ASSERT_TRUE(index.on_commited().ok());
+        ASSERT_EQ(0, index.kv_num_in_immutable_index());
+
+        ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), N));
+        // erase non-exist keys
+        // flush advance
+        ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
+        // not trigger flush advance
+        config::l0_max_mem_usage = 100 * 1024 * 1024; // 100MB
+        std::vector<IndexValue> old_values(keys.size());
+        ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
+        ASSERT_TRUE(index.commit(&index_meta).ok());
+        ASSERT_TRUE(index.on_commited().ok());
+        ASSERT_EQ(N, index.kv_num_in_immutable_index());
+    }
+    ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
+}
+
 } // namespace starrocks

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -84,7 +84,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
         idxes.emplace_back(num);
         num++;
     }
-    vector<IndexValue> erase_old_values(erase_keys.size());
+    vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
     KeysInfo erase_not_found;
     size_t erase_num_found = 0;
     ASSERT_TRUE(idx->erase(erase_key_slices.data(), erase_old_values.data(), &erase_not_found, &erase_num_found, idxes)
@@ -113,7 +113,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
         upsert_values[i] = i * 3;
         idxes.emplace_back(i);
     }
-    vector<IndexValue> upsert_old_values(upsert_keys.size());
+    vector<IndexValue> upsert_old_values(upsert_keys.size(), NullIndexValue);
     KeysInfo upsert_not_found;
     size_t upsert_num_found = 0;
     ASSERT_TRUE(idx->upsert(upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data(), &upsert_not_found,
@@ -179,7 +179,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
         idxes.emplace_back(num);
         num++;
     }
-    vector<IndexValue> erase_old_values(erase_keys.size());
+    vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
     KeysInfo erase_not_found;
     size_t erase_num_found = 0;
     ASSERT_TRUE(idx->erase(erase_key_slices.data(), erase_old_values.data(), &erase_not_found, &erase_num_found, idxes)
@@ -208,7 +208,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
         upsert_values[i] = i * 3;
         idxes.emplace_back(i);
     }
-    vector<IndexValue> upsert_old_values(upsert_keys.size());
+    vector<IndexValue> upsert_old_values(upsert_keys.size(), NullIndexValue);
     KeysInfo upsert_not_found;
     size_t upsert_num_found = 0;
     ASSERT_TRUE(idx->upsert(upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data(), &upsert_not_found,
@@ -296,7 +296,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
     erase_keys.emplace_back(gen_random_string_of_random_length(24, 41));
     erase_key_slices.emplace_back(erase_keys.back());
     idxes.emplace_back(num++);
-    vector<IndexValue> erase_old_values(erase_keys.size());
+    vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
     KeysInfo erase_not_found;
     size_t erase_num_found = 0;
     ASSERT_TRUE(idx->erase(erase_key_slices.data(), erase_old_values.data(), &erase_not_found, &erase_num_found, idxes)
@@ -331,7 +331,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
         upsert_values[i] = i * 3;
         idxes.emplace_back(i);
     }
-    vector<IndexValue> upsert_old_values(upsert_keys.size());
+    vector<IndexValue> upsert_old_values(upsert_keys.size(), NullIndexValue);
     KeysInfo upsert_not_found;
     size_t upsert_num_found = 0;
     ASSERT_TRUE(idx->upsert(upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data(), &upsert_not_found,
@@ -412,7 +412,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
         version.to_pb(snapshot_meta->mutable_version());
 
-        std::vector<IndexValue> old_values(N);
+        std::vector<IndexValue> old_values(N, NullIndexValue);
         PersistentIndex index(kPersistentIndexDir);
         // flush l0 first
         ASSERT_OK(index.load(index_meta));
@@ -437,7 +437,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
             ASSERT_EQ(values[i], get_values[i]);
         }
 
-        vector<IndexValue> erase_old_values(erase_keys.size());
+        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
         ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -472,7 +472,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size());
+        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
         ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -536,7 +536,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
     IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
     version.to_pb(snapshot_meta->mutable_version());
 
-    std::vector<IndexValue> old_values(N);
+    std::vector<IndexValue> old_values(N, NullIndexValue);
     PersistentIndex index(kPersistentIndexDir);
     auto one_time_num = N / 4;
     // do snapshot twice, when cannot do flush_l0, which mean index_file checker works
@@ -615,7 +615,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_memory_usage) {
     version.to_pb(snapshot_meta->mutable_version());
 
     const int64_t old_l0_max_mem_usage = config::l0_max_mem_usage;
-    std::vector<IndexValue> old_values(N);
+    std::vector<IndexValue> old_values(N, NullIndexValue);
     PersistentIndex index(kPersistentIndexDir);
     config::l0_max_mem_usage = 100;
     for (auto t = 0; t < 100; ++t) {
@@ -682,7 +682,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_min_memory_usage) {
     const int64_t old_l0_min_mem_usage = config::l0_min_mem_usage;
     const int64_t old_l0_max_mem_usage = config::l0_max_mem_usage;
     config::l0_max_mem_usage = 1000000000000;
-    std::vector<IndexValue> old_values(N);
+    std::vector<IndexValue> old_values(N, NullIndexValue);
     PersistentIndex index(kPersistentIndexDir);
     config::l0_min_mem_usage = 100;
     for (auto t = 0; t < 100; ++t) {
@@ -832,7 +832,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
             snapshot_key_slices.emplace_back(snapshot_keys[i]);
         }
 
-        std::vector<IndexValue> old_values(NUM_SNAPSHOT);
+        std::vector<IndexValue> old_values(NUM_SNAPSHOT, NullIndexValue);
         ASSERT_OK(index.prepare(EditVersion(2, 0), NUM_SNAPSHOT));
         ASSERT_OK(index.upsert(NUM_SNAPSHOT, snapshot_key_slices.data(), snapshot_values.data(), old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
@@ -850,7 +850,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
         }
 
         config::l0_l1_merge_ratio = 1;
-        std::vector<IndexValue> wal_old_values(NUM_WAL);
+        std::vector<IndexValue> wal_old_values(NUM_WAL, NullIndexValue);
         ASSERT_OK(index.prepare(EditVersion(3, 0), NUM_WAL));
         ASSERT_OK(index.upsert(NUM_WAL, wal_key_slices.data(), wal_values.data(), wal_old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
@@ -936,13 +936,13 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
-        std::vector<IndexValue> old_values(keys.size());
+        std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
         ASSERT_TRUE(index.prepare(EditVersion(2, 0), keys.size()).ok());
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
-        vector<IndexValue> erase_old_values(erase_keys.size());
+        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
         ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -976,7 +976,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size());
+        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
         ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -1062,13 +1062,13 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
-        std::vector<IndexValue> old_values(keys.size());
+        std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
         ASSERT_TRUE(index.prepare(EditVersion(2, 0), keys.size()).ok());
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
-        vector<IndexValue> erase_old_values(erase_keys.size());
+        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
         ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -1102,7 +1102,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size());
+        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
         ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -1718,7 +1718,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
             for (int j = 0; j < N; j++) {
                 values.emplace_back(i * j);
             }
-            std::vector<IndexValue> old_values(N);
+            std::vector<IndexValue> old_values(N, NullIndexValue);
             ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
             std::vector<IndexValue> get_values(N);
             ASSERT_OK(index.get(N, key_slices.data(), get_values.data()));
@@ -1813,14 +1813,14 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
 
         // generate 3 versions
         for (int i = 0; i < 3; i++) {
-            std::vector<IndexValue> old_values(keys.size());
+            std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
             ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), keys.size()).ok());
             ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
             ASSERT_TRUE(index.commit(&index_meta).ok());
             ASSERT_TRUE(index.on_commited().ok());
         }
 
-        vector<IndexValue> erase_old_values(erase_keys.size());
+        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
         ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -1854,7 +1854,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size());
+        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
         ASSERT_TRUE(new_index.prepare(EditVersion(cur_version++, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -1930,7 +1930,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
         // 1. upsert
         for (int i = 0; i < K; i++) {
             incre_key(i);
-            std::vector<IndexValue> old_values(M);
+            std::vector<IndexValue> old_values(M, NullIndexValue);
             ASSERT_OK(index.load(index_meta));
             ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
             ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));
@@ -2049,7 +2049,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
         // 1. upsert
         for (int i = 0; i < K; i++) {
             incre_key(i);
-            std::vector<IndexValue> old_values(M);
+            std::vector<IndexValue> old_values(M, NullIndexValue);
             ASSERT_OK(index.load(index_meta));
             ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
             ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));
@@ -2133,14 +2133,14 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_delete) {
 
         // generate 3 versions
         for (int i = 0; i < 3; i++) {
-            std::vector<IndexValue> old_values(keys.size());
+            std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
             ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), keys.size()).ok());
             ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
             ASSERT_TRUE(index.commit(&index_meta).ok());
             ASSERT_TRUE(index.on_commited().ok());
         }
 
-        vector<IndexValue> erase_old_values(erase_keys.size());
+        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
         ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), erase_keys.size()).ok());
         // not trigger l0 advance flush
         config::l0_max_mem_usage = 100 * 1024 * 1024; // 100MB
@@ -2261,7 +2261,7 @@ PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
         ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), N));
         // erase non-exist keys
         // flush advance
-        vector<IndexValue> erase_old_values(erase_keys.size());
+        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
@@ -2273,7 +2273,7 @@ PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // not trigger flush advance
         config::l0_max_mem_usage = 100 * 1024 * 1024; // 100MB
-        std::vector<IndexValue> old_values(keys.size());
+        std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -84,7 +84,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
         idxes.emplace_back(num);
         num++;
     }
-    vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+    vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
     KeysInfo erase_not_found;
     size_t erase_num_found = 0;
     ASSERT_TRUE(idx->erase(erase_key_slices.data(), erase_old_values.data(), &erase_not_found, &erase_num_found, idxes)
@@ -113,7 +113,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
         upsert_values[i] = i * 3;
         idxes.emplace_back(i);
     }
-    vector<IndexValue> upsert_old_values(upsert_keys.size(), NullIndexValue);
+    vector<IndexValue> upsert_old_values(upsert_keys.size(), IndexValue(NullIndexValue));
     KeysInfo upsert_not_found;
     size_t upsert_num_found = 0;
     ASSERT_TRUE(idx->upsert(upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data(), &upsert_not_found,
@@ -179,7 +179,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
         idxes.emplace_back(num);
         num++;
     }
-    vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+    vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
     KeysInfo erase_not_found;
     size_t erase_num_found = 0;
     ASSERT_TRUE(idx->erase(erase_key_slices.data(), erase_old_values.data(), &erase_not_found, &erase_num_found, idxes)
@@ -208,7 +208,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
         upsert_values[i] = i * 3;
         idxes.emplace_back(i);
     }
-    vector<IndexValue> upsert_old_values(upsert_keys.size(), NullIndexValue);
+    vector<IndexValue> upsert_old_values(upsert_keys.size(), IndexValue(NullIndexValue));
     KeysInfo upsert_not_found;
     size_t upsert_num_found = 0;
     ASSERT_TRUE(idx->upsert(upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data(), &upsert_not_found,
@@ -296,7 +296,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
     erase_keys.emplace_back(gen_random_string_of_random_length(24, 41));
     erase_key_slices.emplace_back(erase_keys.back());
     idxes.emplace_back(num++);
-    vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+    vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
     KeysInfo erase_not_found;
     size_t erase_num_found = 0;
     ASSERT_TRUE(idx->erase(erase_key_slices.data(), erase_old_values.data(), &erase_not_found, &erase_num_found, idxes)
@@ -331,7 +331,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
         upsert_values[i] = i * 3;
         idxes.emplace_back(i);
     }
-    vector<IndexValue> upsert_old_values(upsert_keys.size(), NullIndexValue);
+    vector<IndexValue> upsert_old_values(upsert_keys.size(), IndexValue(NullIndexValue));
     KeysInfo upsert_not_found;
     size_t upsert_num_found = 0;
     ASSERT_TRUE(idx->upsert(upsert_key_slices.data(), upsert_values.data(), upsert_old_values.data(), &upsert_not_found,
@@ -412,7 +412,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
         version.to_pb(snapshot_meta->mutable_version());
 
-        std::vector<IndexValue> old_values(N, NullIndexValue);
+        std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
         PersistentIndex index(kPersistentIndexDir);
         // flush l0 first
         ASSERT_OK(index.load(index_meta));
@@ -437,7 +437,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
             ASSERT_EQ(values[i], get_values[i]);
         }
 
-        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+        vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -472,7 +472,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
+        vector<IndexValue> old_values(invalid_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -536,7 +536,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
     IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
     version.to_pb(snapshot_meta->mutable_version());
 
-    std::vector<IndexValue> old_values(N, NullIndexValue);
+    std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
     PersistentIndex index(kPersistentIndexDir);
     auto one_time_num = N / 4;
     // do snapshot twice, when cannot do flush_l0, which mean index_file checker works
@@ -615,7 +615,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_memory_usage) {
     version.to_pb(snapshot_meta->mutable_version());
 
     const int64_t old_l0_max_mem_usage = config::l0_max_mem_usage;
-    std::vector<IndexValue> old_values(N, NullIndexValue);
+    std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
     PersistentIndex index(kPersistentIndexDir);
     config::l0_max_mem_usage = 100;
     for (auto t = 0; t < 100; ++t) {
@@ -682,7 +682,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_min_memory_usage) {
     const int64_t old_l0_min_mem_usage = config::l0_min_mem_usage;
     const int64_t old_l0_max_mem_usage = config::l0_max_mem_usage;
     config::l0_max_mem_usage = 1000000000000;
-    std::vector<IndexValue> old_values(N, NullIndexValue);
+    std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
     PersistentIndex index(kPersistentIndexDir);
     config::l0_min_mem_usage = 100;
     for (auto t = 0; t < 100; ++t) {
@@ -832,7 +832,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
             snapshot_key_slices.emplace_back(snapshot_keys[i]);
         }
 
-        std::vector<IndexValue> old_values(NUM_SNAPSHOT, NullIndexValue);
+        std::vector<IndexValue> old_values(NUM_SNAPSHOT, IndexValue(NullIndexValue));
         ASSERT_OK(index.prepare(EditVersion(2, 0), NUM_SNAPSHOT));
         ASSERT_OK(index.upsert(NUM_SNAPSHOT, snapshot_key_slices.data(), snapshot_values.data(), old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
@@ -850,7 +850,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
         }
 
         config::l0_l1_merge_ratio = 1;
-        std::vector<IndexValue> wal_old_values(NUM_WAL, NullIndexValue);
+        std::vector<IndexValue> wal_old_values(NUM_WAL, IndexValue(NullIndexValue));
         ASSERT_OK(index.prepare(EditVersion(3, 0), NUM_WAL));
         ASSERT_OK(index.upsert(NUM_WAL, wal_key_slices.data(), wal_values.data(), wal_old_values.data()));
         ASSERT_OK(index.commit(&index_meta));
@@ -936,13 +936,13 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
-        std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
+        std::vector<IndexValue> old_values(keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.prepare(EditVersion(2, 0), keys.size()).ok());
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
-        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+        vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -976,7 +976,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
+        vector<IndexValue> old_values(invalid_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -1062,13 +1062,13 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         ASSERT_OK(index.commit(&index_meta));
         ASSERT_OK(index.on_commited());
 
-        std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
+        std::vector<IndexValue> old_values(keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.prepare(EditVersion(2, 0), keys.size()).ok());
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
 
-        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+        vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.prepare(EditVersion(3, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -1102,7 +1102,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
+        vector<IndexValue> old_values(invalid_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(new_index.prepare(EditVersion(4, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -1718,7 +1718,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
             for (int j = 0; j < N; j++) {
                 values.emplace_back(i * j);
             }
-            std::vector<IndexValue> old_values(N, NullIndexValue);
+            std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
             ASSERT_OK(index.upsert(N, key_slices.data(), values.data(), old_values.data()));
             std::vector<IndexValue> get_values(N);
             ASSERT_OK(index.get(N, key_slices.data(), get_values.data()));
@@ -1813,14 +1813,14 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
 
         // generate 3 versions
         for (int i = 0; i < 3; i++) {
-            std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
+            std::vector<IndexValue> old_values(keys.size(), IndexValue(NullIndexValue));
             ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), keys.size()).ok());
             ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
             ASSERT_TRUE(index.commit(&index_meta).ok());
             ASSERT_TRUE(index.on_commited().ok());
         }
 
-        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+        vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), erase_keys.size()).ok());
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // update PersistentMetaPB in memory
@@ -1854,7 +1854,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
         }
 
         // upsert key/value to new_index
-        vector<IndexValue> old_values(invalid_keys.size(), NullIndexValue);
+        vector<IndexValue> old_values(invalid_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(new_index.prepare(EditVersion(cur_version++, 0), invalid_keys.size()).ok());
         ASSERT_TRUE(new_index
                             .upsert(invalid_keys.size(), invalid_key_slices.data(), invalid_values.data(),
@@ -1930,7 +1930,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
         // 1. upsert
         for (int i = 0; i < K; i++) {
             incre_key(i);
-            std::vector<IndexValue> old_values(M, NullIndexValue);
+            std::vector<IndexValue> old_values(M, IndexValue(NullIndexValue));
             ASSERT_OK(index.load(index_meta));
             ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
             ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));
@@ -2049,7 +2049,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
         // 1. upsert
         for (int i = 0; i < K; i++) {
             incre_key(i);
-            std::vector<IndexValue> old_values(M, NullIndexValue);
+            std::vector<IndexValue> old_values(M, IndexValue(NullIndexValue));
             ASSERT_OK(index.load(index_meta));
             ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
             ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));
@@ -2133,14 +2133,14 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_delete) {
 
         // generate 3 versions
         for (int i = 0; i < 3; i++) {
-            std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
+            std::vector<IndexValue> old_values(keys.size(), IndexValue(NullIndexValue));
             ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), keys.size()).ok());
             ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
             ASSERT_TRUE(index.commit(&index_meta).ok());
             ASSERT_TRUE(index.on_commited().ok());
         }
 
-        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+        vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), erase_keys.size()).ok());
         // not trigger l0 advance flush
         config::l0_max_mem_usage = 100 * 1024 * 1024; // 100MB
@@ -2261,7 +2261,7 @@ PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
         ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), N));
         // erase non-exist keys
         // flush advance
-        vector<IndexValue> erase_old_values(erase_keys.size(), NullIndexValue);
+        vector<IndexValue> erase_old_values(erase_keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());
@@ -2273,7 +2273,7 @@ PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
         ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
         // not trigger flush advance
         config::l0_max_mem_usage = 100 * 1024 * 1024; // 100MB
-        std::vector<IndexValue> old_values(keys.size(), NullIndexValue);
+        std::vector<IndexValue> old_values(keys.size(), IndexValue(NullIndexValue));
         ASSERT_TRUE(index.upsert(keys.size(), key_slices.data(), values.data(), old_values.data()).ok());
         ASSERT_TRUE(index.commit(&index_meta).ok());
         ASSERT_TRUE(index.on_commited().ok());


### PR DESCRIPTION
When we ingest a large amount of data to the primary key table with a persistent index, we may flush many temp l1 files in advance to reduce memory usage during ingestion. These temp l1 files will keep deleting operations to ensure data is correct. After ingestion, we will merge these temp l1 files and merge delete operations. However, if we have only one temp l1 file, the delete operation also writes into the new l1 file, which can make the l1 file larger than expected, leading to a waste of disk IO.
