### PR TITLE
[Doc] Fix some fault example code of loading data using Spark connector

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+Why I'm doing:
+
+What I'm doing:
+
 Fixes #issue
 
 ## What type of PR is this:

--- a/docs/loading/Spark-connector-starrocks.md
+++ b/docs/loading/Spark-connector-starrocks.md
@@ -303,31 +303,34 @@ Construct a streaming read of data from a CSV file and load data into the StarRo
         .getOrCreate()
    
     # 1. Create a DataFrame from CSV.
-    schema = StructType([ \
-            StructField("id", IntegerType()), \
-            StructField("name", StringType()), \
-            StructField("score", IntegerType()) \
+    schema = StructType([
+            StructField("id", IntegerType()),
+            StructField("name", StringType()),
+            StructField("score", IntegerType())
         ])
-    df = spark.readStream \
-            .option("sep", ",") \
-            .schema(schema) \
-            .format("csv") \
-            # Replace it with your path to the directory "csv-data".
-            .load("/path/to/csv-data")
+    df = (
+        spark.readStream
+        .option("sep", ",")
+        .schema(schema)
+        .format("csv")
+        # Replace it with your path to the directory "csv-data".
+        .load("/path/to/csv-data")
+    )
 
     # 2. Write to StarRocks by configuring the format as "starrocks" and the following options. 
     # You need to modify the options according your own environment.
-    query = df.writeStream.format("starrocks") \
-            .option("starrocks.fe.http.url", "127.0.0.1:8030") \
-            .option("starrocks.fe.jdbc.url", "jdbc:mysql://127.0.0.1:9030") \
-            .option("starrocks.table.identifier", "test.score_board") \
-            .option("starrocks.user", "root") \
-            .option("starrocks.password", "") \
-            # replace it with your checkpoint directory
-            .option("checkpointLocation", "/path/to/checkpoint") \
-            .outputMode("append") \
-            .start()
-        )
+    query = (
+        df.writeStream.format("starrocks")
+        .option("starrocks.fe.http.url", "127.0.0.1:8030")
+        .option("starrocks.fe.jdbc.url", "jdbc:mysql://127.0.0.1:9030")
+        .option("starrocks.table.identifier", "test.score_board")
+        .option("starrocks.user", "root")
+        .option("starrocks.password", "")
+        # replace it with your checkpoint directory
+        .option("checkpointLocation", "/path/to/checkpoint")
+        .outputMode("append")
+        .start()
+    )
     ```
 
 3. Query data in the StarRocks table.


### PR DESCRIPTION
Why I'm doing:
1. The back slash in create schema for df is redundant.
2. The code was error because of the  original data format with "\\" and annotation.

What I'm doing:
1. Delete the redundant back slash.
2. Wrap the PySpark code with bracket, so that the code can be used directly with annotation in the original place.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [x] 3.0
  - [ ] 2.5