### PR TITLE
[Enhancement] turn on clang delete-non-virtual-dtor diagnostic

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -610,7 +610,11 @@ set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-deprecated -Wno-vla -Wno-comment"
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -fno-sized-deallocation")
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables -Werror=string-plus-int -Werror=pessimizing-move")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-unused-parameter -Wno-documentation -Wno-weak-vtables")
+    # Turn on following warning as error explicitly
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=string-plus-int")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=pessimizing-move")
+    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=delete-non-virtual-dtor")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "11.0.0")
         set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Wno-reserved-identifier -Wno-suggest-destructor-override")
     endif()

--- a/be/src/formats/orc/orc_chunk_writer.h
+++ b/be/src/formats/orc/orc_chunk_writer.h
@@ -67,6 +67,8 @@ public:
               _schema(std::move(schema)),
               _output_stream(std::move(writable_file)){};
 
+    virtual ~OrcChunkWriter() = default;
+
     Status set_compression(const TCompressionType::type& compression_type);
 
     Status write(Chunk* chunk);

--- a/be/src/storage/row_store_encoder.h
+++ b/be/src/storage/row_store_encoder.h
@@ -33,6 +33,8 @@ std::unique_ptr<Schema> create_binary_schema();
 
 class RowStoreEncoder {
 public:
+    virtual ~RowStoreEncoder() = default;
+
     virtual Status encode_chunk_to_full_row_column(const Schema& schema, const Chunk& chunk,
                                                    BinaryColumn* dest_column) = 0;
     // columns only contain value column, exclude key columns

--- a/be/src/tools/CMakeLists.txt
+++ b/be/src/tools/CMakeLists.txt
@@ -27,7 +27,6 @@ add_library(Tools STATIC
 
 # libmockjvm will be build as shared lib. we use it to mock a libjvm.so to 
 # make sure BE can start without real java runtime
-set_source_files_properties(mock_jvm.c PROPERTIES COMPILE_FLAGS "-shared")
 add_library(mockjvm SHARED mock_jvm.c)
 # define `A` SUNWprivate_1.1 symbol to mockjvm to suppress some warning 
 target_link_options(mockjvm PRIVATE "LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/mock_jvm.lds")


### PR DESCRIPTION
* turn on clang `delete-non-virtual-dtor` diagnostic warning as error

Why: detect more potential code flaws.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
