### PR TITLE
[Feature] support heap profile using script

### DIFF
--- a/be/src/common/CMakeLists.txt
+++ b/be/src/common/CMakeLists.txt
@@ -27,6 +27,7 @@ add_library(Common STATIC
   configbase.cpp
   s3_uri.cpp
   tracer.cpp
+  prof/heap_prof.cpp
 )
 
 if ("${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86" OR "${CMAKE_BUILD_TARGET_ARCH}" STREQUAL "x86_64")

--- a/be/src/common/prof/heap_prof.cpp
+++ b/be/src/common/prof/heap_prof.cpp
@@ -1,0 +1,88 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "common/prof/heap_prof.h"
+
+#include <unistd.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <mutex>
+
+#include "common/config.h"
+#include "fmt/format.h"
+#include "jemalloc/jemalloc.h"
+
+namespace starrocks {
+// detail implements for allocator
+static int set_jemalloc_profiling(bool enable) {
+    int ret = je_mallctl("prof.active", nullptr, nullptr, &enable, 1);
+    ret |= je_mallctl("prof.thread_active_init", nullptr, nullptr, &enable, 1);
+    return ret;
+}
+
+static int has_enable_heap_profile() {
+    int value = 0;
+    size_t size = sizeof(value);
+    je_mallctl("prof.active", &value, &size, nullptr, 0);
+    return value;
+}
+
+bool dump_snapshot(const std::string& filename) {
+    const char* fname = filename.c_str();
+    return je_mallctl("prof.dump", nullptr, nullptr, &fname, sizeof(const char*)) == 0;
+}
+
+// declare exec from script
+std::string exec(const std::string& cmd);
+
+void HeapProf::enable_prof() {
+    LOG(INFO) << "try to enable the heap profiling";
+    std::lock_guard guard(_mutex);
+    set_jemalloc_profiling(true);
+}
+
+void HeapProf::disable_prof() {
+    LOG(INFO) << "try to disable the heap profiling";
+    std::lock_guard guard(_mutex);
+    set_jemalloc_profiling(false);
+}
+
+bool HeapProf::has_enable() {
+    return has_enable_heap_profile();
+}
+
+std::string HeapProf::snapshot() {
+    std::string output_name = fmt::format("{}/heap_profile.{}.{}", config::pprof_profile_dir, getpid(), rand());
+    LOG(INFO) << "try to dump the heap profile " << output_name;
+    //
+    std::lock_guard guard(_mutex);
+    if (dump_snapshot(output_name)) {
+        return output_name;
+    } else {
+        return "";
+    }
+}
+
+std::string HeapProf::to_dot_format(const std::string& heapdump_filename) {
+    LOG(INFO) << "converting heap snapshot:" << heapdump_filename << " to dot format";
+    std::lock_guard guard(_mutex);
+    // jeprof --dot be/lib/starrocks_be b.heap > a.dot
+    auto base_home = getenv("STARROCKS_HOME");
+    std::string jeprof = fmt::format("{}/bin/jeprof", base_home);
+    std::string binary = fmt::format("{}/lib/starrocks_be", base_home);
+    return exec(fmt::format("{} --dot {} {}", jeprof, binary, heapdump_filename));
+}
+
+} // namespace starrocks

--- a/be/src/common/prof/heap_prof.h
+++ b/be/src/common/prof/heap_prof.h
@@ -1,0 +1,51 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <mutex>
+
+#include "common/status.h"
+#include "gutil/macros.h"
+
+namespace starrocks {
+class HeapProf {
+public:
+    static HeapProf& getInstance() {
+        static HeapProf profiler;
+        return profiler;
+    }
+
+    // set enable to profiler
+    void enable_prof();
+    // set disable to profiler
+    void disable_prof();
+    // return true if jemalloc enable heap profile
+    bool has_enable();
+    // return heap dump filename
+    std::string snapshot();
+    // convert raw heap dump to dot format
+    std::string to_dot_format(const std::string& heapdump_filename);
+
+    std::string dump_dot_snapshot() { return to_dot_format(snapshot()); }
+
+    DISALLOW_COPY_AND_MOVE(HeapProf);
+
+private:
+    HeapProf() = default;
+
+private:
+    std::mutex _mutex;
+};
+} // namespace starrocks

