### PR TITLE
[Doc] update query in tpc-h benchmarking

### DIFF
--- a/docs/benchmarking/TPC-H_Benchmarking.md
+++ b/docs/benchmarking/TPC-H_Benchmarking.md
@@ -69,7 +69,6 @@ group by  l_returnflag,  l_linestatus
 order by  l_returnflag,  l_linestatus;
 
 --Q2
-select count(*) from (
 select  s_acctbal, s_name,  n_name,  p_partkey,  p_mfgr,  s_address,  s_phone,  s_comment
 from  part,  partsupp,  supplier,  nation,  region
 where
@@ -90,24 +89,21 @@ where
       and n_regionkey = r_regionkey
       and r_name = 'EUROPE'
   )
-order by  s_acctbal desc, n_name,  s_name,  p_partkey
-) as t1;
+order by  s_acctbal desc, n_name,  s_name,  p_partkey;
 
 --Q3
-select count(*) from (
-    select
-      l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority
-    from
-      customer, orders, lineitem
-    where
-      c_mktsegment = 'BUILDING'
-      and c_custkey = o_custkey
-      and l_orderkey = o_orderkey
-      and o_orderdate < date '1995-03-15'
-      and l_shipdate > date '1995-03-15'
-    group by l_orderkey, o_orderdate, o_shippriority
-    order by revenue desc, o_orderdate
-    ) as t1;
+select
+  l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority
+from
+  customer, orders, lineitem
+where
+  c_mktsegment = 'BUILDING'
+  and c_custkey = o_custkey
+  and l_orderkey = o_orderkey
+  and o_orderdate < date '1995-03-15'
+  and l_shipdate > date '1995-03-15'
+group by l_orderkey, o_orderdate, o_shippriority
+order by revenue desc, o_orderdate;
 
 --Q4
 select  o_orderpriority,  count(*) as order_count
@@ -199,7 +195,6 @@ group by o_year
 order by o_year;
 
 --Q9
-select count(*) from (
 select nation, o_year, sum(amount) as sum_profit
 from
   (
@@ -218,11 +213,9 @@ from
       and p_name like '%green%'
   ) as profit
 group by nation, o_year
-order by nation, o_year desc
-) as t1;
+order by nation, o_year desc;
 
 --Q10
-select count(*) from (
 select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment
     from customer, orders, lineitem, nation
     where
@@ -233,11 +226,9 @@ select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_
       and l_returnflag = 'R'
       and c_nationkey = n_nationkey
     group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment
-    order by revenue desc
-) as t1;
+    order by revenue desc;
 
 --Q11
-select count(*) from (
 select ps_partkey, sum(ps_supplycost * ps_availqty) as value
 from partsupp, supplier, nation
 where
@@ -253,8 +244,7 @@ group by ps_partkey having
         and s_nationkey = n_nationkey
         and n_name = 'GERMANY'
     )
-order by value desc
-) as t1;
+order by value desc;
 
 --Q12
 select
@@ -301,7 +291,6 @@ where
 order by s_suppkey;
 
 --Q16
-select count(*) from (
 select p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
 from partsupp, part
 where
@@ -313,8 +302,7 @@ where
     select s_suppkey from supplier where s_comment like '%Customer%Complaints%'
   )
 group by p_brand, p_type, p_size
-order by supplier_cnt desc, p_brand, p_type, p_size
-) as t1;
+order by supplier_cnt desc, p_brand, p_type, p_size;
 
 --Q17
 select sum(l_extendedprice) / 7.0 as avg_yearly
@@ -328,7 +316,6 @@ where
   );
 
 --Q18
-select count(*) from (
 select c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum(l_quantity)
 from customer, orders, lineitem
 where
@@ -340,8 +327,7 @@ where
   and c_custkey = o_custkey
   and o_orderkey = l_orderkey
 group by c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
-order by o_totalprice desc, o_orderdate
-) as t1;
+order by o_totalprice desc, o_orderdate;
 
 --Q19
 select sum(l_extendedprice* (1 - l_discount)) as revenue
@@ -404,7 +390,6 @@ where
 order by s_name;
 
 --Q21
-select count(*) from (
 select s_name, count(*) as numwait
 from  supplier,  lineitem l1,  orders,  nation
 where
@@ -428,8 +413,7 @@ where
   and s_nationkey = n_nationkey
   and n_name = 'SAUDI ARABIA'
 group by s_name
-order by  numwait desc, s_name
-) as t1;
+order by  numwait desc, s_name;
 
 
 --Q22
@@ -1281,7 +1265,6 @@ group by  l_returnflag,  l_linestatus
 order by  l_returnflag,  l_linestatus;
 
 --Q2
