### PR TITLE
[BugFix] Fix partition prune for str2date materialized views with in predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -567,13 +567,11 @@ public class PartitionUtil {
         if (partitionColumnFilter == null || partitionColumn == null) {
             return false;
         }
-        LiteralExpr lowerBound = partitionColumnFilter.getLowerBound();
-        LiteralExpr upperBound = partitionColumnFilter.getUpperBound();
-        LiteralExpr literalExpr = (lowerBound == null) ? upperBound : lowerBound;
-        if (literalExpr == null) {
+        Type filterType = partitionColumnFilter.getFilterType();
+        if (filterType == null) {
             return false;
         }
-        return isConvertToDate(partitionColumn.getType(), literalExpr.getType());
+        return isConvertToDate(partitionColumn.getType(), filterType);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PartitionColumnFilter.java
@@ -39,12 +39,13 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
 import com.starrocks.analysis.InPredicate;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.PartitionKey;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.connector.PartitionUtil;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.PartitionValue;
-import com.starrocks.catalog.Column;
-import com.starrocks.catalog.PartitionKey;
-import com.starrocks.common.AnalysisException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -169,6 +170,22 @@ public class PartitionColumnFilter {
         return null;
     }
 
+    public Type getFilterType() {
+        if (lowerBound != null) {
+            return lowerBound.getType();
+        }
+        if (upperBound != null) {
+            return upperBound.getType();
+        }
+        if (inPredicate != null) {
+            return inPredicate.getChild(0).getType();
+        }
+        if (inPredicateLiterals != null && !inPredicateLiterals.isEmpty()) {
+            return inPredicateLiterals.get(0).getType();
+        }
+        return null;
+    }
+
     @Override
     public String toString() {
         String str = "";
@@ -188,6 +205,11 @@ public class PartitionColumnFilter {
             str += "\ninPredicate is UNSET";
         } else {
             str += "\ninPredicate is " + inPredicate;
+        }
+        if (null == inPredicateLiterals || inPredicateLiterals.isEmpty()) {
+            str += "\ninPredicateLiterals is UNSET";
+        } else {
+            str += "\ninPredicateLiterals is " + inPredicateLiterals;
         }
         return str;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
@@ -82,7 +82,11 @@ public class RangePartitionPruner implements PartitionPruner {
         LOG.debug("column idx {}, column filters {}", columnIdx, partitionColumnFilters);
         // the last column in partition Key
         if (columnIdx == partitionColumns.size()) {
-            return Lists.newArrayList(rangeMap.subRangeMap(Range.closed(minKey, maxKey)).asMapOfRanges().values());
+            try {
+                return Lists.newArrayList(rangeMap.subRangeMap(Range.closed(minKey, maxKey)).asMapOfRanges().values());
+            } catch (IllegalArgumentException e) {
+                return Lists.newArrayList();
+            }
         }
         // no filter in this column
         Column keyColumn = partitionColumns.get(columnIdx);
@@ -174,8 +178,14 @@ public class RangePartitionPruner implements PartitionPruner {
                 pushMaxCount++;
             }
 
-            List<Long> result = Lists.newArrayList(rangeMap.subRangeMap(
-                    Range.range(minKey, lowerType, maxKey, upperType)).asMapOfRanges().values());
+            List<Long> result;
+            try {
+                result = Lists.newArrayList(rangeMap.subRangeMap(
+                        Range.range(minKey, lowerType, maxKey, upperType)).asMapOfRanges().values());
+            } catch (IllegalArgumentException e) {
+                result = Lists.newArrayList();
+            }
+
             for (; pushMinCount > 0; pushMinCount--) {
                 minKey.popColumn();
             }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/RangePartitionPruner.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.planner;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Range;
@@ -81,11 +82,7 @@ public class RangePartitionPruner implements PartitionPruner {
         LOG.debug("column idx {}, column filters {}", columnIdx, partitionColumnFilters);
         // the last column in partition Key
         if (columnIdx == partitionColumns.size()) {
-            try {
-                return Lists.newArrayList(rangeMap.subRangeMap(Range.closed(minKey, maxKey)).asMapOfRanges().values());
-            } catch (IllegalArgumentException e) {
-                return Lists.newArrayList();
-            }
+            return Lists.newArrayList(rangeMap.subRangeMap(Range.closed(minKey, maxKey)).asMapOfRanges().values());
         }
         // no filter in this column
         Column keyColumn = partitionColumns.get(columnIdx);
@@ -113,9 +110,10 @@ public class RangePartitionPruner implements PartitionPruner {
         }
 
         boolean isConvertToDate = PartitionUtil.isConvertToDate(keyColumn, filter);
-        if (null == inPredicateLiterals || inPredicateLiterals.size() * complex > inPredicateMaxLen) {
-            LiteralExpr lowerBound = filter.getLowerBound();
-            LiteralExpr upperBound = filter.getUpperBound();
+        LiteralExpr lowerBound = filter.getLowerBound();
+        LiteralExpr upperBound = filter.getUpperBound();
+        if (null == inPredicateLiterals || ((lowerBound != null || upperBound != null) &&
+                inPredicateLiterals.size() * complex > inPredicateMaxLen)) {
             if (filter.lowerBoundInclusive && filter.upperBoundInclusive
                     && lowerBound != null && upperBound != null
                     && 0 == lowerBound.compareLiteral(upperBound)) {
@@ -176,14 +174,8 @@ public class RangePartitionPruner implements PartitionPruner {
                 pushMaxCount++;
             }
 
-            List<Long> result;
-            try {
-                result = Lists.newArrayList(rangeMap.subRangeMap(
-                        Range.range(minKey, lowerType, maxKey, upperType)).asMapOfRanges().values());
-            } catch (IllegalArgumentException e) {
-                result = Lists.newArrayList();
-            }
-
+            List<Long> result = Lists.newArrayList(rangeMap.subRangeMap(
+                    Range.range(minKey, lowerType, maxKey, upperType)).asMapOfRanges().values());
             for (; pushMinCount > 0; pushMinCount--) {
                 minKey.popColumn();
             }
@@ -195,8 +187,16 @@ public class RangePartitionPruner implements PartitionPruner {
         Set<Long> resultSet = Sets.newHashSet();
         int newComplex = inPredicateLiterals.size() * complex;
         for (LiteralExpr expr : inPredicateLiterals) {
-            minKey.pushColumn(expr, keyColumn.getPrimitiveType());
-            maxKey.pushColumn(expr, keyColumn.getPrimitiveType());
+            if (isConvertToDate) {
+                LiteralExpr convertExpr = PartitionUtil.convertToDateLiteral(expr);
+                Preconditions.checkState(convertExpr.getType().equals(keyColumn.getType()));
+                minKey.pushColumn(convertExpr, keyColumn.getPrimitiveType());
+                maxKey.pushColumn(convertExpr, keyColumn.getPrimitiveType());
+            } else {
+                Preconditions.checkState(expr.getType().equals(keyColumn.getType()));
+                minKey.pushColumn(expr, keyColumn.getPrimitiveType());
+                maxKey.pushColumn(expr, keyColumn.getPrimitiveType());
+            }
             Collection<Long> subList = prune(rangeMap, columnIdx + 1, minKey, maxKey, newComplex);
             resultSet.addAll(subList);
             minKey.popColumn();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/OptOlapPartitionPruner.java
@@ -179,7 +179,6 @@ public class OptOlapPartitionPruner {
             if (null != lowerBound) {
                 lowerBind = false;
                 PartitionKey min = new PartitionKey();
-                // TODO: take care `isConvertToDate` for olap table
                 min.pushColumn(pcf.getLowerBound(), column.getPrimitiveType());
                 int cmp = minRange.compareTo(min);
                 if (cmp > 0 || (0 == cmp && pcf.lowerBoundInclusive)) {
@@ -190,7 +189,6 @@ public class OptOlapPartitionPruner {
             if (null != upperBound) {
                 upperBind = false;
                 PartitionKey max = new PartitionKey();
-                // TODO: take care `isConvertToDate` for olap table
                 max.pushColumn(upperBound, column.getPrimitiveType());
                 int cmp = maxRange.compareTo(max);
                 if (cmp < 0 || (0 == cmp && pcf.upperBoundInclusive)) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -312,4 +312,314 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
 
         starRocksAssert.dropMaterializedView(mvName);
     }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_PartitionPrune1() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d='2023-08-01';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d in ('2023-08-01');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d in ('2023-08-01', '2023-08-02');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02')\n" +
+                    "     partitions=2/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                    "     partitions=3/3");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d not in ('2023-08-01', '2023-08-02');";
+            String plan = getFragmentPlan(query);
+            // TODO: no partition prune
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 4: d NOT IN ('2023-08-01', '2023-08-02')\n" +
+                    "     partitions=3/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d >= '2023-08-01' and d < '2023-08-02';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where cast(d as date) >= '2023-08-01'";
+            String plan = getFragmentPlan(query);
+            // TODO: no partition prune
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: CAST(4: d AS DATE) >= '2023-08-01'\n" +
+                    "     partitions=3/3");
+        }
+
+        connectContext.getSessionVariable().setRangePrunerPredicateMaxLen(0);
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d in ('2023-08-01');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d in ('2023-08-01', '2023-08-02');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02')\n" +
+                    "     partitions=2/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  count(*) from " + mvName +
+                    " where d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 4: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                    "     partitions=3/3");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_PartitionPrune2() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.a, t2.b, t3.c, t1.d " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d ;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803", "p20230803_20230804"), partitions);
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d='2023-08-01';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d in ('2023-08-01');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d in ('2023-08-01', '2023-08-02');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02')\n" +
+                    "     partitions=2/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                    "     partitions=3/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d not in ('2023-08-01', '2023-08-02');";
+            String plan = getFragmentPlan(query);
+            // TODO: no partition prune
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: ((16: d < '2023-08-01') OR ((16: d > '2023-08-01') AND " +
+                    "(16: d < '2023-08-02'))) OR (16: d > '2023-08-02')\n" +
+                    "     partitions=3/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d >= '2023-08-01' and t1.d < '2023-08-02';";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where cast(t1.d as date) >= '2023-08-01'";
+            String plan = getFragmentPlan(query);
+            // TODO: no partition prune
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: CAST(16: d AS DATE) >= '2023-08-01'\n" +
+                    "     partitions=3/3");
+        }
+
+        connectContext.getSessionVariable().setRangePrunerPredicateMaxLen(0);
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d in ('2023-08-01');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d in ('2023-08-01', '2023-08-02');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02')\n" +
+                    "     partitions=2/3");
+        }
+
+        {
+            String query = "select  t1.a, t2.b, t3.c, t1.d \n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d in ('2023-08-01', '2023-08-02', '2023-08-03');";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 16: d IN ('2023-08-01', '2023-08-02', '2023-08-03')\n" +
+                    "     partitions=3/3");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
 }


### PR DESCRIPTION
Why I'm doing:

Query with partitioned mv which is created by `str2date` will return wrong result when it meets `in-predicates`.

This is because the mv has a string date type partition column and a date type partition key which may be not handled in partition pruner.

![36641016-809e-4998-9185-64fa54d9e3f3](https://github.com/StarRocks/starrocks/assets/5104975/995dfcb3-4d04-4fe5-93f6-7c46f6f1dc8d)


What I'm doing:
- Try to convert query expr into date type from strong type when it is not in `inPredicate` optimization.
- Not use `inPredicate` optimization when the partition filter does not contain lower-bound and upper-bound.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
