### PR TITLE
[BugFix] Tables that support fast schema evolution may encounter failures when executing ALTER tasks.

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1364,7 +1364,8 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
                             DCHECK(column.col_unique_id == old_unique_id);
                             if (column.col_unique_id != old_unique_id) {
                                 std::string msg = strings::Substitute(
-                                        "Tablet[$0] column[$1] has different column unique id during schema change. $2(FE) "
+                                        "Tablet[$0] column[$1] has different column unique id during schema change. "
+                                        "$2(FE) "
                                         "vs $3(BE)",
                                         base_tablet->tablet_id(), old_col_idx, column.col_unique_id, old_unique_id);
                                 return Status::InternalError(msg);

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1358,15 +1358,17 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
             for (old_col_idx = 0; old_col_idx < old_num_columns; ++old_col_idx) {
                 auto old_name = base_tablet_schema->column(old_col_idx).name();
                 if (old_name == column.column_name) {
-                    uint32_t old_unique_id = base_tablet->tablet_schema()->column(old_col_idx).unique_id();
-                    if (column.col_unique_id > 0) {
-                        DCHECK(column.col_unique_id == old_unique_id);
-                        if (column.col_unique_id != old_unique_id) {
-                            std::string msg = strings::Substitute(
-                                    "Tablet[$0] column[$1] has different column unique id during schema change. $2(FE) "
-                                    "vs $3(BE)",
-                                    base_tablet->tablet_id(), old_col_idx, column.col_unique_id, old_unique_id);
-                            return Status::InternalError(msg);
+                    uint32_t old_unique_id = base_tablet_schema->column(old_col_idx).unique_id();
+                    if (normal_request.tablet_schema.schema_version <= base_tablet_schema->schema_version()) {
+                        if (column.col_unique_id > 0) {
+                            DCHECK(column.col_unique_id == old_unique_id);
+                            if (column.col_unique_id != old_unique_id) {
+                                std::string msg = strings::Substitute(
+                                        "Tablet[$0] column[$1] has different column unique id during schema change. $2(FE) "
+                                        "vs $3(BE)",
+                                        base_tablet->tablet_id(), old_col_idx, column.col_unique_id, old_unique_id);
+                                return Status::InternalError(msg);
+                            }
                         }
                     }
 

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1359,7 +1359,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
                 auto old_name = base_tablet_schema->column(old_col_idx).name();
                 if (old_name == column.column_name) {
                     uint32_t old_unique_id = base_tablet_schema->column(old_col_idx).unique_id();
-                    if (normal_request.tablet_schema.schema_version <= base_tablet_schema->schema_version()) {
+                    if (normal_request.tablet_schema.schema_version > base_tablet_schema->schema_version() + 1) {
                         if (column.col_unique_id > 0) {
                             DCHECK(column.col_unique_id == old_unique_id);
                             if (column.col_unique_id != old_unique_id) {

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1359,7 +1359,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
                 auto old_name = base_tablet_schema->column(old_col_idx).name();
                 if (old_name == column.column_name) {
                     uint32_t old_unique_id = base_tablet_schema->column(old_col_idx).unique_id();
-                    if (normal_request.tablet_schema.schema_version > base_tablet_schema->schema_version() + 1) {
+                    if (normal_request.tablet_schema.schema_version <= base_tablet_schema->schema_version() + 1) {
                         if (column.col_unique_id > 0) {
                             DCHECK(column.col_unique_id == old_unique_id);
                             if (column.col_unique_id != old_unique_id) {

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -422,3 +422,101 @@ None
 drop database meta_scan;
 -- result:
 -- !result
+-- name: test_fast_schema_evolution_and_alter
+create database test_fast_schema_evolution_and_alter;
+-- result:
+-- !result
+use test_fast_schema_evolution_and_alter;
+-- result:
+-- !result
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+-- result:
+-- !result
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+-- result:
+-- !result
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+-- result:
+-- !result
+alter table tab1 add column c1 bigint;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600", 111);
+-- result:
+-- !result
+alter table tab1 drop column c1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+alter table tab1 add column c1 bigint;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100	None
+200	k2_200	200	200	200	v4_200	v5_200	None
+300	k2_300	300	300	300	v4_300	v5_300	None
+400	k2_400	400	400	400	v4_400	v5_400	None
+500	k2_500	500	500	500	v4_500	v5_500	None
+600	k2_600	600	600	600	v4_600	v5_600	None
+-- !result
+alter table tab1 modify column c1 largeint;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100	None
+200	k2_200	200	200	200	v4_200	v5_200	None
+300	k2_300	300	300	300	v4_300	v5_300	None
+400	k2_400	400	400	400	v4_400	v5_400	None
+500	k2_500	500	500	500	v4_500	v5_500	None
+600	k2_600	600	600	600	v4_600	v5_600	None
+-- !result
+drop table tab1;
+-- result:
+-- !result
+drop database test_fast_schema_evolution_and_alter;
+-- result:
+-- !result

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -31,6 +31,7 @@ delete from t1 where v3>4;
 select * from t1 order by k;
 
 
+
 CREATE table tab1 (
       k1 INTEGER,
       k2 VARCHAR(50),
@@ -160,3 +161,53 @@ function: wait_analyze_finish("meta_scan", "reproducex4", "explain select v2 fro
 
 
 drop database meta_scan;
+
+
+-- name: test_fast_schema_evolution_and_alter
+
+create database test_fast_schema_evolution_and_alter;
+use test_fast_schema_evolution_and_alter;
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+PRIMARY KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+
+alter table tab1 add column c1 bigint;
+function: wait_alter_table_finish()
+
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600", 111);
+
+alter table tab1 drop column c1;
+function: wait_alter_table_finish()
+
+alter table tab1 add column c1 bigint;
+function: wait_alter_table_finish()
+
+select * from tab1;
+
+alter table tab1 modify column c1 largeint;
+function: wait_alter_table_finish()
+
+select * from tab1;
+
+drop table tab1;
+drop database test_fast_schema_evolution_and_alter;


### PR DESCRIPTION
Why I'm doing:
After enable fast schema evolution, the tablet schema in BE maybe not latest. And the column unique id should be assigned by FE and we check the unique id consistency when we do alter job for safe. However, if the tablet schema in BE is not newest, the column with the same name saved on BE saved on FE may not be the same column just as shown in the following:
1. create a table with column `c1`
2. insert values
3. drop column `c1`
4. add column `c1`
5. trigger alter job

In step5, we will create new tablet and the new tablet and base tablet both have column `c1`, but the `c1` column are not the same column because the tablet schema version is not the latest, so the check will failed.

What I'm doing:

We need to check the schema version before check unique id consistency. If the tablet schema in BE is not the latest, the check should be skip.

Fixes https://github.com/StarRocks/StarRocksTest/issues/4733

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
