### PR TITLE
[Enhancement] Check meta size enough for BDB Log

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -34,7 +34,6 @@
 
 package com.starrocks.leader;
 
-import com.sleepycat.je.EnvironmentConfig;
 import com.sleepycat.je.config.EnvironmentParams;
 import com.starrocks.common.Config;
 import com.starrocks.common.InvalidMetaDirException;
@@ -53,6 +52,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.nio.file.FileStore;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -168,8 +168,8 @@ public class MetaHelper {
         }
 
         long lowerFreeDiskSize = Long.parseLong(EnvironmentParams.FREE_DISK.getDefault());
-        File finalMetaFile = new File(Config.meta_dir);
-        if (finalMetaFile.getFreeSpace() < lowerFreeDiskSize) {
+        FileStore store = Files.getFileStore(Paths.get(Config.meta_dir));
+        if (store.getUsableSpace() < lowerFreeDiskSize) {
             LOG.error("Free size on meta dir: {} is less than {}",
                     Config.meta_dir, new ByteSizeValue(lowerFreeDiskSize));
             throw new InvalidMetaDirException();

--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -164,6 +164,8 @@ public class MetaHelper {
             }
         }
 
+
+
         Path imageDir = Paths.get(Config.meta_dir + GlobalStateMgr.IMAGE_DIR);
         Path bdbDir = Paths.get(BDBEnvironment.getBdbDir());
         boolean haveImageData = false;

--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -34,10 +34,13 @@
 
 package com.starrocks.leader;
 
+import com.sleepycat.je.EnvironmentConfig;
+import com.sleepycat.je.config.EnvironmentParams;
 import com.starrocks.common.Config;
 import com.starrocks.common.InvalidMetaDirException;
 import com.starrocks.common.io.IOUtils;
 import com.starrocks.journal.bdbje.BDBEnvironment;
+import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -164,7 +167,13 @@ public class MetaHelper {
             }
         }
 
-
+        long lowerFreeDiskSize = Long.parseLong(EnvironmentParams.FREE_DISK.getDefault());
+        File finalMetaFile = new File(Config.meta_dir);
+        if (finalMetaFile.getFreeSpace() < lowerFreeDiskSize) {
+            LOG.error("Free size on meta dir: {} is less than {}",
+                    Config.meta_dir, new ByteSizeValue(lowerFreeDiskSize));
+            throw new InvalidMetaDirException();
+        }
 
         Path imageDir = Paths.get(Config.meta_dir + GlobalStateMgr.IMAGE_DIR);
         Path bdbDir = Paths.get(BDBEnvironment.getBdbDir());

--- a/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/MetaHelper.java
@@ -170,7 +170,7 @@ public class MetaHelper {
         long lowerFreeDiskSize = Long.parseLong(EnvironmentParams.FREE_DISK.getDefault());
         FileStore store = Files.getFileStore(Paths.get(Config.meta_dir));
         if (store.getUsableSpace() < lowerFreeDiskSize) {
-            LOG.error("Free size on meta dir: {} is less than {}",
+            LOG.error("Free capacity left for meta dir: {} is less than {}",
                     Config.meta_dir, new ByteSizeValue(lowerFreeDiskSize));
             throw new InvalidMetaDirException();
         }


### PR DESCRIPTION
For the new version of BDB (18.3.13), the available disk size is limited: at least 5G. If there is not enough space, BDB will fail to start, but the error log is only printed in bdb/je.info.0, so this enhancement checks the available disk size before starting bdb, which makes the log easy to find the cause of the failure.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
