### PR TITLE
[BugFix] Fix APPROX_TOP_K limit count

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -83,6 +83,9 @@ public class FeConstants {
     // the raw data of one tablet equals to 10GB approximately
     public static final long AUTO_DISTRIBUTION_UNIT = 3221225472L;
 
+    // Max counter num of TOP K function
+    public static final int MAX_COUNTER_NUM_OF_TOP_K = 100000;
+
     public static final String DOCUMENT_SHOW_ALTER =
             "https://docs.starrocks.io/en-us/latest/sql-reference/sql-statements/data-manipulation/SHOW%20ALTER";
     public static final String DOCUMENT_SHOW_ALTER_MATERIALIZED_VIEW =

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/FunctionAnalyzer.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.AggregateFunction;
 import com.starrocks.catalog.ArrayType;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.ExprUtil;
 import com.starrocks.qe.ConnectContext;
 
@@ -385,15 +386,15 @@ public class FunctionAnalyzer {
                 }
                 counterNum = ExprUtil.getIntegerConstant(counterNumExpr);
             }
-            if (k != null && k > 10000) {
-                throw new SemanticException("The maximum number of the second parameter is 10000" +
-                        functionCallExpr.toSql(), kExpr.getPos());
+            if (k != null && k > FeConstants.MAX_COUNTER_NUM_OF_TOP_K) {
+                throw new SemanticException("The maximum number of the second parameter is "
+                        + FeConstants.MAX_COUNTER_NUM_OF_TOP_K + ", " + functionCallExpr.toSql(), kExpr.getPos());
             }
             if (counterNum != null) {
                 Preconditions.checkNotNull(k);
-                if (counterNum > 10000) {
-                    throw new SemanticException("The maximum number of the third parameter is 10000" +
-                            functionCallExpr.toSql(), counterNumExpr.getPos());
+                if (counterNum > FeConstants.MAX_COUNTER_NUM_OF_TOP_K) {
+                    throw new SemanticException("The maximum number of the third parameter is "
+                            + FeConstants.MAX_COUNTER_NUM_OF_TOP_K + ", " + functionCallExpr.toSql(), counterNumExpr.getPos());
                 }
                 if (k > counterNum) {
                     throw new SemanticException(

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2491,10 +2491,10 @@ public class AggregateTest extends PlanTestBase {
         }
         {
             Exception exception = Assertions.assertThrows(SemanticException.class, () -> {
-                String sql = "select approx_top_k(L_LINENUMBER, 10001) from lineitem";
+                String sql = "select approx_top_k(L_LINENUMBER, 100001) from lineitem";
                 getFragmentPlan(sql);
             });
-            String expectedMessage = "The maximum number of the second parameter is 10000";
+            String expectedMessage = "The maximum number of the second parameter is 100000";
             String actualMessage = exception.getMessage();
             Assert.assertTrue(actualMessage.contains(expectedMessage));
         }
@@ -2509,10 +2509,10 @@ public class AggregateTest extends PlanTestBase {
         }
         {
             Exception exception = Assertions.assertThrows(SemanticException.class, () -> {
-                String sql = "select approx_top_k(L_LINENUMBER, 1, 10001) from lineitem";
+                String sql = "select approx_top_k(L_LINENUMBER, 1, 100001) from lineitem";
                 getFragmentPlan(sql);
             });
-            String expectedMessage = "The maximum number of the third parameter is 10000";
+            String expectedMessage = "The maximum number of the third parameter is 100000";
             String actualMessage = exception.getMessage();
             Assert.assertTrue(actualMessage.contains(expectedMessage));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/WindowTest.java
@@ -1155,10 +1155,10 @@ public class WindowTest extends PlanTestBase {
         }
         {
             Exception exception = Assertions.assertThrows(SemanticException.class, () -> {
-                String sql = "select approx_top_k(L_LINENUMBER, 10001) over() from lineitem";
+                String sql = "select approx_top_k(L_LINENUMBER, 100001) over() from lineitem";
                 getFragmentPlan(sql);
             });
-            String expectedMessage = "The maximum number of the second parameter is 10000";
+            String expectedMessage = "The maximum number of the second parameter is 100000";
             String actualMessage = exception.getMessage();
             Assert.assertTrue(actualMessage.contains(expectedMessage));
         }
@@ -1173,10 +1173,10 @@ public class WindowTest extends PlanTestBase {
         }
         {
             Exception exception = Assertions.assertThrows(SemanticException.class, () -> {
-                String sql = "select approx_top_k(L_LINENUMBER, 1, 10001) over() from lineitem";
+                String sql = "select approx_top_k(L_LINENUMBER, 1, 100001) over() from lineitem";
                 getFragmentPlan(sql);
             });
-            String expectedMessage = "The maximum number of the third parameter is 10000";
+            String expectedMessage = "The maximum number of the third parameter is 100000";
             String actualMessage = exception.getMessage();
             Assert.assertTrue(actualMessage.contains(expectedMessage));
         }


### PR DESCRIPTION
Why I'm doing:
function `approx_top_k` limit in FE should be 100000 instead of 10000, because limit in BE is 100000 and doc shows that limit is 100000. https://docs.starrocks.io/docs/sql-reference/sql-functions/aggregate-functions/approx_top_k/#arguments

What I'm doing:

increase limit to 100000

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
