### PR TITLE
[BugFix] fix blocked scan and add more logs to check blocked drivers

### DIFF
--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -204,15 +204,24 @@ void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
                     remain_rpc_num++;
                 }
             }
-            LOG(WARNING) << "Finishing fragment " << print_id(_fragment_ctx->fragment_instance_id())
-                         << " SinkBuffer remains " << remain_rpc_num << " rpcs, dest are " << ss.str();
+            LOG(WARNING) << "Fragment " << print_id(_fragment_ctx->fragment_instance_id()) << " SinkBuffer remains "
+                         << remain_rpc_num << " rpcs, dest are " << ss.str();
+        }
+        if (_num_remaining_eos > 0) {
+            std::stringstream ss;
+            for (auto& remain_eos : _num_sinkers) {
+                ss << print_id(_instance_id2finst_id[remain_eos.first]) << "(" << remain_eos.second << "),";
+            }
+            LOG(WARNING) << "Fragment " << print_id(_fragment_ctx->fragment_instance_id())
+                         << " remains EOS : " << ss.str();
         }
     }
     if (state != nullptr) {
         LOG(INFO) << fmt::format(
-                "fragment_instance_id {} -> {}, _num_uncancelled_sinkers {}, _is_finishing {}, _num_remaining_eos {}",
-                print_id(_fragment_ctx->fragment_instance_id()), print_id(state->fragment_instance_id()),
-                _num_uncancelled_sinkers, _is_finishing, _num_remaining_eos);
+                "fragment_instance_id {}, _num_uncancelled_sinkers {}, _is_finishing {}, _num_remaining_eos {}, "
+                "_num_sending_rpc {}, chunk is full {}",
+                print_id(_fragment_ctx->fragment_instance_id()), _num_uncancelled_sinkers, _is_finishing,
+                _num_remaining_eos, _num_sending_rpc, is_full());
     }
 }
 

