### PR TITLE
[Enhancement] disable insert or drop hive non managed table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -84,6 +84,23 @@ import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.getResource
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog;
 
 public class HiveTable extends Table implements HiveMetaStoreTable {
+    public enum HiveTableType {
+        VIRTUAL_VIEW,
+        EXTERNAL_TABLE,
+        MANAGED_TABLE,
+        MATERIALIZED_VIEW,
+        UNKNOWN;
+
+        public static HiveTableType fromString(String hiveTableType) {
+            for (HiveTableType type : HiveTableType.values()) {
+                if (type.name().equalsIgnoreCase(hiveTableType)) {
+                    return type;
+                }
+            }
+            return UNKNOWN;
+        }
+    }
+
     private static final Logger LOG = LogManager.getLogger(HiveTable.class);
 
     private static final String JSON_KEY_HIVE_DB = "hiveDb";
@@ -129,6 +146,8 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     // This error will happen when appending files to an existed partition on user side.
     private boolean useMetadataCache = true;
 
+    private HiveTableType hiveTableType = HiveTableType.MANAGED_TABLE;
+
     private HiveStorageFormat storageFormat;
 
     public HiveTable() {
@@ -138,7 +157,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     public HiveTable(long id, String name, List<Column> fullSchema, String resourceName, String catalog,
                      String hiveDbName, String hiveTableName, String tableLocation, long createTime,
                      List<String> partColumnNames, List<String> dataColumnNames, Map<String, String> properties,
-                     HiveStorageFormat storageFormat) {
+                     HiveStorageFormat storageFormat, HiveTableType hiveTableType) {
         super(id, name, TableType.HIVE, fullSchema);
         this.resourceName = resourceName;
         this.catalogName = catalog;
@@ -150,6 +169,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         this.dataColumnNames = dataColumnNames;
         this.hiveProperties = properties;
         this.storageFormat = storageFormat;
+        this.hiveTableType = hiveTableType;
     }
 
     public String getHiveDbTable() {
@@ -231,6 +251,10 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     @Override
     public String getTableIdentifier() {
         return Joiner.on(":").join(name, createTime);
+    }
+
+    public HiveTableType getHiveTableType() {
+        return hiveTableType;
     }
 
     @Override
@@ -546,6 +570,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         private List<String> dataColNames = Lists.newArrayList();
         private Map<String, String> properties = Maps.newHashMap();
         private HiveStorageFormat storageFormat;
+        private HiveTableType hiveTableType = HiveTableType.MANAGED_TABLE;
 
         public Builder() {
         }
@@ -615,9 +640,14 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
             return this;
         }
 
+        public Builder setHiveTableType(HiveTableType hiveTableType) {
+            this.hiveTableType = hiveTableType;
+            return this;
+        }
+
         public HiveTable build() {
             return new HiveTable(id, tableName, fullSchema, resourceName, catalogName, hiveDbName, hiveTableName,
-                    tableLocation, createTime, partitionColNames, dataColNames, properties, storageFormat);
+                    tableLocation, createTime, partitionColNames, dataColNames, properties, storageFormat, hiveTableType);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -148,9 +148,14 @@ public class HiveMetadata implements ConnectorMetadata {
                         " Please execute 'drop table %s.%s.%s force'", stmt.getCatalogName(), dbName, tableName));
             }
 
