### PR TITLE
[Enhancement][branch-3.2] Increase jdk11 compatibility

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -20,6 +20,7 @@ import com.starrocks.analysis.IntLiteral;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.load.pipe.PipeTaskDesc;
@@ -89,6 +90,9 @@ public class TaskBuilder {
         } else if ("full".equalsIgnoreCase(analyze)) {
             stmt = "ANALYZE TABLE " + tableName + async;
         } else {
+            stmt = "";
+        }
+        if (FeConstants.runningUnitTest) {
             stmt = "";
         }
         return stmt;

--- a/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PriorityLeaderTaskExecutor.java
@@ -111,11 +111,17 @@ public class PriorityLeaderTaskExecutor {
     }
 
     public void setPoolSize(int poolSize) {
-        // corePoolSize and maximumPoolSize are same.
-        // Must set corePoolSize first, because setMaximumPoolSize() will throw IllegalArgumentException
-        // if maximumPoolSize < corePoolSize.
-        executor.setCorePoolSize(poolSize);
-        executor.setMaximumPoolSize(poolSize);
+        // When the previous poolSize is larger than the poolSize to be set,
+        // you need to setCorePoolSize first and then setMaximumPoolSize, and vice versa.
+        // Otherwise, it will throw IllegalArgumentException
+        int prePoolSize = executor.getCorePoolSize();
+        if (poolSize < prePoolSize) {
+            executor.setCorePoolSize(poolSize);
+            executor.setMaximumPoolSize(poolSize);
+        } else {
+            executor.setMaximumPoolSize(poolSize);
+            executor.setCorePoolSize(poolSize);
+        }
     }
 
     private class TaskChecker implements Runnable {


### PR DESCRIPTION
Why I'm doing:
Improve the compatibility of JDK11, so that there will be no problem with the running code of the JDK11.
What I'm doing:
Modifying code JDK11 is different from the thread pool of 8, and the modified code can work normally on 11 and 8. In addition, for UT, the Postrun of the materialized view is useless, so it is removed directly.

Fixes #33738

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
