### PR TITLE
[Enhancement] support skip specified transaction state

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -258,6 +258,14 @@ public class Config extends ConfigBase {
     public static int label_keep_max_second = 3 * 24 * 3600; // 3 days
 
     /**
+     * Transaction between [skip_transaction_range[0], skip_transaction_range[1]] will be removed,
+     * even though they are not in final status.
+     * Used for temporary solve issues
+     */
+    @ConfField(mutable = true)
+    public static long[] skip_transaction_range = {};
+
+    /**
      * for load job managed by LoadManager, such as Insert, Broker load and Spark load.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -670,6 +670,11 @@ public class TransactionState implements Writable {
 
     // return true if txn is in final status and label is expired
     public boolean isExpired(long currentMillis) {
+        if (Config.skip_transaction_range != null && Config.skip_transaction_range.length == 2) {
+            if (Config.skip_transaction_range[0] <= transactionId && transactionId <= Config.skip_transaction_range[1]) {
+                return true;
+            }
+        }
         return transactionStatus.isFinalStatus() && (currentMillis - finishTime) / 1000 > Config.label_keep_max_second;
     }
 


### PR DESCRIPTION
Why I'm doing:
In some issues, transactions can't finish normally, we need some way to skip them.

What I'm doing:
Add FE config  `skip_transaction_range`, so I can skip load transaction between [skip_transaction_range[0], skip_transaction_range[1]].

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
