### PR TITLE
[BugFix] Fix automatic partition write data into wrong partition when many partition created concurrency

### DIFF
--- a/be/src/runtime/lake_tablets_channel.cpp
+++ b/be/src/runtime/lake_tablets_channel.cpp
@@ -537,7 +537,7 @@ Status LakeTabletsChannel::_create_delta_writers(const PTabletWriterOpenRequest&
         std::sort(tablet_ids.begin(), tablet_ids.end());
         DCHECK_EQ(_delta_writers.size(), tablet_ids.size());
         for (size_t i = 0; i < tablet_ids.size(); ++i) {
-            _tablet_id_to_sorted_indexes.emplace(tablet_ids[i], i);
+            _tablet_id_to_sorted_indexes[tablet_ids[i]] = i;
         }
     }
     return Status::OK();

--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -834,7 +834,7 @@ Status LocalTabletsChannel::incremental_open(const PTabletWriterOpenRequest& par
         DCHECK_EQ(_delta_writers.size(), tablet_ids.size());
         std::sort(tablet_ids.begin(), tablet_ids.end());
         for (size_t i = 0; i < tablet_ids.size(); ++i) {
-            _tablet_id_to_sorted_indexes.emplace(tablet_ids[i], i);
+            _tablet_id_to_sorted_indexes[tablet_ids[i]] = i;
         }
     }
 


### PR DESCRIPTION
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
