### PR TITLE
[Enhancement] Enable fast schema evolution for rollup

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -97,6 +97,10 @@ Status OlapTableSchemaParam::init(const POlapTableSchemaParam& pschema) {
             col_param->short_key_column_count = p_index.column_param().short_key_column_count();
             index->column_param = col_param;
         }
+
+        if (p_index.has_schema_version()) {
+            index->schema_version = p_index.schema_version();
+        }
         _indexes.emplace_back(index);
     }
 
@@ -143,6 +147,9 @@ Status OlapTableSchemaParam::init(const TOlapTableSchemaParam& tschema, RuntimeS
         }
         if (t_index.__isset.where_clause) {
             RETURN_IF_ERROR(Expr::create_expr_tree(&_obj_pool, t_index.where_clause, &index->where_clause, state));
+        }
+        if (t_index.__isset.schema_version) {
+            index->schema_version = t_index.schema_version;
         }
         _indexes.emplace_back(index);
     }

--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -54,6 +54,7 @@ void OlapTableColumnParam::to_protobuf(POlapTableColumnParam* pcolumn) const {
 void OlapTableIndexSchema::to_protobuf(POlapTableIndexSchema* pindex) const {
     pindex->set_id(index_id);
     pindex->set_schema_hash(schema_hash);
+    pindex->set_schema_version(schema_version);
     for (auto slot : slots) {
         pindex->add_columns(slot->col_name());
     }

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -47,6 +47,8 @@ struct OlapTableIndexSchema {
     int32_t schema_hash;
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;
+    int32_t schema_version = -1;
+    ;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };

--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -45,10 +45,9 @@ struct OlapTableIndexSchema {
     int64_t index_id;
     std::vector<SlotDescriptor*> slots;
     int32_t schema_hash;
+    int32_t schema_version = -1;
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;
-    int32_t schema_version = -1;
-    ;
 
     void to_protobuf(POlapTableIndexSchema* pindex) const;
 };

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -544,11 +544,13 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
         if (ptable_schema_param.indexes(i).id() == index_id) break;
     }
     if (i < ptable_schema_param.indexes_size()) {
-        if (ptable_schema_param.indexes_size() > 0 && ptable_schema_param.indexes(i).has_column_param() &&
-            ptable_schema_param.indexes(i).column_param().columns_desc_size() != 0 &&
-            ptable_schema_param.indexes(i).column_param().columns_desc(0).unique_id() >= 0) {
+        auto& index = ptable_schema_param.indexes(i);
+        if (index.has_column_param() && index.column_param().columns_desc_size() != 0 &&
+            index.column_param().columns_desc(0).unique_id() >= 0 && index.has_schema_version() &&
+            index.schema_version() > _tablet_schema->schema_version()) {
             RETURN_IF_ERROR(_tablet_schema->build_current_tablet_schema(
-                    index_id, ptable_schema_param.version(), ptable_schema_param.indexes(i), ori_tablet_schema));
+                    index_id, ptable_schema_param.indexes(i).schema_version(), index,
+                    ori_tablet_schema));
         }
     }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -548,8 +548,8 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
         if (index.has_column_param() && index.column_param().columns_desc_size() != 0 &&
             index.column_param().columns_desc(0).unique_id() >= 0 && index.has_schema_version() &&
             index.schema_version() > _tablet_schema->schema_version()) {
-            RETURN_IF_ERROR(_tablet_schema->build_current_tablet_schema(
-                    index_id, index.schema_version(), index, ori_tablet_schema));
+            RETURN_IF_ERROR(_tablet_schema->build_current_tablet_schema(index_id, index.schema_version(), index,
+                                                                        ori_tablet_schema));
         }
     }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -549,8 +549,7 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
             index.column_param().columns_desc(0).unique_id() >= 0 && index.has_schema_version() &&
             index.schema_version() > _tablet_schema->schema_version()) {
             RETURN_IF_ERROR(_tablet_schema->build_current_tablet_schema(
-                    index_id, ptable_schema_param.indexes(i).schema_version(), index,
-                    ori_tablet_schema));
+                    index_id, ptable_schema_param.indexes(i).schema_version(), index, ori_tablet_schema));
         }
     }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -549,7 +549,7 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
             index.column_param().columns_desc(0).unique_id() >= 0 && index.has_schema_version() &&
             index.schema_version() > _tablet_schema->schema_version()) {
             RETURN_IF_ERROR(_tablet_schema->build_current_tablet_schema(
-                    index_id, ptable_schema_param.indexes(i).schema_version(), index, ori_tablet_schema));
+                    index_id, index.schema_version(), index, ori_tablet_schema));
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -357,7 +357,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             }
         }
 
-        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0 /* initial schema version */,
+        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);
         MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(rollupIndexId);
         Preconditions.checkNotNull(indexMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2396,6 +2396,9 @@ public class SchemaChangeHandler extends AlterHandler {
                         newSortKeyIdxes.add(sortKeyIdx);
                     }
                 }
+                if (!newSortKeyIdxes.isEmpty()) {
+                    currentIndexMeta.setSortKeyIdxes(newSortKeyIdxes);
+                }
                 currentIndexMeta.setSchema(indexSchema);
 
                 int currentSchemaVersion = currentIndexMeta.getSchemaVersion();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2369,10 +2369,6 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             // update base index schema
