### PR TITLE
[BugFix][Cherry-Pick][Branch-2.5] Fix HDFS stat information lost in profile and avoid BE crashed when get HDFS stat

### DIFF
--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -67,6 +67,10 @@ inline bool is_hdfs_uri(std::string_view uri) {
 }
  */
 
+inline bool is_hdfs_uri(std::string_view uri) {
+    return starts_with(uri, "hdfs://");
+}
+
 inline bool is_posix_uri(std::string_view uri) {
     return (memchr(uri.data(), ':', uri.size()) == nullptr) || starts_with(uri, "posix://");
 }

--- a/be/src/fs/fs.cpp
+++ b/be/src/fs/fs.cpp
@@ -67,10 +67,6 @@ inline bool is_hdfs_uri(std::string_view uri) {
 }
  */
 
-inline bool is_hdfs_uri(std::string_view uri) {
-    return starts_with(uri, "hdfs://");
-}
-
 inline bool is_posix_uri(std::string_view uri) {
     return (memchr(uri.data(), ':', uri.size()) == nullptr) || starts_with(uri, "posix://");
 }

--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -8,7 +8,7 @@
 #include <atomic>
 #include <utility>
 
-#include "fs/fs_util.h"
+#include "fs/fs.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/file_result_writer.h"
 #include "runtime/hdfs/hdfs_fs_cache.h"
@@ -100,7 +100,7 @@ void HdfsInputStream::set_size(int64_t value) {
 
 StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_statistics() {
     // `GetReadStatistics` is not supported in juicefs hadoop sdk, and will cause the be crash
-    if (!fs::is_hdfs_uri(_file_name)) {
+    if (!is_hdfs_uri(_file_name)) {
         return nullptr;
     }
 

--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -8,7 +8,6 @@
 #include <atomic>
 #include <utility>
 
-#include "fs/fs.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/file_result_writer.h"
 #include "runtime/hdfs/hdfs_fs_cache.h"
@@ -39,6 +38,8 @@ public:
     void set_size(int64_t size) override;
 
 private:
+    bool _is_hdfs_file() const;
+        
     hdfsFS _fs;
     hdfsFile _file;
     std::string _file_name;
@@ -98,9 +99,14 @@ void HdfsInputStream::set_size(int64_t value) {
     _file_size = value;
 }
 
+bool HdfsInputStream::_is_hdfs_file() const {
+    static const char* kFileSysPrefixJuicefs = "hdfs://";
+    return strncmp(_file_name.c_str(), kFileSysPrefixJuicefs, strlen(kFileSysPrefixJuicefs)) == 0;
+}
+
 StatusOr<std::unique_ptr<io::NumericStatistics>> HdfsInputStream::get_numeric_statistics() {
     // `GetReadStatistics` is not supported in juicefs hadoop sdk, and will cause the be crash
-    if (!is_hdfs_uri(_file_name)) {
+    if (!_is_hdfs_file()) {
         return nullptr;
     }
 

--- a/be/src/fs/fs_hdfs.cpp
+++ b/be/src/fs/fs_hdfs.cpp
@@ -39,7 +39,7 @@ public:
 
 private:
     bool _is_hdfs_file() const;
-        
+
     hdfsFS _fs;
     hdfsFile _file;
     std::string _file_name;


### PR DESCRIPTION
cp from #24590

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
