### PR TITLE
[BugFix] fix planner version check for mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -22,7 +22,6 @@ import com.starrocks.common.Config;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.http.HttpConnectContext;
-import com.starrocks.planner.OlapScanNode;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ResultSink;
 import com.starrocks.qe.ConnectContext;
@@ -229,15 +228,11 @@ public class StatementPlanner {
                         optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
                         resultSinkType,
                         !session.getSessionVariable().isSingleNodeExecPlan());
-
-                // Check rewritten tables in case of there are some materialized views
-                List<OlapTable> hitTables = plan.getScanNodes().stream()
-                        .filter(scan -> scan instanceof OlapScanNode)
-                        .map(scan -> ((OlapScanNode) scan).getOlapTable())
-                        .collect(Collectors.toList());
-                isSchemaValid = hitTables.stream().noneMatch(t -> hasSchemaChange(t, planStartTime));
-                isSchemaValid = isSchemaValid && hitTables.stream().allMatch(
-                        t -> noVersionChange(t, buildFragmentStartTime));
+                isSchemaValid = olapTables.stream().noneMatch(t ->
+                        t.lastSchemaUpdateTime.get() > planStartTime);
+                isSchemaValid = isSchemaValid && olapTables.stream().allMatch(t ->
+                        t.lastVersionUpdateEndTime.get() < buildFragmentStartTime &&
+                                t.lastVersionUpdateEndTime.get() >= t.lastVersionUpdateStartTime.get());
                 if (isSchemaValid) {
                     return plan;
                 }
@@ -246,15 +241,6 @@ public class StatementPlanner {
         Preconditions.checkState(false, "The tablet write operation update metadata " +
                 "take a long time");
         return null;
-    }
-
-    private static boolean hasSchemaChange(OlapTable table, long since) {
-        return table.lastSchemaUpdateTime.get() > since;
-    }
-
-    private static boolean noVersionChange(OlapTable table, long since) {
-        return (table.lastVersionUpdateEndTime.get() < since &&
-                table.lastVersionUpdateEndTime.get() >= table.lastVersionUpdateStartTime.get());
     }
 
     // Lock all database before analyze


### PR DESCRIPTION
Why I'm doing:
- Planner checks the copied Table, which actually is not correct, since it doesn't copy the `lastVersionUpdate` field

What I'm doing:
- Check the original table, instead of copied table
- The raised risk is, MV rewrited table would not checked. But that should be generally safe, since base-table schema-change/version change would reflect on the corresponding MV,

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
