### PR TITLE
[Doc] add release note 2.3.18&17

### DIFF
--- a/docs/en/release_notes/release-2.3.md
+++ b/docs/en/release_notes/release-2.3.md
@@ -4,6 +4,29 @@ displayed_sidebar: "English"
 
 # StarRocks version 2.3
 
+## 2.3.18
+
+Release date: October 11, 2023
+
+### Bug Fixes
+
+Fixed the following issues:
+
+- The bug in the third-party library librdkafka causes the load tasks of Routine Load jobs to get stuck during data loading, and newly created load tasks also fail to execute. [#28301](https://github.com/StarRocks/starrocks/pull/28301)
+- Spark or Flink connectors may fail to export data because of inaccurate memory statistics. [#31200](https://github.com/StarRocks/starrocks/pull/31200) [#30751](https://github.com/StarRocks/starrocks/pull/30751)
+- BEs crash when a Stream Load job uses the keyword `if`. [#31926](https://github.com/StarRocks/starrocks/pull/31926)
+- An error `"get TableMeta failed from TNetworkAddress"` is reported when data is loaded into partitioned StarRocks external tables.  [#30466](https://github.com/StarRocks/starrocks/pull/30466)
+
+## 2.3.17
+
+Release date: September 4, 2023
+
+### Bug Fixes
+
+Fixed the following issue:
+
+- A Routine Load job fails to consume data. [#29883](https://github.com/StarRocks/starrocks/issues/29883) [#18550](https://github.com/StarRocks/starrocks/pull/18550)
+
 ## 2.3.16
 
 Release date: August 4, 2023

--- a/docs/zh/release_notes/release-2.3.md
+++ b/docs/zh/release_notes/release-2.3.md
@@ -15,7 +15,7 @@ displayed_sidebar: "Chinese"
 - 第三方库 librdkafka 的缺陷，会导致 Routine Load 中导入任务消费时被卡住，新建的导入任务也无法执行。[#28301](https://github.com/StarRocks/starrocks/pull/28301)
 - 由于内存统计不准确有几率会导致 Spark 或者 Flink connector 读取数据报错。[#31200](https://github.com/StarRocks/starrocks/pull/31200) [#30751](https://github.com/StarRocks/starrocks/pull/30751)
 - Stream Load 中包括 `if` 关键字时，会引起 BE crash。[#31926](https://github.com/StarRocks/starrocks/pull/31926)
-- 向有分区的 StarRocks 外表写入数据时有报错 `"get TableMeta failed from TNetworkAddress"`。[#30466](https://github.com/StarRocks/starrocks/pull/30466) 
+- 向有分区的 StarRocks 外表写入数据时有报错 `"get TableMeta failed from TNetworkAddress"`。[#30466](https://github.com/StarRocks/starrocks/pull/30466)
 
 ## 2.3.17
 
@@ -25,7 +25,7 @@ displayed_sidebar: "Chinese"
 
 修复了如下问题：
 
-- Routine Load 消费失败。[#29883](https://github.com/StarRocks/starrocks/issues/29883) [#18550](
+- Routine Load 消费失败。[#29883](https://github.com/StarRocks/starrocks/issues/29883) [#18550](https://github.com/StarRocks/starrocks/pull/18550)
 
 ## 2.3.16
 

--- a/docs/zh/release_notes/release-2.3.md
+++ b/docs/zh/release_notes/release-2.3.md
@@ -4,6 +4,29 @@ displayed_sidebar: "Chinese"
 
 # StarRocks version 2.3
 
+## 2.3.18
+
+发布日期： 2023 年 10 月 11 日
+
+### 问题修复
+
+修复了如下问题：
+
+- 第三方库 librdkafka 的缺陷，会导致 Routine Load 中导入任务消费时被卡住，新建的导入任务也无法执行。[#28301](https://github.com/StarRocks/starrocks/pull/28301)
+- 由于内存统计不准确有几率会导致 Spark 或者 Flink connector 读取数据报错。[#31200](https://github.com/StarRocks/starrocks/pull/31200) [#30751](https://github.com/StarRocks/starrocks/pull/30751)
+- Stream Load 中包括 `if` 关键字时，会引起 BE crash。[#31926](https://github.com/StarRocks/starrocks/pull/31926)
+- 向有分区的 StarRocks 外表写入数据时有报错 `"get TableMeta failed from TNetworkAddress"`。[#30466](https://github.com/StarRocks/starrocks/pull/30466) 
+
+## 2.3.17
+
+发布日期： 2023 年 9 月 4 日
+
+### 问题修复
+
+修复了如下问题：
+
+- Routine Load 消费失败。[#29883](https://github.com/StarRocks/starrocks/issues/29883) [#18550](
+
 ## 2.3.16
 
 发布日期： 2023 年 8 月 4 日


### PR DESCRIPTION
Why I'm doing:
The release notes 2.3.18&17 are missing on our doc website.
What I'm doing:
To  add release notes 2.3.18&17.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5