### PR TITLE
[BugFix] Fix wrong file name in restore if the path end with slash (#34597)

### DIFF
--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -518,20 +518,11 @@ Status HdfsFileSystem::iterate_dir2(const std::string& dir, const std::function<
     for (int i = 0; i < numEntries && fileinfo; ++i) {
         // obj_key.data() + uri.key().size(), obj_key.size() - uri.key().size()
         int32_t dir_size;
-        if (dir[dir.size() - 1] == '/') {
-            dir_size = dir.size();
+        std::string mName(fileinfo[i].mName);
+        std::size_t found = mName.rfind('/');
+        if (found == std::string::npos) {
+            dir_size = 0;
         } else {
-            dir_size = dir.size() + 1;
-        }
-
-        const std::string local_fs("file:/");
-        if (dir.compare(0, local_fs.length(), local_fs) == 0) {
-            std::string mName(fileinfo[i].mName);
-            std::size_t found = mName.rfind('/');
-            if (found == std::string::npos) {
-                return Status::InvalidArgument(fmt::format("parse path fail {}", dir));
-            }
-
             dir_size = found + 1;
         }
 


### PR DESCRIPTION
Supposing a path `hdfs:/abc///`, in function iterate_dir2.
We will get `dir = hdfs:/abc///path1/path2/path3` which is unnormalized path, 
`fileinfo[i] = hdfs:/abc/path1/path2/path3/filename` which is normalized path

The problem is that we use the dir_size calculated by dir and
get the filename as follows:
`filename = string(fileinfo[i] + dir_size)`
This is wrong because `fileinfo[i]` is a normalized path but the dir_size calculated
by unnormalized path.

Fixes #34597

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
