### PR TITLE
[BugFix] distinguish function and its alias when ast to sql (backport #35105)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -154,10 +154,7 @@ public class AstToSQLBuilder {
                                 columnName));
                     }
                 } else {
-                    selectListString.add(
-                            expr.getFn() == null || expr.getFn().getFunctionName().getDb() == null ?
-                                    visit(expr) + " AS `" + columnName + "`" :
-                                    visit(expr) + " AS `" + expr.getFn().getFunctionName().getFunction() + "`");
+                    selectListString.add(visit(expr) + " AS `" + columnName + "`");
                 }
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -119,10 +119,28 @@ import static java.util.stream.Collectors.toList;
  */
 public class AstToStringBuilder {
     public static String toString(ParseNode expr) {
-        return new AST2StringBuilderVisitor().visit(expr);
+        return toString(expr, true);
+    }
+
+    public static String toString(ParseNode expr, boolean addFunctionDbName) {
+        return new AST2StringBuilderVisitor(addFunctionDbName).visit(expr);
     }
 
     public static class AST2StringBuilderVisitor extends AstVisitor<String, Void> {
+
+        // when you want to get the full string of a functionCallExpr set it true
+        // when you just want to a function name as its alias set it false
+        protected boolean addFunctionDbName;
+
+
+        public AST2StringBuilderVisitor() {
+            this(true);
+        }
+
+        public AST2StringBuilderVisitor(boolean addFunctionDbName) {
+            this.addFunctionDbName = addFunctionDbName;
+        }
+
 
         // ------------------------------------------- Privilege Statement -------------------------------------------------
 
@@ -874,7 +892,7 @@ public class AstToStringBuilder {
         public String visitFunctionCall(FunctionCallExpr node, Void context) {
             FunctionParams fnParams = node.getParams();
             StringBuilder sb = new StringBuilder();
-            if (node.getFnName().getDb() != null) {
+            if (addFunctionDbName && node.getFnName().getDb() != null) {
                 sb.append("`" + node.getFnName().getDb() + "`.");
             }
             String functionName = node.getFnName().getFunction();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -246,7 +246,7 @@ public class SelectAnalyzer {
                 if (item.getExpr() instanceof SlotRef) {
                     name = item.getAlias() == null ? ((SlotRef) item.getExpr()).getColumnName() : item.getAlias();
                 } else {
-                    name = item.getAlias() == null ? AstToStringBuilder.toString(item.getExpr()) : item.getAlias();
+                    name = item.getAlias() == null ? AstToStringBuilder.toString(item.getExpr(), false) : item.getAlias();
                 }
 
                 analyzeExpression(item.getExpr(), analyzeState, scope);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/AstToSqlTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/AstToSqlTest.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.parser;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AstToSQLBuilder;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.Assert.fail;
+
+public class AstToSqlTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+    }
+
+    @ParameterizedTest
+    @MethodSource("testSqls")
+    void testAstToSQl(String sql) {
+        StatementBase stmt = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        Analyzer.analyze(stmt, connectContext);
+        String afterSql = AstToSQLBuilder.toSQL(stmt);
+        try {
+            SqlParser.parse(afterSql, connectContext.getSessionVariable());
+        } catch (Exception e) {
+            fail("failed to parse the sql: " + afterSql + ". errMsg: " + e.getMessage());
+        }
+    }
+
+
+    private static Stream<Arguments> testSqls() {
+        List<String> sqls = Lists.newArrayList();
+        sqls.add("with with_t_0 as (select t0.days_add(t0.v1, -1692245077) from t0) select * from t1, with_t_0;");
+        sqls.add("with with_t_0 as (select t0.days_add(v1, -1692245077) as c from t0) select * from t1, with_t_0;");
+        sqls.add("with with_t_0 (abc) as (select t0.days_add(v1, -1692245077) as c from t0) select * from t1, with_t_0;");
+        sqls.add("with with_t_0 as (select t0.days_add(v1, -1692245077) as c from t0) " +
+                "select * from t1, with_t_0 where t1.abs(v4) = 1 order by t1.abs(v6) = 2;");
+        return sqls.stream().map(e -> Arguments.of(e));
+    }
+}


### PR DESCRIPTION


Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
