### PR TITLE
[Enhancement] report num of tablets to FE along with heartbeat response in shared-data mode

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -46,6 +46,7 @@
 #include "gen_cpp/HeartbeatService.h"
 #include "runtime/heartbeat_flags.h"
 #include "service/backend_options.h"
+#include "service/staros_fwd.h"
 #include "storage/storage_engine.h"
 #include "util/debug_util.h"
 #include "util/network_util.h"
@@ -122,6 +123,7 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
         } else {
             heartbeat_result.backend_info.__set_is_set_storage_path(false);
         }
+        heartbeat_result.backend_info.__set_num_tablets(staros_worker_approx_num_shards());
 #endif
         heartbeat_result.backend_info.__set_version(get_short_version());
         heartbeat_result.backend_info.__set_num_hardware_cores(num_hardware_cores);

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -51,6 +51,7 @@
 #include "http/http_headers.h"
 #include "http/http_request.h"
 #include "http/http_status.h"
+#include "service/staros_fwd.h"
 #include "storage/compaction_manager.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
@@ -62,10 +63,6 @@
 #include "storage/storage_engine.h"
 #include "storage/update_manager.h"
 #include "util/priority_thread_pool.hpp"
-
-#ifdef USE_STAROS
-#include "service/staros_worker.h"
-#endif // USE_STAROS
 
 namespace starrocks {
 

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -35,7 +35,7 @@
 #include "service/service_be/http_service.h"
 #include "service/service_be/internal_service.h"
 #include "service/service_be/lake_service.h"
-#include "service/staros_worker.h"
+#include "service/staros_fwd.h"
 #include "storage/storage_engine.h"
 #include "util/logging.h"
 #include "util/mem_info.h"

--- a/be/src/service/staros_fwd.h
+++ b/be/src/service/staros_fwd.h
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef USE_STAROS
+
+// Q: Why need this header file?
+// A: Resolve the macro redefinition error of ANNOTATE_*. starrocks project has them defined
+//   in `gutil/dynamic_annotations.h` while they are also defined in `absl/base/internal/dynamic_annotations.h`
+//   as a thirdparty dependency introduced by starlet library.
+namespace starrocks {
+
+// declare a few C-style interface without knowing the detailed type definition or implementation detail.
+void init_staros_worker();
+void shutdown_staros_worker();
+void update_staros_starcache();
+
+// return approximate number of shards from the worker
+size_t staros_worker_approx_num_shards();
+
+} // namespace starrocks
+#endif // USE_STAROS

--- a/be/src/service/staros_worker.h
+++ b/be/src/service/staros_worker.h
@@ -27,6 +27,7 @@
 #include "common/status.h"
 #include "fslib/configuration.h"
 #include "fslib/file_system.h"
+#include "service/staros_fwd.h"
 
 namespace starrocks {
 
@@ -71,6 +72,9 @@ public:
     // the worker will try to fetch it back from starmgr.
     absl::StatusOr<ShardInfo> retrieve_shard_info(ShardId id);
 
+    // retrieve number of shards under no lock.
+    inline size_t approx_num_shards() const { return _approx_num_shards; }
+
 private:
     struct ShardInfoDetails {
         ShardInfo shard_info;
@@ -105,12 +109,13 @@ private:
     mutable std::shared_mutex _mtx;
     std::unordered_map<ShardId, ShardInfoDetails> _shards;
     std::unique_ptr<Cache> _fs_cache;
+
+    // a counter to record the number of shards, caller can retrieve the number with no lock.
+    // NOTE: the number may be inaccurate due to it is retrieved under no lock.
+    size_t _approx_num_shards;
 };
 
 extern std::shared_ptr<StarOSWorker> g_worker;
-void init_staros_worker();
-void shutdown_staros_worker();
-void update_staros_starcache();
 
 } // namespace starrocks
 #endif // USE_STAROS

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -59,7 +59,6 @@
 #include "runtime/jdbc_driver_manager.h"
 #include "service/backend_options.h"
 #include "service/service.h"
-#include "service/staros_worker.h"
 #include "storage/options.h"
 #include "storage/storage_engine.h"
 #include "util/debug_util.h"

--- a/be/src/storage/lake/starlet_location_provider.cpp
+++ b/be/src/storage/lake/starlet_location_provider.cpp
@@ -22,7 +22,6 @@
 #include "common/logging.h"
 #include "fs/fs_starlet.h"
 #include "gutil/strings/util.h"
-#include "service/staros_worker.h"
 
 namespace starrocks::lake {
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(EXEC_FILES
+        ./agent/heartbeat_server_test.cpp
         ./agent/master_info_test.cpp
         ./column/array_column_test.cpp
         ./column/binary_column_test.cpp

--- a/be/test/agent/heartbeat_server_test.cpp
+++ b/be/test/agent/heartbeat_server_test.cpp
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "agent/heartbeat_server.h"
+
+#include "gtest/gtest.h"
+#include "service/staros_worker.h"
+#include "util/thrift_server.h"
+
+namespace starrocks {
+
+#ifdef USE_STAROS
+extern std::shared_ptr<StarOSWorker> g_worker;
+#endif
+
+class HeartbeatServerTest : public testing::Test {
+public:
+    void SetUp() override {
+#ifdef USE_STAROS
+        g_worker = std::make_shared<StarOSWorker>();
+#endif
+    }
+
+    void TearDown() override {
+#ifdef USE_STAROS
+        g_worker.reset();
+#endif
+    }
+};
+
+TEST_F(HeartbeatServerTest, test_heartbeat_info_num_tablets) {
+    auto heartbeat_server = std::make_unique<HeartbeatServer>();
+
+    {
+        THeartbeatResult result;
+        TMasterInfo master_info;
+        heartbeat_server->heartbeat(result, master_info);
+#ifdef USE_STAROS
+        EXPECT_TRUE(result.backend_info.__isset.num_tablets);
+        EXPECT_EQ(0, result.backend_info.num_tablets);
+#else
+        // the field is not set under shared-nothing mode
+        EXPECT_FALSE(result.backend_info.__isset.num_tablets);
+#endif
+    }
+
+#ifdef USE_STAROS
+    // Following are all for shared-data mode testing
+    StarOSWorker::ShardInfo shard1, shard2;
+    shard1.id = 10086;
+    shard2.id = 10087;
+
+    // add two shards
+    EXPECT_TRUE(g_worker->add_shard(shard1).ok());
+    EXPECT_TRUE(g_worker->add_shard(shard2).ok());
+
+    {
+        THeartbeatResult result;
+        TMasterInfo master_info;
+        heartbeat_server->heartbeat(result, master_info);
+        EXPECT_TRUE(result.backend_info.__isset.num_tablets);
+        EXPECT_EQ(2, result.backend_info.num_tablets);
+    }
+
+    // remove one shard
+    EXPECT_TRUE(g_worker->remove_shard(shard1.id).ok());
+    {
+        THeartbeatResult result;
+        TMasterInfo master_info;
+        heartbeat_server->heartbeat(result, master_info);
+        EXPECT_TRUE(result.backend_info.__isset.num_tablets);
+        EXPECT_EQ(1, result.backend_info.num_tablets);
+    }
+#endif
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -117,9 +117,15 @@ public class BackendsProcDir implements ProcDirInterface {
                 continue;
             }
 
+            long tabletNum = 0;
             watch.start();
-            long tabletNum = GlobalStateMgr.getCurrentInvertedIndex().getTabletNumByBackendId(backendId);
+            if (RunMode.allowCreateLakeTable()) {
+                tabletNum = backend.getNumTablets();
+            } else {
+                tabletNum = GlobalStateMgr.getCurrentInvertedIndex().getTabletNumByBackendId(backendId);
+            }
             watch.stop();
+
             List<Comparable> backendInfo = Lists.newArrayList();
             backendInfo.add(String.valueOf(backendId));
             backendInfo.add(backend.getHost());

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/ComputeNodeProcDir.java
@@ -48,7 +48,7 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 .add("Version")
                 .add("CpuCores").add("NumRunningQueries").add("MemUsedPct").add("CpuUsedPct").add("HasStoragePath");
         if (RunMode.allowCreateLakeTable()) {
-            builder.add("StarletPort").add("WorkerId");
+            builder.add("StarletPort").add("WorkerId").add("TabletNum");
         }
         TITLE_NAMES = builder.build();
     }
@@ -138,6 +138,7 @@ public class ComputeNodeProcDir implements ProcDirInterface {
                 computeNodeInfo.add(String.valueOf(computeNode.getStarletPort()));
                 long workerId = GlobalStateMgr.getCurrentStarOSAgent().getWorkerIdByBackendId(computeNodeId);
                 computeNodeInfo.add(String.valueOf(workerId));
+                computeNodeInfo.add(String.valueOf(computeNode.getNumTablets()));
             }
 
             comparableComputeNodeInfos.add(computeNodeInfo);

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
@@ -64,6 +64,8 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     @SerializedName(value = "rebootTime")
     private long rebootTime = -1L;
     private boolean isSetStoragePath = false;
+    // number of tablets on the backend, Only meaningful in SHARED_DATA mode, -1 means UNKNOWN
+    private int numTablets = -1;
 
     public BackendHbResponse() {
         super(HeartbeatResponse.Type.BACKEND);
@@ -130,6 +132,14 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public int getCpuCores() {
         return cpuCores;
+    }
+
+    public int getNumTablets() {
+        return numTablets;
+    }
+
+    public void setNumTablets(int num) {
+        numTablets = num;
     }
 
     public boolean isSetStoragePath() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -113,6 +113,8 @@ public class ComputeNode implements IComputable, Writable {
     private volatile long memUsedBytes = 0;
     private volatile int cpuUsedPermille = 0;
     private volatile long lastUpdateResourceUsageMs = 0;
+    // number of tablets on the backend/compute node, for SHARED_DATA mode only. No need persistent
+    private volatile int numTablets = -1;
     private final AtomicReference<Map<Long, ResourceGroupUsage>> groupIdToUsage = new AtomicReference<>(new HashMap<>());
 
     public ComputeNode() {
@@ -206,6 +208,10 @@ public class ComputeNode implements IComputable, Writable {
 
     public int getBrpcPort() {
         return brpcPort;
+    }
+
+    public int getNumTablets() {
+        return numTablets;
     }
 
     public TNetworkAddress getAddress() {
@@ -522,6 +528,9 @@ public class ComputeNode implements IComputable, Writable {
                 // we need notify coordinator to cancel query
                 becomeDead = true;
             }
+
+            // take whatever numbers hbResponse tells, -1 means unknown.
+            this.numTablets = hbResponse.getNumTablets();
 
             if (this.cpuCores != hbResponse.getCpuCores()) {
                 isChanged = true;

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -305,6 +305,9 @@ public class HeartbeatMgr extends FrontendDaemon {
                     if (tBackendInfo.isSetReboot_time()) {
                         backendHbResponse.setRebootTime(tBackendInfo.getReboot_time());
                     }
+                    if (tBackendInfo.isSetNum_tablets()) {
+                        backendHbResponse.setNumTablets(tBackendInfo.getNum_tablets());
+                    }
                     return backendHbResponse;
                 } else {
                     return new BackendHbResponse(computeNodeId,

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -43,6 +43,8 @@ struct TBackendInfo {
     7: optional Types.TPort starlet_port
     8: optional i64 reboot_time
     9: optional bool is_set_storage_path
+    // Only for shared-data mode, report the total number of tablets allocated the backend/compute node
+    10: optional i32 num_tablets
 }
 
 struct THeartbeatResult {

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -65,6 +65,7 @@ OPTS=$(getopt \
   -l 'with-aws' \
   -l 'with-bench' \
   -l 'use-staros' \
+  -l 'enable-shared-data' \
   -o 'j:' \
   -l 'help' \
   -l 'run' \


### PR DESCRIPTION
* fix `show backends`/`show compute nodes` sql doesn't show the tablets number in shared-data mode

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
