### PR TITLE
[BugFix] Fix the bug that the read range of CSV reader is out of bounds. (#21373)

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_text.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_text.cpp
@@ -92,7 +92,7 @@ Status HdfsScannerCSVReader::_fill_buffer() {
     // maybe its a SequenceFile because we support to read compressed text file.
     // For uncompressed text file, we can split csv file into chunks and process chunks parallelly.
     // For compressed text file, we only can parse csv file in sequential way.
-    ASSIGN_OR_RETURN(s.size, _file->read(s.data, s.size));
+    ASSIGN_OR_RETURN(s.size, _file->read(s.data, std::min(s.size, _file_length - _offset)));
     _offset += s.size;
     _buff.add_limit(s.size);
     if (s.size == 0) {

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -46,6 +46,9 @@ CacheInputStream::CacheInputStream(std::shared_ptr<SeekableInputStream> stream, 
 Status CacheInputStream::read_at_fully(int64_t offset, void* out, int64_t count) {
     BlockCache* cache = BlockCache::instance();
     count = std::min(_size - offset, count);
+    if (count < 0) {
+        return Status::EndOfFile("");
+    }
     const int64_t BLOCK_SIZE = cache->block_size();
     char* p = static_cast<char*>(out);
     char* pe = p + count;


### PR DESCRIPTION
For CSV Reader, if the last row has no row delimeter, it will try to read the range equal in size to the free space of the current csv buffer, which may exceed the file length. As some underly streams, such as `CacheInputStream`, assume all ranges are valid, it may cause some unexpected errors.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
