### PR TITLE
[BugFix][Hadoop-Ext] rewrite configuration before get UGI and bind UGI to filesystem

### DIFF
--- a/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/hadoop/HadoopExt.java
+++ b/java-extensions/hadoop-ext/src/main/java/com/starrocks/connector/hadoop/HadoopExt.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.hadoop;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,6 +38,10 @@ public class HadoopExt {
     }
 
     public void rewriteConfiguration(Configuration conf) {
+    }
+
+    public FileSystem bindUGIToFileSystem(FileSystem fs, UserGroupInformation ugi) {
+        return fs;
     }
 
     public String getCloudConfString(Configuration conf) {

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -603,7 +603,8 @@ public abstract class FileSystem extends Configured
             }
             return CACHE.get(uri, conf);
         });
-        return fs;
+        FileSystem fs2 = HadoopExt.getInstance().bindUGIToFileSystem(fs, ugi);
+        return fs2;
     }
 
     /**

--- a/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
+++ b/java-extensions/hadoop-ext/src/main/java/org/apache/hadoop/fs/FileSystem.java
@@ -593,6 +593,7 @@ public abstract class FileSystem extends Configured
             }
         }
 
+        HadoopExt.getInstance().rewriteConfiguration(conf);
         UserGroupInformation ugi = HadoopExt.getInstance().getHDFSUGI(conf);
         FileSystem fs = HadoopExt.getInstance().doAs(ugi, () -> {
             String disableCacheName = String.format("fs.%s.impl.disable.cache", scheme);
@@ -3731,7 +3732,6 @@ public abstract class FileSystem extends Configured
      */
     private static FileSystem createFileSystem(URI uri, Configuration conf)
             throws IOException {
-        HadoopExt.getInstance().rewriteConfiguration(conf);
         LOGGER.info(String.format("%s FileSystem.createFileSystem", HadoopExt.LOGGER_MESSAGE_PREFIX));
         Tracer tracer = FsTracer.get(conf);
         try (TraceScope scope = tracer.newScope("FileSystem#createFileSystem");


### PR DESCRIPTION
Fixes #issue

Because to support multiple kerberos account, keytab/principal information are usually in configuration files like hive-site.xml/core-site.xml. So we have to load those files and then we can get keytab/principal infomration.

Because right now hadoop filesystem internally use global ugi, we have to bind ugi to filesytsem so we can switch account when we access filesystem.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
