### PR TITLE
[Doc] modify the headlines of sr ecosystem docs

### DIFF
--- a/docs/ecosystem_release/flink_connector.md
+++ b/docs/ecosystem_release/flink_connector.md
@@ -1,4 +1,4 @@
-# Flink connector
+# Releases of StarRocks Connector for Flink
 
 ## **Notifications**
 
@@ -35,7 +35,7 @@
 
 ### 1.2
 
-**1.2.8**
+#### 1.2.8
 
 This release includes some improvements and bug fixes. The notable changes are as follows:
 

--- a/docs/ecosystem_release/flink_connector.md
+++ b/docs/ecosystem_release/flink_connector.md
@@ -1,6 +1,6 @@
 # Releases of StarRocks Connector for Flink
 
-## **Notifications**
+## Notifications
 
 **User guide:**
 

--- a/docs/ecosystem_release/kafka_connector.md
+++ b/docs/ecosystem_release/kafka_connector.md
@@ -1,4 +1,4 @@
-# Kafka connector
+# Releases of StarRocks Connector for Kafka
 
 ## Notifications
 
@@ -18,7 +18,7 @@
 
 ### 1.0
 
-**1.0.0**
+#### 1.0.0
 
 Release date: June 25, 2023
 

--- a/docs/ecosystem_release/kubernetes_operator.md
+++ b/docs/ecosystem_release/kubernetes_operator.md
@@ -26,7 +26,7 @@ The Operator provided by StarRocks is used to deploy StarRocks clusters in the K
   - Default configuration file for StarRocks Operator: `operator.yaml`
   - Helm Chart, including `kube-starrocks` Chart `kube-starrocks-${chart_version}.tgz`. The `kube-starrocks` Chart is divided into two subcharts: `starrocks` Chart `starrocks-${chart_version}.tgz` and `operator` Chart `operator-${chart_version}.tgz`.
 
-For example, the download URL for kube-starrocks chart v1.8.6 is: 
+For example, the download URL for kube-starrocks chart v1.8.6 is:
 
 `https://github.com/StarRocks/starrocks-kubernetes-operator/releases/download/v1.8.6/kube-starrocks-1.8.6.tgz`
 

--- a/docs/ecosystem_release/kubernetes_operator.md
+++ b/docs/ecosystem_release/kubernetes_operator.md
@@ -1,4 +1,4 @@
-# starrocks-kubernetes-operator
+# Releases of Kubernetes Operator for StarRocks
 
 ## Notifications
 
@@ -26,7 +26,9 @@ The Operator provided by StarRocks is used to deploy StarRocks clusters in the K
   - Default configuration file for StarRocks Operator: `operator.yaml`
   - Helm Chart, including `kube-starrocks` Chart `kube-starrocks-${chart_version}.tgz`. The `kube-starrocks` Chart is divided into two subcharts: `starrocks` Chart `starrocks-${chart_version}.tgz` and `operator` Chart `operator-${chart_version}.tgz`.
 
-For example, the download URL for kube-starrocks chart v1.8.6 is: [kube-starrocks](https://github.com/StarRocks/starrocks-kubernetes-operator/releases/download/v1.8.6/kube-starrocks-1.8.6.tgz)
+For example, the download URL for kube-starrocks chart v1.8.6 is: 
+
+`https://github.com/StarRocks/starrocks-kubernetes-operator/releases/download/v1.8.6/kube-starrocks-1.8.6.tgz`
 
 **Version requirements**
 
@@ -35,9 +37,9 @@ For example, the download URL for kube-starrocks chart v1.8.6 is: [kube-starrock
 
 ## **Release notes**
 
-## 1.8
+### 1.8
 
-**1.8.6**
+#### 1.8.6
 
 **Bug Fixes**
 
@@ -50,7 +52,7 @@ Fixed the following issue:
 - [Load data from outside the Kubernetes network to StarRocks through FE proxy](https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/doc/load_data_using_stream_load_howto.md)
 - [Update the root user's password using Helm](https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/doc/change_root_password_howto.md)
 
-**1.8.5**
+#### 1.8.5
 
 **Improvements**
 
@@ -65,7 +67,7 @@ Fixed the following issue:
 
 - **[Helm Chart]** When the value specified in `starrocks.starrocksCluster.name` is different from the value of `starrocks.nameOverride`, the old configmaps for FE, BE, and CN will be deleted. New configmaps with new names for the FE, BE, and CN will be created. **This may result in the restart of the FE, BE, and CN pods.**
 
-**1.8.4**
+#### 1.8.4
 
 **Features**
 
@@ -86,7 +88,7 @@ Fixed the following issue:
 - Add more user guides on how to deploy a StarRocks cluster with different configurations. For example, how to [deploy a StarRocks cluster with all supported features](https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/examples/starrocks/deploy_a_starrocks_cluster_with_all_features.yaml). For more user guides, see [docs](https://github.com/StarRocks/starrocks-kubernetes-operator/tree/main/examples/starrocks).
 - Add more user guides on how to manage the StarRocks cluster. For example, how to configure [logging and related fields](https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/doc/logging_and_related_configurations_howto.md) and [mount external configmaps or secrets](https://github.com/StarRocks/starrocks-kubernetes-operator/blob/main/doc/mount_external_configmaps_or_secrets_howto.md). For more user guides, see [docs](https://github.com/StarRocks/starrocks-kubernetes-operator/tree/main/doc).
 
-**1.8.3**
+#### 1.8.3
 
 **Upgrade notes**
 
@@ -101,13 +103,13 @@ Fixed the following issue:
 
 - The value of the `proxy_read_timeout` parameter is changed in the **nginx.conf** file to 600s from 60s, in order to avoid timeout.
 
-**1.8.2**
+#### 1.8.2
 
 **Improvements**
 
 - Increase the maximum memory usage allowed for the operator pods to avoid OOM. [#254](https://github.com/StarRocks/starrocks-kubernetes-operator/pull/254)
 
-**1.8.1**
+#### 1.8.1
 
 **Features**
 
@@ -118,7 +120,7 @@ Fixed the following issue:
 
 - Remove the related Kubernetes resources when the `BeSpec` or `CnSpec` of the StarRocks cluster is deleted, ensuring a clean and consistent state of the cluster. [#245](https://github.com/StarRocks/starrocks-kubernetes-operator/pull/245)
 
-**1.8.0**
+#### 1.8.0
 
 **Upgrade notes and behavior changes**
 

--- a/docs/ecosystem_release/spark_connector.md
+++ b/docs/ecosystem_release/spark_connector.md
@@ -1,6 +1,6 @@
-#  Releases of StarRocks Connector for Spark
+# Releases of StarRocks Connector for Spark
 
-## **Notifications**
+## Notifications
 
 **User guide:**
 

--- a/docs/ecosystem_release/spark_connector.md
+++ b/docs/ecosystem_release/spark_connector.md
@@ -1,4 +1,4 @@
-# Spark connector
+#  Releases of StarRocks Connector for Spark
 
 ## **Notifications**
 


### PR DESCRIPTION
Why I'm doing:
The headlines of sr ecosystem docs are not consistent.
What I'm doing:
modify the headlines of sr ecosystem docs
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5