-select count(*) from (
 select  s_acctbal, s_name,  n_name,  p_partkey,  p_mfgr,  s_address,  s_phone,  s_comment
 from  part,  partsupp,  supplier,  nation,  region
 where
@@ -1302,24 +1285,21 @@ where
       and n_regionkey = r_regionkey
       and r_name = 'EUROPE'
   )
-order by  s_acctbal desc, n_name,  s_name,  p_partkey
-) as t1;
+order by  s_acctbal desc, n_name,  s_name,  p_partkey;
 
 --Q3
-select count(*) from (
-    select
-      l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority
-    from
-      customer, orders, lineitem
-    where
-      c_mktsegment = 'BUILDING'
-      and c_custkey = o_custkey
-      and l_orderkey = o_orderkey
-      and o_orderdate < date '1995-03-15'
-      and l_shipdate > date '1995-03-15'
-    group by l_orderkey, o_orderdate, o_shippriority
-    order by revenue desc, o_orderdate
-    ) as t1;
+select
+  l_orderkey, sum(l_extendedprice * (1 - l_discount)) as revenue, o_orderdate, o_shippriority
+from
+  customer, orders, lineitem
+where
+  c_mktsegment = 'BUILDING'
+  and c_custkey = o_custkey
+  and l_orderkey = o_orderkey
+  and o_orderdate < date '1995-03-15'
+  and l_shipdate > date '1995-03-15'
+group by l_orderkey, o_orderdate, o_shippriority
+order by revenue desc, o_orderdate;
 
 --Q4
 select  o_orderpriority,  count(*) as order_count
@@ -1411,7 +1391,6 @@ group by o_year
 order by o_year;
 
 --Q9
-select count(*) from (
 select nation, o_year, sum(amount) as sum_profit
 from
   (
@@ -1430,11 +1409,9 @@ from
       and p_name like '%green%'
   ) as profit
 group by nation, o_year
-order by nation, o_year desc
-) as t1;
+order by nation, o_year desc;
 
 --Q10
-select count(*) from (
 select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_acctbal, n_name, c_address, c_phone, c_comment
     from customer, orders, lineitem, nation
     where
@@ -1445,11 +1422,9 @@ select c_custkey, c_name, sum(l_extendedprice * (1 - l_discount)) as revenue, c_
       and l_returnflag = 'R'
       and c_nationkey = n_nationkey
     group by c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment
-    order by revenue desc
-) as t1;
+    order by revenue desc;
 
 --Q11
-select count(*) from (
 select ps_partkey, sum(ps_supplycost * ps_availqty) as value
 from partsupp, supplier, nation
 where
@@ -1465,8 +1440,7 @@ group by ps_partkey having
         and s_nationkey = n_nationkey
         and n_name = 'GERMANY'
     )
-order by value desc
-) as t1;
+order by value desc;
 
 --Q12
 select
@@ -1513,7 +1487,6 @@ where
 order by s_suppkey;
 
 --Q16
-select count(*) from (
 select p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt
 from partsupp, part
 where
@@ -1525,8 +1498,7 @@ where
     select s_suppkey from supplier where s_comment like '%Customer%Complaints%'
   )
 group by p_brand, p_type, p_size
-order by supplier_cnt desc, p_brand, p_type, p_size
-) as t1;
+order by supplier_cnt desc, p_brand, p_type, p_size;
 
 --Q17
 select sum(l_extendedprice) / 7.0 as avg_yearly
@@ -1540,7 +1512,6 @@ where
   );
 
 --Q18
-select count(*) from (
 select c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice, sum(l_quantity)
 from customer, orders, lineitem
 where
@@ -1552,8 +1523,7 @@ where
   and c_custkey = o_custkey
   and o_orderkey = l_orderkey
 group by c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice
-order by o_totalprice desc, o_orderdate
-) as t1;
+order by o_totalprice desc, o_orderdate;
 
 --Q19
 select sum(l_extendedprice* (1 - l_discount)) as revenue
@@ -1616,7 +1586,6 @@ where
 order by s_name;
 
 --Q21
-select count(*) from (
 select s_name, count(*) as numwait
 from  supplier,  lineitem l1,  orders,  nation
 where
@@ -1640,8 +1609,7 @@ where
   and s_nationkey = n_nationkey
   and n_name = 'SAUDI ARABIA'
 group by s_name
-order by  numwait desc, s_name
-) as t1;
+order by  numwait desc, s_name;
 
 --Q22
 select


### PR DESCRIPTION
Why I'm doing: the queries in english doc are inconsistent with those in the Chinese doc

What I'm doing: to align the queries

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
