### PR TITLE
[BugFix] re-generated fn signature when change the input of window function

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -116,6 +116,43 @@ public class AggregatePushDownTest extends PlanTestBase {
     }
 
     @Test
+    public void testPushDownDistinctAggBelowWindow_2() throws Exception {
+        // unsupported window func ref cols from partition by cols
+        String sql = "select distinct t1d from (select *, sum(t1d) over (partition by t1d, t1e) as cnt from " +
+                "test_all_type ) t where cnt > 1 limit 10;";
+
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "4:ANALYTIC\n" +
+                "  |  functions: [, sum(12: sum), ]\n" +
+                "  |  partition by: 4: t1d, 5: t1e\n" +
+                "  |  \n" +
+                "  3:SORT\n" +
+                "  |  order by: <slot 4> 4: t1d ASC, <slot 5> 5: t1e ASC\n" +
+                "  |  offset: 0\n" +
+                "  |  \n" +
+                "  2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(4: t1d)\n" +
+                "  |  group by: 4: t1d, 5: t1e\n" +
+                "  |  \n" +
+                "  1:EXCHANGE");
+    }
+
+    @Test
+    public void testPushDownDistinctAggBelowWindow_3() throws Exception {
+        // unsupported window func ref cols from partition by cols
+        String sql = "select distinct t1c from (select *, sum(t1d) over (partition by t1e order by t1d) as cnt from " +
+                "test_all_type ) t where cnt > 1 limit 10;";
+
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "2:AGGREGATE (update finalize)\n" +
+                "  |  output: sum(4: t1d)\n" +
+                "  |  group by: 3: t1c, 4: t1d, 5: t1e\n" +
+                "  |  \n" +
+                "  1:EXCHANGE");
+    }
+
+    @Test
     public void testNotPushDownDistinctAggBelowWindow_1() throws Exception {
         // unsupported count function
         String sql = "select distinct t1d from (select *, count(1) over (partition by t1d) as cnt from test_all_type ) " +
@@ -134,27 +171,4 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "  |  \n" +
                 "  1:EXCHANGE");
     }
-
-    @Test
-    public void testNotPushDownDistinctAggBelowWindow_2() throws Exception {
-        // unsupported window func ref cols from partition by cols
-        String sql = "select distinct t1d from (select *, sum(t1d + 1) over (partition by t1d, t1e) as cnt from " +
-                "test_all_type ) t where cnt > 1 limit 10;";
-
-        String plan = getFragmentPlan(sql);
-        assertContains(plan, "4:SELECT\n" +
-                "  |  predicates: 11: sum(add(4: t1d, 1)) > 1\n" +
-                "  |  \n" +
-                "  3:ANALYTIC\n" +
-                "  |  functions: [, sum(4: t1d + 1), ]\n" +
-                "  |  partition by: 4: t1d, 5: t1e\n" +
-                "  |  \n" +
-                "  2:SORT\n" +
-                "  |  order by: <slot 4> 4: t1d ASC, <slot 5> 5: t1e ASC\n" +
-                "  |  offset: 0\n" +
-                "  |  \n" +
-                "  1:EXCHANGE");
-    }
-
-
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -138,8 +138,8 @@ public class AggregatePushDownTest extends PlanTestBase {
     @Test
     public void testNotPushDownDistinctAggBelowWindow_2() throws Exception {
         // unsupported window func ref cols from partition by cols
-        String sql = "select distinct t1d from (select *, sum(t1d + 1) over (partition by t1d, t1e) as cnt from test_all_type ) " +
-                "t where cnt > 1 limit 10;";
+        String sql = "select distinct t1d from (select *, sum(t1d + 1) over (partition by t1d, t1e) as cnt from " +
+                "test_all_type ) t where cnt > 1 limit 10;";
 
         String plan = getFragmentPlan(sql);
         assertContains(plan, "4:SELECT\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -144,7 +144,6 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "test_all_type ) t where cnt > 1 limit 10;";
 
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
         assertContains(plan, "2:AGGREGATE (update finalize)\n" +
                 "  |  output: sum(4: t1d)\n" +
                 "  |  group by: 3: t1c, 4: t1d, 5: t1e\n" +


### PR DESCRIPTION
Why I'm doing:
- the check code of push down agg below window operator has bugs
- need re-generated fn signature when change the input of window function becuase of the argument type changing.

What I'm doing:
- ensure that the checking logic aligns with our design
- re-generated fn signature

Fixes #issue
Sql like 
```
select distinct t1d from (select *, count(1) over (partition by t1d) as cnt from test_all_type ) t where cnt > 1 limit 10;
```
failed to pass `Preconditions.checkArgument(aggCall.getChildren().size() == 1 && aggCall.getChild(0).isColumnRef());`

Sql like
```
# t1e is float type
select distinct t1d from (select *, sum(t1e) over (partition by t1d) as cnt from test_all_type ) t where cnt > 1 limit 10;
```
failed to pass type checker.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
