### PR TITLE
[Enhancement] Avoid lock when get the length of pipeline block queue (#33721)

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -148,6 +148,7 @@ void PipelineDriverPoller::run_internal() {
 void PipelineDriverPoller::add_blocked_driver(const DriverRawPtr driver) {
     std::unique_lock<std::mutex> lock(_global_mutex);
     _blocked_drivers.push_back(driver);
+    _blocked_driver_queue_len++;
     driver->_pending_timer_sw->reset();
     _cond.notify_one();
 }
@@ -156,6 +157,7 @@ void PipelineDriverPoller::remove_blocked_driver(DriverList& local_blocked_drive
     auto& driver = *driver_it;
     driver->_pending_timer->update(driver->_pending_timer_sw->elapsed_time());
     local_blocked_drivers.erase(driver_it++);
+    _blocked_driver_queue_len--;
 }
 
 void PipelineDriverPoller::iterate_immutable_driver(const IterateImmutableDriverFunc& call) const {

--- a/be/src/exec/pipeline/pipeline_driver_poller.h
+++ b/be/src/exec/pipeline/pipeline_driver_poller.h
@@ -24,24 +24,20 @@ public:
             : _driver_queue(driver_queue),
               _polling_thread(nullptr),
               _is_polling_thread_initialized(false),
-              _is_shutdown(false) {}
+              _is_shutdown(false),
+              _blocked_driver_queue_len(0) {}
 
     using DriverList = std::list<DriverRawPtr>;
 
     ~PipelineDriverPoller() { shutdown(); };
-    // start poller thread
     void start();
-    // shutdown poller thread
     void shutdown();
     // add blocked driver to poller
     void add_blocked_driver(const DriverRawPtr driver);
     // remove blocked driver from poller
     void remove_blocked_driver(DriverList& local_blocked_drivers, DriverList::iterator& driver_it);
     // only used for collect metrics
-    size_t blocked_driver_queue_len() const {
-        std::shared_lock guard(_local_mutex);
-        return _local_blocked_drivers.size();
-    }
+    size_t blocked_driver_queue_len() const { return _blocked_driver_queue_len; }
 
     void iterate_immutable_driver(const IterateImmutableDriverFunc& call) const;
 
@@ -50,7 +46,6 @@ private:
     PipelineDriverPoller(const PipelineDriverPoller&) = delete;
     PipelineDriverPoller& operator=(const PipelineDriverPoller&) = delete;
 
-private:
     mutable std::mutex _global_mutex;
     std::condition_variable _cond;
     DriverList _blocked_drivers;
@@ -62,6 +57,8 @@ private:
     scoped_refptr<Thread> _polling_thread;
     std::atomic<bool> _is_polling_thread_initialized;
     std::atomic<bool> _is_shutdown;
+
+    std::atomic<size_t> _blocked_driver_queue_len;
 };
 } // namespace pipeline
 } // namespace starrocks


### PR DESCRIPTION
backport #33721 