### PR TITLE
[BugFix] Fix bugs for mv rollup with complex expressions 

### DIFF
--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -461,6 +461,7 @@ Status SchemaChangeDirectly::process(TabletReader* reader, RowsetWriter* new_row
             LOG(WARNING) << alter_msg_header() + err_msg;
             return Status::InternalError(alter_msg_header() + err_msg);
         }
+        // Since mv supports where expression, new_chunk may be empty after where expression evalutions.
         if (new_chunk->num_rows() == 0) {
             continue;
         }
@@ -563,6 +564,7 @@ Status SchemaChangeWithSorting::process(TabletReader* reader, RowsetWriter* new_
             LOG(WARNING) << alter_msg_header() << err_msg;
             return Status::InternalError(alter_msg_header() + err_msg);
         }
+        // Since mv supports where expression, new_chunk may be empty after where expression evalutions.
         if (new_chunk->num_rows() == 0) {
             continue;
         }

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -461,6 +461,9 @@ Status SchemaChangeDirectly::process(TabletReader* reader, RowsetWriter* new_row
             LOG(WARNING) << alter_msg_header() + err_msg;
             return Status::InternalError(alter_msg_header() + err_msg);
         }
+        if (new_chunk->num_rows() == 0) {
+            continue;
+        }
 
         if (auto st = _chunk_changer->fill_generated_columns(new_chunk); !st.ok()) {
             LOG(WARNING) << alter_msg_header() << "fill generated columns failed: " << st.get_error_msg();
@@ -559,6 +562,9 @@ Status SchemaChangeWithSorting::process(TabletReader* reader, RowsetWriter* new_
                                                       base_tablet->tablet_id(), new_tablet->tablet_id());
             LOG(WARNING) << alter_msg_header() << err_msg;
             return Status::InternalError(alter_msg_header() + err_msg);
+        }
+        if (new_chunk->num_rows() == 0) {
+            continue;
         }
 
         ChunkHelper::padding_char_columns(char_field_indexes, new_schema, new_tablet->tablet_schema(), new_chunk.get());

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -236,9 +236,9 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
     if (_alter_job_type == TAlterJobType::ROLLUP) {
         for (auto slot : _query_slots) {
             size_t column_index = base_chunk->schema()->get_field_index_by_name(slot->col_name());
-            VLOG(2) << "col name:" << slot->col_name() << ", slot_id:" << slot->id()
-                    << ", column_index:" << column_index;
             if (column_index != -1) {
+                VLOG(2) << "col name:" << slot->col_name() << ", slot_id:" << slot->id()
+                        << ", column_index:" << column_index;
                 base_chunk->set_slot_id_to_index(slot->id(), column_index);
             }
         }
@@ -250,11 +250,12 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
 
     for (size_t i = 0; i < new_chunk->num_columns(); ++i) {
         int ref_column = _schema_mapping[i].ref_column;
+        const TypeInfoPtr& new_type_info = new_schema.field(i)->type();
 
         // For rollup, if new column has expr, just evalute the mv expr, otherwise do the normal schema change.
         if (_alter_job_type == TAlterJobType::ROLLUP && _schema_mapping[i].mv_expr_ctx != nullptr) {
-            VLOG(2) << "This rollup column has mv expr, i=" << i << ", ref_column=" << ref_column;
-
+            VLOG(2) << "This rollup column has mv expr, i=" << i << ", ref_column=" << ref_column
+                    << ", new_type=" << new_type_info->type();
             // init for expression evaluation only
             auto new_col_status = (_schema_mapping[i].mv_expr_ctx)->evaluate(base_chunk.get());
             if (!new_col_status.ok()) {
@@ -268,10 +269,22 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
             }
 
             // NOTE: Unpack const column first to avoid generating NullColumn<ConstColumn> result.
-            new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
+            if (new_col->only_null()) {
+                auto unfold_col = new_col->clone_empty();
+                if (!unfold_col->append_nulls(new_col->size())) {
+                    return false;
+                }
+                new_col = std::move(unfold_col);
+            } else {
+                new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
+            }
+
             if (new_schema.field(i)->is_nullable()) {
                 new_col = ColumnHelper::cast_to_nullable_column(new_col);
             }
+#ifdef BE_TEST
+            VLOG(2) << "evaluate result:" << new_col->debug_string();
+#endif
             new_chunk->columns()[i] = std::move(new_col);
             continue;
         }
@@ -280,7 +293,6 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
             DCHECK(_column_ref_mapping.find(ref_column) != _column_ref_mapping.end());
             int base_index = _column_ref_mapping.at(ref_column);
             const TypeInfoPtr& ref_type_info = base_schema.field(base_index)->type();
-            const TypeInfoPtr& new_type_info = new_schema.field(i)->type();
 
             int reftype_precision = ref_type_info->precision();
             int reftype_scale = ref_type_info->scale();

--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -268,14 +268,13 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
                 return false;
             }
 
-            // NOTE: Unpack const column first to avoid generating NullColumn<ConstColumn> result.
             if (new_col->only_null()) {
+                // unfold only null columns to avoid no default values.
                 auto unfold_col = new_col->clone_empty();
-                if (!unfold_col->append_nulls(new_col->size())) {
-                    return false;
-                }
+                unfold_col->append_nulls(new_col->size());
                 new_col = std::move(unfold_col);
             } else {
+                // NOTE: Unpack const column first to avoid generating NullColumn<ConstColumn> result.
                 new_col = ColumnHelper::unpack_and_duplicate_const_column(new_col->size(), new_col);
             }
 

--- a/be/src/storage/schema_change_utils.h
+++ b/be/src/storage/schema_change_utils.h
@@ -99,7 +99,7 @@ public:
     void set_query_slots(DescriptorTbl* desc_tbl) {
         std::vector<TupleDescriptor*> tuples;
         desc_tbl->get_tuple_descs(&tuples);
-        DCHECK_EQ(0, tuples.size());
+        DCHECK_LE(0, tuples.size());
         _query_slots = tuples[0]->slots();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1492,7 +1492,8 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * @return : The materialized view's referred base table and its partition column.
      */
     public Pair<Table, Column> getBaseTableAndPartitionColumn() {
-        if (!(partitionInfo instanceof ExpressionRangePartitionInfo || partitionInfo instanceof ListPartitionInfo)) {
+        if (partitionRefTableExprs == null ||
+                !(partitionInfo instanceof ExpressionRangePartitionInfo || partitionInfo instanceof ListPartitionInfo)) {
             return null;
         }
         Expr partitionExpr = getPartitionRefTableExprs().get(0);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -201,7 +201,7 @@ public class MvRewritePreprocessor {
                 preprocessMv(mv, queryTables, originQueryColumns);
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
-                logMVPrepare(connectContext, "Preprocess MV {} failed: {}", mv.getName(), e);
+                logMVPrepare(connectContext, "Preprocess MV {} failed: {}", mv.getName(), e.getMessage());
                 LOG.warn("Preprocess mv {} failed for query tables:{}", mv.getName(), tableNames, e);
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregateFunctionRewriter.java
@@ -79,7 +79,7 @@ public class AggregateFunctionRewriter {
         if (aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct()) {
             return true;
         }
-        if (aggFuncName.equals(FunctionSet.BITMAP_UNION_COUNT)) {
+        if (aggFuncName.equals(FunctionSet.BITMAP_UNION_COUNT) || aggFuncName.equals(FunctionSet.MULTI_DISTINCT_COUNT)) {
             return true;
         }
         // HLL
@@ -97,7 +97,8 @@ public class AggregateFunctionRewriter {
     public CallOperator rewriteAggFunction(CallOperator aggFunc) {
         String aggFuncName = aggFunc.getFnName();
         if ((aggFuncName.equals(FunctionSet.COUNT) && aggFunc.isDistinct()) ||
-                aggFuncName.equals(FunctionSet.BITMAP_UNION_COUNT)) {
+                aggFuncName.equals(FunctionSet.BITMAP_UNION_COUNT) ||
+                aggFuncName.equals(FunctionSet.MULTI_DISTINCT_COUNT)) {
             return rewriteCountDistinct(aggFunc);
         } else if (aggFuncName.equals(FunctionSet.AVG)) {
             return rewriteAvg(aggFunc);

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -942,6 +942,14 @@ class StarrocksSQLApiLib(object):
         tools.assert_equal("FINISHED", status, "didn't wait pipe finish")
 
 
+    def check_hit_materialized_view_plan(self, res, mv_name):
+        """
+        assert mv_name is hit in query
+        """
+        time.sleep(1)
+        print(res)
+        tools.assert_true(str(res).find(mv_name) > 0, "assert mv %s is not found" % (mv_name))
+
     def check_hit_materialized_view(self, query, mv_name):
         """
         assert mv_name is hit in query

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -946,8 +946,6 @@ class StarrocksSQLApiLib(object):
         """
         assert mv_name is hit in query
         """
-        time.sleep(1)
-        print(res)
         tools.assert_true(str(res).find(mv_name) > 0, "assert mv %s is not found" % (mv_name))
 
     def check_hit_materialized_view(self, query, mv_name):

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
@@ -110,7 +110,43 @@ distributed by hash(id);
 -- result:
 -- !result
  
-
+ ------- CASE0: NO DATA
+create materialized view test_mv1
+as 
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
 INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
 VALUES
 ('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
@@ -141,6 +141,30 @@ function: wait_materialized_view_finish()
 -- result:
 None
 -- !result
+result=explain select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+function: check_hit_materialized_view_plan("""${result}""", "test_mv1")
+-- result:
+None
+-- !result
 function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
 -- result:
 None
@@ -201,14 +225,15 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds
  ,column_19
  ,column_36;
 -- result:
-E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+19	36	20	1	1	0
 -- !result
 INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
 VALUES
@@ -278,14 +303,15 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds
  ,column_19
  ,column_36;
 -- result:
-E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+19	36	30	1	1	0
 -- !result
 drop materialized view test_mv1;
 -- result:
@@ -381,14 +407,15 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds
  ,column_19
  ,column_36;
 -- result:
-E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+19	36	30	1	1	0
 -- !result
 INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
 VALUES
@@ -462,14 +489,15 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds
  ,column_19
  ,column_36;
 -- result:
-E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+19	36	40	1	1	0
 -- !result
  drop materialized view test_mv1;
 -- result:

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
@@ -1,4 +1,7 @@
 -- name: test_sync_materialized_view_count_distinct
+drop table if exists user_event;
+-- result:
+-- !result
 CREATE TABLE user_event (
     ds date   NOT NULL,
     id  varchar(256)    NOT NULL,
@@ -41,69 +44,7 @@ CREATE TABLE user_event (
     column_34   varchar(256)    DEFAULT NULL,
     column_35   varchar(256)    DEFAULT NULL,
     column_36   varchar(256)    DEFAULT NULL,
-    column_37   varchar(256)    DEFAULT NULL,
-    column_38   varchar(256)    DEFAULT NULL,
-    column_39   varchar(256)    DEFAULT NULL,
-    column_40   varchar(256)    DEFAULT NULL,
-    column_41   varchar(256)    DEFAULT NULL,
-    column_42   varchar(256)    DEFAULT NULL,
-    column_43   varchar(256)    DEFAULT NULL,
-    column_44   varchar(256)    DEFAULT NULL,
-    column_45   varchar(256)    DEFAULT NULL,
-    column_46   varchar(256)    DEFAULT NULL,
-    column_47   varchar(256)    DEFAULT NULL,
-    column_48   varchar(256)    DEFAULT NULL,
-    column_49   varchar(256)    DEFAULT NULL,
-    column_50   varchar(256)    DEFAULT NULL,
-    column_51   varchar(256)    DEFAULT NULL,
-    column_52   varchar(256)    DEFAULT NULL,
-    column_53   varchar(256)    DEFAULT NULL,
-    column_54   varchar(256)    DEFAULT NULL,
-    column_55   varchar(256)    DEFAULT NULL,
-    column_56   varchar(256)    DEFAULT NULL,
-    column_57   varchar(256)    DEFAULT NULL,
-    column_58   varchar(256)    DEFAULT NULL,
-    column_59   varchar(256)    DEFAULT NULL,
-    column_60   varchar(256)    DEFAULT NULL,
-    column_61   varchar(256)    DEFAULT NULL,
-    column_62   varchar(256)    DEFAULT NULL,
-    column_63   varchar(256)    DEFAULT NULL,
-    column_64   varchar(256)    DEFAULT NULL,
-    column_65   varchar(256)    DEFAULT NULL,
-    column_66   varchar(256)    DEFAULT NULL,
-    column_67   varchar(256)    DEFAULT NULL,
-    column_68   varchar(256)    DEFAULT NULL,
-    column_69   varchar(256)    DEFAULT NULL,
-    column_70   varchar(256)    DEFAULT NULL,
-    column_71   varchar(256)    DEFAULT NULL,
-    column_72   varchar(256)    DEFAULT NULL,
-    column_73   varchar(256)    DEFAULT NULL,
-    column_74   varchar(256)    DEFAULT NULL,
-    column_75   varchar(256)    DEFAULT NULL,
-    column_76   varchar(256)    DEFAULT NULL,
-    column_77   varchar(256)    DEFAULT NULL,
-    column_78   varchar(256)    DEFAULT NULL,
-    column_79   varchar(256)    DEFAULT NULL,
-    column_80   varchar(256)    DEFAULT NULL,
-    column_81   varchar(256)    DEFAULT NULL,
-    column_82   varchar(256)    DEFAULT NULL,
-    column_83   varchar(256)    DEFAULT NULL,
-    column_84   varchar(256)    DEFAULT NULL,
-    column_85   varchar(256)    DEFAULT NULL,
-    column_86   varchar(256)    DEFAULT NULL,
-    column_87   varchar(256)    DEFAULT NULL,
-    column_88   varchar(256)    DEFAULT NULL,
-    column_89   varchar(256)    DEFAULT NULL,
-    column_90   varchar(256)    DEFAULT NULL,
-    column_91   varchar(256)    DEFAULT NULL,
-    column_92   varchar(256)    DEFAULT NULL,
-    column_93   varchar(256)    DEFAULT NULL,
-    column_94   varchar(256)    DEFAULT NULL,
-    column_95   varchar(256)    DEFAULT NULL,
-    column_96   varchar(256)    DEFAULT NULL,
-    column_97   varchar(256)    DEFAULT NULL,
-    column_98   varchar(256)    DEFAULT NULL
-
+    column_37   varchar(256)    DEFAULT NULL
 )
 partition by date_trunc("day", ds)
 distributed by hash(id);
@@ -147,10 +88,10 @@ None
 drop materialized view test_mv1;
 -- result:
 -- !result
-INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37)
 VALUES
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37');
 -- result:
 -- !result
 create materialized view test_mv1
@@ -226,7 +167,8 @@ ds
  ,column_19
  ,column_36;
 -- result:
-2023-11-02	19	36	20	1	1	0	0	1	0
+2023-11-01	19	36	10	1	1	0	0	1	0
+2023-11-02	19	36	10	1	1	0	0	1	0
 -- !result
 select
 ds
@@ -249,7 +191,8 @@ ds
  ,column_19
  ,column_36;
 -- result:
-2023-11-02	19	36	20	1	1	0	0	1	0
+2023-11-01	19	36	10	1	1	0	0	1	0
+2023-11-02	19	36	10	1	1	0	0	1	0
 -- !result
  select
  column_19 
@@ -269,12 +212,12 @@ ds
  ,column_19
  ,column_36;
 -- result:
-19	36	20	1	1	0
+19	36	10	1	1	0
 -- !result
-INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37)
 VALUES
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
-('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37');
 -- result:
 -- !result
 function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
@@ -302,8 +245,8 @@ ds
  ,column_19
  ,column_36;
 -- result:
-2023-11-01	19	36	10	1	1	0	0	1	0
-2023-11-02	19	36	30	1	1	0	0	1	0
+2023-11-01	19	36	20	1	1	0	0	1	0
+2023-11-02	19	36	20	1	1	0	0	1	0
 -- !result
 select
 ds
@@ -326,8 +269,8 @@ ds
  ,column_19
  ,column_36;
 -- result:
-2023-11-01	19	36	10	1	1	0	0	1	0
-2023-11-02	19	36	30	1	1	0	0	1	0
+2023-11-01	19	36	20	1	1	0	0	1	0
+2023-11-02	19	36	20	1	1	0	0	1	0
 -- !result
  select
  column_19 
@@ -347,7 +290,7 @@ ds
  ,column_19
  ,column_36;
 -- result:
-19	36	30	1	1	0
+19	36	20	1	1	0
 -- !result
 drop materialized view test_mv1;
 -- result:
@@ -407,6 +350,88 @@ ds
  ,column_19
  ,column_36;
 -- result:
+2023-11-02	19	36	20	1	1	0	0	1	0
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-02	19	36	20	1	1	0	0	1	0
+-- !result
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+19	36	20	1	1	0
+-- !result
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37)
+VALUES
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
 2023-11-02	19	36	30	1	1	0	0	1	0
 -- !result
 select
@@ -452,88 +477,6 @@ ds
  ,column_36;
 -- result:
 19	36	30	1	1	0
--- !result
-INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
-VALUES
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
-('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
--- result:
--- !result
-function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
--- result:
-None
--- !result
-function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
--- result:
-None
--- !result
-select
-ds
-,column_19 
-,column_36
-,sum(column_01) as column_01_sum
-,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
-,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
-,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
-,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
-,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
-,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
- from user_event
- where ds >= '2023-11-02'
- group by
- ds
- ,column_19
- ,column_36
- order by 
- ds
- ,column_19
- ,column_36;
--- result:
-2023-11-02	19	36	40	1	1	0	0	1	0
--- !result
-select
-ds
-,column_19 
-,column_36
-,sum(column_01) as column_01_sum
- ,count(distinct  user_id) as user_id_dist_cnt
- ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
- ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
- ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
- ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
- ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
- from user_event
- where ds >= '2023-11-02'
- group by
- ds
- ,column_19
- ,column_36
-  order by 
- ds
- ,column_19
- ,column_36;
--- result:
-2023-11-02	19	36	40	1	1	0	0	1	0
--- !result
- select
- column_19 
-,column_36
- ,sum(column_01) as column_01_sum
- ,count(distinct user_id) as user_id_dist_cnt
-,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
-,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
- from user_event
- where ds in ('2023-11-02')
- group by
- ds
- ,column_19
- ,column_36
-  order by 
- ds
- ,column_19
- ,column_36;
--- result:
-19	36	40	1	1	0
 -- !result
  drop materialized view test_mv1;
 -- result:

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view_count_distinct
@@ -1,0 +1,476 @@
+-- name: test_sync_materialized_view_count_distinct
+CREATE TABLE user_event (
+    ds date   NOT NULL,
+    id  varchar(256)    NOT NULL,
+    user_id int DEFAULT NULL,
+    user_id1    varchar(256)    DEFAULT NULL,
+    user_id2    varchar(256)    DEFAULT NULL,
+    column_01   int DEFAULT NULL,
+    column_02   int DEFAULT NULL,
+    column_03   int DEFAULT NULL,
+    column_04   int DEFAULT NULL,
+    column_05   int DEFAULT NULL,
+    column_06   DECIMAL(12,2)   DEFAULT NULL,
+    column_07   DECIMAL(12,3)   DEFAULT NULL,
+    column_08   JSON   DEFAULT NULL,
+    column_09   DATETIME    DEFAULT NULL,
+    column_10   DATETIME    DEFAULT NULL,
+    column_11   DATE    DEFAULT NULL,
+    column_12   varchar(256)    DEFAULT NULL,
+    column_13   varchar(256)    DEFAULT NULL,
+    column_14   varchar(256)    DEFAULT NULL,
+    column_15   varchar(256)    DEFAULT NULL,
+    column_16   varchar(256)    DEFAULT NULL,
+    column_17   varchar(256)    DEFAULT NULL,
+    column_18   varchar(256)    DEFAULT NULL,
+    column_19   varchar(256)    DEFAULT NULL,
+    column_20   varchar(256)    DEFAULT NULL,
+    column_21   varchar(256)    DEFAULT NULL,
+    column_22   varchar(256)    DEFAULT NULL,
+    column_23   varchar(256)    DEFAULT NULL,
+    column_24   varchar(256)    DEFAULT NULL,
+    column_25   varchar(256)    DEFAULT NULL,
+    column_26   varchar(256)    DEFAULT NULL,
+    column_27   varchar(256)    DEFAULT NULL,
+    column_28   varchar(256)    DEFAULT NULL,
+    column_29   varchar(256)    DEFAULT NULL,
+    column_30   varchar(256)    DEFAULT NULL,
+    column_31   varchar(256)    DEFAULT NULL,
+    column_32   varchar(256)    DEFAULT NULL,
+    column_33   varchar(256)    DEFAULT NULL,
+    column_34   varchar(256)    DEFAULT NULL,
+    column_35   varchar(256)    DEFAULT NULL,
+    column_36   varchar(256)    DEFAULT NULL,
+    column_37   varchar(256)    DEFAULT NULL,
+    column_38   varchar(256)    DEFAULT NULL,
+    column_39   varchar(256)    DEFAULT NULL,
+    column_40   varchar(256)    DEFAULT NULL,
+    column_41   varchar(256)    DEFAULT NULL,
+    column_42   varchar(256)    DEFAULT NULL,
+    column_43   varchar(256)    DEFAULT NULL,
+    column_44   varchar(256)    DEFAULT NULL,
+    column_45   varchar(256)    DEFAULT NULL,
+    column_46   varchar(256)    DEFAULT NULL,
+    column_47   varchar(256)    DEFAULT NULL,
+    column_48   varchar(256)    DEFAULT NULL,
+    column_49   varchar(256)    DEFAULT NULL,
+    column_50   varchar(256)    DEFAULT NULL,
+    column_51   varchar(256)    DEFAULT NULL,
+    column_52   varchar(256)    DEFAULT NULL,
+    column_53   varchar(256)    DEFAULT NULL,
+    column_54   varchar(256)    DEFAULT NULL,
+    column_55   varchar(256)    DEFAULT NULL,
+    column_56   varchar(256)    DEFAULT NULL,
+    column_57   varchar(256)    DEFAULT NULL,
+    column_58   varchar(256)    DEFAULT NULL,
+    column_59   varchar(256)    DEFAULT NULL,
+    column_60   varchar(256)    DEFAULT NULL,
+    column_61   varchar(256)    DEFAULT NULL,
+    column_62   varchar(256)    DEFAULT NULL,
+    column_63   varchar(256)    DEFAULT NULL,
+    column_64   varchar(256)    DEFAULT NULL,
+    column_65   varchar(256)    DEFAULT NULL,
+    column_66   varchar(256)    DEFAULT NULL,
+    column_67   varchar(256)    DEFAULT NULL,
+    column_68   varchar(256)    DEFAULT NULL,
+    column_69   varchar(256)    DEFAULT NULL,
+    column_70   varchar(256)    DEFAULT NULL,
+    column_71   varchar(256)    DEFAULT NULL,
+    column_72   varchar(256)    DEFAULT NULL,
+    column_73   varchar(256)    DEFAULT NULL,
+    column_74   varchar(256)    DEFAULT NULL,
+    column_75   varchar(256)    DEFAULT NULL,
+    column_76   varchar(256)    DEFAULT NULL,
+    column_77   varchar(256)    DEFAULT NULL,
+    column_78   varchar(256)    DEFAULT NULL,
+    column_79   varchar(256)    DEFAULT NULL,
+    column_80   varchar(256)    DEFAULT NULL,
+    column_81   varchar(256)    DEFAULT NULL,
+    column_82   varchar(256)    DEFAULT NULL,
+    column_83   varchar(256)    DEFAULT NULL,
+    column_84   varchar(256)    DEFAULT NULL,
+    column_85   varchar(256)    DEFAULT NULL,
+    column_86   varchar(256)    DEFAULT NULL,
+    column_87   varchar(256)    DEFAULT NULL,
+    column_88   varchar(256)    DEFAULT NULL,
+    column_89   varchar(256)    DEFAULT NULL,
+    column_90   varchar(256)    DEFAULT NULL,
+    column_91   varchar(256)    DEFAULT NULL,
+    column_92   varchar(256)    DEFAULT NULL,
+    column_93   varchar(256)    DEFAULT NULL,
+    column_94   varchar(256)    DEFAULT NULL,
+    column_95   varchar(256)    DEFAULT NULL,
+    column_96   varchar(256)    DEFAULT NULL,
+    column_97   varchar(256)    DEFAULT NULL,
+    column_98   varchar(256)    DEFAULT NULL
+
+)
+partition by date_trunc("day", ds)
+distributed by hash(id);
+-- result:
+-- !result
+ 
+
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+VALUES
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+-- result:
+-- !result
+create materialized view test_mv1
+as 
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-02	19	36	20	1	1	0	0	1	0
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-02	19	36	20	1	1	0	0	1	0
+-- !result
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+-- !result
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+VALUES
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+-- result:
+-- !result
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-01	19	36	10	1	1	0	0	1	0
+2023-11-02	19	36	30	1	1	0	0	1	0
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-01	19	36	10	1	1	0	0	1	0
+2023-11-02	19	36	30	1	1	0	0	1	0
+-- !result
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+-- !result
+drop materialized view test_mv1;
+-- result:
+-- !result
+create materialized view test_mv1
+as 
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-02	19	36	30	1	1	0	0	1	0
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-02	19	36	30	1	1	0	0	1	0
+-- !result
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+-- !result
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+VALUES
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+-- result:
+-- !result
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
+-- result:
+None
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-02	19	36	40	1	1	0	0	1	0
+-- !result
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+2023-11-02	19	36	40	1	1	0	0	1	0
+-- !result
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+-- result:
+E: (1064, "Getting analyzing error at line 14, column 1. Detail message: '`test_db_8fe50de47ecf11eea6c7b590aef28e5e`.`user_event`.`ds`' must be an aggregate expression or appear in GROUP BY clause.")
+-- !result
+ drop materialized view test_mv1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
@@ -137,6 +137,29 @@ ds
 
 function: wait_materialized_view_finish()
 
+result=explain select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+
+function: check_hit_materialized_view_plan("""${result}""", "test_mv1")
+
 function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
 
 select
@@ -191,7 +214,8 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds
@@ -257,7 +281,8 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds
@@ -288,6 +313,7 @@ ds
  ,column_36;
 
 function: wait_materialized_view_finish()
+
 function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
 function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
 
@@ -345,7 +371,8 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds
@@ -414,7 +441,8 @@ ds
  from user_event
  where ds in ('2023-11-02')
  group by
- column_19
+ ds
+ ,column_19
  ,column_36
   order by 
  ds

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
@@ -1,5 +1,6 @@
 -- name: test_sync_materialized_view_count_distinct
 
+drop table if exists user_event;
 CREATE TABLE user_event (
     ds date   NOT NULL,
     id  varchar(256)    NOT NULL,
@@ -42,69 +43,7 @@ CREATE TABLE user_event (
     column_34   varchar(256)    DEFAULT NULL,
     column_35   varchar(256)    DEFAULT NULL,
     column_36   varchar(256)    DEFAULT NULL,
-    column_37   varchar(256)    DEFAULT NULL,
-    column_38   varchar(256)    DEFAULT NULL,
-    column_39   varchar(256)    DEFAULT NULL,
-    column_40   varchar(256)    DEFAULT NULL,
-    column_41   varchar(256)    DEFAULT NULL,
-    column_42   varchar(256)    DEFAULT NULL,
-    column_43   varchar(256)    DEFAULT NULL,
-    column_44   varchar(256)    DEFAULT NULL,
-    column_45   varchar(256)    DEFAULT NULL,
-    column_46   varchar(256)    DEFAULT NULL,
-    column_47   varchar(256)    DEFAULT NULL,
-    column_48   varchar(256)    DEFAULT NULL,
-    column_49   varchar(256)    DEFAULT NULL,
-    column_50   varchar(256)    DEFAULT NULL,
-    column_51   varchar(256)    DEFAULT NULL,
-    column_52   varchar(256)    DEFAULT NULL,
-    column_53   varchar(256)    DEFAULT NULL,
-    column_54   varchar(256)    DEFAULT NULL,
-    column_55   varchar(256)    DEFAULT NULL,
-    column_56   varchar(256)    DEFAULT NULL,
-    column_57   varchar(256)    DEFAULT NULL,
-    column_58   varchar(256)    DEFAULT NULL,
-    column_59   varchar(256)    DEFAULT NULL,
-    column_60   varchar(256)    DEFAULT NULL,
-    column_61   varchar(256)    DEFAULT NULL,
-    column_62   varchar(256)    DEFAULT NULL,
-    column_63   varchar(256)    DEFAULT NULL,
-    column_64   varchar(256)    DEFAULT NULL,
-    column_65   varchar(256)    DEFAULT NULL,
-    column_66   varchar(256)    DEFAULT NULL,
-    column_67   varchar(256)    DEFAULT NULL,
-    column_68   varchar(256)    DEFAULT NULL,
-    column_69   varchar(256)    DEFAULT NULL,
-    column_70   varchar(256)    DEFAULT NULL,
-    column_71   varchar(256)    DEFAULT NULL,
-    column_72   varchar(256)    DEFAULT NULL,
-    column_73   varchar(256)    DEFAULT NULL,
-    column_74   varchar(256)    DEFAULT NULL,
-    column_75   varchar(256)    DEFAULT NULL,
-    column_76   varchar(256)    DEFAULT NULL,
-    column_77   varchar(256)    DEFAULT NULL,
-    column_78   varchar(256)    DEFAULT NULL,
-    column_79   varchar(256)    DEFAULT NULL,
-    column_80   varchar(256)    DEFAULT NULL,
-    column_81   varchar(256)    DEFAULT NULL,
-    column_82   varchar(256)    DEFAULT NULL,
-    column_83   varchar(256)    DEFAULT NULL,
-    column_84   varchar(256)    DEFAULT NULL,
-    column_85   varchar(256)    DEFAULT NULL,
-    column_86   varchar(256)    DEFAULT NULL,
-    column_87   varchar(256)    DEFAULT NULL,
-    column_88   varchar(256)    DEFAULT NULL,
-    column_89   varchar(256)    DEFAULT NULL,
-    column_90   varchar(256)    DEFAULT NULL,
-    column_91   varchar(256)    DEFAULT NULL,
-    column_92   varchar(256)    DEFAULT NULL,
-    column_93   varchar(256)    DEFAULT NULL,
-    column_94   varchar(256)    DEFAULT NULL,
-    column_95   varchar(256)    DEFAULT NULL,
-    column_96   varchar(256)    DEFAULT NULL,
-    column_97   varchar(256)    DEFAULT NULL,
-    column_98   varchar(256)    DEFAULT NULL
-
+    column_37   varchar(256)    DEFAULT NULL
 )
 partition by date_trunc("day", ds)
 distributed by hash(id);
@@ -134,10 +73,10 @@ function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(col
 function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
 drop materialized view test_mv1;
 
-INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37)
 VALUES
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37');
 
 ------- CASE1 : NO WHERE
 create materialized view test_mv1
@@ -246,10 +185,10 @@ ds
  ,column_19
  ,column_36;
 
-INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37)
 VALUES
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
-('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37');
 
 function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
 
@@ -403,10 +342,11 @@ ds
  ,column_19
  ,column_36;
 
-INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37)
 VALUES
-('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
-('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37');
+
 function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
 function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
 

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
@@ -109,6 +109,30 @@ CREATE TABLE user_event (
 partition by date_trunc("day", ds)
 distributed by hash(id);
  
+ ------- CASE0: NO DATA
+create materialized view test_mv1
+as 
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36;
+function: wait_materialized_view_finish()
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
+drop materialized view test_mv1;
 
 INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
 VALUES

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_count_distinct
@@ -1,0 +1,424 @@
+-- name: test_sync_materialized_view_count_distinct
+
+CREATE TABLE user_event (
+    ds date   NOT NULL,
+    id  varchar(256)    NOT NULL,
+    user_id int DEFAULT NULL,
+    user_id1    varchar(256)    DEFAULT NULL,
+    user_id2    varchar(256)    DEFAULT NULL,
+    column_01   int DEFAULT NULL,
+    column_02   int DEFAULT NULL,
+    column_03   int DEFAULT NULL,
+    column_04   int DEFAULT NULL,
+    column_05   int DEFAULT NULL,
+    column_06   DECIMAL(12,2)   DEFAULT NULL,
+    column_07   DECIMAL(12,3)   DEFAULT NULL,
+    column_08   JSON   DEFAULT NULL,
+    column_09   DATETIME    DEFAULT NULL,
+    column_10   DATETIME    DEFAULT NULL,
+    column_11   DATE    DEFAULT NULL,
+    column_12   varchar(256)    DEFAULT NULL,
+    column_13   varchar(256)    DEFAULT NULL,
+    column_14   varchar(256)    DEFAULT NULL,
+    column_15   varchar(256)    DEFAULT NULL,
+    column_16   varchar(256)    DEFAULT NULL,
+    column_17   varchar(256)    DEFAULT NULL,
+    column_18   varchar(256)    DEFAULT NULL,
+    column_19   varchar(256)    DEFAULT NULL,
+    column_20   varchar(256)    DEFAULT NULL,
+    column_21   varchar(256)    DEFAULT NULL,
+    column_22   varchar(256)    DEFAULT NULL,
+    column_23   varchar(256)    DEFAULT NULL,
+    column_24   varchar(256)    DEFAULT NULL,
+    column_25   varchar(256)    DEFAULT NULL,
+    column_26   varchar(256)    DEFAULT NULL,
+    column_27   varchar(256)    DEFAULT NULL,
+    column_28   varchar(256)    DEFAULT NULL,
+    column_29   varchar(256)    DEFAULT NULL,
+    column_30   varchar(256)    DEFAULT NULL,
+    column_31   varchar(256)    DEFAULT NULL,
+    column_32   varchar(256)    DEFAULT NULL,
+    column_33   varchar(256)    DEFAULT NULL,
+    column_34   varchar(256)    DEFAULT NULL,
+    column_35   varchar(256)    DEFAULT NULL,
+    column_36   varchar(256)    DEFAULT NULL,
+    column_37   varchar(256)    DEFAULT NULL,
+    column_38   varchar(256)    DEFAULT NULL,
+    column_39   varchar(256)    DEFAULT NULL,
+    column_40   varchar(256)    DEFAULT NULL,
+    column_41   varchar(256)    DEFAULT NULL,
+    column_42   varchar(256)    DEFAULT NULL,
+    column_43   varchar(256)    DEFAULT NULL,
+    column_44   varchar(256)    DEFAULT NULL,
+    column_45   varchar(256)    DEFAULT NULL,
+    column_46   varchar(256)    DEFAULT NULL,
+    column_47   varchar(256)    DEFAULT NULL,
+    column_48   varchar(256)    DEFAULT NULL,
+    column_49   varchar(256)    DEFAULT NULL,
+    column_50   varchar(256)    DEFAULT NULL,
+    column_51   varchar(256)    DEFAULT NULL,
+    column_52   varchar(256)    DEFAULT NULL,
+    column_53   varchar(256)    DEFAULT NULL,
+    column_54   varchar(256)    DEFAULT NULL,
+    column_55   varchar(256)    DEFAULT NULL,
+    column_56   varchar(256)    DEFAULT NULL,
+    column_57   varchar(256)    DEFAULT NULL,
+    column_58   varchar(256)    DEFAULT NULL,
+    column_59   varchar(256)    DEFAULT NULL,
+    column_60   varchar(256)    DEFAULT NULL,
+    column_61   varchar(256)    DEFAULT NULL,
+    column_62   varchar(256)    DEFAULT NULL,
+    column_63   varchar(256)    DEFAULT NULL,
+    column_64   varchar(256)    DEFAULT NULL,
+    column_65   varchar(256)    DEFAULT NULL,
+    column_66   varchar(256)    DEFAULT NULL,
+    column_67   varchar(256)    DEFAULT NULL,
+    column_68   varchar(256)    DEFAULT NULL,
+    column_69   varchar(256)    DEFAULT NULL,
+    column_70   varchar(256)    DEFAULT NULL,
+    column_71   varchar(256)    DEFAULT NULL,
+    column_72   varchar(256)    DEFAULT NULL,
+    column_73   varchar(256)    DEFAULT NULL,
+    column_74   varchar(256)    DEFAULT NULL,
+    column_75   varchar(256)    DEFAULT NULL,
+    column_76   varchar(256)    DEFAULT NULL,
+    column_77   varchar(256)    DEFAULT NULL,
+    column_78   varchar(256)    DEFAULT NULL,
+    column_79   varchar(256)    DEFAULT NULL,
+    column_80   varchar(256)    DEFAULT NULL,
+    column_81   varchar(256)    DEFAULT NULL,
+    column_82   varchar(256)    DEFAULT NULL,
+    column_83   varchar(256)    DEFAULT NULL,
+    column_84   varchar(256)    DEFAULT NULL,
+    column_85   varchar(256)    DEFAULT NULL,
+    column_86   varchar(256)    DEFAULT NULL,
+    column_87   varchar(256)    DEFAULT NULL,
+    column_88   varchar(256)    DEFAULT NULL,
+    column_89   varchar(256)    DEFAULT NULL,
+    column_90   varchar(256)    DEFAULT NULL,
+    column_91   varchar(256)    DEFAULT NULL,
+    column_92   varchar(256)    DEFAULT NULL,
+    column_93   varchar(256)    DEFAULT NULL,
+    column_94   varchar(256)    DEFAULT NULL,
+    column_95   varchar(256)    DEFAULT NULL,
+    column_96   varchar(256)    DEFAULT NULL,
+    column_97   varchar(256)    DEFAULT NULL,
+    column_98   varchar(256)    DEFAULT NULL
+
+)
+partition by date_trunc("day", ds)
+distributed by hash(id);
+ 
+
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+VALUES
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+
+------- CASE1 : NO WHERE
+create materialized view test_mv1
+as 
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36;
+
+function: wait_materialized_view_finish()
+
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+VALUES
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+drop materialized view test_mv1;
+
+------- CASE2 : WITH WHERE
+create materialized view test_mv1
+as 
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36;
+
+function: wait_materialized_view_finish()
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+INSERT INTO user_event (ds, id, user_id, user_id1, user_id2, column_01, column_02, column_03, column_04, column_05, column_06, column_07, column_08, column_09, column_10, column_11, column_12, column_13, column_14, column_15, column_16, column_17, column_18, column_19, column_20, column_21, column_22, column_23, column_24, column_25, column_26, column_27, column_28, column_29, column_30, column_31, column_32, column_33, column_34, column_35, column_36, column_37, column_38, column_39, column_40, column_41, column_42, column_43, column_44, column_45, column_46, column_47, column_48, column_49, column_50, column_51, column_52, column_53, column_54, column_55, column_56, column_57, column_58, column_59, column_60, column_61, column_62, column_63, column_64, column_65, column_66, column_67, column_68, column_69, column_70, column_71, column_72, column_73, column_74, column_75, column_76, column_77, column_78, column_79, column_80, column_81, column_82, column_83, column_84, column_85, column_86, column_87, column_88, column_89, column_90, column_91, column_92, column_93, column_94, column_95, column_96, column_97, column_98)
+VALUES
+('2023-11-02', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98'),
+('2023-11-01', '1', 1, '2', '1', 10, 20, 30, 40, 50, 12.34, 56.789, '{"key":""}', '2023-11-02 12:34:56', '2023-11-02 12:34:56', '2023-11-02', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35', '36', '37', '38', '39', '40', '41', '42', '43', '44', '45', '46', '47', '48', '49', '50', '51', '52', '53', '54', '55', '56', '57', '58', '59', '60', '61', '62', '63', '64', '65', '66', '67', '68', '69', '70', '71', '72', '73', '74', '75', '76', '77', '78', '79', '80', '81', '82', '83', '84', '85', '86', '87', '88', '89', '90', '91', '92', '93', '94', '95', '96', '97', '98');
+function: check_no_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event group by ds,column_19,column_36", "test_mv1")
+function: check_hit_materialized_view("select ds,column_19 ,column_36,sum(column_01) as column_01_sum,count(distinct  user_id) as user_id_dist_cnt,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5 from user_event where ds >= '2023-11-02' group by ds,column_19,column_36", "test_mv1")
+
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+,bitmap_union_count(to_bitmap( user_id)) as user_id_dist_cnt
+,bitmap_union_count(to_bitmap(case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+,bitmap_union_count(to_bitmap( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+,bitmap_union_count(to_bitmap(case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+,bitmap_union_count(to_bitmap(case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+,bitmap_union_count(to_bitmap( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+ order by 
+ ds
+ ,column_19
+ ,column_36;
+
+select
+ds
+,column_19 
+,column_36
+,sum(column_01) as column_01_sum
+ ,count(distinct  user_id) as user_id_dist_cnt
+ ,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')   then user_id2 else null end)) as filter_dist_cnt_1
+ ,count(distinct ( case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ ,count(distinct (case when column_03 > 70 and column_36 IN ('21','23') then  user_id2 else null end)) as filter_dist_cnt_3
+ ,count(distinct (case when column_04 > 20 and column_27 IN ('31','27') then  user_id2 else null end)) as filter_dist_cnt_4
+ ,count(distinct ( case when column_05 > 90 and column_28 IN ('41','43') then  user_id2 else null end)) as filter_dist_cnt_5
+ from user_event
+ where ds >= '2023-11-02'
+ group by
+ ds
+ ,column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+ select
+ column_19 
+,column_36
+ ,sum(column_01) as column_01_sum
+ ,count(distinct user_id) as user_id_dist_cnt
+,count(distinct (case when column_01 > 1 and column_34 IN ('1','34')  then user_id2 else null end)) as filter_dist_cnt_1
+,count(distinct (case when column_02 > 60 and column_35 IN ('11','13') then  user_id2 else null end)) as filter_dist_cnt_2
+ from user_event
+ where ds in ('2023-11-02')
+ group by
+ column_19
+ ,column_36
+  order by 
+ ds
+ ,column_19
+ ,column_36;
+
+ drop materialized view test_mv1;

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view_with_where
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view_with_where
@@ -1,4 +1,4 @@
--- name: test_sync_materialized_view_rewrite @sequential
+-- name: test_sync_materialized_view_with_where @sequential
 CREATE TABLE `duplicate_tbl` (
     `k1` date NULL COMMENT "",   
     `k2` datetime NULL COMMENT "",   


### PR DESCRIPTION
Fix bugs:
- Unfold only null columns to avoid no default values after expression evaluation in SchemaChange
- Support MULTI_COUNT_DISTINCT to rewrite into bitmap_union(to_bitmap xxx))

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
