### PR TITLE
[BugFix] Fix version not found when transactional stream load and clone run concurrently (backport #35115)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -411,9 +411,6 @@ public class DatabaseTransactionMgr {
         if (transactionState.getWriteEndTimeMs() < 0) {
             transactionState.setWriteEndTimeMs(System.currentTimeMillis());
         }
-        if (!tabletCommitInfos.isEmpty()) {
-            transactionState.setTabletCommitInfos(tabletCommitInfos);
-        }
 
         // update transaction state extra if exists
         if (txnCommitAttachment != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -82,6 +82,12 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         Map<Long, Set<Long>> tabletToBackends = new HashMap<>();
         Set<Long> allCommittedBackends = new HashSet<>();
 
+        // 1. record tablet commit infos in TransactionState,
+        // so we can decide to update version in replica when finish transaction
+        if (!tabletCommitInfos.isEmpty()) {
+            txnState.setTabletCommitInfos(tabletCommitInfos);
+        }
+
         // 2. validate potential exists problem: db->table->partition
         // guarantee exist exception during a transaction
         // if index is dropped, it does not matter.

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -40,9 +40,11 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.List;
 import java.util.UUID;
 
 public class TransactionStateTest {
@@ -168,5 +170,27 @@ public class TransactionStateTest {
             transactionState.setTransactionStatus(status);
             Assert.assertEquals(nonRunningStatus.contains(status), !transactionState.isRunning());
         }
+    }
+
+    @Test
+    public void testCommitInfos() {
+        UUID uuid = UUID.randomUUID();
+        TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
+                3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
+                60 * 1000L);
+        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(1001, 1001));
+        TabletCommitInfo info1 = new TabletCommitInfo(10001, 10001);
+        TabletCommitInfo info2 = new TabletCommitInfo(10001, 10002);
+        TabletCommitInfo info3 = new TabletCommitInfo(10002, 10002);
+        List<TabletCommitInfo> infos = new ArrayList<>();
+        infos.add(info1);
+        infos.add(info2);
+        infos.add(info3);
+        transactionState.setTabletCommitInfos(infos);
+        Assert.assertFalse(transactionState.tabletCommitInfosContainsReplica(1001, 1001));
+        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(10001, 10001));
+        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(10001, 10002));
+        Assert.assertTrue(transactionState.tabletCommitInfosContainsReplica(10002, 10002));
     }
 }


### PR DESCRIPTION
Why I'm doing:
There is a bug which will cause "version not found" error in BE:
```
Begin ingestion transaction on replicas (A, B, C)
Begin clone from A to A'
Clone finish, replicas become (A', B, C)
Load finish, and try to update replica (A', B, C) version and success, 
but A' doesn't have new load data, so a query on A' will return "version not found"
```
So we use `TabletCommitInfo` to record if this replica has new load data, only the replica containing new load data can update the version. But now we only record this in `commitTransaction`, and transaction load won't call `commitTransaction`.

What I'm doing: 
Move `setTabletCommitInfos` to `preCommit`, so all kinds of load can record this status success.

Fixes #35115

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