-            if (getTable(dbName, tableName) == null && stmt.isSetIfExists()) {
+            HiveTable hiveTable = (HiveTable) getTable(dbName, tableName);
+            if (hiveTable == null && stmt.isSetIfExists()) {
                 LOG.warn("Table {}.{} doesn't exist", dbName, tableName);
                 return;
+            }
+
+            if (hiveTable.getHiveTableType() != HiveTable.HiveTableType.MANAGED_TABLE) {
+                throw new StarRocksConnectorException("Only support to drop hive managed table");
             }
 
             hmsOps.dropTable(dbName, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -147,7 +147,9 @@ public class HiveMetastoreApiConverter {
                         HiveStorageFormat.get(fromHdfsInputFormatClass(table.getSd().getInputFormat()).name())))
                 .setStorageFormat(
                         HiveStorageFormat.get(fromHdfsInputFormatClass(table.getSd().getInputFormat()).name()))
-                .setCreateTime(table.getCreateTime());
+                .setCreateTime(table.getCreateTime())
+                .setHiveTableType(HiveTable.HiveTableType.fromString(table.getTableType()));
+
         return tableBuilder.build();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -342,6 +342,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_HIVE_COLUMN_STATS = "enable_hive_column_stats";
 
+    public static final String ENABLE_WRITE_HIVE_EXTERNAL_TABLE = "enable_write_hive_external_table";
+
     public static final String ENABLE_HIVE_METADATA_CACHE_WITH_INSERT = "enable_hive_metadata_cache_with_insert";
 
     public static final String DEFAULT_TABLE_COMPRESSION = "default_table_compression";
@@ -1076,6 +1078,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VariableMgr.VarAttr(name = ENABLE_HIVE_COLUMN_STATS)
     private boolean enableHiveColumnStats = true;
 
+    @VariableMgr.VarAttr(name = ENABLE_WRITE_HIVE_EXTERNAL_TABLE)
+    private boolean enableWriteHiveExternalTable = false;
+
     @VariableMgr.VarAttr(name = ENABLE_HIVE_METADATA_CACHE_WITH_INSERT)
     private boolean enableHiveMetadataCacheWithInsert = false;
 
@@ -1431,6 +1436,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public String getHiveTempStagingDir() {
         return hiveTempStagingDir;
+    }
+
+    public boolean enableWriteHiveExternalTable() {
+        return enableWriteHiveExternalTable;
     }
 
     public SessionVariable setHiveTempStagingDir(String hiveTempStagingDir) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -120,6 +120,13 @@ public class InsertAnalyzer {
                     HiveWriteUtils.isS3Url(table.getTableLocation()) && insertStmt.isOverwrite()) {
                 throw new SemanticException("Unsupported insert overwrite hive unpartitioned table with s3 location");
             }
+
+            if (table.isHiveTable() && ((HiveTable) table).getHiveTableType() != HiveTable.HiveTableType.MANAGED_TABLE &&
+                    !session.getSessionVariable().enableWriteHiveExternalTable()) {
+                throw new SemanticException("Only support to write hive managed table, tableType: " +
+                        ((HiveTable) table).getHiveTableType());
+            }
+
             PartitionNames targetPartitionNames = insertStmt.getTargetPartitionNames();
             List<String> tablePartitionColumnNames = table.getPartitionColumnNames();
             if (insertStmt.getTargetColumnNames() != null) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
@@ -130,7 +130,7 @@ public class ShowCreateTableStmtTest {
 
         HiveTable table = new HiveTable(100, "test", fullSchema, "aa", "bb", "cc", "dd", "hdfs://xxx",
                 0, new ArrayList<>(), fullSchema.stream().map(x -> x.getName()).collect(Collectors.toList()),
-                props, HiveStorageFormat.ORC);
+                props, HiveStorageFormat.ORC, HiveTable.HiveTableType.MANAGED_TABLE);
         List<String> result = new ArrayList<>();
         GlobalStateMgr.getDdlStmt(table, result, null, null, false, true);
         Assert.assertEquals(result.size(), 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -18,6 +18,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
@@ -43,6 +44,9 @@ public class AnalyzeInsertTest {
         String createIcebergCatalogStmt = "create external catalog iceberg_catalog properties (\"type\"=\"iceberg\", " +
                 "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";
         starRocksAssert.withCatalog(createIcebergCatalogStmt);
+
+        starRocksAssert.withCatalog("create external catalog hive_catalog properties (\"type\"=\"hive\", " +
+                "\"hive.metastore.uris\"=\"thrift://hms:9083\")");
     }
 
     @Test
@@ -212,6 +216,39 @@ public class AnalyzeInsertTest {
 
         analyzeFail("insert into iceberg_catalog.db.tbl select 1, 2, \"2023-01-01 12:34:45\"",
                 "Unsupported partition column type [DATETIME] for ICEBERG table sink.");
+    }
+
+    @Test
+    public void testInsertHiveNonManagedTable(@Mocked HiveTable hiveTable) {
+        MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
+        new Expectations(metadata) {
+            {
+                metadata.getDb(anyString, anyString);
+                result = new Database();
+
+                metadata.getTable(anyString, anyString, anyString);
+                result = hiveTable;
+            }
+        };
+
+        new Expectations(hiveTable) {
+            {
+                hiveTable.supportInsert();
+                result = true;
+
+                hiveTable.isHiveTable();
+                result = true;
+
+                hiveTable.isUnPartitioned();
+                result = false;
+
+                hiveTable.getHiveTableType();
+                result = HiveTable.HiveTableType.EXTERNAL_TABLE;
+            }
+        };
+
+        analyzeFail("insert into hive_catalog.db.tbl select 1, 2, 3",
+                "Only support to write hive managed table");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
we can't support to create hive external_table. So we forbid write and delete as well.

What I'm doing:
If user want to write hive external_table using starrocks, they could set session variables `set enable_write_hive_external_table=true` to do it. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
