### PR TITLE
[Enhancement] Read S3 object without sending head object request

### DIFF
--- a/be/src/io/s3_input_stream.cpp
+++ b/be/src/io/s3_input_stream.cpp
@@ -87,4 +87,17 @@ void S3InputStream::set_size(int64_t value) {
     _size = value;
 }
 
+StatusOr<std::string> S3InputStream::read_all() {
+    Aws::S3::Model::GetObjectRequest request;
+    request.SetBucket(_bucket);
+    request.SetKey(_object);
+    Aws::S3::Model::GetObjectOutcome outcome = _s3client->GetObject(request);
+    if (outcome.IsSuccess()) {
+        Aws::IOStream& body = outcome.GetResult().GetBody();
+        return std::string(std::istreambuf_iterator<char>(body), {});
+    } else {
+        return make_error_status(outcome.GetError());
+    }
+}
+
 } // namespace starrocks::io

--- a/be/src/io/s3_input_stream.h
+++ b/be/src/io/s3_input_stream.h
@@ -50,6 +50,8 @@ public:
 
     void set_size(int64_t size) override;
 
+    StatusOr<std::string> read_all() override;
+
 private:
     std::shared_ptr<Aws::S3::S3Client> _s3client;
     std::string _bucket;

--- a/be/src/io/seekable_input_stream.cpp
+++ b/be/src/io/seekable_input_stream.cpp
@@ -16,6 +16,8 @@
 
 #include <fmt/format.h>
 
+#include "util/raw_container.h"
+
 namespace starrocks::io {
 
 StatusOr<int64_t> SeekableInputStream::read_at(int64_t offset, void* data, int64_t count) {
@@ -34,5 +36,13 @@ Status SeekableInputStream::skip(int64_t count) {
 }
 
 void SeekableInputStream::set_size(int64_t count) {}
+
+StatusOr<std::string> SeekableInputStream::read_all() {
+    ASSIGN_OR_RETURN(auto size, get_size());
+    std::string ret;
+    raw::stl_string_resize_uninitialized(&ret, size);
+    RETURN_IF_ERROR(read_at_fully(0, ret.data(), ret.size()));
+    return std::move(ret);
+}
 
 } // namespace starrocks::io

--- a/be/src/io/seekable_input_stream.h
+++ b/be/src/io/seekable_input_stream.h
@@ -68,6 +68,15 @@ public:
     Status skip(int64_t count) override;
 
     virtual void set_size(int64_t);
+
+    // Reads all the data in this stream and returns it as std::string.
+    //
+    // Some implementations may override this method to get all
+    // the data without calling `get_size()`.
+    // For example, S3InputStream can read the contents of an entire
+    // object directly with a single GET OBJECT call, without the need
+    // to first send a HEAD OBJECT request to get the object size.
+    virtual StatusOr<std::string> read_all();
 };
 
 class SeekableInputStreamWrapper : public SeekableInputStream {
@@ -115,6 +124,8 @@ public:
     Status seek(int64_t offset) override { return _impl->seek(offset); }
 
     void set_size(int64_t value) override { return _impl->set_size(value); }
+
+    StatusOr<std::string> read_all() override { return _impl->read_all(); }
 
 private:
     SeekableInputStream* _impl;

--- a/be/src/storage/protobuf_file.cpp
+++ b/be/src/storage/protobuf_file.cpp
@@ -122,17 +122,8 @@ Status ProtobufFile::load(::google::protobuf::Message* message, bool fill_cache)
     RandomAccessFileOptions opts{.skip_fill_local_cache = !fill_cache};
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_path));
     ASSIGN_OR_RETURN(auto input_file, fs->new_random_access_file(opts, _path));
