### PR TITLE
[BugFix] Use correct parameter for pulsar_consumer.seek()

### DIFF
--- a/be/src/runtime/routine_load/data_consumer.cpp
+++ b/be/src/runtime/routine_load/data_consumer.cpp
@@ -540,9 +540,9 @@ Status PulsarDataConsumer::assign_partition(const std::string& partition, Stream
     }
 
     if (initial_position == InitialPosition::LATEST || initial_position == InitialPosition::EARLIEST) {
-        pulsar::InitialPosition p_initial_position = initial_position == InitialPosition::LATEST
-                                                             ? pulsar::InitialPosition::InitialPositionLatest
-                                                             : pulsar::InitialPosition::InitialPositionEarliest;
+        pulsar::MessageId p_initial_position = initial_position == InitialPosition::LATEST
+                                                       ? pulsar::MessageId::latest()
+                                                       : pulsar::MessageId::earliest();
         result = _p_consumer.seek(p_initial_position);
         if (result != pulsar::ResultOk) {
             LOG(WARNING) << "PAUSE: failed to reset the subscription: " << ctx->brief(true) << ", err: " << result;


### PR DESCRIPTION
According to the [pulsar C++ API](https://github.com/apache/pulsar-client-cpp/blob/main/include/pulsar/Consumer.h#L423), we have 2 ways to call: `consumer.seek()`:
```
    Result seek(const MessageId& messageId);
    Result seek(uint64_t timestamp);
```
And we intended to use the first one. But we use the wrong parameter [here](https://github.com/StarRocks/starrocks/blob/main/be/src/runtime/routine_load/data_consumer.cpp#L473):
```
if (initial_position == InitialPosition::LATEST || initial_position == InitialPosition::EARLIEST) {
        pulsar::InitialPosition p_initial_position = initial_position == InitialPosition::LATEST
                                                             ? pulsar::InitialPosition::InitialPositionLatest
                                                             : pulsar::InitialPosition::InitialPositionEarliest;
        result = _p_consumer.seek(p_initial_position);
        ...
    }
```
So it call the 2nd function instead.
This PR will fix this issue.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3
  - [ ] 3.2
  - [ ] 3.1