### PR TITLE
[BugFix] Fix date_trunc rewrite by using equlation prediate rewriter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -30,7 +30,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.DateTruncReplaceChecker;
-import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.PredicateReplaceChecker;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.IRewriteEquivalent;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.TimeSliceReplaceChecker;
 
 import java.util.Map;
@@ -39,7 +39,7 @@ import java.util.Optional;
 public class EquationRewriter {
 
     private Multimap<ScalarOperator, Pair<ColumnRefOperator, ScalarOperator>> equationMap;
-    private Multimap<ScalarOperator, Pair<ColumnRefOperator, PredicateReplaceChecker>> predicateProbMap;
+    private Multimap<ScalarOperator, Pair<ColumnRefOperator, IRewriteEquivalent>> predicateProbMap;
     private Map<ColumnRefOperator, ColumnRefOperator> columnMapping;
     private AggregateFunctionRewriter aggregateFunctionRewriter;
     boolean underAggFunctionRewriteContext;
@@ -99,7 +99,7 @@ public class EquationRewriter {
                 if (!predicateProbMap.containsKey(left)) {
                     return null;
                 }
-                Pair<ColumnRefOperator, PredicateReplaceChecker> pair = predicateProbMap.get(left).iterator().next();
+                Pair<ColumnRefOperator, IRewriteEquivalent> pair = predicateProbMap.get(left).iterator().next();
                 if (!pair.second.canReplace(right)) {
                     return null;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -100,7 +100,7 @@ public class EquationRewriter {
                     return null;
                 }
                 Pair<ColumnRefOperator, IRewriteEquivalent> pair = predicateProbMap.get(left).iterator().next();
-                if (!pair.second.canReplace(right)) {
+                if (!pair.second.isEquivalent(right)) {
                     return null;
 
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/EquationRewriter.java
@@ -21,8 +21,6 @@ import com.google.common.collect.Multimap;
 import com.starrocks.analysis.Expr;
 import com.starrocks.catalog.Function;
 import com.starrocks.catalog.FunctionSet;
-import com.starrocks.catalog.PrimitiveType;
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
@@ -31,7 +29,9 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.rewrite.BaseScalarOperatorShuttle;
-import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.DateTruncReplaceChecker;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.PredicateReplaceChecker;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.TimeSliceReplaceChecker;
 
 import java.util.Map;
 import java.util.Optional;
@@ -85,22 +85,36 @@ public class EquationRewriter {
                     return tmp.get();
                 }
 
-                ScalarOperator left = predicate.getChild(0);
-                ScalarOperator right = predicate.getChild(1);
-
-                if (predicateProbMap.containsKey(left)) {
-                    Pair<ColumnRefOperator, PredicateReplaceChecker> pair = predicateProbMap.get(left).iterator().next();
-                    if (pair.second.canReplace(right)) {
-                        ColumnRefOperator replaced = columnMapping.get(pair.first);
-                        if (replaced != null) {
-                            ScalarOperator clonePredicate = predicate.clone();
-                            clonePredicate.setChild(0, replaced.clone());
-                            return clonePredicate;
-                        }
-                    }
+                ScalarOperator replaced = rewriteByEquivalent(predicate);
+                if (replaced != null) {
+                    return replaced;
                 }
 
                 return super.visitBinaryPredicate(predicate, context);
+            }
+
+            private ScalarOperator rewriteByEquivalent(BinaryPredicateOperator predicate) {
+                ScalarOperator left = predicate.getChild(0);
+                ScalarOperator right = predicate.getChild(1);
+                if (!predicateProbMap.containsKey(left)) {
+                    return null;
+                }
+                Pair<ColumnRefOperator, PredicateReplaceChecker> pair = predicateProbMap.get(left).iterator().next();
+                if (!pair.second.canReplace(right)) {
+                    return null;
+
+                }
+
+                ColumnRefOperator replaced = pair.first;
+                if (columnMapping != null) {
+                    replaced = columnMapping.get(pair.first);
+                    if (replaced == null) {
+                        return null;
+                    }
+                }
+                ScalarOperator clonePredicate = predicate.clone();
+                clonePredicate.setChild(0, replaced.clone());
+                return clonePredicate;
             }
 
             @Override
@@ -215,12 +229,15 @@ public class EquationRewriter {
                 // query: SELECT time_slice(dt, INTERVAL 5 MINUTE) as t FROM table WHERE dt > '2023-06-01'
                 // if '2023-06-01'=time_slice('2023-06-01', INTERVAL 5 MINUTE), can replace predicate dt => t
                 ScalarOperator first = expr.getChild(0);
-                predicateProbMap.put(first, Pair.create(col, new TimeSliceReplaceChecker(((CallOperator) expr))));
+                predicateProbMap.put(first, Pair.create(col, new TimeSliceReplaceChecker(aggFunc)));
             } else if (aggFunc.getFnName().equals(FunctionSet.COUNT) && !aggFunc.isDistinct()) {
                 CallOperator newAggFunc = normalizeCallOperator(aggFunc);
                 if (newAggFunc != null && newAggFunc != aggFunc) {
                     equationMap.put(newAggFunc,  Pair.create(col, null));
                 }
+            } else if (aggFunc.getFnName().equals(FunctionSet.DATE_TRUNC)) {
+                ScalarOperator first = expr.getChild(1);
+                predicateProbMap.put(first, Pair.create(col, new DateTruncReplaceChecker(aggFunc)));
             }
         }
     }
@@ -277,36 +294,5 @@ public class EquationRewriter {
         private Function findArithmeticFunction(CallOperator call, String fnName) {
             return Expr.getBuiltinFunction(fnName, call.getFunction().getArgs(), Function.CompareMode.IS_IDENTICAL);
         }
-
     }
-
-    private interface PredicateReplaceChecker {
-        boolean canReplace(ScalarOperator operator);
-    }
-
-    private static class TimeSliceReplaceChecker implements PredicateReplaceChecker {
-        private final CallOperator mvTimeSlice;
-
-        public TimeSliceReplaceChecker(CallOperator mvTimeSlice) {
-            this.mvTimeSlice = mvTimeSlice;
-        }
-
-        @Override
-        public boolean canReplace(ScalarOperator operator) {
-            try {
-                if (operator.isConstantRef() && operator.getType().getPrimitiveType() == PrimitiveType.DATETIME) {
-                    ConstantOperator sliced = ScalarOperatorFunctions.timeSlice(
-                            (ConstantOperator) operator,
-                            ((ConstantOperator) mvTimeSlice.getChild(1)),
-                            ((ConstantOperator) mvTimeSlice.getChild(2)),
-                            ((ConstantOperator) mvTimeSlice.getChild(3)));
-                    return sliced.equals(operator);
-                }
-            } catch (AnalysisException e) {
-                return false;
-            }
-            return false;
-        }
-    }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
@@ -133,11 +133,11 @@ public class PredicateExtractor extends ScalarOperatorVisitor<RangePredicate, Pr
             return null;
         }
 
-        if (DateTruncReplaceChecker.INSTANCE.canReplace(op1, op2)) {
+        if (DateTruncReplaceChecker.INSTANCE.isEquivalent(op1, op2)) {
             TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
             rangeSet.addAll(range(predicate.getBinaryType(), op2));
             return new ColumnRangePredicate(op1.getChild(1).cast(), rangeSet);
-        } else if (TimeSliceReplaceChecker.INSTANCE.canReplace(op1, op2)) {
+        } else if (TimeSliceReplaceChecker.INSTANCE.isEquivalent(op1, op2)) {
             TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
             rangeSet.addAll(range(predicate.getBinaryType(), op2));
             return new ColumnRangePredicate(op1.getChild(0).cast(), rangeSet);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateExtractor.java
@@ -20,11 +20,14 @@ import com.google.common.collect.TreeRangeSet;
 import com.starrocks.analysis.BinaryType;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.DateTruncReplaceChecker;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent.TimeSliceReplaceChecker;
 
 import java.util.List;
 import java.util.Optional;
@@ -62,19 +65,14 @@ public class PredicateExtractor extends ScalarOperatorVisitor<RangePredicate, Pr
     @Override
     public RangePredicate visitBinaryPredicate(
             BinaryPredicateOperator predicate, PredicateExtractorContext context) {
+        RangePredicate rangePredicate = rewriteBinaryPredicate(predicate);
+        if (rangePredicate != null) {
+            return rangePredicate;
+        }
+
         ScalarOperator left = predicate.getChild(0);
         ScalarOperator right = predicate.getChild(1);
-        if (isSupportedRangeExpr(left) && right.isConstantRef()) {
-            ConstantOperator constant = (ConstantOperator) right;
-            TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
-            rangeSet.addAll(range(predicate.getBinaryType(), constant));
-            return new ColumnRangePredicate(left, rangeSet);
-        } else if (left.isConstantRef() && isSupportedRangeExpr(right)) {
-            ConstantOperator constant = (ConstantOperator) left;
-            TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
-            rangeSet.addAll(range(predicate.getBinaryType(), constant));
-            return new ColumnRangePredicate(right, rangeSet);
-        } else if (left.isColumnRef() && right.isColumnRef() && context.isAnd()) {
+        if (left.isColumnRef() && right.isColumnRef() && context.isAnd()) {
             if (predicate.getBinaryType().isEqual()) {
                 columnEqualityPredicates.add(predicate);
             } else {
@@ -89,6 +87,63 @@ public class PredicateExtractor extends ScalarOperatorVisitor<RangePredicate, Pr
     private boolean isSupportedRangeExpr(ScalarOperator op) {
         List<ColumnRefOperator> columns = Utils.collect(op, ColumnRefOperator.class);
         return op.isVariable() && columns.size() == 1;
+    }
+
+    private RangePredicate rewriteBinaryPredicate(BinaryPredicateOperator predicate) {
+        ScalarOperator left = predicate.getChild(0);
+        ScalarOperator right = predicate.getChild(1);
+        ScalarOperator op1 = null;
+        ConstantOperator op2 = null;
+        if (isSupportedRangeExpr(left) && right instanceof ConstantOperator) {
+            op1 = left;
+            op2 = (ConstantOperator) right;
+        } else if (isSupportedRangeExpr(right) && left instanceof ConstantOperator) {
+            op1 = right;
+            op2 = (ConstantOperator) left;
+        } else {
+            return null;
+        }
+
+        // rewrite to column ref by equivalent
+        if (!(op1 instanceof ColumnRefOperator)) {
+            RangePredicate rangePredicate = rewriteByEquivalent(predicate);
+            if (rangePredicate != null) {
+                return rangePredicate;
+            }
+        }
+
+        // by default
+        TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
+        rangeSet.addAll(range(predicate.getBinaryType(), op2));
+        return new ColumnRangePredicate(op1, rangeSet);
+    }
+
+    private static RangePredicate rewriteByEquivalent(BinaryPredicateOperator predicate) {
+        ScalarOperator left = predicate.getChild(0);
+        ScalarOperator right = predicate.getChild(1);
+        ScalarOperator op1 = null;
+        ConstantOperator op2 = null;
+        if (left instanceof CallOperator && right instanceof ConstantOperator) {
+            op1 = left;
+            op2 = (ConstantOperator) right;
+        } else if (right instanceof CallOperator && left instanceof ConstantOperator) {
+            op1 = right;
+            op2 = (ConstantOperator) left;
+        } else {
+            return null;
+        }
+
+        if (DateTruncReplaceChecker.INSTANCE.canReplace(op1, op2)) {
+            TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
+            rangeSet.addAll(range(predicate.getBinaryType(), op2));
+            return new ColumnRangePredicate(op1.getChild(1).cast(), rangeSet);
+        } else if (TimeSliceReplaceChecker.INSTANCE.canReplace(op1, op2)) {
+            TreeRangeSet<ConstantOperator> rangeSet = TreeRangeSet.create();
+            rangeSet.addAll(range(predicate.getBinaryType(), op2));
+            return new ColumnRangePredicate(op1.getChild(0).cast(), rangeSet);
+        } else {
+            return null;
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncReplaceChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncReplaceChecker.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+
+public class DateTruncReplaceChecker implements PredicateReplaceChecker {
+    public static final DateTruncReplaceChecker INSTANCE = new DateTruncReplaceChecker();
+
+    private CallOperator mvDateTrunc;
+
+    public DateTruncReplaceChecker() {}
+
+    public DateTruncReplaceChecker(CallOperator mvDateTrunc) {
+        this.mvDateTrunc = mvDateTrunc;
+    }
+
+    @Override
+    public boolean canReplace(ScalarOperator operator) {
+        if (mvDateTrunc == null) {
+            return false;
+        }
+        if (operator.isConstantRef() && operator.getType().getPrimitiveType() == PrimitiveType.DATETIME) {
+            ConstantOperator sliced = ScalarOperatorFunctions.dateTrunc(
+                    ((ConstantOperator) mvDateTrunc.getChild(0)),
+                    (ConstantOperator) operator);
+            return sliced.equals(operator);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canReplace(ScalarOperator op1, ConstantOperator op2) {
+        if (!(op1 instanceof CallOperator)) {
+            return false;
+        }
+        CallOperator func = (CallOperator) op1;
+        if (!func.getFnName().equalsIgnoreCase(FunctionSet.DATE_TRUNC)) {
+            return false;
+        }
+        if (!(func.getChild(1) instanceof ColumnRefOperator)) {
+            return false;
+        }
+        ConstantOperator sliced = ScalarOperatorFunctions.dateTrunc(
+                ((ConstantOperator) op1.getChild(0)),
+                op2);
+        return sliced.equals(op2);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncReplaceChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/DateTruncReplaceChecker.java
@@ -33,18 +33,18 @@ public class DateTruncReplaceChecker implements IRewriteEquivalent {
     }
 
     @Override
-    public boolean canReplace(ScalarOperator operator) {
+    public boolean isEquivalent(ScalarOperator operator) {
         if (mvDateTrunc == null) {
             return false;
         }
         if (!operator.isConstantRef()) {
             return false;
         }
-        return canReplace(mvDateTrunc, (ConstantOperator) operator);
+        return isEquivalent(mvDateTrunc, (ConstantOperator) operator);
     }
 
     @Override
-    public boolean canReplace(ScalarOperator op1, ConstantOperator op2) {
+    public boolean isEquivalent(ScalarOperator op1, ConstantOperator op2) {
         if (!(op1 instanceof CallOperator)) {
             return false;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
@@ -17,8 +17,28 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization.equivale
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
-public interface PredicateReplaceChecker {
+/**
+ * Two expression can be equivalent even they are not the same expressions especially for partition datetime functions,
+ * example1:
+ *   a. time_slice(dt, INTERVAL 1 HOUR) >= '2023-11-21 00:00:00'
+ *   b. dt >= '2023-11-21 00:00:00'
+ * example2:
+ *   a. date_trunc('hour', dt) >= '2023-11-21 00:00:00'
+ *   b. dt >= '2023-11-21 00:00:00'
+ *
+ * {@code IRewriteEquivalent} is used to check whether different expression are equivalent or not.
+ */
+public interface IRewriteEquivalent {
+    /**
+     * @param operator : The input scalar operator to be checked
+     * @return: The input operator can be replaced by the {@code IRewriteEquivalent}
+     */
     boolean canReplace(ScalarOperator operator);
 
+    /**
+     * @param operator : The input scalar operator eg:date_trunc/time_slice expression
+     * @param constantOperator : const operator of the binary predicate's right child
+     * @return : The input operator can be replaced by the {@code IRewriteEquivalent}
+     */
     boolean canReplace(ScalarOperator operator, ConstantOperator constantOperator);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/IRewriteEquivalent.java
@@ -33,12 +33,12 @@ public interface IRewriteEquivalent {
      * @param operator : The input scalar operator to be checked
      * @return: The input operator can be replaced by the {@code IRewriteEquivalent}
      */
-    boolean canReplace(ScalarOperator operator);
+    boolean isEquivalent(ScalarOperator operator);
 
     /**
      * @param operator : The input scalar operator eg:date_trunc/time_slice expression
      * @param constantOperator : const operator of the binary predicate's right child
      * @return : The input operator can be replaced by the {@code IRewriteEquivalent}
      */
-    boolean canReplace(ScalarOperator operator, ConstantOperator constantOperator);
+    boolean isEquivalent(ScalarOperator operator, ConstantOperator constantOperator);
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/PredicateReplaceChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/PredicateReplaceChecker.java
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+
+public interface PredicateReplaceChecker {
+    boolean canReplace(ScalarOperator operator);
+
+    boolean canReplace(ScalarOperator operator, ConstantOperator constantOperator);
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceReplaceChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceReplaceChecker.java
@@ -1,0 +1,80 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule.transformation.materialization.equivalent;
+
+import com.starrocks.catalog.FunctionSet;
+import com.starrocks.catalog.PrimitiveType;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorFunctions;
+
+public class TimeSliceReplaceChecker implements PredicateReplaceChecker {
+    public static final TimeSliceReplaceChecker INSTANCE = new TimeSliceReplaceChecker();
+
+    private CallOperator mvTimeSlice;
+
+    public TimeSliceReplaceChecker() {}
+
+    public TimeSliceReplaceChecker(CallOperator mvTimeSlice) {
+        this.mvTimeSlice = mvTimeSlice;
+    }
+
+    @Override
+    public boolean canReplace(ScalarOperator operator) {
+        if (mvTimeSlice == null) {
+            return false;
+        }
+
+        try {
+            if (operator.isConstantRef() && operator.getType().getPrimitiveType() == PrimitiveType.DATETIME) {
+                ConstantOperator sliced = ScalarOperatorFunctions.timeSlice(
+                        (ConstantOperator) operator,
+                        ((ConstantOperator) mvTimeSlice.getChild(1)),
+                        ((ConstantOperator) mvTimeSlice.getChild(2)),
+                        ((ConstantOperator) mvTimeSlice.getChild(3)));
+                return sliced.equals(operator);
+            }
+        } catch (AnalysisException e) {
+            return false;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean canReplace(ScalarOperator op1, ConstantOperator op2) {
+        if (!(op1 instanceof CallOperator)) {
+            return false;
+        }
+        CallOperator func = (CallOperator) op1;
+        if (!func.getFnName().equalsIgnoreCase(FunctionSet.TIME_SLICE)) {
+            return false;
+        }
+        if (!(func.getChild(0) instanceof ColumnRefOperator)) {
+            return false;
+        }
+        try {
+            ConstantOperator sliced = ScalarOperatorFunctions.timeSlice(
+                    op2,
+                    ((ConstantOperator) op1.getChild(1)),
+                    ((ConstantOperator) op1.getChild(2)),
+                    ((ConstantOperator) op1.getChild(3)));
+            return sliced.equals(op2);
+        } catch (AnalysisException e) {
+            return false;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceReplaceChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/equivalent/TimeSliceReplaceChecker.java
@@ -34,18 +34,18 @@ public class TimeSliceReplaceChecker implements IRewriteEquivalent {
     }
 
     @Override
-    public boolean canReplace(ScalarOperator operator) {
+    public boolean isEquivalent(ScalarOperator operator) {
         if (mvTimeSlice == null) {
             return false;
         }
         if (!operator.isConstantRef()) {
             return false;
         }
-        return canReplace(mvTimeSlice, (ConstantOperator) operator);
+        return isEquivalent(mvTimeSlice, (ConstantOperator) operator);
     }
 
     @Override
-    public boolean canReplace(ScalarOperator op1, ConstantOperator op2) {
+    public boolean isEquivalent(ScalarOperator op1, ConstantOperator op2) {
         if (!(op1 instanceof CallOperator)) {
             return false;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -186,6 +186,7 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "WHERE `dt` >= '2023-04-10 17:00:00' and `dt` < '2023-04-10 18:00:00'\n" +
                 "group by ts")
                 .match("test_partition_expr_mv1");
+        starRocksAssert.dropTable("test_partition_expr_tbl1");
         starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -213,4 +213,68 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
                 "join depts_null using (deptno) where depts_null.deptno < 10;")
                 .match("join_null_mv");
     }
+
+    @Test
+    public void testDateTruncPartitionColumnExpr() throws Exception {
+        String tableSQL = "CREATE TABLE `test_partition_expr_tbl1` (\n" +
+                "  `order_id` bigint(20) NOT NULL DEFAULT \"-1\" COMMENT \"\",\n" +
+                "  `dt` datetime NOT NULL DEFAULT \"1996-01-01 00:00:00\" COMMENT \"\",\n" +
+                "  `value` varchar(256) NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`order_id`, `dt`)\n" +
+                "PARTITION BY RANGE(`dt`)\n" +
+                "(\n" +
+                "PARTITION p2023041017 VALUES [(\"2023-04-10 17:00:00\"), (\"2023-04-10 18:00:00\")),\n" +
+                "PARTITION p2023041021 VALUES [(\"2023-04-10 21:00:00\"), (\"2023-04-10 22:00:00\"))\n" +
+                ")\n" +
+                "DISTRIBUTED BY HASH(`order_id`) BUCKETS 9\n" +
+                "PROPERTIES (\n" +
+                "\"dynamic_partition.enable\" = \"true\",\n" +
+                "\"dynamic_partition.time_unit\" = \"HOUR\",\n" +
+                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                "\"dynamic_partition.start\" = \"-240\",\n" +
+                "\"dynamic_partition.end\" = \"2\",\n" +
+                "\"dynamic_partition.prefix\" = \"p\",\n" +
+                "\"dynamic_partition.buckets\" = \"9\"," +
+                "\"replication_num\" = \"1\"" +
+                ");";
+        starRocksAssert.withTable(tableSQL);
+        String mv = "CREATE MATERIALIZED VIEW `test_partition_expr_mv1`\n" +
+                "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                "PARTITION BY ds \n" +
+                "DISTRIBUTED BY HASH(`order_num`) BUCKETS 10\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"" +
+                ")\n" +
+                "AS\n" +
+                "SELECT \n" +
+                "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                "date_trunc('minute', `dt`) AS ds\n" +
+                "FROM `test_partition_expr_tbl1`\n" +
+                "group by ds;";
+        starRocksAssert.withMaterializedView(mv);
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('minute', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE date_trunc('minute', `dt`) BETWEEN '2023-04-11' AND '2023-04-12'\n" +
+                    "group by ds")
+                    .match("test_partition_expr_mv1");
+        }
+
+        {
+            sql("SELECT \n" +
+                    "count(DISTINCT `order_id`) AS `order_num`, \n" +
+                    "date_trunc('minute', `dt`) AS ds \n" +
+                    "FROM `test_partition_expr_tbl1`\n" +
+                    "WHERE `dt` BETWEEN '2023-04-11' AND '2023-04-12'\n" +
+                    "group by ds")
+                    .match("test_partition_expr_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
+        starRocksAssert.dropTable("test_partition_expr_tbl1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewritePartialPartitionTest.java
@@ -802,4 +802,313 @@ public class MvRewritePartialPartitionTest extends MvRewriteTestBase {
         }
     }
 
+    @Test
+    public void testPartialPartitionRewriteWithDateTruncExpr1() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_tbl1 (\n" +
+                " k1 datetime,\n" +
+                " v1 INT,\n" +
+                " v2 INT)\n" +
+                " DUPLICATE KEY(k1)\n" +
+                " PARTITION BY RANGE(`k1`)\n" +
+                " (\n" +
+                "  PARTITION `p1` VALUES LESS THAN ('2020-01-01'),\n" +
+                "  PARTITION `p2` VALUES LESS THAN ('2020-02-01'),\n" +
+                "  PARTITION `p3` VALUES LESS THAN ('2020-03-01')\n" +
+                " )\n" +
+                " DISTRIBUTED BY HASH(k1) properties('replication_num'='1');");
+        cluster.runSql("test", "insert into base_tbl1 values " +
+                " (\"2020-01-01\",1,1),(\"2020-01-01\",1,2),(\"2020-01-11\",2,1),(\"2020-01-11\",2,2);");
+
+        createAndRefreshMv("test", "test_mv1", "CREATE MATERIALIZED VIEW test_mv1 \n" +
+                " PARTITION BY ds \n" +
+                " DISTRIBUTED BY HASH(ds) BUCKETS 10\n" +
+                " REFRESH MANUAL\n" +
+                " AS SELECT " +
+                " date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                " FROM base_tbl1 " +
+                " group by ds;");
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 where date_trunc('minute', `k1`) = '2020-02-11' group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 where `k1` = '2020-02-11' group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
+        cluster.runSql("test", "insert into base_tbl1 partition('p3') values (\"2020-02-02\",1,1)");
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE date_trunc('minute', `k1`) >= '2020-01-01 00:00:00'" +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE date_trunc('minute', `k1`) >= '2020-01-01 00:00:00' and " +
+                    "   date_trunc('minute', `k1`) <= '2020-03-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        dropMv("test", "test_mv1");
+        starRocksAssert.dropTable("base_tbl1");
+    }
+
+    @Test
+    public void testPartialPartitionRewriteWithDateTruncExpr2() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_tbl1 (\n" +
+                " k1 datetime,\n" +
+                " v1 INT,\n" +
+                " v2 INT)\n" +
+                " DUPLICATE KEY(k1)\n" +
+                " PARTITION BY RANGE(`k1`)\n" +
+                " (\n" +
+                "  PARTITION `p1` VALUES [('2020-01-01') , ('2020-02-01')),\n" +
+                "  PARTITION `p2` VALUES [('2020-02-01') , ('2020-03-01')),\n" +
+                "  PARTITION `p3` VALUES [('2020-03-01') , ('2020-04-01'))\n" +
+                " )\n" +
+                " DISTRIBUTED BY HASH(k1) properties('replication_num'='1');");
+        cluster.runSql("test", "insert into base_tbl1 values " +
+                " (\"2020-01-01\",1,1),(\"2020-01-01\",1,2),(\"2020-01-11\",2,1),(\"2020-01-11\",2,2);");
+
+        createAndRefreshMv("test", "test_mv1", "CREATE MATERIALIZED VIEW test_mv1 \n" +
+                " PARTITION BY ds \n" +
+                " DISTRIBUTED BY HASH(ds) BUCKETS 10\n" +
+                " REFRESH MANUAL\n" +
+                " AS SELECT " +
+                " date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                " FROM base_tbl1 " +
+                " group by ds;");
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 where date_trunc('minute', `k1`) = '2020-02-11' group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 where `k1` = '2020-02-11' group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
+        cluster.runSql("test", "insert into base_tbl1 partition('p3') values (\"2020-02-02\",1,1)");
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE date_trunc('minute', `k1`) >= '2020-01-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE date_trunc('minute', `k1`) <= '2020-03-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        {
+            String query = "select date_trunc('minute', `k1`) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE date_trunc('minute', `k1`) >= '2020-01-01 00:00:00' and " +
+                    "   date_trunc('minute', `k1`) <= '2020-03-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        dropMv("test", "test_mv1");
+        starRocksAssert.dropTable("base_tbl1");
+    }
+
+    @Test
+    public void testPartialPartitionRewriteWithTimeSliceExpr1() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_tbl1 (\n" +
+                " k1 datetime,\n" +
+                " v1 INT,\n" +
+                " v2 INT)\n" +
+                " DUPLICATE KEY(k1)\n" +
+                " PARTITION BY RANGE(`k1`)\n" +
+                " (\n" +
+                "  PARTITION `p1` VALUES LESS THAN ('2020-01-01'),\n" +
+                "  PARTITION `p2` VALUES LESS THAN ('2020-02-01'),\n" +
+                "  PARTITION `p3` VALUES LESS THAN ('2020-03-01')\n" +
+                " )\n" +
+                " DISTRIBUTED BY HASH(k1) properties('replication_num'='1');");
+        cluster.runSql("test", "insert into base_tbl1 values " +
+                " (\"2020-01-01\",1,1),(\"2020-01-01\",1,2),(\"2020-01-11\",2,1),(\"2020-01-11\",2,2);");
+
+        createAndRefreshMv("test", "test_mv1", "CREATE MATERIALIZED VIEW test_mv1 \n" +
+                " PARTITION BY date_trunc('day', ds) \n" +
+                " DISTRIBUTED BY HASH(ds) BUCKETS 10\n" +
+                " REFRESH MANUAL\n" +
+                " AS SELECT " +
+                " time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                " FROM base_tbl1 " +
+                " group by ds;");
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 where time_slice(k1, interval 1 hour) = '2020-02-11 00:00:00' " +
+                    "group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
+        }
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
+        cluster.runSql("test", "insert into base_tbl1 partition('p3') values (\"2020-02-02\",1,1)");
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " where time_slice(k1, interval 1 hour) >= '2020-02-11 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " where time_slice(k1, interval 1 hour) >= '2020-02-11 00:00:00' " +
+                    " and time_slice(k1, interval 1 hour) <= '2020-03-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        dropMv("test", "test_mv1");
+        starRocksAssert.dropTable("base_tbl1");
+    }
+
+    @Test
+    public void testPartialPartitionRewriteWiteTimeSliceExpr2() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE base_tbl1 (\n" +
+                " k1 datetime,\n" +
+                " v1 INT,\n" +
+                " v2 INT)\n" +
+                " DUPLICATE KEY(k1)\n" +
+                " PARTITION BY RANGE(`k1`)\n" +
+                " (\n" +
+                "  PARTITION `p1` VALUES [('2020-01-01') , ('2020-02-01')),\n" +
+                "  PARTITION `p2` VALUES [('2020-02-01') , ('2020-03-01')),\n" +
+                "  PARTITION `p3` VALUES [('2020-03-01') , ('2020-04-01'))\n" +
+                " )\n" +
+                " DISTRIBUTED BY HASH(k1) properties('replication_num'='1');");
+        cluster.runSql("test", "insert into base_tbl1 values " +
+                " (\"2020-01-01\",1,1),(\"2020-01-01\",1,2),(\"2020-01-11\",2,1),(\"2020-01-11\",2,2);");
+
+        createAndRefreshMv("test", "test_mv1", "CREATE MATERIALIZED VIEW test_mv1 \n" +
+                " PARTITION BY date_trunc('day', ds) \n" +
+                " DISTRIBUTED BY HASH(ds) BUCKETS 10\n" +
+                " REFRESH MANUAL\n" +
+                " AS SELECT " +
+                " time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                " FROM base_tbl1 " +
+                " group by ds;");
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 where time_slice(k1, interval 1 hour) = '2020-02-11' group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
+        }
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 where `k1` = '2020-02-11' group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "ds = '2020-02-11 00:00:00'");
+        }
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
+        cluster.runSql("test", "insert into base_tbl1 partition('p3') values (\"2020-02-02\",1,1)");
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE time_slice(k1, interval 1 hour) >= '2020-01-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE time_slice(k1, interval 1 hour) <= '2020-03-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        {
+            String query = "select time_slice(k1, interval 1 hour) AS ds, sum(v1) " +
+                    " FROM base_tbl1 " +
+                    " WHERE time_slice(k1, interval 1 hour) >= '2020-01-01 00:00:00' and " +
+                    "   time_slice(k1, interval 1 hour) <= '2020-03-01 00:00:00' " +
+                    " group by ds";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "test_mv1", "UNION");
+        }
+
+        dropMv("test", "test_mv1");
+        starRocksAssert.dropTable("base_tbl1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -118,10 +118,9 @@ public class MvRewriteTestBase {
                     Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
                     OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
                     if (tbl != null) {
-                        for (Partition partition : tbl.getPartitions()) {
-                            if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
-                                setPartitionVersion(partition, partition.getVisibleVersion() + 1);
-                            }
+                        for (Long partitionId : insertStmt.getTargetPartitionIds()) {
+                            Partition partition = tbl.getPartition(partitionId);
+                            setPartitionVersion(partition, partition.getVisibleVersion() + 1);
                         }
                     }
                 }


### PR DESCRIPTION
Why I'm doing:
When user's base table uses `datetime` rather than `date`, and has an mv which by `date_trunc('minute', dt)`.
There is no way to rewrite it by `union all` rewrite when the mv only contains partial partitions.
```
SELECT date_trunc('minute', `timestamp`) AS `timestamp`, 
bitmap_union(to_bitmap(`user_id`)) AS `distinct_user`
FROM `tbl`
GROUP BY date_trunc('minute', `timestamp`);
```


What I'm doing:

1. Support date_trunc for equivalent predicate rewrite
2. Support union all rewrite for the time_slice/date_trunc range predicates.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
