### PR TITLE
[Enhancement][branch-3.2] Deprecate jdk8 use jdk11 bytecode

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -107,24 +107,24 @@ JAVA=$JAVA_HOME/bin/java
 # check java version and choose correct JAVA_OPTS
 JAVA_VERSION=$(jdk_version)
 final_java_opt=$JAVA_OPTS
-if [[ "$JAVA_VERSION" -gt 8 ]]; then
-    if [[ "$JAVA_VERSION" -lt 11 ]]; then
-        echo "JDK $JAVA_VERSION is not supported, please use JDK 11 or 17"
-        exit -1
+if [[ "$JAVA_VERSION" -lt 11 ]]; then
+    echo "JDK $JAVA_VERSION is not supported, please use JDK 11 or 17"
+    exit -1
+fi
+
+# for config compatibility
+if [ -n "$JAVA_OPTS_FOR_JDK_11" ]; then
+    final_java_opt=$JAVA_OPTS_FOR_JDK_11
+elif [ -n "$JAVA_OPTS_FOR_JDK_9" ]; then
+    final_java_opt=$JAVA_OPTS_FOR_JDK_9
+else
+    if [ -z "$DATE" ] ; then
+        DATE=`date +%Y%m%d-%H%M%S`
     fi
-        
-    if [ -n "$JAVA_OPTS_FOR_JDK_11" ]; then
-        final_java_opt=$JAVA_OPTS_FOR_JDK_11
-    # for config compatibility
-    elif [ -n "$JAVA_OPTS_FOR_JDK_9" ]; then 
-        final_java_opt=$JAVA_OPTS_FOR_JDK_9
-    else
-        if [ -z "$DATE" ] ; then
-            DATE=`date +%Y%m%d-%H%M%S`
-        fi
-        default_java_opts_for_jdk11="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time"
-        echo "JAVA_OPTS_FOR_JDK_11 is not set in fe.conf, use default java options for jdk11 to start fe process: $default_java_opts_for_jdk11"
-        final_java_opt=$default_java_opts_for_jdk11
+    if [ -z "$final_java_opt" ] ; then
+      default_java_opts="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
+      echo "JAVA_OPTS is not set in fe.conf, use default java options to start fe process: $default_java_opts"
+      final_java_opt=default_java_opts
     fi
 fi
 

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -24,10 +24,7 @@
 LOG_DIR = ${STARROCKS_HOME}/log
 
 DATE = "$(date +%Y%m%d-%H%M%S)"
-JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:${LOG_DIR}/fe.gc.log.$DATE -XX:+PrintConcurrentLocks -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
-
-# For jdk 11+, this JAVA_OPTS will be used as default JVM options
-JAVA_OPTS_FOR_JDK_11="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
+JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
 
 ##
 ## the lowercase properties are read by main program.

--- a/env.sh
+++ b/env.sh
@@ -85,9 +85,15 @@ fi
 
 # check java version
 export JAVA=${JAVA_HOME}/bin/java
-JAVA_VER=$(${JAVA} -version 2>&1 | sed 's/.* version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q' | cut -f1 -d " ")
-if [[ $JAVA_VER -lt 18 ]]; then
-    echo "Error: require JAVA with JDK version at least 1.8"
+JAVA_VER=$(${JAVA} -version 2>&1 | grep -oP 'version "\K[^"]+')
+
+# split version
+IFS='.' read -ra ADDR <<< "$JAVA_VER"
+major_version=${ADDR[0]}
+
+# compare version
+if [[ $major_version -lt 11 ]]; then
+    echo "Error: require JAVA with JDK version at least 11, but got $JAVA_VER"
     exit 1
 fi
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -39,8 +39,8 @@ under the License.
     <properties>
         <starrocks.home>${basedir}/../</starrocks.home>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <jprotobuf.version>2.4.12</jprotobuf.version>
         <log4j.version>2.19.0</log4j.version>
         <jackson.version>2.15.2</jackson.version>

--- a/fe/spark-dpp/pom.xml
+++ b/fe/spark-dpp/pom.xml
@@ -427,7 +427,16 @@ under the License.
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <release>8</release>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
Why I'm doing:
The performance of jdk11 is better than jdk8, and the G1 garbage collector is more suitable for large memory scenarios.
What I'm doing:
Modify the pom file so that the direct target of compilation becomes jdk11
Fixes #33738

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
