### PR TITLE
[BugFix] fix FE UT http port conflict when running in parallel

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -128,6 +128,15 @@ public abstract class StarRocksHttpTestCase {
     @Mocked
     private static EditLog editLog;
 
+    public static int detectUsableSocketPort() {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        } catch (Exception e) {
+            throw new IllegalStateException("Could not find a free TCP/IP port");
+        }
+    }
+
     public static OlapTable newTable(String name) {
         GlobalStateMgr.getCurrentInvertedIndex().clear();
         Column k1 = new Column("k1", Type.BIGINT);

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionOnSharedDataClusterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionOnSharedDataClusterTest.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 public class TransactionLoadActionOnSharedDataClusterTest extends StarRocksHttpTestCase {
 
     private static HttpServer beServer;
+    private static int TEST_HTTP_PORT = 0;
 
     @Override
     @Before
@@ -58,7 +59,7 @@ public class TransactionLoadActionOnSharedDataClusterTest extends StarRocksHttpT
         ComputeNode computeNode = new ComputeNode(1234, "localhost", 8040);
         computeNode.setBePort(9300);
         computeNode.setAlive(true);
-        computeNode.setHttpPort(9737);
+        computeNode.setHttpPort(TEST_HTTP_PORT);
         GlobalStateMgr.getCurrentSystemInfo().addComputeNode(computeNode);
         new MockUp<GlobalStateMgr>() {
             @Mock
@@ -79,7 +80,8 @@ public class TransactionLoadActionOnSharedDataClusterTest extends StarRocksHttpT
 
     @BeforeClass
     public static void initBeServer() throws IllegalArgException, InterruptedException {
-        beServer = new HttpServer(9737);
+        TEST_HTTP_PORT = detectUsableSocketPort();
+        beServer = new HttpServer(TEST_HTTP_PORT);
         BaseAction ac = new BaseAction(beServer.getController()) {
 
             @Override

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -44,6 +44,7 @@ import java.io.IOException;
 public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
     private static HttpServer beServer;
+    private static int TEST_HTTP_PORT = 0;
 
     @Override
     @Before
@@ -51,7 +52,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
         Backend backend4 = new Backend(1234, "localhost", 8040);
         backend4.setBePort(9300);
         backend4.setAlive(true);
-        backend4.setHttpPort(9737);
+        backend4.setHttpPort(TEST_HTTP_PORT);
         backend4.setDisks(new ImmutableMap.Builder<String, DiskInfo>().put("1", new DiskInfo("")).build());
         GlobalStateMgr.getCurrentSystemInfo().addBackend(backend4);
         new MockUp<GlobalStateMgr>() {
@@ -73,7 +74,9 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
 
     @BeforeClass
     public static void initBeServer() throws IllegalArgException, InterruptedException {
-        beServer = new HttpServer(9737);
+        TEST_HTTP_PORT = detectUsableSocketPort();
+
+        beServer = new HttpServer(TEST_HTTP_PORT);
         BaseAction ac = new BaseAction(beServer.getController()) {
 
             @Override


### PR DESCRIPTION
FE UT has http port conflict when running in parallel. Fix it by detecting useable port when running the case.

Introduced in #33371

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
