### PR TITLE
[Enhancement] Lake pk index load optimization

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1205,6 +1205,8 @@ CONF_mInt32(json_flat_internal_column_min_limit, "5");
 
 // the maximum number of extracted JSON sub-field
 CONF_mInt32(json_flat_column_max, "20");
+CONF_mBool(use_lake_pk_index_loader, "true");
+CONF_mInt32(lake_pk_index_loader_thread, "10");
 
 // Allowable intervals for continuous generation of pk dumps
 // Disable when pk_dump_interval_seconds <= 0

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -954,6 +954,7 @@ CONF_mBool(lake_enable_compaction_async_write, "false");
 CONF_mInt64(lake_pk_compaction_max_input_rowsets, "5");
 // Used for control memory usage of update state cache and compaction state cache
 CONF_mInt32(lake_pk_preload_memory_limit_percent, "30");
+CONF_Bool(lake_enable_pk_index_loader, "false");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 
@@ -1205,7 +1206,6 @@ CONF_mInt32(json_flat_internal_column_min_limit, "5");
 
 // the maximum number of extracted JSON sub-field
 CONF_mInt32(json_flat_column_max, "20");
-CONF_mBool(use_lake_pk_index_loader, "true");
 
 // Allowable intervals for continuous generation of pk dumps
 // Disable when pk_dump_interval_seconds <= 0

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1206,7 +1206,6 @@ CONF_mInt32(json_flat_internal_column_min_limit, "5");
 // the maximum number of extracted JSON sub-field
 CONF_mInt32(json_flat_column_max, "20");
 CONF_mBool(use_lake_pk_index_loader, "true");
-CONF_mInt32(lake_pk_index_loader_thread, "10");
 
 // Allowable intervals for continuous generation of pk dumps
 // Disable when pk_dump_interval_seconds <= 0

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -78,6 +78,7 @@
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/stream_load/transaction_mgr.h"
 #include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/pk_index_loader.h"
 #include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/starlet_location_provider.h"
 #include "storage/lake/tablet_manager.h"
@@ -505,6 +506,12 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
         });
         config::starlet_cache_dir = JoinStrings(starlet_cache_paths, ":");
     }
+    _lake_pk_index_loader = new lake::PkIndexLoader();
+    status = _lake_pk_index_loader->init();
+    if (!status.ok()) {
+        LOG(ERROR) << "lake pk index loader init failed." << status.get_error_msg();
+        exit(-1);
+    }
 
 #elif defined(BE_TEST)
     _lake_location_provider = new lake::FixedLocationProvider(_store_paths.front().path);
@@ -513,6 +520,12 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _lake_tablet_manager =
             new lake::TabletManager(_lake_location_provider, _lake_update_manager, config::lake_metadata_cache_limit);
     _lake_replication_txn_manager = new lake::ReplicationTxnManager(_lake_tablet_manager);
+    _lake_pk_index_loader = new lake::PkIndexLoader();
+    status = _lake_pk_index_loader->init();
+    if (!status.ok()) {
+        LOG(ERROR) << "lake pk index loader init failed." << status.get_error_msg();
+        exit(-1);
+    }
 #endif
 
     _agent_server = new AgentServer(this, false);

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -506,7 +506,9 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
         });
         config::starlet_cache_dir = JoinStrings(starlet_cache_paths, ":");
     }
-    _lake_pk_index_loader = new lake::PkIndexLoader();
+    if (config::lake_enable_pk_index_loader) {
+        _lake_pk_index_loader = new lake::PkIndexLoader();
+    }
 
 #elif defined(BE_TEST)
     _lake_location_provider = new lake::FixedLocationProvider(_store_paths.front().path);
@@ -693,6 +695,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_lake_update_manager);
     SAFE_DELETE(_lake_replication_txn_manager);
     SAFE_DELETE(_cache_mgr);
