### PR TITLE
[BugFix] Provide detail error message when alter task failed

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -122,6 +122,7 @@ static void alter_tablet(const TAlterTabletReqV2& agent_task_req, int64_t signat
         LOG(WARNING) << alter_msg_head << "alter failed. signature: " << signature;
         error_msgs.emplace_back("alter failed");
         error_msgs.emplace_back("status: " + print_agent_status(status));
+        error_msgs.emplace_back(sc_status.get_error_msg());
         task_status.__set_status_code(TStatusCode::RUNTIME_ERROR);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.leader;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -228,8 +229,9 @@ public class LeaderImpl {
         } else {
             if (taskStatus.getStatus_code() != TStatusCode.OK) {
                 task.failed();
-                String errMsg = "task type: " + taskType + ", status_code: " + taskStatus.getStatus_code().toString() +
-                        ", backendId: " + backendId + ", signature: " + signature;
+                String taskErrMsg = taskStatus.getError_msgs() != null ? Joiner.on(",").join(taskStatus.getError_msgs()) : "";
+                String errMsg = "task type: " + taskType + ", status_code: " + taskStatus.getStatus_code().toString() + ", " +
+                        taskErrMsg + ", backendId: " + backendId + ", signature: " + signature;
                 task.setErrorMsg(errMsg);
                 LOG.warn(errMsg);
                 // We start to let FE perceive the task's error msg

--- a/fe/fe-core/src/test/java/com/starrocks/alter/PseudoClusterAlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/PseudoClusterAlterTest.java
@@ -45,7 +45,30 @@ public class PseudoClusterAlterTest {
         String createTableSql = PseudoCluster.newCreateTableSqlBuilder().setTableName(table).build();
         String insertSql = PseudoCluster.buildInsertSql("test", table);
         cluster.runSqls("test", createTableSql, insertSql, insertSql, insertSql);
-        cluster.runSql("test", "alter table " + table + " add column add_column1 int");
+        // after introducing light schema change, add/drop column will not trigger schema change task, so change to add index
+        cluster.runSql("test", "alter table " + table + " add index age_bitmap(age) using bitmap");
+        while (true) {
+            long num = handler.getAlterJobV2Num(AlterJobV2.JobState.FINISHED);
+            if (num == expectAlterFinishNumber) {
+                break;
+            }
+            System.out.println("wait alter job to finish...");
+            Thread.sleep(2000);
+        }
+    }
+
+    @Test
+    public void testAlterTableWithTaskFailure() throws Exception {
+        // test alter should success even experienced 1 task failure, failed task should be retried
+        PseudoCluster cluster = PseudoCluster.getInstance();
+        cluster.getBackend(10001).injectAlterTaskError("injected alter task error");
+        AlterHandler handler = GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler();
+        long expectAlterFinishNumber = handler.getAlterJobV2Num(AlterJobV2.JobState.FINISHED) + 1;
+        String table = "table_simple_with_1_failure";
+        String createTableSql = PseudoCluster.newCreateTableSqlBuilder().setTableName(table).build();
+        String insertSql = PseudoCluster.buildInsertSql("test", table);
+        cluster.runSqls("test", createTableSql, insertSql, insertSql, insertSql);
+        cluster.runSql("test", "alter table " + table + " add index age_bitmap(age) using bitmap");
         while (true) {
             long num = handler.getAlterJobV2Num(AlterJobV2.JobState.FINISHED);
             if (num == expectAlterFinishNumber) {
@@ -86,7 +109,7 @@ public class PseudoClusterAlterTest {
             }
         });
         concurrentInsertThread.start();
-        cluster.runSql("test", "alter table " + table + " add column add_column1 int");
+        cluster.runSql("test", "alter table " + table + " add index age_bitmap(age) using bitmap");
         while (true) {
             long num = handler.getAlterJobV2Num(AlterJobV2.JobState.FINISHED);
             if (num == expectAlterFinishNumber) {

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -615,7 +615,18 @@ public class PseudoBackend {
         finish.finish_tablet_infos = Lists.newArrayList(destTablet.getTabletInfo());
     }
 
+    private String alterTaskError = null;
+
+    public void injectAlterTaskError(String errMsg) {
+        alterTaskError = errMsg;
+    }
+
     private void handleAlter(TAgentTaskRequest request, TFinishTaskRequest finishTaskRequest) throws Exception {
+        if (alterTaskError != null) {
+            String err = alterTaskError;
+            alterTaskError = null;
+            throw new Exception(err);
+        }
         TAlterTabletReqV2 task = request.alter_tablet_req_v2;
         if (task.tablet_type == TTabletType.TABLET_TYPE_LAKE) {
             finishTaskRequest.finish_tablet_infos = Lists.newArrayList(


### PR DESCRIPTION
This PR partially fixes #34606, providing detail error message when alter task failed, currently in only shows runtime error, user can not know the detailed reason like OOM.

Error message before and after PR

```
mysql> show alter table column;
+-------+------------+---------------------+---------------------+------------+---------+---------------+---------------+---------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| JobId | TableName  | CreateTime          | FinishTime          | IndexName  | IndexId | OriginIndexId | SchemaVersion | TransactionId | State     | Msg                                                                                                                                                                                                                                                                                                                                                | Progress | Timeout |
+-------+------------+---------------------+---------------------+------------+---------+---------------+---------------+---------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+
| 78076 | testbitmap | 2023-11-08 19:40:38 | 2023-11-08 19:42:06 | testbitmap | 78077   | 78060         | 1:1698655310  | 29047         | CANCELLED | schema change task failed: task type: ALTER, status_code: RUNTIME_ERROR, backendId: 10006, signature: 78078                                                                                                                                                                                                                                        | NULL     | 86400   |
| 80061 | testbitmap | 2023-11-09 19:23:36 | 2023-11-09 19:25:16 | testbitmap | 80062   | 78060         | 1:744579715   | 31033         | CANCELLED | schema change task failed: task type: ALTER, status_code: RUNTIME_ERROR, alter failed,status: STARROCKS_ERROR,Memory of schema change task exceed limit. DirectSchemaChange Used: 2148315712, Limit: 2147483648. You can change the limit by modify BE config [memory_limitation_per_thread_for_schema_change], backendId: 10006, signature: 80063 | NULL     | 86400   |
+-------+------------+---------------------+---------------------+------------+---------+---------------+---------------+---------------+-----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------+---------+

```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
