### PR TITLE
[Doc] Add ENABLE_WRITE_HIVE_EXTERNAL_TABLE to Hive catalog and System variable docs

### DIFF
--- a/docs/en/data_source/catalog/hive_catalog.md
+++ b/docs/en/data_source/catalog/hive_catalog.md
@@ -1130,7 +1130,7 @@ PARTITION (par_col1=<value> [, par_col2=<value>...])
 
 ## Drop a Hive table
 
-Similar to the internal tables of StarRocks, if you have the [DROP](../../administration/privilege_item.md#table) privilege on a Hive table, you can use the [DROP TABLE](../../sql-reference/sql-statements/data-definition/DROP_TABLE.md) statement to drop that Hive table. This feature is supported from v3.1 onwards.
+Similar to the internal tables of StarRocks, if you have the [DROP](../../administration/privilege_item.md#table) privilege on a Hive table, you can use the [DROP TABLE](../../sql-reference/sql-statements/data-definition/DROP_TABLE.md) statement to drop that Hive table. This feature is supported from v3.1 onwards. Note that currently StarRocks supports dropping only managed tables of Hive.
 
 > **NOTE**
 >

--- a/docs/en/data_source/catalog/hive_catalog.md
+++ b/docs/en/data_source/catalog/hive_catalog.md
@@ -1041,7 +1041,7 @@ The following table describes a few key properties.
 
 ## Sink data to a Hive table
 
-Similar to the internal tables of StarRocks, if you have the [INSERT](../../administration/privilege_item.md#table) privilege on a Hive table (which can be a managed table or an external table), you can use the [INSERT](../../sql-reference/sql-statements/data-manipulation/insert.md) statement to sink the data of a StarRocks table to that Hive table (currently only Parquet-formatted Hive tables are supported). This feature is supported from v3.2 onwards.
+Similar to the internal tables of StarRocks, if you have the [INSERT](../../administration/privilege_item.md#table) privilege on a Hive table (which can be a managed table or an external table), you can use the [INSERT](../../sql-reference/sql-statements/data-manipulation/insert.md) statement to sink the data of a StarRocks table to that Hive table (currently only Parquet-formatted Hive tables are supported). This feature is supported from v3.2 onwards. Sinking data to external tables is disabled by default. To sink data to external tables, you must set the [system variable `ENABLE_WRITE_HIVE_EXTERNAL_TABLE`](../../reference/System_variable.md) to `true`.
 
 > **NOTE**
 >

--- a/docs/en/reference/System_variable.md
+++ b/docs/en/reference/System_variable.md
@@ -299,7 +299,7 @@ If a Join (other than Broadcast Join and Replicated Join) has multiple equi-join
 * If this feature is disabled, only Local RF works.
 * If this feature is enabled, multi-column Global RF takes effect and carries `multi-column` in the partition by clause.
 
-### ENABLE_WRITE_HIVE_EXTERNAL_TABLE
+### ENABLE_WRITE_HIVE_EXTERNAL_TABLE (v3.2 and later)
 
 Whether to allow for sinking data to external tables of Hive. Default value: `false`.
 

--- a/docs/en/reference/System_variable.md
+++ b/docs/en/reference/System_variable.md
@@ -299,6 +299,10 @@ If a Join (other than Broadcast Join and Replicated Join) has multiple equi-join
 * If this feature is disabled, only Local RF works.
 * If this feature is enabled, multi-column Global RF takes effect and carries `multi-column` in the partition by clause.
 
+### ENABLE_WRITE_HIVE_EXTERNAL_TABLE
+
+Whether to allow for sinking data to external tables of Hive. Default value: `false`.
+
 ### event_scheduler
 
 Used for MySQL client compatibility. No practical usage.

--- a/docs/zh/data_source/catalog/hive_catalog.md
+++ b/docs/zh/data_source/catalog/hive_catalog.md
@@ -1052,7 +1052,7 @@ PARTITION BY (par_col1[, par_col2...])
 
 ## 向 Hive 表中插入数据
 
-同 StarRocks 内表一致，如果您拥有 Hive 表（Managed Table 或 External Table）的 [INSERT](../../administration/privilege_item.md#表权限-table) 权限，那么您可以使用 [INSERT](../../sql-reference/sql-statements/data-manipulation/insert.md) 将 StarRocks 表数据写入到该 Hive 表中（当前仅支持写入到 Parquet 格式的 Hive 表）。本功能自 3.2 版本起开始支持。
+同 StarRocks 内表一致，如果您拥有 Hive 表（Managed Table 或 External Table）的 [INSERT](../../administration/privilege_item.md#表权限-table) 权限，那么您可以使用 [INSERT](../../sql-reference/sql-statements/data-manipulation/insert.md) 将 StarRocks 表数据写入到该 Hive 表中（当前仅支持写入到 Parquet 格式的 Hive 表）。本功能自 3.2 版本起开始支持。需要注意的是，写数据到 External Table 的功能默认是关闭的，您可以通过[系统变量 ENABLE_WRITE_HIVE_EXTERNAL_TABLE](../../reference/System_variable.md) 打开。
 
 > **说明**
 >

--- a/docs/zh/data_source/catalog/hive_catalog.md
+++ b/docs/zh/data_source/catalog/hive_catalog.md
@@ -1141,7 +1141,7 @@ PARTITION (par_col1=<value> [, par_col2=<value>...])
 
 ## 删除 Hive 表
 
-同 StarRocks 内表一致，如果您拥有 Hive 表的 [DROP](../../administration/privilege_item.md#表权限-table) 权限，那么您可以使用 [DROP TABLE](../../sql-reference/sql-statements/data-definition/DROP_TABLE.md) 来删除该 Hive 表。本功能自 3.2 版本起开始支持。
+同 StarRocks 内表一致，如果您拥有 Hive 表的 [DROP](../../administration/privilege_item.md#表权限-table) 权限，那么您可以使用 [DROP TABLE](../../sql-reference/sql-statements/data-definition/DROP_TABLE.md) 来删除该 Hive 表。本功能自 3.2 版本起开始支持。注意当前只支持删除 Hive 的 Managed Table。
 
 > **说明**
 >

--- a/docs/zh/reference/System_variable.md
+++ b/docs/zh/reference/System_variable.md
@@ -288,6 +288,10 @@ Global runtime filter 开关。Runtime Filter（简称 RF）在运行时对数�
 
 是否对所有复合谓词以及 WHERE 子句中的表达式进行隐式转换。默认值：false。
 
+### ENABLE_WRITE_HIVE_EXTERNAL_TABLE（3.2 及以后）
+
+是否开启往 Hive 的 External Table 写数据的功能。默认值：`false`。
+
 ### event_scheduler
 
 用于兼容 MySQL 客户端。无实际作用。


### PR DESCRIPTION
… variable docs

Signed-off-by: amber-create <yangyanping@starrocks.com>

Why I'm doing:

What I'm doing: Add ENABLE_WRITE_HIVE_EXTERNAL_TABLE related info to Hive catalog and System variable docs; Add drop table support info to Hive catalog doc.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
