### PR TITLE
[Doc] Add the supported version for Partitioning based on the column expression in starrocks shared-data mode

### DIFF
--- a/docs/table_design/expression_partitioning.md
+++ b/docs/table_design/expression_partitioning.md
@@ -249,7 +249,7 @@ MySQL > SHOW PARTITIONS FROM t_recharge_detail1;
 
 ## Limits
 
-- Since v3.1.0, StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the [time function expression](#partitioning-based-on-a-time-function-expression). Since v3.1.1,  StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the [column expression](#partitioning-based-on-the-column-expression-since-v31).
+- Since v3.1.0, StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the [time function expression](#partitioning-based-on-a-time-function-expression). And since v3.1.1,  StarRocks's [shared-data mode](../deployment/shared_data/s3.md) further supports the [column expression](#partitioning-based-on-the-column-expression-since-v31).
 - Currently, using CTAS to create tables configured expression partitioning is not supported.
 - Currently, using Spark Load to load data to tables that use expression partitioning is not supported.
 - When the `ALTER TABLE <table_name> DROP PARTITION <partition_name>` statement is used to delete a partition created by using the column expression, data in the partition is directly removed and cannot be recovered.

--- a/docs/table_design/expression_partitioning.md
+++ b/docs/table_design/expression_partitioning.md
@@ -249,7 +249,7 @@ MySQL > SHOW PARTITIONS FROM t_recharge_detail1;
 
 ## Limits
 
-- Since v3.1, StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the time function expression and does not support the column expression.
+- Since v3.1.0, StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the [time function expression](#partitioning-based-on-a-time-function-expression). Since v3.1.1,  StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the [column expression](#partitioning-based-on-the-column-expression-since-v31).
 - Currently, using CTAS to create tables configured expression partitioning is not supported.
 - Currently, using Spark Load to load data to tables that use expression partitioning is not supported.
 - When the `ALTER TABLE <table_name> DROP PARTITION <partition_name>` statement is used to delete a partition created by using the column expression, data in the partition is directly removed and cannot be recovered.

--- a/docs/table_design/expression_partitioning.md
+++ b/docs/table_design/expression_partitioning.md
@@ -249,7 +249,7 @@ MySQL > SHOW PARTITIONS FROM t_recharge_detail1;
 
 ## Limits
 
-- Since v3.1.0, StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the [time function expression](#partitioning-based-on-a-time-function-expression). And since v3.1.1,  StarRocks's [shared-data mode](../deployment/shared_data/s3.md) further supports the [column expression](#partitioning-based-on-the-column-expression-since-v31).
+- Since v3.1.0, StarRocks's [shared-data mode](../deployment/shared_data/s3.md) supports the [time function expression](#partitioning-based-on-a-time-function-expression). And since v3.1.1, StarRocks's [shared-data mode](../deployment/shared_data/s3.md) further supports the [column expression](#partitioning-based-on-the-column-expression-since-v31).
 - Currently, using CTAS to create tables configured expression partitioning is not supported.
 - Currently, using Spark Load to load data to tables that use expression partitioning is not supported.
 - When the `ALTER TABLE <table_name> DROP PARTITION <partition_name>` statement is used to delete a partition created by using the column expression, data in the partition is directly removed and cannot be recovered.


### PR DESCRIPTION
Why I'm doing: 
The supported version for Partitioning based on the column expression in starrocks shared-data mode is missing in the doc.

What I'm doing:
Add the supported version in the doc.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5