### PR TITLE
[Enhancement] add del row count to rowset meta in cloud native pk table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -911,6 +911,7 @@ CONF_mBool(experimental_lake_ignore_lost_segment, "false");
 CONF_mInt64(experimental_lake_wait_per_put_ms, "0");
 CONF_mInt64(experimental_lake_wait_per_get_ms, "0");
 CONF_mInt64(experimental_lake_wait_per_delete_ms, "0");
+CONF_mBool(experimental_lake_ignore_pk_consistency_check, "false");
 CONF_mInt64(lake_publish_version_slow_log_ms, "1000");
 CONF_mBool(lake_enable_publish_version_trace_log, "false");
 

--- a/be/src/storage/lake/compaction_policy.cpp
+++ b/be/src/storage/lake/compaction_policy.cpp
@@ -110,6 +110,7 @@ public:
     }
     double delete_bytes() const {
         if (stat.num_rows == 0) return 0.0;
+        if (stat.num_dels >= stat.num_rows) return (double)stat.bytes;
         return (double)stat.bytes * ((double)stat.num_dels / (double)stat.num_rows);
     }
     double read_bytes() const { return (double)stat.bytes - delete_bytes() + 1; }
@@ -158,7 +159,11 @@ StatusOr<std::vector<RowsetPtr>> PrimaryCompactionPolicy::pick_rowsets(
         RowsetStat stat;
         stat.num_rows = rowset_pb.num_rows();
         stat.bytes = rowset_pb.data_size();
-        stat.num_dels = mgr->get_rowset_num_deletes(tablet_id, tablet_version, rowset_pb);
+        if (rowset_pb.has_num_dels()) {
+            stat.num_dels = rowset_pb.num_dels();
+        } else {
+            stat.num_dels = mgr->get_rowset_num_deletes(tablet_id, tablet_version, rowset_pb);
+        }
         rowset_queue.emplace(std::make_shared<const RowsetMetadata>(rowset_pb), stat);
     }
     size_t cur_compaction_result_bytes = 0;

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -131,6 +131,36 @@ void MetaFileBuilder::apply_opcompaction(const TxnLogPB_OpCompaction& op_compact
                            op_compaction.output_rowset().ShortDebugString());
 }
 
