### PR TITLE
[Enhancement] Add dead lock checker daemon in FE node

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -178,7 +178,7 @@ public class Database extends MetaObject implements Writable {
     public void readLock() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         String threadDump = getOwnerInfo(rwLock.getOwner());
-        this.rwLock.readLock().lock();
+        this.rwLock.sharedLock();
         logSlowLockEventIfNeeded(startMs, "readLock", threadDump);
     }
 
@@ -186,12 +186,12 @@ public class Database extends MetaObject implements Writable {
     public boolean readLockAndCheckExist() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         String threadDump = getOwnerInfo(rwLock.getOwner());
-        this.rwLock.readLock().lock();
+        this.rwLock.sharedLock();
         logSlowLockEventIfNeeded(startMs, "readLock", threadDump);
         if (exist) {
             return true;
         } else {
-            this.rwLock.readLock().unlock();
+            this.rwLock.sharedUnlock();
             return false;
         }
     }
@@ -200,7 +200,7 @@ public class Database extends MetaObject implements Writable {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
             String threadDump = getOwnerInfo(rwLock.getOwner());
-            if (!this.rwLock.readLock().tryLock(timeout, unit)) {
+            if (!this.rwLock.trySharedLock(timeout, unit)) {
                 logTryLockFailureEvent("readLock", threadDump);
                 return false;
             }
@@ -217,7 +217,7 @@ public class Database extends MetaObject implements Writable {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
             String threadDump = getOwnerInfo(rwLock.getOwner());
-            if (!this.rwLock.readLock().tryLock(timeout, unit)) {
+            if (!this.rwLock.trySharedLock(timeout, unit)) {
                 logTryLockFailureEvent("readLock", threadDump);
                 return false;
             }
@@ -225,7 +225,7 @@ public class Database extends MetaObject implements Writable {
             if (exist) {
                 return true;
             } else {
-                this.rwLock.readLock().unlock();
+                this.rwLock.sharedUnlock();
                 return false;
             }
         } catch (InterruptedException e) {
@@ -236,7 +236,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     public void readUnlock() {
-        this.rwLock.readLock().unlock();
+        this.rwLock.sharedUnlock();
     }
 
     public boolean isReadLockHeldByCurrentThread() {
@@ -246,7 +246,7 @@ public class Database extends MetaObject implements Writable {
     public void writeLock() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         String threadDump = getOwnerInfo(rwLock.getOwner());
-        this.rwLock.writeLock().lock();
+        this.rwLock.exclusiveLock();
         logSlowLockEventIfNeeded(startMs, "writeLock", threadDump);
     }
 
@@ -254,12 +254,12 @@ public class Database extends MetaObject implements Writable {
     public boolean writeLockAndCheckExist() {
         long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
         String threadDump = getOwnerInfo(rwLock.getOwner());
-        this.rwLock.writeLock().lock();
+        this.rwLock.exclusiveLock();
         logSlowLockEventIfNeeded(startMs, "writeLock", threadDump);
         if (exist) {
             return true;
         } else {
-            this.rwLock.writeLock().unlock();
+            this.rwLock.exclusiveUnlock();
             return false;
         }
     }
@@ -268,7 +268,7 @@ public class Database extends MetaObject implements Writable {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
             String threadDump = getOwnerInfo(rwLock.getOwner());
-            if (!this.rwLock.writeLock().tryLock(timeout, unit)) {
+            if (!this.rwLock.tryExclusiveLock(timeout, unit)) {
                 logTryLockFailureEvent("writeLock", threadDump);
                 return false;
             }
@@ -285,7 +285,7 @@ public class Database extends MetaObject implements Writable {
         try {
             long startMs = TimeUnit.MILLISECONDS.convert(System.nanoTime(), TimeUnit.NANOSECONDS);
             String threadDump = getOwnerInfo(rwLock.getOwner());
-            if (!this.rwLock.writeLock().tryLock(timeout, unit)) {
+            if (!this.rwLock.tryExclusiveLock(timeout, unit)) {
                 logTryLockFailureEvent("tryWriteLock", threadDump);
                 return false;
             }
@@ -293,7 +293,7 @@ public class Database extends MetaObject implements Writable {
             if (exist) {
                 return true;
             } else {
-                this.rwLock.writeLock().unlock();
+                this.rwLock.exclusiveUnlock();
                 return false;
             }
         } catch (InterruptedException e) {
@@ -304,11 +304,15 @@ public class Database extends MetaObject implements Writable {
     }
 
     public void writeUnlock() {
-        this.rwLock.writeLock().unlock();
+        this.rwLock.exclusiveUnlock();
     }
 
     public boolean isWriteLockHeldByCurrentThread() {
-        return this.rwLock.writeLock().isHeldByCurrentThread();
+        return this.rwLock.isWriteLockHeldByCurrentThread();
+    }
+
+    public QueryableReentrantReadWriteLock getLock() {
+        return this.rwLock;
     }
 
     public long getId() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -240,7 +240,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     public boolean isReadLockHeldByCurrentThread() {
-        return this.rwLock.getReadHoldCount() > 0;
+        return this.rwLock.isReadLockHeldByCurrentThread();
     }
 
     public void writeLock() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -821,7 +821,7 @@ public class Config extends ConfigBase {
      * Check of deadlock is time consuming. Open it only when tracking problems.
      */
     @ConfField(mutable = true)
-    public static boolean enable_deadlock_check = false;
+    public static boolean lock_checker_enable_deadlock_check = false;
 
     /**
      * Default broker load timeout

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -814,6 +814,9 @@ public class Config extends ConfigBase {
     @ConfField
     public static int load_checker_interval_second = 5;
 
+    @ConfField(mutable = true)
+    public static long deadlock_checker_interval_second = 30;
+
     /**
      * Default broker load timeout
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -815,7 +815,13 @@ public class Config extends ConfigBase {
     public static int load_checker_interval_second = 5;
 
     @ConfField(mutable = true)
-    public static long deadlock_checker_interval_second = 30;
+    public static long lock_checker_interval_second = 30;
+
+    /**
+     * Check of deadlock is time consuming. Open it only when tracking problems.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_deadlock_check = false;
 
     /**
      * Default broker load timeout

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -50,6 +50,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.lang.management.ThreadInfo;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLConnection;
@@ -312,9 +313,16 @@ public class Util {
     }
 
     public static String dumpThread(Thread t, int lineNum) {
+        return dumpThread(t.getName(), t.getId(), t.getStackTrace(), lineNum);
+    }
+
+    public static String dumpThread(ThreadInfo t, int lineNum) {
+        return dumpThread(t.getThreadName(), t.getThreadId(), t.getStackTrace(), lineNum);
+    }
+
+    public static String dumpThread(String name, long id, StackTraceElement[] elements, int lineNum) {
         StringBuilder sb = new StringBuilder();
-        StackTraceElement[] elements = t.getStackTrace();
-        sb.append("dump thread: ").append(t.getName()).append(", id: ").append(t.getId()).append("\n");
+        sb.append("dump thread: ").append(name).append(", id: ").append(id).append("\n");
         int count = lineNum;
         for (StackTraceElement element : elements) {
             if (count == 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/QueryableReentrantReadWriteLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/QueryableReentrantReadWriteLock.java
@@ -45,7 +45,9 @@ public class QueryableReentrantReadWriteLock extends ReentrantReadWriteLock {
 
     public boolean trySharedLock(long timeout, TimeUnit unit) throws InterruptedException {
         boolean succ = this.readLock().tryLock(timeout, unit);
-        this.sharedLockThreads.put(Thread.currentThread().getId(), System.currentTimeMillis());
+        if (succ) {
+            this.sharedLockThreads.put(Thread.currentThread().getId(), System.currentTimeMillis());
+        }
         return succ;
     }
 
@@ -61,7 +63,9 @@ public class QueryableReentrantReadWriteLock extends ReentrantReadWriteLock {
 
     public boolean tryExclusiveLock(long timeout, TimeUnit unit) throws InterruptedException {
         boolean succ = this.writeLock().tryLock(timeout, unit);
-        this.exclusiveLockTime = System.currentTimeMillis();
+        if (succ) {
+            this.exclusiveLockTime = System.currentTimeMillis();
+        }
         return succ;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/QueryableReentrantReadWriteLock.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/concurrent/QueryableReentrantReadWriteLock.java
@@ -15,6 +15,13 @@
 
 package com.starrocks.common.util.concurrent;
 
+import com.google.common.collect.Lists;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /*
@@ -22,13 +29,74 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * which is a protected method of ReentrantReadWriteLock
  */
 public class QueryableReentrantReadWriteLock extends ReentrantReadWriteLock {
+    // threadId -> lockTime
+    Map<Long, Long> sharedLockThreads = new ConcurrentHashMap<>();
+
+    long exclusiveLockTime = -1L;
 
     public QueryableReentrantReadWriteLock(boolean fair) {
         super(fair);
     }
 
+    public void sharedLock() {
+        this.readLock().lock();
+        this.sharedLockThreads.put(Thread.currentThread().getId(), System.currentTimeMillis());
+    }
+
+    public boolean trySharedLock(long timeout, TimeUnit unit) throws InterruptedException {
+        boolean succ = this.readLock().tryLock(timeout, unit);
+        this.sharedLockThreads.put(Thread.currentThread().getId(), System.currentTimeMillis());
+        return succ;
+    }
+
+    public void sharedUnlock() {
+        this.readLock().unlock();
+        this.sharedLockThreads.remove(Thread.currentThread().getId());
+    }
+
+    public void exclusiveLock() {
+        this.writeLock().lock();
+        this.exclusiveLockTime = System.currentTimeMillis();
+    }
+
+    public boolean tryExclusiveLock(long timeout, TimeUnit unit) throws InterruptedException {
+        boolean succ = this.writeLock().tryLock(timeout, unit);
+        this.exclusiveLockTime = System.currentTimeMillis();
+        return succ;
+    }
+
+    public void exclusiveUnlock() {
+        this.writeLock().unlock();
+        this.exclusiveLockTime = -1L;
+    }
+
     @Override
     public Thread getOwner() {
         return super.getOwner();
+    }
+
+    public List<Long> getSharedLockThreadIds() {
+        return Lists.newArrayList(sharedLockThreads.keySet());
+    }
+
+    public long getSharedLockTime(long threadId) {
+        return sharedLockThreads.getOrDefault(threadId, -1L);
+    }
+
+    public long getExclusiveLockTime() {
+        return exclusiveLockTime;
+    }
+
+    @Override
+    public Collection<Thread> getQueuedThreads() {
+        return super.getQueuedThreads();
+    }
+
+    public boolean isWriteLockHeldByCurrentThread() {
+        return this.writeLock().isHeldByCurrentThread();
+    }
+
+    public boolean isReadLockHeldByCurrentThread() {
+        return this.getReadHoldCount() > 0;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/DeadlockChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/DeadlockChecker.java
@@ -64,8 +64,8 @@ public class DeadlockChecker extends FrontendDaemon {
                 if (lockStartTime > 0L && System.currentTimeMillis() - lockStartTime > Config.slow_lock_threshold_ms) {
                     hasSlowLock = true;
                     ownerInfo.addProperty("lockState", "writeLocked");
-                    ownerInfo.addProperty("dumpThread", Util.dumpThread(exclusiveLockThread, 50));
                     ownerInfo.addProperty("lockHoldTime", (System.currentTimeMillis() - lockStartTime) + " ms");
+                    ownerInfo.addProperty("dumpThread", Util.dumpThread(exclusiveLockThread, 50));
                 }
             } else if (sharedLockThreadIds.size() > 0) {
                 StringBuilder infos = new StringBuilder();

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/DeadlockChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/DeadlockChecker.java
@@ -1,0 +1,173 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.consistency;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.Config;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.common.util.Util;
+import com.starrocks.common.util.concurrent.QueryableReentrantReadWriteLock;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class DeadlockChecker extends FrontendDaemon {
+
+    private static final Logger LOG = LogManager.getLogger(DeadlockChecker.class);
+
+    public DeadlockChecker() {
+        super("DeadlockChecker", 1000 * Config.deadlock_checker_interval_second);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        checkDbLocks();
+        checkDeadlocks();
+        checkSlowLock();
+
+        setInterval(Config.deadlock_checker_interval_second * 1000);
+    }
+
+    private void checkDbLocks() {
+        Map<String, Database> dbs = GlobalStateMgr.getCurrentState().getFullNameToDb();
+        JsonArray dbLocks = new JsonArray();
+        for (Database db : dbs.values()) {
+            boolean useful = false;
+            JsonObject ownerInfo = new JsonObject();
+            String name = db.getFullName();
+            ownerInfo.addProperty("lockDbName", name);
+
+            QueryableReentrantReadWriteLock lock = db.getLock();
+
+            // holder information
+            Thread owner = lock.getOwner();
+            List<Long> sharedLockThreads = lock.getSharedLockThreadIds();
+            if (owner != null) {
+                useful = true;
+                ownerInfo.addProperty("lockState", "writeLocked");
+                ownerInfo.addProperty("ownerThreadName", owner.getName());
+                ownerInfo.addProperty("ownerThreadId", owner.getId());
+                if (System.currentTimeMillis() - db.getLock().getExclusiveLockTime() > Config.slow_lock_threshold_ms) {
+                    ownerInfo.addProperty("dumpThread", Util.dumpThread(owner, 50));
+                }
+            } else if (sharedLockThreads.size() > 0) {
+                useful = true;
+                ownerInfo.addProperty("lockState", "readLocked");
+                ownerInfo.addProperty("readLockCount", sharedLockThreads.size());
+
+                StringBuilder infos = new StringBuilder();
+                for (long threadId : sharedLockThreads) {
+                    long lockHoldTime = lock.getSharedLockTime(threadId);
+                    ThreadInfo threadInfo;
+                    if (lockHoldTime > 0 &&
+                            (System.currentTimeMillis() - lockHoldTime
+                                    > Config.slow_lock_threshold_ms)) {
+                        threadInfo = ManagementFactory.getThreadMXBean().getThreadInfo(threadId, 50);
+                    } else {
+                        // maxDepth = 0 means do not print thread stack
+                        threadInfo = ManagementFactory.getThreadMXBean().getThreadInfo(threadId, 0);
+                    }
+                    if (threadInfo != null) {
+                        infos.append(Util.dumpThread(threadInfo, 50)).append(";");
+                    }
+                }
+                ownerInfo.addProperty("threadInfo", infos.toString());
+            }
+
+            // waiters
+            Collection<Thread> waiters = lock.getQueuedThreads();
+            JsonArray waiterIds = new JsonArray();
+            for (Thread th : CollectionUtils.emptyIfNull(waiters)) {
+                if (th != null) {
+                    JsonObject waiter = new JsonObject();
+                    waiter.addProperty("threadId", th.getId());
+                    waiter.addProperty("threadName", th.getName());
+                    waiterIds.add(waiter);
+                }
+            }
+            if (!waiterIds.isEmpty()) {
+                useful = true;
+                ownerInfo.add("lockWaiters", waiterIds);
+            }
+
+            if (useful) {
+                dbLocks.add(ownerInfo);
+            }
+        }
+
+        if (!dbLocks.isEmpty()) {
+            LOG.info("dbLocks: {}", dbLocks.toString());
+        } else {
+            LOG.debug("no db locks held");
+        }
+    }
+
+    private void checkDeadlocks() {
+        ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
+        long[] ids = tmx.findDeadlockedThreads();
+        if (ids != null) {
+            LOG.info("deadlock threads: {}", ids);
+        }
+    }
+
+    private void checkSlowLock() {
+        Map<String, Database> dbs = GlobalStateMgr.getCurrentState().getFullNameToDb();
+        Map<QueryableReentrantReadWriteLock, Thread> lockOwnerMap = new HashMap<>();
+
+        for (Database db : dbs.values()) {
+            QueryableReentrantReadWriteLock lock = db.getLock();
+            Thread owner = lock.getOwner();
+            if (owner != null) {
+                lockOwnerMap.put(lock, owner);
+            }
+        }
+        if (MapUtils.isEmpty(lockOwnerMap)) {
+            return;
+        }
+
+        // sleep 5s and check whether the lock is still held
+        try {
+            Thread.sleep(5000);
+        } catch (InterruptedException e) {
+            LOG.warn("check slow lock failed", e);
+            return;
+        }
+
+        for (Map.Entry<QueryableReentrantReadWriteLock, Thread> entry : lockOwnerMap.entrySet()) {
+            Thread currentOwner = entry.getKey().getOwner();
+            if (currentOwner != null && currentOwner.getId() == entry.getValue().getId()) {
+                String stack = Arrays.toString(currentOwner.getStackTrace()).replace(',', '\n');
+                LOG.warn("thread {}-{} hold the lock {} too long, with waiters: [{}], stack: {}",
+                        currentOwner.getId(), currentOwner.getName(),
+                        entry.getKey(), entry.getKey().getQueuedThreads(),
+                        stack);
+            }
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
@@ -33,12 +33,12 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-public class DeadlockChecker extends FrontendDaemon {
+public class LockChecker extends FrontendDaemon {
 
-    private static final Logger LOG = LogManager.getLogger(DeadlockChecker.class);
+    private static final Logger LOG = LogManager.getLogger(LockChecker.class);
 
-    public DeadlockChecker() {
-        super("DeadlockChecker", 1000 * Config.deadlock_checker_interval_second);
+    public LockChecker() {
+        super("DeadlockChecker", 1000 * Config.lock_checker_interval_second);
     }
 
     @Override
@@ -46,7 +46,7 @@ public class DeadlockChecker extends FrontendDaemon {
         checkDeadlocks();
         checkSlowLocks();
 
-        setInterval(Config.deadlock_checker_interval_second * 1000);
+        setInterval(Config.lock_checker_interval_second * 1000);
     }
 
     private void checkSlowLocks() {
@@ -113,10 +113,12 @@ public class DeadlockChecker extends FrontendDaemon {
     }
 
     private void checkDeadlocks() {
-        ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
-        long[] ids = tmx.findDeadlockedThreads();
-        if (ids != null) {
-            LOG.info("deadlock threads: {}", ids);
+        if (Config.enable_deadlock_check) {
+            ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
+            long[] ids = tmx.findDeadlockedThreads();
+            if (ids != null) {
+                LOG.info("deadlock threads: {}", ids);
+            }
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
@@ -113,11 +113,13 @@ public class LockChecker extends FrontendDaemon {
     }
 
     private void checkDeadlocks() {
-        if (Config.enable_deadlock_check) {
+        if (Config.lock_checker_enable_deadlock_check) {
             ThreadMXBean tmx = ManagementFactory.getThreadMXBean();
             long[] ids = tmx.findDeadlockedThreads();
             if (ids != null) {
-                LOG.info("deadlock threads: {}", ids);
+                for (long id : ids) {
+                    LOG.info("deadlock thread: {}", Util.dumpThread(tmx.getThreadInfo(id, 50), 50));
+                }
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -142,6 +142,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.ConnectorTableMetadataProcessor;
 import com.starrocks.connector.hive.events.MetastoreEventsProcessor;
 import com.starrocks.consistency.ConsistencyChecker;
+import com.starrocks.consistency.DeadlockChecker;
 import com.starrocks.credential.CredentialUtil;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.HAProtocol;
@@ -480,6 +481,7 @@ public class GlobalStateMgr {
     private LoadTimeoutChecker loadTimeoutChecker;
     private LoadEtlChecker loadEtlChecker;
     private LoadLoadingChecker loadLoadingChecker;
+    private DeadlockChecker deadlockChecker;
 
     private RoutineLoadScheduler routineLoadScheduler;
     private RoutineLoadTaskScheduler routineLoadTaskScheduler;
@@ -741,6 +743,7 @@ public class GlobalStateMgr {
         this.loadTimeoutChecker = new LoadTimeoutChecker(loadMgr);
         this.loadEtlChecker = new LoadEtlChecker(loadMgr);
         this.loadLoadingChecker = new LoadLoadingChecker(loadMgr);
+        this.deadlockChecker = new DeadlockChecker();
         this.routineLoadScheduler = new RoutineLoadScheduler(routineLoadMgr);
         this.routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadMgr);
         this.mvMVJobExecutor = new MVJobExecutor();
@@ -1441,6 +1444,8 @@ public class GlobalStateMgr {
         configRefreshDaemon.start();
 
         slotManager.start();
+
+        deadlockChecker.start();
     }
 
     private void transferToNonLeader(FrontendNodeType newType) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -142,7 +142,7 @@ import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.ConnectorTableMetadataProcessor;
 import com.starrocks.connector.hive.events.MetastoreEventsProcessor;
 import com.starrocks.consistency.ConsistencyChecker;
-import com.starrocks.consistency.DeadlockChecker;
+import com.starrocks.consistency.LockChecker;
 import com.starrocks.credential.CredentialUtil;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.ha.HAProtocol;
@@ -481,7 +481,7 @@ public class GlobalStateMgr {
     private LoadTimeoutChecker loadTimeoutChecker;
     private LoadEtlChecker loadEtlChecker;
     private LoadLoadingChecker loadLoadingChecker;
-    private DeadlockChecker deadlockChecker;
+    private LockChecker lockChecker;
 
     private RoutineLoadScheduler routineLoadScheduler;
     private RoutineLoadTaskScheduler routineLoadTaskScheduler;
@@ -743,7 +743,7 @@ public class GlobalStateMgr {
         this.loadTimeoutChecker = new LoadTimeoutChecker(loadMgr);
         this.loadEtlChecker = new LoadEtlChecker(loadMgr);
         this.loadLoadingChecker = new LoadLoadingChecker(loadMgr);
-        this.deadlockChecker = new DeadlockChecker();
+        this.lockChecker = new LockChecker();
         this.routineLoadScheduler = new RoutineLoadScheduler(routineLoadMgr);
         this.routineLoadTaskScheduler = new RoutineLoadTaskScheduler(routineLoadMgr);
         this.mvMVJobExecutor = new MVJobExecutor();
@@ -1445,7 +1445,7 @@ public class GlobalStateMgr {
 
         slotManager.start();
 
-        deadlockChecker.start();
+        lockChecker.start();
     }
 
     private void transferToNonLeader(FrontendNodeType newType) {


### PR DESCRIPTION
Why I'm doing:
Dead lock is a hard problem to solve, we need more information to help find the reason.

What I'm doing:
- Use a map in `QueryableReentrantReadWriteLock` to record the thread who holds the read lock.
- Start a daemon `DeadlockChecker` to check the lock hold time and print the stack if hold time exceeds `Config.slow_lock_threshold_ms`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