-            long baseIndexId = olapTable.getBaseIndexId();
-            List<Long> indexIds = new ArrayList<Long>();
-            indexIds.add(baseIndexId);
-            indexIds.addAll(olapTable.getIndexIdListExceptBaseIndex());
             Set<String> modifiedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
             Boolean hasMv = !olapTable.getRelatedMaterializedViews().isEmpty();
             for (Map.Entry<Long, List<Column>> entry : changedIndexIdToSchema.entrySet()) {
@@ -2401,9 +2397,6 @@ public class SchemaChangeHandler extends AlterHandler {
                     }
                 }
                 currentIndexMeta.setSchema(indexSchema);
-                if (!newSortKeyIdxes.isEmpty()) {
-                    currentIndexMeta.setSortKeyIdxes(newSortKeyIdxes);
-                }
 
                 int currentSchemaVersion = currentIndexMeta.getSchemaVersion();
                 int newSchemaVersion = currentSchemaVersion + 1;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -892,7 +892,6 @@ public class SchemaChangeHandler extends AlterHandler {
                     return fastSchemaEvolution;
                 }
                 // 2. add to rollup
-                fastSchemaEvolution = false;
                 modIndexSchema = indexSchemaMap.get(targetIndexId);
                 checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false);
             }
@@ -905,7 +904,6 @@ public class SchemaChangeHandler extends AlterHandler {
                 return fastSchemaEvolution;
             } else {
                 // add to rollup index
-                fastSchemaEvolution = false;
                 List<Column> modIndexSchema = indexSchemaMap.get(targetIndexId);
                 checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false);
 
@@ -932,7 +930,6 @@ public class SchemaChangeHandler extends AlterHandler {
                 return fastSchemaEvolution;
             }
 
-            fastSchemaEvolution = false;
             // 2. add to rollup index
             modIndexSchema = indexSchemaMap.get(targetIndexId);
             checkAndAddColumn(modIndexSchema, newColumn, columnPos, newColNameSet, false);

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/RollupProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/RollupProcDir.java
@@ -20,13 +20,27 @@ package com.starrocks.common.proc;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.MaterializedViewHandler;
 import com.starrocks.alter.RollupJobV2;
