### PR TITLE
[Enhancement] jdbc use connectionAttributes to help developers implement some parameters

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlAuthPacket.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlAuthPacket.java
@@ -83,6 +83,10 @@ public class MysqlAuthPacket extends MysqlPacket {
         return capability.isSSL();
     }
 
+    public Map<String, String> getConnectAttributes() {
+        return connectAttributes;
+    }
+
     @Override
     public boolean readFrom(ByteBuffer buffer) {
         // read capability four byte, which CLIENT_PROTOCOL_41 must be set
@@ -119,7 +123,7 @@ public class MysqlAuthPacket extends MysqlPacket {
         if (buffer.remaining() > 0 && capability.isPluginAuth()) {
             pluginName = new String(MysqlProto.readNulTerminateString(buffer));
         }
-        // connect attrs, no use now.
+        // connect attrs
         if (buffer.remaining() > 0 && capability.isConnectAttrs()) {
             connectAttributes = parseConnectAttrs(buffer);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlCapability.java
+++ b/fe/fe-core/src/main/java/com/starrocks/mysql/MysqlCapability.java
@@ -92,7 +92,8 @@ public class MysqlCapability {
     // Protocol::ColumnDefinition41 Flags uses two byte integer, so CLIENT_LONG_FLAG should be set.
     private static final int DEFAULT_FLAGS = Flag.CLIENT_PROTOCOL_41.getFlagBit()
             | Flag.CLIENT_CONNECT_WITH_DB.getFlagBit() | Flag.CLIENT_SECURE_CONNECTION.getFlagBit()
-            | Flag.CLIENT_PLUGIN_AUTH.getFlagBit() | Flag.CLIENT_LONG_FLAG.getFlagBit();
+            | Flag.CLIENT_PLUGIN_AUTH.getFlagBit() | Flag.CLIENT_LONG_FLAG.getFlagBit()
+            | Flag.CLIENT_CONNECT_ATTRS.getFlagBit();
     public static final MysqlCapability DEFAULT_CAPABILITY = new MysqlCapability(DEFAULT_FLAGS);
 
     private int flags;


### PR DESCRIPTION
jdbc use connectionAttributes to help developers implement some custom parameters
eg:
mysql jdbc query:
            Properties props = new Properties();
            props.setProperty("user", "root");
            props.setProperty("password", "");
            **props.setProperty("connectionAttributes", "query_user:_Query account_,catalog:_Custom catalog name_");**
            conn = DriverManager.getConnection("jdbc:mysql://127.0.1.1:9030", props);
            stmt = conn.createStatement();

sr custom code in MysqlProto.java:
Map<String, String> connectAttributes = authPacket.getConnectAttributes();
        if (connectAttributes.size() > 0) {
            String queryUser = connectAttributes.get("query_user");
            if (StringUtils.isNotBlank(queryUser)) {
                UserIdentity currentUserIdentity = ConnectContext.get().getCurrentUserIdentity();
                currentUserIdentity.setQueryUser(queryUser);
                ConnectContext.get().setCurrentUserIdentity(currentUserIdentity);
                String catalog = connectAttributes.get("catalog");
                Catalog currentCatalog = GlobalStateMgr.getCurrentState().getCatalogMgr().getCatalogByName(catalog);
......

**We want to separate the MySQL account from the query account in the above code, allowing different users to transfer different catalogs.**

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