-    ASSIGN_OR_RETURN(auto file_size, input_file->get_size());
-    TEST_SYNC_POINT_CALLBACK("ProtobufFile::load:get_size", &file_size);
-    if (UNLIKELY(file_size > std::numeric_limits<int>::max())) {
-        return Status::Corruption(fmt::format("protobuf file too large: {}", file_size));
-    }
-    std::string serialized_string;
-    raw::stl_string_resize_uninitialized(&serialized_string, file_size);
-    RETURN_IF_ERROR(input_file->read_at_fully(0, serialized_string.data(), file_size));
-    TEST_SYNC_POINT_CALLBACK("ProtobufFile::load:2", &serialized_string);
-    bool parsed = message->ParseFromArray(serialized_string.data(), static_cast<int>(file_size));
-    if (!parsed) {
+    ASSIGN_OR_RETURN(auto serialized_string, input_file->read_all());
+    if (bool parsed = message->ParseFromString(serialized_string); !parsed) {
         return Status::Corruption(fmt::format("failed to parse protobuf file {}", _path));
     }
     return Status::OK();

--- a/be/test/io/array_input_stream_test.cpp
+++ b/be/test/io/array_input_stream_test.cpp
@@ -119,4 +119,18 @@ PARALLEL_TEST(ArrayInputStreamTest, test_seek_and_peek) {
     ASSERT_EQ("", *in.peek(10));
 }
 
+// NOLINTNEXTLINE
+PARALLEL_TEST(ArrayInputStreamTest, test_read_all) {
+    std::string s("0123456789");
+    ArrayInputStream in(s.data(), static_cast<int64_t>(s.size()));
+
+    ASSIGN_OR_ABORT(auto content, in.read_all());
+    EXPECT_EQ(s, content);
+
+    ASSERT_OK(in.seek(5));
+
+    ASSIGN_OR_ABORT(content, in.read_all());
+    EXPECT_EQ(s, content);
+}
+
 } // namespace starrocks::io