+import com.starrocks.analysis.BinaryPredicate;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.LimitElement;
+import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.util.ListComparator;
+import com.starrocks.common.util.OrderByPair;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 
 public class RollupProcDir implements ProcDirInterface {
@@ -35,6 +49,8 @@ public class RollupProcDir implements ProcDirInterface {
             .add("BaseIndexName").add("RollupIndexName").add("RollupId").add("TransactionId")
             .add("State").add("Msg").add("Progress").add("Timeout")
             .build();
+
+    private static final Logger LOG = LogManager.getLogger(RollupProcDir.class);
 
     private MaterializedViewHandler materializedViewHandler;
     private Database db;
@@ -59,6 +75,104 @@ public class RollupProcDir implements ProcDirInterface {
                 oneInfo.add(element.toString());
             }
             result.addRow(oneInfo);
+        }
+        return result;
+    }
+
+    boolean filterResult(String columnName, Comparable element, HashMap<String, Expr> filter) throws AnalysisException {
+        if (filter == null) {
+            return true;
+        }
+        Expr subExpr = filter.get(columnName.toLowerCase());
+        if (subExpr == null) {
+            return true;
+        }
+        BinaryPredicate binaryPredicate = (BinaryPredicate) subExpr;
+        if (subExpr.getChild(1) instanceof StringLiteral && binaryPredicate.getOp() == BinaryType.EQ) {
+            return ((StringLiteral) subExpr.getChild(1)).getValue().equals(element);
+        }
+        if (subExpr.getChild(1) instanceof DateLiteral) {
+            Long leftVal = (new DateLiteral((String) element, Type.DATETIME)).getLongValue();
+            Long rightVal = ((DateLiteral) subExpr.getChild(1)).getLongValue();
+            switch (binaryPredicate.getOp()) {
+                case EQ:
+                case EQ_FOR_NULL:
+                    return leftVal.equals(rightVal);
+                case GE:
+                    return leftVal >= rightVal;
+                case GT:
+                    return leftVal > rightVal;
+                case LE:
+                    return leftVal <= rightVal;
+                case LT:
+                    return leftVal < rightVal;
+                case NE:
+                    return !leftVal.equals(rightVal);
+                default:
+                    Preconditions.checkState(false, "No defined binary operator.");
+            }
+        }
+        return true;
+    }
+
+    public ProcResult fetchResultByFilter(HashMap<String, Expr> filter, ArrayList<OrderByPair> orderByPairs,
+                                          LimitElement limitElement) throws AnalysisException {
+        Preconditions.checkNotNull(db);
+        Preconditions.checkNotNull(materializedViewHandler);
+
+        List<List<Comparable>> rollupJobInfos = materializedViewHandler.getAlterJobInfosByDb(db);
+
+        //where
+        List<List<Comparable>> jobInfos;
+        if (filter == null || filter.size() == 0) {
+            jobInfos = rollupJobInfos;
+        } else {
+            jobInfos = Lists.newArrayList();
+            for (List<Comparable> infoStr : rollupJobInfos) {
+                if (infoStr.size() != TITLE_NAMES.size()) {
+                    LOG.warn("RollupJobInfos.size() " + rollupJobInfos.size()
+                            + " not equal TITLE_NAMES.size() " + TITLE_NAMES.size());
+                    continue;
+                }
+                boolean isNeed = true;
+                for (int i = 0; i < infoStr.size(); i++) {
+                    isNeed = filterResult(TITLE_NAMES.get(i), infoStr.get(i), filter);
+                    if (!isNeed) {
+                        break;
+                    }
+                }
+                if (isNeed) {
+                    jobInfos.add(infoStr);
+                }
+            }
+        }
+
+        // order by
+        if (orderByPairs != null) {
+            ListComparator<List<Comparable>> comparator = null;
+            OrderByPair[] orderByPairArr = new OrderByPair[orderByPairs.size()];
+            comparator = new ListComparator<List<Comparable>>(orderByPairs.toArray(orderByPairArr));
+            Collections.sort(jobInfos, comparator);
+        }
+
+        // limit
+        if (limitElement != null && limitElement.hasLimit()) {
+            int beginIndex = (int) limitElement.getOffset();
+            int endIndex = (int) (beginIndex + limitElement.getLimit());
+            if (endIndex > jobInfos.size()) {
+                endIndex = jobInfos.size();
+            }
+            jobInfos = jobInfos.subList(beginIndex, endIndex);
+        }
+
+        BaseProcResult result = new BaseProcResult();
+        result.setNames(TITLE_NAMES);
+        for (List<Comparable> jobInfo : jobInfos) {
+            List<String> oneResult = new ArrayList<String>(jobInfos.size());
+            for (Comparable column : jobInfo) {
+                oneResult.add(column.toString());
+            }
+            result.addRow(oneResult);
         }
         return result;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -315,6 +315,7 @@ public class OlapTableSink extends DataSink {
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
                     indexMeta.getSchemaHash());
             indexSchema.setColumn_param(columnParam);
+            indexSchema.setSchema_version(indexMeta.getSchemaVersion());
             schemaParam.addToIndexes(indexSchema);
             if (indexMeta.getWhereClause() != null) {
                 String dbName = MetaUtils.getDatabase(dbId).getFullName();

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -93,6 +93,7 @@ import com.starrocks.common.proc.LocalTabletsProcDir;
 import com.starrocks.common.proc.OptimizeProcDir;
 import com.starrocks.common.proc.PartitionsProcDir;
 import com.starrocks.common.proc.ProcNodeInterface;
+import com.starrocks.common.proc.RollupProcDir;
 import com.starrocks.common.proc.SchemaChangeProcDir;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.DebugUtil;
@@ -1648,6 +1649,9 @@ public class ShowExecutor {
                     showStmt.getOrderPairs(), showStmt.getLimitElement()).getRows();
         } else if (procNodeI instanceof OptimizeProcDir) {
             rows = ((OptimizeProcDir) procNodeI).fetchResultByFilter(showStmt.getFilterMap(),
+                    showStmt.getOrderPairs(), showStmt.getLimitElement()).getRows();
+        } else if (procNodeI instanceof RollupProcDir) {
+            rows = ((RollupProcDir) procNodeI).fetchResultByFilter(showStmt.getFilterMap(),
                     showStmt.getOrderPairs(), showStmt.getLimitElement()).getRows();
         } else {
             rows = procNodeI.fetchResult().getRows();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -376,15 +376,25 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         }
         List<Index> newIndexes = tbl.getCopiedIndexes();
 
-        Assertions.assertDoesNotThrow(
+        Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
                         .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 100, 100, false));
-        jobSize++;
-        Assertions.assertEquals(jobSize, alterJobs.size());
 
+        indexSchemaMap.get(tbl.getBaseIndexId()).add(6, new Column("kk", Type.INT));
         Assertions.assertDoesNotThrow(
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
                         .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 101, 101, true));
+        jobSize++;
+        Assertions.assertEquals(jobSize, alterJobs.size());
+
+        Map<Long, LinkedList<Column>> indexSchemaMap2 = new HashMap<>();
+        for (Map.Entry<Long, List<Column>> entry : tbl.getIndexIdToSchema().entrySet()) {
+            indexSchemaMap2.put(entry.getKey(), new LinkedList<>(entry.getValue()));
+        }
+        indexSchemaMap2.get(tbl.getBaseIndexId()).remove(6);
+        Assertions.assertDoesNotThrow(
+                () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap2, newIndexes, 102, 102, true));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
@@ -392,7 +402,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         tbl.setState(OlapTableState.ROLLUP);
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 102, 102, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 103, 103, false));
         tbl.setState(beforeState);
 
         Map<Long, LinkedList<Column>> indexSchemaMapInvalid2 = new HashMap<>(indexSchemaMap);
@@ -402,7 +412,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid2, newIndexes, 103, 103, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid2, newIndexes, 104, 104, false));
 
         Map<Long, LinkedList<Column>> indexSchemaMapInvalid3 = new HashMap<>(indexSchemaMap);
 
