### PR TITLE
[Enhancement][Cherry-Pick] Automatically create partition table to support insert overwrite by partition name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ListPartitionInfo;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
@@ -228,21 +229,49 @@ public class InsertOverwriteJobRunner {
             return;
         }
         OlapTable olapTable = (OlapTable) insertStmt.getTargetTable();
+        List<List<String>> partitionValues = Lists.newArrayList();
         if (!olapTable.getPartitionInfo().isAutomaticPartition()) {
             return;
         }
-        List<Expr> partitionColValues = insertStmt.getTargetPartitionNames().getPartitionColValues();
-        List<List<String>> partitionValues = Lists.newArrayList();
-        // Currently we only support overwriting one partition at a time
-        List<String> firstValues = Lists.newArrayList();
-        partitionValues.add(firstValues);
-        for (Expr expr : partitionColValues) {
-            if (expr instanceof LiteralExpr) {
-                firstValues.add(((LiteralExpr) expr).getStringValue());
-            } else {
-                throw new SemanticException("Only support literal value for partition column.");
+
+        if (insertStmt.isSpecifyPartitionNames())  {
+            List<String> partitionNames = insertStmt.getTargetPartitionNames().getPartitionNames();
+            PartitionInfo partitionInfo = olapTable.getPartitionInfo();
+            for (String partitionName : partitionNames) {
+                Partition partition = olapTable.getPartition(partitionName);
+                if (partition == null) {
+                    throw new RuntimeException("Partition '" + partitionName
+                            + "' does not exist in table '" + olapTable.getName() + "'.");
+                }
+                if (partitionInfo instanceof ListPartitionInfo) {
+                    ListPartitionInfo listPartitionInfo = (ListPartitionInfo) partitionInfo;
+                    List<List<LiteralExpr>> lists = listPartitionInfo.getMultiLiteralExprValues().get(partition.getId());
+                    for (List<LiteralExpr> list : lists) {
+                        List<String> values = Lists.newArrayList();
+                        for (LiteralExpr literalExpr : list) {
+                            values.add(literalExpr.getStringValue());
+                        }
+                        partitionValues.add(values);
+                    }
+                } else {
+                    throw new RuntimeException("Specify the partition name, and automatically create partition names. " +
+                            "Currently, only List partitions are supported.");
+                }
+            }
+        } else {
+            List<Expr> partitionColValues = insertStmt.getTargetPartitionNames().getPartitionColValues();
+            // Currently we only support overwriting one partition at a time
+            List<String> firstValues = Lists.newArrayList();
+            partitionValues.add(firstValues);
+            for (Expr expr : partitionColValues) {
+                if (expr instanceof LiteralExpr) {
+                    firstValues.add(((LiteralExpr) expr).getStringValue());
+                } else {
+                    throw new SemanticException("Only support literal value for partition column.");
+                }
             }
         }
+
         try {
             addPartitionClause = AnalyzerUtils.getAddPartitionClauseFromPartitionValues(olapTable, partitionValues);
         } catch (AnalysisException ex) {
@@ -270,7 +299,9 @@ public class InsertOverwriteJobRunner {
         }
         for (String partitionColName : partitionColNames) {
             Partition partition = olapTable.getPartition(partitionColName);
-            sourcePartitionIds.add(partition.getId());
+            if (!sourcePartitionIds.contains(partition.getId())) {
+                sourcePartitionIds.add(partition.getId());
+            }
         }
     }
 


### PR DESCRIPTION
Why I'm doing:

// Insert overwrite with specified partition
mysql> insert overwrite t_recharge_detail2 partition(p20231102_MenloPark) values (1, 2, 1.1, "Menlo Park", "2023-11-02");
ERROR 1064 (HY000): com.starrocks.common.DdlException: () size should be equal to partition column size

What I'm doing:

support this.

Fixes #34777

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