--- a/be/test/io/s3_input_stream_test.cpp
+++ b/be/test/io/s3_input_stream_test.cpp
@@ -30,13 +30,11 @@
 
 namespace starrocks::io {
 
-static const char* kBucketName = "s3randomaccessfiletest";
-static const char* kObjectName = "test.txt";
+static const char* kObjectName = "starrocks_ut_s3_input_stream_test.txt";
+static const char* kObjectContent = "0123456789";
 static std::shared_ptr<Aws::S3::S3Client> g_s3client;
 
 static void init_s3client();
-static void init_bucket();
-static void destroy_bucket();
 static void destroy_s3client();
 
 class S3InputStreamTest : public testing::Test {
@@ -56,63 +54,46 @@ public:
     void TearDown() override {}
 
     std::unique_ptr<S3InputStream> new_random_access_file();
+
+protected:
+    inline static const char* s_bucket_name = nullptr;
 };
 
 void S3InputStreamTest::SetUpTestCase() {
     Aws::InitAPI(Aws::SDKOptions());
     init_s3client();
-    init_bucket();
-    put_object("0123456789");
+
+    s_bucket_name = config::object_storage_bucket.empty() ? getenv("STARROCKS_UT_S3_BUCKET")
+                                                          : config::object_storage_bucket.c_str();
+    if (s_bucket_name == nullptr) {
+        FAIL() << "s3 bucket name not set";
+    }
+    put_object(kObjectContent);
 }
 
 void S3InputStreamTest::TearDownTestCase() {
-    destroy_bucket();
     destroy_s3client();
     Aws::ShutdownAPI(Aws::SDKOptions());
 }
 
 void init_s3client() {
     Aws::Client::ClientConfiguration config;
-    config.endpointOverride = config::object_storage_endpoint;
-    const char* ak = config::object_storage_access_key_id.c_str();
-    const char* sk = config::object_storage_secret_access_key.c_str();
+    config.endpointOverride = config::object_storage_endpoint.empty() ? getenv("STARROCKS_UT_S3_ENDPOINT")
+                                                                      : config::object_storage_endpoint;
+    const char* ak = config::object_storage_access_key_id.empty() ? getenv("STARROCKS_UT_S3_AK")
+                                                                  : config::object_storage_access_key_id.c_str();
+    const char* sk = config::object_storage_secret_access_key.empty()
+                             ? getenv("STARROCKS_UT_S3_SK")
+                             : config::object_storage_secret_access_key.c_str();
+    if (ak == nullptr) {
+        FAIL() << "s3 access key id not set";
+    }
+    if (sk == nullptr) {
+        FAIL() << "s3 secret access key not set";
+    }
     auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
     g_s3client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
                                                      Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
-}
-
-void init_bucket() {
-    Aws::S3::Model::CreateBucketRequest request;
-    request.SetBucket(kBucketName);
-    Aws::S3::Model::CreateBucketOutcome outcome = g_s3client->CreateBucket(request);
-    LOG_IF(ERROR, !outcome.IsSuccess()) << outcome.GetError().GetMessage();
-}
-
-void destroy_bucket() {
-    // delete object first
-    {
-        Aws::S3::Model::DeleteObjectRequest request;
-        request.SetBucket(kBucketName);
-        request.SetKey(kObjectName);
-        Aws::S3::Model::DeleteObjectOutcome outcome = g_s3client->DeleteObject(request);
-        if (!outcome.IsSuccess()) {
-            std::cerr << "Fail to delete s3://" << kBucketName << "/" << kObjectName << ": "
-                      << outcome.GetError().GetMessage() << '\n';
-        } else {
-            std::cout << "Deleted object s3://" << kBucketName << "/" << kObjectName << '\n';
-        }
-    }
-    // delete bucket
-    {
-        Aws::S3::Model::DeleteBucketRequest request;
-        request.SetBucket(kBucketName);
-        Aws::S3::Model::DeleteBucketOutcome outcome = g_s3client->DeleteBucket(request);
-        if (outcome.IsSuccess()) {
-            std::cout << "Deleted bucket " << kBucketName << '\n';
-        } else {
-            std::cerr << "Fail to delete bucket " << kBucketName << ": " << outcome.GetError().GetMessage() << '\n';
-        }
-    }
 }
 
 void destroy_s3client() {
@@ -120,14 +101,14 @@ void destroy_s3client() {
 }
 
 std::unique_ptr<S3InputStream> S3InputStreamTest::new_random_access_file() {
-    return std::make_unique<S3InputStream>(g_s3client, kBucketName, kObjectName);
+    return std::make_unique<S3InputStream>(g_s3client, s_bucket_name, kObjectName);
 }
 
 void S3InputStreamTest::put_object(const std::string& object_content) {
     std::shared_ptr<Aws::IOStream> stream = Aws::MakeShared<Aws::StringStream>("", object_content);
 
     Aws::S3::Model::PutObjectRequest request;
-    request.SetBucket(kBucketName);
+    request.SetBucket(s_bucket_name);
     request.SetKey(kObjectName);
     request.SetBody(stream);
 
@@ -206,6 +187,21 @@ TEST_F(S3InputStreamTest, test_read_at) {
     ASSERT_EQ(11, *f->position());
 
     ASSERT_FALSE(f->read_at(-1, buf, sizeof(buf)).ok());
+}
+
+TEST_F(S3InputStreamTest, test_read_all) {
+    auto f = new_random_access_file();
+
+    ASSIGN_OR_ABORT(auto s, f->read_all());
+    EXPECT_EQ(kObjectContent, s);
+
+    char buf[6];
+    ASSIGN_OR_ABORT(auto r, f->read_at(3, buf, sizeof(buf)));
+    ASSERT_EQ("345678", std::string_view(buf, r));
+    ASSERT_EQ(9, *f->position());
+
+    ASSIGN_OR_ABORT(s, f->read_all());
+    EXPECT_EQ(kObjectContent, s);
 }
 
 } // namespace starrocks::io

--- a/be/test/io/s3_input_stream_test.cpp
+++ b/be/test/io/s3_input_stream_test.cpp
@@ -93,7 +93,7 @@ void init_s3client() {
     }
     auto credentials = std::make_shared<Aws::Auth::SimpleAWSCredentialsProvider>(ak, sk);
     g_s3client = std::make_shared<Aws::S3::S3Client>(std::move(credentials), std::move(config),
-                                                     Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, false);
+                                                     Aws::Client::AWSAuthV4Signer::PayloadSigningPolicy::Never, true);
 }
 
 void destroy_s3client() {


### PR DESCRIPTION
## Why I'm doing:
The current interface requires obtaining the file size before reading the entire file, which is inefficient for S3.

## What I'm doing:
Add a new SeekableInputStream API and override it in S3InputStream to read the full object without sending a HEAD request.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
