### PR TITLE
[BugFix] Memory double free in json_scanner

### DIFF
--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -683,6 +683,14 @@ Status JsonReader::_read_file_stream() {
     auto* stream_file = down_cast<StreamLoadPipeInputStream*>(_file->stream().get());
     SCOPED_RAW_TIMER(&_counter->file_read_ns);
     ASSIGN_OR_RETURN(_file_stream_buffer, stream_file->pipe()->read());
+    if (_file_stream_buffer->capacity < _file_stream_buffer->remaining() + simdjson::SIMDJSON_PADDING) {
+        // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
+        // Hence, a re-allocation is needed if the space is not enough.
+        auto buf = ByteBuffer::allocate(_file_stream_buffer->remaining() + simdjson::SIMDJSON_PADDING);
+        buf->put_bytes(_file_stream_buffer->ptr, _file_stream_buffer->remaining());
+        buf->flip();
+        std::swap(buf, _file_stream_buffer);
+    }
 
     _state->update_num_bytes_scan_from_source(_file_stream_buffer->remaining());
 

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -738,12 +738,12 @@ Status JsonReader::_read_file_broker() {
         if (!res.ok()) {
             return res.status();
         }
-        _file_broker_buffer_size = sz;
+        _file_broker_buffer_size = res.value();
 
         if (res.value() <= 0) {
             return Status::EndOfFile("EOF of reading file");
         }
-        _state->update_num_bytes_scan_from_source(sz);
+        _state->update_num_bytes_scan_from_source(_file_broker_buffer_size);
     }
     _payload = _file_broker_buffer.get();
     _payload_size = _file_broker_buffer_size;

--- a/be/src/exec/json_scanner.cpp
+++ b/be/src/exec/json_scanner.cpp
@@ -339,10 +339,7 @@ JsonReader::JsonReader(starrocks::RuntimeState* state, starrocks::ScannerCounter
           _strict_mode(strict_mode),
           _file(std::move(file)),
           _slot_descs(std::move(slot_descs)),
-          _op_col_index(-1),
-          _payload_buffer(nullptr),
-          _payload_buffer_size(0),
-          _payload_buffer_capacity(0) {
+          _op_col_index(-1) {
     int index = 0;
     for (const auto& desc : _slot_descs) {
         if (desc == nullptr) {
@@ -684,31 +681,22 @@ Status JsonReader::_construct_row(simdjson::ondemand::object* row, Chunk* chunk)
 Status JsonReader::_read_file_stream() {
     // TODO: Remove the down_cast, should not rely on the specific implementation.
     auto* stream_file = down_cast<StreamLoadPipeInputStream*>(_file->stream().get());
-    {
-        SCOPED_RAW_TIMER(&_counter->file_read_ns);
-        ASSIGN_OR_RETURN(_parser_buf, stream_file->pipe()->read());
+    SCOPED_RAW_TIMER(&_counter->file_read_ns);
+    ASSIGN_OR_RETURN(_file_stream_buffer, stream_file->pipe()->read());
 
-        _state->update_num_bytes_scan_from_source(_parser_buf->remaining());
+    _state->update_num_bytes_scan_from_source(_file_stream_buffer->remaining());
 
-        if (_parser_buf->capacity < _parser_buf->remaining() + simdjson::SIMDJSON_PADDING) {
-            // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
-            // Hence, a re-allocation is needed if the space is not enough.
-            auto buf = ByteBuffer::allocate(_parser_buf->remaining() + simdjson::SIMDJSON_PADDING);
-            buf->put_bytes(_parser_buf->ptr, _parser_buf->remaining());
-            buf->flip();
-            std::swap(buf, _parser_buf);
-        }
-    }
+    _payload = _file_stream_buffer->ptr;
+    _payload_size = _file_stream_buffer->remaining();
+    _payload_capacity = _file_stream_buffer->capacity;
 
-    _payload_buffer.reset(_parser_buf->ptr);
-    _parser_buf->flip();
-    _payload_buffer_size = _parser_buf->remaining();
-    _payload_buffer_capacity = _parser_buf->remaining() + simdjson::SIMDJSON_PADDING;
     return Status::OK();
 }
 
 // read one json string from file read and parse it to json doc.
 Status JsonReader::_read_file_broker() {
+    SCOPED_RAW_TIMER(&_counter->file_read_ns);
+
     // TODO: Remove the down_cast, should not rely on the specific implementation.
     auto* stream = down_cast<io::SeekableInputStream*>(_file->stream().get());
     auto res = stream->get_size();
@@ -727,25 +715,31 @@ Status JsonReader::_read_file_broker() {
                             sz, _scanner->_params.json_file_size_limit));
     }
 
-    if (sz > _payload_buffer_capacity) {
+    if (sz + simdjson::SIMDJSON_PADDING > _file_broker_buffer_capacity) {
         // reallocate if needed.
+        // For efficiency reasons, simdjson requires a string with a few bytes (simdjson::SIMDJSON_PADDING) at the end.
+        // Hence, a re-allocation is needed if the space is not enough.
         auto allocated = sz + simdjson::SIMDJSON_PADDING;
-        _payload_buffer.reset(new char[allocated]);
-        _payload_buffer_capacity = allocated;
+        _file_broker_buffer.reset(new char[allocated]);
+        _file_broker_buffer_capacity = allocated;
+        _file_broker_buffer_size = 0;
     }
 
     {
-        SCOPED_RAW_TIMER(&_counter->file_read_ns);
-        auto res = _file->read(reinterpret_cast<void*>(_payload_buffer.get()), sz);
+        auto res = _file->read(reinterpret_cast<void*>(_file_broker_buffer.get()), sz);
         if (!res.ok()) {
             return res.status();
         }
-        _payload_buffer_size = sz;
+        _file_broker_buffer_size = sz;
 
         if (res.value() <= 0) {
             return Status::EndOfFile("EOF of reading file");
         }
+        _state->update_num_bytes_scan_from_source(sz);
     }
+    _payload = _file_broker_buffer.get();
+    _payload_size = _file_broker_buffer_size;
+    _payload_capacity = _file_broker_buffer_capacity;
 
     return Status::OK();
 }
@@ -754,9 +748,9 @@ Status JsonReader::_check_ndjson() {
     // Check the content format according to the first non-space character.
     // Treat json string started with '{' as ndjson.
     // Treat json string started with '[' as json array.
-    for (size_t i = 0; i < _payload_buffer_size; ++i) {
+    for (size_t i = 0; i < _payload_size; ++i) {
         // Skip spaces at the string head.
-        const auto& c = _payload_buffer.get()[i];
+        const auto& c = _payload[i];
         if (c == ' ' || c == '\t' || c == '\r' || c == '\n') continue;
 
         if (c == '[') {
@@ -814,8 +808,7 @@ Status JsonReader::_read_and_parse_json() {
     }
 
     _empty_parser = false;
-    return _parser->parse(_payload_buffer.get(), _payload_buffer_size,
-                          _payload_buffer_size + simdjson::SIMDJSON_PADDING);
+    return _parser->parse(_payload, _payload_size, _payload_capacity);
 }
 
 // _construct_column constructs column based on no value.

--- a/be/src/exec/json_scanner.h
+++ b/be/src/exec/json_scanner.h
@@ -137,7 +137,6 @@ private:
     // For performance reason, the simdjson parser should be reused over several files.
     //https://github.com/simdjson/simdjson/blob/master/doc/performance.md
     simdjson::ondemand::parser _simdjson_parser;
-    ByteBufferPtr _parser_buf;
     bool _is_ndjson = false;
 
     std::unique_ptr<JsonParser> _parser;
@@ -150,9 +149,15 @@ private:
     // record the "__op" column's index
     int _op_col_index;
 
-    std::unique_ptr<char[]> _payload_buffer;
-    size_t _payload_buffer_size;
-    size_t _payload_buffer_capacity;
+    ByteBufferPtr _file_stream_buffer;
+
+    std::unique_ptr<char[]> _file_broker_buffer = nullptr;
+    size_t _file_broker_buffer_size = 0;
+    size_t _file_broker_buffer_capacity = 0;
+
+    char* _payload = nullptr;
+    size_t _payload_size = 0;
+    size_t _payload_capacity = 0;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing this:
The misuse of `unique_ptr` may lead to double free of `JsonScanner::_payload_buffer`. The memory would be freed in the desctructor of `JsonScanner::_payload_buffer` and the desctructor of `JsonScanner::ByteBufferPtr _parser_buf`.
What I'm doing:
This PR uses separate buffers for `JsonScanner::_read_file_broker` and `JsonScanner::_read_file_stream` to illuminate this issue.

Fixes https://github.com/StarRocks/StarRocksTest/issues/4724

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
