### PR TITLE
[Enhancement] improve mv rewrite performance

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/MvNormalizePredicateRule.java
@@ -18,7 +18,6 @@ package com.starrocks.sql.optimizer.rewrite.scalar;
 import autovalue.shaded.com.google.common.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -32,25 +31,9 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 public class MvNormalizePredicateRule extends NormalizePredicateRule {
-    // Comparator to normalize predicates, only use scalar operators' string to compare.
-    private static final Comparator<ScalarOperator> SCALAR_OPERATOR_COMPARATOR = new Comparator<ScalarOperator>() {
-        @Override
-        public int compare(ScalarOperator o1, ScalarOperator o2) {
-            if (o1 == null && o2 == null) {
-                return 0;
-            } else if (o1 == null) {
-                return -1;
-            } else if (o2 == null) {
-                return 1;
-            } else {
-                return o1.toString().toLowerCase().compareTo(o2.toString().toLowerCase());
-            }
-        }
-    };
 
     // Comparator to normalize predicates, only use scalar operators' string to compare.
     private static final Comparator<ScalarOperator> SCALAR_OPERATOR_COMPARATOR_IGNORE_COLUMN_ID =
@@ -87,21 +70,23 @@ public class MvNormalizePredicateRule extends NormalizePredicateRule {
     @Override
     public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator predicate,
                                                  ScalarOperatorRewriteContext context) {
-        Set<ScalarOperator> after = Sets.newTreeSet(SCALAR_OPERATOR_COMPARATOR);
+        Map<String, ScalarOperator> sorted = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         if (predicate.isAnd()) {
             List<ScalarOperator> before = Utils.extractConjuncts(predicate);
-            after.addAll(before);
-            if (Lists.newArrayList(after).equals(before)) {
+            before.forEach(x -> sorted.put(x.toString(), x));
+            List<ScalarOperator> after = Lists.newArrayList(sorted.values());
+            if ((after).equals(before)) {
                 return predicate;
             }
-            return Utils.compoundAnd(Lists.newArrayList(after));
+            return Utils.compoundAnd((after));
         } else if (predicate.isOr()) {
             List<ScalarOperator> before = Utils.extractDisjunctive(predicate);
-            after.addAll(before);
-            if (Lists.newArrayList(after).equals(before)) {
+            before.forEach(x -> sorted.put(x.toString(), x));
+            List<ScalarOperator> after = Lists.newArrayList(sorted.values());
+            if ((after).equals(before)) {
                 return predicate;
             }
-            return Utils.compoundOr(Lists.newArrayList(after));
+            return Utils.compoundOr((after));
         } else {
             // for not
             return predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -100,6 +100,8 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         List<Table> queryTables = MvUtils.getAllTables(queryExpression);
         ConnectContext connectContext = ConnectContext.get();
         for (MaterializationContext mvContext : mvCandidateContexts) {
+            context.checkTimeout();
+
             // 1. check whether to need compensate or not
             // 2. `queryPredicateSplit` is different for each materialized view, so we can not cache it anymore.
             boolean isCompensatePartitionPredicate = MvUtils.isNeedCompensatePartitionPredicate(queryExpression, mvContext);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/SeriallyTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/SeriallyTaskScheduler.java
@@ -37,7 +37,7 @@ public class SeriallyTaskScheduler implements TaskScheduler {
     @Override
     public void executeTasks(TaskContext context) {
         long timeout = context.getOptimizerContext().getSessionVariable().getOptimizerExecuteTimeout();
-        long watch = context.getOptimizerContext().getCostTimeMs();
+        long watch = context.getOptimizerContext().optimizerElapsedMs();
         while (!tasks.empty()) {
             if (timeout > 0 && watch > timeout) {
                 // Should have at least one valid plan

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/NormalizePredicateBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/NormalizePredicateBench.java
@@ -1,0 +1,136 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.google.common.collect.ImmutableList;
+import com.starrocks.analysis.BinaryType;
+import com.starrocks.catalog.Type;
+import com.starrocks.sql.optimizer.base.ColumnRefFactory;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import org.apache.commons.lang3.NotImplementedException;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.CompoundType.AND;
+import static com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator.CompoundType.OR;
+
+/**
+ * Benchmark the MvUtils.canonizePredicateForRewrite
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1)
+@Warmup(iterations = 1)
+@Measurement(time = 1, timeUnit = TimeUnit.SECONDS)
+public class NormalizePredicateBench {
+
+    @Param({"10", "20", "40", "80", "160"})
+    private int predicateSize;
+
+    private ScalarOperator sourcePredicate;
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(NormalizePredicateBench.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+
+    @Setup
+    public void setup() {
+        sourcePredicate = generatePredicate();
+    }
+
+    private BinaryType randomBinary() {
+        int n = ThreadLocalRandom.current().nextInt(6);
+        return BinaryType.values()[n];
+    }
+
+    private ColumnRefOperator randomColumn(ColumnRefFactory factory) {
+        final List<String> columns = IntStream.range(1, 10)
+                .mapToObj(x -> RandomStringUtils.randomAlphabetic(2))
+                .collect(Collectors.toList());
+        final List<Type> types = ImmutableList.of(Type.INT, Type.VARCHAR, Type.DATETIME);
+        int x = ThreadLocalRandom.current().nextInt(columns.size());
+        String name = columns.get(x);
+        x = ThreadLocalRandom.current().nextInt(types.size());
+        Type t = types.get(x);
+        return factory.create(name, t, true);
+    }
+
+    private ConstantOperator randomConstant(Type type) {
+        int x = ThreadLocalRandom.current().nextInt(1024);
+        if (type.equals(Type.INT)) {
+            return ConstantOperator.createInt(x);
+        } else if (type.equals(Type.DATETIME)) {
+            return ConstantOperator.createDatetime(LocalDateTime.now().plusDays(x));
+        } else if (type.equals(Type.VARCHAR)) {
+            return ConstantOperator.createVarchar(RandomStringUtils.randomAlphabetic(10));
+        }
+        throw new NotImplementedException("not supported");
+    }
+
+    private ScalarOperator generatePredicate() {
+        ColumnRefFactory factory = new ColumnRefFactory();
+        ScalarOperator res = null;
+        for (int i = 0; i < predicateSize; i++) {
+            ColumnRefOperator ref = randomColumn(factory);
+            ConstantOperator constant = randomConstant(ref.getType());
+            BinaryType b = randomBinary();
+            BinaryPredicateOperator predicate = new BinaryPredicateOperator(b, ref, constant);
+
+            if (res == null) {
+                res = predicate;
+            } else {
+                int orAnd = ThreadLocalRandom.current().nextInt(2);
+                CompoundPredicateOperator.CompoundType type = orAnd == 0 ? OR : AND;
+                res = new CompoundPredicateOperator(type, res, predicate);
+            }
+        }
+        System.err.println("generate predicate: " + res.toString());
+        return res;
+    }
+
+    @Benchmark
+    public void bench_NormalizePredicate() {
+        ScalarOperator res = MvUtils.canonizePredicateForRewrite(sourcePredicate);
+    }
+}


### PR DESCRIPTION
Why I'm doing:
1. The `MvUtils.canonizePredicateForRewrite` may be pretty slow for the sql with a long predicates

What I'm doing:
1. Check optimizer timeout when rewriting MV
2. Improve performance of `MvUtils.canonizePredicateForRewrite` 


Benchmark:
```sql
Benchmark                                                     (predicateSize)  Mode  Cnt   Score    Error  Units
-- Before
NormalizePredicateBench.bench_NormalizePredicate_Random                   160  avgt    5  53.448 ± 10.608  ms/op

-- After
NormalizePredicateBench.bench_NormalizePredicate_Random                   160  avgt    5  15.312 ± 0.094  ms/op
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
