### PR TITLE
[BugFix] fix query_excluding_mv_names and query_including_mv_names bugs for 3.1

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -17,26 +17,14 @@ package com.starrocks.sql.optimizer;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.sql.optimizer.rule.RuleSetType;
-import com.starrocks.sql.optimizer.rule.RuleType;
 
 public class MvPlanContextBuilder {
     public MvPlanContext getPlanContext(MaterializedView mv) {
         // build mv query logical plan
         MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
-        // optimize the sql by rule and disable rule based materialized view rewrite
-        OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.RULE_BASED);
-        optimizerConfig.disableRuleSet(RuleSetType.PARTITION_PRUNE);
-        optimizerConfig.disableRuleSet(RuleSetType.SINGLE_TABLE_MV_REWRITE);
-        optimizerConfig.disableRule(RuleType.TF_REWRITE_GROUP_BY_COUNT_DISTINCT);
-        // For sync mv, no rewrite query by original sync mv rule to avoid useless rewrite.
-        if (mv.getRefreshScheme().isSync()) {
-            optimizerConfig.disableRule(RuleType.TF_MATERIALIZED_VIEW);
-        }
-        optimizerConfig.setMVRewritePlan(true);
         ConnectContext connectContext = new ConnectContext();
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(
                 ConnectContext.get().getSessionVariable().getOptimizerExecuteTimeout());
-        return mvOptimizer.optimize(mv, connectContext, optimizerConfig);
+        return mvOptimizer.optimize(mv, connectContext);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -54,6 +54,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -175,11 +176,17 @@ public class MvRewritePreprocessor {
         String queryExcludingMVNames = connectContext.getSessionVariable().getQueryExcludingMVNames();
         String queryIncludingMVNames = connectContext.getSessionVariable().getQueryIncludingMVNames();
         if (!Strings.isNullOrEmpty(queryExcludingMVNames) || !Strings.isNullOrEmpty(queryIncludingMVNames)) {
-            Set<String> queryExcludingMVNamesSet = Sets.newHashSet(queryExcludingMVNames.split(","));
-            Set<String> queryIncludingMVNamesSet = Sets.newHashSet(queryIncludingMVNames.split(","));
+            logMVPrepare(connectContext, "queryExcludingMVNames:{}, queryIncludingMVNames:{}",
+                    Strings.nullToEmpty(queryExcludingMVNames), Strings.nullToEmpty(queryIncludingMVNames));
+
+            final Set<String> queryExcludingMVNamesSet = Strings.isNullOrEmpty(queryExcludingMVNames) ? Sets.newHashSet()
+                    : Arrays.stream(queryExcludingMVNames.split(",")).map(String::trim).collect(Collectors.toSet());
+
+            final Set<String> queryIncludingMVNamesSet = Strings.isNullOrEmpty(queryIncludingMVNames) ? Sets.newHashSet()
+                    : Arrays.stream(queryIncludingMVNames.split(",")).map(String::trim).collect(Collectors.toSet());
             relatedMvs = relatedMvs.stream()
-                    .filter(mv -> queryIncludingMVNamesSet.contains(mv.getName()))
-                    .filter(mv -> !queryExcludingMVNamesSet.contains(mv.getName()))
+                    .filter(mv -> queryIncludingMVNamesSet.isEmpty() || queryIncludingMVNamesSet.contains(mv.getName()))
+                    .filter(mv -> queryExcludingMVNamesSet.isEmpty() || !queryExcludingMVNamesSet.contains(mv.getName()))
                     .collect(Collectors.toSet());
         }
         if (relatedMvs.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerConfig.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerConfig.java
@@ -31,8 +31,6 @@ public class OptimizerConfig {
     private BitSet ruleSetSwitches;
     private BitSet ruleSwitches;
 
-    private boolean isMVRewritePlan;
-
     private static final OptimizerConfig DEFAULT_CONFIG = new OptimizerConfig();
 
     public static OptimizerConfig defaultConfig() {
@@ -69,13 +67,5 @@ public class OptimizerConfig {
 
     public boolean isRuleDisable(RuleType ruleType) {
         return !ruleSwitches.get(ruleType.ordinal());
-    }
-
-    public boolean isMVRewritePlan() {
-        return this.isMVRewritePlan;
-    }
-
-    public void setMVRewritePlan(boolean isMVRewritePlan) {
-        this.isMVRewritePlan = isMVRewritePlan;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/dump/QueryDumpInfo.java
@@ -27,7 +27,6 @@ import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.MaterializedViewOptimizer;
-import com.starrocks.sql.optimizer.OptimizerConfig;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 
 import java.util.ArrayList;
@@ -120,11 +119,10 @@ public class QueryDumpInfo implements DumpInfo {
             connectContext.getSessionVariable().setQueryExcludingMVNames(table.getName());
             {
                 MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
-                OptimizerConfig optimizerConfig = new OptimizerConfig(OptimizerConfig.OptimizerAlgorithm.COST_BASED);
                 // NOTE: Since materialized view support unique/foreign constraints, we use `optimize` here to visit
                 // all dependent tables again to add it into `dump info`.
                 // NOTE: The optimizer should not contain self to avoid stack overflow.
-                mvOptimizer.optimize((MaterializedView) table, connectContext, optimizerConfig);
+                mvOptimizer.optimize((MaterializedView) table, connectContext);
                 tableMap.put(table.getId(), new Pair<>(dbName, table));
             }
             connectContext.getSessionVariable().setQueryExcludingMVNames(queryExcludingMVNames);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -2066,4 +2066,77 @@ public class MvRewriteTest extends MvRewriteTestBase {
         starRocksAssert.dropMaterializedView("mv_t1_v0");
         starRocksAssert.dropTable("t1_agg");
     }
+
+    @Test
+    public void testQueryIncludingExcludingMVNames() throws Exception {
+        starRocksAssert.getCtx().getSessionVariable().setOptimizerExecuteTimeout(3000000);
+        createAndRefreshMv("test", "mv_agg_1", "CREATE MATERIALIZED VIEW mv_agg_1 " +
+                " distributed by hash(empid) " +
+                "AS " +
+                "SELECT empid, sum(salary) as total " +
+                "FROM emps " +
+                "GROUP BY empid");
+        createAndRefreshMv("test", "mv_agg_2", "CREATE MATERIALIZED VIEW mv_agg_2 " +
+                " distributed by hash(empid) " +
+                "AS " +
+                "SELECT empid, sum(salary) as total " +
+                "FROM emps " +
+                "GROUP BY empid");
+        {
+            starRocksAssert.getCtx().getSessionVariable().setQueryIncludingMVNames("mv_agg_1");
+            String query = "SELECT empid, sum(salary) as total " +
+                    "FROM emps " +
+                    "GROUP BY empid";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "mv_agg_1");
+            starRocksAssert.getCtx().getSessionVariable().setQueryIncludingMVNames("");
+        }
+        {
+            starRocksAssert.getCtx().getSessionVariable().setQueryIncludingMVNames("mv_agg_2");
+            String query = "SELECT empid, sum(salary) as total " +
+                    "FROM emps " +
+                    "GROUP BY empid";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "mv_agg_2");
+            starRocksAssert.getCtx().getSessionVariable().setQueryIncludingMVNames("");
+        }
+        {
+            starRocksAssert.getCtx().getSessionVariable().setQueryIncludingMVNames("mv_agg_1, mv_agg_2");
+            String query = "SELECT empid, sum(salary) as total " +
+                    "FROM emps " +
+                    "GROUP BY empid";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "mv_agg_");
+            starRocksAssert.getCtx().getSessionVariable().setQueryIncludingMVNames("");
+        }
+        {
+            starRocksAssert.getCtx().getSessionVariable().setQueryExcludingMVNames("mv_agg_1");
+            String query = "SELECT empid, sum(salary) as total " +
+                    "FROM emps " +
+                    "GROUP BY empid";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "mv_agg_2");
+            starRocksAssert.getCtx().getSessionVariable().setQueryExcludingMVNames("");
+        }
+        {
+            starRocksAssert.getCtx().getSessionVariable().setQueryExcludingMVNames("mv_agg_2");
+            String query = "SELECT empid, sum(salary) as total " +
+                    "FROM emps " +
+                    "GROUP BY empid";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "mv_agg_1");
+            starRocksAssert.getCtx().getSessionVariable().setQueryExcludingMVNames("");
+        }
+        {
+            starRocksAssert.getCtx().getSessionVariable().setQueryExcludingMVNames("mv_agg_1, mv_agg_2");
+            String query = "SELECT empid, sum(salary) as total " +
+                    "FROM emps " +
+                    "GROUP BY empid";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "mv_agg_");
+            starRocksAssert.getCtx().getSessionVariable().setQueryExcludingMVNames("");
+        }
+        starRocksAssert.dropMaterializedView("mv_agg_1");
+        starRocksAssert.dropMaterializedView("mv_agg_2");
+    }
 }


### PR DESCRIPTION
Why I'm doing:
ref #34867

1. when query_excluding_mv_names is set, but query_including_mv_names is not set, no mvs are used to rewrite
2. names with space in query_excluding_mv_names/query_including_mv_names are not supported

What I'm doing:

1. when query_including_mv_names is not set, should consider all related mvs
2. add trim for mv names for better usability

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
