### PR TITLE
[BugFix] Fix non-pk table can not use delete in preparedstmt

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
@@ -45,6 +45,7 @@ import com.starrocks.qe.QueryStateException;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DeleteAnalyzer;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -94,7 +95,7 @@ public class LakeDeleteJob extends DeleteJob {
         }
 
         // create delete predicate
-        List<Predicate> conditions = stmt.getDeleteConditions();
+        List<Predicate> conditions = DeleteAnalyzer.replaceParameterInExpr(stmt.getDeleteConditions());
         DeletePredicatePB deletePredicate = createDeletePredicate(conditions);
 
         // send delete data request to BE

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteMgr.java
@@ -90,6 +90,7 @@ import com.starrocks.planner.RangePartitionPruner;
 import com.starrocks.qe.QueryStateException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
+import com.starrocks.sql.analyzer.DeleteAnalyzer;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.transaction.BeginTransactionException;
 import com.starrocks.transaction.TransactionState;
@@ -177,7 +178,7 @@ public class DeleteMgr implements Writable {
                     throw new DdlException("Delete is not supported on " + table.getType() + " table");
                 }
 
-                List<Predicate> conditions = stmt.getDeleteConditions();
+                List<Predicate> conditions = DeleteAnalyzer.replaceParameterInExpr(stmt.getDeleteConditions());
                 deleteJob = createJob(stmt, conditions, db, (OlapTable) table, partitions);
                 if (deleteJob == null) {
                     return;
@@ -317,7 +318,7 @@ public class DeleteMgr implements Writable {
                                                                    List<Column> partitionColumns)
             throws DdlException, AnalysisException {
         Map<String, PartitionColumnFilter> columnFilters = Maps.newHashMap();
-        List<Predicate> deleteConditions = stmt.getDeleteConditions();
+        List<Predicate> deleteConditions = DeleteAnalyzer.replaceParameterInExpr(stmt.getDeleteConditions());
         Map<String, Column> nameToColumn = Maps.newTreeMap(String.CASE_INSENSITIVE_ORDER);
         for (Column column : table.getBaseSchema()) {
             nameToColumn.put(column.getName(), column);

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -59,6 +59,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
 import com.starrocks.qe.QueryStateException;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.DeleteAnalyzer;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -111,7 +112,7 @@ public class OlapDeleteJob extends DeleteJob {
         Preconditions.checkState(table.isOlapTable());
         OlapTable olapTable = (OlapTable) table;
         MarkedCountDownLatch<Long, Long> countDownLatch;
-        List<Predicate> conditions = stmt.getDeleteConditions();
+        List<Predicate> conditions = DeleteAnalyzer.replaceParameterInExpr(stmt.getDeleteConditions());
 
         db.readLock();
         try {
@@ -219,7 +220,7 @@ public class OlapDeleteJob extends DeleteJob {
             LOG.warn("InterruptedException: ", e);
         }
         LOG.info("delete job finish, countDownLatch count: {}", countDownLatch.getCount());
- 
+
         String errMsg = "";
         List<Map.Entry<Long, Long>> unfinishedMarks = countDownLatch.getLeftMarks();
         Status st = countDownLatch.getStatus();
@@ -257,7 +258,7 @@ public class OlapDeleteJob extends DeleteJob {
                     long endQuorumTimeoutMs = nowQuorumTimeMs + timeoutMs / 2;
                     // if job's state is quorum_finished then wait for a period of time and commit it.
                     while (getState() == DeleteState.QUORUM_FINISHED && endQuorumTimeoutMs > nowQuorumTimeMs
-                          && countDownLatch.getCount() > 0) {
+                            && countDownLatch.getCount() > 0) {
                         checkAndUpdateQuorum();
                         Thread.sleep(1000);
                         nowQuorumTimeMs = System.currentTimeMillis();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DeleteStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DeleteStmt.java
@@ -77,7 +77,6 @@ public class DeleteStmt extends DmlStmt {
         this.usingRelations = usingRelations;
         this.wherePredicate = wherePredicate;
         this.commonTableExpressions = commonTableExpressions;
-        this.deleteConditions = Lists.newLinkedList();
     }
 
     public long getJobId() {

--- a/test/sql/test_preparestatement/R/test_preprare_statement
+++ b/test/sql/test_preparestatement/R/test_preprare_statement
@@ -1,13 +1,131 @@
-k1	k2	k3	k4	k5	v6	v7	v8	v9	v10	v11
+-- name: test_prepare_statement
+CREATE TABLE IF NOT EXISTS prepare_stmt (
+    k1 INT,
+    k2 TINYINT Default '20',
+    k3 BIGINT,
+    k4 SMALLINT  Default '4',
+    k5 varchar(10) Default 'k5',
+    v6 BOOLEAN,
+    v7 DATE Default '2000-02-02',
+    v8 VARCHAR(2048) Default 'row',
+    v9 DATETIME Default '2000-02-02 00:00:12',
+    v10 STRING NULL,
+    v11 Decimal(10,2) NULL)
+    PRIMARY KEY (k1, k2, k3, k4, k5)
+    DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
+-- result:
+[]
+-- !result
+PREPARE stmt1 FROM insert into prepare_stmt values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+-- result:
+[]
+-- !result
+PREPARE stmt2 FROM select * from prepare_stmt where k1 = ? and k2 = ?;
+-- result:
+[]
+-- !result
+PREPARE stmt3 FROM 'update prepare_stmt set v8 = ?, v10 = ? where k1 = ? and k2 = ?';
+-- result:
+[]
+-- !result
+PREPARE stmt4 FROM 'select * from prepare_stmt';
+-- result:
+[]
+-- !result
+PREPARE stmt5 FROM select * from prepare_stmt;
+-- result:
+[]
+-- !result
+PREPARE stmt6 FROM select k1, k2 from prepare_stmt order by ?, ? desc;
+-- result:
+[]
+-- !result
+PREPARE stmt7 FROM delete from prepare_stmt where k1 = ? and k2 = ?;
+-- result:
+[]
+-- !result
+set @i = 1;
+-- result:
+[]
+-- !result
+set @i2 = 2;
+-- result:
+[]
+-- !result
+set @v = '1';
+-- result:
+[]
+-- !result
+set @v2 = '2';
+-- result:
+[]
+-- !result
+set @b = true;
+-- result:
+[]
+-- !result
+set @t = '2021-02-01 00:00:12';
+-- result:
+[]
+-- !result
+execute stmt1 using @i, @i, @i, @i, @v, @b, @t, @v, @t, @v, @i;
+-- result:
+[]
+-- !result
+execute stmt1 using @i2, @i, @i, @i, @v, @b, @t, @v, @t, @v, @i;
+-- result:
+[]
+-- !result
+execute stmt2 using @i, @i;
+-- result:
 1	1	1	1	1	1	2021-02-01	1	2021-02-01 00:00:12	1	1.00
-k1	k2	k3	k4	k5	v6	v7	v8	v9	v10	v11
+-- !result
+execute stmt2 using @i2, @i;
+-- result:
 2	1	1	1	1	1	2021-02-01	1	2021-02-01 00:00:12	1	1.00
-k1	k2	k3	k4	k5	v6	v7	v8	v9	v10	v11
+-- !result
+execute stmt3 using @v2, @v2, @i, @i;
+-- result:
+[]
+-- !result
+execute stmt4;
+-- result:
+2	1	1	1	1	1	2021-02-01	1	2021-02-01 00:00:12	1	1.00
 1	1	1	1	1	1	2021-02-01	2	2021-02-01 00:00:12	2	1.00
+-- !result
+execute stmt5;
+-- result:
 2	1	1	1	1	1	2021-02-01	1	2021-02-01 00:00:12	1	1.00
-k1	k2	k3	k4	k5	v6	v7	v8	v9	v10	v11
 1	1	1	1	1	1	2021-02-01	2	2021-02-01 00:00:12	2	1.00
-2	1	1	1	1	1	2021-02-01	1	2021-02-01 00:00:12	1	1.00
-k1  k2
-2   1
-1   1
+-- !result
+execute stmt6 using @i, @v2;
+-- result:
+2	1
+1	1
+-- !result
+execute stmt6 using @i, @i2;
+-- result:
+2	1
+1	1
+-- !result
+drop prepare stmt1;
+-- result:
+[]
+-- !result
+drop prepare stmt2;
+-- result:
+[]
+-- !result
+drop prepare stmt3;
+-- result:
+[]
+-- !result
+deallocate prepare stmt4; -- deallocate is alias
+drop prepare stmt5;
+-- result:
+[]
+-- !result
+DROP TABLE prepare_stmt FORCE;
+-- result:
+[]
+-- !result

--- a/test/sql/test_preparestatement/R/test_preprare_statement_nopk_delete
+++ b/test/sql/test_preparestatement/R/test_preprare_statement_nopk_delete
@@ -1,0 +1,57 @@
+-- name: test_prepare_stmt_delete
+CREATE TABLE IF NOT EXISTS prepare_stmt_delete (
+    k1 INT,
+    v1 INT
+)
+DUPLICATE KEY (k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 2 PROPERTIES("replication_num" = "1");
+-- result:
+[]
+-- !result
+insert into prepare_stmt_delete values (1, 1), (2, 2);
+-- result:
+[]
+-- !result
+PREPARE stmt FROM delete from prepare_stmt_delete where k1 = ? and v1 = ?;
+-- result:
+[]
+-- !result
+PREPARE stmt2 FROM delete from prepare_stmt_delete where k1 in (?);
+-- result:
+[]
+-- !result
+set @i = 1;
+-- result:
+[]
+-- !result
+set @v = 1;
+-- result:
+[]
+-- !result
+set @i2 = 2;
+-- result:
+[]
+-- !result
+execute stmt using @i, @v;
+-- result:
+[]
+-- !result
+execute stmt2 using @i2;
+-- result:
+[]
+-- !result
+select k1, v1 from prepare_stmt_delete;
+-- result:
+-- !result
+drop prepare stmt;
+-- result:
+[]
+-- !result
+deallocate prepare stmt2;
+-- result:
+[]
+-- !result
+DROP TABLE prepare_stmt_delete FORCE;
+-- result:
+[]
+-- !result

--- a/test/sql/test_preparestatement/T/test_preprare_statement
+++ b/test/sql/test_preparestatement/T/test_preprare_statement
@@ -1,7 +1,5 @@
-CREATE DATABASE IF NOT EXISTS demo;
-
-DROP TABLE IF EXISTS demo.prepare_stmt;
-CREATE TABLE IF NOT EXISTS demo.prepare_stmt (
+-- name: test_prepare_statement
+CREATE TABLE IF NOT EXISTS prepare_stmt (
     k1 INT,
     k2 TINYINT Default '20',
     k3 BIGINT,
@@ -16,13 +14,13 @@ CREATE TABLE IF NOT EXISTS demo.prepare_stmt (
     PRIMARY KEY (k1, k2, k3, k4, k5)
     DISTRIBUTED BY HASH(k1, k2, k3, k4, k5) BUCKETS 8 PROPERTIES("replication_num" = "1");
 
-PREPARE stmt1 FROM insert into demo.prepare_stmt values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
-PREPARE stmt2 FROM select * from demo.prepare_stmt where k1 = ? and k2 = ?;
-PREPARE stmt3 FROM 'update demo.prepare_stmt set v8 = ?, v10 = ? where k1 = ? and k2 = ?';
-PREPARE stmt4 FROM 'select * from demo.prepare_stmt';
-PREPARE stmt5 FROM select * from demo.prepare_stmt;
-PREPARE stmt6 FROM select k1, k2 from demo.prepare_stmt order by ?, ? desc;
-
+PREPARE stmt1 FROM insert into prepare_stmt values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
+PREPARE stmt2 FROM select * from prepare_stmt where k1 = ? and k2 = ?;
+PREPARE stmt3 FROM 'update prepare_stmt set v8 = ?, v10 = ? where k1 = ? and k2 = ?';
+PREPARE stmt4 FROM 'select * from prepare_stmt';
+PREPARE stmt5 FROM select * from prepare_stmt;
+PREPARE stmt6 FROM select k1, k2 from prepare_stmt order by ?, ? desc;
+PREPARE stmt7 FROM delete from prepare_stmt where k1 = ? and k2 = ?;
 
 set @i = 1;
 set @i2 = 2;
@@ -42,6 +40,7 @@ execute stmt3 using @v2, @v2, @i, @i;
 execute stmt4;
 execute stmt5;
 execute stmt6 using @i, @v2;
+execute stmt7 using @i, @i2;
 
 drop prepare stmt1;
 drop prepare stmt2;
@@ -49,4 +48,4 @@ drop prepare stmt3;
 deallocate prepare stmt4; -- deallocate is alias
 drop prepare stmt5;
 
-DROP TABLE demo.prepare_stmt FORCE;
+DROP TABLE prepare_stmt FORCE;

--- a/test/sql/test_preparestatement/T/test_preprare_statement_nopk_delete
+++ b/test/sql/test_preparestatement/T/test_preprare_statement_nopk_delete
@@ -1,0 +1,24 @@
+-- name: test_prepare_stmt_delete
+CREATE TABLE IF NOT EXISTS prepare_stmt_delete (
+    k1 INT,
+    v1 INT
+)
+DUPLICATE KEY (k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 2 PROPERTIES("replication_num" = "1");
+
+insert into prepare_stmt_delete values (1, 1), (2, 2);
+PREPARE stmt FROM delete from prepare_stmt_delete where k1 = ? and v1 = ?;
+PREPARE stmt2 FROM delete from prepare_stmt_delete where k1 in (?);
+
+set @i = 1;
+set @v = 1;
+set @i2 = 2;
+execute stmt using @i, @v;
+execute stmt2 using @i2;
+select k1, v1 from prepare_stmt_delete;
+
+
+drop prepare stmt;
+deallocate prepare stmt2;
+
+DROP TABLE prepare_stmt_delete FORCE;


### PR DESCRIPTION
Why I'm doing:

Currently, when using preparedstmt to delete from non PK table, the analyzer will throw error when check predicates because it cannot handle parameters.

What I'm doing:
Make analyze can handle parameters and replace parameter to actual exprs during execution phase.


Fixes #34551

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
