### PR TITLE
[Enhancement] Check ready_for_next in has_output (backport #34863)

### DIFF
--- a/be/src/exec/pipeline/scan/scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/scan_operator.cpp
@@ -165,7 +165,10 @@ bool ScanOperator::has_output() const {
 
     // Can pick up more morsels or submit more tasks
     if (!_morsel_queue->empty()) {
-        return true;
+        auto status_or_is_ready = _morsel_queue->ready_for_next();
+        if (status_or_is_ready.ok() && status_or_is_ready.value()) {
+            return true;
+        }
     }
     for (int i = 0; i < _io_tasks_per_scan_operator; ++i) {
         std::shared_lock guard(_task_mutex);


### PR DESCRIPTION
This is cherry-picked from #34863.

### Why I'm doing
The per-bucket optimization introduces `MorselQueue::ready_for_next`. When this function returns false, a ScanOperator cannot poll a morsel from the morsel queue, even if the morsel queue is non-empty. 

However, `ready_for_next` is only checked in `pull_chunk`, not in `has_output`, leading to a false positive in `has_output`.

### What I'm doing
Check `ready_for_next` in `has_output`.

### Test
Cluster:
- 3 BE each of which has 16 vCPUs.

Query:
- --concurrency=8 --number-of-queries=8
```sql
SELECT SearchPhrase, MIN(URL), MIN(Title), COUNT(*) AS c, COUNT(DISTINCT UserID) FROM hits WHERE Title LIKE '%Google%' AND URL NOT LIKE '%.google.%' AND SearchPhrase <> '' GROUP BY SearchPhrase ORDER BY c DESC LIMIT 10
```

Result
- 3.1.4: 2245ms
- 3.2.0
    - enable_per_bucket_optimize=false: 2347ms
    - enable_per_bucket_optimize=true before this PR: 4034ms
    - enable_per_bucket_optimize=true after this PR: 2362ms


### Which issue to be fixed
Fixes https://github.com/StarRocks/StarRocksTest/issues/4720.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
