### PR TITLE
[BugFix] copy olap table when re-analyzing

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -248,7 +248,10 @@ public class StatementPlanner {
     public static List<String> reAnalyzeStmt(QueryStatement queryStmt, Map<String, Database> dbs, ConnectContext session) {
         try {
             lock(dbs);
+            // analyze to obtain the latest table from metadata
             Analyzer.analyze(queryStmt, session);
+            // only copy the latest olap table
+            AnalyzerUtils.copyOlapTable(queryStmt, Sets.newHashSet());
             return queryStmt.getQueryRelation().getColumnOutputNames();
         } finally {
             unLock(dbs);


### PR DESCRIPTION
Why I'm doing:
https://github.com/StarRocks/starrocks/pull/35408 forget to copy olap table when re-analyzing

What I'm doing:
just add the copy olap table step

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
