### PR TITLE
[Enhancement] report error to FE if backend is not compiled with shared-data support

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -79,13 +79,6 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
                           << ", port:" << master_info.network_address.port << ", cluster id:" << master_info.cluster_id
                           << ", run_mode:" << master_info.run_mode << ", counter:" << google::COUNTER;
 
-#ifndef USE_STAROS
-    if (master_info.run_mode == TRunMode::SHARED_DATA) {
-        // TODO: log fatal?
-        LOG_EVERY_N(ERROR, 12)
-                << "This program is not compiled with SHARED_DATA support, but FE is running in SHARED_DATA mode!";
-    }
-#endif
     // do heartbeat
     StatusOr<CmpResult> res = compare_master_info(master_info);
     res.status().to_thrift(&heartbeat_result.status);
@@ -168,6 +161,14 @@ StatusOr<HeartbeatServer::CmpResult> HeartbeatServer::compare_master_info(const 
     if ((master_info.network_address.hostname == LOCALHOST) && (master_info.backend_ip != LOCALHOST)) {
         return Status::InternalError("FE heartbeat with localhost ip but BE is not deployed on the same machine");
     }
+
+#ifndef USE_STAROS
+    if (master_info.run_mode == TRunMode::SHARED_DATA) {
+        LOG_EVERY_N(ERROR, 12)
+                << "This program is not compiled with SHARED_DATA support, but FE is running in SHARED_DATA mode!";
+        return Status::InternalError("Backend service binary was not compiled with SHARED_DATA support!");
+    }
+#endif
 
     if (master_info.__isset.backend_ip) {
         if (master_info.backend_ip != BackendOptions::get_localhost()) {


### PR DESCRIPTION
* handle the case that the binary is not compiled with shared-data support but is added to a shared-data cluster
* before this change, only a logline will be printed into be log, now it will report heartbeait response back to FE with the error message "Backend service binary was not compiled with SHARED_DATA support!"

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
