### PR TITLE
[BugFix] Fix iceberg catalog's aws region problem

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -35,6 +35,7 @@ import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
+import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
@@ -54,6 +55,7 @@ import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_SESS
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_USE_AWS_SDK_DEFAULT_BEHAVIOR;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_USE_INSTANCE_PROFILE;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_ACCESS_KEY;
+import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_ENABLE_PATH_STYLE_ACCESS;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_ENDPOINT;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_EXTERNAL_ID;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_IAM_ROLE_ARN;
@@ -78,7 +80,7 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
     private String s3ExternalId;
     private String s3Region;
     private String s3Endpoint;
-
+    private boolean s3EnablePathStyleAccess;
     private boolean glueUseAWSSDKDefaultBehavior;
     private boolean glueUseInstanceProfile;
     private String glueAccessKey;
@@ -102,6 +104,8 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         s3ExternalId = properties.getOrDefault(AWS_S3_EXTERNAL_ID, "");
         s3Region = properties.getOrDefault(AWS_S3_REGION, "");
         s3Endpoint = properties.getOrDefault(AWS_S3_ENDPOINT, "");
+        s3EnablePathStyleAccess =
+                Boolean.parseBoolean(properties.getOrDefault(AWS_S3_ENABLE_PATH_STYLE_ACCESS, "false"));
 
         glueUseAWSSDKDefaultBehavior = Boolean.parseBoolean(
                 properties.getOrDefault(AWS_GLUE_USE_AWS_SDK_DEFAULT_BEHAVIOR, "false"));
@@ -162,6 +166,10 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         if (!s3Endpoint.isEmpty()) {
             s3ClientBuilder.endpointOverride(ensureSchemeInEndpoint(s3Endpoint));
         }
+
+        // set for s3 path style access
+        s3ClientBuilder.serviceConfiguration(
+                S3Configuration.builder().pathStyleAccessEnabled(s3EnablePathStyleAccess).build());
 
         return s3ClientBuilder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -248,7 +248,7 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
         if (!strRegion.isEmpty()) {
             return Region.of(strRegion);
         }
-        Region region = null;
+        Region region = Region.of(AWSCloudConfigurationProvider.DEFAULT_AWS_REGION);
         try {
             DefaultAwsRegionProviderChain providerChain = DefaultAwsRegionProviderChain.builder()
                     .profileFile(ProfileFile::defaultProfileFile)
@@ -258,7 +258,6 @@ public class IcebergAwsClientFactory implements AwsClientFactory {
             LOG.info(
                     "AWS sdk unable to load region from DefaultAwsRegionProviderChain, using default region us-east-1 instead",
                     e);
-            region = Region.of(AWSCloudConfigurationProvider.DEFAULT_AWS_REGION);
         }
         return region;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergAwsClientFactory.java
@@ -35,7 +35,6 @@ import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClient;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
-import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.sts.StsClient;
 import software.amazon.awssdk.services.sts.StsClientBuilder;
 import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
@@ -14,12 +14,49 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.starrocks.credential.CloudConfigurationConstants;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
+import software.amazon.awssdk.regions.Region;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 public class IcebergAwsClientFactoryTest {
+    @Before
+    public void setup() {
+        System.setProperty("software.amazon.awssdk.http.service.impl",
+                "software.amazon.awssdk.http.urlconnection.UrlConnectionSdkHttpService");
+    }
+
+    @Test
+    public void testAKSK() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put(CloudConfigurationConstants.AWS_S3_ACCESS_KEY, "ak");
+        properties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, "sk");
+        properties.put(CloudConfigurationConstants.AWS_S3_ENDPOINT, "endpoint");
+        properties.put(CloudConfigurationConstants.AWS_S3_REGION, "xxx");
+
+        properties.put(CloudConfigurationConstants.AWS_GLUE_ACCESS_KEY, "ak");
+        properties.put(CloudConfigurationConstants.AWS_GLUE_SECRET_KEY, "sk");
+        properties.put(CloudConfigurationConstants.AWS_GLUE_ENDPOINT, "endpoint");
+        properties.put(CloudConfigurationConstants.AWS_GLUE_REGION, "region");
+        IcebergAwsClientFactory factory = new IcebergAwsClientFactory();
+        factory.initialize(properties);
+        Assert.assertNotNull(factory.s3());
+        Assert.assertNotNull(factory.glue());
+
+        Assert.assertNull(factory.dynamo());
+        Assert.assertNull(factory.kms());
+    }
+
+    @Test
+    public void testResolveRegion() {
+        Assert.assertEquals(Region.US_WEST_1, IcebergAwsClientFactory.tryToResolveRegion("us-west-1"));
+    }
+
     @Test
     public void testEnsureSchemeInEndpoint() {
         // test endpoint without scheme

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergAwsClientFactoryTest.java
@@ -18,20 +18,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
 
 public class IcebergAwsClientFactoryTest {
-
-    @Test
-    public void testInvalidCredential() {
-        IcebergAwsClientFactory factory = new IcebergAwsClientFactory();
-        Map<String, String> properties = new HashMap<>();
-        factory.initialize(properties);
-        Assert.assertThrows(IllegalArgumentException.class, factory::s3);
-        Assert.assertThrows(IllegalArgumentException.class, factory::glue);
-    }
-
     @Test
     public void testEnsureSchemeInEndpoint() {
         // test endpoint without scheme


### PR DESCRIPTION
Why I'm doing:
When the user didn't set region in iceberg catalog, we need to detect region, if detect failed, set default region us-east-1.

What I'm doing:
1. Make people using iceberg + s3 happy.
2. Support path style access parameters.
3. If user didn't configure any credentials, using SDK default behavior.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
