### PR TITLE
[BugFix] fix resource name from stmt propery instead of catalog recast

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
@@ -39,6 +39,20 @@ public class HiveTableFactory extends ExternalTableFactory {
 
     }
 
+    public static void copyFromOldTable(HiveTable.Builder tableBuilder, HiveTable oHiveTable, Map<String, String> properties) {
+        tableBuilder
+                .setCatalogName(oHiveTable.getCatalogName())
+                .setResourceName(properties.get(RESOURCE))
+                .setHiveDbName(oHiveTable.getDbName())
+                .setHiveTableName(oHiveTable.getTableName())
+                .setPartitionColumnNames(oHiveTable.getPartitionColumnNames())
+                .setDataColumnNames(oHiveTable.getDataColumnNames())
+                .setTableLocation(oHiveTable.getTableLocation())
+                .setStorageFormat(oHiveTable.getStorageFormat())
+                .setCreateTime(oHiveTable.getCreateTime())
+                .setProperties(oHiveTable.getProperties());
+    }
+
     @Override
     @NotNull
     public Table createTable(LocalMetastore metastore, Database database, CreateTableStmt stmt) throws DdlException {
@@ -60,17 +74,8 @@ public class HiveTableFactory extends ExternalTableFactory {
         HiveTable.Builder tableBuilder = HiveTable.builder()
                 .setId(tableId)
                 .setTableName(tableName)
-                .setCatalogName(oHiveTable.getCatalogName())
-                .setResourceName(properties.get(RESOURCE))
-                .setHiveDbName(oHiveTable.getDbName())
-                .setHiveTableName(oHiveTable.getTableName())
-                .setPartitionColumnNames(oHiveTable.getPartitionColumnNames())
-                .setDataColumnNames(oHiveTable.getDataColumnNames())
-                .setFullSchema(columns)
-                .setTableLocation(oHiveTable.getTableLocation())
-                .setStorageFormat(oHiveTable.getStorageFormat())
-                .setCreateTime(oHiveTable.getCreateTime())
-                .setProperties(oHiveTable.getProperties());
+                .setFullSchema(columns);
+        copyFromOldTable(tableBuilder, oHiveTable, properties);
 
         HiveTable hiveTable = tableBuilder.build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
@@ -61,7 +61,7 @@ public class HiveTableFactory extends ExternalTableFactory {
                 .setId(tableId)
                 .setTableName(tableName)
                 .setCatalogName(oHiveTable.getCatalogName())
-                .setResourceName(oHiveTable.getResourceName())
+                .setResourceName(properties.get(RESOURCE))
                 .setHiveDbName(oHiveTable.getDbName())
                 .setHiveTableName(oHiveTable.getTableName())
                 .setPartitionColumnNames(oHiveTable.getPartitionColumnNames())

--- a/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
@@ -39,18 +39,19 @@ public class HiveTableFactory extends ExternalTableFactory {
 
     }
 
-    public static void copyFromOldTable(HiveTable.Builder tableBuilder, HiveTable oHiveTable, Map<String, String> properties) {
+    public static void copyFromCatalogTable(HiveTable.Builder tableBuilder, HiveTable catalogTable,
+                                            Map<String, String> properties) {
         tableBuilder
-                .setCatalogName(oHiveTable.getCatalogName())
+                .setCatalogName(catalogTable.getCatalogName())
                 .setResourceName(properties.get(RESOURCE))
-                .setHiveDbName(oHiveTable.getDbName())
-                .setHiveTableName(oHiveTable.getTableName())
-                .setPartitionColumnNames(oHiveTable.getPartitionColumnNames())
-                .setDataColumnNames(oHiveTable.getDataColumnNames())
-                .setTableLocation(oHiveTable.getTableLocation())
-                .setStorageFormat(oHiveTable.getStorageFormat())
-                .setCreateTime(oHiveTable.getCreateTime())
-                .setProperties(oHiveTable.getProperties());
+                .setHiveDbName(catalogTable.getDbName())
+                .setHiveTableName(catalogTable.getTableName())
+                .setPartitionColumnNames(catalogTable.getPartitionColumnNames())
+                .setDataColumnNames(catalogTable.getDataColumnNames())
+                .setTableLocation(catalogTable.getTableLocation())
+                .setStorageFormat(catalogTable.getStorageFormat())
+                .setCreateTime(catalogTable.getCreateTime())
+                .setProperties(catalogTable.getProperties());
     }
 
     @Override
@@ -75,7 +76,7 @@ public class HiveTableFactory extends ExternalTableFactory {
                 .setId(tableId)
                 .setTableName(tableName)
                 .setFullSchema(columns);
-        copyFromOldTable(tableBuilder, oHiveTable, properties);
+        copyFromCatalogTable(tableBuilder, oHiveTable, properties);
 
         HiveTable hiveTable = tableBuilder.build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/HudiTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/HudiTableFactory.java
@@ -47,15 +47,15 @@ public class HudiTableFactory extends ExternalTableFactory {
 
     }
 
-    public static void copyFromOldTable(HudiTable.Builder builder, HudiTable oHudiTable, Map<String, String> properties) {
-        builder.setCatalogName(oHudiTable.getCatalogName())
+    public static void copyFromCatalogTable(HudiTable.Builder builder, HudiTable catalogTable, Map<String, String> properties) {
+        builder.setCatalogName(catalogTable.getCatalogName())
                 .setResourceName(properties.get(RESOURCE))
-                .setHiveDbName(oHudiTable.getDbName())
-                .setHiveTableName(oHudiTable.getTableName())
-                .setPartitionColNames(oHudiTable.getPartitionColumnNames())
-                .setDataColNames(oHudiTable.getDataColumnNames())
-                .setHudiProperties(oHudiTable.getProperties())
-                .setCreateTime(oHudiTable.getCreateTime());
+                .setHiveDbName(catalogTable.getDbName())
+                .setHiveTableName(catalogTable.getTableName())
+                .setPartitionColNames(catalogTable.getPartitionColumnNames())
+                .setDataColNames(catalogTable.getDataColumnNames())
+                .setHudiProperties(catalogTable.getProperties())
+                .setCreateTime(catalogTable.getCreateTime());
     }
 
     @Override
@@ -91,7 +91,7 @@ public class HudiTableFactory extends ExternalTableFactory {
                 .setId(tableId)
                 .setTableName(tableName)
                 .setFullSchema(columns);
-        copyFromOldTable(tableBuilder, oHudiTable, properties);
+        copyFromCatalogTable(tableBuilder, oHudiTable, properties);
         HudiTable hudiTable = tableBuilder.build();
 
         // partition key, commented for show partition key

--- a/fe/fe-core/src/main/java/com/starrocks/server/HudiTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/HudiTableFactory.java
@@ -80,7 +80,7 @@ public class HudiTableFactory extends ExternalTableFactory {
                 .setId(tableId)
                 .setTableName(tableName)
                 .setCatalogName(oHudiTable.getCatalogName())
-                .setResourceName(oHudiTable.getResourceName())
+                .setResourceName(properties.get(RESOURCE))
                 .setHiveDbName(oHudiTable.getDbName())
                 .setHiveTableName(oHudiTable.getTableName())
                 .setFullSchema(columns)

--- a/fe/fe-core/src/main/java/com/starrocks/server/HudiTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/HudiTableFactory.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
@@ -43,7 +44,10 @@ import static com.starrocks.catalog.Resource.ResourceType.HUDI;
 public class HudiTableFactory extends ExternalTableFactory {
     public static final HudiTableFactory INSTANCE = new HudiTableFactory();
 
-    private HudiTableFactory() {
+    protected boolean byPassColumnTypeValidation = false;
+
+    @VisibleForTesting
+    protected HudiTableFactory() {
 
     }
 
@@ -74,7 +78,9 @@ public class HudiTableFactory extends ExternalTableFactory {
                     + " from the resource " + properties.get(RESOURCE));
         }
         HudiTable oHudiTable = (HudiTable) table;
-        validateHudiColumnType(columns, oHudiTable);
+        if (!byPassColumnTypeValidation) {
+            validateHudiColumnType(columns, oHudiTable);
+        }
 
         HudiTable.Builder tableBuilder = HudiTable.builder()
                 .setId(tableId)

--- a/fe/fe-core/src/main/java/com/starrocks/server/IcebergTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/IcebergTableFactory.java
@@ -40,6 +40,16 @@ public class IcebergTableFactory extends ExternalTableFactory {
 
     }
 
+    public static void copyFromOldTable(IcebergTable.Builder tableBuilder, IcebergTable oIcebergTable,
+                                        Map<String, String> properties) {
+        tableBuilder.setCatalogName(oIcebergTable.getCatalogName())
+                .setResourceName(properties.get(RESOURCE))
+                .setRemoteDbName(oIcebergTable.getRemoteDbName())
+                .setRemoteTableName(oIcebergTable.getRemoteTableName())
+                .setIcebergProperties(properties)
+                .setNativeTable(oIcebergTable.getNativeTable());
+    }
+
     @Override
     @NotNull
     public Table createTable(LocalMetastore metastore, Database database, CreateTableStmt stmt) throws DdlException {
@@ -63,13 +73,9 @@ public class IcebergTableFactory extends ExternalTableFactory {
         IcebergTable.Builder tableBuilder = IcebergTable.builder()
                 .setId(tableId)
                 .setSrTableName(tableName)
-                .setCatalogName(oIcebergTable.getCatalogName())
-                .setResourceName(properties.get(RESOURCE))
-                .setRemoteDbName(oIcebergTable.getRemoteDbName())
-                .setRemoteTableName(oIcebergTable.getRemoteTableName())
-                .setFullSchema(columns)
-                .setIcebergProperties(properties)
-                .setNativeTable(oIcebergTable.getNativeTable());
+                .setFullSchema(columns);
+
+        copyFromOldTable(tableBuilder, oIcebergTable, properties);
 
         IcebergTable icebergTable = tableBuilder.build();
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/IcebergTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/IcebergTableFactory.java
@@ -64,7 +64,7 @@ public class IcebergTableFactory extends ExternalTableFactory {
                 .setId(tableId)
                 .setSrTableName(tableName)
                 .setCatalogName(oIcebergTable.getCatalogName())
-                .setResourceName(oIcebergTable.getResourceName())
+                .setResourceName(properties.get(RESOURCE))
                 .setRemoteDbName(oIcebergTable.getRemoteDbName())
                 .setRemoteTableName(oIcebergTable.getRemoteTableName())
                 .setFullSchema(columns)

--- a/fe/fe-core/src/main/java/com/starrocks/server/IcebergTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/IcebergTableFactory.java
@@ -40,14 +40,14 @@ public class IcebergTableFactory extends ExternalTableFactory {
 
     }
 
-    public static void copyFromOldTable(IcebergTable.Builder tableBuilder, IcebergTable oIcebergTable,
-                                        Map<String, String> properties) {
-        tableBuilder.setCatalogName(oIcebergTable.getCatalogName())
+    public static void copyFromCatalogTable(IcebergTable.Builder tableBuilder, IcebergTable catalogTable,
+                                            Map<String, String> properties) {
+        tableBuilder.setCatalogName(catalogTable.getCatalogName())
                 .setResourceName(properties.get(RESOURCE))
-                .setRemoteDbName(oIcebergTable.getRemoteDbName())
-                .setRemoteTableName(oIcebergTable.getRemoteTableName())
+                .setRemoteDbName(catalogTable.getRemoteDbName())
+                .setRemoteTableName(catalogTable.getRemoteTableName())
                 .setIcebergProperties(properties)
-                .setNativeTable(oIcebergTable.getNativeTable());
+                .setNativeTable(catalogTable.getNativeTable());
     }
 
     @Override
@@ -75,7 +75,7 @@ public class IcebergTableFactory extends ExternalTableFactory {
                 .setSrTableName(tableName)
                 .setFullSchema(columns);
 
-        copyFromOldTable(tableBuilder, oIcebergTable, properties);
+        copyFromCatalogTable(tableBuilder, oIcebergTable, properties);
 
         IcebergTable icebergTable = tableBuilder.build();
 

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -44,6 +44,7 @@ import com.starrocks.connector.hive.HiveMetastoreTest;
 import com.starrocks.connector.hive.HiveStorageFormat;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.HiveTableFactory;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.server.TableFactoryProvider;
 import com.starrocks.sql.ast.CreateTableStmt;
@@ -62,10 +63,13 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.starrocks.connector.hive.HiveClassNames.MAPRED_PARQUET_INPUT_FORMAT_CLASS;
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName;
+import static com.starrocks.server.ExternalTableFactory.RESOURCE;
 
 public class HiveTableTest {
     private static ConnectContext connectContext;
@@ -211,7 +215,7 @@ public class HiveTableTest {
         HiveTable oTable = HiveMetastoreApiConverter.toHiveTable(msTable, getResourceMappingCatalogName("hive0", "hive"));
         Assert.assertFalse(oTable.hasBooleanTypePartitionColumn());
     }
-    
+
     // create a hive table with specific storage format
     private HiveTable createExternalTableByFormat(String format) throws Exception {
         String inputFormatClass = HiveStorageFormat.get(format).getInputFormat();
@@ -292,4 +296,31 @@ public class HiveTableTest {
         }
     }
 
+    @Test
+    public void testCreateTableResourceName() throws DdlException {
+
+        String resourceName = "Hive_resource_29bb53dc_7e04_11ee_9b35_00163e0e489a";
+        Map<String, String> properties = new HashMap() {
+            {
+                put(RESOURCE, resourceName);
+            }
+        };
+        HiveTable.Builder tableBuilder = HiveTable.builder()
+                .setId(1000)
+                .setTableName("supplier")
+                .setCatalogName("hice_catalog")
+                .setHiveDbName("hive_oss_tpch_1g_parquet_gzip")
+                .setHiveTableName("supplier")
+                .setResourceName(resourceName)
+                .setTableLocation("")
+                .setFullSchema(new ArrayList<>())
+                .setDataColumnNames(new ArrayList<>())
+                .setPartitionColumnNames(Lists.newArrayList())
+                .setStorageFormat(null);
+        HiveTable oTable = tableBuilder.build();
+        HiveTable.Builder newBuilder = HiveTable.builder();
+        HiveTableFactory.copyFromOldTable(newBuilder, oTable, properties);
+        HiveTable table = newBuilder.build();
+        Assert.assertEquals(table.getResourceName(), resourceName);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HiveTableTest.java
@@ -319,7 +319,7 @@ public class HiveTableTest {
                 .setStorageFormat(null);
         HiveTable oTable = tableBuilder.build();
         HiveTable.Builder newBuilder = HiveTable.builder();
-        HiveTableFactory.copyFromOldTable(newBuilder, oTable, properties);
+        HiveTableFactory.copyFromCatalogTable(newBuilder, oTable, properties);
         HiveTable table = newBuilder.build();
         Assert.assertEquals(table.getResourceName(), resourceName);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/HudiTableTest.java
@@ -275,7 +275,7 @@ public class HudiTableTest {
         HudiTable oTable = tableBuilder.build();
 
         HudiTable.Builder newBuilder = HudiTable.builder();
-        HudiTableFactory.copyFromOldTable(newBuilder, oTable, properties);
+        HudiTableFactory.copyFromCatalogTable(newBuilder, oTable, properties);
         HudiTable table = newBuilder.build();
         Assert.assertEquals(table.getResourceName(), resourceName);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -65,7 +65,7 @@ public class IcebergTableTest extends TableTestBase {
                 .setIcebergProperties(new HashMap<>());
         IcebergTable oTable = tableBuilder.build();
         IcebergTable.Builder newBuilder = IcebergTable.builder();
-        IcebergTableFactory.copyFromOldTable(newBuilder, oTable, properties);
+        IcebergTableFactory.copyFromCatalogTable(newBuilder, oTable, properties);
         IcebergTable table = newBuilder.build();
         Assert.assertEquals(table.getResourceName(), resourceName);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/IcebergTableTest.java
@@ -19,11 +19,18 @@ import com.google.common.collect.Maps;
 import com.starrocks.common.DdlException;
 import com.starrocks.connector.iceberg.TableTestBase;
 import com.starrocks.server.IcebergTableFactory;
+import mockit.Mocked;
+import org.apache.iceberg.Table;
+import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.starrocks.catalog.Type.INT;
+import static com.starrocks.server.ExternalTableFactory.RESOURCE;
 
 public class IcebergTableTest extends TableTestBase {
 
@@ -34,5 +41,32 @@ public class IcebergTableTest extends TableTestBase {
                 "resource_name", "iceberg_db", "iceberg_table", columns, mockedNativeTableB, Maps.newHashMap());
         List<Column> inputColumns = Lists.newArrayList(new Column("k1", INT, true));
         IcebergTableFactory.validateIcebergColumnType(inputColumns, oTable);
+    }
+
+    @Test
+    public void testCreateTableResourceName(@Mocked Table icebergNativeTable) throws DdlException {
+
+        String resourceName = "Iceberg_resource_29bb53dc_7e04_11ee_9b35_00163e0e489a";
+        Map<String, String> properties = new HashMap() {
+            {
+                put(RESOURCE, resourceName);
+            }
+        };
+
+        IcebergTable.Builder tableBuilder = IcebergTable.builder()
+                .setId(1000)
+                .setSrTableName("supplier")
+                .setCatalogName("iceberg_catalog")
+                .setRemoteDbName("iceberg_oss_tpch_1g_parquet_gzip")
+                .setRemoteTableName("supplier")
+                .setResourceName(resourceName)
+                .setFullSchema(new ArrayList<>())
+                .setNativeTable(icebergNativeTable)
+                .setIcebergProperties(new HashMap<>());
+        IcebergTable oTable = tableBuilder.build();
+        IcebergTable.Builder newBuilder = IcebergTable.builder();
+        IcebergTableFactory.copyFromOldTable(newBuilder, oTable, properties);
+        IcebergTable table = newBuilder.build();
+        Assert.assertEquals(table.getResourceName(), resourceName);
     }
 }


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/4706

----- 


The root cause of this problem is resource name has been lower cased since 2.5

From 2.5, we add a new concept `catalog`. And resource name has  been added to catalog name(a virtual catalog), and also lower cased. And when we fetch resource name from this catalog name, we get lower cased resource name.

```java
// --- CatalogMgr.java
    public static class ResourceMappingCatalog {
        public static final String RESOURCE_MAPPING_CATALOG_PREFIX = "resource_mapping_inside_catalog_";

        public static boolean isResourceMappingCatalog(String catalogName) {
            return catalogName.startsWith(RESOURCE_MAPPING_CATALOG_PREFIX);
        }

        public static String getResourceMappingCatalogName(String resourceName, String type) {
           // ---- HERE, we lower case catalog name, and meanwhile we also lower case resource name
            return (RESOURCE_MAPPING_CATALOG_PREFIX + type + "_" + resourceName).toLowerCase(Locale.ROOT);
        }

        public static String toResourceName(String catalogName, String type) {
           // ----- HERE, we actually get lower cased resource name from catalog name.
            return isResourceMappingCatalog(catalogName) ?
                    catalogName.substring(RESOURCE_MAPPING_CATALOG_PREFIX.length() + type.length() + 1) : catalogName;
        }
    }
```

However this lower cased resource name can not be found when we downgrade FE to version 2.3. There is no catalog concept in that version, and we use `ResourceMgr.java` to find resource.

```java
// ---- ResourceMgr.java
    public Resource getResource(String name) {
        this.readLock();
        try {
            return nameToResource.get(name);
        } finally {
            this.readUnlock();
        }
    }

```

So to fix this problem, resource name can not be fetched from catalog name, but from properties.

```Java
    public static void copyFromCatalogTable(HiveTable.Builder tableBuilder, HiveTable catalogTable,
                                            Map<String, String> properties) {
        tableBuilder
                .setCatalogName(catalogTable.getCatalogName())
                .setResourceName(properties.get(RESOURCE))  // <--- actual fix.
                .setHiveDbName(catalogTable.getDbName())
                .setHiveTableName(catalogTable.getTableName())
                .setPartitionColumnNames(catalogTable.getPartitionColumnNames())
                .setDataColumnNames(catalogTable.getDataColumnNames())
                .setTableLocation(catalogTable.getTableLocation())
                .setStorageFormat(catalogTable.getStorageFormat())
                .setCreateTime(catalogTable.getCreateTime())
                .setProperties(catalogTable.getProperties());
    }
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