@@ -410,13 +420,13 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         indexSchemaMapInvalid3.get(tbl.getBaseIndexId()).removeIf(Column::isKey);
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid3, newIndexes, 104, 104, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid3, newIndexes, 105, 105, false));
 
         Map<Long, LinkedList<Column>> emptyIndexMap = new HashMap<>();
 
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, emptyIndexMap, newIndexes, 105, 105, false));
+                        .modifyTableAddOrDropColumns(db, tbl, emptyIndexMap, newIndexes, 106, 106, false));
 
     }
 

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -74,6 +74,7 @@ message POlapTableIndexSchema {
     repeated string columns = 2;
     required int32 schema_hash = 3;
     optional POlapTableColumnParam column_param = 4;
+    optional int32 schema_version = 5;
 };
 
 message POlapTableSchemaParam {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -270,6 +270,7 @@ struct TOlapTableIndexSchema {
     3: required i32 schema_hash
     4: optional TOlapTableColumnParam column_param
     5: optional Exprs.TExpr where_clause
+    6: optional i32 schema_version
 }
 
 struct TOlapTableSchemaParam {

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -720,6 +720,7 @@ function: wait_alter_table_finish("ROLLUP", 8)
 -- result:
 None
 -- !result
+<<<<<<< HEAD
 [UC]show alter table rollup where State = "FINISHED";
 -- result:
 15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
@@ -739,6 +740,27 @@ None
 -- result:
 -- !result
 [UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";
+=======
+show alter table rollup where State = "FINISHED";
+-- result:
+12054	tab1	2023-11-22 15:54:39	2023-11-22 15:54:58	tab1	r1	12055	2036	FINISHED		None	86400
+12132	tab1	2023-11-22 15:55:00	2023-11-22 15:55:18	r1	r2	12133	2080	FINISHED		None	86400
+-- !result
+show alter table rollup where CreateTime >= "1970-01-01 00:00:00";
+-- result:
+12054	tab1	2023-11-22 15:54:39	2023-11-22 15:54:58	tab1	r1	12055	2036	FINISHED		None	86400
+12132	tab1	2023-11-22 15:55:00	2023-11-22 15:55:18	r1	r2	12133	2080	FINISHED		None	86400
+-- !result
+show alter table rollup where CreateTime > "1970-01-01 00:00:00";
+-- result:
+12054	tab1	2023-11-22 15:54:39	2023-11-22 15:54:58	tab1	r1	12055	2036	FINISHED		None	86400
+12132	tab1	2023-11-22 15:55:00	2023-11-22 15:55:18	r1	r2	12133	2080	FINISHED		None	86400
+-- !result
+show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
+-- result:
+-- !result
+show alter table rollup where CreateTime < "1970-01-01 00:00:00";
+>>>>>>> 5c6db65e7c (add test)
 -- result:
 -- !result
 desc r2;

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -1,4 +1,4 @@
--- name: test_fast_schema_evolution
+-- name: test_fast_schema_evolution_normal
 create database test_fast_schema_evolution;
 -- result:
 -- !result
@@ -268,10 +268,10 @@ PROPERTIES (
 -- !result
 select * from tab1;
 -- result:
-100	k2_100	100	100	1000	v6_100	v5_100
 400	k2_400	400	400	600	v6_400	v5_400
-500	k2_500	500	500	900	v6_500	v5_500
 600	k2_600	600	600	700	v6_600	v5_600
+500	k2_500	500	500	900	v6_500	v5_500
+100	k2_100	100	100	1000	v6_100	v5_100
 -- !result
 drop table t1;
 -- result:
@@ -518,6 +518,380 @@ drop table tab1;
 -- result:
 -- !result
 drop database test_fast_schema_evolution_and_alter;
+-- result:
+-- !result
+-- name: test_fast_schema_evolution_for_rollup
+create database test_fast_schema_evolution_for_rollup;
+-- result:
+-- !result
+use test_fast_schema_evolution_for_rollup;
+-- result:
+-- !result
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+-- result:
+-- !result
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+-- result:
+-- !result
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+-- result:
+-- !result
+alter table tab1 add rollup r1(k1,v1,v2,v3);
+-- result:
+-- !result
+function: wait_alter_table_finish("ROLLUP", 8)
+-- result:
+None
+-- !result
+desc r1;
+-- result:
+k1	int	YES	true	None	
+v1	int	YES	true	None	NONE
+v2	int	YES	true	None	NONE
+v3	int	YES	false	None	NONE
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+300	k2_300	300	300	300	v4_300	v5_300
+400	k2_400	400	400	400	v4_400	v5_400
+500	k2_500	500	500	500	v4_500	v5_500
+600	k2_600	600	600	600	v4_600	v5_600
+-- !result
+alter table tab1 add column c1 bigint default "0" to r1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+desc r1;
+-- result:
+k1	int	YES	true	None	
+v1	int	YES	true	None	NONE
+v2	int	YES	true	None	NONE
+v3	int	YES	false	None	NONE
+c1	bigint	YES	false	0	NONE
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` varchar(50) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` varchar(50) NULL COMMENT "",
+  `c1` bigint(20) NULL DEFAULT "0" COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100	0
+200	k2_200	200	200	200	v4_200	v5_200	0
+300	k2_300	300	300	300	v4_300	v5_300	0
+400	k2_400	400	400	400	v4_400	v5_400	0
+500	k2_500	500	500	500	v4_500	v5_500	0
+600	k2_600	600	600	600	v4_600	v5_600	0
+-- !result
+insert into tab1 values (700, "k2_700", 700, 700, 700, "v4_700", "v5_700", "111");
+-- result:
+-- !result
+insert into tab1 values (800, "k2_800", 800, 800, 800, "v4_800", "v5_800", "222");
+-- result:
+-- !result
+insert into tab1 values (900, "k2_900", 900, 900, 900, "v4_900", "v5_900", "333");
+-- result:
+-- !result
+select * from tabl1;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table 'test_fast_schema_evolution_for_rollup.tabl1'.")
+-- !result
+alter table tab1 add column c2 bigint default "1" after v2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+desc r1;
+-- result:
+k1	int	YES	true	None	
+v1	int	YES	true	None	NONE
+v2	int	YES	true	None	NONE
+v3	int	YES	false	None	NONE
+c1	bigint	YES	false	0	NONE
+-- !result
+show create table tab1;
+-- result:
+tab1	CREATE TABLE `tab1` (
+  `k1` int(11) NULL COMMENT "",
+  `k2` varchar(50) NULL COMMENT "",
+  `v1` int(11) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `c2` bigint(20) NULL DEFAULT "1" COMMENT "",
+  `v3` int(11) NULL COMMENT "",
+  `v4` varchar(50) NULL COMMENT "",
+  `v5` varchar(50) NULL COMMENT "",
+  `c1` bigint(20) NULL DEFAULT "0" COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`k1`, `k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	1	100	v4_100	v5_100	0
+200	k2_200	200	200	1	200	v4_200	v5_200	0
+300	k2_300	300	300	1	300	v4_300	v5_300	0
+400	k2_400	400	400	1	400	v4_400	v5_400	0
+500	k2_500	500	500	1	500	v4_500	v5_500	0
+600	k2_600	600	600	1	600	v4_600	v5_600	0
+700	k2_700	700	700	1	700	v4_700	v5_700	111
+800	k2_800	800	800	1	800	v4_800	v5_800	222
+900	k2_900	900	900	1	900	v4_900	v5_900	333
+-- !result
+insert into tab1 values (101, "k2_101", 101, 101, 101, 101, "v4_101", "v5_101", "101");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	1	100	v4_100	v5_100	0
+200	k2_200	200	200	1	200	v4_200	v5_200	0
+300	k2_300	300	300	1	300	v4_300	v5_300	0
+400	k2_400	400	400	1	400	v4_400	v5_400	0
+500	k2_500	500	500	1	500	v4_500	v5_500	0
+600	k2_600	600	600	1	600	v4_600	v5_600	0
+700	k2_700	700	700	1	700	v4_700	v5_700	111
+800	k2_800	800	800	1	800	v4_800	v5_800	222
+900	k2_900	900	900	1	900	v4_900	v5_900	333
+101	k2_101	101	101	101	101	v4_101	v5_101	101
+-- !result
+alter table tab1 add rollup r2(k1,v2) from r1;
+-- result:
+-- !result
+function: wait_alter_table_finish("ROLLUP", 8)
+-- result:
+None
+-- !result
+[UC]show alter table rollup where State = "FINISHED";
+-- result:
+15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
+15308	tab1	2023-11-24 20:19:40	2023-11-24 20:19:57	r1	r2	15309	5176	FINISHED		None	86400
+-- !result
+[UC]show alter table rollup where CreateTime >= "1970-01-01 pdel00:00:00";
+-- result:
+15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
+15308	tab1	2023-11-24 20:19:40	2023-11-24 20:19:57	r1	r2	15309	5176	FINISHED		None	86400
+-- !result
+[UC]show alter table rollup where CreateTime > "1970-01-01 00:00:00";
+-- result:
+15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
+15308	tab1	2023-11-24 20:19:40	2023-11-24 20:19:57	r1	r2	15309	5176	FINISHED		None	86400
+-- !result
+[UC]show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
+-- result:
+-- !result
+[UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";
+-- result:
+-- !result
+desc r2;
+-- result:
+k1	int	YES	true	None	
+v2	int	YES	true	None	NONE
+-- !result
+alter table tab1 add column c3 bigint default "2" to r2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+desc r1;
+-- result:
+k1	int	YES	true	None	
+v1	int	YES	true	None	NONE
+v2	int	YES	true	None	NONE
+v3	int	YES	false	None	NONE
+c1	bigint	YES	false	0	NONE
+-- !result
+desc r2;
+-- result:
+k1	int	YES	true	None	
+v2	int	YES	true	None	NONE
+c3	bigint	YES	false	2	NONE
+-- !result
+desc tab1;
+-- result:
+k1	int	YES	true	None	
+k2	varchar(50)	YES	true	None	
+v1	int	YES	false	None	
+v2	int	YES	false	None	
+c2	bigint	YES	false	1	
+v3	int	YES	false	None	
+v4	varchar(50)	YES	false	None	
+v5	varchar(50)	YES	false	None	
+c1	bigint	YES	false	0	
+c3	bigint	YES	false	2	
+-- !result
+insert into tab1 values (102, "k2_102", 102, 102, 102, 102, "v4_102", "v5_102", "102", "102");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	1	100	v4_100	v5_100	0	2
+101	k2_101	101	101	101	101	v4_101	v5_101	101	2
+200	k2_200	200	200	1	200	v4_200	v5_200	0	2
+300	k2_300	300	300	1	300	v4_300	v5_300	0	2
+400	k2_400	400	400	1	400	v4_400	v5_400	0	2
+500	k2_500	500	500	1	500	v4_500	v5_500	0	2
+600	k2_600	600	600	1	600	v4_600	v5_600	0	2
+700	k2_700	700	700	1	700	v4_700	v5_700	111	2
+800	k2_800	800	800	1	800	v4_800	v5_800	222	2
+900	k2_900	900	900	1	900	v4_900	v5_900	333	2
+102	k2_102	102	102	102	102	v4_102	v5_102	102	102
+-- !result
+alter table tab1 drop column c1;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+desc r1;
+-- result:
+k1	int	YES	true	None	
+v1	int	YES	true	None	NONE
+v2	int	YES	true	None	NONE
+v3	int	YES	false	None	NONE
+-- !result
+desc r2;
+-- result:
+k1	int	YES	true	None	
+v2	int	YES	true	None	NONE
+c3	bigint	YES	false	2	NONE
+-- !result
+desc tab1;
+-- result:
+k1	int	YES	true	None	
+k2	varchar(50)	YES	true	None	
+v1	int	YES	false	None	
+v2	int	YES	false	None	
+c2	bigint	YES	false	1	
+v3	int	YES	false	None	
+v4	varchar(50)	YES	false	None	
+v5	varchar(50)	YES	false	None	
+c3	bigint	YES	false	2	
+-- !result
+alter table tab1 drop column c3;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+desc r1;
+-- result:
+k1	int	YES	true	None	
+v1	int	YES	true	None	NONE
+v2	int	YES	true	None	NONE
+v3	int	YES	false	None	NONE
+-- !result
+desc r2;
+-- result:
+k1	int	YES	true	None	
+v2	int	YES	true	None	NONE
+-- !result
+desc tab1;
+-- result:
+k1	int	YES	true	None	
+k2	varchar(50)	YES	true	None	
+v1	int	YES	false	None	
+v2	int	YES	false	None	
+c2	bigint	YES	false	1	
+v3	int	YES	false	None	
+v4	varchar(50)	YES	false	None	
+v5	varchar(50)	YES	false	None	
+-- !result
+alter table tab1 drop column c2;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+desc r1;
+-- result:
+k1	int	YES	true	None	
+v1	int	YES	true	None	NONE
+v2	int	YES	true	None	NONE
+v3	int	YES	false	None	NONE
+-- !result
+desc r2;
+-- result:
+k1	int	YES	true	None	
+v2	int	YES	true	None	NONE
+-- !result
+desc tab1;
+-- result:
+k1	int	YES	true	None	
+k2	varchar(50)	YES	true	None	
+v1	int	YES	false	None	
+v2	int	YES	false	None	
+v3	int	YES	false	None	
+v4	varchar(50)	YES	false	None	
+v5	varchar(50)	YES	false	None	
+-- !result
+drop table tab1;
+-- result:
+-- !result
+drop database test_fast_schema_evolution_for_rollup;
 -- result:
 -- !result
 -- name: test_fast_schema_evolution_and_mv

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -268,10 +268,10 @@ PROPERTIES (
 -- !result
 select * from tab1;
 -- result:
-400	k2_400	400	400	600	v6_400	v5_400
-600	k2_600	600	600	700	v6_600	v5_600
-500	k2_500	500	500	900	v6_500	v5_500
 100	k2_100	100	100	1000	v6_100	v5_100
+400	k2_400	400	400	600	v6_400	v5_400
+500	k2_500	500	500	900	v6_500	v5_500
+600	k2_600	600	600	700	v6_600	v5_600
 -- !result
 drop table t1;
 -- result:
@@ -642,9 +642,17 @@ insert into tab1 values (800, "k2_800", 800, 800, 800, "v4_800", "v5_800", "222"
 insert into tab1 values (900, "k2_900", 900, 900, 900, "v4_900", "v5_900", "333");
 -- result:
 -- !result
-select * from tabl1;
+select * from tab1;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Unknown table 'test_fast_schema_evolution_for_rollup.tabl1'.")
+100	k2_100	100	100	100	v4_100	v5_100	0
+200	k2_200	200	200	200	v4_200	v5_200	0
+300	k2_300	300	300	300	v4_300	v5_300	0
+400	k2_400	400	400	400	v4_400	v5_400	0
+500	k2_500	500	500	500	v4_500	v5_500	0
+600	k2_600	600	600	600	v4_600	v5_600	0
+700	k2_700	700	700	700	v4_700	v5_700	111
+800	k2_800	800	800	800	v4_800	v5_800	222
+900	k2_900	900	900	900	v4_900	v5_900	333
 -- !result
 alter table tab1 add column c2 bigint default "1" after v2;
 -- result:
@@ -720,55 +728,25 @@ function: wait_alter_table_finish("ROLLUP", 8)
 -- result:
 None
 -- !result
-<<<<<<< HEAD
-<<<<<<< HEAD
 [UC]show alter table rollup where State = "FINISHED";
 -- result:
-15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
-15308	tab1	2023-11-24 20:19:40	2023-11-24 20:19:57	r1	r2	15309	5176	FINISHED		None	86400
--- !result
-[UC]show alter table rollup where CreateTime >= "1970-01-01 pdel00:00:00";
--- result:
-15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
-15308	tab1	2023-11-24 20:19:40	2023-11-24 20:19:57	r1	r2	15309	5176	FINISHED		None	86400
--- !result
-[UC]show alter table rollup where CreateTime > "1970-01-01 00:00:00";
--- result:
-15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
-15308	tab1	2023-11-24 20:19:40	2023-11-24 20:19:57	r1	r2	15309	5176	FINISHED		None	86400
--- !result
-[UC]show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
--- result:
--- !result
-[UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";
-=======
-show alter table rollup where State = "FINISHED";
-=======
-[UC]show alter table rollup where State = "FINISHED";
->>>>>>> 5a1e1fc850 (update test)
--- result:
-12222	tab1	2023-11-22 16:02:26	2023-11-22 16:02:38	tab1	r1	12223	2198	FINISHED		None	86400
-12268	tab1	2023-11-22 16:02:41	2023-11-22 16:02:58	r1	r2	12269	2223	FINISHED		None	86400
+15650	tab1	2023-11-24 20:25:49	2023-11-24 20:26:07	tab1	r1	15651	5551	FINISHED		None	86400
+15731	tab1	2023-11-24 20:26:09	2023-11-24 20:26:27	r1	r2	15732	5594	FINISHED		None	86400
 -- !result
 [UC]show alter table rollup where CreateTime >= "1970-01-01 00:00:00";
 -- result:
-12222	tab1	2023-11-22 16:02:26	2023-11-22 16:02:38	tab1	r1	12223	2198	FINISHED		None	86400
-12268	tab1	2023-11-22 16:02:41	2023-11-22 16:02:58	r1	r2	12269	2223	FINISHED		None	86400
+15650	tab1	2023-11-24 20:25:49	2023-11-24 20:26:07	tab1	r1	15651	5551	FINISHED		None	86400
+15731	tab1	2023-11-24 20:26:09	2023-11-24 20:26:27	r1	r2	15732	5594	FINISHED		None	86400
 -- !result
 [UC]show alter table rollup where CreateTime > "1970-01-01 00:00:00";
 -- result:
-12222	tab1	2023-11-22 16:02:26	2023-11-22 16:02:38	tab1	r1	12223	2198	FINISHED		None	86400
-12268	tab1	2023-11-22 16:02:41	2023-11-22 16:02:58	r1	r2	12269	2223	FINISHED		None	86400
+15650	tab1	2023-11-24 20:25:49	2023-11-24 20:26:07	tab1	r1	15651	5551	FINISHED		None	86400
+15731	tab1	2023-11-24 20:26:09	2023-11-24 20:26:27	r1	r2	15732	5594	FINISHED		None	86400
 -- !result
 [UC]show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
 -- result:
 -- !result
-<<<<<<< HEAD
-show alter table rollup where CreateTime < "1970-01-01 00:00:00";
->>>>>>> 5c6db65e7c (add test)
-=======
 [UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";
->>>>>>> 5a1e1fc850 (update test)
 -- result:
 -- !result
 desc r2;

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -721,6 +721,7 @@ function: wait_alter_table_finish("ROLLUP", 8)
 None
 -- !result
 <<<<<<< HEAD
+<<<<<<< HEAD
 [UC]show alter table rollup where State = "FINISHED";
 -- result:
 15253	tab1	2023-11-24 20:19:27	2023-11-24 20:19:37	tab1	r1	15254	5150	FINISHED		None	86400
@@ -742,25 +743,32 @@ None
 [UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";
 =======
 show alter table rollup where State = "FINISHED";
+=======
+[UC]show alter table rollup where State = "FINISHED";
+>>>>>>> 5a1e1fc850 (update test)
 -- result:
-12054	tab1	2023-11-22 15:54:39	2023-11-22 15:54:58	tab1	r1	12055	2036	FINISHED		None	86400
-12132	tab1	2023-11-22 15:55:00	2023-11-22 15:55:18	r1	r2	12133	2080	FINISHED		None	86400
+12222	tab1	2023-11-22 16:02:26	2023-11-22 16:02:38	tab1	r1	12223	2198	FINISHED		None	86400
+12268	tab1	2023-11-22 16:02:41	2023-11-22 16:02:58	r1	r2	12269	2223	FINISHED		None	86400
 -- !result
-show alter table rollup where CreateTime >= "1970-01-01 00:00:00";
+[UC]show alter table rollup where CreateTime >= "1970-01-01 00:00:00";
 -- result:
-12054	tab1	2023-11-22 15:54:39	2023-11-22 15:54:58	tab1	r1	12055	2036	FINISHED		None	86400
-12132	tab1	2023-11-22 15:55:00	2023-11-22 15:55:18	r1	r2	12133	2080	FINISHED		None	86400
+12222	tab1	2023-11-22 16:02:26	2023-11-22 16:02:38	tab1	r1	12223	2198	FINISHED		None	86400
+12268	tab1	2023-11-22 16:02:41	2023-11-22 16:02:58	r1	r2	12269	2223	FINISHED		None	86400
 -- !result
-show alter table rollup where CreateTime > "1970-01-01 00:00:00";
+[UC]show alter table rollup where CreateTime > "1970-01-01 00:00:00";
 -- result:
-12054	tab1	2023-11-22 15:54:39	2023-11-22 15:54:58	tab1	r1	12055	2036	FINISHED		None	86400
-12132	tab1	2023-11-22 15:55:00	2023-11-22 15:55:18	r1	r2	12133	2080	FINISHED		None	86400
+12222	tab1	2023-11-22 16:02:26	2023-11-22 16:02:38	tab1	r1	12223	2198	FINISHED		None	86400
+12268	tab1	2023-11-22 16:02:41	2023-11-22 16:02:58	r1	r2	12269	2223	FINISHED		None	86400
 -- !result
-show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
+[UC]show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
 -- result:
 -- !result
+<<<<<<< HEAD
 show alter table rollup where CreateTime < "1970-01-01 00:00:00";
 >>>>>>> 5c6db65e7c (add test)
+=======
+[UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";
+>>>>>>> 5a1e1fc850 (update test)
 -- result:
 -- !result
 desc r2;

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -1,4 +1,4 @@
--- name: test_fast_schema_evolution
+-- name: test_fast_schema_evolution_normal
 create database test_fast_schema_evolution;
 use test_fast_schema_evolution;
 create table t1(k int, v int not null) ENGINE=OLAP DUPLICATE KEY(k) PROPERTIES ("replication_num" = "1", 'fast_schema_evolution' = 'true');
@@ -211,6 +211,102 @@ select * from tab1;
 
 drop table tab1;
 drop database test_fast_schema_evolution_and_alter;
+
+
+-- name: test_fast_schema_evolution_for_rollup
+create database test_fast_schema_evolution_for_rollup;
+use test_fast_schema_evolution_for_rollup;
+
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+
+alter table tab1 add rollup r1(k1,v1,v2,v3);
+function: wait_alter_table_finish("ROLLUP", 8)
+desc r1;
+select * from tab1;
+
+alter table tab1 add column c1 bigint default "0" to r1;
+function: wait_alter_table_finish()
+
+desc r1;
+show create table tab1;
+select * from tab1;
+
+insert into tab1 values (700, "k2_700", 700, 700, 700, "v4_700", "v5_700", "111");
+insert into tab1 values (800, "k2_800", 800, 800, 800, "v4_800", "v5_800", "222");
+insert into tab1 values (900, "k2_900", 900, 900, 900, "v4_900", "v5_900", "333");
+
+select * from tabl1;
+
+alter table tab1 add column c2 bigint default "1" after v2;
+function: wait_alter_table_finish()
+desc r1;
+show create table tab1;
+select * from tab1;
+
+insert into tab1 values (101, "k2_101", 101, 101, 101, 101, "v4_101", "v5_101", "101");
+select * from tab1;
+
+alter table tab1 add rollup r2(k1,v2) from r1;
+function: wait_alter_table_finish("ROLLUP", 8)
+
+[UC]show alter table rollup where State = "FINISHED";
+[UC]show alter table rollup where CreateTime >= "1970-01-01 pdel00:00:00";
+[UC]show alter table rollup where CreateTime > "1970-01-01 00:00:00";
+[UC]show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
+[UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";
+
+desc r2;
+alter table tab1 add column c3 bigint default "2" to r2;
+function: wait_alter_table_finish()
+
+desc r1;
+desc r2;
+desc tab1;
+insert into tab1 values (102, "k2_102", 102, 102, 102, 102, "v4_102", "v5_102", "102", "102");
+select * from tab1;
+
+alter table tab1 drop column c1;
+function: wait_alter_table_finish()
+desc r1;
+desc r2;
+desc tab1;
+
+alter table tab1 drop column c3;
+function: wait_alter_table_finish()
+desc r1;
+desc r2;
+desc tab1;
+
+alter table tab1 drop column c2;
+function: wait_alter_table_finish()
+desc r1;
+desc r2;
+desc tab1;
+
+drop table tab1;
+drop database test_fast_schema_evolution_for_rollup;
 
 
 -- name: test_fast_schema_evolution_and_mv

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -257,7 +257,7 @@ insert into tab1 values (700, "k2_700", 700, 700, 700, "v4_700", "v5_700", "111"
 insert into tab1 values (800, "k2_800", 800, 800, 800, "v4_800", "v5_800", "222");
 insert into tab1 values (900, "k2_900", 900, 900, 900, "v4_900", "v5_900", "333");
 
-select * from tabl1;
+select * from tab1;
 
 alter table tab1 add column c2 bigint default "1" after v2;
 function: wait_alter_table_finish()

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -272,7 +272,7 @@ alter table tab1 add rollup r2(k1,v2) from r1;
 function: wait_alter_table_finish("ROLLUP", 8)
 
 [UC]show alter table rollup where State = "FINISHED";
-[UC]show alter table rollup where CreateTime >= "1970-01-01 pdel00:00:00";
+[UC]show alter table rollup where CreateTime >= "1970-01-01 00:00:00";
 [UC]show alter table rollup where CreateTime > "1970-01-01 00:00:00";
 [UC]show alter table rollup where CreateTime <= "1970-01-01 00:00:00";
 [UC]show alter table rollup where CreateTime < "1970-01-01 00:00:00";


### PR DESCRIPTION
Why I'm doing:

If we create a table enable fast schema evolution, add a new column task will run as a fast schema evolution task but now the original linked schema change task. However, if we add a new column to rollup, the task still run as linked schema change task. But these operations could be run as fast schema evolution task.

What I'm doing:

Enable fast schema evolution for rollup.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
