### PR TITLE
[Enhancement] Optimize skew join

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/ChildOutputPropertyGuarantor.java
@@ -340,7 +340,7 @@ public class ChildOutputPropertyGuarantor extends PropertyDeriverBase<Void, Expr
             HashDistributionDesc rightDistributionDesc = rightDistributionSpec.getHashDistributionDesc();
 
             // 2.1 respect the hint
-            if (JoinOperator.HINT_SHUFFLE.equals(hint)) {
+            if (JoinOperator.HINT_SHUFFLE.equals(hint) || JoinOperator.HINT_SKEW.equals(hint)) {
                 if (leftDistributionDesc.isLocal()) {
                     enforceChildShuffleDistribution(leftShuffleColumns, leftChild, leftChildOutputProperty, 0);
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/JoinHelper.java
@@ -142,7 +142,7 @@ public class JoinHelper {
 
     public boolean onlyShuffle() {
         return type.isRightJoin() || type.isFullOuterJoin() || JoinOperator.HINT_SHUFFLE.equals(hint) ||
-                JoinOperator.HINT_BUCKET.equals(hint);
+                JoinOperator.HINT_BUCKET.equals(hint) || JoinOperator.HINT_SKEW.equals(hint);
     }
 
     public static List<BinaryPredicateOperator> getEqualsPredicate(ColumnRefSet leftColumns, ColumnRefSet rightColumns,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -328,7 +328,7 @@ public class Optimizer {
         ruleRewriteIterative(tree, rootTaskContext, new MergeTwoProjectRule());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownAggToMetaScanRule());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownPredicateRankingWindowRule());
-        ruleRewriteIterative(tree, rootTaskContext, new SkewJoinOptimizeRule());
+        ruleRewriteOnlyOnce(tree, rootTaskContext, new SkewJoinOptimizeRule());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
         deriveLogicalProperty(tree);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -130,7 +130,7 @@ public class SkewJoinOptimizeRule extends TransformationRule {
         LogicalJoinOperator.Builder joinBuilder = LogicalJoinOperator.builder();
         LogicalJoinOperator newJoinOperator = joinBuilder.withOperator(oldJoinOperator)
                 .setOnPredicate(andPredicateOperator)
-                .setJoinHint(JoinOperator.HINT_SHUFFLE)
+                .setJoinHint(JoinOperator.HINT_SKEW)
                 .build();
 
         OptExpression joinExpression = OptExpression.create(newJoinOperator, newLeftChild, newRightChild);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/SkewJoinOptimizeRule.java
@@ -288,7 +288,8 @@ public class SkewJoinOptimizeRule extends TransformationRule {
 
         LogicalJoinOperator.Builder joinBuilder = new LogicalJoinOperator.Builder();
         joinBuilder.setJoinType(JoinOperator.LEFT_OUTER_JOIN)
-                .setOnPredicate(onPredicate);
+                .setOnPredicate(onPredicate)
+                .setJoinHint(JoinOperator.HINT_BROADCAST);
         LogicalJoinOperator joinOperator = joinBuilder.build();
         OptExpression joinOptExpression = OptExpression.create(joinOperator, input, skewValueSaltOpt);
         Map<ColumnRefOperator, ScalarOperator> joinProjectMap = input.getOutputColumns().getStream().

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PruneShuffleColumnRule.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.rule.tree;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.JoinOperator;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
@@ -27,6 +28,7 @@ import com.starrocks.sql.optimizer.base.HashDistributionDesc;
 import com.starrocks.sql.optimizer.base.HashDistributionSpec;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalDistributionOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
@@ -178,7 +180,8 @@ public class PruneShuffleColumnRule implements TreeRewriteRule {
             optExpression.getInputs().get(0).getOp().accept(this, optExpression.getInputs().get(0), lc);
             optExpression.getInputs().get(1).getOp().accept(this, optExpression.getInputs().get(1), rc);
 
-            if (lc.distributionList.isEmpty() || rc.distributionList.isEmpty()) {
+            if (lc.distributionList.isEmpty() || rc.distributionList.isEmpty() ||
+                    ((PhysicalJoinOperator) optExpression.getOp()).getJoinHint().equals(JoinOperator.HINT_SKEW)) {
                 return optExpression;
             }
 


### PR DESCRIPTION
Why I'm doing: slat table usually is small, so broadcast will be better. for skew join never prune exchange column because that's what we designed.

What I'm doing: treat skew hint as shuffle hint except prune exchange column

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
