### PR TITLE
[BugFix][branch-3.1] fix ut introduced in backport of 34915

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/HiveTableFactory.java
@@ -49,8 +49,7 @@ public class HiveTableFactory extends ExternalTableFactory {
                 .setPartitionColumnNames(catalogTable.getPartitionColumnNames())
                 .setDataColumnNames(catalogTable.getDataColumnNames())
                 .setTableLocation(catalogTable.getTableLocation())
-                .setCreateTime(catalogTable.getCreateTime())
-                .setProperties(catalogTable.getProperties());
+                .setCreateTime(catalogTable.getCreateTime());
     }
 
     @Override


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

Fixed bad cp of this pr: https://github.com/StarRocks/starrocks/pull/34915

As you can see, old code does not call `setProperties`.

![img_v3_0256_0a3bb20d-c011-467f-b3d2-b893386b6cag](https://github.com/StarRocks/starrocks/assets/1081215/1a406c0a-666c-492f-85e2-a4cd15c6dee2)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
