### PR TITLE
[BugFix] Fix text-based profile analysis not showing node id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfilingExecPlan.java
@@ -120,7 +120,8 @@ public class ProfilingExecPlan {
         }
 
         public boolean isFinalSink() {
-            return !instanceOf(DataStreamSink.class) && !instanceOf(MultiCastDataSink.class);
+            return instanceOf(DataSink.class) &&
+                    !instanceOf(DataStreamSink.class) && !instanceOf(MultiCastDataSink.class);
         }
 
         public boolean hasChild(int i) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ArrayTypeTest.java
@@ -123,7 +123,7 @@ public class ArrayTypeTest extends PlanTestBase {
                 "from t0;";
         plan = getFragmentPlan(sql);
         getThriftPlan(sql); // Check null type handling
-        assertContains(plan, "<slot 3> : array_concat(CAST(2: c1 AS ARRAY<TINYINT>), [1])");
+        assertContains(plan, "array_concat(CAST(1: c1 AS ARRAY<TINYINT>), [1])");
 
         sql = "with t0 as (\n" +
                 "    select c1 from (values([])) as t(c1)\n" +
@@ -133,7 +133,7 @@ public class ArrayTypeTest extends PlanTestBase {
                 "from t0;";
         plan = getFragmentPlan(sql);
         getThriftPlan(sql); // Check null type handling
-        assertContains(plan, "<slot 3> : array_concat(CAST(2: c1 AS ARRAY<TINYINT>), [1])");
+        assertContains(plan, "array_concat(CAST(1: c1 AS ARRAY<TINYINT>), [1])");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MapTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MapTypeTest.java
@@ -48,7 +48,7 @@ public class MapTypeTest extends PlanTestBase {
                 "select map_concat(map('a',1, 'b',2), c1)\n" +
                 "from t0;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "map_concat(map{'a':1,'b':2}, CAST(2: c1 AS MAP<VARCHAR,TINYINT>))");
+        assertContains(plan, "map_concat(map{'a':1,'b':2}, CAST(1: c1 AS MAP<VARCHAR,TINYINT>))");
 
         sql = "with t0 as (\n" +
                 "    select c1 from (values(map())) as t(c1)\n" +
@@ -56,7 +56,7 @@ public class MapTypeTest extends PlanTestBase {
                 "select map_concat(c1, map('a',1, 'b',2))\n" +
                 "from t0;";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "map_concat(CAST(2: c1 AS MAP<VARCHAR,TINYINT>), map{'a':1,'b':2})");
+        assertContains(plan, "map_concat(CAST(1: c1 AS MAP<VARCHAR,TINYINT>), map{'a':1,'b':2})");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
The text-based profile analysis doesn't show plan_node_id.

What I'm doing:
Fix a wrong condition of determining whether a planNode is a finalSink

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
