### PR TITLE
[BugFix]Backport pr 31747 to branch 3.1

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -41,7 +41,7 @@ namespace starrocks::config {
 CONF_Int32(cluster_id, "-1");
 // The port on which ImpalaInternalService is exported.
 CONF_Int32(be_port, "9060");
-CONF_Int32(thrift_port, "9060");
+CONF_Int32(thrift_port, "0");
 
 // The port for brpc.
 CONF_Int32(brpc_port, "8060");

--- a/be/src/service/service.h
+++ b/be/src/service/service.h
@@ -28,4 +28,4 @@ void wait_for_fragments_finish(ExecEnv* exec_env, size_t max_loop_cnt_cfg);
 } // namespace starrocks
 
 void start_cn();
-void start_be();
+void start_be(bool as_cn=false);

--- a/be/src/service/service.h
+++ b/be/src/service/service.h
@@ -28,4 +28,4 @@ void wait_for_fragments_finish(ExecEnv* exec_env, size_t max_loop_cnt_cfg);
 } // namespace starrocks
 
 void start_cn();
-void start_be(bool as_cn=false);
+void start_be(bool as_cn = false);

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -28,26 +28,25 @@ DECLARE_int64(socket_max_unwritten_bytes);
 
 } // namespace brpc
 
-void start_be() {
+void start_be(bool as_cn) {
     using starrocks::BackendService;
 
     auto* exec_env = starrocks::ExecEnv::GetInstance();
 
     // Begin to start services
     // 1. Start thrift server with 'be_port'.
-    int thrift_port = config::be_port;
-    if (as_cn && config::thrift_port != 0) {
-        thrift_port = config::thrift_port;
+    int thrift_port = starrocks::config::be_port;
+    if (as_cn && starrocks::config::thrift_port != 0) {
+        thrift_port = starrocks::config::thrift_port;
         LOG(WARNING) << "'thrift_port' is deprecated, please update be.conf to use 'be_port' instead!";
     }
     auto thrift_server = BackendService::create<BackendService>(exec_env, thrift_port);
-    
+
     if (auto status = thrift_server->start(); !status.ok()) {
         LOG(ERROR) << "Fail to start BackendService thrift server on port " << thrift_port << ": " << status;
-        shutdown_logging();
+        starrocks::shutdown_logging();
         exit(1);
     }
-
 
     // 2. Start brpc services.
     brpc::FLAGS_max_body_size = starrocks::config::brpc_max_body_size;

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -35,13 +35,19 @@ void start_be() {
 
     // Begin to start services
     // 1. Start thrift server with 'be_port'.
-    auto thrift_server = BackendService::create<BackendService>(exec_env, starrocks::config::be_port);
+    int thrift_port = config::be_port;
+    if (as_cn && config::thrift_port != 0) {
+        thrift_port = config::thrift_port;
+        LOG(WARNING) << "'thrift_port' is deprecated, please update be.conf to use 'be_port' instead!";
+    }
+    auto thrift_server = BackendService::create<BackendService>(exec_env, thrift_port);
+    
     if (auto status = thrift_server->start(); !status.ok()) {
-        LOG(ERROR) << "Fail to start BackendService thrift server on port " << starrocks::config::be_port << ": "
-                   << status;
-        starrocks::shutdown_logging();
+        LOG(ERROR) << "Fail to start BackendService thrift server on port " << thrift_port << ": " << status;
+        shutdown_logging();
         exit(1);
     }
+
 
     // 2. Start brpc services.
     brpc::FLAGS_max_body_size = starrocks::config::brpc_max_body_size;

--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -358,7 +358,7 @@ int main(int argc, char** argv) {
     }
 
     // cn need to support all ops for cloudnative table, so just start_be
-    start_be();
+    start_be(as_cn);
 
     if (starrocks::k_starrocks_exit_quick.load()) {
         LOG(INFO) << "BE is shutting down，will exit quickly";

--- a/conf/cn.conf
+++ b/conf/cn.conf
@@ -19,7 +19,7 @@
 sys_log_level = INFO
 
 # ports for admin, web, heartbeat service 
-thrift_port = 9060
+be_port = 9060
 be_http_port = 8040
 heartbeat_service_port = 9050
 brpc_port = 8060


### PR DESCRIPTION
Why I'm doing:

forget backport pr: https://github.com/StarRocks/starrocks/pull/31747/files to branch-3.1

What I'm doing:
manually backport pr: https://github.com/StarRocks/starrocks/pull/31747/files to branch-3.1

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
