### PR TITLE
[BugFix] Fix external olap table not updating backend host  in external cluster

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExternalOlapTable.java
@@ -588,6 +588,7 @@ public class ExternalOlapTable extends OlapTable {
                 systemInfoService.addBackend(backend);
             } else {
                 backend.setId(backendMeta.getBackend_id());
+                backend.setHost(backendMeta.getHost());
                 backend.setBePort(backendMeta.getBe_port());
                 backend.setHttpPort(backendMeta.getHttp_port());
                 backend.setBrpcPort(backendMeta.getRpc_port());


### PR DESCRIPTION
Why I'm doing:
When cluster A has an external olap table pointing to cluster B and cluster B changes to FQDN mode, then the external olap table in cluster A does not work. This pr fixed this situation.

What I'm doing:
Fixed external olap table not updating backend host in external cluster, 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
