### PR TITLE
[BugFix] fix partial update column mode execute concurrent with incremental clone issue (backport #34555)

### DIFF
--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -123,7 +123,8 @@ public:
     // return semgent_footer position and size if rowset is partial_rowset
     const FooterPointerPB* partial_rowset_footer(uint32_t segment_id) const {
         if (!_rowset_meta_pb->has_txn_meta() || _rowset_meta_pb->txn_meta().has_merge_condition() ||
-            _rowset_meta_pb->txn_meta().has_auto_increment_partial_update_column_id()) {
+            _rowset_meta_pb->txn_meta().has_auto_increment_partial_update_column_id() ||
+            _rowset_meta_pb->num_update_files() > 0) {
             return nullptr;
         }
         return &_rowset_meta_pb->txn_meta().partial_rowset_footers(segment_id);

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -52,6 +52,7 @@
 #include "json2pb/pb_to_json.h"
 #include "storage/chunk_helper.h"
 #include "storage/data_dir.h"
+#include "storage/delta_column_group.h"
 #include "storage/key_coder.h"
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
@@ -85,6 +86,7 @@ using starrocks::PageHandle;
 using starrocks::PagePointer;
 using starrocks::ColumnIteratorOptions;
 using starrocks::PageFooterPB;
+using starrocks::DeltaColumnGroupList;
 
 DEFINE_string(root_path, "", "storage root path");
 DEFINE_string(operation, "get_meta",
@@ -131,6 +133,8 @@ std::string get_usage(const std::string& progname) {
     ss << "./meta_tool --operation=dump_short_key_index --file=/path/to/segment/file --key_column_count=2\n";
     ss << "./meta_tool --operation=check_table_meta_consistency --root_path=/path/to/storage/path "
           "--table_id=tableid\n";
+    ss << "./meta_tool --operation=scan_dcgs --root_path=/path/to/storage/path "
+          "--tablet_id=tabletid\n";
     ss << "cat 0001000000001394_0000000000000004.meta | ./meta_tool --operation=print_lake_metadata\n";
     ss << "cat 0001000000001391_0000000000000001.log | ./meta_tool --operation=print_lake_txn_log\n";
     return ss.str();
@@ -579,6 +583,18 @@ void check_meta_consistency(DataDir* data_dir) {
     return;
 }
 
+void scan_dcgs(DataDir* data_dir) {
+    DeltaColumnGroupList dcgs;
+    Status st = TabletMetaManager::scan_tablet_delta_column_group(data_dir->get_meta(), FLAGS_tablet_id, &dcgs);
+    if (!st.ok()) {
+        std::cout << "scan delta column group, st: " << st.to_string() << std::endl;
+        return;
+    }
+    for (const auto& dcg : dcgs) {
+        std::cout << dcg->debug_string() << std::endl;
+    }
+}
+
 namespace starrocks {
 
 class SegmentDump {
@@ -932,7 +948,8 @@ int meta_tool_main(int argc, char** argv) {
                                                   "compact_meta",
                                                   "get_meta_stats",
                                                   "ls",
-                                                  "check_table_meta_consistency"};
+                                                  "check_table_meta_consistency",
+                                                  "scan_dcgs"};
         if (valid_operations.find(FLAGS_operation) == valid_operations.end()) {
             std::cout << "invalid operation:" << FLAGS_operation << std::endl;
             return -1;
@@ -940,7 +957,7 @@ int meta_tool_main(int argc, char** argv) {
 
         bool read_only = false;
         if (FLAGS_operation == "get_meta" || FLAGS_operation == "get_meta_stats" || FLAGS_operation == "ls" ||
-            FLAGS_operation == "check_table_meta_consistency") {
+            FLAGS_operation == "check_table_meta_consistency" || FLAGS_operation == "scan_dcgs") {
             read_only = true;
         }
 
@@ -969,6 +986,8 @@ int meta_tool_main(int argc, char** argv) {
             list_meta(data_dir.get());
         } else if (FLAGS_operation == "check_table_meta_consistency") {
             check_meta_consistency(data_dir.get());
+        } else if (FLAGS_operation == "scan_dcgs") {
+            scan_dcgs(data_dir.get());
         } else {
             std::cout << "invalid operation: " << FLAGS_operation << "\n" << usage << std::endl;
             return -1;


### PR DESCRIPTION
This PR contains these parts:

1. remove clear_txn_meta after applying finish. Because if we clear the txn meta and then this rowset has been incremental clone, then the source tablet can't apply this rowset to generate dcg, which will cause data loss.
2. Add a meta tool to print dcg.

Fix #34555

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
