### PR TITLE
[BugFix] MV creation maybe failed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/MaterializedViewHandler.java
@@ -344,6 +344,8 @@ public class MaterializedViewHandler extends AlterHandler {
         long dbId = db.getId();
         long tableId = olapTable.getId();
         int baseSchemaHash = olapTable.getSchemaHashByIndexId(baseIndexId);
+        // mvSchemaVersion will keep same with the src MaterializedIndex
+        int mvSchemaVersion = olapTable.getIndexMetaByIndexId(baseIndexId).getSchemaVersion();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         long jobId = globalStateMgr.getNextId();
         long mvIndexId = globalStateMgr.getNextId();
@@ -360,7 +362,7 @@ public class MaterializedViewHandler extends AlterHandler {
                     "mv colocate optimization.", olapTable.getName()));
         }
         RollupJobV2 mvJob = new RollupJobV2(jobId, dbId, tableId, olapTable.getName(), timeoutMs,
-                baseIndexId, mvIndexId, baseIndexName, mvName,
+                baseIndexId, mvIndexId, baseIndexName, mvName, mvSchemaVersion, 
                 mvColumns, whereClause, baseSchemaHash, mvSchemaHash,
                 mvKeysType, mvShortKeyColumnCount, origStmt, viewDefineSql, isColocateMv);
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AlterReplicaTask.java
@@ -148,11 +148,11 @@ public class AlterReplicaTask extends AgentTask implements Runnable {
     public static AlterReplicaTask rollupLocalTablet(long backendId, long dbId, long tableId, long partitionId,
             long rollupIndexId, long rollupTabletId, long baseTabletId,
             long newReplicaId, int newSchemaHash, int baseSchemaHash, long version,
-            long jobId, RollupJobV2Params rollupJobV2Params) {
+            long jobId, RollupJobV2Params rollupJobV2Params, List<Column> baseSchemaColumns) {
         return new AlterReplicaTask(backendId, dbId, tableId, partitionId, rollupIndexId, rollupTabletId,
                 baseTabletId, newReplicaId, newSchemaHash, baseSchemaHash, version, jobId, AlterJobV2.JobType.ROLLUP,
                 TTabletType.TABLET_TYPE_DISK, 0, null,
-                Collections.emptyList(), rollupJobV2Params);
+                baseSchemaColumns, rollupJobV2Params);
     }
 
     private AlterReplicaTask(long backendId, long dbId, long tableId, long partitionId, long rollupIndexId, long rollupTabletId,

--- a/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/RollupJobV2Test.java
@@ -258,7 +258,7 @@ public class RollupJobV2Test extends DDLTestBase {
                 new ColumnDef.DefaultValueDef(true, new StringLiteral("1")), "");
         columns.add(column);
         RollupJobV2 rollupJobV2 = new RollupJobV2(1, 1, 1, "test", 1, 1,
-                1, "test", "rollup", columns, null, 1, 1,
+                1, "test", "rollup", 0, columns, null, 1, 1,
                 KeysType.AGG_KEYS, keysCount,
                 new OriginStatement("create materialized view rollup as select bitmap_union(to_bitmap(c1)) from test",
                         0), "", false);

--- a/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/task/AlterReplicaTaskTest.java
@@ -82,7 +82,7 @@ public class AlterReplicaTaskTest {
     @Test
     public void testRollupLocalTablet() {
         AlterReplicaTask task = AlterReplicaTask.rollupLocalTablet(1, 2, 3, 4, 5, 6,
-                7, 8, 9, 10, 11, 12, null);
+                7, 8, 9, 10, 11, 12, null, null);
 
         Assert.assertEquals(1, task.getBackendId());
         Assert.assertEquals(2, task.getDbId());

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -967,7 +967,7 @@ class StarrocksSQLApiLib(object):
         res = self.execute_sql(sql, True)
         tools.assert_false(str(res["result"]).find(mv_name) > 0, "assert mv %s is not found" % (mv_name))
 
-    def wait_alter_table_finish(self, alter_type="COLUMN"):
+    def wait_alter_table_finish(self, alter_type="COLUMN", off=9):
         """
         wait alter table job finish and return status
         """
@@ -981,7 +981,7 @@ class StarrocksSQLApiLib(object):
             if (not res["status"]) or len(res["result"]) <= 0:
                 return ""
 
-            status = res["result"][0][9]
+            status = res["result"][0][off]
             if status == "FINISHED" or status == "CANCELLED" or status == "":
                 if sleep_time <= 1:
                     time.sleep(1)

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -625,8 +625,9 @@ select * from tab1;
 500	k2_500	500	500	500	v4_500	v5_500
 600	k2_600	600	600	600	v4_600	v5_600
 -- !result
-drop table tab1
-drop database test_fast_schema_evolution_and_mv
+drop table tab1;
 -- result:
-E: (1064, "Getting syntax error at line 2, column 0. Detail message: Unexpected input 'drop', the most similar input is {<EOF>, ';'}.")
+-- !result
+drop database test_fast_schema_evolution_and_mv;
+-- result:
 -- !result

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -520,3 +520,113 @@ drop table tab1;
 drop database test_fast_schema_evolution_and_alter;
 -- result:
 -- !result
+-- name: test_fast_schema_evolution_and_mv
+create database test_fast_schema_evolution_and_mv;
+-- result:
+-- !result
+use test_fast_schema_evolution_and_mv;
+-- result:
+-- !result
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+-- result:
+-- !result
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+-- result:
+-- !result
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+300	k2_300	300	300	300	v4_300	v5_300
+400	k2_400	400	400	400	v4_400	v5_400
+500	k2_500	500	500	500	v4_500	v5_500
+600	k2_600	600	600	600	v4_600	v5_600
+-- !result
+CREATE MATERIALIZED VIEW mv1
+    AS
+        SELECT
+            v5,
+            v4,
+            k1,
+            k2
+        FROM tab1;
+-- result:
+-- !result
+function: wait_alter_table_finish("ROLLUP", 8)
+-- result:
+None
+-- !result
+ALTER TABLE tab1 DROP COLUMN v5;
+-- result:
+E: (1064, 'Unexpected exception: No key column left. index[mv1]')
+-- !result
+function: wait_alter_table_finish()
+-- result:
+
+-- !result
+ALTER TABLE tab1 ADD COLUMN v5 tinyint;
+-- result:
+E: (1064, 'Unexpected exception: Repeatedly add same column with different definition: v5')
+-- !result
+function: wait_alter_table_finish()
+-- result:
+
+-- !result
+CREATE MATERIALIZED VIEW mv2
+    AS
+        SELECT
+            v5,
+            v4,
+            k1,
+            k2
+        FROM tab1;
+-- result:
+-- !result
+function: wait_alter_table_finish("ROLLUP", 8)
+-- result:
+None
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+300	k2_300	300	300	300	v4_300	v5_300
+400	k2_400	400	400	400	v4_400	v5_400
+500	k2_500	500	500	500	v4_500	v5_500
+600	k2_600	600	600	600	v4_600	v5_600
+-- !result
+drop table tab1
+drop database test_fast_schema_evolution_and_mv
+-- result:
+E: (1064, "Getting syntax error at line 2, column 0. Detail message: Unexpected input 'drop', the most similar input is {<EOF>, ';'}.")
+-- !result

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -269,5 +269,5 @@ function: wait_alter_table_finish("ROLLUP", 8)
 
 select * from tab1;
 
-drop table tab1
-drop database test_fast_schema_evolution_and_mv
+drop table tab1;
+drop database test_fast_schema_evolution_and_mv;

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -211,3 +211,63 @@ select * from tab1;
 
 drop table tab1;
 drop database test_fast_schema_evolution_and_alter;
+
+
+-- name: test_fast_schema_evolution_and_mv
+create database test_fast_schema_evolution_and_mv;
+use test_fast_schema_evolution_and_mv;
+
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+select * from tab1;
+
+CREATE MATERIALIZED VIEW mv1
+    AS
+        SELECT
+            v5,
+            v4,
+            k1,
+            k2
+        FROM tab1;
+function: wait_alter_table_finish("ROLLUP", 8)
+
+ALTER TABLE tab1 DROP COLUMN v5;
+function: wait_alter_table_finish()
+
+ALTER TABLE tab1 ADD COLUMN v5 tinyint;
+function: wait_alter_table_finish()
+
+CREATE MATERIALIZED VIEW mv2
+    AS
+        SELECT
+            v5,
+            v4,
+            k1,
+            k2
+        FROM tab1;
+function: wait_alter_table_finish("ROLLUP", 8)
+
+select * from tab1;
+
+drop table tab1
+drop database test_fast_schema_evolution_and_mv


### PR DESCRIPTION
Why I'm doing:

After support fast schema evolution, the tablet schema in BE maybe not the latest. So we will check the column unique id 
 when we create a new tablet(alter/rollup) to avoid serious issue. However, if we drop a column first and add a new column with same column name secondly, if the tablet schema in BE is not the latest, the check will failed because these two columns with same column name are not the same column. So we should first check schema version, but when we create a rollup, the schema version is not set which cause check failed.

What I'm doing:

Set schema version for create rollup task.

Fixes https://github.com/StarRocks/StarRocksTest/issues/4855

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
