### PR TITLE
[BugFix] Add a dummy cache handle to avoid dependency error if build without starcache. (#35391)

### DIFF
--- a/be/src/block_cache/cache_handle.h
+++ b/be/src/block_cache/cache_handle.h
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifdef WITH_STARCACHE
+#include "starcache/obj_handle.h"
+#endif
+
+namespace starrocks {
+
+class DummyCacheHandle {
+public:
+    DummyCacheHandle() = default;
+    ~DummyCacheHandle() = default;
+
+    const void* ptr() { return nullptr; }
+    void release() {}
+};
+
+// We use the `starcache::ObjectHandle` directly because implementing a new one seems unnecessary.
+// Importing the starcache headers here is not graceful, but the `cachelib` doesn't support
+// object cache and we'll deprecate it for some performance reasons. Now there is no need to
+// pay too much attention to the compatibility and upper-level abstraction of the cachelib interface.
+#ifdef WITH_STARCACHE
+using CacheHandle = starcache::ObjectHandle;
+#else
+using CacheHandle = DummyCacheHandle;
+#endif
+
+} // namespace starrocks

--- a/be/src/block_cache/io_buffer.h
+++ b/be/src/block_cache/io_buffer.h
@@ -16,8 +16,6 @@
 
 #include <butil/iobuf.h>
 
-#include "starcache/obj_handle.h"
-
 namespace starrocks {
 
 class IOBuffer {
@@ -48,11 +46,5 @@ public:
 private:
     butil::IOBuf _buf;
 };
-
-// We use the `starcache::ObjectHandle` directly because implementing a new one seems unnecessary.
-// Importing the starcache headers here is not graceful, but the `cachelib` doesn't support
-// object cache and we'll deprecate it for some performance reasons. Now there is no need to
-// pay too much attention to the compatibility and upper-level abstraction of the cachelib interface.
-using CacheHandle = starcache::ObjectHandle;
 
 } // namespace starrocks

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "block_cache/cache_handle.h"
 #include "block_cache/cache_options.h"
 #include "block_cache/io_buffer.h"
 #include "common/status.h"

--- a/be/src/formats/parquet/file_reader.cpp
+++ b/be/src/formats/parquet/file_reader.cpp
@@ -72,10 +72,13 @@ void FileReader::_build_metacache_key() {
 
 Status FileReader::init(HdfsScannerContext* ctx) {
     _scanner_ctx = ctx;
+#ifdef WITH_STARCACHE
+    // Only support file metacache in starcache engine
     if (ctx->use_file_metacache && config::datacache_enable) {
         _build_metacache_key();
         _cache = BlockCache::instance();
     }
+#endif
     RETURN_IF_ERROR(_get_footer());
 
     if (_scanner_ctx->iceberg_schema != nullptr && _file_metadata->schema().exist_filed_id()) {


### PR DESCRIPTION
(Cherry-picked from https://github.com/StarRocks/starrocks/pull/35391)

Why I'm doing:
As we depend on the starcache object handle in parquet file reader to support footer cache, which make the starcache be a strong dependency to starrocks and must be included. So, if we build the starrocks with WITH_STARCACHE=OFF, there will be "no such file" error happen.

What I'm doing:
We create a dummy cache handle in this PR to decouple starrocks and starcache if build without starcache. So, when building starrocks with WITH_STARCACHE=OFF, we use the dummy cache handle instead of starcache object handle, to avoid the dpendency building errors.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
