### PR TITLE
[Enhancement] Print exception logs while exporting jobs failed with hdfs rename operation

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1280,7 +1280,7 @@ public class HdfsFsManager {
                 throw new UserException("failed to rename path from " + srcPath + " to " + destPath);
             }
         } catch (IOException e) {
-            LOG.error("errors while rename path from " + srcPath + " to " + destPath);
+            LOG.error("errors while rename path from " + srcPath + " to " + destPath, e);
             throw new UserException("errors while rename " + srcPath + "to " + destPath);
         }
     }


### PR DESCRIPTION
Why I'm doing:

* It's hard to debug an exception while exporting job failed with a user error  only said `type:RUN_FAIL; msg:move tmp file to final destination fail, errors while rename xxx`

What I'm doing:

* Print the IO Exception encountered while renaming operation failed to fe logs

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
