### PR TITLE
[BugFix] Fix 'NPE: The URI scheme of endpointOverride must not be null'

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -151,6 +151,8 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
             s3ClientBuilder.region(Region.of(s3Region));
         }
 
+        // To prevent the 's3ClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
+        // 'scheme', it is considered invalid, we will not set 'endpointOverride' property.
         URI uri;
         if (!s3Endpoint.isEmpty() && (uri = URI.create(s3Endpoint)).getScheme() != null) {
             s3ClientBuilder.endpointOverride(uri);
@@ -176,6 +178,8 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
             glueClientBuilder.region(Region.of(glueRegion));
         }
 
+        // To prevent the 'glueClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
+        // 'scheme', it is considered invalid, we will not set 'endpointOverride' property.
         URI uri;
         if (!glueEndpoint.isEmpty() && (uri = URI.create(glueEndpoint)).getScheme() != null) {
             glueClientBuilder.endpointOverride(uri);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -17,6 +17,8 @@ package com.starrocks.connector.iceberg;
 import com.starrocks.credential.aws.AWSCloudConfigurationProvider;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -59,6 +61,7 @@ import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_AW
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 
 public class IcebergAwsClientFactory implements AwsClientFactory {
+    private static final Logger LOG = LogManager.getLogger(IcebergAwsClientFactory.class);
 
     private AwsProperties awsProperties;
 
@@ -153,9 +156,14 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
 
         // To prevent the 's3ClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
         // 'scheme', it is considered invalid, we will not set 'endpointOverride' property.
-        URI uri;
-        if (!s3Endpoint.isEmpty() && (uri = URI.create(s3Endpoint)).getScheme() != null) {
-            s3ClientBuilder.endpointOverride(uri);
+        if (!s3Endpoint.isEmpty()) {
+            URI uri = URI.create(s3Endpoint);
+            if (uri.getScheme() != null) {
+                s3ClientBuilder.endpointOverride(uri);
+            } else {
+                LOG.warn("s3Endpoint: {} is missing the scheme information, skipping" +
+                        "setting the client endpointOverride.", s3Endpoint);
+            }
         }
 
         return s3ClientBuilder.build();
@@ -180,9 +188,14 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
 
         // To prevent the 'glueClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
         // 'scheme', it is considered invalid, we will not set 'endpointOverride' property.
-        URI uri;
-        if (!glueEndpoint.isEmpty() && (uri = URI.create(glueEndpoint)).getScheme() != null) {
-            glueClientBuilder.endpointOverride(uri);
+        if (!glueEndpoint.isEmpty()) {
+            URI uri = URI.create(glueEndpoint);
+            if (uri.getScheme() != null) {
+                glueClientBuilder.endpointOverride(uri);
+            } else {
+                LOG.warn("glueEndpoint: {} is missing the scheme information, skipping" +
+                        "setting the client endpointOverride.", glueEndpoint);
+            }
         }
 
         return glueClientBuilder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -155,11 +155,7 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         // To prevent the 's3ClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
         // 'scheme', we will add https scheme.
         if (!s3Endpoint.isEmpty()) {
-            URI uri = URI.create(s3Endpoint);
-            if (uri.getScheme() == null) {
-                uri = URI.create(HTTPS_SCHEME + s3Endpoint);
-            }
-            s3ClientBuilder.endpointOverride(uri);
+            s3ClientBuilder.endpointOverride(ensureSchemeInEndpoint(s3Endpoint));
         }
 
         return s3ClientBuilder.build();
@@ -185,11 +181,7 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         // To prevent the 'glueClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
         // 'scheme', we will add https scheme.
         if (!glueEndpoint.isEmpty()) {
-            URI uri = URI.create(glueEndpoint);
-            if (uri.getScheme() == null) {
-                uri = URI.create(HTTPS_SCHEME + glueEndpoint);
-            }
-            glueClientBuilder.endpointOverride(uri);
+            glueClientBuilder.endpointOverride(ensureSchemeInEndpoint(glueEndpoint));
         }
 
         return glueClientBuilder.build();
@@ -220,5 +212,19 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
     @Override
     public DynamoDbClient dynamo() {
         return null;
+    }
+
+    /**
+     * Checks if the given 'endpoint' contains a scheme. If not, the default HTTPS scheme is added.
+     *
+     * @param endpoint The endpoint string to be checked
+     * @return The URI with the added scheme
+     */
+    public static URI ensureSchemeInEndpoint(String endpoint) {
+        URI uri = URI.create(endpoint);
+        if (uri.getScheme() != null) {
+            return uri;
+        }
+        return URI.create(HTTPS_SCHEME + endpoint);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -151,8 +151,9 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
             s3ClientBuilder.region(Region.of(s3Region));
         }
 
-        if (!s3Endpoint.isEmpty()) {
-            s3ClientBuilder.endpointOverride(URI.create(s3Endpoint));
+        URI uri;
+        if (!s3Endpoint.isEmpty() && (uri = URI.create(s3Endpoint)).getScheme() != null) {
+            s3ClientBuilder.endpointOverride(uri);
         }
 
         return s3ClientBuilder.build();
@@ -175,8 +176,9 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
             glueClientBuilder.region(Region.of(glueRegion));
         }
 
-        if (!glueEndpoint.isEmpty()) {
-            glueClientBuilder.endpointOverride(URI.create(glueEndpoint));
+        URI uri;
+        if (!glueEndpoint.isEmpty() && (uri = URI.create(glueEndpoint)).getScheme() != null) {
+            glueClientBuilder.endpointOverride(uri);
         }
 
         return glueClientBuilder.build();

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -17,8 +17,6 @@ package com.starrocks.connector.iceberg;
 import com.starrocks.credential.aws.AWSCloudConfigurationProvider;
 import org.apache.iceberg.aws.AwsClientFactory;
 import org.apache.iceberg.aws.AwsProperties;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -61,7 +59,7 @@ import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_AW
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 
 public class IcebergAwsClientFactory implements AwsClientFactory {
-    private static final Logger LOG = LogManager.getLogger(IcebergAwsClientFactory.class);
+    public static final String HTTPS_SCHEME = "https://";
 
     private AwsProperties awsProperties;
 
@@ -155,15 +153,13 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         }
 
         // To prevent the 's3ClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
-        // 'scheme', it is considered invalid, we will not set 'endpointOverride' property.
+        // 'scheme', we will add https scheme.
         if (!s3Endpoint.isEmpty()) {
             URI uri = URI.create(s3Endpoint);
-            if (uri.getScheme() != null) {
-                s3ClientBuilder.endpointOverride(uri);
-            } else {
-                LOG.warn("s3Endpoint: {} is missing the scheme information, skipping" +
-                        "setting the client endpointOverride.", s3Endpoint);
+            if (uri.getScheme() == null) {
+                uri = URI.create(HTTPS_SCHEME + s3Endpoint);
             }
+            s3ClientBuilder.endpointOverride(uri);
         }
 
         return s3ClientBuilder.build();
@@ -187,15 +183,13 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         }
 
         // To prevent the 'glueClientBuilder' (NPE) exception, when 'aws.s3.endpoint' does not have
-        // 'scheme', it is considered invalid, we will not set 'endpointOverride' property.
+        // 'scheme', we will add https scheme.
         if (!glueEndpoint.isEmpty()) {
             URI uri = URI.create(glueEndpoint);
-            if (uri.getScheme() != null) {
-                glueClientBuilder.endpointOverride(uri);
-            } else {
-                LOG.warn("glueEndpoint: {} is missing the scheme information, skipping" +
-                        "setting the client endpointOverride.", glueEndpoint);
+            if (uri.getScheme() == null) {
+                uri = URI.create(HTTPS_SCHEME + glueEndpoint);
             }
+            glueClientBuilder.endpointOverride(uri);
         }
 
         return glueClientBuilder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.iceberg;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -29,5 +30,20 @@ public class IcebergAwsClientFactoryTest {
         factory.initialize(properties);
         Assert.assertThrows(IllegalArgumentException.class, factory::s3);
         Assert.assertThrows(IllegalArgumentException.class, factory::glue);
+    }
+
+    @Test
+    public void testEnsureSchemeInEndpoint() {
+        // test endpoint without scheme
+        URI uriWithoutScheme = IcebergAwsClientFactory.ensureSchemeInEndpoint("s3.aa-bbbbb-3.amazonaws.com.cn");
+        Assert.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithoutScheme.toString());
+
+        // test endpoint with scheme HTTPS
+        URI uriWithHttps = IcebergAwsClientFactory.ensureSchemeInEndpoint("https://s3.aa-bbbbb-3.amazonaws.com.cn");
+        Assert.assertEquals("https://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttps.toString());
+
+        // test endpoint with scheme HTTP
+        URI uriWithHttp = IcebergAwsClientFactory.ensureSchemeInEndpoint("http://s3.aa-bbbbb-3.amazonaws.com.cn");
+        Assert.assertEquals("http://s3.aa-bbbbb-3.amazonaws.com.cn", uriWithHttp.toString());
     }
 }


### PR DESCRIPTION

When there is no 'Scheme' in the 'aws.s3.endpoint' catalog properties, we
should consider this as an invalid configuration, and do not set the
'aws SdkClient endpointOverride' property.

refs:
software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder#endpointOverride
```
  public final B endpointOverride(URI endpointOverride) {
      if (endpointOverride == null) {
          this.clientConfiguration.option(SdkClientOption.ENDPOINT, (Object)null);
          this.clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN, false);
      } else {
          Validate.paramNotNull(endpointOverride.getScheme(), "The URI scheme of endpointOverride");
          this.clientConfiguration.option(SdkClientOption.ENDPOINT, endpointOverride);
          this.clientConfiguration.option(SdkClientOption.ENDPOINT_OVERRIDDEN, true);
      }

      return this.thisBuilder();
  }
```

exception_stack:
```
java.lang.NullPointerException: The URI scheme of endpointOverride must not be null.
        at software.amazon.awssdk.utils.Validate.paramNotNull(Validate.java:156) ~[bundle-2.17.257.jar:?]
        at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.endpointOverride(SdkDefaultClientBuilder.java:439) ~[bundle-2.17.257.jar:?]
        at com.starrocks.connector.iceberg.IcebergAwsClientFactory.s3(IcebergAwsClientFactory.java:155) ~[starrocks-fe.jar:?]
        at org.apache.iceberg.aws.s3.S3FileIO.client(S3FileIO.java:326) ~[iceberg-aws-1.2.1.jar:?]
        at org.apache.iceberg.aws.s3.S3FileIO.newInputFile(S3FileIO.java:124) ~[iceberg-aws-1.2.1.jar:?]
        at org.apache.iceberg.io.ResolvingFileIO.newInputFile(ResolvingFileIO.java:61) ~[iceberg-core-1.2.1.jar:?]
        at com.starrocks.connector.iceberg.io.IcebergCachingFileIO.newInputFile(IcebergCachingFileIO.java:133) ~[starrocks-fe.jar:?]
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
