### PR TITLE
[BugFix] make config enable_new_publish_mechanism static

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2002,7 +2002,7 @@ public class Config extends ConfigBase {
     @ConfField
     public static int lake_compaction_max_tasks = -1;
 
-    @ConfField(mutable = true)
+    @ConfField
     public static boolean enable_new_publish_mechanism = false;
 
     @ConfField(mutable = true)


### PR DESCRIPTION
Why I'm doing:
Fe config `enable_new_publish_mechanism` can't support dynamic modify, because we need to rebuild transaction dependency before switch to new publish mechanism. We support rebuild transaction dependency when config change after version 3.2+, but now we don't plan to support it in 2.5/3.0/3.1.

What I'm doing:
Make `enable_new_publish_mechanism` become static config. So if we want to enable `enable_new_publish_mechanism`, we have to restart FE, and transaction dependency will rebuild when restart.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