--- a/be/src/exprs/debug_expr.cpp
+++ b/be/src/exprs/debug_expr.cpp
@@ -1,0 +1,63 @@
+#include "exprs/debug_expr.h"
+
+#include <stdexcept>
+
+#include "column/chunk.h"
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "common/object_pool.h"
+#include "exprs/expr.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+Status DebugExpr::prepare(RuntimeState* state, ExprContext* context) {
+    RETURN_IF_ERROR(Expr::prepare(state, context));
+    if (!_fn.__isset.fid) {
+        return Status::InternalError("unset fid for DebugExpr: " + _fn.name.function_name);
+    }
+    if (_fn.name.function_name == "chunk_memusage") {
+        _func_caller = &DebugFunctions::chunk_memusage;
+    } else if (_fn.name.function_name == "chunk_check_valid") {
+        _func_caller = &DebugFunctions::chunk_check_valid;
+    }
+    return Status::NotSupported("unsupported function name");
+}
+
+StatusOr<ColumnPtr> DebugExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
+    return _func_caller(context, ptr);
+}
+
+StatusOr<ColumnPtr> DebugFunctions::chunk_memusage(ExprContext* context, Chunk* ptr) {
+    if (ptr == nullptr) {
+        return ColumnHelper::create_const_column<TYPE_BIGINT>(0, 1);
+    }
+    size_t mem_usage = ptr->memory_usage();
+    size_t num_rows = ptr->num_rows();
+    return ColumnHelper::create_const_column<TYPE_BIGINT>(mem_usage, num_rows);
+}
+
+StatusOr<ColumnPtr> DebugFunctions::chunk_check_valid(ExprContext* context, Chunk* ptr) {
+    // check chunk valid
+    if (ptr == nullptr) {
+        return ColumnHelper::create_const_column<TYPE_BOOLEAN>(true, 1);
+    }
+    ptr->check_or_die();
+    size_t num_rows = ptr->num_rows();
+    for (const auto& column : ptr->columns()) {
+        // check column size capacity
+        std::string msg;
+        column->capacity_limit_reached(&msg);
+        if (!msg.empty()) {
+            DCHECK(false) << "not expected";
+            throw std::runtime_error(msg);
+        }
+        // check column size matched
+        if (column->size() != num_rows) {
+            DCHECK(false) << "not expected";
+            throw std::runtime_error(fmt::format("unmatched rows detected"));
+        }
+    }
+    return ColumnHelper::create_const_column<TYPE_BOOLEAN>(true, ptr->num_rows());
+}
+
+} // namespace starrocks

--- a/be/src/exprs/debug_expr.h
+++ b/be/src/exprs/debug_expr.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "column/column.h"
+#include "common/object_pool.h"
+#include "exprs/expr.h"
+
+namespace starrocks {
+class DebugExpr final : public Expr {
+public:
+    using DebugFunctionCall = StatusOr<ColumnPtr> (*)(ExprContext* context, Chunk* columns);
+    DebugExpr(const TExprNode& node) : Expr(node){};
+
+    ~DebugExpr() override = default;
+
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new DebugExpr(*this)); }
+
+    [[nodiscard]] Status prepare(RuntimeState* state, ExprContext* context) override;
+
+    StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
+
+private:
+    DebugFunctionCall _func_caller;
+};
+
+class DebugFunctions {
+public:
+    /**
+     * return the memory usage for the chunk
+     * @param: []
+     * @return const BIGINT column
+     */
+    static StatusOr<ColumnPtr> chunk_memusage(ExprContext* context, Chunk* ptr);
+    /**
+     * check chunk is valid
+     * @param: []
+     * @return const BOOLEAN column always true
+     */
+    static StatusOr<ColumnPtr> chunk_check_valid(ExprContext* context, Chunk* ptr);
+};
+
+} // namespace starrocks

--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -41,13 +41,13 @@
 #include <mutex>
 
 #include "common/config.h"
+#include "common/prof/heap_prof.h"
 #include "common/status.h"
 #include "common/tracer.h"
 #include "http/ev_http_server.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
