### PR TITLE
[Enhancement] Support transform random function in trino parser

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoQueryTest.java
@@ -1148,4 +1148,25 @@ public class TrinoQueryTest extends TrinoTestBase {
         assertPlanContains(sql, "[1,2]", "[10: expr,11: expr]", "returnTypes: [TINYINT, ARRAY<TINYINT>]",
                 "returnTypes: [TINYINT]");
     }
+
+    @Test
+    public void testRandom() throws Exception {
+        String sql = "select rand();";
+        assertPlanContains(sql, "<slot 2> : rand()");
+
+        sql = "select rand(100);";
+        assertPlanContains(sql, "<slot 2> : floor(random() * 100.0)");
+
+        sql = "select rand(10, 100);";
+        assertPlanContains(sql, "floor(random() * 90.0 + 10.0)");
+
+        sql = "select random();";
+        assertPlanContains(sql, "<slot 2> : random()");
+
+        sql = "select random(100);";
+        assertPlanContains(sql, "<slot 2> : floor(random() * 100.0)");
+
+        sql = "select rand(10, 100);";
+        assertPlanContains(sql, "<slot 2> : floor(random() * 90.0 + 10.0)");
+    }
 }


### PR DESCRIPTION
Why I'm doing:
- `rand(n)`, when there are parameters, SR represents seed, and Trino represents the output range. The semantics of the two are different;
- Trino support `rand(m, n)`. 
Reference: https://trino.io/docs/current/functions/math.html?highlight=rand#rand

What I'm doing:
Function conversion in trino compatibility layer: 
- `random(n) -> floor(random()*n)`
- `random(m, n) -> floor(random()*(n-m)+m)`

Fixes #34026 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
