### PR TITLE
[Enhancement] collect statistics immediately when fe not cached table statistics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -240,7 +240,8 @@ public class StatisticsCollectJobFactory {
             List<ConnectorTableColumnStats> validColumnStatistics = columnStatisticList.stream().
                     filter(columnStatistic -> !columnStatistic.isUnknown()).collect(Collectors.toList());
 
-            long tableRowCount = Config.statistic_auto_collect_small_table_rows;
+            // use small table row count as default table row count
+            long tableRowCount = Config.statistic_auto_collect_small_table_rows - 1;
             if (!validColumnStatistics.isEmpty()) {
                 tableRowCount = validColumnStatistics.get(0).getRowCount();
             }


### PR DESCRIPTION
Why I'm doing:
external analyze job do not collect immediately when insert new rows into table
What I'm doing:
modify default estimate row count, to collect immediately when insert new rows into table

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