--- a/be/src/exec/pipeline/exchange/sink_buffer.cpp
+++ b/be/src/exec/pipeline/exchange/sink_buffer.cpp
@@ -194,29 +194,31 @@ int64_t SinkBuffer::_network_time() {
 void SinkBuffer::cancel_one_sinker(RuntimeState* const state) {
     if (--_num_uncancelled_sinkers == 0) {
         _is_finishing = true;
-        if (_total_in_flight_rpc > 0) {
-            std::stringstream ss;
-            auto remain_rpc_num = 0;
-            for (auto& remain_rpc : _num_in_flight_rpcs) {
-                std::lock_guard<Mutex> l(*_mutexes[remain_rpc.first]);
-                if (remain_rpc.second > 0) {
-                    ss << (remain_rpc_num > 0 ? ", " : "") << print_id(_instance_id2finst_id[remain_rpc.first]);
-                    remain_rpc_num++;
+        if (state != nullptr && state->query_ctx()->is_query_expired()) {
+            if (_total_in_flight_rpc > 0) {
+                std::stringstream ss;
+                auto remain_rpc_num = 0;
+                for (auto& remain_rpc : _num_in_flight_rpcs) {
+                    std::lock_guard<Mutex> l(*_mutexes[remain_rpc.first]);
+                    if (remain_rpc.second > 0) {
+                        ss << (remain_rpc_num > 0 ? ", " : "") << print_id(_instance_id2finst_id[remain_rpc.first]);
+                        remain_rpc_num++;
+                    }
                 }
+                LOG(WARNING) << "Fragment " << print_id(_fragment_ctx->fragment_instance_id()) << " SinkBuffer remains "
+                             << remain_rpc_num << " rpcs, dest are " << ss.str();
             }
-            LOG(WARNING) << "Fragment " << print_id(_fragment_ctx->fragment_instance_id()) << " SinkBuffer remains "
-                         << remain_rpc_num << " rpcs, dest are " << ss.str();
-        }
-        if (_num_remaining_eos > 0) {
-            std::stringstream ss;
-            for (auto& remain_eos : _num_sinkers) {
-                ss << print_id(_instance_id2finst_id[remain_eos.first]) << "(" << remain_eos.second << "),";
+            if (_num_remaining_eos > 0) {
+                std::stringstream ss;
+                for (auto& remain_eos : _num_sinkers) {
+                    ss << print_id(_instance_id2finst_id[remain_eos.first]) << "(" << remain_eos.second << "),";
+                }
+                LOG(WARNING) << "Fragment " << print_id(_fragment_ctx->fragment_instance_id())
+                             << " remains EOS : " << ss.str();
             }
-            LOG(WARNING) << "Fragment " << print_id(_fragment_ctx->fragment_instance_id())
-                         << " remains EOS : " << ss.str();
         }
     }
-    if (state != nullptr) {
+    if (state != nullptr && state->query_ctx()->is_query_expired()) {
         LOG(INFO) << fmt::format(
                 "fragment_instance_id {}, _num_uncancelled_sinkers {}, _is_finishing {}, _num_remaining_eos {}, "
                 "_num_sending_rpc {}, chunk is full {}",

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -632,10 +632,15 @@ void PipelineDriver::_update_driver_level_timer() {
 
 std::string PipelineDriver::to_readable_string() const {
     std::stringstream ss;
+    std::string block_reasons = "";
+    if (_state == PRECONDITION_BLOCK) {
+        block_reasons = const_cast<PipelineDriver*>(this)->get_preconditions_block_reasons();
+    }
     ss << "query_id=" << (this->_query_ctx == nullptr ? "None" : print_id(this->query_ctx()->query_id()))
        << " fragment_id="
        << (this->_fragment_ctx == nullptr ? "None" : print_id(this->fragment_ctx()->fragment_instance_id()))
-       << " driver=" << _driver_name << ", status=" << ds_to_string(this->driver_state()) << ", operator-chain: [";
+       << " driver=" << _driver_name << ", status=" << ds_to_string(this->driver_state()) << block_reasons
+       << ", operator-chain: [";
     for (size_t i = 0; i < _operators.size(); ++i) {
         if (i == 0) {
             ss << _operators[i]->get_name();

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -535,7 +535,9 @@ void PipelineDriver::finish_operators(RuntimeState* runtime_state) {
 }
 
 void PipelineDriver::cancel_operators(RuntimeState* runtime_state) {
-    LOG(WARNING) << "begin to cancel operators for " << to_readable_string();
+    if (this->query_ctx()->is_query_expired()) {
+        LOG(WARNING) << "begin to cancel operators for " << to_readable_string();
+    }
     for (auto& op : _operators) {
         _mark_operator_cancelled(op, runtime_state);
     }

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -535,6 +535,7 @@ void PipelineDriver::finish_operators(RuntimeState* runtime_state) {
 }
 
 void PipelineDriver::cancel_operators(RuntimeState* runtime_state) {
+    LOG(WARNING) << "begin to cancel operators for " << to_readable_string();
     for (auto& op : _operators) {
         _mark_operator_cancelled(op, runtime_state);
     }

--- a/be/src/exec/pipeline/pipeline_driver.h
+++ b/be/src/exec/pipeline/pipeline_driver.h
@@ -371,6 +371,16 @@ public:
         }
     }
 
+    std::string get_preconditions_block_reasons() {
+        if (_state == DriverState::PRECONDITION_BLOCK) {
+            return std::string(dependencies_block() ? "(dependencies," : "(") +
+                   std::string(global_rf_block() ? "global runtime filter," : "") +
+                   std::string(local_rf_block() ? "local runtime filter)" : ")");
+        } else {
+            return "";
+        }
+    }
+
     bool is_not_blocked() {
         // If the sink operator is finished, the rest operators of this driver needn't be executed anymore.
         if (sink_operator()->is_finished()) {

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -75,7 +75,6 @@ void PipelineDriverPoller::run_internal() {
 
             auto driver_it = _local_blocked_drivers.begin();
             while (driver_it != _local_blocked_drivers.end()) {
-                //
                 auto* driver = *driver_it;
                 if (!driver->is_query_never_expired() && driver->query_ctx()->is_query_expired()) {
                     // there are not any drivers belonging to a query context can make progress for an expiration period
@@ -86,8 +85,7 @@ void PipelineDriverPoller::run_internal() {
                     // The state of driver shouldn't be changed.
                     size_t expired_log_count = driver->fragment_ctx()->expired_log_count();
                     if (expired_log_count <= 100) {
-                        LOG(WARNING) << "[Driver] Timeout, query_id=" << print_id(driver->query_ctx()->query_id())
-                                     << ", instance_id=" << print_id(driver->fragment_ctx()->fragment_instance_id());
+                        LOG(WARNING) << "[Driver] Timeout " << driver->to_readable_string();
                         driver->fragment_ctx()->set_expired_log_count(++expired_log_count);
                     }
                     driver->fragment_ctx()->cancel(

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -95,7 +95,7 @@ public:
     void set_enable_profile() { _enable_profile = true; }
     bool enable_profile() { return _enable_profile; }
     void set_runtime_profile_report_interval(int64_t runtime_profile_report_interval_s) {
-        _runtime_profile_report_interval_ns = 1'000'000'000L * runtime_profile_report_interval_s;
+        _runtime_profile_report_interval_ns = 1'000'000'000LL * runtime_profile_report_interval_s;
     }
     int64_t get_runtime_profile_report_interval_ns() { return _runtime_profile_report_interval_ns; }
     void set_profile_level(const TPipelineProfileLevel::type& profile_level) { _profile_level = profile_level; }

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -216,7 +216,9 @@ void ScanOperator::_detach_chunk_sources() {
 
 Status ScanOperator::set_finishing(RuntimeState* state) {
     std::lock_guard guard(_task_mutex);
-    if (_num_running_io_tasks > 0 || _submit_task_counter->value() == 0 || _peak_io_tasks_counter->value() == 0) {
+    if (UNLIKELY(state != nullptr && state->query_ctx()->is_query_expired() &&
+                 (_num_running_io_tasks > 0 || _submit_task_counter->value() == 0 ||
+                  _peak_io_tasks_counter->value() == 0))) {
         LOG(WARNING) << "set_finishing scan fragment " << print_id(CurrentThread::current().fragment_instance_id())
                      << " driver " << CurrentThread::current().get_driver_id() << " _num_running_io_tasks"
                      << _num_running_io_tasks << " _submit_task_counter " << _submit_task_counter->value()

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -82,7 +82,6 @@ Status ScanOperator::prepare(RuntimeState* state) {
 }
 
 void ScanOperator::close(RuntimeState* state) {
-    set_buffer_finished();
     // For the running io task, we close its chunk sources in ~ScanOperator not in ScanOperator::close.
     for (size_t i = 0; i < _chunk_sources.size(); i++) {
         std::lock_guard guard(_task_mutex);
@@ -217,8 +216,16 @@ void ScanOperator::_detach_chunk_sources() {
 
 Status ScanOperator::set_finishing(RuntimeState* state) {
     std::lock_guard guard(_task_mutex);
+    if (_num_running_io_tasks > 0 || _submit_task_counter->value() == 0 || _peak_io_tasks_counter->value() == 0) {
+        LOG(WARNING) << "set_finishing scan fragment " << print_id(CurrentThread::current().fragment_instance_id())
+                     << " driver " << CurrentThread::current().get_driver_id() << " _num_running_io_tasks"
+                     << _num_running_io_tasks << " _submit_task_counter " << _submit_task_counter->value()
+                     << " _morsels_counter  " << _morsels_counter->value() << " _peak_io_tasks_counter "
+                     << _peak_io_tasks_counter->value();
+    }
     _detach_chunk_sources();
     _is_finished = true;
+    set_buffer_finished();
     return Status::OK();
 }
 
@@ -398,7 +405,9 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
             auto status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
             if (!status.ok() && !status.is_end_of_file()) {
-                LOG(WARNING) << get_name() << " Scan tasks error: " << status.to_string();
+                LOG(ERROR) << "scan fragment " << print_id(CurrentThread::current().fragment_instance_id())
+                           << " driver " << CurrentThread::current().get_driver_id() << get_name()
+                           << " Scan tasks error: " << status.to_string();
                 _set_scan_status(status);
             }
 

--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -255,7 +255,7 @@ int64_t ScanOperator::global_rf_wait_timeout_ns() const {
         return 0;
     }
 
-    return 1000'000L * global_rf_collector->scan_wait_timeout_ms();
+    return 1000'000LL * global_rf_collector->scan_wait_timeout_ms();
 }
 Status ScanOperator::_try_to_trigger_next_scan(RuntimeState* state) {
     // to sure to put it here for updating state.
@@ -398,6 +398,7 @@ Status ScanOperator::_trigger_next_scan(RuntimeState* state, int chunk_source_in
             int64_t prev_scan_bytes = chunk_source->get_scan_bytes();
             auto status = chunk_source->buffer_next_batch_chunks_blocking(state, kIOTaskBatchSize, _workgroup.get());
             if (!status.ok() && !status.is_end_of_file()) {
+                LOG(WARNING) << get_name() << " Scan tasks error: " << status.to_string();
                 _set_scan_status(status);
             }
 

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -151,6 +151,7 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
         // in acquiring _lock.
         // TODO: Rethink the lifecycle of DataStreamRecvr to distinguish
         // errors from receiver-initiated teardowns.
+        LOG(WARNING) <<"transmit chunks to a non-existing receiver from "<< print_id(request.finst_id());
         return Status::OK();
     }
 

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -151,7 +151,7 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
         // in acquiring _lock.
         // TODO: Rethink the lifecycle of DataStreamRecvr to distinguish
         // errors from receiver-initiated teardowns.
-        LOG(WARNING) <<"transmit chunks to a non-existing receiver from "<< print_id(request.finst_id());
+        LOG(WARNING) << "transmit chunks to a non-existing receiver from " << print_id(request.finst_id());
         return Status::OK();
     }
 

--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -151,7 +151,8 @@ Status DataStreamMgr::transmit_chunk(const PTransmitChunkParams& request, ::goog
         // in acquiring _lock.
         // TODO: Rethink the lifecycle of DataStreamRecvr to distinguish
         // errors from receiver-initiated teardowns.
-        LOG(WARNING) << "transmit chunks to a non-existing receiver from " << print_id(request.finst_id());
+        LOG(WARNING) << request.sender_id() << " sender transmits chunks to a non-existing receiver fragment "
+                     << print_id(request.finst_id());
         return Status::OK();
     }
 

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -667,8 +667,8 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
     DCHECK(!(keep_order && use_pass_through));
     DCHECK(request.chunks_size() > 0 || use_pass_through);
     if (_is_cancelled || _num_remaining_senders <= 0) {
-        LOG(WARNING) << print_id(request.finst_id()) << " adds chunks to " << _is_cancelled ? "cancelled queue"
-                                                                                            : "ended queue";
+        LOG(WARNING) << print_id(request.finst_id()) << " adds chunks to "
+                     << (_is_cancelled ? "cancelled queue" : "ended queue");
         return Status::OK();
     }
 

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -550,9 +550,6 @@ void DataStreamRecvr::PipelineSenderQueue::cancel() {
 }
 
 void DataStreamRecvr::PipelineSenderQueue::close() {
-    if (UNLIKELY(!_is_cancelled && (!_chunk_queues.empty() || !_buffered_chunk_queues.empty()))) {
-        LOG(ERROR) << "Closing non-cancelled PipelineSenderQueue but its chunk queues are not empty";
-    }
     clean_buffer_queues();
 }
 

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -667,8 +667,8 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
     DCHECK(!(keep_order && use_pass_through));
     DCHECK(request.chunks_size() > 0 || use_pass_through);
     if (_is_cancelled || _num_remaining_senders <= 0) {
-        LOG(WARNING) << print_id(request.finst_id()) << " adds chunks to "
-                     << (_is_cancelled ? "cancelled queue" : "ended queue");
+        VLOG_ROW << print_id(request.finst_id()) << " adds chunks to "
+                 << (_is_cancelled ? "cancelled queue" : "ended queue");
         return Status::OK();
     }
 

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -789,11 +789,10 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
             _recvr->_num_buffered_bytes += chunk_bytes;
             COUNTER_ADD(metrics.peak_buffer_mem_bytes, chunk_bytes);
         }
+    }
 
-        if (_is_cancelled) {
-            clean_buffer_queues();
-            return Status::OK();
-        }
+    if (_is_cancelled) {
+        clean_buffer_queues();
     }
 
     return Status::OK();


### PR DESCRIPTION
Fixes #issue

1. scan operator is blocked if one dirver don't submit tasks and waiting until timeout, as it can't get tokens which is holded by other dirvers in the same fragment; so this PR let finishing scan operators release tokens in time.
2. add more logs to check blocked drivers.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
