### PR TITLE
[Enhancement] add logic of replay TransactionStateBatch to be compatible

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -224,6 +224,7 @@ public class OperationType {
     public static final short OP_SAVE_TRANSACTION_ID = 104;
     public static final short OP_SAVE_AUTO_INCREMENT_ID = 105;
     public static final short OP_DELETE_AUTO_INCREMENT_ID = 106;
+    public static final short OP_UPSERT_TRANSACTION_STATE_BATCH = 108;
 
     // routine load 110~120
     @Deprecated

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -707,6 +707,15 @@ public class GlobalTransactionMgr implements Writable {
         }
     }
 
+    public void replayUpsertTransactionStateBatch(TransactionStateBatch transactionStateBatch) {
+        try {
+            DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(transactionStateBatch.getDbId());
+            dbTransactionMgr.replayUpsertTransactionStateBatch(transactionStateBatch);
+        } catch (AnalysisException e) {
+            LOG.warn("replay upsert transaction batch[" + transactionStateBatch + "] failed", e);
+        }
+    }
+
     public void replayDeleteTransactionState(TransactionState transactionState) {
         try {
             DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(transactionState.getDbId());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -90,4 +90,11 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             }
         }
     }
+
+    public void applyVisibleLogBatch(TransactionStateBatch txnStateBatch, Database db) {
+        for (TransactionState txnState : txnStateBatch.getTransactionStates()) {
+            TableCommitInfo tableCommitInfo = txnState.getTableCommitInfo(txnStateBatch.getTableId());
+            applyVisibleLog(txnState, tableCommitInfo, db);
+        }
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -1,0 +1,130 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.UserException;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.lake.compaction.Quantiles;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class TransactionStateBatch implements Writable {
+
+    private static final Logger LOG = LogManager.getLogger(TransactionStateBatch.class);
+
+    @SerializedName("transactionStates")
+    List<TransactionState> transactionStates = new ArrayList<>();
+
+    public TransactionStateBatch() {
+    }
+    public TransactionStateBatch(List<TransactionState> transactionStates) {
+        this.transactionStates = transactionStates;
+    }
+
+    public void setCompactionScore(long tableId, long partitionId, Quantiles quantiles) {
+        transactionStates.stream().forEach(transactionState -> transactionState.getTableCommitInfo(tableId).
+                getPartitionCommitInfo(partitionId).setCompactionScore(quantiles));
+    }
+
+    public void setTransactionVisibleInfo() {
+        for (TransactionState transactionState : transactionStates) {
+            transactionState.setFinishTime(System.currentTimeMillis());
+            transactionState.clearErrorMsg();
+            transactionState.setNewFinish();
+            transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
+            transactionState.notifyVisible();
+        }
+    }
+
+    public void setTransactionStatus(TransactionStatus transactionStatus) {
+        for (TransactionState state : transactionStates) {
+            state.setTransactionStatus(transactionStatus);
+        }
+    }
+
+    // a proxy method
+    public void afterVisible(TransactionStatus transactionStatus, boolean txnOperated) {
+        for (TransactionState transactionState : transactionStates) {
+            // after status changed
+            TxnStateChangeCallback callback = GlobalStateMgr.getCurrentGlobalTransactionMgr()
+                    .getCallbackFactory().getCallback(transactionState.getCallbackId());
+            if (callback != null) {
+                if (Objects.requireNonNull(transactionStatus) == TransactionStatus.VISIBLE) {
+                    callback.afterVisible(transactionState, txnOperated);
+                }
+            }
+        }
+    }
+
+    // all transctionState in TransactionStateBatch have the same dbId
+    public long getDbId() {
+        if (transactionStates.size() != 0) {
+            return transactionStates.get(0).getDbId();
+        }
+        return -1;
+    }
+
+    public List<Long> getTxnIds() {
+        return transactionStates.stream().map(state -> state.getTransactionId()).collect(Collectors.toList());
+    }
+
+    public long getTableId() {
+        if (transactionStates.size() != 0) {
+            return transactionStates.get(0).getTableIdList().get(0);
+        }
+        return -1;
+    }
+
+    public long size() {
+        return transactionStates.size();
+    }
+
+    public TransactionState index(int index) throws UserException {
+        if (index < 0 || index >= transactionStates.size()) {
+            throw new UserException("index out of bound");
+        }
+        return transactionStates.get(index);
+    }
+
+    public List<TransactionState> getTransactionStates() {
+        return transactionStates;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static TransactionStateBatch read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), TransactionStateBatch.class);
+    }
+
+    @Override
+    public String toString() {
+        return transactionStates.toString();
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.UserException;
+import com.starrocks.thrift.TUniqueId;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class TransactionStateBatchTest {
+    private static String fileName = "./TransactionStateBatchTest";
+
+    @After
+    public void tearDown() {
+        File file = new File(fileName);
+        file.delete();
+    }
+
+    @Test
+    public void testSerDe() throws IOException, UserException {
+        // 1. Write objects to file
+        File file = new File(fileName);
+        file.createNewFile();
+        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
+
+        Long dbId = 1000L;
+        Long tableId = 20000L;
+        UUID uuid = UUID.randomUUID();
+        List<TransactionState> transactionStateList = new ArrayList<TransactionState>();
+        TransactionState transactionState1 = new TransactionState(dbId, Lists.newArrayList(tableId),
+                3000, "label1", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
+                60 * 1000L);
+        uuid = UUID.randomUUID();
+        TransactionState transactionState2 = new TransactionState(dbId, Lists.newArrayList(tableId),
+                3001, "label2", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
+                60 * 1000L);
+        transactionStateList.add(transactionState1);
+        transactionStateList.add(transactionState2);
+
+        TransactionStateBatch stateBatch = new TransactionStateBatch(transactionStateList);
+        stateBatch.write(out);
+        out.flush();
+        out.close();
+
+        // 2. Read objects from file
+        DataInputStream in = new DataInputStream(new FileInputStream(file));
+        TransactionStateBatch readTransactionStateBatch = TransactionStateBatch.read(in);
+
+        Assert.assertEquals(readTransactionStateBatch.getTableId(), tableId.longValue());
+        Assert.assertEquals(2, readTransactionStateBatch.getTxnIds().size());
+
+        TransactionState state = readTransactionStateBatch.index(0);
+        Assert.assertEquals(state.getTransactionId(), 3000L);
+        Assert.assertEquals(state.getTransactionId(), transactionState1.getTransactionId());
+        Assert.assertEquals(state.getDbId(), dbId.longValue());
+
+        readTransactionStateBatch.setTransactionStatus(TransactionStatus.VISIBLE);
+        Assert.assertEquals(TransactionStatus.VISIBLE, state.getTransactionStatus());
+
+        in.close();
+    }
+
+}


### PR DESCRIPTION
Why I'm doing:

PR #28789 introduce a new type of editLog about transaction, this pr is to keep compatible in case downgrade to branch 3.1

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
