### PR TITLE
[BugFix] Fix error message when substr/substring meets illegal interger

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/IntLiteral.java
@@ -112,7 +112,7 @@ public class IntLiteral extends LiteralExpr {
         }
 
         if (!valid) {
-            throw new ArithmeticException("Number out of range[" + value + "]. type: " + type);
+            throw new ArithmeticException("Number out of range[" + longValue + "]. type: " + type);
         }
 
         this.value = longValue;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -5488,10 +5488,14 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     private static void addArgumentUseTypeInt(Expr value, List<Expr> exprs) {
         // IntLiteral may use TINYINT/SMALLINT/INT/BIGINT type
         // but time_slice only support INT type when executed in BE
-        if (value instanceof IntLiteral) {
-            exprs.add(new IntLiteral(((IntLiteral) value).getValue(), Type.INT));
-        } else {
-            exprs.add(value);
+        try {
+            if (value instanceof IntLiteral) {
+                exprs.add(new IntLiteral(((IntLiteral) value).getValue(), Type.INT));
+            } else {
+                exprs.add(value);
+            }
+        } catch (Exception e) {
+            throw  new IllegalArgumentException(String.format("Cast argument %s to int type failed.", value.toSql()));
         }
     }
 

--- a/test/sql/test_function/R/test_substr
+++ b/test/sql/test_function/R/test_substr
@@ -1,0 +1,75 @@
+-- name: test_substr
+create table t1 (id int, v bigint) distributed by hash(id) properties ("replication_num" = "1");
+-- result:
+-- !result
+select SUBSTR('', 9223372036854775807) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+-- !result
+select SUBSTR('', 9223372036854775807, 465254298) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+-- !result
+select SUBSTR('', -9223372036854775807, 465254298) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument -9223372036854775807 to int type failed.')
+-- !result
+select SUBSTR('', 9223372036854775806, 465254298) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument 9223372036854775806 to int type failed.')
+-- !result
+select SUBSTRING('', 9223372036854775807) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+-- !result
+select SUBSTRING('', 9223372036854775807, 465254298) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument 9223372036854775807 to int type failed.')
+-- !result
+select SUBSTRING('', -9223372036854775807, 465254298) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument -9223372036854775807 to int type failed.')
+-- !result
+select SUBSTRING('', 9223372036854775806, 465254298) ;
+-- result:
+E: (1064, 'Unexpected exception: Cast argument 9223372036854775806 to int type failed.')
+-- !result
+insert into t1 values(1, 9223372036854775807), (2, -9223372036854775807), (3, 9223372036854775806);
+-- result:
+-- !result
+select SUBSTR('', v) from t1;
+-- result:
+None
+None
+None
+-- !result
+select SUBSTR('', v, id) from t1;
+-- result:
+None
+None
+None
+-- !result
+select SUBSTR('STARROCKS', v, id) from t1;
+-- result:
+None
+None
+None
+-- !result
+select SUBSTRING('', v) from t1;
+-- result:
+None
+None
+None
+-- !result
+select SUBSTRING('', v, id) from t1;
+-- result:
+None
+None
+None
+-- !result
+select SUBSTRING('STARROCKS', v, id) from t1;
+-- result:
+None
+None
+None
+-- !result

--- a/test/sql/test_function/T/test_substr
+++ b/test/sql/test_function/T/test_substr
@@ -1,0 +1,23 @@
+-- name: test_substr
+
+create table t1 (id int, v bigint) distributed by hash(id) properties ("replication_num" = "1");
+
+select SUBSTR('', 9223372036854775807) ;
+select SUBSTR('', 9223372036854775807, 465254298) ;
+select SUBSTR('', -9223372036854775807, 465254298) ;
+select SUBSTR('', 9223372036854775806, 465254298) ;
+
+select SUBSTRING('', 9223372036854775807) ;
+select SUBSTRING('', 9223372036854775807, 465254298) ;
+select SUBSTRING('', -9223372036854775807, 465254298) ;
+select SUBSTRING('', 9223372036854775806, 465254298) ;
+
+insert into t1 values(1, 9223372036854775807), (2, -9223372036854775807), (3, 9223372036854775806);
+
+select SUBSTR('', v) from t1;
+select SUBSTR('', v, id) from t1;
+select SUBSTR('STARROCKS', v, id) from t1;
+
+select SUBSTRING('', v) from t1;
+select SUBSTRING('', v, id) from t1;
+select SUBSTRING('STARROCKS', v, id) from t1;


### PR DESCRIPTION
Why I'm doing:

`substring/substr` only supports int type as argument, when it meets overflow long value, it throws exception below:

> Unexpected exception: Number out of range[0]. type: INT


What I'm doing:
- Fix error message when substr/substring meets illegal interger
- Add more illegal tests

Fixes #3196

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
