### PR TITLE
[Feature] support set_var hint for DML

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -194,6 +194,7 @@ import com.starrocks.transaction.TransactionCommitFailedException;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.transaction.TransactionStatus;
 import com.starrocks.transaction.VisibleStateWaiter;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
@@ -245,7 +246,6 @@ public class StmtExecutor {
     private HttpResultSender httpResultSender;
 
     private PrepareStmtContext prepareStmtContext;
-
 
     // this constructor is mainly for proxy
     public StmtExecutor(ConnectContext context, OriginStatement originStmt, boolean isProxy) {
@@ -407,27 +407,10 @@ public class StmtExecutor {
             // parsedStmt may already by set when constructing this StmtExecutor();
             resolveParseStmtForForward();
 
-            // support select hint e.g. select /*+ SET_VAR(query_timeout=1) */ sleep(3);
-            if (parsedStmt != null) {
-                Map<String, String> optHints = null;
-                if (parsedStmt instanceof QueryStatement &&
-                        ((QueryStatement) parsedStmt).getQueryRelation() instanceof SelectRelation) {
-                    SelectRelation selectRelation = (SelectRelation) ((QueryStatement) parsedStmt).getQueryRelation();
-                    optHints = selectRelation.getSelectList().getOptHints();
-                }
+            processVarHint(sessionVariableBackup);
 
-                if (optHints != null) {
-                    SessionVariable sessionVariable = (SessionVariable) sessionVariableBackup.clone();
-                    for (String key : optHints.keySet()) {
-                        VariableMgr.setSystemVariable(sessionVariable,
-                                new SystemVariable(key, new StringLiteral(optHints.get(key))), true);
-                    }
-                    context.setSessionVariable(sessionVariable);
-                }
-
-                if (parsedStmt.isExplain()) {
-                    context.setExplainLevel(parsedStmt.getExplainLevel());
-                }
+            if (parsedStmt.isExplain()) {
+                context.setExplainLevel(parsedStmt.getExplainLevel());
             }
 
             // execPlan is the output of new planner
@@ -461,7 +444,8 @@ public class StmtExecutor {
                         prepareStmtContext = context.getPreparedStmt(executeStmt.getStmtName());
                         if (null == prepareStmtContext) {
                             throw new StarRocksPlannerException(ErrorType.INTERNAL_ERROR,
-                                    "prepare statement can't be found @ %s, maybe has expired", executeStmt.getStmtName());
+                                    "prepare statement can't be found @ %s, maybe has expired",
+                                    executeStmt.getStmtName());
                         }
                         PrepareStmt prepareStmt = prepareStmtContext.getStmt();
                         parsedStmt = prepareStmt.assignValues(executeStmt.getParamsExpr());
@@ -725,6 +709,31 @@ public class StmtExecutor {
             }
 
             context.setSessionVariable(sessionVariableBackup);
+        }
+    }
+
+    // support select hint e.g. select /*+ SET_VAR(query_timeout=1) */ sleep(3);
+    private void processVarHint(SessionVariable variables) throws DdlException, CloneNotSupportedException {
+        if (parsedStmt == null) {
+            return;
+        }
+        Map<String, String> optHints = null;
+        if (parsedStmt instanceof QueryStatement &&
+                ((QueryStatement) parsedStmt).getQueryRelation() instanceof SelectRelation) {
+            SelectRelation selectRelation = (SelectRelation) ((QueryStatement) parsedStmt).getQueryRelation();
+            optHints = selectRelation.getSelectList().getOptHints();
+        } else if (parsedStmt instanceof DmlStmt) {
+            DmlStmt dml = (DmlStmt) parsedStmt;
+            optHints = dml.getOptHints();
+        }
+
+        if (MapUtils.isNotEmpty(optHints)) {
+            SessionVariable sessionVariable = (SessionVariable) variables.clone();
+            for (String key : optHints.keySet()) {
+                VariableMgr.setSystemVariable(sessionVariable,
+                        new SystemVariable(key, new StringLiteral(optHints.get(key))), true);
+            }
+            context.setSessionVariable(sessionVariable);
         }
     }
 
@@ -1558,7 +1567,8 @@ public class StmtExecutor {
         // proxy send show export result
         String db = exportStmt.getTblName().getDb();
         String showStmt = String.format("SHOW EXPORT FROM %s WHERE QueryId = \"%s\";", db, queryId);
-        StatementBase statementBase = com.starrocks.sql.parser.SqlParser.parse(showStmt, context.getSessionVariable()).get(0);
+        StatementBase statementBase =
+                com.starrocks.sql.parser.SqlParser.parse(showStmt, context.getSessionVariable()).get(0);
         ShowExportStmt showExportStmt = (ShowExportStmt) statementBase;
         showExportStmt.setQueryId(queryId);
         ShowExecutor executor = new ShowExecutor(context, showExportStmt);
@@ -1801,14 +1811,14 @@ public class StmtExecutor {
             authenticateParams.setDb_name(externalTable.getSourceTableDbName());
             authenticateParams.setTable_names(Lists.newArrayList(externalTable.getSourceTableName()));
             transactionId = transactionMgr.beginRemoteTransaction(externalTable.getSourceTableDbId(),
-                                    Lists.newArrayList(externalTable.getSourceTableId()), label,
-                                    externalTable.getSourceTableHost(),
-                                    externalTable.getSourceTablePort(),
-                                    new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
-                                            FrontendOptions.getLocalHostAddress()),
-                                    sourceType,
-                                    context.getSessionVariable().getQueryTimeoutS(),
-                                    authenticateParams);
+                    Lists.newArrayList(externalTable.getSourceTableId()), label,
+                    externalTable.getSourceTableHost(),
+                    externalTable.getSourceTablePort(),
+                    new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
+                            FrontendOptions.getLocalHostAddress()),
+                    sourceType,
+                    context.getSessionVariable().getQueryTimeoutS(),
+                    authenticateParams);
         } else if (targetTable instanceof SystemTable || targetTable.isIcebergTable() || targetTable.isHiveTable()
                 || targetTable.isTableFunctionTable()) {
             // schema table and iceberg and hive table does not need txn

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
@@ -18,7 +18,11 @@ import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.analysis.TableName;
 import com.starrocks.sql.parser.NodePosition;
 
+import java.util.Map;
+
 public abstract class DmlStmt extends StatementBase {
+
+    private Map<String, String> optHints;
 
     protected DmlStmt(NodePosition pos) {
         super(pos);
@@ -31,4 +35,11 @@ public abstract class DmlStmt extends StatementBase {
 
     public abstract TableName getTableName();
 
+    public Map<String, String> getOptHints() {
+        return optHints;
+    }
+
+    public void setOptHints(Map<String, String> optHints) {
+        this.optHints = optHints;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1033,17 +1033,17 @@ partitionRenameClause
 // ------------------------------------------- DML Statement -----------------------------------------------------------
 
 insertStatement
-    : explainDesc? INSERT (INTO | OVERWRITE) (qualifiedName | (FILES propertyList)) partitionNames?
+    : explainDesc? INSERT setVarHint* (INTO | OVERWRITE) (qualifiedName | (FILES propertyList)) partitionNames?
         (WITH LABEL label=identifier)? columnAliases?
         (queryStatement | (VALUES expressionsWithDefault (',' expressionsWithDefault)*))
     ;
 
 updateStatement
-    : explainDesc? withClause? UPDATE qualifiedName SET assignmentList fromClause (WHERE where=expression)?
+    : explainDesc? withClause? UPDATE setVarHint* qualifiedName SET assignmentList fromClause (WHERE where=expression)?
     ;
 
 deleteStatement
-    : explainDesc? withClause? DELETE FROM qualifiedName partitionNames? (USING using=relations)? (WHERE where=expression)?
+    : explainDesc? withClause? DELETE setVarHint* FROM qualifiedName partitionNames? (USING using=relations)? (WHERE where=expression)?
     ;
 
 // ------------------------------------------- Routine Statement -----------------------------------------------------------

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.plan;
+
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.sql.ast.DmlStmt;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SetVarTest extends PlanTestBase {
+
+    @Test
+    public void testInsertStmt() throws Exception {
+        SessionVariable variable = starRocksAssert.getCtx().getSessionVariable();
+        int queryTimeout = variable.getQueryTimeoutS();
+
+        // prepare table
+        starRocksAssert.withTable("create table tbl (c1 int) properties('replication_num'='1')");
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                SessionVariable variables = execPlan.getConnectContext().getSessionVariable();
+                Assert.assertEquals(10, variables.getQueryTimeoutS());
+            }
+        };
+
+        // insert
+        {
+            String sql = "insert /*+set_var(query_timeout=10) */ into tbl values(1) ";
+            starRocksAssert.getCtx().executeSql(sql);
+            Assert.assertEquals(queryTimeout, variable.getQueryTimeoutS());
+        }
+
+        // update
+        {
+            String sql = "update /*+set_var(query_timeout=10) */ tbl set c1 = 2 where c1 = 1";
+            starRocksAssert.getCtx().executeSql(sql);
+            Assert.assertEquals(queryTimeout, variable.getQueryTimeoutS());
+        }
+
+        // delete
+        {
+            String sql = "delete /*+set_var(query_timeout=10) */ from tbl where c1 = 1";
+            starRocksAssert.getCtx().executeSql(sql);
+            Assert.assertEquals(queryTimeout, variable.getQueryTimeoutS());
+        }
+
+        starRocksAssert.dropTable("tbl");
+    }
+
+}


### PR DESCRIPTION
Why I'm doing:
- The `SET_VAR` hint is only viable for query, but not DML

What I'm doing:
- Support `set_var` for insert/update/delete sql

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
