### PR TITLE
[Feature] support set_var hint for LOAD statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -725,6 +725,9 @@ public class StmtExecutor {
         } else if (parsedStmt instanceof DmlStmt) {
             DmlStmt dml = (DmlStmt) parsedStmt;
             optHints = dml.getOptHints();
+        } else if (parsedStmt instanceof DdlStmt) {
+            DdlStmt ddl = (DdlStmt) parsedStmt;
+            optHints = ddl.getOptHints();
         }
 
         if (MapUtils.isNotEmpty(optHints)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DdlStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DdlStmt.java
@@ -18,7 +18,10 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.RedirectStatus;
 import com.starrocks.sql.parser.NodePosition;
 
+import java.util.Map;
+
 public abstract class DdlStmt extends StatementBase {
+    private Map<String, String> optHints;
 
     protected DdlStmt(NodePosition pos) {
         super(pos);
@@ -32,5 +35,13 @@ public abstract class DdlStmt extends StatementBase {
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
         return visitor.visitDDLStatement(this, context);
+    }
+
+    public Map<String, String> getOptHints() {
+        return optHints;
+    }
+
+    public void setOptHints(Map<String, String> optHints) {
+        this.optHints = optHints;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -2350,7 +2350,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         if (context.system != null) {
             cluster = ((Identifier) visit(context.system)).getValue();
         }
-        return new LoadStmt(label, dataDescriptions, brokerDesc, cluster, properties, pos);
+        LoadStmt stmt = new LoadStmt(label, dataDescriptions, brokerDesc, cluster, properties, pos);
+        stmt.setOptHints(visitVarHints(context.setVarHint()));
+        return stmt;
     }
 
     private LabelName getLabelName(StarRocksParser.LabelNameContext context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -1258,12 +1258,12 @@ typeList
 // ------------------------------------------- Load Statement ----------------------------------------------------------
 
 loadStatement
-    : LOAD LABEL label=labelName
+    : LOAD setVarHint* LABEL label=labelName
         data=dataDescList?
         broker=brokerDesc?
         (BY system=identifierOrString)?
         (PROPERTIES props=propertyList)?
-    | LOAD LABEL label=labelName
+    | LOAD setVarHint* LABEL label=labelName
         data=dataDescList?
         resource=resourceDesc
         (PROPERTIES props=propertyList)?


### PR DESCRIPTION
Why I'm doing:
Add support set_var in the LOAD statement

What I'm doing:
```
LOAD /*+set_var(enable_adaptive_sink_dop=false)*/ "
LABEL label0 (DATA INFILE('/path1/file') INTO TABLE tbl);
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
