### PR TITLE
[BugFix] Fix BE graceful exit

### DIFF
--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -130,6 +130,9 @@ StorageEngine::StorageEngine(const EngineOptions& options)
 }
 
 StorageEngine::~StorageEngine() {
+    // tablet manager need to destruct before set storage engine instance to nullptr because tablet may access storage
+    // engine instance during their destruction.
+    _tablet_manager.reset();
 #ifdef BE_TEST
     if (_s_instance == this) {
         _s_instance = _p_instance;


### PR DESCRIPTION
Why I'm doing:

The graceful exit of the BE might fail due to incorrect resource destruction order.

What I'm doing:

Fix resource release order to make graceful exit work.

Fixes #issue

In the destruction of storage engine instance in BE, we will first set the instance to nullptr and release the other resource. But during destruction of tablet manager, we maybe access the storage engine instance which cause nullptr exception.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