+    SAFE_DELETE(_lake_pk_index_loader);
     _metrics = nullptr;
 }
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -507,11 +507,6 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
         config::starlet_cache_dir = JoinStrings(starlet_cache_paths, ":");
     }
     _lake_pk_index_loader = new lake::PkIndexLoader();
-    status = _lake_pk_index_loader->init();
-    if (!status.ok()) {
-        LOG(ERROR) << "lake pk index loader init failed." << status.get_error_msg();
-        exit(-1);
-    }
 
 #elif defined(BE_TEST)
     _lake_location_provider = new lake::FixedLocationProvider(_store_paths.front().path);
@@ -521,11 +516,6 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
             new lake::TabletManager(_lake_location_provider, _lake_update_manager, config::lake_metadata_cache_limit);
     _lake_replication_txn_manager = new lake::ReplicationTxnManager(_lake_tablet_manager);
     _lake_pk_index_loader = new lake::PkIndexLoader();
-    status = _lake_pk_index_loader->init();
-    if (!status.ok()) {
-        LOG(ERROR) << "lake pk index loader init failed." << status.get_error_msg();
-        exit(-1);
-    }
 #endif
 
     _agent_server = new AgentServer(this, false);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -98,6 +98,7 @@ class LocationProvider;
 class TabletManager;
 class UpdateManager;
 class ReplicationTxnManager;
