### PR TITLE
[Feature] Schema table sink supported in pipeline

### DIFF
--- a/be/src/common/configbase.cpp
+++ b/be/src/common/configbase.cpp
@@ -396,4 +396,16 @@ std::vector<ConfigInfo> list_configs() {
     return infos;
 }
 
+StatusOr<std::string> get_config(const std::string& field) {
+    auto it = Register::_s_field_map->find(field);
+    if (it == Register::_s_field_map->end()) {
+        return Status::NotFound(strings::Substitute("'$0' is not found", field));
+    }
+
+    if (!it->second.valmutable) {
+        return Status::NotSupported(strings::Substitute("'$0' is not support to modify", field));
+    }
+
+    return it->second.value();
+}
 } // namespace starrocks::config

--- a/be/src/common/configbase.h
+++ b/be/src/common/configbase.h
@@ -22,6 +22,8 @@
 #include <string>
 #include <vector>
 
+#include "common/statusor.h"
+
 namespace starrocks {
 class Status;
 
@@ -132,6 +134,8 @@ Status set_config(const std::string& field, const std::string& value);
 std::mutex* get_mstring_conf_lock();
 
 std::vector<ConfigInfo> list_configs();
+
+StatusOr<std::string> get_config(const std::string& field);
 
 } // namespace config
 } // namespace starrocks

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -194,6 +194,7 @@ set(EXEC_FILES
     pipeline/sink/iceberg_table_sink_operator.cpp
     pipeline/sink/hive_table_sink_operator.cpp
     pipeline/sink/table_function_table_sink_operator.cpp
+    pipeline/sink/schema_table_sink_operator.cpp
     pipeline/scan/morsel.cpp
     pipeline/scan/chunk_buffer_limiter.cpp
     pipeline/sink/file_sink_operator.cpp

--- a/be/src/exec/pipeline/sink/schema_table_sink_opeartor.h
+++ b/be/src/exec/pipeline/sink/schema_table_sink_opeartor.h
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+
+#include "exec/pipeline/fragment_context.h"
+#include "exec/pipeline/operator.h"
+#include "gen_cpp/InternalService_types.h"
+
+namespace starrocks {
+class ExprContext;
+
+namespace pipeline {
+
+class SchemaTableSinkOperator final : public Operator {
+public:
+    SchemaTableSinkOperator(OperatorFactory* factory, int32_t id, int32_t plan_node_id, int32_t driver_sequence,
+                            std::vector<ExprContext*> output_expr_ctxs, std::string table_name)
+            : Operator(factory, id, "schema_table_sink", plan_node_id, false, driver_sequence),
+              _output_expr_ctxs(std::move(output_expr_ctxs)),
+              _table_name(std::move(table_name)) {}
+
+    ~SchemaTableSinkOperator() override = default;
+
+    Status prepare(RuntimeState* state) override;
+
+    void close(RuntimeState* state) override;
+
+    bool has_output() const override { return false; }
+
+    bool need_input() const override;
+
+    bool is_finished() const override;
+
+    Status set_finishing(RuntimeState* state) override;
+
+    bool pending_finish() const override;
+
+    Status set_cancelled(RuntimeState* state) override;
+
+    StatusOr<ChunkPtr> pull_chunk(RuntimeState* state) override;
+
+    Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
+
+private:
+    static Status write_be_configs_table(Columns& columns);
+    std::vector<ExprContext*> _output_expr_ctxs;
+    bool _is_finished = false;
+    std::string _table_name;
+};
+
+class SchemaTableSinkOperatorFactory final : public OperatorFactory {
+public:
+    SchemaTableSinkOperatorFactory(int32_t id, std::vector<TExpr> t_output_expr,
+                                   const TSchemaTableSink& t_schema_table_sink, FragmentContext* const fragment_ctx);
+
+    ~SchemaTableSinkOperatorFactory() override = default;
+
+    OperatorPtr create(int32_t degree_of_parallelism, int32_t driver_sequence) override {
+        return std::make_shared<SchemaTableSinkOperator>(this, _id, _plan_node_id, driver_sequence, _output_expr_ctxs,
+                                                         _table_name);
+    }
+
+    Status prepare(RuntimeState* state) override;
+
+    void close(RuntimeState* state) override;
+
+private:
+    std::vector<TExpr> _t_output_expr;
+    std::vector<ExprContext*> _output_expr_ctxs;
+    std::string _table_name;
+};
+
+} // namespace pipeline
+} // namespace starrocks

--- a/be/src/exec/pipeline/sink/schema_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/schema_table_sink_operator.cpp
@@ -1,0 +1,130 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "agent/master_info.h"
+#include "common/configbase.h"
+#include "exec/pipeline/pipeline_driver_executor.h"
+#include "exec/pipeline/sink/schema_table_sink_opeartor.h"
+#include "exprs/expr_context.h"
+#include "http/action/update_config_action.h"
+
+namespace starrocks::pipeline {
+Status SchemaTableSinkOperator::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(Operator::prepare(state));
+    return Status::OK();
+}
+
+void SchemaTableSinkOperator::close(RuntimeState* state) {
+    Operator::close(state);
+}
+
+bool SchemaTableSinkOperator::need_input() const {
+    return !_is_finished;
+}
+
+bool SchemaTableSinkOperator::is_finished() const {
+    return _is_finished;
+}
+
+Status SchemaTableSinkOperator::set_finishing(RuntimeState* state) {
+    _is_finished = true;
+    return Status::OK();
+}
+
+bool SchemaTableSinkOperator::pending_finish() const {
+    return false;
+}
+
+Status SchemaTableSinkOperator::set_cancelled(RuntimeState* state) {
+    _is_finished = true;
+    return Status::OK();
+}
+
+StatusOr<ChunkPtr> SchemaTableSinkOperator::pull_chunk(RuntimeState* state) {
+    return Status::InternalError("Shouldn't pull chunk from SchemaTableSinkOperator");
+}
+
+Status SchemaTableSinkOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    // Same as ResultSinkOperator, The memory of the output result set should not be counted in the query memory,
+    // otherwise it will cause memory statistics errors.
+    Columns result_columns(_output_expr_ctxs.size());
+    for (int i = 0; i < _output_expr_ctxs.size(); ++i) {
+        ASSIGN_OR_RETURN(result_columns[i], _output_expr_ctxs[i]->evaluate(chunk.get()));
+    }
+    if (_table_name == "be_configs") {
+        return write_be_configs_table(result_columns);
+    }
+    return Status::OK();
+}
+
+Status SchemaTableSinkOperator::write_be_configs_table(Columns& columns) {
+    if (columns.size() < 3) {
+        return Status::InternalError("write be_configs table should have at least 3 columns");
+    }
+
+    auto o_id = get_backend_id();
+    auto self_be_id = o_id.has_value() ? o_id.value() : -1;
+
+    auto update_config = UpdateConfigAction::instance();
+    if (update_config == nullptr) {
+        LOG(WARNING) << "write_be_configs_table ignored: UpdateConfigAction is not inited";
+        return Status::OK();
+    }
+    Status ret;
+    for (size_t i = 0; i < columns[0]->size(); ++i) {
+        int64_t be_id = columns[0]->get(i).get_int64();
+        const auto& name = columns[1]->get(i).get_slice().to_string();
+        const auto& value = columns[2]->get(i).get_slice().to_string();
+        Status s;
+        if (be_id == -1) {
+            LOG(INFO) << strings::Substitute("set_config ignored: be_id=-1 name:$0 value:$1", name, value);
+            continue;
+        } else if (be_id == self_be_id) {
+            s = update_config->update_config(name, value);
+        } else {
+            continue;
+        }
+        if (s.ok()) {
+            LOG(INFO) << "set_config "
+                      << " " << name << "=" << value << " success";
+        } else {
+            LOG(WARNING) << "set_config "
+                         << " " << name << "=" << value << " failed " << s.to_string();
+        }
+        ret.update(s);
+    }
+    return ret;
+}
+
+SchemaTableSinkOperatorFactory::SchemaTableSinkOperatorFactory(int32_t id, std::vector<TExpr> t_output_expr,
+                                                               const TSchemaTableSink& t_schema_table_sink,
+                                                               FragmentContext* const fragment_ctx)
+        : OperatorFactory(id, "schema_table_sink", Operator::s_pseudo_plan_node_id_for_final_sink),
+          _t_output_expr(std::move(t_output_expr)),
+          _table_name(t_schema_table_sink.table) {}
+
+Status SchemaTableSinkOperatorFactory::prepare(RuntimeState* state) {
+    RETURN_IF_ERROR(OperatorFactory::prepare(state));
+    RETURN_IF_ERROR(Expr::create_expr_trees(state->obj_pool(), _t_output_expr, &_output_expr_ctxs, state));
+    RETURN_IF_ERROR(Expr::prepare(_output_expr_ctxs, state));
+    RETURN_IF_ERROR(Expr::open(_output_expr_ctxs, state));
+
+    return Status::OK();
+}
+
+void SchemaTableSinkOperatorFactory::close(RuntimeState* state) {
+    Expr::close(_output_expr_ctxs, state);
+    OperatorFactory::close(state);
+}
+} // namespace starrocks::pipeline

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -411,6 +411,12 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl,
     if (is_pipeline) {
         return _exec_plan_fragment_by_pipeline(t_request, t_request);
     } else {
+        bool has_schema_table_sink = t_request.__isset.fragment && t_request.fragment.__isset.output_sink &&
+                                     t_request.fragment.output_sink.type == TDataSinkType::SCHEMA_TABLE_SINK;
+        // this will be removed in the next version. keep it right now for gray upgrade
+        if (has_schema_table_sink) {
+            return _exec_plan_fragment_by_non_pipeline(t_request);
+        }
         return Status::InvalidArgument(
                 "non-pipeline engine is no longer supported since 3.2, please set enable_pipeline_engine=true.");
     }

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -411,13 +411,6 @@ Status PInternalServiceImplBase<T>::_exec_plan_fragment(brpc::Controller* cntl,
     if (is_pipeline) {
         return _exec_plan_fragment_by_pipeline(t_request, t_request);
     } else {
-        bool has_schema_table_sink = t_request.__isset.fragment && t_request.fragment.__isset.output_sink &&
-                                     t_request.fragment.output_sink.type == TDataSinkType::SCHEMA_TABLE_SINK;
-        // SchemaTableSink is not supported on the Pipeline engine, we have to allow it to be executed on non-pipeline engine temporarily,
-        // this will be removed in the future.
-        if (has_schema_table_sink) {
-            return _exec_plan_fragment_by_non_pipeline(t_request);
-        }
         return Status::InvalidArgument(
                 "non-pipeline engine is no longer supported since 3.2, please set enable_pipeline_engine=true.");
     }

--- a/be/src/storage/lake/key_index.h
+++ b/be/src/storage/lake/key_index.h
@@ -14,9 +14,8 @@
 
 #pragma once
 
-#include <stdint.h>
-
 #include <cstddef>
+#include <cstdint>
 #include <vector>
 
 namespace starrocks::lake {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
@@ -40,8 +40,8 @@ import com.starrocks.catalog.MysqlTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TExplainLevel;
 
@@ -100,6 +100,8 @@ public abstract class DataSink {
         } else if (table instanceof HiveTable) {
             return true;
         } else if (table instanceof TableFunctionTable) {
+            return true;
+        } else if (table instanceof SystemTable) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -359,6 +359,10 @@ public class PlanFragment extends TreeNode<PlanFragment> {
         this.outputExprs = Expr.cloneList(outputExprs, null);
     }
 
+    public List<Expr> getOutputExpr() {
+        return outputExprs;
+    }
+
     /**
      * Finalize plan tree and create stream sink, if needed.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaTableSink.java
@@ -60,7 +60,6 @@ public class SchemaTableSink extends DataSink {
 
     @Override
     public boolean canUsePipeLine() {
-        // @TODO(silverbullet233): need to be adapted on pipeline engine
         return true;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/SchemaTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/SchemaTableSink.java
@@ -61,6 +61,6 @@ public class SchemaTableSink extends DataSink {
     @Override
     public boolean canUsePipeLine() {
         // @TODO(silverbullet233): need to be adapted on pipeline engine
-        return false;
+        return true;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -55,7 +55,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -562,21 +561,21 @@ public class PlanTestNoneDBBase {
         return i;
     }
 
-    public static Map<Integer, Integer>  extractFragmentAndInstanceFromSchedulerPlan(String plan){
+    public static Map<Integer, Integer> extractFragmentAndInstanceFromSchedulerPlan(String plan) {
         Map<Integer, Integer> result = new HashMap<>();
         String[] lines = plan.trim().split("\n");
         int index = 0;
 
         int fragmentIndex = -1;
         int instanceNumber = 0;
-        while(index < lines.length){
+        while (index < lines.length) {
             String line = lines[index];
             index++;
             if ("INSTANCES".equals(line.trim())) {
                 fragmentIndex++;
                 Map<Long, String> instances = Maps.newHashMap();
                 index = extractInstancesFromSchedulerPlan(lines, index, instances);
-                result.put(fragmentIndex,instances.size());
+                result.put(fragmentIndex, instances.size());
             }
         }
         return result;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -55,7 +55,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -558,6 +560,26 @@ public class PlanTestNoneDBBase {
         }
 
         return i;
+    }
+
+    public static Map<Integer, Integer>  extractFragmentAndInstanceFromSchedulerPlan(String plan){
+        Map<Integer, Integer> result = new HashMap<>();
+        String[] lines = plan.trim().split("\n");
+        int index = 0;
+
+        int fragmentIndex = -1;
+        int instanceNumber = 0;
+        while(index < lines.length){
+            String line = lines[index];
+            index++;
+            if ("INSTANCES".equals(line.trim())) {
+                fragmentIndex++;
+                Map<Long, String> instances = Maps.newHashMap();
+                index = extractInstancesFromSchedulerPlan(lines, index, instances);
+                result.put(fragmentIndex,instances.size());
+            }
+        }
+        return result;
     }
 
     private void checkWithIgnoreTabletList(String expect, String actual) {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -86,6 +86,7 @@ import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.common.SqlDigestBuilder;
 import com.starrocks.sql.optimizer.LogicalPlanPrinter;
@@ -483,7 +484,8 @@ public class UtFrameUtils {
                         execPlan));
     }
 
-    public static DefaultCoordinator startScheduling(ConnectContext connectContext, String originStmt) throws Exception {
+    public static DefaultCoordinator startScheduling(ConnectContext connectContext, String originStmt)
+            throws Exception {
         return buildPlan(connectContext, originStmt,
                 (context, statementBase, execPlan) -> {
                     DefaultCoordinator scheduler = createScheduler(context, statementBase, execPlan);
@@ -494,7 +496,8 @@ public class UtFrameUtils {
                 });
     }
 
-    public static Pair<String, DefaultCoordinator> getPlanAndStartScheduling(ConnectContext connectContext, String originStmt)
+    public static Pair<String, DefaultCoordinator> getPlanAndStartScheduling(ConnectContext connectContext,
+                                                                             String originStmt)
             throws Exception {
         return buildPlan(connectContext, originStmt,
                 (context, statementBase, execPlan) -> {
@@ -511,11 +514,12 @@ public class UtFrameUtils {
         return buildPlan(connectContext, originStmt, UtFrameUtils::createScheduler);
     }
 
-    private static DefaultCoordinator createScheduler(ConnectContext context, StatementBase statementBase, ExecPlan execPlan) {
+    private static DefaultCoordinator createScheduler(ConnectContext context, StatementBase statementBase,
+                                                      ExecPlan execPlan) {
         context.setExecutionId(new TUniqueId(1, 2));
         DefaultCoordinator scheduler;
         if (statementBase instanceof DmlStmt) {
-            if (statementBase instanceof InsertStmt) {
+            if (statementBase instanceof InsertStmt || statementBase instanceof UpdateStmt) {
                 scheduler = new DefaultCoordinator.Factory().createInsertScheduler(context,
                         execPlan.getFragments(), execPlan.getScanNodes(),
                         execPlan.getDescTbl().toThrift());

--- a/test/sql/test_others/R/test_deprecated_non_pipeline_engine
+++ b/test/sql/test_others/R/test_deprecated_non_pipeline_engine
@@ -8,6 +8,7 @@ select 1;
 -- !result
 update information_schema.be_configs set value=60 where name = 'base_compaction_check_interval_seconds';
 -- result:
+[REGEX].*non-pipeline engine is no longer supported since 3.2, please set enable_pipeline_engine=true.*
 -- !result
 select `value` from information_schema.be_configs where name = 'base_compaction_check_interval_seconds' limit 1;
 -- result:

--- a/test/sql/test_others/R/test_deprecated_non_pipeline_engine
+++ b/test/sql/test_others/R/test_deprecated_non_pipeline_engine
@@ -8,7 +8,6 @@ select 1;
 -- !result
 update information_schema.be_configs set value=60 where name = 'base_compaction_check_interval_seconds';
 -- result:
-[REGEX].*non-pipeline engine is no longer supported since 3.2, please set enable_pipeline_engine=true.*
 -- !result
 select `value` from information_schema.be_configs where name = 'base_compaction_check_interval_seconds' limit 1;
 -- result:


### PR DESCRIPTION
In non-pipeline implementation, schem table sink may use rpc to change other BE's be_config, but rpc in pipeline need to be asynchronous, which is complex. Instead, we can add a new extra plan fragment on top, and set schema sink in this plan fragment. we set this plan fragment's instance number as all alive BE number, and old top plan fragment broadcast it output to new top plan fragment. In this way, we can ensure update be_config's behavior is correct, and also avoid rpc 

enhance https://github.com/StarRocks/starrocks/pull/18574

usage:

mysql> select * from be_configs where name = 'txn_info_history_size';
+-------+-----------------------+-------+
| BE_ID | NAME                  | VALUE |
+-------+-----------------------+-------+
| 10004 | txn_info_history_size | 20000 |
+-------+-----------------------+-------+
1 row in set (0.05 sec)

mysql> update be_configs set value = cast(cast(value as bigint)*2 as string) where name = 'txn_info_history_size';
Query OK, 0 rows affected (0.07 sec)

mysql> select * from be_configs where name = 'txn_info_history_size';
+-------+-----------------------+-------+
| BE_ID | NAME                  | VALUE |
+-------+-----------------------+-------+
| 10004 | txn_info_history_size | 40000 |
+-------+-----------------------+-------+
1 row in set (0.01 sec)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5