-#include "jemalloc/jemalloc.h"
 #include "util/bfd_parser.h"
 
 namespace starrocks {
@@ -59,12 +59,6 @@ static const int kPprofDefaultSampleSecs = 30;
 // Protect, only one thread can work
 static std::mutex kPprofActionMutex;
 
-int set_jemalloc_profiling(bool enable) {
-    int ret = je_mallctl("prof.active", nullptr, nullptr, &enable, 1);
-    ret |= je_mallctl("prof.thread_active_init", nullptr, nullptr, &enable, 1);
-    return ret;
-}
-
 void HeapAction::handle(HttpRequest* req) {
 #if defined(ADDRESS_SANITIZER) || defined(LEAK_SANITIZER) || defined(THREAD_SANITIZER)
     (void)kPprofDefaultSampleSecs; // Avoid unused variable warning.
@@ -73,38 +67,15 @@ void HeapAction::handle(HttpRequest* req) {
 
     HttpChannel::send_reply(req, str);
 #else
-    int seconds = kPprofDefaultSampleSecs;
-    const std::string& seconds_str = req->param(SECOND_KEY);
-    if (!seconds_str.empty()) {
-        if (int value = std::atoi(seconds_str.c_str()); value > 0) {
-            seconds = value;
-        }
-    }
-
     std::lock_guard<std::mutex> lock(kPprofActionMutex);
-    std::string str;
-    std::stringstream tmp_prof_file_name;
-    tmp_prof_file_name << config::pprof_profile_dir << "/heap_profile." << getpid() << "." << rand();
-    if (set_jemalloc_profiling(true) != 0) {
-        std::string error_msg = "enable jemalloc profiling error.";
-        HttpChannel::send_reply(req, HttpStatus::BAD_REQUEST, error_msg);
-        return;
-    }
-    LOG(INFO) << "enable jemalloc profiling";
-    sleep(seconds);
+    std::string str = HeapProf::getInstance().snapshot();
 
-    // NOTE: Use fname to make the content which fname_cstr references to is still valid
-    // when je_mallctl is executing
-    auto fname = tmp_prof_file_name.str();
-    const char* fname_cstr = fname.c_str();
-    if (je_mallctl("prof.dump", nullptr, nullptr, &fname_cstr, sizeof(const char*)) == 0) {
-        std::ifstream f(fname_cstr);
-        str = std::string(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
-    } else {
+    if (str.empty()) {
         str = "dump jemalloc prof file failed";
+    } else {
+        std::ifstream f(str);
+        str = std::string(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>());
     }
-    (void)set_jemalloc_profiling(false);
-    LOG(INFO) << "disable jemalloc profiling";
     HttpChannel::send_reply(req, str);
 #endif
 }

--- a/build.sh
+++ b/build.sh
@@ -468,6 +468,7 @@ if [ ${BUILD_BE} -eq 1 ]; then
     fi
     cp -r -p ${STARROCKS_HOME}/be/output/lib/starrocks_be ${STARROCKS_OUTPUT}/be/lib/
     cp -r -p ${STARROCKS_HOME}/be/output/lib/libmockjvm.so ${STARROCKS_OUTPUT}/be/lib/libjvm.so
+    cp -r -p ${STARROCKS_THIRDPARTY}/installed/jemalloc/bin/jeprof ${STARROCKS_OUTPUT}/be/bin
     # format $BUILD_TYPE to lower case
     ibuildtype=`echo ${BUILD_TYPE} | tr 'A-Z' 'a-z'`
     if [ "${ibuildtype}" == "release" ] ; then


### PR DESCRIPTION
Why I'm doing:
Obtaining a heap profile via http usually requires logging into the machine for further analysis. It is usually difficult to get

What I'm doing:
Allow BE scripting support to quickly fetch dot formats and parse them with online tools

```
sudo apt-get install graphviz
sudo yum install graphviz
```

eg:
check has enable the heap profile
```

mysql> admin execute on 10004 'System.print(HeapProf.getInstance().has_enable())';
+--------+
| result |
+--------+
| false  |
+--------+
1 row in set (0.00 sec)
```
enable the heap profile (begin to collect heap metrics)
```
mysql> admin execute on 10004 'System.print(HeapProf.getInstance().enable_prof())';
+----------------------+
| result               |
+----------------------+
| instance of HeapProf |
+----------------------+
1 row in set (0.00 sec)

mysql> admin execute on 10004 'System.print(HeapProf.getInstance().has_enable())';
+--------+
| result |
+--------+
| true   |
+--------+
1 row in set (0.01 sec)
```

dump the heap profile snap shot as dot format
```
mysql> admin execute on 10004 'System.print(HeapProf.getInstance().dump_dot_snapshot())';
0+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| result                                                                                                                                                                                                          |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| digraph "/home/disk5/fha/opt/env/default/be/lib/starrocks_be; 1.0 MB" {                                                                                                                                         |
| node [width=0.375,height=0.25];                                                                                                                                                                                 |
| Legend [shape=box,fontsize=24,shape=plaintext,label="/home/disk5/fha/opt/env/default/be/lib/starrocks_be\lTotal MB: 1.0\lFocusing on: 1.0\lDropped nodes with <= 0.0 abs(MB)\lDropped edges with <= 0.0 MB\l"]; |
| N1 [label="brpc\nInputMessenger\nOnNewMessages\n0.0 (0.0%)\rof 1.0 (100.0%)\r",shape=box,fontsize=8.0];                                                                                                         |
| N2 [label="brpc\nSocket\nProcessEvent\n0.0 (0.0%)\rof 1.0 (100.0%)\r",shape=box,fontsize=8.0];                                                                                                                  |
| N3 [label="bthread\nTaskGroup\ntask_runner\n0.0 (0.0%)\rof 1.0 (100.0%)\r",shape=box,fontsize=8.0];                                                                                                             |
| N4 [label="bthread_make_fcontext\n0.0 (0.0%)\rof 1.0 (100.0%)\r",shape=box,fontsize=8.0];                                                                                                                       |
| N5 [label="brpc\nInputMessenger\nCutInputMessage\n0.0 (0.0%)\rof 0.5 (50.1%)\r",shape=box,fontsize=8.0];                                                                                                        |
| N6 [label="brpc\npolicy\nParseRpcMessage\n0.5 (50.1%)\r",shape=box,fontsize=43.4];                                                                                                                              |
| N7 [label="brpc\nProcessInputMessage\n0.0 (0.0%)\rof 0.5 (49.9%)\r",shape=box,fontsize=8.0];                                                                                                                    |
| N8 [label="brpc\npolicy\nProcessRpcRequest\n0.0 (0.0%)\rof 0.5 (49.9%)\r",shape=box,fontsize=8.0];                                                                                                              |
| N9 [label="starrocks\nPInternalServiceImplBase\nexecute_command\n0.0 (0.0%)\rof 0.5 (49.9%)\r",shape=box,fontsize=8.0];                                                                                         |
| N10 [label="starrocks\nStorageEngineRef\nbind\n0.0 (0.0%)\rof 0.5 (49.9%)\r",shape=box,fontsize=8.0];                                                                                                           |
| N11 [label="starrocks\nexecute_command\n0.0 (0.0%)\rof 0.5 (49.9%)\r",shape=box,fontsize=8.0];                                                                                                                  |
| N12 [label="starrocks\nexecute_script\n0.0 (0.0%)\rof 0.5 (49.9%)\r",shape=box,fontsize=8.0];                                                                                                                   |
| N13 [label="std\nmake_unique\n0.5 (49.9%)\r",shape=box,fontsize=43.3];                                                                                                                                          |
| N2 -> N1 [label=1.0, weight=16398, style="setlinewidth(2.000000)"];                                                                                                                                             |
| N3 -> N2 [label=1.0, weight=16398, style="setlinewidth(2.000000)"];                                                                                                                                             |
| N4 -> N3 [label=1.0, weight=16398, style="setlinewidth(2.000000)"];                                                                                                                                             |
| N1 -> N5 [label=0.5, weight=10102, style="setlinewidth(2.000000)"];                                                                                                                                             |
| N5 -> N6 [label=0.5, weight=10102, style="setlinewidth(2.000000)"];                                                                                                                                             |
| N9 -> N11 [label=0.5, weight=10086, style="setlinewidth(2.000000)"];                                                                                                                                            |
| N12 -> N10 [label=0.5, weight=10086, style="setlinewidth(2.000000)"];                                                                                                                                           |
| N11 -> N12 [label=0.5, weight=10086, style="setlinewidth(2.000000)"];                                                                                                                                           |
| N1 -> N7 [label=0.5, weight=10086, style="setlinewidth(2.000000)"];                                                                                                                                             |
| N7 -> N8 [label=0.5, weight=10086, style="setlinewidth(2.000000)"];                                                                                                                                             |
| N10 -> N13 [label=0.5, weight=10086, style="setlinewidth(2.000000)"];                                                                                                                                           |
| N8 -> N9 [label=0.5, weight=10086, style="setlinewidth(2.000000)"];                                                                                                                                             |
| }                                                                                                                                                                                                               |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
29 rows in set (30.22 sec)
```

then paste it to https://dreampuf.github.io/GraphvizOnline/
we will got a heap profile
![image](https://github.com/StarRocks/starrocks/assets/34912776/0adbc854-872c-474e-a0da-c08c0ee07653)

we also could use other visual tools. like graph-easy
```
apt-get install graph-easy
graph-easy < a.dot
```
```
                             Total MB: 1.0
                             Focusing on: 1.0
                             Dropped nodes with <= 0.0 abs(MB)
                             Dropped edges with <= 0.0 MB

                           +---------------------------------------------------+
                           |               bthread_make_fcontext               |
                           |                    0.0 (0.0%)                     |
                           |                                   of 1.0 (100.0%) |
                           +---------------------------------------------------+
                             |
                             | 1.0
                             v
                           +---------------------------------------------------+
                           |                      bthread                      |
                           |                     TaskGroup                     |
                           |                    task_runner                    |
                           |                    0.0 (0.0%)                     |
                           |                                   of 1.0 (100.0%) |
                           +---------------------------------------------------+
                             |
                             | 1.0
                             v
                           +---------------------------------------------------+
                           |                       brpc                        |
                           |                      Socket                       |
                           |                   ProcessEvent                    |
                           |                    0.0 (0.0%)                     |
                           |                                   of 1.0 (100.0%) |
                           +---------------------------------------------------+
                             |
                             | 1.0
                             v
+-----------------+        +---------------------------------------------------+
|      brpc       |        |                       brpc                        |
| InputMessenger  |        |                  InputMessenger                   |
| CutInputMessage |        |                   OnNewMessages                   |
|   0.0 (0.0%)    |  0.5   |                    0.0 (0.0%)                     |
|  of 0.5 (50.1%) | <----- |                                   of 1.0 (100.0%) |
+-----------------+        +---------------------------------------------------+
  |                          |
  | 0.5                      | 0.5
  v                          v
+-----------------+        +---------------------------------------------------+
|      brpc       |        |                       brpc                        |
|     policy      |        |                ProcessInputMessage                |
| ParseRpcMessage |        |                    0.0 (0.0%)                     |
|   0.5 (50.1%)   |        |                                    of 0.5 (49.9%) |
+-----------------+        +---------------------------------------------------+
                             |
                             | 0.5
                             v
                           +---------------------------------------------------+
                           |                       brpc                        |
                           |                      policy                       |
                           |                 ProcessRpcRequest                 |
                           |                    0.0 (0.0%)                     |
                           |                                    of 0.5 (49.9%) |
                           +---------------------------------------------------+
                             |
                             | 0.5
                             v
                           +---------------------------------------------------+
                           |                     starrocks                     |
                           |             PInternalServiceImplBase              |
                           |                  execute_command                  |
                           |                    0.0 (0.0%)                     |
                           |                                    of 0.5 (49.9%) |
                           +---------------------------------------------------+
                             |
                             | 0.5
                             v
                           +---------------------------------------------------+
                           |                     starrocks                     |
                           |                  execute_command                  |
                           |                    0.0 (0.0%)                     |
                           |                                    of 0.5 (49.9%) |
                           +---------------------------------------------------+
                             |
                             | 0.5
                             v
                           +---------------------------------------------------+
                           |                     starrocks                     |
                           |                  execute_script                   |
                           |                    0.0 (0.0%)                     |
                           |                                    of 0.5 (49.9%) |
                           +---------------------------------------------------+
                             |
                             | 0.5
                             v
                           +---------------------------------------------------+
                           |                     starrocks                     |
                           |                 StorageEngineRef                  |
                           |                       bind                        |
                           |                    0.0 (0.0%)                     |
                           |                                    of 0.5 (49.9%) |
                           +---------------------------------------------------+
                             |
                             | 0.5
                             v
                           +---------------------------------------------------+
                           |                        std                        |
                           |                    make_unique                    |
                           |                    0.5 (49.9%)                    |
                           +---------------------------------------------------+
```


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
