### PR TITLE
[Enhancement] Reduce HEAD OBJECT requests during abort transactions

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -326,6 +326,10 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
         }
     }
 
+    if (request->has_skip_cleanup() && request->skip_cleanup()) {
+        return;
+    }
+
     auto thread_pool = abort_txn_thread_pool(_env);
     auto latch = BThreadCountDownLatch(1);
     auto task = [&]() {

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -326,7 +326,7 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
         }
     }
 
-    if (request->has_skip_cleanup() && request->skip_cleanup()) {
+    if (!request->has_skip_cleanup() || request->skip_cleanup()) {
         return;
     }
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -729,6 +729,7 @@ TEST_F(LakeServiceTest, test_abort) {
 
     lake::AbortTxnRequest request;
     request.add_tablet_ids(_tablet_id);
+    request.set_skip_cleanup(false);
     for (auto&& log : logs) {
         request.add_txn_ids(log.txn_id());
     }
@@ -1697,6 +1698,7 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
         lake::AbortTxnResponse response;
         request.add_tablet_ids(_tablet_id);
         request.add_txn_ids(txn_id);
+        request.set_skip_cleanup(false);
         _lake_service.abort_txn(nullptr, &request, &response, nullptr);
     }
 

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1703,4 +1703,25 @@ TEST_F(LakeServiceTest, test_abort_txn2) {
     t1.join();
 }
 
+// NOLINTNEXTLINE
+TEST_F(LakeServiceTest, test_abort3) {
+    auto txn_id = next_id();
+    lake::TxnLog log;
+    log.set_tablet_id(_tablet_id);
+    log.set_txn_id(txn_id);
+    ASSERT_OK(_tablet_mgr->put_txn_log(log));
+
+    lake::AbortTxnRequest request;
+    lake::AbortTxnResponse response;
+    request.add_tablet_ids(_tablet_id);
+    request.set_skip_cleanup(true);
+    request.add_txn_ids(log.txn_id());
+
+    _lake_service.abort_txn(nullptr, &request, &response, nullptr);
+
+    ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+
+    EXPECT_TRUE(fs::path_exist(_tablet_mgr->txn_log_location(_tablet_id, log.txn_id())));
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -27,8 +27,6 @@ import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
 import com.starrocks.lake.CommitRateLimiter;
 import com.starrocks.lake.compaction.CompactionMgr;
-import com.starrocks.meta.lock.LockType;
-import com.starrocks.meta.lock.Locker;
 import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.server.GlobalStateMgr;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -18,7 +18,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PhysicalPartition;
@@ -26,26 +25,28 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.common.Config;
-import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.lake.CommitRateLimiter;
-import com.starrocks.lake.Utils;
 import com.starrocks.lake.compaction.CompactionMgr;
 import com.starrocks.meta.lock.LockType;
 import com.starrocks.meta.lock.Locker;
 import com.starrocks.proto.AbortTxnRequest;
 import com.starrocks.rpc.BrpcProxy;
-import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
 
 public class LakeTableTxnStateListener implements TransactionStateListener {
@@ -76,6 +77,9 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
     public void preCommit(TransactionState txnState, List<TabletCommitInfo> finishedTablets,
                           List<TabletFailInfo> failedTablets) throws TransactionException {
         Preconditions.checkState(txnState.getTransactionStatus() != TransactionStatus.COMMITTED);
+        if (!finishedTablets.isEmpty()) {
+            txnState.setTabletCommitInfos(finishedTablets);
+        }
         if (table.getState() == OlapTable.OlapTableState.RESTORE) {
             throw new TransactionCommitFailedException("Cannot write RESTORE state table \"" + table.getName() + "\"");
         }
@@ -200,45 +204,64 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
 
     @Override
     public void postAbort(TransactionState txnState, List<TabletFailInfo> failedTablets) {
-        Map<Long, List<Long>> tabletGroup = null;
-        Database db = GlobalStateMgr.getCurrentState().getDb(txnState.getDbId());
-        if (db == null) {
-            return;
+        if (CollectionUtils.isEmpty(txnState.getTabletCommitInfos())) {
+            abortTxnSkipCleanup(txnState);
+        } else {
+            abortTxnWithCleanup(txnState);
         }
+    }
 
-        Locker locker = new Locker();
-        locker.lockDatabase(db, LockType.READ);
-        try {
-            // Preconditions: has acquired the database's reader or writer lock.
-            tabletGroup = Utils.groupTabletID(table);
-        } catch (NoAliveBackendException e) {
-            LOG.warn(e);
-        } finally {
-            locker.unLockDatabase(db, LockType.READ);
+    private void abortTxnSkipCleanup(TransactionState txnState) {
+        List<Long> txnIds = Collections.singletonList(txnState.getTransactionId());
+        List<ComputeNode> nodes = getAllAliveNodes();
+        for (ComputeNode node : nodes) { // Send abortTxn() request to all nodes
+            AbortTxnRequest request = new AbortTxnRequest();
+            request.txnIds = txnIds;
+            request.skipCleanup = true;
+            request.tabletIds = null; // unused when skipCleanup is false
+
+            sendAbortTxnRequestIgnoreResponse(request, node);
         }
+    }
 
-        if (tabletGroup == null) {
-            return;
+    private void abortTxnWithCleanup(TransactionState txnState) {
+        List<Long> txnIds = Collections.singletonList(txnState.getTransactionId());
+        Map<Long, List<Long>> tabletGroup = new HashMap<>();
+        for (TabletCommitInfo info : txnState.getTabletCommitInfos()) {
+            tabletGroup.computeIfAbsent(info.getBackendId(), k -> Lists.newArrayList()).add(info.getTabletId());
         }
-
         for (Map.Entry<Long, List<Long>> entry : tabletGroup.entrySet()) {
-            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(entry.getKey());
-            if (backend == null) {
-                // It's ok to skip sending abort transaction request.
+            ComputeNode node = getAliveNode(entry.getKey());
+            if (node == null) {
                 continue;
             }
             AbortTxnRequest request = new AbortTxnRequest();
-            request.txnIds = Lists.newArrayList();
-            request.txnIds.add(txnState.getTransactionId());
+            request.txnIds = txnIds;
             request.tabletIds = entry.getValue();
+            request.skipCleanup = false;
 
-            try {
-                LakeService lakeService = BrpcProxy.getLakeService(backend.getHost(), backend.getBrpcPort());
-                lakeService.abortTxn(request);
-            } catch (Throwable e) {
-                LOG.error(e);
-            }
+            sendAbortTxnRequestIgnoreResponse(request, node);
         }
+    }
+
+    static void sendAbortTxnRequestIgnoreResponse(AbortTxnRequest request, ComputeNode node) {
+        try {
+            BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort()).abortTxn(request);
+        } catch (Throwable e) {
+            LOG.error(e);
+        }
+    }
+
+    static List<ComputeNode> getAllAliveNodes() {
+        List<ComputeNode> nodes = new ArrayList<>();
+        nodes.addAll(GlobalStateMgr.getCurrentSystemInfo().getAvailableComputeNodes());
+        nodes.addAll(GlobalStateMgr.getCurrentSystemInfo().getAvailableBackends());
+        return nodes;
+    }
+
+    @Nullable
+    static ComputeNode getAliveNode(Long nodeId) {
+        return GlobalStateMgr.getCurrentSystemInfo().getBackendOrComputeNode(nodeId);
     }
 
     static boolean enableIngestSlowdown() {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -218,7 +218,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
             AbortTxnRequest request = new AbortTxnRequest();
             request.txnIds = txnIds;
             request.skipCleanup = true;
-            request.tabletIds = null; // unused when skipCleanup is false
+            request.tabletIds = null; // unused when skipCleanup is true
 
             sendAbortTxnRequestIgnoreResponse(request, node);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -394,6 +394,10 @@ public class TransactionState implements Writable {
                 transactionStatus == TransactionStatus.COMMITTED;
     }
 
+    public Set<TabletCommitInfo> getTabletCommitInfos() {
+        return tabletCommitInfos;
+    }
+
     public void setTabletCommitInfos(List<TabletCommitInfo> infos) {
         this.tabletCommitInfos = Sets.newHashSet();
         this.tabletCommitInfos.addAll(infos);

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -44,6 +44,8 @@ message PublishVersionResponse {
 message AbortTxnRequest {
     repeated int64 tablet_ids = 1;
     repeated int64 txn_ids = 2;    
+    // Whether need to clean up the txn logs
+    optional bool skip_cleanup = 3;
 }
 
 message AbortTxnResponse {


### PR DESCRIPTION
Reduce HEAD OBJECT requests during abort transactions.
- Skip txn log cleanup on abort if there is no committed tablet.
- Only send abortTxn request to commited tablets.

In the previous implementation, aborting a transaction where
all tablet in the table sends a HEAD OBJECT request to the
object store is costly.

This patch will only notify those tablets that have already
committed, i.e., those that generated the Txn log to perform
the cleanup.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
