### PR TITLE
[Feature] support shared mode in scalar UDF

### DIFF
--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -14,6 +14,7 @@
 
 #include "exprs/java_function_call_expr.h"
 
+#include <any>
 #include <memory>
 #include <sstream>
 #include <tuple>
@@ -42,7 +43,6 @@ namespace starrocks {
 struct UDFFunctionCallHelper {
     JavaUDFContext* fn_desc;
     JavaMethodDescriptor* call_desc;
-    std::vector<std::string> _data_buffer;
 
     // Now we don't support logical type function
     ColumnPtr call(FunctionContext* ctx, Columns& columns, size_t size) {
@@ -158,6 +158,64 @@ bool JavaFunctionCallExpr::is_constant() const {
     return Expr::is_constant();
 }
 
+StatusOr<std::shared_ptr<JavaUDFContext>> JavaFunctionCallExpr::_build_udf_func_desc(
+        ExprContext* context, FunctionContext::FunctionStateScope scope, const std::string& libpath) {
+    auto desc = std::make_shared<JavaUDFContext>();
+    // init class loader and analyzer
+    desc->udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
+    RETURN_IF_ERROR(desc->udf_classloader->init());
+    desc->analyzer = std::make_unique<ClassAnalyzer>();
+
+    ASSIGN_OR_RETURN(desc->udf_class, desc->udf_classloader->getClass(_fn.scalar_fn.symbol));
+
+    auto add_method = [&](const std::string& name, std::unique_ptr<JavaMethodDescriptor>* res) {
+        bool has_method = false;
+        std::string method_name = name;
+        std::string signature;
+        std::vector<MethodTypeDescriptor> mtdesc;
+        RETURN_IF_ERROR(desc->analyzer->has_method(desc->udf_class.clazz(), method_name, &has_method));
+        if (has_method) {
+            RETURN_IF_ERROR(desc->analyzer->get_signature(desc->udf_class.clazz(), method_name, &signature));
+            RETURN_IF_ERROR(desc->analyzer->get_method_desc(signature, &mtdesc));
+            *res = std::make_unique<JavaMethodDescriptor>();
+            (*res)->name = std::move(method_name);
+            (*res)->signature = std::move(signature);
+            (*res)->method_desc = std::move(mtdesc);
+            ASSIGN_OR_RETURN((*res)->method, desc->analyzer->get_method_object(desc->udf_class.clazz(), name));
+        }
+        return Status::OK();
+    };
+
+    // Now we don't support prepare/close for UDF
+    // RETURN_IF_ERROR(add_method("prepare", &desc->prepare));
+    // RETURN_IF_ERROR(add_method("method_close", &desc->close));
+    RETURN_IF_ERROR(add_method("evaluate", &desc->evaluate));
+
+    // create UDF function instance
+    ASSIGN_OR_RETURN(desc->udf_handle, desc->udf_class.newInstance());
+    // BatchEvaluateStub
+    auto* stub_clazz = BatchEvaluateStub::stub_clazz_name;
+    auto* stub_method_name = BatchEvaluateStub::batch_evaluate_method_name;
+    auto udf_clazz = desc->udf_class.clazz();
+    auto update_method = desc->evaluate->method.handle();
+
+    ASSIGN_OR_RETURN(auto update_stub_clazz, desc->udf_classloader->genCallStub(stub_clazz, udf_clazz, update_method,
+                                                                                ClassLoader::BATCH_EVALUATE));
+    ASSIGN_OR_RETURN(auto method, desc->analyzer->get_method_object(update_stub_clazz.clazz(), stub_method_name));
+    auto function_ctx = context->fn_context(_fn_context_index);
+    desc->call_stub = std::make_unique<BatchEvaluateStub>(
+            function_ctx, desc->udf_handle.handle(), std::move(update_stub_clazz), JavaGlobalRef(std::move(method)));
+
+    if (desc->prepare != nullptr) {
+        // we only support fragment local scope to call prepare
+        if (scope == FunctionContext::FRAGMENT_LOCAL) {
+            // TODO: handle prepare function
+        }
+    }
+
+    return desc;
+}
+
 Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
                                   FunctionContext::FunctionStateScope scope) {
     // init parent open
@@ -172,74 +230,33 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
             const_columns.emplace_back(std::move(child_col));
         }
     }
-    auto open_state = [this, scope, context]() {
-        // init class loader and analyzer
-        std::string libpath;
-        auto function_cache = UserFunctionCache::instance();
-        RETURN_IF_ERROR(function_cache->get_libpath(_fn.fid, _fn.hdfs_location, _fn.checksum, &libpath));
-        _func_desc->udf_classloader = std::make_unique<ClassLoader>(std::move(libpath));
-        RETURN_IF_ERROR(_func_desc->udf_classloader->init());
-        _func_desc->analyzer = std::make_unique<ClassAnalyzer>();
-
-        ASSIGN_OR_RETURN(_func_desc->udf_class, _func_desc->udf_classloader->getClass(_fn.scalar_fn.symbol));
-
-        auto add_method = [&](const std::string& name, std::unique_ptr<JavaMethodDescriptor>* res) {
-            bool has_method = false;
-            std::string method_name = name;
-            std::string signature;
-            std::vector<MethodTypeDescriptor> mtdesc;
-            RETURN_IF_ERROR(_func_desc->analyzer->has_method(_func_desc->udf_class.clazz(), method_name, &has_method));
-            if (has_method) {
-                RETURN_IF_ERROR(
-                        _func_desc->analyzer->get_signature(_func_desc->udf_class.clazz(), method_name, &signature));
-                RETURN_IF_ERROR(_func_desc->analyzer->get_method_desc(signature, &mtdesc));
-                *res = std::make_unique<JavaMethodDescriptor>();
-                (*res)->name = std::move(method_name);
-                (*res)->signature = std::move(signature);
-                (*res)->method_desc = std::move(mtdesc);
-                ASSIGN_OR_RETURN((*res)->method,
-                                 _func_desc->analyzer->get_method_object(_func_desc->udf_class.clazz(), name));
-            }
-            return Status::OK();
+    // cacheable
+    if (scope == FunctionContext::FRAGMENT_LOCAL) {
+        auto get_func_desc = [this, scope, context, state](const std::string& lib) -> StatusOr<std::any> {
+            std::any func_desc;
+            auto call = [&]() {
+                ASSIGN_OR_RETURN(func_desc, _build_udf_func_desc(context, scope, lib));
+                return Status::OK();
+            };
+            RETURN_IF_ERROR(call_function_in_pthread(state, call)->get_future().get());
+            return func_desc;
         };
 
-        // Now we don't support prepare/close for UDF
-        // RETURN_IF_ERROR(add_method("prepare", &_func_desc->prepare));
-        // RETURN_IF_ERROR(add_method("method_close", &_func_desc->close));
-        RETURN_IF_ERROR(add_method("evaluate", &_func_desc->evaluate));
-
-        // create UDF function instance
-        ASSIGN_OR_RETURN(_func_desc->udf_handle, _func_desc->udf_class.newInstance());
-        // BatchEvaluateStub
-        auto* stub_clazz = BatchEvaluateStub::stub_clazz_name;
-        auto* stub_method_name = BatchEvaluateStub::batch_evaluate_method_name;
-        auto udf_clazz = _func_desc->udf_class.clazz();
-        auto update_method = _func_desc->evaluate->method.handle();
-
-        ASSIGN_OR_RETURN(auto update_stub_clazz,
-                         _func_desc->udf_classloader->genCallStub(stub_clazz, udf_clazz, update_method,
-                                                                  ClassLoader::BATCH_EVALUATE));
-        ASSIGN_OR_RETURN(auto method,
-                         _func_desc->analyzer->get_method_object(update_stub_clazz.clazz(), stub_method_name));
-        auto function_ctx = context->fn_context(_fn_context_index);
-        _func_desc->call_stub =
-                std::make_unique<BatchEvaluateStub>(function_ctx, _func_desc->udf_handle.handle(),
-                                                    std::move(update_stub_clazz), JavaGlobalRef(std::move(method)));
+        auto function_cache = UserFunctionCache::instance();
+        if (!_fn.cacheable) {
+            std::string libpath;
+            RETURN_IF_ERROR(function_cache->get_libpath(_fn.fid, _fn.hdfs_location, _fn.checksum, &libpath));
+            ASSIGN_OR_RETURN(auto desc, get_func_desc(libpath));
+            _func_desc = std::any_cast<std::shared_ptr<JavaUDFContext>>(desc);
+        } else {
+            ASSIGN_OR_RETURN(auto desc, function_cache->load_cacheable_java_udf(_fn.fid, _fn.hdfs_location,
+                                                                                _fn.checksum, get_func_desc));
+            _func_desc = std::any_cast<std::shared_ptr<JavaUDFContext>>(desc);
+        }
 
         _call_helper = std::make_shared<UDFFunctionCallHelper>();
         _call_helper->fn_desc = _func_desc.get();
         _call_helper->call_desc = _func_desc->evaluate.get();
-
-        if (_func_desc->prepare != nullptr) {
-            // we only support fragment local scope to call prepare
-            if (scope == FunctionContext::FRAGMENT_LOCAL) {
-                // TODO: handle prepare function
-            }
-        }
-        return Status::OK();
-    };
-    if (scope == FunctionContext::FRAGMENT_LOCAL) {
-        RETURN_IF_ERROR(call_function_in_pthread(state, open_state)->get_future().get());
     }
     return Status::OK();
 }
@@ -259,16 +276,6 @@ void JavaFunctionCallExpr::close(RuntimeState* state, ExprContext* context, Func
     Expr::close(state, context, scope);
 }
 
-void JavaFunctionCallExpr::_call_udf_close() {
-    auto& helper = JVMFunctionHelper::getInstance();
-    JNIEnv* env = helper.getEnv();
-    jmethodID methodID = env->GetMethodID(_func_desc->udf_class.clazz(), _func_desc->close->name.c_str(),
-                                          _func_desc->close->signature.c_str());
-    env->CallVoidMethod(_func_desc->udf_handle.handle(), methodID);
-    if (jthrowable jthr = env->ExceptionOccurred(); jthr) {
-        LOG(WARNING) << "Exception occur:" << helper.dumpExceptionString(jthr);
-        env->ExceptionClear();
-    }
-}
+void JavaFunctionCallExpr::_call_udf_close() {}
 
 } // namespace starrocks

--- a/be/src/exprs/java_function_call_expr.cpp
+++ b/be/src/exprs/java_function_call_expr.cpp
@@ -243,14 +243,14 @@ Status JavaFunctionCallExpr::open(RuntimeState* state, ExprContext* context,
         };
 
         auto function_cache = UserFunctionCache::instance();
-        if (!_fn.cacheable) {
+        if (_fn.__isset.isolated && !_fn.isolated) {
+            ASSIGN_OR_RETURN(auto desc, function_cache->load_cacheable_java_udf(_fn.fid, _fn.hdfs_location,
+                                                                                _fn.checksum, get_func_desc));
+            _func_desc = std::any_cast<std::shared_ptr<JavaUDFContext>>(desc);
+        } else {
             std::string libpath;
             RETURN_IF_ERROR(function_cache->get_libpath(_fn.fid, _fn.hdfs_location, _fn.checksum, &libpath));
             ASSIGN_OR_RETURN(auto desc, get_func_desc(libpath));
-            _func_desc = std::any_cast<std::shared_ptr<JavaUDFContext>>(desc);
-        } else {
-            ASSIGN_OR_RETURN(auto desc, function_cache->load_cacheable_java_udf(_fn.fid, _fn.hdfs_location,
-                                                                                _fn.checksum, get_func_desc));
             _func_desc = std::any_cast<std::shared_ptr<JavaUDFContext>>(desc);
         }
 

--- a/be/src/exprs/java_function_call_expr.h
+++ b/be/src/exprs/java_function_call_expr.h
@@ -37,6 +37,9 @@ public:
     bool is_constant() const override;
 
 private:
+    StatusOr<std::shared_ptr<JavaUDFContext>> _build_udf_func_desc(ExprContext* context,
+                                                                   FunctionContext::FunctionStateScope scope,
+                                                                   const std::string& libpath);
     void _call_udf_close();
     RuntimeState* _runtime_state = nullptr;
     std::shared_ptr<JavaUDFContext> _func_desc;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -67,6 +67,11 @@ public class ScalarFunction extends Function {
     private String prepareFnSymbol;
     @SerializedName(value = "closeFnSymbol")
     private String closeFnSymbol;
+    // isolated/shared
+    private static final String ISOLATED = "isolated";
+    private static final String SHARED = "shared";
+    @SerializedName(value = "isolation")
+    private String isolationType = ISOLATED;
 
     // Only used for serialization
     protected ScalarFunction() {
@@ -101,6 +106,7 @@ public class ScalarFunction extends Function {
         symbolName = other.symbolName;
         prepareFnSymbol = other.prepareFnSymbol;
         closeFnSymbol = other.closeFnSymbol;
+        isolationType = other.isolationType;
     }
 
     public static ScalarFunction createVectorizedBuiltin(long fid,
@@ -143,15 +149,25 @@ public class ScalarFunction extends Function {
             FunctionName name, Type[] args,
             Type returnType, boolean isVariadic,
             TFunctionBinaryType binaryType,
-            String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol) {
+            String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol, String isolationType) {
         ScalarFunction fn = new ScalarFunction(name, args, returnType, isVariadic);
         fn.setBinaryType(binaryType);
         fn.setUserVisible(true);
         fn.symbolName = symbol;
         fn.prepareFnSymbol = prepareFnSymbol;
         fn.closeFnSymbol = closeFnSymbol;
+        fn.setIsolationType(isolationType);
         fn.setLocation(new HdfsURI(objectFile));
         return fn;
+    }
+
+    public static ScalarFunction createUdf(
+            FunctionName name, Type[] args,
+            Type returnType, boolean isVariadic,
+            TFunctionBinaryType binaryType,
+            String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol) {
+        return createUdf(name, args, returnType, isVariadic, binaryType, objectFile,
+                symbol, prepareFnSymbol, closeFnSymbol, ISOLATED);
     }
 
     public void setSymbolName(String s) {
@@ -176,6 +192,14 @@ public class ScalarFunction extends Function {
 
     public String getCloseFnSymbol() {
         return closeFnSymbol;
+    }
+
+    public String getIsolationType() {
+        return isolationType == null ? "isolated" : isolationType;
+    }
+
+    public void setIsolationType(String isolationType) {
+        this.isolationType = isolationType;
     }
 
     @Override
@@ -203,6 +227,7 @@ public class ScalarFunction extends Function {
             scalarFunction.setClose_fn_symbol(closeFnSymbol);
         }
         fn.setScalar_fn(scalarFunction);
+        fn.setCacheable("shared".equals(isolationType));
         return fn;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ScalarFunction.java
@@ -68,10 +68,8 @@ public class ScalarFunction extends Function {
     @SerializedName(value = "closeFnSymbol")
     private String closeFnSymbol;
     // isolated/shared
-    private static final String ISOLATED = "isolated";
-    private static final String SHARED = "shared";
-    @SerializedName(value = "isolation")
-    private String isolationType = ISOLATED;
+    @SerializedName(value = "isolated")
+    private boolean isolationType = true;
 
     // Only used for serialization
     protected ScalarFunction() {
@@ -149,7 +147,7 @@ public class ScalarFunction extends Function {
             FunctionName name, Type[] args,
             Type returnType, boolean isVariadic,
             TFunctionBinaryType binaryType,
-            String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol, String isolationType) {
+            String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol, boolean isolationType) {
         ScalarFunction fn = new ScalarFunction(name, args, returnType, isVariadic);
         fn.setBinaryType(binaryType);
         fn.setUserVisible(true);
@@ -167,7 +165,7 @@ public class ScalarFunction extends Function {
             TFunctionBinaryType binaryType,
             String objectFile, String symbol, String prepareFnSymbol, String closeFnSymbol) {
         return createUdf(name, args, returnType, isVariadic, binaryType, objectFile,
-                symbol, prepareFnSymbol, closeFnSymbol, ISOLATED);
+                symbol, prepareFnSymbol, closeFnSymbol, true);
     }
 
     public void setSymbolName(String s) {
@@ -194,11 +192,11 @@ public class ScalarFunction extends Function {
         return closeFnSymbol;
     }
 
-    public String getIsolationType() {
-        return isolationType == null ? "isolated" : isolationType;
+    public boolean getIsolationType() {
+        return isolationType;
     }
 
-    public void setIsolationType(String isolationType) {
+    public void setIsolationType(boolean isolationType) {
         this.isolationType = isolationType;
     }
 
@@ -227,7 +225,7 @@ public class ScalarFunction extends Function {
             scalarFunction.setClose_fn_symbol(closeFnSymbol);
         }
         fn.setScalar_fn(scalarFunction);
-        fn.setCacheable("shared".equals(isolationType));
+        fn.setIsolated(isolationType);
         return fn;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -60,6 +60,7 @@ public class CreateFunctionStmt extends DdlStmt {
     public static final String SYMBOL_KEY = "symbol";
     public static final String MD5_CHECKSUM = "md5";
     public static final String TYPE_KEY = "type";
+    public static final String ISOLATION_KEY = "isolation";
     public static final String TYPE_STARROCKS_JAR = "StarrocksJar";
     public static final String EVAL_METHOD_NAME = "evaluate";
     public static final String CREATE_METHOD_NAME = "create";
@@ -89,6 +90,7 @@ public class CreateFunctionStmt extends DdlStmt {
     private String objectFile;
     private Function function;
     private String checksum;
+    private String isolation;
 
     private static final ImmutableMap<PrimitiveType, Class> PRIMITIVE_TYPE_TO_JAVA_CLASS_TYPE =
             new ImmutableMap.Builder<PrimitiveType, Class>()
@@ -332,6 +334,9 @@ public class CreateFunctionStmt extends DdlStmt {
         if (Strings.isNullOrEmpty(objectFile)) {
             throw new AnalysisException("No 'object_file' in properties");
         }
+
+        isolation = properties.get(ISOLATION_KEY);
+
         try {
             computeObjectChecksum();
         } catch (IOException | NoSuchAlgorithmException e) {
@@ -420,7 +425,7 @@ public class CreateFunctionStmt extends DdlStmt {
         function = ScalarFunction.createUdf(
                 functionName, argsDef.getArgTypes(),
                 returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
-                objectFile, mainClass.getCanonicalName(), "", "");
+                objectFile, mainClass.getCanonicalName(), "", "", isolation);
         function.setChecksum(checksum);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateFunctionStmt.java
@@ -425,7 +425,7 @@ public class CreateFunctionStmt extends DdlStmt {
         function = ScalarFunction.createUdf(
                 functionName, argsDef.getArgTypes(),
                 returnType.getType(), argsDef.isVariadic(), TFunctionBinaryType.SRJAR,
-                objectFile, mainClass.getCanonicalName(), "", "", isolation);
+                objectFile, mainClass.getCanonicalName(), "", "", !"shared".equalsIgnoreCase(isolation));
         function.setChecksum(checksum);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -468,9 +468,7 @@ public class ExpressionTest extends PlanTestBase {
     public void testFunctionNullable() throws Exception {
         String sql = "select UNIX_TIMESTAMP(\"2015-07-28 19:41:12\", \"22\");";
         String plan = getThriftPlan(sql);
-        Assert.assertTrue(plan, plan.contains("scalar_fn:TScalarFunction(symbol:), " +
-                "id:50287, fid:50287, could_apply_dict_optimize:false, ignore_nulls:false), " +
-                "has_nullable_child:false, is_nullable:true"));
+        Assert.assertTrue(plan, plan.contains("could_apply_dict_optimize:false, ignore_nulls:false"));
     }
 
     @Test

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -360,6 +360,7 @@ struct TFunction {
 
   // Ignore nulls
   33: optional bool ignore_nulls
+  34: optional bool cacheable
 }
 
 enum TLoadJobState {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -360,7 +360,7 @@ struct TFunction {
 
   // Ignore nulls
   33: optional bool ignore_nulls
-  34: optional bool cacheable
+  34: optional bool isolated
 }
 
 enum TLoadJobState {


### PR DESCRIPTION
In our implementation UDF is isolated at the classloader level, and each execution fetches a new class, which leads to major headaches if we want to rely on static variables to do something, or use background threads/singletons to cache something, hence the introduction of shared UDF in this PR.We take the class loader and the associated instances are cached.

usage: 
```
public class SharedUDF {
    private static int a = 0;
    public String evaluate(String a) {
        a++;
        return "" + a;
    }
}  
javac SharedUDF.java
jar -xf udf.jar ./*.class
```

```
CREATE FUNCTION test_shared(string)  
RETURNS string properties  ( 
"symbol" = "SharedUDF",
"type" = "StarrocksJar", 
"file" = "http://XXXXX/create_file.jar",
"isolation"="shared"
);

CREATE TABLE `dummy` (
  `tst_key` int(11) NOT NULL COMMENT "",
) ENGINE=OLAP 
DUPLICATE KEY(`tst_key`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`tst_key`) BUCKETS 1
PROPERTIES (
"replication_num" = "1"
);
insert into dummy values(1);
```
in shared mode
```
select test_shared(k1) from dummy;
{'status': True, 'result': (('1',),), 'msg': None}
select test_shared(k1) from dummy;
{'status': True, 'result': (('2',),), 'msg': None}
```

default is in isolated mode
```
select test_shared(k1) from dummy;
{'status': True, 'result': (('1',),), 'msg': None}
select test_shared(k1) from dummy;
{'status': True, 'result': (('1',),), 'msg': None}
```

1. Create a UDF to add the new property isolation The supported values are isolated/shared. The default value is isolated.
2. Modify function caching to support caching scalar UDF class loaders/class instances/call stubs

the test case is in admit test: https://github.com/StarRocks/StarRocksTest/pull/4730 



## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
