### PR TITLE
[Doc] Fix missing comma in BROKER LOAD

### DIFF
--- a/docs/sql-reference/sql-statements/data-manipulation/BROKER_LOAD.md
+++ b/docs/sql-reference/sql-statements/data-manipulation/BROKER_LOAD.md
@@ -220,7 +220,7 @@ Open-source HDFS supports two authentication methods: simple authentication and 
   - If you use simple authentication, configure `StorageCredentialParams` as follows:
 
     ```Plain
-    "hadoop.security.authentication" = "simple"
+    "hadoop.security.authentication" = "simple",
     "username" = "<hdfs_username>",
     "password" = "<hdfs_password>"
     ```


### PR DESCRIPTION
Signed-off-by: amber-create <yangyanping@starrocks.com>

Why I'm doing: "hadoop.security.authentication" = "simple" should be followed by a comma which is missing.

What I'm doing: Add a comma following "hadoop.security.authentication" = "simple".

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5