### PR TITLE
[BugFix] fix lake pk table compaction when compaction state cache not exist

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -531,8 +531,8 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     uint32_t max_src_rssid = max_rowset_id + input_rowset->segments_size() - 1;
 
     // 2. update primary index, and generate delete info.
-    TRACE_COUNTER_INCREMENT("output_rowsets_size", compaction_state.pk_cols.size());
-    for (size_t i = 0; i < compaction_state.pk_cols.size(); i++) {
+    TRACE_COUNTER_INCREMENT("output_rowsets_size", output_rowset->num_segments());
+    for (size_t i = 0; i < output_rowset->num_segments(); i++) {
         RETURN_IF_ERROR(compaction_state.load_segments(output_rowset.get(), this, tablet_schema, i));
         TRACE_COUNTER_INCREMENT("state_bytes", compaction_state.memory_usage());
         auto& pk_col = compaction_state.pk_cols[i];
@@ -677,6 +677,13 @@ bool UpdateManager::TEST_check_compaction_cache_absent(uint32_t tablet_id, int64
     } else {
         _compaction_cache.release(compaction_entry);
         return false;
+    }
+}
+
+void UpdateManager::TEST_remove_compaction_cache(uint32_t tablet_id, int64_t txn_id) {
+    auto compaction_entry = _compaction_cache.get(cache_key(tablet_id, txn_id));
+    if (compaction_entry != nullptr) {
+        _compaction_cache.remove(compaction_entry);
     }
 }
 

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -118,6 +118,7 @@ public:
 
     bool TEST_check_update_state_cache_absent(uint32_t tablet_id, int64_t txn_id);
     bool TEST_check_compaction_cache_absent(uint32_t tablet_id, int64_t txn_id);
+    void TEST_remove_compaction_cache(uint32_t tablet_id, int64_t txn_id);
 
     Status update_primary_index_memory_limit(int32_t update_memory_limit_percent) {
         int64_t byte_limits = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());


### PR DESCRIPTION
Why I'm doing:
Because when BE restart, compaction state cache is not exist, and `compaction_state.pk_cols` will be empty. Then publish compaction will miss to update pk index.

What I'm doing:
Fix this issue, 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
