### PR TITLE
[Enhancement] improve cte transform performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -251,7 +251,8 @@ public class QueryAnalyzer {
                 if (tableName != null && Strings.isNullOrEmpty(tableName.getDb())) {
                     Optional<CTERelation> withQuery = scope.getCteQueries(tableName.getTbl());
                     if (withQuery.isPresent()) {
-                        CTERelation cteRelation = withQuery.get();
+                        CTERelation withRelation = withQuery.get();
+                        withRelation.addTableRef();
                         RelationFields withRelationFields = withQuery.get().getRelationFields();
                         ImmutableList.Builder<Field> outputFields = ImmutableList.builder();
 
@@ -268,9 +269,9 @@ public class QueryAnalyzer {
                         // eg: with w as (select * from t0) select v1,sum(v2) from w group by v1 " +
                         //                "having v1 in (select v3 from w where v2 = 2)
                         // cte used in outer query and sub-query can't use same relation-id and field
-                        CTERelation newCteRelation = new CTERelation(cteRelation.getCteMouldId(), tableName.getTbl(),
-                                cteRelation.getColumnOutputNames(),
-                                cteRelation.getCteQueryStatement());
+                        CTERelation newCteRelation = new CTERelation(withRelation.getCteMouldId(), tableName.getTbl(),
+                                withRelation.getColumnOutputNames(),
+                                withRelation.getCteQueryStatement());
                         newCteRelation.setAlias(tableRelation.getAlias());
                         newCteRelation.setResolvedInFromClause(true);
                         newCteRelation.setScope(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CTERelation.java
@@ -24,6 +24,7 @@ public class CTERelation extends Relation {
     private final String name;
     private final QueryStatement cteQueryStatement;
     private boolean resolvedInFromClause;
+    private int refs = 0; // consume refs
 
     public CTERelation(int cteMouldId, String name, List<String> columnOutputNames,
                        QueryStatement cteQueryStatement) {
@@ -37,6 +38,7 @@ public class CTERelation extends Relation {
         this.name = name;
         this.explicitColumnNames = columnOutputNames;
         this.cteQueryStatement = cteQueryStatement;
+        this.refs = 0;
     }
 
     public int getCteMouldId() {
@@ -53,6 +55,14 @@ public class CTERelation extends Relation {
 
     public void setResolvedInFromClause(boolean resolvedInFromClause) {
         this.resolvedInFromClause = resolvedInFromClause;
+    }
+
+    public void addTableRef() {
+        refs++;
+    }
+
+    public int getRefs() {
+        return refs;
     }
 
     public boolean isResolvedInFromClause() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/CTETransformerContext.java
@@ -29,10 +29,13 @@ public class CTETransformerContext {
     private final Map<Integer, Integer> cteRefIdMapping;
     private final AtomicInteger uniqueId;
 
-    public CTETransformerContext() {
+    private final int cteMaxLimit;
+
+    public CTETransformerContext(int cteMaxLimit) {
         this.cteExpressions = new HashMap<>();
         this.cteRefIdMapping = new HashMap<>();
         this.uniqueId = new AtomicInteger();
+        this.cteMaxLimit = cteMaxLimit;
     }
 
     public CTETransformerContext(CTETransformerContext other) {
@@ -42,6 +45,7 @@ public class CTETransformerContext {
         // must use one instance
         this.cteRefIdMapping = other.cteRefIdMapping;
         this.uniqueId = other.uniqueId;
+        this.cteMaxLimit = other.cteMaxLimit;
     }
 
     public Map<Integer, ExpressionMapping> getCteExpressions() {
@@ -84,13 +88,21 @@ public class CTETransformerContext {
      *  CTEAnchor2 and CTEAnchor2-1 are from same CTE (with x2), but have different cteID
      *  So, generate the cteID everytime on one CTE instance.
      */
-    public int registerCteRef(int cteMouldId) {
+    public int registerCte(int cteMouldId) {
         cteRefIdMapping.put(cteMouldId, uniqueId.incrementAndGet());
         return cteRefIdMapping.get(cteMouldId);
+    }
+
+    public boolean hasRegisteredCte(int cteMouldId) {
+        return cteRefIdMapping.containsKey(cteMouldId);
     }
 
     public int getCurrentCteRef(int cteMouldId) {
         Preconditions.checkState(cteRefIdMapping.containsKey(cteMouldId));
         return cteRefIdMapping.get(cteMouldId);
+    }
+
+    public boolean isForceInline() {
+        return cteRefIdMapping.size() > cteMaxLimit;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/RelationTransformer.java
@@ -144,7 +144,7 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
     public RelationTransformer(ColumnRefFactory columnRefFactory, ConnectContext session) {
         this(columnRefFactory, session,
                 new ExpressionMapping(new Scope(RelationId.anonymous(), new RelationFields())),
-                new CTETransformerContext());
+                new CTETransformerContext(session.getSessionVariable().getCboCTEMaxLimit()));
     }
 
     public RelationTransformer(ColumnRefFactory columnRefFactory, ConnectContext session, ExpressionMapping outer,
@@ -172,10 +172,15 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
     }
 
     public LogicalPlan transform(Relation relation) {
-        OptExprBuilder optExprBuilder;
         if (relation instanceof QueryRelation && !((QueryRelation) relation).getCteRelations().isEmpty()) {
-            Pair<OptExprBuilder, OptExprBuilder> cteRootAndMostDeepAnchor =
-                    buildCTEAnchorAndProducer((QueryRelation) relation);
+            QueryRelation queryRelation = (QueryRelation) relation;
+            if (queryRelation.getCteRelations().stream().noneMatch(c -> c.getRefs() > 1)) {
+                // all cte is only referenced once, no need to reuse
+                return visit(relation);
+            }
+
+            OptExprBuilder optExprBuilder;
+            Pair<OptExprBuilder, OptExprBuilder> cteRootAndMostDeepAnchor = buildCTEAnchorAndProducer(queryRelation);
             optExprBuilder = cteRootAndMostDeepAnchor.first;
             LogicalPlan logicalPlan = visit(relation);
             cteRootAndMostDeepAnchor.second.addChild(logicalPlan.getRootBuilder());
@@ -189,7 +194,11 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
         OptExprBuilder root = null;
         OptExprBuilder anchorOptBuilder = null;
         for (CTERelation cteRelation : node.getCteRelations()) {
-            int cteId = cteContext.registerCteRef(cteRelation.getCteMouldId());
+            if (cteRelation.getRefs() <= 1 || cteContext.isForceInline()) {
+                continue;
+            }
+
+            int cteId = cteContext.registerCte(cteRelation.getCteMouldId());
             LogicalCTEAnchorOperator anchorOperator = new LogicalCTEAnchorOperator(cteId);
             LogicalCTEProduceOperator produceOperator = new LogicalCTEProduceOperator(cteId);
             LogicalPlan producerPlan =
@@ -590,6 +599,15 @@ public class RelationTransformer extends AstVisitor<LogicalPlan, ExpressionMappi
 
     @Override
     public LogicalPlan visitCTE(CTERelation node, ExpressionMapping context) {
+        if (!cteContext.hasRegisteredCte(node.getCteMouldId())) {
+            // doesn't register CTE, should inline directly
+            LogicalPlan childPlan = transform(node.getCteQueryStatement().getQueryRelation());
+            OptExprBuilder builder = new OptExprBuilder(childPlan.getRoot().getOp(),
+                    childPlan.getRootBuilder().getInputs(),
+                    new ExpressionMapping(node.getScope(), childPlan.getOutputColumn()));
+            return new LogicalPlan(builder, childPlan.getOutputColumn(), childPlan.getCorrelation());
+        }
+
         int cteId = cteContext.getCurrentCteRef(node.getCteMouldId());
         ExpressionMapping expressionMapping = cteContext.getCteExpressions().get(cteId);
         Map<ColumnRefOperator, ColumnRefOperator> cteOutputColumnRefMap = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2796,7 +2796,7 @@ public class PlanFragmentBuilder {
                     cteFragment.getPlanRoot(), DistributionSpec.DistributionType.SHUFFLE);
 
             exchangeNode.setReceiveColumns(consume.getCteOutputColumnRefMap().values().stream()
-                    .map(ColumnRefOperator::getId).collect(Collectors.toList()));
+                    .map(ColumnRefOperator::getId).distinct().collect(Collectors.toList()));
             exchangeNode.setDataPartition(cteFragment.getDataPartition());
 
             exchangeNode.setNumInstances(cteFragment.getPlanRoot().getNumInstances());

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RuntimeFilterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RuntimeFilterTest.java
@@ -103,20 +103,20 @@ public class RuntimeFilterTest {
         System.out.println(plan);
         Assert.assertTrue(plan, plan.contains("  4:Project\n" +
                 "  |  output columns:\n" +
-                "  |  66 <-> [66: k1, DATE, true]\n" +
-                "  |  78 <-> [78: k13, DECIMAL128(27,9), true]\n" +
+                "  |  14 <-> [14: k1, DATE, true]\n" +
+                "  |  26 <-> [26: k13, DECIMAL128(27,9), true]\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  3:OlapScanNode\n" +
                 "     table: duplicate_par_tbl, rollup: duplicate_par_tbl\n" +
                 "     preAggregation: on\n" +
-                "     Predicates: 68: k3 IN ('beijing', '')\n" +
+                "     Predicates: 16: k3 IN ('beijing', '')\n" +
                 "     partitionsRatio=1/3, tabletsRatio=3/3\n" +
                 "     tabletList=10010,10012,10014\n" +
                 "     actualRows=0, avgRowSize=3.0\n" +
                 "     cardinality: 1\n" +
                 "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (78: k13)\n" +
+                "     - filter_id = 0, probe_expr = (26: k13)\n" +
                 "\n" +
                 "PLAN FRAGMENT 7(F00)"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -474,16 +474,16 @@ public class SelectStmtTest {
                 {"with t1 as (select count(distinct k1, k2) as a, count(distinct k3) as b from db1.tbl1 " +
                         "group by k2, k3, k4) select * from t1 limit 1",
                         "14:Project\n" +
-                                "  |  <slot 11> : 11: count\n" +
-                                "  |  <slot 12> : 12: count\n" +
+                                "  |  <slot 5> : 5: count\n" +
+                                "  |  <slot 6> : 6: count\n" +
                                 "  |  limit: 1\n" +
                                 "  |  \n" +
                                 "  13:HASH JOIN\n" +
                                 "  |  join op: INNER JOIN (BUCKET_SHUFFLE(S))\n" +
                                 "  |  colocate: false, reason: \n" +
-                                "  |  equal join conjunct: 14: k2 <=> 17: k2\n" +
-                                "  |  equal join conjunct: 15: k3 <=> 18: k3\n" +
-                                "  |  equal join conjunct: 16: k4 <=> 19: k4\n" +
+                                "  |  equal join conjunct: 8: k2 <=> 11: k2\n" +
+                                "  |  equal join conjunct: 9: k3 <=> 12: k3\n" +
+                                "  |  equal join conjunct: 10: k4 <=> 13: k4\n" +
                                 "  |  limit: 1"
                 }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -652,16 +652,16 @@ public class TrinoQueryTest extends TrinoTestBase {
     @Test
     public void testSelectCTE() throws Exception {
         String sql = "with c1(a,b,c) as (select * from t0) select c1.* from c1";
-        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+        assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
 
         sql = "with c1(a,b,c) as (select * from t0) select t.* from c1 t";
-        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+        assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
 
         sql = "with c1 as (select * from t0) select c1.* from c1";
-        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+        assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
 
         sql = "with c1 as (select * from t0) select a.* from c1 a";
-        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
+        assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
 
         sql = "with c1(a,b,c) as (select * from t0), c2 as (select * from t1) select c2.*,t.* from c1 t,c2";
         assertPlanContains(sql, "3:NESTLOOP JOIN");
@@ -671,16 +671,16 @@ public class TrinoQueryTest extends TrinoTestBase {
         assertPlanContains(sql, "4:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 7: v1 = 10: v4");
+                "  |  equal join conjunct: 1: v1 = 4: v4");
 
         sql = "with cte1 as ( with cte1 as (select * from t0) select * from cte1) select * from cte1";
-        assertPlanContains(sql, "10: v1 | 11: v2 | 12: v3");
+        assertPlanContains(sql, "1: v1 | 2: v2 | 3: v3");
 
         sql = "with cte1 as (select * from test.t0), cte2 as (select * from cte1) select * from cte1";
-        assertPlanContains(sql, "7: v1 | 8: v2 | 9: v3");
+        assertPlanContains(sql, "4: v1 | 5: v2 | 6: v3");
 
         sql = "with cte1(c1,c2) as (select v1,v2 from test.t0) select c1,c2 from cte1";
-        assertPlanContains(sql, "4: v1 | 5: v2");
+        assertPlanContains(sql, "1: v1 | 2: v2");
 
         sql = "with x0 as (select * from t0), x1 as (select * from t1) " +
                 "select * from (select * from x0 union all select * from x1 union all select * from x0) tt;";
@@ -695,7 +695,7 @@ public class TrinoQueryTest extends TrinoTestBase {
         assertPlanContains(sql, "4:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 7: v4 = 10: v1");
+                "  |  equal join conjunct: 1: v4 = 4: v1");
 
         sql = "with x0 as (select * from t0) " +
                 "select * from x0 x,t1 y where v1 in (select v2 from x0 z where z.v1 = x.v1)";

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/SelectStmtWithCaseWhenTest.java
@@ -684,8 +684,8 @@ class SelectStmtWithCaseWhenTest {
                         "if (ship_code >= 1 and ship_code <= 4, 1, 0) as layer1," +
                         "if(ship_code is null or ship_code < 1, 1, 0) as layer2 from t0) " +
                         "select * from tmp where layer2 = 1 and layer0 != 1 and layer1 !=1",
-                        "(13: ship_code IS NULL) OR (13: ship_code < 1), if[([13: ship_code, INT, true] > 4, 1, 0)",
-                        "if[((13: ship_code >= 1) AND (13: ship_code <= 4), 1, 0)"
+                        "(5: ship_code IS NULL) OR (5: ship_code < 1), if[([5: ship_code, INT, true] > 4, 1, 0)",
+                        "if[((5: ship_code >= 1) AND (5: ship_code <= 4), 1, 0)"
                 },
 
                 {"select * from test.t0 where nullif('China', region) = 'China'", "[1: region, VARCHAR, false] != 'China'"},

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -376,7 +376,7 @@ public class ArrayTypeTest extends PlanTestBase {
                 "`argument_003`, `argument_004`) AS `source_target_005` from CASE_006;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 14> : array_map(<slot 5> -> 1, 8: c1)");
+                "  |  <slot 10> : array_map(<slot 5> -> 1, 2: c1)");
 
         sql = "WITH `CASE_006` AS\n" +
                 "  (SELECT array_map((arg_001) -> (arg_001), `c1`) AS `argument_003`,\n" +
@@ -387,7 +387,7 @@ public class ArrayTypeTest extends PlanTestBase {
                 "`argument_003`, `argument_004`) AS `source_target_005` from CASE_006;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 14> : array_map(<slot 5> -> CAST(<slot 5> AS DOUBLE) + 1.0, 8: c1)");
+                "  |  <slot 10> : array_map(<slot 5> -> CAST(<slot 5> AS DOUBLE) + 1.0, 2: c1)");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1446,9 +1446,9 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         assertContains(plan, "  3:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (COLOCATE)\n" +
                 "  |  colocate: true\n" +
-                "  |  equal join conjunct: [19: d_datekey, INT, true] = [36: d_datekey, INT, true]\n" +
+                "  |  equal join conjunct: [1: d_datekey, INT, true] = [18: d_datekey, INT, true]\n" +
                 "  |  build runtime filters:\n" +
-                "  |  - filter_id = 0, build_expr = (36: d_datekey), remote = false\n" +
+                "  |  - filter_id = 0, build_expr = (18: d_datekey), remote = false\n" +
                 "  |  cardinality: 2300\n" +
                 "  |  \n" +
                 "  |----2:AGGREGATE (update finalize)");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -639,7 +639,7 @@ public class ExpressionTest extends PlanTestBase {
                 "`argument_003`, `argument_004`) AS `source_target_005` from CASE_006;";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 14> : array_map(<slot 5> -> 1, 8: c1)");
+                "  |  <slot 10> : array_map(<slot 5> -> 1, 2: c1)");
 
         sql = "WITH `CASE_006` AS\n" +
                 "  (SELECT array_map((arg_001) -> (arg_001), `c1`) AS `argument_003`,\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -650,7 +650,7 @@ public class ExpressionTest extends PlanTestBase {
                 "`argument_003`, `argument_004`) AS `source_target_005` from CASE_006;";
         plan = getFragmentPlan(sql);
         assertContains(plan, "  |  common expressions:\n" +
-                "  |  <slot 14> : array_map(<slot 5> -> CAST(<slot 5> AS DOUBLE) + 1.0, 8: c1)");
+                "  |  <slot 10> : array_map(<slot 5> -> CAST(<slot 5> AS DOUBLE) + 1.0, 2: c1)");
 
         sql = "SELECT uid, times, actions, step0_time, step1_time, array_filter((x, y)->(y = '支付' AND (x BETWEEN " +
                 "step1_time AND date_add(step1_time, INTERVAL 90 MINUTE)) AND (step1_time <> '2020-01-01 00:00:00')" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveSubfieldPrunePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HiveSubfieldPrunePlanTest.java
@@ -30,6 +30,6 @@ public class HiveSubfieldPrunePlanTest extends PlanTestBase {
         String sql = "with stream as (select array_agg(col_struct.c0) as t1 from hive0.subfield_db.subfield group by " +
                 "col_int) select t1 from stream";
         String plan = getVerboseExplain(sql);
-        assertContains(plan, "Pruned type: 6 [col_struct] <-> [struct<c0 int(11)>]");
+        assertContains(plan, "Pruned type: 2 [col_struct] <-> [struct<c0 int(11)>]");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -1138,12 +1138,12 @@ public class JoinTest extends PlanTestBase {
         String sql = "WITH t_temp AS (select join1.id as id1, " +
                 "join2.id as id2 from join1 join join2 on join1.id = join2.id) select * from t_temp";
         String explainString = getFragmentPlan(sql);
-        Assert.assertTrue(explainString.contains("equal join conjunct: 8: id = 11: id"));
-        Assert.assertTrue(explainString.contains("  |----2:EXCHANGE\n" +
+        Assert.assertTrue(explainString, explainString.contains("equal join conjunct: 2: id = 5: id"));
+        Assert.assertTrue(explainString, explainString.contains("  |----2:EXCHANGE\n" +
                 "  |    \n" +
                 "  0:OlapScanNode\n" +
                 "     TABLE: join1"));
-        Assert.assertTrue(explainString.contains("  1:OlapScanNode\n" +
+        Assert.assertTrue(explainString, explainString.contains("  1:OlapScanNode\n" +
                 "     TABLE: join2\n" +
                 "     PREAGGREGATION: ON"));
     }
@@ -1707,21 +1707,21 @@ public class JoinTest extends PlanTestBase {
         assertContains(plan, "  6:HASH JOIN\n" +
                 "  |  join op: RIGHT OUTER JOIN (PARTITIONED)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 8: expr = 11: expr");
+                "  |  equal join conjunct: 2: expr = 5: expr");
         assertContains(plan, "  4:Project\n" +
-                "  |  <slot 11> : 2\n" +
-                "  |  <slot 12> : 'mike'\n" +
+                "  |  <slot 5> : 2\n" +
+                "  |  <slot 6> : 'mike'\n" +
                 "  |  \n" +
                 "  3:UNION\n" +
                 "     constant exprs: \n" +
                 "         NULL");
         assertContains(plan, "  1:Project\n" +
-                "  |  <slot 8> : 1\n" +
-                "  |  <slot 9> : 'newzland'\n" +
+                "  |  <slot 2> : 1\n" +
+                "  |  <slot 3> : 'newzland'\n" +
                 "  |  \n" +
                 "  0:UNION\n" +
                 "     constant exprs: \n" +
-                "         NULL");
+                "         NULL\n");
     }
 
     @Test
@@ -2719,7 +2719,7 @@ public class JoinTest extends PlanTestBase {
         assertContains(plan, "21:NESTLOOP JOIN\n" +
                 "  |  join op: LEFT SEMI JOIN\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  other join predicates: 19: v4 = 1");
+                "  |  other join predicates: 13: v4 = 1");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest.java
@@ -262,13 +262,13 @@ public class LowCardinalityTest extends PlanTestBase {
 
         String plan = getVerboseExplain(sql);
         Assert.assertTrue(plan, plan.contains("  3:Decode\n" +
-                "  |  <dict id 98> : <string id 66>\n" +
+                "  |  <dict id 50> : <string id 18>\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  2:AGGREGATE (update finalize)\n" +
-                "  |  aggregate: max[([97: L_COMMENT, INT, false]);" +
-                " args: INT; result: INT; args nullable: false; result nullable: true]\n" +
-                "  |  group by: [63: L_SHIPMODE, CHAR, false]\n" +
+                "  |  aggregate: max[([49: L_COMMENT, INT, false]); args: INT; result: INT; " +
+                "args nullable: false; result nullable: true]\n" +
+                "  |  group by: [15: L_SHIPMODE, CHAR, false]\n" +
                 "  |  cardinality: 1\n" +
                 "  |  \n" +
                 "  1:OlapScanNode\n" +
@@ -280,7 +280,7 @@ public class LowCardinalityTest extends PlanTestBase {
                 "     actualRows=0, avgRowSize=54.0\n" +
                 "     cardinality: 1\n" +
                 "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (63: L_SHIPMODE)\n"));
+                "     - filter_id = 0, probe_expr = (15: L_SHIPMODE)"));
     }
 
     @Test
@@ -1822,14 +1822,14 @@ public class LowCardinalityTest extends PlanTestBase {
                 "    );";
 
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "6:Project\n" +
-                "  |  <slot 22> : 22\n" +
-                "  |  <slot 37> : if(31: S_ADDRESS IN ('hz', 'bj'), 22, CAST(if(31: S_ADDRESS = 'hz', " +
-                "1035, 32: S_NATIONKEY) AS VARCHAR))\n" +
-                "  |  <slot 38> : if(30: S_NAME = '', 31: S_ADDRESS, NULL)\n" +
+        assertContains(plan, "  6:Project\n" +
+                "  |  <slot 4> : 4\n" +
+                "  |  <slot 19> : if(13: S_ADDRESS IN ('hz', 'bj'), 4, " +
+                "CAST(if(13: S_ADDRESS = 'hz', 1035, 14: S_NATIONKEY) AS VARCHAR))\n" +
+                "  |  <slot 20> : if(12: S_NAME = '', 13: S_ADDRESS, NULL)\n" +
                 "  |  \n" +
                 "  5:Decode\n" +
-                "  |  <dict id 40> : <string id 22>");
+                "  |  <dict id 22> : <string id 4>");
     }
 
     @Test
@@ -1863,13 +1863,13 @@ public class LowCardinalityTest extends PlanTestBase {
                 "    );";
 
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "6:Project\n" +
-                "  |  <slot 37> : if(31: S_ADDRESS IN ('hz', 'bj'), 22, CAST(if(31: S_ADDRESS = 'hz', 1035, " +
-                "32: S_NATIONKEY) AS VARCHAR))\n" +
-                "  |  <slot 38> : if(30: S_NAME = '', 31: S_ADDRESS, NULL)\n" +
+        assertContains(plan, "  6:Project\n" +
+                "  |  <slot 19> : if(13: S_ADDRESS IN ('hz', 'bj'), 4, " +
+                "CAST(if(13: S_ADDRESS = 'hz', 1035, 14: S_NATIONKEY) AS VARCHAR))\n" +
+                "  |  <slot 20> : if(12: S_NAME = '', 13: S_ADDRESS, NULL)\n" +
                 "  |  \n" +
                 "  5:Decode\n" +
-                "  |  <dict id 40> : <string id 22>");
+                "  |  <dict id 22> : <string id 4>");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -2050,23 +2050,23 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             plan = getFragmentPlan(sql);
             assertContains(plan, "  6:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 11: v2, 13: max\n" +
-                    "  |  order by: 13: max ASC\n" +
+                    "  |  partition by: 2: v2, 4: max\n" +
+                    "  |  order by: 4: max ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  5:SORT\n" +
-                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 4> 4: max ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  4:PARTITION-TOP-N\n" +
-                    "  |  partition by: 11: v2 , 13: max \n" +
+                    "  |  partition by: 2: v2 , 4: max \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 4> 4: max ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  3:AGGREGATE (merge finalize)\n" +
-                    "  |  output: max(13: max)\n" +
-                    "  |  group by: 11: v2\n" +
+                    "  |  output: max(4: max)\n" +
+                    "  |  group by: 2: v2\n" +
                     "  |  \n" +
                     "  2:EXCHANGE");
 
@@ -2075,25 +2075,25 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "w2 as (select v2, max_v1, row_number() over(partition by v2, max_v1 order by max_v1) as rn from w1) " +
                     "select * from w2 order by rn, v2 limit 2";
             plan = getFragmentPlan(sql);
-            assertContains(plan, "6:ANALYTIC\n" +
+            assertContains(plan, "  6:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 11: v2, 13: max\n" +
-                    "  |  order by: 13: max ASC\n" +
+                    "  |  partition by: 2: v2, 4: max\n" +
+                    "  |  order by: 4: max ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  5:SORT\n" +
-                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 4> 4: max ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  4:PARTITION-TOP-N\n" +
-                    "  |  partition by: 11: v2 , 13: max \n" +
+                    "  |  partition by: 2: v2 , 4: max \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 11> 11: v2 ASC, <slot 13> 13: max ASC\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 4> 4: max ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  3:AGGREGATE (merge finalize)\n" +
-                    "  |  output: max(13: max)\n" +
-                    "  |  group by: 11: v2\n" +
+                    "  |  output: max(4: max)\n" +
+                    "  |  group by: 2: v2\n" +
                     "  |  \n" +
                     "  2:EXCHANGE");
         }
@@ -2107,19 +2107,19 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             plan = getFragmentPlan(sql);
             assertContains(plan, "  7:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 13: max\n" +
-                    "  |  order by: 11: v2 ASC\n" +
+                    "  |  partition by: 4: max\n" +
+                    "  |  order by: 2: v2 ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  6:SORT\n" +
-                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  order by: <slot 4> 4: max ASC, <slot 2> 2: v2 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  5:EXCHANGE");
             assertContains(plan, "  4:PARTITION-TOP-N\n" +
-                    "  |  partition by: 13: max \n" +
+                    "  |  partition by: 4: max \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  order by: <slot 4> 4: max ASC, <slot 2> 2: v2 ASC\n" +
                     "  |  offset: 0");
 
             sql = "with " +
@@ -2129,19 +2129,19 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             plan = getFragmentPlan(sql);
             assertContains(plan, "  7:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 13: max\n" +
-                    "  |  order by: 11: v2 ASC\n" +
+                    "  |  partition by: 4: max\n" +
+                    "  |  order by: 2: v2 ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  6:SORT\n" +
-                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  order by: <slot 4> 4: max ASC, <slot 2> 2: v2 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  5:EXCHANGE");
             assertContains("  4:PARTITION-TOP-N\n" +
-                    "  |  partition by: 13: max \n" +
+                    "  |  partition by: 4: max \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 13> 13: max ASC, <slot 11> 11: v2 ASC\n" +
+                    "  |  order by: <slot 4> 4: max ASC, <slot 2> 2: v2 ASC\n" +
                     "  |  offset: 0");
         }
 
@@ -2151,22 +2151,22 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "select * from w1 where rn = 2";
             plan = getFragmentPlan(sql);
             assertContains(plan, "  4:SELECT\n" +
-                    "  |  predicates: 8: row_number() = 2\n" +
+                    "  |  predicates: 4: row_number() = 2\n" +
                     "  |  \n" +
                     "  3:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 5: v1, 6: v2\n" +
-                    "  |  order by: 7: v3 ASC\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  order by: 3: v3 ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  2:SORT\n" +
-                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  1:PARTITION-TOP-N\n" +
-                    "  |  partition by: 5: v1 , 6: v2 \n" +
+                    "  |  partition by: 1: v1 , 2: v2 \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
@@ -2175,24 +2175,24 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "select * from w1 order by rn, v1 limit 2";
             plan = getFragmentPlan(sql);
             assertContains(plan, "  4:TOP-N\n" +
-                    "  |  order by: <slot 8> 8: row_number() ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  order by: <slot 4> 4: row_number() ASC, <slot 1> 1: v1 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  limit: 2\n" +
                     "  |  \n" +
                     "  3:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 5: v1, 6: v2\n" +
-                    "  |  order by: 7: v3 ASC\n" +
+                    "  |  partition by: 1: v1, 2: v2\n" +
+                    "  |  order by: 3: v3 ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  2:SORT\n" +
-                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  1:PARTITION-TOP-N\n" +
-                    "  |  partition by: 5: v1 , 6: v2 \n" +
+                    "  |  partition by: 1: v1 , 2: v2 \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 5> 5: v1 ASC, <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC\n" +
+                    "  |  order by: <slot 1> 1: v1 ASC, <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
@@ -2204,23 +2204,23 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "select * from w1 where rn = 2";
             plan = getFragmentPlan(sql);
             assertContains(plan, "  5:SELECT\n" +
-                    "  |  predicates: 8: row_number() = 2\n" +
+                    "  |  predicates: 4: row_number() = 2\n" +
                     "  |  \n" +
                     "  4:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 6: v2, 7: v3\n" +
-                    "  |  order by: 5: v1 ASC\n" +
+                    "  |  partition by: 2: v2, 3: v3\n" +
+                    "  |  order by: 1: v1 ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  3:SORT\n" +
-                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
-                    "  2:EXCHANGE\n");
+                    "  2:EXCHANGE");
             assertContains(plan, "  1:PARTITION-TOP-N\n" +
-                    "  |  partition by: 6: v2 , 7: v3 \n" +
+                    "  |  partition by: 2: v2 , 3: v3 \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
@@ -2229,27 +2229,24 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "select * from w1 order by rn, v1 limit 2";
             plan = getFragmentPlan(sql);
             assertContains(plan, "  5:TOP-N\n" +
-                    "  |  order by: <slot 8> 8: row_number() ASC, <slot 5> 5: v1 ASC\n" +
+                    "  |  order by: <slot 4> 4: row_number() ASC, <slot 1> 1: v1 ASC\n" +
                     "  |  offset: 0\n" +
                     "  |  limit: 2\n" +
                     "  |  \n" +
                     "  4:ANALYTIC\n" +
                     "  |  functions: [, row_number(), ]\n" +
-                    "  |  partition by: 6: v2, 7: v3\n" +
-                    "  |  order by: 5: v1 ASC\n" +
+                    "  |  partition by: 2: v2, 3: v3\n" +
+                    "  |  order by: 1: v1 ASC\n" +
                     "  |  window: ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW\n" +
                     "  |  \n" +
                     "  3:SORT\n" +
-                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
-                    "  |  offset: 0\n" +
-                    "  |  \n");
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
+                    "  |  offset: 0");
             assertContains(plan, "  1:PARTITION-TOP-N\n" +
-                    "  |  partition by: 6: v2 , 7: v3 \n" +
+                    "  |  partition by: 2: v2 , 3: v3 \n" +
                     "  |  partition limit: 2\n" +
-                    "  |  order by: <slot 6> 6: v2 ASC, <slot 7> 7: v3 ASC, <slot 5> 5: v1 ASC\n" +
-                    "  |  offset: 0\n" +
-                    "  |  \n" +
-                    "  0:OlapScanNode");
+                    "  |  order by: <slot 2> 2: v2 ASC, <slot 3> 3: v3 ASC, <slot 1> 1: v1 ASC\n" +
+                    "  |  offset: 0");
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -85,10 +85,10 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 "  |    \n" +
                 "  18:UNION\n" +
                 "  |  output exprs:\n" +
-                "  |      [391, INT, true] | [392, DECIMAL64(7,2), true]\n" +
+                "  |      [321, INT, true] | [322, DECIMAL64(7,2), true]\n" +
                 "  |  child exprs:\n" +
-                "  |      [325: ws_sold_date_sk, INT, true] | [346: ws_ext_sales_price, DECIMAL64(7,2), true]\n" +
-                "  |      [359: cs_sold_date_sk, INT, true] | [380: cs_ext_sales_price, DECIMAL64(7,2), true]\n" +
+                "  |      [255: ws_sold_date_sk, INT, true] | [276: ws_ext_sales_price, DECIMAL64(7,2), true]\n" +
+                "  |      [289: cs_sold_date_sk, INT, true] | [310: cs_ext_sales_price, DECIMAL64(7,2), true]\n" +
                 "  |  pass-through-operands: all\n" +
                 "  |  cardinality: 194398472\n" +
                 "  |  column statistics: \n" +
@@ -117,48 +117,18 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         // Check the size of the left and right tables
         Assert.assertTrue(replayPair.second, replayPair.second.contains("51:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
-                "  |  other join predicates: cast([934: d_month_seq, INT, true] as BIGINT) <= [1017: expr, BIGINT, true]\n" +
+                "  |  other join predicates: cast([208: d_month_seq, INT, true] as BIGINT) <= [291: expr, BIGINT, true]\n" +
                 "  |  cardinality: 18262\n" +
                 "  |  column statistics: \n" +
                 "  |  * d_date_sk-->[2415022.0, 2488070.0, 0.0, 4.0, 18262.25] ESTIMATE\n" +
                 "  |  * d_month_seq-->[0.0, 2400.0, 0.0, 4.0, 2398.0] ESTIMATE\n" +
-                "  |  * expr-->[3.0, 2403.0, 0.0, 8.0, 30.13572607260726] ESTIMATE\n" +
-                "  |  \n" +
-                "  |----50:EXCHANGE\n" +
-                "  |       distribution type: BROADCAST\n" +
-                "  |       cardinality: 1\n" +
-                "  |    \n" +
-                "  42:Project\n" +
-                "  |  output columns:\n" +
-                "  |  931 <-> [931: d_date_sk, INT, false]\n" +
-                "  |  934 <-> [934: d_month_seq, INT, true]\n" +
-                "  |  cardinality: 36525\n" +
-                "  |  column statistics: \n" +
-                "  |  * d_date_sk-->[2415022.0, 2488070.0, 0.0, 4.0, 36524.5] ESTIMATE\n" +
-                "  |  * d_month_seq-->[0.0, 2400.0, 0.0, 4.0, 2398.0] ESTIMATE\n" +
-                "  |  \n" +
-                "  41:NESTLOOP JOIN\n" +
-                "  |  join op: INNER JOIN\n" +
-                "  |  other join predicates: cast([934: d_month_seq, INT, true] as BIGINT) >= [987: expr, BIGINT, true]\n" +
-                "  |  cardinality: 36525\n" +
-                "  |  column statistics: \n" +
-                "  |  * d_date_sk-->[2415022.0, 2488070.0, 0.0, 4.0, 36524.5] ESTIMATE\n" +
-                "  |  * d_month_seq-->[0.0, 2400.0, 0.0, 4.0, 2398.0] ESTIMATE\n" +
-                "  |  * expr-->[1.0, 2401.0, 0.0, 8.0, 30.13572607260726] ESTIMATE\n" +
-                "  |  \n" +
-                "  |----40:EXCHANGE\n" +
-                "  |       distribution type: BROADCAST\n" +
-                "  |       cardinality: 1\n" +
-                "  |    \n" +
-                "  32:OlapScanNode\n" +
-                "     table: date_dim, rollup: date_dim"));
-        Assert.assertTrue(replayPair.second, replayPair.second.contains("|----18:EXCHANGE\n" +
+                "  |  * expr-->[3.0, 2403.0, 0.0, 8.0, 30.13572607260726] ESTIMATE\n"));
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("  |----18:EXCHANGE\n" +
                 "  |       distribution type: SHUFFLE\n" +
-                "  |       partition exprs: [796: cs_bill_customer_sk, INT, true]\n" +
+                "  |       partition exprs: [70: cs_bill_customer_sk, INT, true]\n" +
                 "  |       cardinality: 6304\n" +
                 "  |    \n" +
-                "  2:OlapScanNode\n" +
-                "     table: customer, rollup: customer"));
+                "  2:OlapScanNode"));
     }
 
     @Test
@@ -174,12 +144,12 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 "    RANDOM\n" +
                 "\n" +
                 "  40:Project\n" +
-                "  |  <slot 171> : 171: c_customer_sk\n" +
+                "  |  <slot 99> : 99: c_customer_sk\n" +
                 "  |  \n" +
                 "  39:NESTLOOP JOIN\n" +
                 "  |  join op: INNER JOIN\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  other join predicates: CAST(190: sum AS DOUBLE) > CAST(0.5 * 262: max AS DOUBLE)"));
+                "  |  other join predicates: CAST(118: sum AS DOUBLE) > CAST(0.5 * 190: max AS DOUBLE)"));
     }
 
 
@@ -210,17 +180,17 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(getDumpInfoFromFile("query_dump/tpcds78"));
         Assert.assertTrue(replayPair.second, replayPair.second.contains("3:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  equal join conjunct: [257: ss_ticket_number, INT, false] = [280: sr_ticket_number, INT, true]\n" +
-                "  |  equal join conjunct: [256: ss_item_sk, INT, false] = [279: sr_item_sk, INT, true]\n" +
-                "  |  other predicates: 280: sr_ticket_number IS NULL\n" +
-                "  |  output columns: 256, 258, 260, 266, 267, 269, 280\n" +
+                "  |  equal join conjunct: [2: ss_ticket_number, INT, false] = [25: sr_ticket_number, INT, true]\n" +
+                "  |  equal join conjunct: [1: ss_item_sk, INT, false] = [24: sr_item_sk, INT, true]\n" +
+                "  |  other predicates: 25: sr_ticket_number IS NULL\n" +
+                "  |  output columns: 1, 3, 5, 11, 12, 14, 25\n" +
                 "  |  cardinality: 37372757"));
         Assert.assertTrue(replayPair.second, replayPair.second.contains("15:HASH JOIN\n" +
                 "  |  join op: LEFT OUTER JOIN (BUCKET_SHUFFLE)\n" +
-                "  |  equal join conjunct: [331: ws_order_number, INT, false] = [365: wr_order_number, INT, true]\n" +
-                "  |  equal join conjunct: [330: ws_item_sk, INT, false] = [364: wr_item_sk, INT, true]\n" +
-                "  |  other predicates: 365: wr_order_number IS NULL\n" +
-                "  |  output columns: 330, 332, 335, 348, 349, 351, 365\n" +
+                "  |  equal join conjunct: [76: ws_order_number, INT, false] = [110: wr_order_number, INT, true]\n" +
+                "  |  equal join conjunct: [75: ws_item_sk, INT, false] = [109: wr_item_sk, INT, true]\n" +
+                "  |  other predicates: 110: wr_order_number IS NULL\n" +
+                "  |  output columns: 75, 77, 80, 93, 94, 96, 110\n" +
                 "  |  cardinality: 7914602"));
     }
 
@@ -269,23 +239,22 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/tpcds54_with_join_hint"), null, TExplainLevel.NORMAL);
         // checkout join order as hint
-        Assert.assertTrue(replayPair.second, replayPair.second.contains(" 19:HASH JOIN\n" +
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("  19:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 729: ss_sold_date_sk = 750: d_date_sk\n" +
+                "  |  equal join conjunct: 3: ss_sold_date_sk = 24: d_date_sk\n" +
                 "  |  \n" +
                 "  |----18:EXCHANGE\n" +
                 "  |    \n" +
-                "  0:OlapScanNode\n" +
-                "     TABLE: store_sales"));
+                "  0:OlapScanNode"));
     }
 
     @Test
     public void testTPCDS64() throws Exception {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/tpcds64"), null, TExplainLevel.NORMAL);
-        Assert.assertTrue(replayPair.second, replayPair.second.contains(" 83:SELECT\n" +
-                "  |  predicates: 521: d_year = 1999"));
+        Assert.assertTrue(replayPair.second, replayPair.second.contains("  83:SELECT\n" +
+                "  |  predicates: 457: d_year = 1999"));
     }
 
     @Test
@@ -785,15 +754,15 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
 
         // tbl_mock_015
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 1, probe_expr = (37: mock_004)"));
+                "     - filter_id = 1, probe_expr = (1: mock_004)"));
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 3, probe_expr = (60: mock_004)"));
+                "     - filter_id = 3, probe_expr = (24: mock_004)"));
 
         // table: tbl_mock_001, rollup: tbl_mock_001
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (37: mock_004)"));
+                "     - filter_id = 0, probe_expr = (1: mock_004)"));
         Assert.assertTrue(plan, plan.contains("probe runtime filters:\n" +
-                "     - filter_id = 4, probe_expr = (60: mock_004)"));
+                "     - filter_id = 4, probe_expr = (24: mock_004)"));
 
     }
 
@@ -805,8 +774,8 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
         Assert.assertTrue(replayPair.second, replayPair.second.contains("  4:HASH JOIN\n" +
                 "  |  join op: INNER JOIN (COLOCATE)\n" +
                 "  |  colocate: true\n" +
-                "  |  equal join conjunct: 109: mock_007 = 46: mock_007\n" +
-                "  |  equal join conjunct: 153: any_value = 86: mock_008\n" +
+                "  |  equal join conjunct: 64: mock_007 = 1: mock_007\n" +
+                "  |  equal join conjunct: 108: any_value = 41: mock_008\n" +
                 "  |  \n" +
                 "  |----3:OlapScanNode\n" +
                 "  |       TABLE: tbl_mock_024"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UDFTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UDFTest.java
@@ -104,7 +104,7 @@ public class UDFTest extends PlanTestBase {
         PhysicalTableFunctionOperator tp = (PhysicalTableFunctionOperator) getExecPlan(sql).getPhysicalPlan().getOp();
 
         Assert.assertEquals(3, tp.getFnParamColumnRefs().size());
-        Assert.assertEquals("[6, 8, 8]",
+        Assert.assertEquals("[2, 4, 4]",
                 tp.getFnParamColumnRefs().stream().map(ColumnRefOperator::getId).collect(Collectors.toList()).toString());
 
         sql = "select * from tarray, unnest(v3, v3)";
@@ -121,7 +121,7 @@ public class UDFTest extends PlanTestBase {
                 "select unnest.a, unnest.b from t, unnest(a, b) as unnest(a, b);";
         tp = (PhysicalTableFunctionOperator) getExecPlan(sql).getPhysicalPlan().getOp();
         Assert.assertEquals(2, tp.getFnParamColumnRefs().size());
-        Assert.assertEquals("[8, 8]",
+        Assert.assertEquals("[4, 4]",
                 tp.getFnParamColumnRefs().stream().map(ColumnRefOperator::getId).collect(Collectors.toList()).toString());
     }
 

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/select.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/select.sql
@@ -74,13 +74,13 @@ AGGREGATE ([GLOBAL] aggregate [{}] group by [[1: v1, 2: v2, 3: v3]] having [null
 [sql]
 with t0 as (select * from t1) select * from test.t0
 [result]
-SCAN (columns[4: v1, 5: v2, 6: v3] predicate[null])
+SCAN (columns[1: v1, 2: v2, 3: v3] predicate[null])
 [end]
 
 [sql]
 with t0 as (select * from t1) select * from t0
 [result]
-SCAN (columns[4: v4, 5: v5, 6: v6] predicate[null])
+SCAN (columns[1: v4, 2: v5, 3: v6] predicate[null])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/set-operation.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/set-operation.sql
@@ -72,9 +72,9 @@ INTERSECT
 with testC (v) as (select v1 from t0 union all select v4 from t1 union all select v7 from t2) select * from testC;
 [result]
 UNION
-    SCAN (columns[11: v1] predicate[null])
-    SCAN (columns[14: v4] predicate[null])
-    SCAN (columns[17: v7] predicate[null])
+    SCAN (columns[1: v1] predicate[null])
+    SCAN (columns[4: v4] predicate[null])
+    SCAN (columns[7: v7] predicate[null])
 [end]
 
 [sql]

--- a/fe/fe-core/src/test/resources/sql/scheduler/union/union_ungather.sql
+++ b/fe/fe-core/src/test/resources/sql/scheduler/union/union_ungather.sql
@@ -4,7 +4,7 @@ with
     w2 as (select * from w1 UNION ALL select * from w1)
 select /*+SET_VAR(cbo_cte_reuse=true,cbo_cte_reuse_rate=0)*/ count(1) from w2 group by L_SUPPKEY
 [scheduler]
-PLAN FRAGMENT 0(F04)
+    PLAN FRAGMENT 0(F04)
   DOP: 16
   INSTANCES
     INSTANCE(0-F04#0)
@@ -40,21 +40,20 @@ PLAN FRAGMENT 4(F00)
       SCAN RANGES
         0:OlapScanNode
           1. partitionID=1001,tabletID=1006
-
 [fragment]
 PLAN FRAGMENT 0
- OUTPUT EXPRS:120: count
-  PARTITION: HASH_PARTITIONED: 105: L_SUPPKEY
+ OUTPUT EXPRS:69: count
+  PARTITION: HASH_PARTITIONED: 54: L_SUPPKEY
 
   RESULT SINK
 
   12:Project
-  |  <slot 120> : 120: count
-  |  
+  |  <slot 69> : 69: count
+  |
   11:AGGREGATE (merge finalize)
-  |  output: count(120: count)
-  |  group by: 105: L_SUPPKEY
-  |  
+  |  output: count(69: count)
+  |  group by: 54: L_SUPPKEY
+  |
   10:EXCHANGE
 
 PLAN FRAGMENT 1
@@ -62,18 +61,18 @@ PLAN FRAGMENT 1
   PARTITION: RANDOM
 
   STREAM DATA SINK
-    EXCHANGE ID: 10
-    HASH_PARTITIONED: 105: L_SUPPKEY
+  EXCHANGE ID: 10
+  HASH_PARTITIONED: 54: L_SUPPKEY
 
   9:AGGREGATE (update serialize)
   |  STREAMING
   |  output: count(1)
-  |  group by: 105: L_SUPPKEY
-  |  
+  |  group by: 54: L_SUPPKEY
+  |
   2:UNION
-  |  
+  |
   |----8:EXCHANGE
-  |    
+  |
   5:EXCHANGE
 
 PLAN FRAGMENT 2
@@ -85,8 +84,8 @@ PLAN FRAGMENT 2
     RANDOM
 
   7:Project
-  |  <slot 88> : 3: L_SUPPKEY
-  |  
+  |  <slot 37> : 3: L_SUPPKEY
+  |
   6:EXCHANGE
 
 PLAN FRAGMENT 3
@@ -98,8 +97,8 @@ PLAN FRAGMENT 3
     RANDOM
 
   4:Project
-  |  <slot 71> : 3: L_SUPPKEY
-  |  
+  |  <slot 20> : 3: L_SUPPKEY
+  |
   3:EXCHANGE
 
 PLAN FRAGMENT 4

--- a/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
+++ b/fe/fe-core/src/test/resources/sql/subquery/scalar-subquery.sql
@@ -485,21 +485,18 @@ INNER JOIN (join-predicate [2: v2 = 10: v8 AND 8: sum = 12: sum] post-join-predi
 [sql]
 select v1 from t0 where v2 = (with cte as (select v4,v5 from t1 order by 2 limit 10) select v4 from cte order by 1 limit 1)
 [result]
-INNER JOIN (join-predicate [2: v2 = 7: v4] post-join-predicate [null])
+INNER JOIN (join-predicate [2: v2 = 4: v4] post-join-predicate [null])
     SCAN (columns[1: v1, 2: v2] predicate[2: v2 IS NOT NULL])
     EXCHANGE BROADCAST
-        PREDICATE 7: v4 IS NOT NULL
+        PREDICATE 4: v4 IS NOT NULL
             ASSERT LE 1
                 EXCHANGE GATHER
-                    TOP-N (order by [[7: v4 ASC NULLS FIRST]])
-                        TOP-N (order by [[8: v5 ASC NULLS FIRST]])
-                            TOP-N (order by [[8: v5 ASC NULLS FIRST]])
-                                SCAN (columns[7: v4, 8: v5] predicate[null])
+                    TOP-N (order by [[4: v4 ASC NULLS FIRST]])
+                        TOP-N (order by [[5: v5 ASC NULLS FIRST]])
+                            TOP-N (order by [[5: v5 ASC NULLS FIRST]])
+                                SCAN (columns[4: v4, 5: v5] predicate[null])
 [end]
 
-/* test PushDownApplyAggFilterRule */
-/* test PushDownApplyAggFilterRule */
-/* test PushDownApplyAggFilterRule */
 /* test PushDownApplyAggFilterRule */
 
 [sql]


### PR DESCRIPTION
Why I'm doing:
in transform phase, sr will generate inline plan and reuse plan, like

```
                 CTEAnchor
                /         \
        CTEProducer       Join
        /              /         \
    Scan(A)   CTEConsume(1)     CTEConsume(2)
                    |               |
                  Scan(A)         Scan(A)
```

but it's too slow when has a lot CTEs, the time costs about O(2^n), if has nested-CTE, the time costs will be O(n^n)

What I'm doing:

* inline only onece referenced cte in transformer phase
* inline cte when the numbers of cte exceeds the limit

in 75-CTE case, cost 25s -> 4s

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
