### PR TITLE
[Enhancement] Update regexp_extract function for trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
@@ -83,7 +83,7 @@ public class ComplexFunctionCallTransformer {
         } else if (functionName.equalsIgnoreCase("regexp_extract")) {
             // regexp_extract(string, pattern) -> regexp_extract(str, pattern, 0)
             FunctionCallExpr regexpExtractFunc = new FunctionCallExpr("regexp_extract",
-                    ImmutableList.of(args[0], args[1], new IntLiteral(0L)));
+                    ImmutableList.of(args[0], args[1], args.length == 3 ? args[2] : new IntLiteral(0L)));
             BinaryPredicate predicate = new BinaryPredicate(BinaryType.EQ, regexpExtractFunc, new StringLiteral(""));
             // regexp_extract -> if(regexp_extract(xxx)='', null, regexp_extract(xxx))
             return new FunctionCallExpr("if", ImmutableList.of(predicate, new NullLiteral(), regexpExtractFunc));

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
@@ -15,11 +15,14 @@
 package com.starrocks.connector.parser.trino;
 
 import com.google.common.collect.ImmutableList;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.BinaryType;
 import com.starrocks.analysis.CastExpr;
 import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TimestampArithmeticExpr;
 import com.starrocks.catalog.Type;
@@ -77,6 +80,13 @@ public class ComplexFunctionCallTransformer {
                 throw new SemanticException("element_at function must have 2 arguments");
             }
             return new CollectionElementExpr(args[0], args[1]);
+        } else if (functionName.equalsIgnoreCase("regexp_extract")) {
+            // regexp_extract(string, pattern) -> regexp_extract(str, pattern, 0)
+            FunctionCallExpr regexpExtractFunc = new FunctionCallExpr("regexp_extract",
+                    ImmutableList.of(args[0], args[1], new IntLiteral(0L)));
+            BinaryPredicate predicate = new BinaryPredicate(BinaryType.EQ, regexpExtractFunc, new StringLiteral(""));
+            // regexp_extract -> if(regexp_extract(xxx)='', null, regexp_extract(xxx))
+            return new FunctionCallExpr("if", ImmutableList.of(predicate, new NullLiteral(), regexpExtractFunc));
         }
         return null;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -217,10 +217,6 @@ public class Trino2SRFunctionCallTransformer {
         // regexp_like -> regexp
         registerFunctionTransformer("regexp_like", 2, "regexp",
                 ImmutableList.of(Expr.class, Expr.class));
-
-        // regexp_extract(string, pattern) -> regexp_extract(str, pattern, 0)
-        registerFunctionTransformer("regexp_extract", 2, new FunctionCallExpr("regexp_extract",
-                ImmutableList.of(new PlaceholderExpr(1, Expr.class), new PlaceholderExpr(2, Expr.class), new IntLiteral(0L))));
     }
 
     private static void registerJsonFunctionTransformer() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -774,10 +774,19 @@ public class TrinoQueryTest extends TrinoTestBase {
         assertPlanContains(sql, "regexp('abc123', 'abc*')");
 
         sql = "select regexp_extract('1a 2b 14m', '\\d+');";
-        assertPlanContains(sql, "regexp_extract('1a 2b 14m', '\\\\d+', 0)");
+        assertPlanContains(sql, "if(3: regexp_extract = '', NULL, 3: regexp_extract)\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 3> : regexp_extract('1a 2b 14m', '\\\\d+', 0)");
 
         sql = "select regexp_extract('1abb 2b 14m', '[a-z]+');";
-        assertPlanContains(sql, "regexp_extract('1abb 2b 14m', '[a-z]+', 0)");
+        assertPlanContains(sql, "if(3: regexp_extract = '', NULL, 3: regexp_extract)\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 3> : regexp_extract('1abb 2b 14m', '[a-z]+', 0)");
+
+        sql = "select regexp_extract('1abb 2b 14m', '[a-z]+', 1);";
+        assertPlanContains(sql, "if(3: regexp_extract = '', NULL, 3: regexp_extract)\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 3> : regexp_extract('1abb 2b 14m', '[a-z]+', 1)");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
In StarRocks, the regexp_extract function returns an empty string when there is no matching content. Trino returns NULL. The two behave inconsistently.

What I'm doing:
Function conversion in trino compatibility layer: `regexp_extract -> if(regexp_extract(xxx)= ", null, regexp_extract(xxx))`

Fixes #34026

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