+Status MetaFileBuilder::update_num_del_stat(const std::map<uint32_t, size_t>& segment_id_to_add_dels) {
+    std::map<uint32_t, RowsetMetadataPB*> segment_id_to_rowset;
+    for (int i = 0; i < _tablet_meta->rowsets_size(); i++) {
+        auto* mutable_rowset = _tablet_meta->mutable_rowsets(i);
+        for (int j = 0; j < mutable_rowset->segments_size(); j++) {
+            segment_id_to_rowset[mutable_rowset->id() + j] = mutable_rowset;
+        }
+    }
+    for (const auto& each : segment_id_to_add_dels) {
+        if (segment_id_to_rowset.count(each.first) == 0) {
+            // Maybe happen when primary index is in error state.
+            std::string err_msg =
+                    fmt::format("unexpected segment id: {} tablet id: {}", each.first, _tablet_meta->id());
+            LOG(ERROR) << err_msg;
+            if (!config::experimental_lake_ignore_pk_consistency_check) {
+                return Status::InternalError(err_msg);
+            }
+        } else {
+            const int64_t prev_num_dels = segment_id_to_rowset[each.first]->num_dels();
+            if (each.second > std::numeric_limits<int64_t>::max() - prev_num_dels) {
+                // Can't be possible
+                LOG(ERROR) << "Integer overflow detected";
+                return Status::InternalError("Integer overflow detected");
+            }
+            segment_id_to_rowset[each.first]->set_num_dels(prev_num_dels + each.second);
+        }
+    }
+    return Status::OK();
+}
+
 Status MetaFileBuilder::_finalize_delvec(int64_t version, int64_t txn_id) {
     if (!is_primary_key(_tablet_meta.get())) return Status::OK();
 

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -55,6 +55,9 @@ public:
     // collect files that need to removed
     std::shared_ptr<std::vector<std::string>> trash_files() { return _trash_files; }
 
+    // update num dels in rowset meta, `segment_id_to_add_dels` record each segment's incremental del count
+    Status update_num_del_stat(const std::map<uint32_t, size_t>& segment_id_to_add_dels);
+
 private:
     // update delvec in tablet meta
     Status _finalize_delvec(int64_t version, int64_t txn_id);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -165,6 +165,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     size_t idx = 0;
     size_t new_del = 0;
     size_t total_del = 0;
+    std::map<uint32_t, size_t> segment_id_to_add_dels;
     for (auto& new_delete : new_deletes) {
         uint32_t rssid = new_delete.first;
         if (rssid >= rowset_id && rssid < rowset_id + op_write.rowset().segments_size()) {
@@ -175,6 +176,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             new_del_vecs[idx].second->init(metadata.version(), del_ids.data(), del_ids.size());
             new_del += del_ids.size();
             total_del += del_ids.size();
+            segment_id_to_add_dels[rssid] += del_ids.size();
         } else {
             TabletSegmentId tsid;
             tsid.tablet_id = tablet->id();
@@ -188,13 +190,16 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
             size_t cur_new = new_del_vecs[idx].second->cardinality();
             if (cur_old + cur_add != cur_new) {
                 // should not happen, data inconsistent
-                LOG(FATAL) << strings::Substitute(
-                        "delvec inconsistent tablet:$0 rssid:$1 #old:$2 #add:$3 #new:$4 old_v:$5 "
-                        "v:$6",
-                        tablet->id(), rssid, cur_old, cur_add, cur_new, old_del_vec->version(), metadata.version());
+                if (!config::experimental_lake_ignore_pk_consistency_check) {
+                    LOG(FATAL) << strings::Substitute(
+                            "delvec inconsistent tablet:$0 rssid:$1 #old:$2 #add:$3 #new:$4 old_v:$5 "
+                            "v:$6",
+                            tablet->id(), rssid, cur_old, cur_add, cur_new, old_del_vec->version(), metadata.version());
+                }
             }
             new_del += cur_add;
             total_del += cur_new;
+            segment_id_to_add_dels[rssid] += cur_add;
         }
 
         idx++;
@@ -206,6 +211,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
         builder->append_delvec(each.second, each.first);
     }
     builder->apply_opwrite(op_write, replace_segments, orphan_files);
+    RETURN_IF_ERROR(builder->update_num_del_stat(segment_id_to_add_dels));
 
     TRACE_COUNTER_INCREMENT("rowsetid", rowset_id);
     TRACE_COUNTER_INCREMENT("upserts", upserts.size());
@@ -529,6 +535,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
     auto input_rowset = std::find_if(metadata.rowsets().begin(), metadata.rowsets().end(),
                                      [&](const RowsetMetadata& r) { return r.id() == max_rowset_id; });
     uint32_t max_src_rssid = max_rowset_id + input_rowset->segments_size() - 1;
+    std::map<uint32_t, size_t> segment_id_to_add_dels;
 
     // 2. update primary index, and generate delete info.
     TRACE_COUNTER_INCREMENT("output_rowsets_size", output_rowset->num_segments());
@@ -551,6 +558,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
             dv->init(metadata.version(), tmp_deletes.data(), tmp_deletes.size());
             total_deletes += tmp_deletes.size();
         }
+        segment_id_to_add_dels[rssid] += tmp_deletes.size();
         delvecs.emplace_back(rssid, dv);
         compaction_state.release_segments(i);
     }
@@ -560,6 +568,7 @@ Status UpdateManager::publish_primary_compaction(const TxnLogPB_OpCompaction& op
         builder->append_delvec(each.second, each.first);
     }
     builder->apply_opcompaction(op_compaction);
