### PR TITLE
[Enhancement] Optimize the inner-join performance of nest-loop-join when the right table is relatively small

### DIFF
--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -186,8 +186,50 @@ void NLJoinProbeOperator::_reset_build_chunk_index() {
     _move_build_chunk_index(0);
 }
 
-void NLJoinProbeOperator::_next_build_chunk_index() {
+void NLJoinProbeOperator::_next_build_chunk_index_for_other_join() {
     _move_build_chunk_index(_curr_build_chunk_index + 1);
+}
+
+// probe one chunk from right
+void NLJoinProbeOperator::_next_probe_row_index_for_inner_join() {
+    // next probe row
+    _probe_row_current++;
+    // probe chunk iter over
+    if (_probe_row_current >= _probe_chunk->num_rows()) {
+        // next build chunk
+        _curr_build_chunk_index++;
+        if (_curr_build_chunk_index >= _num_build_chunks()) {
+            // build chunks iter over
+            _curr_build_chunk_index = 0;
+            _probe_row_current = 0;
+            _probe_chunk = nullptr;
+        } else {
+            // next build chunk
+            _probe_row_current = 0;
+            _curr_build_chunk = _cross_join_context->get_build_chunk(_curr_build_chunk_index);
+            _build_row_current = 0;
+        }
+    }
+}
+
+// probe one chunk from left
+void NLJoinProbeOperator::_next_build_row_index_for_inner_join() {
+    // next build row
+    _build_row_current++;
+    // all rows of current build chunk iter over
+    if (_build_row_current >= _curr_build_chunk->num_rows()) {
+        // next build chunk
+        _curr_build_chunk_index++;
+        // all build chunks iter over
+        if (_curr_build_chunk_index >= _num_build_chunks()) {
+            _probe_chunk = nullptr;
+        } else {
+            // get next build chunk
+            _curr_build_chunk = _cross_join_context->get_build_chunk(_curr_build_chunk_index);
+        }
+    }
+    // reset probe row index
+    _probe_row_current = 0;
 }
 
 void NLJoinProbeOperator::_move_build_chunk_index(int index) {
@@ -367,11 +409,65 @@ Status NLJoinProbeOperator::_probe_for_other_join(const ChunkPtr& chunk) {
     return Status::OK();
 }
 
+ChunkPtr NLJoinProbeOperator::_permute_chunk_for_inner_join(size_t chunk_size) {
+    ChunkPtr result_chunk = _init_output_chunk(chunk_size);
+
+    do {
+        size_t left_chunk_size = _probe_chunk->num_rows();
+        size_t right_chunk_size = _curr_build_chunk->num_rows();
+        size_t max_chunk_size = std::max(left_chunk_size, right_chunk_size);
+        if (result_chunk->num_rows() != 0 && result_chunk->num_rows() + max_chunk_size > chunk_size) {
+            // Prevent the size of a chunk from exceeding chunk size
+            break;
+        }
+
+        if (left_chunk_size > right_chunk_size) {
+            _permute_chunk_base_left(&result_chunk);
+            _next_build_row_index_for_inner_join();
+        } else {
+            _permute_chunk_base_right(&result_chunk);
+            _next_probe_row_index_for_inner_join();
+        }
+    } while (result_chunk->num_rows() < chunk_size && _probe_chunk != nullptr && _curr_build_chunk != nullptr);
+
+    return result_chunk;
+}
+
+void NLJoinProbeOperator::_permute_chunk_base_left(ChunkPtr* chunk) {
+    for (size_t i = 0; i < _probe_column_count; i++) {
+        SlotId slot_id = _col_types[i]->id();
+        ColumnPtr& dest_col = (*chunk)->get_column_by_slot_id(slot_id);
+        const ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot_id);
+        dest_col->append(*src_col);
+    }
+    for (size_t i = _probe_column_count; i < _col_types.size(); i++) {
+        SlotId slot_id = _col_types[i]->id();
+        ColumnPtr& dest_col = (*chunk)->get_column_by_slot_id(slot_id);
+        const ColumnPtr& src_col = _curr_build_chunk->get_column_by_slot_id(slot_id);
+        dest_col->append_value_multiple_times(*src_col, _build_row_current, _probe_chunk->num_rows());
+    }
+}
+
+void NLJoinProbeOperator::_permute_chunk_base_right(ChunkPtr* chunk) {
+    for (size_t i = 0; i < _probe_column_count; i++) {
+        SlotId slot_id = _col_types[i]->id();
+        ColumnPtr& dest_col = (*chunk)->get_column_by_slot_id(slot_id);
+        const ColumnPtr& src_col = _probe_chunk->get_column_by_slot_id(slot_id);
+        dest_col->append_value_multiple_times(*src_col, _probe_row_current, _curr_build_chunk->num_rows());
+    }
+    for (size_t i = _probe_column_count; i < _col_types.size(); i++) {
+        SlotId slot_id = _col_types[i]->id();
+        ColumnPtr& dest_col = (*chunk)->get_column_by_slot_id(slot_id);
+        const ColumnPtr& src_col = _curr_build_chunk->get_column_by_slot_id(slot_id);
+        dest_col->append(*src_col);
+    }
+}
+
 // Permute enough rows from build side and probe side
 // The chunk either consists two conditions:
 // 1. Multiple probe rows and multiple build single-chunk
 // 2. One probe rows and one build chunk
-ChunkPtr NLJoinProbeOperator::_permute_chunk(size_t chunk_size) {
+ChunkPtr NLJoinProbeOperator::_permute_chunk_for_other_join(size_t chunk_size) {
     // TODO: optimize the loop order for small build chunk
     ChunkPtr chunk = _init_output_chunk(chunk_size);
     bool probe_started = false;
@@ -397,7 +493,7 @@ ChunkPtr NLJoinProbeOperator::_permute_chunk(size_t chunk_size) {
         // Otherwise accumulate more build chunks into a larger chunk
         while (!_probe_row_finished && _curr_build_chunk_index < _num_build_chunks()) {
             _permute_probe_row(chunk);
-            _next_build_chunk_index();
+            _next_build_chunk_index_for_other_join();
             probe_row_start();
             if (chunk->num_rows() >= chunk_size) {
                 return chunk;
@@ -533,7 +629,7 @@ StatusOr<ChunkPtr> NLJoinProbeOperator::_pull_chunk_for_other_join(size_t chunk_
         return chunk;
     }
     while (!_is_curr_probe_chunk_finished()) {
-        ChunkPtr chunk = _permute_chunk(chunk_size);
+        ChunkPtr chunk = _permute_chunk_for_other_join(chunk_size);
         DCHECK(chunk);
         RETURN_IF_ERROR(_probe_for_other_join(chunk));
         RETURN_IF_ERROR(eval_conjuncts(_conjunct_ctxs, chunk.get(), nullptr));
@@ -562,7 +658,7 @@ StatusOr<ChunkPtr> NLJoinProbeOperator::_pull_chunk_for_inner_join(size_t chunk_
     }
 
     while (!_is_curr_probe_chunk_finished()) {
-        ChunkPtr chunk = _permute_chunk(chunk_size);
+        ChunkPtr chunk = _permute_chunk_for_inner_join(chunk_size);
         DCHECK(chunk);
         RETURN_IF_ERROR(_probe_for_inner_join(chunk));
         RETURN_IF_ERROR(eval_conjuncts(_conjunct_ctxs, chunk.get(), nullptr));

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.cpp
@@ -220,6 +220,7 @@ void NLJoinProbeOperator::_next_build_row_index_for_inner_join() {
     if (_build_row_current >= _curr_build_chunk->num_rows()) {
         // next build chunk
         _curr_build_chunk_index++;
+        _build_row_current = 0;
         // all build chunks iter over
         if (_curr_build_chunk_index >= _num_build_chunks()) {
             _probe_chunk = nullptr;

--- a/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
+++ b/be/src/exec/pipeline/nljoin/nljoin_probe_operator.h
@@ -75,7 +75,9 @@ private:
     int _num_build_chunks() const;
     void _move_build_chunk_index(int index);
     void _reset_build_chunk_index();
-    void _next_build_chunk_index();
+    void _next_build_chunk_index_for_other_join();
+    void _next_probe_row_index_for_inner_join();
+    void _next_build_row_index_for_inner_join();
 
     ChunkPtr _init_output_chunk(size_t chunk_size) const;
     Status _probe_for_other_join(const ChunkPtr& chunk);
@@ -85,7 +87,10 @@ private:
     void _check_post_probe() const;
     void _init_build_match() const;
     void _permute_probe_row(const ChunkPtr& chunk);
-    ChunkPtr _permute_chunk(size_t chunk_size);
+    ChunkPtr _permute_chunk_for_other_join(size_t chunk_size);
+    ChunkPtr _permute_chunk_for_inner_join(size_t chunk_size);
+    void _permute_chunk_base_left(ChunkPtr* chunk);
+    void _permute_chunk_base_right(ChunkPtr* chunk);
     Status _permute_right_join(size_t chunk_size);
     void _permute_left_join(const ChunkPtr& chunk, size_t probe_row_index, size_t probe_rows);
     bool _is_curr_probe_chunk_finished() const;
@@ -117,6 +122,7 @@ private:
     size_t _curr_build_chunk_index = 0;
     size_t _prev_chunk_start = 0;
     size_t _prev_chunk_size = 0;
+    size_t _build_row_current = 0;
     mutable std::vector<uint8_t> _self_build_match_flag;
 
     // Probe states

--- a/test/sql/test_nest_loop_join/R/test_nest_loop_join
+++ b/test/sql/test_nest_loop_join/R/test_nest_loop_join
@@ -21,13 +21,41 @@ PROPERTIES (
 );
 -- result:
 -- !result
+CREATE TABLE `t3` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+CREATE TABLE `t4` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
 insert into t1 select generate_series, generate_series from table(generate_series(1, 5));
 -- result:
 -- !result
 insert into t2 select generate_series, generate_series from table(generate_series(1, 2));
 -- result:
 -- !result
-select t1.c2, t2.c2 from t1 join t2 on t1.c1>t2.c2 order by t1.c2, t2.c2;
+insert into t3 select generate_series, generate_series from table(generate_series(1, 9));
+-- result:
+-- !result
+insert into t4 select generate_series, generate_series from table(generate_series(2, 8));
+-- result:
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2;
 -- result:
 2	1
 3	1
@@ -37,7 +65,7 @@ select t1.c2, t2.c2 from t1 join t2 on t1.c1>t2.c2 order by t1.c2, t2.c2;
 5	1
 5	2
 -- !result
-select t1.c2, t2.c2 from t1 left join t2 on t1.c1>t2.c2 order by t1.c2, t2.c2;
+select t1.c2, t2.c2 from t1 left join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2;
 -- result:
 1	None
 2	1
@@ -48,14 +76,406 @@ select t1.c2, t2.c2 from t1 left join t2 on t1.c1>t2.c2 order by t1.c2, t2.c2;
 5	1
 5	2
 -- !result
-select t1.c2 from t1 left semi join t2 on t1.c1>t2.c2 order by t1.c2;
+select t1.c2 from t1 left semi join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2;
 -- result:
 2
 3
 4
 5
 -- !result
-select t1.c2 from t1 left anti join t2 on t1.c1>t2.c2 order by t1.c2;
+select t1.c2 from t1 left anti join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2;
 -- result:
 1
+-- !result
+select t1.c2, t3.c2 from t1 right outer join [shuffle] t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- result:
+None	5
+None	6
+None	7
+None	8
+None	9
+2	1
+3	1
+3	2
+4	1
+4	2
+4	3
+5	1
+5	2
+5	3
+5	4
+-- !result
+select t1.c2, t4.c2 from t1 full outer join [shuffle] t4 on t1.c1>t4.c1 order by t1.c2, t4.c2;
+-- result:
+None	5
+None	6
+None	7
+None	8
+1	None
+2	None
+3	2
+4	2
+4	3
+5	2
+5	3
+5	4
+-- !result
+select t3.c2 from t1 right semi join [shuffle] t3 on t1.c1>t3.c1 order by t3.c2;
+-- result:
+1
+2
+3
+4
+-- !result
+select t4.c2 from t1 right anti join [shuffle] t4 on t1.c1>t4.c1 order by t4.c2;
+-- result:
+5
+6
+7
+8
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 where t2.c1<1 order by t1.c2, t2.c2;
+-- result:
+-- !result
+select t1.c2, t3.c2 from t1 left join [broadcast] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+-- !result
+select t1.c2 from t1 left semi join [broadcast] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2;
+-- result:
+-- !result
+select t1.c2 from t1 left anti join [broadcast] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2;
+-- result:
+1
+2
+3
+4
+5
+-- !result
+select t1.c2, t3.c2 from t1 right outer join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- result:
+-- !result
+select t1.c2, t3.c2 from t1 full outer join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- result:
+1	None
+2	None
+3	None
+4	None
+5	None
+-- !result
+select t3.c2 from t1 right semi join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t3.c2;
+-- result:
+-- !result
+select t3.c2 from t1 right anti join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t3.c2;
+-- result:
+-- !result
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- result:
+-- !result
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 left join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- result:
+-- !result
+select t3.c2 from (select * from t1 where t1.c1<1) t3 left semi join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2;
+-- result:
+-- !result
+select t3.c2 from (select * from t1 where t1.c1<1) t3 left anti join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2;
+-- result:
+-- !result
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 right outer join [shuffle] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- result:
+None	1
+None	2
+-- !result
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 full outer join [shuffle] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- result:
+None	1
+None	2
+-- !result
+select t2.c2 from (select * from t1 where t1.c1<1) t3 right semi join [shuffle] t2 on t3.c1>t2.c1 order by t2.c2;
+-- result:
+-- !result
+select t2.c2 from (select * from t1 where t1.c1<1) t3 right anti join [shuffle] t2 on t3.c1>t2.c1 order by t2.c2;
+-- result:
+1
+2
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(1, 4098));
+-- result:
+-- !result
+insert into t2 select generate_series, generate_series from table(generate_series(2, 8));
+-- result:
+-- !result
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+28651
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+-- result:
+3	2
+4	2
+4	3
+5	2
+5	3
+5	4
+6	2
+6	3
+6	4
+6	5
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+-- result:
+4098	8
+4098	7
+4098	6
+4098	5
+4098	4
+4098	3
+4098	2
+4097	8
+4097	7
+4097	6
+-- !result
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+58791838	143227
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(2, 8));
+-- result:
+-- !result
+insert into t2 select generate_series, generate_series from table(generate_series(1, 4098));
+-- result:
+-- !result
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+28
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+-- result:
+2	1
+3	1
+3	2
+4	1
+4	2
+4	3
+5	1
+5	2
+5	3
+5	4
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+-- result:
+8	7
+8	6
+8	5
+8	4
+8	3
+8	2
+8	1
+7	6
+7	5
+7	4
+-- !result
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+168	84
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(1, 10000));
+-- result:
+-- !result
+insert into t2 select generate_series, generate_series from table(generate_series(1, 10000));
+-- result:
+-- !result
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+49995000
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+-- result:
+2	1
+3	1
+3	2
+4	1
+4	2
+4	3
+5	1
+5	2
+5	3
+5	4
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+-- result:
+10000	9999
+10000	9998
+10000	9997
+10000	9996
+10000	9995
+10000	9994
+10000	9993
+10000	9992
+10000	9991
+10000	9990
+-- !result
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+333333330000	166666665000
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(1, 9998));
+-- result:
+-- !result
+insert into t2 select generate_series, generate_series from table(generate_series(1, 10000));
+-- result:
+-- !result
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+49975003
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+-- result:
+2	1
+3	1
+3	2
+4	1
+4	2
+4	3
+5	1
+5	2
+5	3
+5	4
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+-- result:
+9998	9997
+9998	9996
+9998	9995
+9998	9994
+9998	9993
+9998	9992
+9998	9991
+9998	9990
+9998	9989
+9998	9988
+-- !result
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+333133369998	166566684999
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(1, 10000));
+-- result:
+-- !result
+insert into t2 select generate_series, generate_series from table(generate_series(1, 9998));
+-- result:
+-- !result
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+49994999
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+-- result:
+2	1
+3	1
+3	2
+4	1
+4	2
+4	3
+5	1
+5	2
+5	3
+5	4
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+-- result:
+10000	9998
+10000	9997
+10000	9996
+10000	9995
+10000	9994
+10000	9993
+10000	9992
+10000	9991
+10000	9990
+10000	9989
+-- !result
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+333333320000	166666655001
+-- !result
+truncate table t1;
+-- result:
+-- !result
+truncate table t2;
+-- result:
+-- !result
+insert into t1 select generate_series, generate_series from table(generate_series(1, 77));
+-- result:
+-- !result
+insert into t2 select generate_series, generate_series from table(generate_series(1, 133));
+-- result:
+-- !result
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+2926
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+-- result:
+2	1
+3	1
+3	2
+4	1
+4	2
+4	3
+5	1
+5	2
+5	3
+5	4
+-- !result
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+-- result:
+77	76
+77	75
+77	74
+77	73
+77	72
+77	71
+77	70
+77	69
+77	68
+77	67
+-- !result
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+-- result:
+152152	76076
 -- !result

--- a/test/sql/test_nest_loop_join/T/test_nest_loop_join
+++ b/test/sql/test_nest_loop_join/T/test_nest_loop_join
@@ -20,15 +20,146 @@ PROPERTIES (
 "replication_num" = "1"
 );
 
+CREATE TABLE `t3` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
+CREATE TABLE `t4` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1"
+);
+
 insert into t1 select generate_series, generate_series from table(generate_series(1, 5));
 
 insert into t2 select generate_series, generate_series from table(generate_series(1, 2));
 
--- base test case for inner join
-select t1.c2, t2.c2 from t1 join t2 on t1.c1>t2.c2 order by t1.c2, t2.c2;
--- base test case for left outer join
-select t1.c2, t2.c2 from t1 left join t2 on t1.c1>t2.c2 order by t1.c2, t2.c2;
--- base test case for left semi join
-select t1.c2 from t1 left semi join t2 on t1.c1>t2.c2 order by t1.c2;
--- base test case for left anti join
-select t1.c2 from t1 left anti join t2 on t1.c1>t2.c2 order by t1.c2;
+insert into t3 select generate_series, generate_series from table(generate_series(1, 9));
+
+insert into t4 select generate_series, generate_series from table(generate_series(2, 8));
+
+-- base test case
+-- inner join
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2;
+-- left outer join
+select t1.c2, t2.c2 from t1 left join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2;
+-- left semi join
+select t1.c2 from t1 left semi join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2;
+-- left anti join
+select t1.c2 from t1 left anti join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2;
+-- right outer join
+select t1.c2, t3.c2 from t1 right outer join [shuffle] t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- full outer join
+select t1.c2, t4.c2 from t1 full outer join [shuffle] t4 on t1.c1>t4.c1 order by t1.c2, t4.c2;
+-- right semi join
+select t3.c2 from t1 right semi join [shuffle] t3 on t1.c1>t3.c1 order by t3.c2;
+-- right anti join
+select t4.c2 from t1 right anti join [shuffle] t4 on t1.c1>t4.c1 order by t4.c2;
+
+-- right table is empty
+-- inner join
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 where t2.c1<1 order by t1.c2, t2.c2;
+-- left outer join
+select t1.c2, t3.c2 from t1 left join [broadcast] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- left semi join
+select t1.c2 from t1 left semi join [broadcast] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2;
+-- left anti join
+select t1.c2 from t1 left anti join [broadcast] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2;
+-- right outer join
+select t1.c2, t3.c2 from t1 right outer join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- full outer join
+select t1.c2, t3.c2 from t1 full outer join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t1.c2, t3.c2;
+-- right semi join
+select t3.c2 from t1 right semi join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t3.c2;
+-- right anti join
+select t3.c2 from t1 right anti join [shuffle] (select * from t2 where t2.c1 < 1) t3 on t1.c1>t3.c1 order by t3.c2;
+
+-- left table is emptry
+-- inner join
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- left outer join
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 left join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- left semi join
+select t3.c2 from (select * from t1 where t1.c1<1) t3 left semi join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2;
+-- left anti join
+select t3.c2 from (select * from t1 where t1.c1<1) t3 left anti join [broadcast] t2 on t3.c1>t2.c1 order by t3.c2;
+-- right outer join
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 right outer join [shuffle] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- full outer join
+select t3.c2, t2.c2 from (select * from t1 where t1.c1<1) t3 full outer join [shuffle] t2 on t3.c1>t2.c1 order by t3.c2, t2.c2;
+-- right semi join
+select t2.c2 from (select * from t1 where t1.c1<1) t3 right semi join [shuffle] t2 on t3.c1>t2.c1 order by t2.c2;
+-- right anti join
+select t2.c2 from (select * from t1 where t1.c1<1) t3 right anti join [shuffle] t2 on t3.c1>t2.c1 order by t2.c2;
+
+-- left table is large
+truncate table t1;
+truncate table t2;
+insert into t1 select generate_series, generate_series from table(generate_series(1, 4098));
+insert into t2 select generate_series, generate_series from table(generate_series(2, 8));
+
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+
+-- right table is large
+truncate table t1;
+truncate table t2;
+insert into t1 select generate_series, generate_series from table(generate_series(2, 8));
+insert into t2 select generate_series, generate_series from table(generate_series(1, 4098));
+
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+
+-- multi large chunk
+truncate table t1;
+truncate table t2;
+insert into t1 select generate_series, generate_series from table(generate_series(1, 10000));
+insert into t2 select generate_series, generate_series from table(generate_series(1, 10000));
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+
+-- multi large chunk (swith left)
+truncate table t1;
+truncate table t2;
+insert into t1 select generate_series, generate_series from table(generate_series(1, 9998));
+insert into t2 select generate_series, generate_series from table(generate_series(1, 10000));
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+
+-- multi large chunk (swith right)
+truncate table t1;
+truncate table t2;
+insert into t1 select generate_series, generate_series from table(generate_series(1, 10000));
+insert into t2 select generate_series, generate_series from table(generate_series(1, 9998));
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+
+-- multi small chunk
+truncate table t1;
+truncate table t2;
+insert into t1 select generate_series, generate_series from table(generate_series(1, 77));
+insert into t2 select generate_series, generate_series from table(generate_series(1, 133));
+select count(*) from t1 join [broadcast] t2 on t1.c1>t2.c1;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2, t2.c2 limit 10;
+select t1.c2, t2.c2 from t1 join [broadcast] t2 on t1.c1>t2.c1 order by t1.c2 desc, t2.c2 desc limit 10;
+select sum(t1.c2), sum(t2.c2) from t1 join [broadcast] t2 on t1.c1>t2.c1;


### PR DESCRIPTION
Why I'm doing:

For nest-loop-join for inner join, if the right table is small such as one row, 
In order to generate intermediate chunks, only a small number of rows will be appended at a time, which is very time-consuming.

What I'm doing:

For inner-join, we will generate the intermediate chunk base the larger chunk of build or probe.

```
CREATE TABLE `lineorder` (
  `lo_orderkey` int(11) NOT NULL COMMENT "",
  `lo_linenumber` int(11) NOT NULL COMMENT "",
  `lo_custkey` int(11) NOT NULL COMMENT "",
  `lo_partkey` int(11) NOT NULL COMMENT "",
  `lo_suppkey` int(11) NOT NULL COMMENT "",
  `lo_orderdate` int(11) NOT NULL COMMENT "",
  `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
  `lo_shippriority` int(11) NOT NULL COMMENT "",
  `lo_quantity` int(11) NOT NULL COMMENT "",
  `lo_extendedprice` int(11) NOT NULL COMMENT "",
  `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
  `lo_discount` int(11) NOT NULL COMMENT "",
  `lo_revenue` int(11) NOT NULL COMMENT "",
  `lo_supplycost` int(11) NOT NULL COMMENT "",
  `lo_tax` int(11) NOT NULL COMMENT "",
  `lo_commitdate` int(11) NOT NULL COMMENT "",
  `lo_shipmode` varchar(11) NOT NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`lo_orderkey`)
COMMENT "OLAP"
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 192 
PROPERTIES (
"replication_num" = "1",
"colocate_with" = "groupa1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"compression" = "LZ4"
);

select count(*) from lineorder;
+-----------+
| count(*)  |
+-----------+
| 143999468 |
+-----------+
```

```
CREATE TABLE `t1` (
  `c1` int(11) NULL COMMENT "",
  `c2` int(11) NULL COMMENT ""
) ENGINE=OLAP 
DUPLICATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"fast_schema_evolution" = "true",
"compression" = "LZ4"
); 

select * from t1;
+------+------+
| c1   | c2   |
+------+------+
|    1 |    1 |
+------+------+
```

```
CREATE TABLE `t2` (
  `c1` int(11) NULL COMMENT "",
  `c2` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`) BUCKETS 1 
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"fast_schema_evolution" = "true",
"compression" = "LZ4"
); 

select c1, bitmap_count(c2) from t2;
+------+------------------+
| c1   | bitmap_count(c2) |
+------+------------------+
|    1 |         30000000 |
+------+------------------+
```

Case 1:
```
select count(*) from lineorder join [broadcast] t1 on lo_partkey>c2;
```
Time:  11.974s -> 0.54s
Mem:  5.363M -> 4M

Case 2:
```
select count(*) from lineorder join [broadcast] t2 on bitmap_contains(c2, lo_orderkey);
```
Time: 20.680s -> 9.428s
Mem: 30M -> 30M

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