+class PkIndexLoader;
 } // namespace lake
 namespace spill {
 class DirManager;
@@ -319,6 +320,8 @@ public:
 
     lake::ReplicationTxnManager* lake_replication_txn_manager() const { return _lake_replication_txn_manager; }
 
+    lake::PkIndexLoader* lake_pk_index_loader() const { return _lake_pk_index_loader; }
+
     AgentServer* agent_server() const { return _agent_server; }
 
     query_cache::CacheManagerRawPtr cache_mgr() const { return _cache_mgr; }
@@ -389,6 +392,7 @@ private:
     lake::LocationProvider* _lake_location_provider = nullptr;
     lake::UpdateManager* _lake_update_manager = nullptr;
     lake::ReplicationTxnManager* _lake_replication_txn_manager = nullptr;
+    lake::PkIndexLoader* _lake_pk_index_loader = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -223,6 +223,7 @@ add_library(Storage STATIC
     lake/lake_persistent_index.cpp
     lake/persistent_index_memtable.cpp
     lake/local_pk_index_manager.cpp
+    lake/pk_index_loader.cpp
     primary_key_dump.cpp
     dictionary_cache_manager.cpp
     inverted/index_descriptor.hpp

--- a/be/src/storage/lake/lake_primary_index.cpp
+++ b/be/src/storage/lake/lake_primary_index.cpp
@@ -18,6 +18,7 @@
 
 #include "storage/chunk_helper.h"
 #include "storage/lake/lake_local_persistent_index.h"
+#include "storage/lake/pk_index_loader.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet.h"
 #include "storage/primary_key_encoder.h"
@@ -55,8 +56,13 @@ bool LakePrimaryIndex::is_load(int64_t base_version) {
     return _loaded && _data_version >= base_version;
 }
 
-Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata,
-                                       int64_t base_version, const MetaFileBuilder* builder) {
+Status LakePrimaryIndex::insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks) {
+    std::lock_guard<std::mutex> lg(_mutex);
+    return PrimaryIndex::insert(rssid, rowids, pks);
+}
+
+Status LakePrimaryIndex::_do_lake_load(Tablet* tablet, const TabletMetadata& metadata, int64_t base_version,
+                                       const MetaFileBuilder* builder) {
     MonotonicStopWatch watch;
     watch.start();
     // 1. create and set key column schema
@@ -119,39 +125,51 @@ Status LakePrimaryIndex::_do_lake_load(TabletManager* tablet_mgr, const TabletMe
     auto rowsets = Rowset::get_rowsets(tablet_mgr, metadata);
     // NOTICE: primary index will be builded by segment files in metadata, and delvecs.
     // The delvecs we need are stored in delvec file by base_version and current MetaFileBuilder's cache.
-    for (auto& rowset : rowsets) {
-        auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
-        if (!res.ok()) {
-            return res.status();
+    if (config::use_lake_pk_index_loader) {
+        auto future = ExecEnv::GetInstance()->lake_pk_index_loader()->load(tablet, *rowsets, pkey_schema, base_version,
+                                                                           builder, this);
+        auto st = future.get();
+        if (!st.ok()) {
+            return st;
         }
-        auto& itrs = res.value();
-        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
-        for (size_t i = 0; i < itrs.size(); i++) {
-            auto itr = itrs[i].get();
-            if (itr == nullptr) {
-                continue;
+    } else {
+        for (auto& rowset : *rowsets) {
+            auto res = rowset->get_each_segment_iterator_with_delvec(pkey_schema, base_version, builder, &stats);
+            if (!res.ok()) {
+                return res.status();
             }
-            while (true) {
-                chunk->reset();
-                rowids.clear();
-                auto st = itr->get_next(chunk, &rowids);
-                if (st.is_end_of_file()) {
-                    break;
-                } else if (!st.ok()) {
-                    return st;
-                } else {
-                    Column* pkc = nullptr;
-                    if (pk_column) {
-                        pk_column->reset_column();
-                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
-                        pkc = pk_column.get();
-                    } else {
-                        pkc = chunk->columns()[0].get();
-                    }
-                    RETURN_IF_ERROR(insert(rowset->id() + i, rowids, *pkc));
+            auto& itrs = res.value();
+            CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+            for (size_t i = 0; i < itrs.size(); i++) {
+                auto itr = itrs[i].get();
+                if (itr == nullptr) {
+                    continue;
                 }
+                while (true) {
+                    chunk->reset();
+                    rowids.clear();
+                    auto st = itr->get_next(chunk, &rowids);
+                    if (st.is_end_of_file()) {
+                        break;
+                    } else if (!st.ok()) {
+                        return st;
+                    } else {
+                        Column* pkc = nullptr;
+                        if (pk_column) {
+                            pk_column->reset_column();
+                            PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+                            pkc = pk_column.get();
+                        } else {
+                            pkc = chunk->columns()[0].get();
+                        }
+                        auto st = insert(rowset->id() + i, rowids, *pkc);
+                        if (!st.ok()) {
+                            return st;
+                        }
+                    }
+                }
+                itr->close();
             }
-            itr->close();
         }
     }
     auto cost_ns = watch.elapsed_time();

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -58,16 +58,15 @@ public:
         return nullptr;
     }
 
-    Status insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks);
-
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
 
 private:
     // We don't support multi version in PrimaryIndex yet, but we will record latest data version for some checking
-    std::mutex _mutex;
     int64_t _data_version = 0;
+    // make sure at most 1 thread is read or write primary index
+    std::mutex _mutex;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -14,7 +14,6 @@
 
 #pragma once
 
-#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -69,8 +68,6 @@ private:
     // We don't support multi version in PrimaryIndex yet, but we will record latest data version for some checking
     std::mutex _mutex;
     int64_t _data_version = 0;
-    // make sure at most 1 thread is read or write primary index
-    std::mutex _mutex;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <mutex>
 #include <string>
 #include <unordered_map>
 
@@ -58,12 +59,15 @@ public:
         return nullptr;
     }
 
+    Status insert(uint32_t rssid, const vector<uint32_t>& rowids, const Column& pks);
+
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
 
 private:
     // We don't support multi version in PrimaryIndex yet, but we will record latest data version for some checking
+    std::mutex _mutex;
     int64_t _data_version = 0;
     // make sure at most 1 thread is read or write primary index
     std::mutex _mutex;

--- a/be/src/storage/lake/pk_index_loader.cpp
+++ b/be/src/storage/lake/pk_index_loader.cpp
@@ -1,0 +1,181 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/pk_index_loader.h"
+
+#include "storage/chunk_helper.h"
+#include "storage/lake/lake_primary_index.h"
+#include "storage/lake/update_manager.h"
+#include "storage/olap_common.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rowset/segment_options.h"
+#include "util/defer_op.h"
+
+namespace starrocks::lake {
+
+class LoadPkIndexSubtask : public Runnable {
+public:
+    LoadPkIndexSubtask(Tablet* tablet, uint32_t rowset_id, uint32_t seg_id, std::string seg_name, const Schema& schema,
+                       int64_t version, const MetaFileBuilder* builder, LakePrimaryIndex* index)
+            : _tablet(tablet),
+              _rowset_id(rowset_id),
+              _seg_id(seg_id),
+              _seg_name(std::move(seg_name)),
+              _schema(std::move(schema)),
+              _version(version),
+              _builder(builder),
+              _index(index) {}
+
+    void run() override {
+        auto st = Status::OK();
+        DeferOp defer([&]() {
+            if (st.is_end_of_file()) {
+                st = Status::OK();
+            }
+            ExecEnv::GetInstance()->lake_pk_index_loader()->finish_subtask(_tablet->id(), st);
+        });
+        size_t footer_size_hint = 16 * 1024;
+        auto seg = _tablet->load_segment(_seg_name, _seg_id, &footer_size_hint, false, false);
+        if (!seg.ok()) {
+            st = seg.status();
+            return;
+        }
+        SegmentReadOptions seg_options;
+        auto fs = FileSystem::CreateSharedFromString(_tablet->root_location());
+        if (!fs.ok()) {
+            st = fs.status();
+            return;
+        }
+        OlapReaderStatistics stats;
+        seg_options.fs = *fs;
+        seg_options.stats = &stats;
+        seg_options.is_primary_keys = true;
+        seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(_tablet->update_mgr(), _builder);
+        seg_options.version = _version;
+        seg_options.tablet_id = _tablet->id();
+        seg_options.rowset_id = _rowset_id;
+        auto seg_itr = (*seg)->new_iterator(_schema, seg_options);
+        if (!seg_itr.ok()) {
+            st = seg_itr.status();
+            return;
+        }
+        vector<uint32_t> rowids;
+        rowids.reserve(4096);
+        auto chunk_shared_ptr = ChunkHelper::new_chunk(_schema, 4096);
+        auto chunk = chunk_shared_ptr.get();
+        std::unique_ptr<Column> pk_column;
+        if (_schema.num_key_fields() > 1) {
+            // more than one key column
+            if (!PrimaryKeyEncoder::create_column(_schema, &pk_column).ok()) {
+                CHECK(false) << "create column for primary key encoder failed";
+            }
+        }
+        while (true) {
+            chunk->reset();
+            rowids.clear();
+            st = (*seg_itr)->get_next(chunk, &rowids);
+            if (st.is_end_of_file()) {
+                break;
+            } else if (!st.ok()) {
+                return;
+            } else {
+                Column* pkc = nullptr;
+                if (pk_column) {
+                    pk_column->reset_column();
+                    PrimaryKeyEncoder::encode(_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+                    pkc = pk_column.get();
+                } else {
+                    pkc = chunk->columns()[0].get();
+                }
+                st = _index->insert(_rowset_id + _seg_id, rowids, *pkc);
+                if (!st.ok()) {
+                    return;
+                }
+            }
+        }
+        (*seg_itr)->close();
+    }
+
+private:
+    Tablet* _tablet;
+    uint32_t _rowset_id;
+    uint32_t _seg_id;
+    std::string _seg_name;
+    const Schema _schema;
+    int64_t _version;
+    const MetaFileBuilder* _builder;
+    LakePrimaryIndex* _index;
+};
+
+Status PkIndexLoader::init() {
+    return ThreadPoolBuilder("lake_load_pk_index")
+            .set_max_threads(config::lake_pk_index_loader_thread)
+            .build(&_load_thread_pool);
+}
+
+PkIndexLoader::~PkIndexLoader() {
+    if (_load_thread_pool) {
+        _load_thread_pool->shutdown();
+    }
+}
+
+std::future<Status> PkIndexLoader::load(Tablet* tablet, const std::vector<RowsetPtr>& rowsets, const Schema& schema,
+                                        int64_t version, const MetaFileBuilder* builder, LakePrimaryIndex* index) {
+    uint64_t subtask_num = 0;
+    auto p = std::make_unique<std::promise<Status>>();
+    std::future<Status> f = p->get_future();
+    std::vector<std::shared_ptr<Runnable>> subtasks;
+    for (auto& rowset : rowsets) {
+        auto& rowset_meta = rowset->metadata();
+        for (uint32_t i = 0; i < rowset_meta.segments_size(); ++i) {
+            std::shared_ptr<Runnable> subtask(std::make_shared<LoadPkIndexSubtask>(
+                    tablet, rowset->id(), i, rowset_meta.segments(i), schema, version, builder, index));
+            subtasks.push_back(subtask);
+        }
+        subtask_num += rowset_meta.segments_size();
+    }
+    if (subtask_num == 0) {
+        p->set_value(Status::OK());
+        return f;
+    }
+
+    std::lock_guard<std::mutex> lg(_mutex);
+    for (auto& subtask : subtasks) {
+        auto st = _load_thread_pool->submit(std::move(subtask));
+        if (!st.ok()) {
+            LOG(ERROR) << "Fail to submit pk index loading subtask, error: " << st.to_string();
+            subtask_num--;
+        }
+    }
+    _subtask_nums.emplace(tablet->id(), subtask_num);
+    _promises.emplace(tablet->id(), std::move(p));
+    return f;
+}
+
+void PkIndexLoader::finish_subtask(int64_t tablet_id, const Status& status) {
+    std::lock_guard<std::mutex> lg(_mutex);
+    auto it = _subtask_nums.find(tablet_id);
+    if (it == _subtask_nums.end()) {
+        return;
+    }
+    it->second--;
+    if (!status.ok() || it->second == 0) {
+        _promises[tablet_id]->set_value(status);
+        _subtask_nums.erase(tablet_id);
+        _promises.erase(tablet_id);
+        return;
+    }
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/pk_index_loader.h
+++ b/be/src/storage/lake/pk_index_loader.h
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstdint>
+#include <future>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <queue>
+#include <utility>
+
+#include "common/statusor.h"
+#include "storage/lake/types_fwd.h"
+
+namespace starrocks {
+class Schema;
+class ThreadPool;
+} // namespace starrocks
+
+namespace starrocks::lake {
+
+class MetaFileBuilder;
+class Tablet;
+class LakePrimaryIndex;
+
+class PkIndexLoader {
+public:
+    PkIndexLoader() = default;
+
+    ~PkIndexLoader();
+
+    Status init();
+
+    std::future<Status> load(Tablet* tablet, const std::vector<RowsetPtr>& rowsets, const Schema& schema,
+                             int64_t version, const MetaFileBuilder* builder, LakePrimaryIndex* index);
+
+    void finish_subtask(int64_t tablet_id, const Status& status);
+
+private:
+    std::mutex _mutex;
+    std::unordered_map<int64_t, std::unique_ptr<std::promise<Status>>> _promises;
+    std::unordered_map<int64_t, uint64_t> _subtask_nums;
+    std::unique_ptr<ThreadPool> _load_thread_pool;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/pk_index_loader.h
+++ b/be/src/storage/lake/pk_index_loader.h
@@ -16,26 +16,38 @@
 
 #include <condition_variable>
 #include <cstdint>
-#include <future>
 #include <map>
 #include <memory>
 #include <mutex>
 #include <queue>
-#include <utility>
+#include <vector>
 
+#include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "storage/lake/types_fwd.h"
-
-namespace starrocks {
-class Schema;
-class ThreadPool;
-} // namespace starrocks
 
 namespace starrocks::lake {
 
 class MetaFileBuilder;
-class Tablet;
-class LakePrimaryIndex;
+
+struct ChunkInfo {
+    ChunkUniquePtr chunk;
+    uint64_t rssid;
+    std::vector<uint32_t> rowids;
+};
+
+struct PkSegmentScanTaskContext {
+    std::queue<std::shared_ptr<ChunkInfo>> chunk_infos;
+    uint64_t subtask_num;
+    std::condition_variable cv;
+    Status status;
+
+    std::shared_ptr<ChunkInfo> get_chunk_info() {
+        auto chunk_info = chunk_infos.front();
+        chunk_infos.pop();
+        return chunk_info;
+    }
+};
 
 class PkIndexLoader {
 public:
@@ -43,18 +55,18 @@ public:
 
     ~PkIndexLoader();
 
-    Status init();
+    Status load(Tablet* tablet, const std::vector<RowsetPtr>& rowsets, const Schema& schema, int64_t version,
+                const MetaFileBuilder* builder);
 
-    std::future<Status> load(Tablet* tablet, const std::vector<RowsetPtr>& rowsets, const Schema& schema,
-                             int64_t version, const MetaFileBuilder* builder, LakePrimaryIndex* index);
+    void add_chunk(int64_t tablet_id, const std::shared_ptr<ChunkInfo>& chunk_info);
+
+    StatusOr<std::shared_ptr<ChunkInfo>> get_chunk(int64_t tablet_id);
 
     void finish_subtask(int64_t tablet_id, const Status& status);
 
 private:
     std::mutex _mutex;
-    std::unordered_map<int64_t, std::unique_ptr<std::promise<Status>>> _promises;
-    std::unordered_map<int64_t, uint64_t> _subtask_nums;
-    std::unique_ptr<ThreadPool> _load_thread_pool;
+    std::unordered_map<int64_t, std::shared_ptr<PkSegmentScanTaskContext>> _contexts;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -26,7 +26,6 @@
 #include "util/dynamic_cache.h"
 #include "util/mem_info.h"
 #include "util/parse_util.h"
-#include "util/threadpool.h"
 
 namespace starrocks {
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -414,6 +414,7 @@ set(EXEC_FILES
         ./storage/lake/persistent_index_memtable_test.cpp
         ./storage/lake/lake_persistent_index_test.cpp
         ./storage/lake/replication_txn_manager_test.cpp
+        ./storage/lake/pk_index_loader_test.cpp
         )
 
 if ("${WITH_STARCACHE}" STREQUAL "ON" OR "${WITH_CACHELIB}" STREQUAL "ON")

--- a/be/test/storage/lake/pk_index_loader_test.cpp
+++ b/be/test/storage/lake/pk_index_loader_test.cpp
@@ -1,0 +1,161 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/pk_index_loader.h"
+
+#include <gtest/gtest.h>
+
+#include <random>
+
+#include "column/chunk.h"
+#include "storage/chunk_helper.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/lake_primary_index.h"
+#include "storage/lake/meta_file.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/tablet_writer.h"
+#include "storage/lake/test_util.h"
+#include "storage/primary_key_encoder.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+
+namespace starrocks::lake {
+
+class PkIndexLoaderTest : public TestBase {
+public:
+    PkIndexLoaderTest() : TestBase(kTestGroupPath) {
+        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        _tablet_metadata->set_next_rowset_id(1);
+        _tablet_metadata->set_enable_persistent_index(false);
+
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(PRIMARY_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+            c1->set_aggregation("REPLACE");
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        (void)fs::remove_all(kTestGroupPath);
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kSegmentDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kMetadataDirectoryName)));
+        CHECK_OK(fs::create_directories(lake::join_path(kTestGroupPath, lake::kTxnLogDirectoryName)));
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { (void)fs::remove_all(kTestGroupPath); }
+
+protected:
+    constexpr static const char* const kTestGroupPath = "test_pk_index_loader";
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+TEST_F(PkIndexLoaderTest, test_load) {
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+
+    Chunk chunk0({c0, c1}, _schema);
+    auto rowset_txn_meta = std::make_unique<RowsetTxnMetaPB>();
+
+    int64_t txn_id = next_id();
+    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
+    ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+    ASSERT_OK(writer->open());
+
+    // write segment #1
+    ASSERT_OK(writer->write(chunk0));
+    ASSERT_OK(writer->finish());
+
+    // write txnlog
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(_tablet_metadata->id());
+    txn_log->set_txn_id(txn_id);
+    auto op_write = txn_log->mutable_op_write();
+    for (auto& f : writer->files()) {
+        op_write->mutable_rowset()->add_segments(std::move(f));
+    }
+    op_write->mutable_rowset()->set_num_rows(writer->num_rows());
+    op_write->mutable_rowset()->set_data_size(writer->data_size());
+    op_write->mutable_rowset()->set_overlapped(false);
+
+    ASSERT_OK(_tablet_mgr->put_txn_log(txn_log));
+
+    writer->close();
+
+    auto use_lake_pk_index_loader = config::use_lake_pk_index_loader;
+    config::use_lake_pk_index_loader = false;
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
+    config::use_lake_pk_index_loader = use_lake_pk_index_loader;
+
+    vector<ColumnId> pk_columns(_tablet_schema->num_key_columns());
+    for (auto i = 0; i < _tablet_schema->num_key_columns(); i++) {
+        pk_columns[i] = (ColumnId)i;
+    }
+    auto pkey_schema = ChunkHelper::convert_schema(_tablet_schema, pk_columns);
+    ASSIGN_OR_ABORT(auto rowsets, tablet.get_rowsets(2));
+    auto index = std::make_unique<LakePrimaryIndex>(pkey_schema);
+    MetaFileBuilder builder(tablet, _tablet_metadata);
+    auto future = ExecEnv::GetInstance()->lake_pk_index_loader()->load(&tablet, rowsets, pkey_schema, 2, &builder,
+                                                                       index.get());
+    ASSERT_OK(future.get());
+
+    std::unique_ptr<Column> pk_column;
+    Chunk chunk1({c0}, std::make_shared<Schema>(pkey_schema));
+    PrimaryKeyEncoder::create_column(pkey_schema, &pk_column);
+    PrimaryKeyEncoder::encode(pkey_schema, chunk1, 0, chunk1.num_rows(), pk_column.get());
+    std::vector<uint64_t> rowids;
+    rowids.resize(k0.size());
+    ASSERT_OK(index->get(*(pk_column.get()), &rowids));
+    for (auto& rowid : rowids) {
+        ASSERT_TRUE(rowid != -1);
+    }
+}
+
+} // namespace starrocks::lake


### PR DESCRIPTION
Why I'm doing:
In shared-data mode, the data is stored in remote. When pk index needs to be loaded, the cost will be expensive. The segments can be loaded paralleled to speed up the pk index loading.
What I'm doing:
Optimize the lake pk index load. For a tablet which has 155 segments, pk index loading will be 8-9x faster.
For multiple tablet, pk index loading will be 5-6x faster.
Fixes #issue
Case1: TPCDS 100G table0-9 1 tablet pk index load cost
| | pk index load cost(s) |
| :----: | :----: |
| without opt | 26.63 |
| 10 thread | 3.36 |
| 20 thread | 3.29 |

Case2: TPCDS 100G
|| publish(s) | pk index load cost(s) |
| :-----:| :-----: | :----: |
|without opt| 13 | 1.7-2.9 |
|with opt| 8.28 | 0.5-0.8 |

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
