### PR TITLE
[Enhancement] set grace period for mv checker

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -143,9 +143,9 @@ public class MVActiveChecker extends FrontendDaemon {
 
     public static class MvActiveInfo {
         // Use 2 ** N as failure backoff, and set the max to 30 minutes
-        public final static long MAX_BACKOFF_MINUTES = 60;
-        private final static long BACKOFF_BASE = 2;
-        private final static long MAX_BACKOFF_TIMES = (long) (Math.log(MAX_BACKOFF_MINUTES) / Math.log(BACKOFF_BASE));
+        public static final long MAX_BACKOFF_MINUTES = 60;
+        private static final long BACKOFF_BASE = 2;
+        private static final long MAX_BACKOFF_TIMES = (long) (Math.log(MAX_BACKOFF_MINUTES) / Math.log(BACKOFF_BASE));
 
         private LocalDateTime nextActive;
         private int failureTimes = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -15,13 +15,16 @@
 package com.starrocks.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Maps;
 import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.statistic.StatisticUtils;
@@ -29,7 +32,10 @@ import org.apache.commons.collections4.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -38,6 +44,8 @@ import java.util.Optional;
 public class MVActiveChecker extends FrontendDaemon {
 
     private static final Logger LOG = LogManager.getLogger(MVActiveChecker.class);
+
+    private static final Map<MvId, MvActiveInfo> MV_ACTIVE_INFO = Maps.newConcurrentMap();
 
     public MVActiveChecker() {
         super("MVActiveChecker", Config.mv_active_checker_interval_seconds * 1000);
@@ -56,8 +64,16 @@ public class MVActiveChecker extends FrontendDaemon {
     }
 
     @VisibleForTesting
-    public void runForTest() {
+    public void runForTest(boolean clearGrace) {
+        if (clearGrace) {
+            clearGracePeriod();
+        }
         process();
+    }
+
+    @VisibleForTesting
+    private void clearGracePeriod() {
+        MV_ACTIVE_INFO.clear();
     }
 
     private void process() {
@@ -88,6 +104,12 @@ public class MVActiveChecker extends FrontendDaemon {
             return;
         }
 
+        MvActiveInfo activeInfo = MV_ACTIVE_INFO.get(mv.getMvId());
+        if (activeInfo != null && activeInfo.isInGracePeriod()) {
+            return;
+        }
+
+        boolean activeOk = false;
         String mvFullName = new TableName(dbName.get(), mv.getName()).toString();
         String sql = String.format("ALTER MATERIALIZED VIEW %s active", mvFullName);
         try {
@@ -97,15 +119,68 @@ public class MVActiveChecker extends FrontendDaemon {
 
             connect.executeSql(sql);
             if (mv.isActive()) {
+                activeOk = true;
                 LOG.info("[MVActiveChecker] activate MV {} successfully", mvFullName);
             } else {
                 LOG.warn("[MVActiveChecker] activate MV {} failed", mvFullName);
             }
         } catch (Exception e) {
             LOG.warn("[MVActiveChecker] activate MV {} failed", mvFullName, e);
-            throw new RuntimeException(e);
         } finally {
             ConnectContext.remove();
         }
+
+        if (activeOk) {
+            MV_ACTIVE_INFO.remove(mv.getMvId());
+        } else {
+            if (activeInfo != null) {
+                activeInfo.next();
+            } else {
+                MV_ACTIVE_INFO.put(mv.getMvId(), MvActiveInfo.firstFailure());
+            }
+        }
     }
+
+    public static class MvActiveInfo {
+        // Use 2 ** N as failure backoff, and set the max to 30 minutes
+        public final static long MAX_BACKOFF_MINUTES = 60;
+        private final static long BACKOFF_BASE = 2;
+        private final static long MAX_BACKOFF_TIMES = (long) (Math.log(MAX_BACKOFF_MINUTES) / Math.log(BACKOFF_BASE));
+
+        private LocalDateTime nextActive;
+        private int failureTimes = 0;
+
+        public static MvActiveInfo firstFailure() {
+            MvActiveInfo info = new MvActiveInfo();
+            info.next();
+            return info;
+        }
+
+        /**
+         * If in grace period, it should not activate the mv
+         */
+        public boolean isInGracePeriod() {
+            LocalDateTime now = LocalDateTime.now(TimeUtils.getSystemTimeZone().toZoneId());
+            return now.isBefore(nextActive);
+        }
+
+        public LocalDateTime getNextActive() {
+            return nextActive;
+        }
+
+        public void next() {
+            LocalDateTime lastActive = LocalDateTime.now(TimeUtils.getSystemTimeZone().toZoneId());
+            this.failureTimes++;
+            this.nextActive = lastActive.plus(failureBackoff(failureTimes));
+        }
+
+        private Duration failureBackoff(int failureTimes) {
+            if (failureTimes >= MAX_BACKOFF_TIMES) {
+                return Duration.ofMinutes(MAX_BACKOFF_MINUTES);
+            }
+            long expBackoff = (long) Math.pow(BACKOFF_BASE, failureTimes);
+            return Duration.ofMinutes(expBackoff);
+        }
+    }
+
 }


### PR DESCRIPTION
Why I'm doing:
- Active every 1 minute would print too much log

What I'm doing:
- Add grace period for mv checker, avoid active the mv too frequently 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
