### PR TITLE
[Refactor] encapsulation new method to distinguish shared_data and shared_nothing mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SystemHandler.java
@@ -250,7 +250,7 @@ public class SystemHandler extends AlterHandler {
         }
 
         // when decommission backends in shared_data mode, unnecessary to check clusterCapacity or table replica
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             return decommissionBackends;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -309,7 +309,7 @@ public class CatalogUtils {
     public static int calPhysicalPartitionBucketNum() {
         int backendNum = GlobalStateMgr.getCurrentSystemInfo().getBackendIds().size();
 
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             backendNum = backendNum + GlobalStateMgr.getCurrentSystemInfo().getAliveComputeNodeNumber();
         }
 
@@ -319,7 +319,7 @@ public class CatalogUtils {
     public static int calBucketNumAccordingToBackends() {
         int backendNum = GlobalStateMgr.getCurrentSystemInfo().getBackendIds().size();
 
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             backendNum = backendNum + GlobalStateMgr.getCurrentSystemInfo().getAliveComputeNodeNumber();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -289,11 +289,11 @@ public class TableFunctionTable extends Table {
         }
         TNetworkAddress address;
         List<Long> nodeIds = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(true);
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             nodeIds.addAll(GlobalStateMgr.getCurrentSystemInfo().getComputeNodeIds(true));
         }
         if (nodeIds.isEmpty()) {
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_NOTHING) {
+            if (RunMode.isSharedNothingMode()) {
                 throw new DdlException("Failed to send proxy request. No alive backends");
             } else {
                 throw new DdlException("Failed to send proxy request. No alive backends or compute nodes");

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/AutoInferUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/AutoInferUtil.java
@@ -21,7 +21,7 @@ import com.starrocks.server.RunMode;
 
 public class AutoInferUtil {
     public static int calDefaultReplicationNum() throws UserException {
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             return 1;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/KafkaUtil.java
@@ -182,7 +182,7 @@ public class KafkaUtil {
             try {
                 // TODO: need to refactor after be split into cn + dn
                 List<Long> nodeIds = new ArrayList<>();
-                if ((RunMode.getCurrentRunMode() == RunMode.SHARED_DATA)) {
+                if ((RunMode.isSharedDataMode())) {
                     Warehouse warehouse = GlobalStateMgr.getCurrentWarehouseMgr().getDefaultWarehouse();
                     for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {
                         ComputeNode node = GlobalStateMgr.getCurrentSystemInfo().getBackendOrComputeNode(nodeId);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -493,7 +493,7 @@ public class PropertyAnalyzer {
         }
 
         List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().getAvailableBackendIds();
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             backendIds.addAll(GlobalStateMgr.getCurrentSystemInfo().getAvailableComputeNodeIds());
             if (RunMode.defaultReplicationNum() > backendIds.size()) {
                 throw new AnalysisException("Number of available CN nodes is " + backendIds.size()

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PulsarUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PulsarUtil.java
@@ -140,7 +140,7 @@ public class PulsarUtil {
             try {
                 // TODO: need to refactor after be split into cn + dn
                 List<Long> nodeIds = new ArrayList<>();
-                if ((RunMode.getCurrentRunMode() == RunMode.SHARED_DATA)) {
+                if ((RunMode.isSharedDataMode())) {
                     Warehouse warehouse = GlobalStateMgr.getCurrentWarehouseMgr().getDefaultWarehouse();
                     for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {
                         ComputeNode node = GlobalStateMgr.getCurrentSystemInfo().getBackendOrComputeNode(nodeId);

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/LoadAction.java
@@ -111,7 +111,7 @@ public class LoadAction extends RestBaseAction {
 
         // Choose a backend sequentially, or choose a cn in shared_data mode
         List<Long> nodeIds = new ArrayList<>();
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             Warehouse warehouse = GlobalStateMgr.getCurrentWarehouseMgr().getDefaultWarehouse();
             for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {
                 ComputeNode node = GlobalStateMgr.getCurrentSystemInfo().getBackendOrComputeNode(nodeId);

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -197,7 +197,7 @@ public class LeaderImpl {
         ComputeNode cn = GlobalStateMgr.getCurrentSystemInfo().getBackendWithBePort(host, bePort);
 
         if (cn == null) {
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            if (RunMode.isSharedDataMode()) {
                 cn = GlobalStateMgr.getCurrentSystemInfo().getComputeNodeWithBePort(host, bePort);
             }
             if (cn == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -244,7 +244,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
         // TODO: need to refactor after be split into cn + dn
         int aliveNodeNum = systemInfoService.getAliveBackendNumber();
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             Warehouse warehouse = GlobalStateMgr.getCurrentWarehouseMgr().getDefaultWarehouse();
             aliveNodeNum = 0;
             for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -218,7 +218,7 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
         SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
         // TODO: need to refactor after be split into cn + dn
         int aliveNodeNum = systemInfoService.getAliveBackendNumber();
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             Warehouse warehouse = GlobalStateMgr.getCurrentWarehouseMgr().getDefaultWarehouse();
             aliveNodeNum = 0;
             for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadMgr.java
@@ -175,7 +175,7 @@ public class RoutineLoadMgr implements Writable {
         try {
             List<Long> aliveNodeIds = new ArrayList<>();
             // TODO: need to refactor after be split into cn + dn
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            if (RunMode.isSharedDataMode()) {
                 Warehouse warehouse = GlobalStateMgr.getCurrentWarehouseMgr().getDefaultWarehouse();
                 for (long nodeId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {
                     ComputeNode node = GlobalStateMgr.getCurrentSystemInfo().getBackendOrComputeNode(nodeId);

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -514,7 +514,7 @@ public class FileScanNode extends LoadScanNode {
         nodes = Lists.newArrayList();
 
         // TODO: need to refactor after be split into cn + dn
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             Warehouse warehouse = GlobalStateMgr.getCurrentWarehouseMgr().getDefaultWarehouse();
             for (long cnId : warehouse.getAnyAvailableCluster().getComputeNodeIds()) {
                 ComputeNode cn = GlobalStateMgr.getCurrentSystemInfo().getBackendOrComputeNode(cnId);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -1062,7 +1062,7 @@ public class ShowExecutor {
         createSqlBuilder.append("CREATE DATABASE `").append(showStmt.getDb()).append("`");
         if (!Strings.isNullOrEmpty(db.getLocation())) {
             createSqlBuilder.append("\nPROPERTIES (\"location\" = \"").append(db.getLocation()).append("\")");
-        } else if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        } else if (RunMode.isSharedDataMode()) {
             String volume = GlobalStateMgr.getCurrentState().getStorageVolumeMgr().getStorageVolumeNameOfDb(db.getId());
             createSqlBuilder.append("\nPROPERTIES (\"storage_volume\" = \"").append(volume).append("\")");
         }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
@@ -110,7 +110,7 @@ public class SimpleScheduler {
                 }
 
                 // In shared data mode, we can select any alive node to replace the original dead node for query
-                if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+                if (RunMode.isSharedDataMode()) {
                     List<ComputeNode> allNodes = new ArrayList<>(computeNodes.size());
                     allNodes.addAll(computeNodes.values());
                     List<ComputeNode> candidateNodes = allNodes.stream()

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -89,7 +89,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
             ImmutableMap<Long, ComputeNode> idToComputeNode =
                     buildComputeNodeInfo(systemInfoService, numUsedComputeNodes);
             ImmutableMap<Long, ComputeNode> idToBackend;
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            if (RunMode.isSharedDataMode()) {
                 idToBackend = idToComputeNode;
             } else {
                 idToBackend = ImmutableMap.copyOf(systemInfoService.getIdToBackend());
@@ -128,7 +128,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
 
         this.hasComputeNode = MapUtils.isNotEmpty(availableID2ComputeNode);
         // Backends and compute nodes are identical in the SHARED_DATA mode.
-        this.usedComputeNode = hasComputeNode && (preferComputeNode || RunMode.getCurrentRunMode() == RunMode.SHARED_DATA);
+        this.usedComputeNode = hasComputeNode && (preferComputeNode || RunMode.isSharedDataMode());
         this.preferComputeNode = preferComputeNode;
     }
 
@@ -271,7 +271,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
 
     private static ImmutableMap<Long, ComputeNode> buildComputeNodeInfo(SystemInfoService systemInfoService,
                                                                         int numUsedComputeNodes) {
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             return GlobalStateMgr.getCurrentWarehouseMgr().getComputeNodesFromWarehouse();
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -582,7 +582,7 @@ public class GlobalStateMgr {
         // use default warehouse
         Warehouse warehouse = warehouseMgr.getDefaultWarehouse();
         // TODO: need to refactor after be split into cn + dn
-        if (warehouse != null && RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (warehouse != null && RunMode.isSharedDataMode()) {
             com.starrocks.warehouse.Cluster cluster = warehouse.getAnyAvailableCluster();
             for (Long cnId : cluster.getComputeNodeIds()) {
                 ComputeNode cn = systemInfoService.getBackendOrComputeNode(cnId);

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1862,11 +1862,11 @@ public class LocalMetastore implements ConnectorMetadata {
             return;
         }
         int numAliveBackends = GlobalStateMgr.getCurrentSystemInfo().getAliveBackendNumber();
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             numAliveBackends += GlobalStateMgr.getCurrentSystemInfo().getAliveComputeNodeNumber();
         }
         if (numAliveBackends == 0) {
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            if (RunMode.isSharedDataMode()) {
                 throw new DdlException("no alive compute nodes");
             } else {
                 throw new DdlException("no alive backends");

--- a/fe/fe-core/src/main/java/com/starrocks/server/RunMode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/RunMode.java
@@ -88,6 +88,14 @@ public abstract class RunMode {
 
     public abstract short getDefaultReplicationNum();
 
+    public static boolean isSharedDataMode() {
+        return getCurrentRunMode() == RunMode.SHARED_DATA;
+    }
+
+    public static boolean isSharedNothingMode() {
+        return getCurrentRunMode() == RunMode.SHARED_NOTHING;
+    }
+
     @Override
     public String toString() {
         return getName();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateDbAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateDbAnalyzer.java
@@ -47,7 +47,7 @@ public class CreateDbAnalyzer {
         Map<String, String> properties = statement.getProperties();
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME)) {
             String volume = properties.get(PropertyAnalyzer.PROPERTIES_STORAGE_VOLUME);
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_NOTHING && !StorageVolumeMgr.LOCAL.equalsIgnoreCase(volume)) {
+            if (RunMode.isSharedNothingMode() && !StorageVolumeMgr.LOCAL.equalsIgnoreCase(volume)) {
                 ErrorReport.reportSemanticException(ErrorCode.ERR_COMMON_ERROR,
                         "Storage volume can only be 'local' in shared nothing mode");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -325,7 +325,7 @@ public class PlanFragmentBuilder {
 
     private static boolean enableComputeNode(ExecPlan execPlan) {
         boolean preferComputeNode = execPlan.getConnectContext().getSessionVariable().isPreferComputeNode();
-        if (preferComputeNode || RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (preferComputeNode || RunMode.isSharedDataMode()) {
             return true;
         }
         return false;

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -741,7 +741,7 @@ public class SystemInfoService implements GsonPostProcessable {
         if (CollectionUtils.isNotEmpty(backendIds)) {
             return backendIds.get(0);
         }
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_NOTHING) {
+        if (RunMode.isSharedNothingMode()) {
             throw new UserException("No backend alive.");
         }
         List<Long> computeNodes = seqChooseComputeNodes(1, true, false);
@@ -1134,7 +1134,7 @@ public class SystemInfoService implements GsonPostProcessable {
     }
 
     public void checkClusterCapacity() throws DdlException {
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+        if (RunMode.isSharedDataMode()) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
@@ -173,7 +173,7 @@ public class AgentBatchTask implements Runnable {
             boolean ok = false;
             try {
                 ComputeNode computeNode = GlobalStateMgr.getCurrentSystemInfo().getBackend(backendId);
-                if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA && computeNode == null) {
+                if (RunMode.isSharedDataMode() && computeNode == null) {
                     computeNode = GlobalStateMgr.getCurrentSystemInfo().getComputeNode(backendId);
                 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1182,7 +1182,7 @@ public class DatabaseTransactionMgr {
                     runningTxnNums++;
                 }
             }
-            if ((Config.enable_new_publish_mechanism || RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) &&
+            if ((Config.enable_new_publish_mechanism || RunMode.isSharedDataMode()) &&
                     transactionState.getTransactionStatus() == TransactionStatus.COMMITTED) {
                 transactionGraph.add(transactionState.getTransactionId(), transactionState.getTableIdList());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -97,7 +97,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
     protected void runAfterCatalogReady() {
         try {
             GlobalTransactionMgr globalTransactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
-            if (Config.lake_enable_batch_publish_version && RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            if (Config.lake_enable_batch_publish_version && RunMode.isSharedDataMode()) {
                 // batch publish
                 List<TransactionStateBatch> readyTransactionStatesBatch = globalTransactionMgr.
                         getReadyPublishTransactionsBatch();
@@ -116,7 +116,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
             // TODO: need to refactor after be split into cn + dn
             List<Long> allBackends = GlobalStateMgr.getCurrentSystemInfo().getBackendIds(false);
-            if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            if (RunMode.isSharedDataMode()) {
                 allBackends.addAll(GlobalStateMgr.getCurrentSystemInfo().getComputeNodeIds(false));
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/warehouse/Cluster.java
+++ b/fe/fe-core/src/main/java/com/starrocks/warehouse/Cluster.java
@@ -71,7 +71,7 @@ public class Cluster implements Writable {
 
     public List<Long> getComputeNodeIds() {
         List<Long> nodeIds = new ArrayList<>();
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_NOTHING) {
+        if (RunMode.isSharedNothingMode()) {
             return nodeIds;
         }
         try {


### PR DESCRIPTION
Why I'm doing:

Old code use "RunMode.getCurrentRunMode() == RunMode.SHARED_DATA" and "RunMode.getCurrentRunMode() == RunMode.SHARED_NOTHING" to distinguish runMode. It is too ugly.

What I'm doing:

Just refactor these ugly codes

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
