### PR TITLE
[Enhancement] support discrete partition in mv

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
@@ -53,12 +53,15 @@ public class MVRefreshTestBase {
     protected static StarRocksAssert starRocksAssert;
     @ClassRule
     public static TemporaryFolder temp = new TemporaryFolder();
+    private static short previousReplicationNum = Config.default_replication_num;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         FeConstants.runningUnitTest = true;
         FeConstants.enablePruneEmptyOutputScan = false;
         Config.enable_experimental_mv = true;
+        previousReplicationNum = Config.default_replication_num;
+        Config.default_replication_num = 1;
         UtFrameUtils.createMinStarRocksCluster();
         connectContext = UtFrameUtils.createDefaultCtx();
         ConnectorPlanTestBase.mockCatalog(connectContext, temp.newFolder().toURI().toString());
@@ -104,5 +107,6 @@ public class MVRefreshTestBase {
 
     @AfterClass
     public static void tearDown() throws Exception {
+        Config.default_replication_num = previousReplicationNum;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -357,6 +357,12 @@ public class StarRocksAssert {
         return this;
     }
 
+    public StarRocksAssert refreshMv(String mvName) throws Exception {
+        String sql = String.format("refresh materialized view %s with sync mode", mvName);
+        this.ctx.executeSql(sql);
+        return this;
+    }
+
     public StarRocksAssert refreshMvPartition(String sql) throws Exception {
         StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         if (stmt instanceof RefreshMaterializedViewStatement) {


### PR DESCRIPTION
Why I'm doing:
- The basic assumption of mv mapping is that partitions of base table is continuous, it doesn't support discrete partitions

What I'm doing:
- Adjust the partition mapping mechanism to support discrete partitions


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
