### PR TITLE
[BugFix] fix version not found when transaction stream load and clone run concurrently

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -411,9 +411,6 @@ public class DatabaseTransactionMgr {
         if (transactionState.getWriteEndTimeMs() < 0) {
             transactionState.setWriteEndTimeMs(System.currentTimeMillis());
         }
-        if (!tabletCommitInfos.isEmpty()) {
-            transactionState.setTabletCommitInfos(tabletCommitInfos);
-        }
 
         // update transaction state extra if exists
         if (txnCommitAttachment != null) {
@@ -1032,6 +1029,8 @@ public class DatabaseTransactionMgr {
                 transactionState.setFinishTime(System.currentTimeMillis());
                 transactionState.clearErrorMsg();
                 transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
+                // clear tablet commit info to save meta space
+                transactionState.clearTabletCommitInfos();
                 unprotectUpsertTransactionState(transactionState, false);
                 transactionState.notifyVisible();
                 txnOperated = true;
@@ -1306,6 +1305,7 @@ public class DatabaseTransactionMgr {
         boolean txnOperated = false;
         writeLock();
         try {
+            transactionState.clearTabletCommitInfos();
             txnOperated = unprotectAbortTransaction(transactionId, abortPrepared, reason);
         } finally {
             writeUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -82,6 +82,12 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         Map<Long, Set<Long>> tabletToBackends = new HashMap<>();
         Set<Long> allCommittedBackends = new HashSet<>();
 
+        // 1. record tablet commit infos in TransactionState,
+        // so we can decide to update version in replica when finish transaction
+        if (!tabletCommitInfos.isEmpty()) {
+            transactionState.setTabletCommitInfos(tabletCommitInfos);
+        }
+
         // 2. validate potential exists problem: db->table->partition
         // guarantee exist exception during a transaction
         // if index is dropped, it does not matter.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
@@ -36,6 +36,7 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
 import com.starrocks.thrift.TTabletCommitInfo;
 
@@ -47,7 +48,9 @@ import javax.validation.constraints.NotNull;
 
 public class TabletCommitInfo implements Writable {
 
+    @SerializedName("tabletId")
     private long tabletId;
+    @SerializedName("backendId")
     private long backendId;
 
     // For low cardinality string column with global dict

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -331,6 +331,7 @@ public class TransactionState implements Writable {
     private long checkerCreationTime = 0;
     private Span txnSpan = null;
     private String traceParent = null;
+    @SerializedName("tci")
     private Set<TabletCommitInfo> tabletCommitInfos = null;
 
     public TransactionState() {
@@ -396,10 +397,18 @@ public class TransactionState implements Writable {
         this.tabletCommitInfos.addAll(infos);
     }
 
+    public void clearTabletCommitInfos() {
+        this.tabletCommitInfos = null;
+    }
+
     public boolean tabletCommitInfosContainsReplica(long tabletId, long backendId) {
         TabletCommitInfo info = new TabletCommitInfo(tabletId, backendId);
-        if (this.tabletCommitInfos == null || this.tabletCommitInfos.contains(info)) {
+        if (this.tabletCommitInfos == null) {
             // if tabletCommitInfos is null, skip this check and return true
+            LOG.warn("tabletCommitInfos is null in TransactionState, tabletid {} backendid {} transid {}",
+                tabletId, backendId, transactionId);
+            return true;
+        } else if (this.tabletCommitInfos.contains(info)) {
             return true;
         } else {
             return false;


### PR DESCRIPTION
Why I'm doing:
In finish transaction, we need tablet commit info to decide if we need to upgrade the replica's version. But now if FE restart, tablet commit info will loss.

What I'm doing:
Persistent tablet commit info, so after FE restart, tablet commit info wouldn't loss.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