+    RETURN_IF_ERROR(builder->update_num_del_stat(segment_id_to_add_dels));
 
     TRACE_COUNTER_INCREMENT("rowsetid", rowset_id);
     TRACE_COUNTER_INCREMENT("max_rowsetid", max_rowset_id);

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -230,6 +230,9 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     ASSERT_EQ(kChunkSize, read(version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata1, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata1->rowsets_size(), 3);
+    EXPECT_EQ(new_tablet_metadata1->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata1->rowsets(1).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata1->rowsets(2).num_dels(), 0);
 
     ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
     // make sure delvecs have been generated
@@ -261,6 +264,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     EXPECT_EQ(new_tablet_metadata2->rowsets_size(), 1);
     EXPECT_EQ(3, new_tablet_metadata2->compaction_inputs_size());
     EXPECT_FALSE(new_tablet_metadata2->has_prev_garbage_version());
+    EXPECT_EQ(new_tablet_metadata2->rowsets(0).num_dels(), 0);
 }
 
 // test write 3 diff chunk
@@ -318,6 +322,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
     EXPECT_EQ(3, new_tablet_metadata->compaction_inputs_size());
     EXPECT_FALSE(new_tablet_metadata->has_prev_garbage_version());
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), 0);
 }
 
 // test write empty chunk
@@ -382,6 +387,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
 
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), 0);
     EXPECT_EQ(2, new_tablet_metadata->compaction_inputs_size());
     EXPECT_FALSE(new_tablet_metadata->has_prev_garbage_version());
 }

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -244,6 +244,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -336,6 +339,11 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
     ASSERT_EQ(kChunkSize * 5, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 5);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(3).num_dels(), 0);
+    EXPECT_EQ(new_tablet_metadata->rowsets(4).num_dels(), 0);
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -376,6 +384,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_multi_times) {
     // advince publish should fail, because version + 1 don't exist
     ASSERT_ERROR(publish_single_version(tablet_id, version + 2, txns.back()).status());
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -412,6 +423,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_publish_concurrent) {
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 3);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), 0);
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -472,6 +486,12 @@ TEST_P(LakePrimaryKeyPublishTest, test_resolve_conflict) {
     ASSERT_EQ(kChunkSize, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), 6);
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(1).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(2).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(3).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(4).num_dels(), kChunkSize);
+    EXPECT_EQ(new_tablet_metadata->rowsets(5).num_dels(), 0);
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
     }
@@ -552,6 +572,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
     ASSERT_EQ(kChunkSize * N, read_rows(tablet_id, version));
     ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
     EXPECT_EQ(new_tablet_metadata->rowsets_size(), N);
+    for (int i = 0; i < N; i++) {
+        EXPECT_EQ(new_tablet_metadata->rowsets(i).num_dels(), 0);
+    }
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
     }

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -54,6 +54,8 @@ message RowsetMetadataPB {
     optional int64 num_rows = 4;
     optional int64 data_size = 5;
     optional DeletePredicatePB delete_predicate = 6;
+    // approximate, BE upgrade from old version can't get exact number of dels
+    optional int64 num_dels = 7;
 }
 
 


### PR DESCRIPTION
Why I'm doing:
In cloud native table, each time publish version finish, we will calculate compaction score of this partition, and response back to FE. We calculate compaction score by current tablet meta, and expect that won't cost too much time. But in fact, in PK table, calculating compaction score could read delete vector files from S3 if meta cache missing. So if we have too many delete vector to read, it will takes too much time here.

What I'm doing:
Record `num_dels` in RowsetMeta, and try to generate `num_dels` when publish. But if we upgrade BE from old version cluster, `num_dels` in RowsetMeta could be inaccurate, so we only use it in compaction score calculation now.
Another benefit about `num_dels` is that we can do some consistency check when publish, so I add config `experimental_lake_ignore_pk_consistency_check` to control if we need this check.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
