### PR TITLE
[BugFix] fix partial update column mode execute concurrent with incremental clone issue (backport #34555)

### DIFF
--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -125,7 +125,8 @@ public:
     // return semgent_footer position and size if rowset is partial_rowset
     const FooterPointerPB* partial_rowset_footer(uint32_t segment_id) const {
         if (!_rowset_meta_pb->has_txn_meta() || _rowset_meta_pb->txn_meta().has_merge_condition() ||
-            _rowset_meta_pb->txn_meta().has_auto_increment_partial_update_column_id()) {
+            _rowset_meta_pb->txn_meta().has_auto_increment_partial_update_column_id() ||
+            _rowset_meta_pb->num_update_files() > 0) {
             return nullptr;
         }
         return &_rowset_meta_pb->txn_meta().partial_rowset_footers(segment_id);

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -529,7 +529,7 @@ Status RowsetColumnUpdateState::_update_rowset_meta(const RowsetSegmentStat& sta
     if (stat.num_segment <= 1) {
         rowset->rowset_meta()->set_segments_overlap_pb(NONOVERLAPPING);
     }
-    rowset->rowset_meta()->clear_txn_meta();
+    (void)rowset->reload();
     return Status::OK();
 }
 
@@ -616,6 +616,8 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
     watch.start();
 
     DCHECK(rowset->num_update_files() == _partial_update_states.size());
+    DCHECK(rowset->rowset_meta()->get_meta_pb().has_txn_meta())
+            << fmt::format("tablet_id: {} rowset_id: {}", tablet->tablet_id(), rowset_id);
     const auto& txn_meta = rowset->rowset_meta()->get_meta_pb().txn_meta();
 
     // 1. resolve conflicts and generate `ColumnPartialUpdateState` finally.
@@ -667,6 +669,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
                                                   latest_applied_version.major_number() + 1, idx);
     };
     // 2. getter all rss_rowid_to_update_rowid, and prepare .col writer by the way
+    int64_t insert_rows = 0;
     // rss_id -> rowid -> <update file id, update_rowids>
     std::map<uint32_t, RowidsToUpdateRowids> rss_rowid_to_update_rowid;
     for (int upt_id = 0; upt_id < _partial_update_states.size(); upt_id++) {
@@ -675,6 +678,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             auto rowid = (uint32_t)(each.first & ROWID_MASK);
             rss_rowid_to_update_rowid[rssid][rowid] = std::make_pair(upt_id, each.second);
         }
+        insert_rows += _partial_update_states[upt_id].insert_rowids.size();
     }
     cost_str << " [generate delta column group writer] " << watch.elapsed_time();
     watch.reset();
@@ -773,9 +777,10 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             "avg_finalize_dcg_time(ms):$3 ",
             total_seek_source_segment_time, total_read_column_from_update_time, total_merge_column_time,
             total_finalize_dcg_time);
-    cost_str << strings::Substitute("rss_cnt:$0 update_cnt:$1 column_cnt:$2 update_rows:$3 handle_cnt:$4",
-                                    rss_rowid_to_update_rowid.size(), _partial_update_states.size(),
-                                    update_column_ids.size(), update_rows, handle_cnt);
+    cost_str << strings::Substitute(
+            "rss_cnt:$0 update_cnt:$1 column_cnt:$2 update_rows:$3 handle_cnt:$4 insert_rows:$5",
+            rss_rowid_to_update_rowid.size(), _partial_update_states.size(), update_column_ids.size(), update_rows,
+            handle_cnt, insert_rows);
 
     LOG(INFO) << "RowsetColumnUpdateState tablet_id: " << tablet->tablet_id() << ", txn_id: " << rowset->txn_id()
               << ", finalize cost:" << cost_str.str();

--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -803,6 +803,7 @@ TEST_P(RowsetColumnPartialUpdateTest, test_upsert) {
     int64_t version = 1;
     int64_t version_before_partial_update = 1;
     prepare_tablet(this, tablet, version, version_before_partial_update, N);
+    int64_t version_after_partial_update = version;
     auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
     auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
 
@@ -836,6 +837,33 @@ TEST_P(RowsetColumnPartialUpdateTest, test_upsert) {
                     StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
         }
         ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+    }
+
+    {
+        // test clone after upsert
+        // 1. full clone with version after partial update
+        auto new_tablet = create_tablet(rand(), rand());
+        ASSERT_EQ(1, new_tablet->updates()->version_history_count());
+        ASSERT_OK(full_clone(tablet, version_after_partial_update, new_tablet));
+        ASSERT_TRUE(check_tablet(new_tablet, version_after_partial_update, N, [](int64_t k1, int64_t v1, int32_t v2) {
+            return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
+        }));
+        // 2. increment clone, upsert v1 = k1 % 100 + 3
+        ASSERT_OK(increment_clone(tablet, {version_after_partial_update + 1}, new_tablet));
+        ASSERT_TRUE(check_tablet(new_tablet, version_after_partial_update + 1, 2 * N,
+                                 [](int64_t k1, int64_t v1, int32_t v2) {
+                                     if (k1 < N) {
+                                         return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
+                                     } else {
+                                         return (int16_t)((k1 - N) % 100 + 3) == v1 && (int32_t)0 == v2;
+                                     }
+                                 }));
+        // 3. increment clone, update v2 = k1 % 100 + 4
+        ASSERT_OK(increment_clone(tablet, {version_after_partial_update + 2}, new_tablet));
+        ASSERT_TRUE(check_tablet(new_tablet, version_after_partial_update + 2, 2 * N,
+                                 [](int64_t k1, int64_t v1, int32_t v2) {
+                                     return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
+                                 }));
     }
 }
 


### PR DESCRIPTION
Why I'm doing:
Because when we execute `show data`, we will find that `.cols` (generate by partial column update or generated column) and persistent index file size aren't included.

What I'm doing:
Keep tracing the file size of  `.cols` and persistent index files.

Fix #34555

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
