### PR TITLE
[Enhancement] Fix java version parsing in env script for jdk11 

### DIFF
--- a/env.sh
+++ b/env.sh
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
+set -ex
 # check STARROCKS_HOME
 if [[ -z ${STARROCKS_HOME} ]]; then
     echo "Error: STARROCKS_HOME is not set"
@@ -85,9 +85,15 @@ fi
 
 # check java version
 export JAVA=${JAVA_HOME}/bin/java
-JAVA_VER=$(${JAVA} -version 2>&1 | sed 's/.* version "\(.*\)\.\(.*\)\..*"/\1\2/; 1q' | cut -f1 -d " ")
-if [[ $JAVA_VER -lt 18 ]]; then
-    echo "Error: require JAVA with JDK version at least 1.8"
+JAVA_VER=$(${JAVA} -version 2>&1 | grep -oP 'version "\K[^"]+')
+
+# split version
+IFS='.' read -ra ADDR <<< "$JAVA_VER"
+major_version=${ADDR[0]}
+
+# compare version
+if [[ $major_version -lt 11 ]]; then
+    echo "Error: require JAVA with JDK version at least 11, but got $JAVA_VER"
     exit 1
 fi
 

--- a/env.sh
+++ b/env.sh
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-set -ex
+
 # check STARROCKS_HOME
 if [[ -z ${STARROCKS_HOME} ]]; then
     echo "Error: STARROCKS_HOME is not set"


### PR DESCRIPTION
Why I'm doing:
Script code to parse java version does not work with jdk11
What I'm doing:
Fix this problem so that he can determine the jdk version normally
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
