### PR TITLE
[BugFix] Fix partition resolve bug for materialized view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -92,7 +92,6 @@ import com.starrocks.sql.ast.PartitionValue;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.RangePartitionDesc;
 import com.starrocks.sql.ast.Relation;
-import com.starrocks.sql.ast.SelectListItem;
 import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.SetOperationRelation;
 import com.starrocks.sql.ast.SingleRangePartitionDesc;
@@ -100,7 +99,6 @@ import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.UpdateStmt;
-import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.ast.ViewRelation;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.StarRocksPlannerException;
@@ -1341,138 +1339,6 @@ public class AnalyzerUtils {
         return null;
     }
 
-    private static class SlotRefResolverFactory {
-        public static class AstVisitors {
-            public AstVisitor<Expr, Relation> exprShuttle;
-            public AstVisitor<Expr, SlotRef> slotRefResolver;
-        }
-
-        public static AstVisitors createAstVisitors() {
-            AstVisitors visitors = new AstVisitors();
-
-            visitors.exprShuttle = new AstVisitor<Expr, Relation>() {
-                @Override
-                public Expr visitExpression(Expr expr, Relation node) {
-                    expr = expr.clone();
-                    for (int i = 0; i < expr.getChildren().size(); i++) {
-                        Expr child = expr.getChild(i);
-                        expr.setChild(i, child.accept(this, node));
-                    }
-                    return expr;
-                }
-
-                @Override
-                public Expr visitSlot(SlotRef slotRef, Relation node) {
-                    String tableName = slotRef.getTblNameWithoutAnalyzed().getTbl();
-                    if (node.getAlias() != null && !node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
-                        return slotRef;
-                    }
-                    return node.accept(visitors.slotRefResolver, slotRef);
-                }
-            };
-
-            visitors.slotRefResolver = new AstVisitor<Expr, SlotRef>() {
-                @Override
-                public Expr visitSelect(SelectRelation node, SlotRef slot) {
-                    for (SelectListItem selectListItem : node.getSelectList().getItems()) {
-                        TableName tableName = slot.getTblNameWithoutAnalyzed();
-                        if (selectListItem.getAlias() == null) {
-                            if (selectListItem.getExpr() instanceof SlotRef) {
-                                SlotRef result = (SlotRef) selectListItem.getExpr();
-                                if (result.getColumnName().equalsIgnoreCase(slot.getColumnName())
-                                        && (tableName == null || tableName.equals(result.getTblNameWithoutAnalyzed()))) {
-                                    return selectListItem.getExpr().accept(visitors.exprShuttle, node.getRelation());
-                                }
-                            }
-                        } else {
-                            if (tableName != null && tableName.isFullyQualified()) {
-                                continue;
-                            }
-                            if (selectListItem.getAlias().equalsIgnoreCase(slot.getColumnName())) {
-                                return selectListItem.getExpr().accept(visitors.exprShuttle, node.getRelation());
-                            }
-                        }
-                    }
-                    return node.getRelation().accept(this, slot);
-                }
-                @Override
-                public Expr visitSubquery(SubqueryRelation node, SlotRef slot) {
-                    String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
-                    if (!node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
-                        return null;
-                    }
-                    slot = (SlotRef) slot.clone();
-                    slot.setTblName(null); //clear table name here, not check it inside
-                    return node.getQueryStatement().getQueryRelation().accept(this, slot);
-                }
-                @Override
-                public Expr visitTable(TableRelation node, SlotRef slot) {
-                    TableName tableName = slot.getTblNameWithoutAnalyzed();
-                    if (node.getName().equals(tableName)) {
-                        return slot;
-                    }
-                    if (tableName != null && !node.getResolveTableName().equals(tableName)) {
-                        return null;
-                    }
-                    slot = (SlotRef) slot.clone();
-                    slot.setTblName(node.getName());
-                    return slot;
-                }
-                @Override
-                public Expr visitView(ViewRelation node, SlotRef slot) {
-                    TableName tableName = slot.getTblNameWithoutAnalyzed();
-                    if (tableName != null && !node.getResolveTableName().equals(tableName)) {
-                        return null;
-                    }
-                    slot = (SlotRef) slot.clone();
-                    slot.setTblName(null); //clear table name here, not check it inside
-                    return node.getQueryStatement().getQueryRelation().accept(this, slot);
-                }
-                @Override
-                public Expr visitJoin(JoinRelation node, SlotRef slot) {
-                    Relation leftRelation = node.getLeft();
-                    Expr leftExpr = leftRelation.accept(this, slot);
-                    if (leftExpr != null) {
-                        return leftExpr;
-                    }
-                    Relation rightRelation = node.getRight();
-                    Expr rightExpr = rightRelation.accept(this, slot);
-                    if (rightExpr != null) {
-                        return rightExpr;
-                    }
-                    return null;
-                }
-
-                @Override
-                public Expr visitSetOp(SetOperationRelation node, SlotRef slot) {
-                    for (Relation relation : node.getRelations()) {
-                        Expr resolved = relation.accept(this, slot);
-                        if (resolved != null) {
-                            return resolved;
-                        }
-                    }
-                    return null;
-                }
-
-                @Override
-                public SlotRef visitValues(ValuesRelation node, SlotRef slot) {
-                    return null;
-                }
-            };
-
-            return visitors;
-        }
-    }
-
-    public static Expr resolveSlotRef(SlotRef slotRef, QueryStatement queryStatement) {
-        SlotRefResolverFactory.AstVisitors visitors = SlotRefResolverFactory.createAstVisitors();
-        return queryStatement.getQueryRelation().accept(visitors.slotRefResolver, slotRef);
-    }
-    public static Expr resolveExpr(Expr expr, QueryStatement queryStatement) {
-        SlotRefResolverFactory.AstVisitors visitors = SlotRefResolverFactory.createAstVisitors();
-        return expr.accept(visitors.exprShuttle, queryStatement.getQueryRelation());
-    }
-
     public static boolean containsIgnoreCase(List<String> list, String soughtFor) {
         for (String current : list) {
             if (current.equalsIgnoreCase(soughtFor)) {
@@ -1502,5 +1368,4 @@ public class AnalyzerUtils {
         }
         return expr;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -612,7 +612,7 @@ public class MaterializedViewAnalyzer {
 
         private void checkPartitionColumnExprs(CreateMaterializedViewStatement statement,
                                                Map<Column, Expr> columnExprMap,
-                                               ConnectContext connectContext) {
+                                               ConnectContext connectContext) throws SemanticException {
             ExpressionPartitionDesc expressionPartitionDesc = statement.getPartitionExpDesc();
             Column partitionColumn = statement.getPartitionColumn();
 
@@ -622,7 +622,8 @@ public class MaterializedViewAnalyzer {
                 partitionColumnExpr = resolvePartitionExpr(partitionColumnExpr, connectContext, statement.getQueryStatement());
             } catch (Exception e) {
                 LOG.warn("resolve partition column failed", e);
-                throw new SemanticException("resolve partition column failed", statement.getPartitionExpDesc().getPos());
+                throw new SemanticException("Resolve partition column failed:" + e.getMessage(),
+                        statement.getPartitionExpDesc().getPos());
             }
 
             if (expressionPartitionDesc.isFunction()) {
@@ -672,7 +673,7 @@ public class MaterializedViewAnalyzer {
         private Expr resolvePartitionExpr(Expr partitionColumnExpr,
                                           ConnectContext connectContext,
                                           QueryStatement queryStatement) {
-            Expr expr = AnalyzerUtils.resolveExpr(partitionColumnExpr, queryStatement);
+            Expr expr = SlotRefResolver.resolveExpr(partitionColumnExpr, queryStatement);
             SlotRef slot;
             if (expr instanceof SlotRef) {
                 slot = (SlotRef) expr;
@@ -709,11 +710,11 @@ public class MaterializedViewAnalyzer {
                         MaterializedViewPartitionFunctionChecker.FN_NAME_TO_PATTERN.get(functionName);
                 if (checkPartitionFunction == null) {
                     throw new SemanticException("Materialized view partition function " +
-                            functionName + " is not support", functionCallExpr.getPos());
+                            functionName + " is not support: " + expr.toSqlWithoutTbl(), functionCallExpr.getPos());
                 }
                 if (!checkPartitionFunction.check(functionCallExpr)) {
                     throw new SemanticException("Materialized view partition function " +
-                            functionName + " check failed", functionCallExpr.getPos());
+                            functionName + " check failed: " + expr.toSqlWithoutTbl(), functionCallExpr.getPos());
                 }
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SlotRefResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SlotRefResolver.java
@@ -1,0 +1,165 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.analyzer;
+
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
+import com.starrocks.sql.ast.AstVisitor;
+import com.starrocks.sql.ast.FieldReference;
+import com.starrocks.sql.ast.JoinRelation;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.Relation;
+import com.starrocks.sql.ast.SelectListItem;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.SetOperationRelation;
+import com.starrocks.sql.ast.SubqueryRelation;
+import com.starrocks.sql.ast.TableRelation;
+import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.sql.ast.ViewRelation;
+
+/**
+ * Resolve the expression(eg: partition column expression) through join/sub-query/view/set operator fo find the slot ref
+ * which it comes from.
+ */
+public class SlotRefResolver {
+    private  static final AstVisitor<Expr, Relation> EXPR_SHUTTLE = new AstVisitor<Expr, Relation>() {
+        @Override
+        public Expr visitExpression(Expr expr, Relation node) {
+            expr = expr.clone();
+            for (int i = 0; i < expr.getChildren().size(); i++) {
+                Expr child = expr.getChild(i);
+                expr.setChild(i, child.accept(this, node));
+            }
+            return expr;
+        }
+
+        @Override
+        public Expr visitSlot(SlotRef slotRef, Relation node) {
+            String tableName = slotRef.getTblNameWithoutAnalyzed().getTbl();
+            if (node.getAlias() != null && !node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
+                return slotRef;
+            }
+            return node.accept(SLOT_REF_RESOLVER, slotRef);
+        }
+
+        @Override
+        public Expr visitFieldReference(FieldReference fieldReference, Relation node) {
+            Field field = node.getScope().getRelationFields()
+                    .getFieldByIndex(fieldReference.getFieldIndex());
+            return new SlotRef(field.getRelationAlias(), field.getName());
+        }
+    };
+
+    private static final AstVisitor<Expr, SlotRef> SLOT_REF_RESOLVER = new AstVisitor<Expr, SlotRef>() {
+        @Override
+        public Expr visitSelect(SelectRelation node, SlotRef slot) {
+            for (SelectListItem selectListItem : node.getSelectList().getItems()) {
+                TableName tableName = slot.getTblNameWithoutAnalyzed();
+                if (selectListItem.getAlias() == null) {
+                    if (selectListItem.getExpr() instanceof SlotRef) {
+                        SlotRef result = (SlotRef) selectListItem.getExpr();
+                        if (result.getColumnName().equalsIgnoreCase(slot.getColumnName())
+                                && (tableName == null || tableName.equals(result.getTblNameWithoutAnalyzed()))) {
+                            return selectListItem.getExpr().accept(EXPR_SHUTTLE, node.getRelation());
+                        }
+                    }
+                } else {
+                    if (tableName != null && tableName.isFullyQualified()) {
+                        continue;
+                    }
+                    if (selectListItem.getAlias().equalsIgnoreCase(slot.getColumnName())) {
+                        return selectListItem.getExpr().accept(EXPR_SHUTTLE, node.getRelation());
+                    }
+                }
+            }
+            return node.getRelation().accept(this, slot);
+        }
+
+        @Override
+        public Expr visitSubquery(SubqueryRelation node, SlotRef slot) {
+            String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
+            if (!node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
+                return null;
+            }
+            slot = (SlotRef) slot.clone();
+            slot.setTblName(null); //clear table name here, not check it inside
+            return node.getQueryStatement().getQueryRelation().accept(this, slot);
+        }
+
+        @Override
+        public Expr visitTable(TableRelation node, SlotRef slot) {
+            TableName tableName = slot.getTblNameWithoutAnalyzed();
+            if (node.getName().equals(tableName)) {
+                return slot;
+            }
+            if (tableName != null && !node.getResolveTableName().equals(tableName)) {
+                return null;
+            }
+            slot = (SlotRef) slot.clone();
+            slot.setTblName(node.getName());
+            return slot;
+        }
+
+        @Override
+        public Expr visitView(ViewRelation node, SlotRef slot) {
+            TableName tableName = slot.getTblNameWithoutAnalyzed();
+            if (tableName != null && !node.getResolveTableName().equals(tableName)) {
+                return null;
+            }
+            slot = (SlotRef) slot.clone();
+            slot.setTblName(null); //clear table name here, not check it inside
+            return node.getQueryStatement().getQueryRelation().accept(this, slot);
+        }
+
+        @Override
+        public Expr visitJoin(JoinRelation node, SlotRef slot) {
+            Relation leftRelation = node.getLeft();
+            Expr leftExpr = leftRelation.accept(this, slot);
+            if (leftExpr != null) {
+                return leftExpr;
+            }
+            Relation rightRelation = node.getRight();
+            Expr rightExpr = rightRelation.accept(this, slot);
+            if (rightExpr != null) {
+                return rightExpr;
+            }
+            return null;
+        }
+
+        @Override
+        public Expr visitSetOp(SetOperationRelation node, SlotRef slot) {
+            for (Relation relation : node.getRelations()) {
+                Expr resolved = relation.accept(this, slot);
+                if (resolved != null) {
+                    return resolved;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public SlotRef visitValues(ValuesRelation node, SlotRef slot) {
+            return null;
+        }
+    };
+
+    /**
+     * Resolve the expression through join/sub-query/view/set operator fo find the slot ref
+     * which it comes from.
+     */
+    public static Expr resolveExpr(Expr expr, QueryStatement queryStatement) {
+        return expr.accept(EXPR_SHUTTLE, queryStatement.getQueryRelation());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -1242,7 +1242,8 @@ public class CreateMaterializedViewTest {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
             Assert.assertEquals("Getting analyzing error from line 3, column 11 to line 3, column 32. " +
-                    "Detail message: Materialized view partition function date_trunc check failed.", e.getMessage());
+                    "Detail message: Materialized view partition function date_trunc check failed: " +
+                    "date_trunc('month', `k2`).", e.getMessage());
         }
     }
 
@@ -1279,7 +1280,7 @@ public class CreateMaterializedViewTest {
             UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
         } catch (Exception e) {
             Assert.assertEquals("Getting analyzing error from line 3, column 16 to line 3, column 28. " +
-                    "Detail message: Materialized view partition function sqrt is not support.", e.getMessage());
+                    "Detail message: Materialized view partition function sqrt is not support: sqrt(`k1`).", e.getMessage());
         }
     }
 
@@ -3611,6 +3612,106 @@ public class CreateMaterializedViewTest {
             }
         }
         return Lists.newArrayList();
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithSelectStar1() {
+        // sort key by default
+        String sql = "create materialized view test_mv1 " +
+                "partition by c_1_3 " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select * from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_1"));
+        Assert.assertTrue(keyColumns.get(2).getName().equals("c_1_2"));
+        Assert.assertTrue(keyColumns.get(3).getName().equals("c_1_3"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithSelectStar2() {
+        // sort key by default
+        String sql = "create materialized view test_mv2 " +
+                "partition by c_1_3 " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select * from t1 union all select * from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_1"));
+        Assert.assertTrue(keyColumns.get(2).getName().equals("c_1_2"));
+        Assert.assertTrue(keyColumns.get(3).getName().equals("c_1_3"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithSelectStar3() {
+        // sort key by default
+        String sql = "create materialized view test_mv1 " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select * from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_1"));
+        Assert.assertTrue(keyColumns.get(2).getName().equals("c_1_2"));
+        Assert.assertTrue(keyColumns.get(3).getName().equals("c_1_3"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithSelectStar4() {
+        // sort key by default
+        String sql = "create materialized view test_mv2 " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select * from t1 union all select * from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_1"));
+        Assert.assertTrue(keyColumns.get(2).getName().equals("c_1_2"));
+        Assert.assertTrue(keyColumns.get(3).getName().equals("c_1_3"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithSelectStar5() {
+        // sort key by default
+        String sql = "create materialized view test_mv2 " +
+                "partition by date_trunc('day', c_1_3) " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select * from t1 union all select * from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_1"));
+        Assert.assertTrue(keyColumns.get(2).getName().equals("c_1_2"));
+        Assert.assertTrue(keyColumns.get(3).getName().equals("c_1_3"));
+    }
+
+    @Test
+    public void testCreateMaterializedViewWithSelectStar6() {
+        // sort key by default
+        String sql = "create materialized view test_mv2 " +
+                "partition by date_trunc('month', c_1_3) " +
+                "distributed by hash(c_1_3, c_1_0) buckets 10 " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ") " +
+                "as select * from t1 union all select * from t1";
+        List<Column> keyColumns = getMaterializedViewKeysChecked(sql);
+        Assert.assertTrue(keyColumns.get(0).getName().equals("c_1_0"));
+        Assert.assertTrue(keyColumns.get(1).getName().equals("c_1_1"));
+        Assert.assertTrue(keyColumns.get(2).getName().equals("c_1_2"));
+        Assert.assertTrue(keyColumns.get(3).getName().equals("c_1_3"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -19,7 +19,6 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Partition;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -33,10 +32,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
         MvRewriteTestBase.beforeClass();
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteJDBCTest.java
@@ -21,7 +21,6 @@ import com.starrocks.connector.MockedMetadataMgr;
 import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,10 +38,6 @@ public class MvRefreshAndRewriteJDBCTest extends MvRewriteTestBase {
         MockedJDBCMetadata mockedJDBCMetadata =
                 (MockedJDBCMetadata) metadataMgr.getOptionalMetadata(MockedJDBCMetadata.MOCKED_JDBC_CATALOG_NAME).get();
         mockedJDBCMetadata.initPartitions();
-    }
-
-    @AfterClass
-    public static void tearDown() throws Exception {
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:

After PR(#32077)， analyzer cannot resolve partition column from `select *`.

```
CREATE MATERIALIZED VIEW IF NOT EXISTS `test_mv` 
PARTITION BY str2date(`d_datekey`,'%Y%m%d')
DISTRIBUTED BY RANDOM
REFRESH ASYNC EVERY (INTERVAL 1 DAY)
AS
SELECT
 *
FROM
 `hive`.`ssb_1g_orc`.`part_dates` ;
```

It throws `Resolve partition column failed.` with nothing else.


What I'm doing:
1. Fix analyzer to support partition column from `select *` by adding `visitFieldReference` in `c`;
2. Add more extra information when meeting  `Resolve partition column failed.`
3. Refactor `SlotRefResolverFactory ` into an indenpendant class `SlotRefResolverFactory `

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
