### PR TITLE
[BugFix] refactor auto infer default replication num (backport #32792)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/AutoInferUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/AutoInferUtil.java
@@ -21,13 +21,13 @@ import com.starrocks.server.RunMode;
 
 public class AutoInferUtil {
     public static int calDefaultReplicationNum() throws UserException {
+        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
+            return 1;
+        }
+
         int defaultReplicationNum = Math.min(3, GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber());
         if (defaultReplicationNum == 0) {
             throw new NoAliveBackendException("No alive backend");
-        }
-
-        if (RunMode.getCurrentRunMode() == RunMode.SHARED_DATA) {
-            defaultReplicationNum = 1;
         }
         return defaultReplicationNum;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/common/util/AutoInferUtilTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/AutoInferUtilTest.java
@@ -16,6 +16,9 @@ package com.starrocks.common.util;
 
 import com.starrocks.common.NoAliveBackendException;
 import com.starrocks.common.UserException;
+import com.starrocks.server.RunMode;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -29,5 +32,14 @@ public class AutoInferUtilTest {
             Assert.assertTrue(e instanceof NoAliveBackendException
                     && e.getMessage().contains("No alive backend"));
         }
+
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        Assert.assertEquals(1, AutoInferUtil.calDefaultReplicationNum());
     }
 }


### PR DESCRIPTION
Why I'm doing:
previous backport of pr: https://github.com/StarRocks/starrocks/pull/32792/files failed

What I'm doing:

manually backport pr :  https://github.com/StarRocks/starrocks/pull/32792/files failed


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
