### PR TITLE
[BugFix] Fix SenderQueue hang when cancel

### DIFF
--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -598,6 +598,7 @@ void DataStreamRecvr::PipelineSenderQueue::check_leak_closure() {
         while (chunk_queue.size_approx() > 0) {
             if (chunk_queue.try_dequeue(item)) {
                 if (item.closure != nullptr) {
+                    DCHECK(false) << "leak closure detected";
                     LOG(WARNING) << "leak closure detected in fragment:" << print_id(_recvr->fragment_instance_id());
                 }
             }
@@ -608,6 +609,7 @@ void DataStreamRecvr::PipelineSenderQueue::check_leak_closure() {
         for (auto& [_, chunk_queue] : chunk_queues) {
             for (auto& item : chunk_queue) {
                 if (item.closure != nullptr) {
+                    DCHECK(false) << "leak closure detected";
                     LOG(WARNING) << "leak closure detected in fragment:" << print_id(_recvr->fragment_instance_id());
                 }
             }

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -786,12 +786,12 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
                 // We cannot early-return for short circuit, it may occur for parts of parallelism,
                 // and the other parallelism may need to proceed.
             }
-            if (_is_cancelled) {
-                clean_buffer_queues();
-                return Status::OK();
-            }
             _recvr->_num_buffered_bytes += chunk_bytes;
             COUNTER_ADD(metrics.peak_buffer_mem_bytes, chunk_bytes);
+        }
+        //
+        if (_is_cancelled) {
+            clean_buffer_queues();
         }
     }
 

--- a/be/src/runtime/sender_queue.cpp
+++ b/be/src/runtime/sender_queue.cpp
@@ -27,6 +27,7 @@
 #include "util/logging.h"
 #include "util/runtime_profile.h"
 #include "util/time.h"
+#include "util/uid_util.h"
 
 namespace starrocks {
 
@@ -589,6 +590,31 @@ void DataStreamRecvr::PipelineSenderQueue::clean_buffer_queues() {
     }
 }
 
+void DataStreamRecvr::PipelineSenderQueue::check_leak_closure() {
+    std::lock_guard<Mutex> l(_lock);
+    for (size_t i = 0; i < _chunk_queues.size(); i++) {
+        auto& chunk_queue = _chunk_queues[i];
+        ChunkItem item;
+        while (chunk_queue.size_approx() > 0) {
+            if (chunk_queue.try_dequeue(item)) {
+                if (item.closure != nullptr) {
+                    LOG(WARNING) << "leak closure detected in fragment:" << print_id(_recvr->fragment_instance_id());
+                }
+            }
+        }
+    }
+
+    for (auto& [_, chunk_queues] : _buffered_chunk_queues) {
+        for (auto& [_, chunk_queue] : chunk_queues) {
+            for (auto& item : chunk_queue) {
+                if (item.closure != nullptr) {
+                    LOG(WARNING) << "leak closure detected in fragment:" << print_id(_recvr->fragment_instance_id());
+                }
+            }
+        }
+    }
+}
+
 Status DataStreamRecvr::PipelineSenderQueue::try_to_build_chunk_meta(const PTransmitChunkParams& request,
                                                                      Metrics& metrics) {
     // We only need to build chunk meta on first chunk and not use_pass_through
@@ -789,10 +815,11 @@ Status DataStreamRecvr::PipelineSenderQueue::add_chunks(const PTransmitChunkPara
             _recvr->_num_buffered_bytes += chunk_bytes;
             COUNTER_ADD(metrics.peak_buffer_mem_bytes, chunk_bytes);
         }
-        //
-        if (_is_cancelled) {
-            clean_buffer_queues();
-        }
+    }
+
+    // if senderqueue is cancelled clear all closure buffers
+    if (_is_cancelled) {
+        clean_buffer_queues();
     }
 
     return Status::OK();

--- a/be/src/runtime/sender_queue.h
+++ b/be/src/runtime/sender_queue.h
@@ -147,7 +147,10 @@ private:
 class DataStreamRecvr::PipelineSenderQueue final : public DataStreamRecvr::SenderQueue {
 public:
     PipelineSenderQueue(DataStreamRecvr* parent_recvr, int num_senders, int degree_of_parallism);
-    ~PipelineSenderQueue() override { close(); }
+    ~PipelineSenderQueue() override {
+        check_leak_closure();
+        close();
+    }
 
     Status get_chunk(Chunk** chunk, const int32_t driver_sequence = -1) override;
 
@@ -209,6 +212,8 @@ private:
     typedef std::list<ChunkItem> ChunkList;
 
     void clean_buffer_queues();
+
+    void check_leak_closure();
 
     StatusOr<ChunkList> get_chunks_from_pass_through(const int32_t sender_id, size_t& total_chunk_bytes);
 


### PR DESCRIPTION
Why I'm doing:
when SenderQueue receieve cancel, and the last rpc has multi chunks.
```
for ( chunk : chunks) {
...
if (_is_cancel) {
   ...
   return Status::OK();
}
...
}
```
now the only last chunk in chunks has the closure. if is_cancel happened the SenderQueue closure will leak. 

What I'm doing:

check _is_cancel in outer loop

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
