### PR TITLE
[Enhancement] improve multi-join rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -2049,6 +2049,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         return optimizerMaterializedViewTimeLimitMillis;
     }
 
+    public void setOptimizerMaterializedViewTimeLimitMillis(long millis) {
+        this.optimizerMaterializedViewTimeLimitMillis = millis;
+    }
+
     public boolean getEnableGroupbyUseOutputAlias() {
         return enableGroupbyUseOutputAlias;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -452,6 +452,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE =
             "enable_materialized_view_view_delta_rewrite";
 
+    public static final String MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT =
+            "materialized_view_join_same_table_permutation_limit";
+
     public static final String ENABLE_MATERIALIZED_VIEW_SINGLE_TABLE_VIEW_DELTA_REWRITE =
             "enable_materialized_view_single_table_view_delta_rewrite";
     public static final String ANALYZE_FOR_MV = "analyze_mv";
@@ -1293,6 +1296,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_VIEW_DELTA_REWRITE)
     private boolean enableMaterializedViewViewDeltaRewrite = true;
+
+    @VarAttr(name = MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT, flag = VariableMgr.INVISIBLE)
+    private int materializedViewJoinSameTablePermutationLimit = 5;
 
     @VarAttr(name = MATERIALIZED_VIEW_REWRITE_MODE)
     private String materializedViewRewriteMode = MaterializedViewRewriteMode.MODE_DEFAULT;
@@ -2539,6 +2545,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableMaterializedViewViewDeltaRewrite(boolean enableMaterializedViewViewDeltaRewrite) {
         this.enableMaterializedViewViewDeltaRewrite = enableMaterializedViewViewDeltaRewrite;
+    }
+
+    public int getMaterializedViewJoinSameTablePermutationLimit() {
+        return materializedViewJoinSameTablePermutationLimit;
     }
 
     public boolean isEnableMaterializedViewSingleTableViewDeltaRewrite() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -271,6 +271,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String NEW_PLANNER_OPTIMIZER_TIMEOUT = "new_planner_optimize_timeout";
     public static final String ENABLE_GROUPBY_USE_OUTPUT_ALIAS = "enable_groupby_use_output_alias";
     public static final String ENABLE_QUERY_DUMP = "enable_query_dump";
+    public static final String OPTIMIZER_MATERIALIZED_VIEW_TIMELIMIT = "optimizer_materialized_view_timelimit";
 
     public static final String CBO_MAX_REORDER_NODE_USE_EXHAUSTIVE = "cbo_max_reorder_node_use_exhaustive";
     public static final String CBO_ENABLE_DP_JOIN_REORDER = "cbo_enable_dp_join_reorder";
@@ -976,6 +977,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = NEW_PLANNER_OPTIMIZER_TIMEOUT)
     private long optimizerExecuteTimeout = 3000;
+
+    @VariableMgr.VarAttr(name = OPTIMIZER_MATERIALIZED_VIEW_TIMELIMIT)
+    private long optimizerMaterializedViewTimeLimitMillis = 1000;
 
     @VariableMgr.VarAttr(name = ENABLE_QUERY_DUMP)
     private boolean enableQueryDump = false;
@@ -2039,6 +2043,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setOptimizerExecuteTimeout(long optimizerExecuteTimeout) {
         this.optimizerExecuteTimeout = optimizerExecuteTimeout;
+    }
+
+    public long getOptimizerMaterializedViewTimeLimitMillis() {
+        return optimizerMaterializedViewTimeLimitMillis;
     }
 
     public boolean getEnableGroupbyUseOutputAlias() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/ErrorType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/ErrorType.java
@@ -18,7 +18,8 @@ public enum ErrorType {
     USER_ERROR(0),
     INTERNAL_ERROR(1),
     UNSUPPORTED(2),
-    META_NOT_FOUND(3);
+    META_NOT_FOUND(3),
+    RULE_EXHAUSTED(4);
 
     private final int code;
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
@@ -26,11 +27,13 @@ import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.dump.DumpInfo;
 import com.starrocks.sql.optimizer.rule.RuleSet;
+import com.starrocks.sql.optimizer.rule.RuleType;
 import com.starrocks.sql.optimizer.task.SeriallyTaskScheduler;
 import com.starrocks.sql.optimizer.task.TaskContext;
 import com.starrocks.sql.optimizer.task.TaskScheduler;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -51,6 +54,7 @@ public class OptimizerContext {
     private long updateTableId = -1;
     private boolean enableLeftRightJoinEquivalenceDerive = true;
     private final Stopwatch optimizerTimer = Stopwatch.createStarted();
+    private final Map<RuleType, Stopwatch> ruleWatchMap = Maps.newHashMap();
 
     @VisibleForTesting
     public OptimizerContext(Memo memo, ColumnRefFactory columnRefFactory) {
@@ -167,6 +171,13 @@ public class OptimizerContext {
 
     public long optimizerElapsedMs() {
         return optimizerTimer.elapsed(TimeUnit.MILLISECONDS);
+    }
+
+    public boolean ruleExhausted(RuleType ruleType) {
+        Stopwatch watch = ruleWatchMap.computeIfAbsent(ruleType, (k) -> Stopwatch.createStarted());
+        long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
+        long timeLimit = sessionVariable.getOptimizerMaterializedViewTimeLimitMillis();
+        return elapsed > timeLimit;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -176,7 +176,8 @@ public class OptimizerContext {
     public boolean ruleExhausted(RuleType ruleType) {
         Stopwatch watch = ruleWatchMap.computeIfAbsent(ruleType, (k) -> Stopwatch.createStarted());
         long elapsed = watch.elapsed(TimeUnit.MILLISECONDS);
-        long timeLimit = sessionVariable.getOptimizerMaterializedViewTimeLimitMillis();
+        long timeLimit = Math.min(sessionVariable.getOptimizerMaterializedViewTimeLimitMillis(),
+                sessionVariable.getOptimizerExecuteTimeout());
         return elapsed > timeLimit;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -76,6 +76,11 @@ public class OptimizerTraceUtil {
         });
     }
 
+    public static void logRuleExhausted(OptimizerContext ctx, Rule rule) {
+        Tracers.log(Tracers.Module.OPTIMIZER,
+                args -> String.format("[TRACE QUERY %s] RULE %s exhausted \n", ctx.getQueryId(), rule));
+    }
+
     public static void logApplyRule(OptimizerContext ctx, Rule rule,
                                     OptExpression oldExpression, List<OptExpression> newExpressions) {
         Tracers.log(Tracers.Module.OPTIMIZER, args -> {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/pattern/Pattern.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.operator.pattern;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.starrocks.sql.optimizer.GroupExpression;
@@ -27,7 +28,7 @@ import java.util.List;
  * Pattern is used in rules as a placeholder for group
  */
 public class Pattern {
-    private static final ImmutableList<OperatorType> ALL_SCAN_TYPES = ImmutableList.<OperatorType>builder()
+    public static final ImmutableList<OperatorType> ALL_SCAN_TYPES = ImmutableList.<OperatorType>builder()
             .add(OperatorType.LOGICAL_OLAP_SCAN)
             .add(OperatorType.LOGICAL_HIVE_SCAN)
             .add(OperatorType.LOGICAL_ICEBERG_SCAN)
@@ -70,6 +71,8 @@ public class Pattern {
     }
 
     public Pattern addChildren(Pattern... children) {
+        Preconditions.checkArgument(opType != OperatorType.PATTERN_MULTIJOIN,
+                "MULTI_JOIN cannot has children");
         this.children.addAll(Arrays.asList(children));
         return this;
     }
@@ -91,10 +94,6 @@ public class Pattern {
     }
 
     public boolean matchWithoutChild(GroupExpression expression) {
-        return matchWithoutChild(expression, 0);
-    }
-
-    public boolean matchWithoutChild(GroupExpression expression, int level) {
         if (expression == null) {
             return false;
         }
@@ -112,7 +111,7 @@ public class Pattern {
             return true;
         }
 
-        if (isPatternMultiJoin() && isMultiJoin(expression.getOp().getOpType(), level)) {
+        if (isPatternMultiJoin() && isMultiJoin(expression.getOp().getOpType())) {
             return true;
         }
 
@@ -140,8 +139,8 @@ public class Pattern {
         return getOpType().equals(expression.getOp().getOpType());
     }
 
-    private boolean isMultiJoin(OperatorType operatorType, int level) {
-        if (ALL_SCAN_TYPES.contains(operatorType) && level != 0) {
+    private boolean isMultiJoin(OperatorType operatorType) {
+        if (ALL_SCAN_TYPES.contains(operatorType)) {
             return true;
         } else if (operatorType.equals(OperatorType.LOGICAL_JOIN)) {
             return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
@@ -235,15 +235,11 @@ public class Binder {
 
         private boolean hasRewrittenMvScan(Group g) {
             for (GroupExpression ge : g.getLogicalExpressions()) {
-                if ((isScanOp(ge.getOp().getOpType()))) {
+                if ((ge.getOp().getOpType() == OperatorType.LOGICAL_OLAP_SCAN)) {
                     return true;
                 }
             }
             return false;
-        }
-
-        private boolean isScanOp(OperatorType operatorType) {
-            return Pattern.ALL_SCAN_TYPES.contains(operatorType);
         }
 
         private boolean isMultiJoinGE(GroupExpression ge) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Binder.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rule;
 
 import com.google.common.collect.Lists;
@@ -90,11 +89,10 @@ public class Binder {
      * Pattern tree match groupExpression tree
      */
     private OptExpression match(Pattern pattern, GroupExpression groupExpression) {
-        return match(pattern, groupExpression, 0);
-    }
-
-    private OptExpression match(Pattern pattern, GroupExpression groupExpression, int level) {
-        if (!pattern.matchWithoutChild(groupExpression, level)) {
+        if (pattern.isPatternMultiJoin()) {
+            return new MultiJoinBinder().match(groupExpression);
+        }
+        if (!pattern.matchWithoutChild(groupExpression)) {
             return null;
         }
 
@@ -104,18 +102,11 @@ public class Binder {
         int patternIndex = 0;
         int groupExpressionIndex = 0;
 
-        while ((pattern.isPatternMultiJoin() || patternIndex < pattern.children().size())
-                && groupExpressionIndex < groupExpression.getInputs().size()) {
+        while (patternIndex < pattern.children().size() && groupExpressionIndex < groupExpression.getInputs().size()) {
             trace();
             Group group = groupExpression.getInputs().get(groupExpressionIndex);
-            Pattern childPattern;
-            if (pattern.isPatternMultiJoin()) {
-                childPattern = Pattern.create(OperatorType.PATTERN_MULTIJOIN);
-            } else {
-                childPattern = pattern.childAt(patternIndex);
-            }
-            level = pattern.isPatternMultiJoin() && childPattern.isPatternMultiJoin() ? level + 1 : 0;
-            OptExpression opt = match(childPattern, extractGroupExpression(childPattern, group), level);
+            Pattern childPattern = pattern.childAt(patternIndex);
+            OptExpression opt = match(childPattern, extractGroupExpression(childPattern, group));
 
             if (opt == null) {
                 return null;
@@ -123,9 +114,9 @@ public class Binder {
                 resultInputs.add(opt);
             }
 
-            if (!(pattern.isPatternMultiJoin() || (childPattern.isPatternMultiLeaf()
-                    && (groupExpression.getInputs().size() - groupExpressionIndex) >
-                    (pattern.children().size() - patternIndex)))) {
+            if (!(childPattern.isPatternMultiLeaf() &&
+                    groupExpression.getInputs().size() - groupExpressionIndex >
+                            pattern.children().size() - patternIndex)) {
                 patternIndex++;
             }
 
@@ -159,6 +150,76 @@ public class Binder {
                 return null;
             }
             return group.getLogicalExpressions().get(valueIndex);
+        }
+    }
+
+    /**
+     * Expression binding for MULTI_JOIN, which contains only JOIN/SCAN nodes
+     * <p>
+     * NOTE: Why not match using regular pattern ?
+     * 1. Regular matching cannot bind the tree but only the partial expression. But MULTI_JOIN needs to extract
+     * the entire tree
+     * 2. Regular matching is extremely slow in this case since it needs to recursive descent the tree, build the
+     * binding state and check the expression at the same time. But MULTI_JOIN could enumerate the GE without any check
+     */
+    class MultiJoinBinder {
+
+        public OptExpression match(GroupExpression ge) {
+            // 1. Check if the entire tree is MULTI_JOIN
+            // 2. Enumerate GE
+            if (ge == null || !isMultiJoin(ge)) {
+                return null;
+            }
+
+            return enumerate(ge);
+        }
+
+        private OptExpression enumerate(GroupExpression ge) {
+            if (ge == null) {
+                return null;
+            }
+            List<OptExpression> resultInputs = Lists.newArrayList();
+
+            int groupExpressionIndex = 0;
+            while (groupExpressionIndex < ge.getInputs().size()) {
+                trace();
+                Group group = ge.getInputs().get(groupExpressionIndex);
+                OptExpression opt = enumerate(extractGroupExpression(group));
+
+                if (opt == null) {
+                    return null;
+                } else {
+                    resultInputs.add(opt);
+                }
+
+                groupExpressionIndex++;
+            }
+
+            return new OptExpression(ge, resultInputs);
+        }
+
+        private GroupExpression extractGroupExpression(Group group) {
+            int valueIndex = groupExpressionIndex.get(groupTraceKey);
+            if (valueIndex >= group.getLogicalExpressions().size()) {
+                groupExpressionIndex.remove(groupTraceKey);
+                return null;
+            }
+            return group.getLogicalExpressions().get(valueIndex);
+        }
+
+        private boolean isMultiJoin(GroupExpression ge) {
+            return ge.getOp().getOpType() == OperatorType.LOGICAL_JOIN && isMultiJoinRecursive(ge);
+        }
+
+        private boolean isMultiJoinRecursive(GroupExpression ge) {
+            if (!isMultiJoinOp(ge.getOp().getOpType())) {
+                return false;
+            }
+            return ge.getInputs().stream().allMatch(x -> isMultiJoinRecursive(x.getFirstLogicalExpression()));
+        }
+
+        private boolean isMultiJoinOp(OperatorType operatorType) {
+            return Pattern.ALL_SCAN_TYPES.contains(operatorType) || operatorType.equals(OperatorType.LOGICAL_JOIN);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Rule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/Rule.java
@@ -71,6 +71,14 @@ public abstract class Rule {
      */
     public abstract List<OptExpression> transform(OptExpression input, OptimizerContext context);
 
+    /**
+     * For some rules it could be treated as a best-effort optimization, which means it could give up the optimization
+     * if it takes too much time.
+     */
+    public boolean exhausted(OptimizerContext context) {
+        return false;
+    }
+
     @Override
     public String toString() {
         return type.name() + " " + type.id();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -42,12 +42,17 @@ import com.starrocks.catalog.UniqueConstraint;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.StringUtils;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.PermutationGenerator;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.OptimizerTraceUtil;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -2363,7 +2368,20 @@ public class MaterializedViewRewriter {
         }
     }
 
-    public static List<List<Integer>> getPermutationsOfTableIds(List<Integer> tableIds, int n) {
+    // TODO: optimize the search algorithm to prune search space
+    private List<List<Integer>> getPermutationsOfTableIds(List<Integer> tableIds, int n) {
+        ConnectContext context = ConnectContext.get();
+        if (context != null) {
+            int limit = context.getSessionVariable().getMaterializedViewJoinSameTablePermutationLimit();
+            if (tableIds.size() > limit || n > limit) {
+                String message = String.format("MV or query use the same table too many times(mvTables=%d, " +
+                                "queryTables=%d), the optimizer cannot rewrite this query within the limited time. " +
+                                "You can enlarge the variable %s to break this limitation, current limit is %d",
+                        tableIds.size(), n, SessionVariable.MATERIALIZED_VIEW_JOIN_SAME_TABLE_PERMUTATION_LIMIT, limit);
+                OptimizerTraceUtil.logMVRewrite(mvRewriteContext, message);
+                throw new StarRocksPlannerException(message, ErrorType.RULE_EXHAUSTED);
+            }
+        }
         List<Integer> t = new ArrayList<>();
         List<List<Integer>> ret = new ArrayList<>();
         getPermutationsOfTableIds(tableIds, n, t, ret);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -18,6 +18,7 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.metric.MaterializedViewMetricsEntity;
 import com.starrocks.metric.MaterializedViewMetricsRegistry;
 import com.starrocks.qe.ConnectContext;
@@ -72,6 +73,15 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
     @Override
     public boolean check(OptExpression input, OptimizerContext context) {
         return !context.getCandidateMvs().isEmpty() && checkOlapScanWithoutTabletOrPartitionHints(input);
+    }
+
+    @Override
+    public boolean exhausted(OptimizerContext context) {
+        if (context.ruleExhausted(type())) {
+            Tracers.log(Tracers.Module.MV, args -> String.format("[MV TRACE] RULE %s exhausted\n", this));
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/OnlyJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/OnlyJoinRule.java
@@ -15,8 +15,6 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 
-import com.starrocks.sql.optimizer.OptExpression;
-import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -37,11 +35,4 @@ public class OnlyJoinRule extends BaseMaterializedViewRewriteRule {
         return INSTANCE;
     }
 
-    private static int counter = 0;
-
-    @Override
-    public boolean check(OptExpression optExpr, OptimizerContext context) {
-        System.err.println("OnlyJoinRule check " + counter++);
-        return super.check(optExpr, context);
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/OnlyJoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/OnlyJoinRule.java
@@ -15,6 +15,8 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.rule.RuleType;
@@ -33,5 +35,13 @@ public class OnlyJoinRule extends BaseMaterializedViewRewriteRule {
 
     public static OnlyJoinRule getInstance() {
         return INSTANCE;
+    }
+
+    private static int counter = 0;
+
+    @Override
+    public boolean check(OptExpression optExpr, OptimizerContext context) {
+        System.err.println("OnlyJoinRule check " + counter++);
+        return super.check(optExpr, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
@@ -65,8 +65,7 @@ public class ApplyRuleTask extends OptimizerTask {
 
     @Override
     public void execute() {
-        if (groupExpression.hasRuleExplored(rule) ||
-                groupExpression.isUnused()) {
+        if (groupExpression.hasRuleExplored(rule) || groupExpression.isUnused()) {
             return;
         }
         SessionVariable sessionVariable = context.getOptimizerContext().getSessionVariable();
@@ -85,6 +84,10 @@ public class ApplyRuleTask extends OptimizerTask {
             List<OptExpression> targetExpressions;
             try (Timer ignore = Tracers.watchScope(Tracers.Module.OPTIMIZER, rule.getClass().getSimpleName())) {
                 targetExpressions = rule.transform(extractExpr, context.getOptimizerContext());
+            }
+            if (rule.exhausted(context.getOptimizerContext())) {
+                OptimizerTraceUtil.logRuleExhausted(context.getOptimizerContext(), rule);
+                break;
             }
 
             newExpressions.addAll(targetExpressions);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/ApplyRuleTask.java
@@ -19,6 +19,8 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.common.ErrorType;
+import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.GroupExpression;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
@@ -84,6 +86,12 @@ public class ApplyRuleTask extends OptimizerTask {
             List<OptExpression> targetExpressions;
             try (Timer ignore = Tracers.watchScope(Tracers.Module.OPTIMIZER, rule.getClass().getSimpleName())) {
                 targetExpressions = rule.transform(extractExpr, context.getOptimizerContext());
+            } catch (StarRocksPlannerException e) {
+                if (e.getType() == ErrorType.RULE_EXHAUSTED) {
+                    break;
+                } else {
+                    throw e;
+                }
             }
             if (rule.exhausted(context.getOptimizerContext())) {
                 OptimizerTraceUtil.logRuleExhausted(context.getOptimizerContext(), rule);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/OptimizerTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/OptimizerTask.java
@@ -59,6 +59,9 @@ public abstract class OptimizerTask {
             if (optimizerConfig.isRuleDisable(rule.type())) {
                 continue;
             }
+            if (rule.exhausted(context.getOptimizerContext())) {
+                continue;
+            }
             validRules.add(rule);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/RewriteTreeTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/task/RewriteTreeTask.java
@@ -67,6 +67,9 @@ public class RewriteTreeTask extends OptimizerTask {
         SessionVariable sessionVariable = context.getOptimizerContext().getSessionVariable();
 
         for (Rule rule : rules) {
+            if (rule.exhausted(context.getOptimizerContext())) {
+                continue;
+            }
             if (!match(rule.getPattern(), root) || !rule.check(root, context.getOptimizerContext())) {
                 continue;
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
@@ -1,0 +1,123 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.google.common.base.Stopwatch;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.text.MessageFormat;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+/**
+ * Test MV with many tables join
+ */
+public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        MaterializedViewTestBase.setUp();
+        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+        starRocksAssert.withTable(
+                "CREATE TABLE tbl_0 (\n" +
+                        " dt date NULL COMMENT \"etl\",\n" +
+                        " p1_col1 varchar(60) NULL COMMENT \"\",\n" +
+                        " p1_col2 varchar(240) NULL COMMENT \"\",\n" +
+                        " p1_col3 varchar(30) NULL COMMENT \"\",\n" +
+                        " p1_col4 decimal128(22, 2) NULL COMMENT \"\"\n" +
+                        ") ENGINE=OLAP \n" +
+                        "DUPLICATE KEY(dt, p1_col1)\n" +
+                        "PARTITION BY RANGE(dt)\n" +
+                        "(PARTITION p20221230 VALUES [(\"2022-12-30\"), (\"2022-12-31\")),\n" +
+                        "PARTITION p20230331 VALUES [(\"2023-03-31\"), (\"2023-04-01\")))\n" +
+                        "DISTRIBUTED BY HASH(dt, p1_col2) BUCKETS 1 \n" +
+                        "PROPERTIES (\n" +
+                        "\"replication_num\"=\"1\"" +
+                        ");");
+
+        for (int i = 1; i < 20; i++) {
+            starRocksAssert.withTable(
+                    MessageFormat.format(
+                            "CREATE TABLE tbl_{0} (\n" +
+                                    " dt date NULL COMMENT \"\",\n" +
+                                    " p{0}_col1 varchar(240) NULL COMMENT \"\",\n" +
+                                    " p{0}_col2 varchar(240) NULL COMMENT \"\"\n" +
+                                    ") ENGINE=OLAP \n" +
+                                    "DUPLICATE KEY(dt, p{0}_col1)\n" +
+                                    "PARTITION BY RANGE(dt)\n" +
+                                    "   (PARTITION p202212 VALUES [(\"2022-12-01\"), (\"2023-01-01\")),\n" +
+                                    "       PARTITION p202301 VALUES [(\"2023-01-01\"), (\"2023-02-01\")),\n" +
+                                    "       PARTITION p202302 VALUES [(\"2023-02-01\"), (\"2023-03-01\")))\n" +
+                                    "DISTRIBUTED BY HASH(dt, p{0}_col2) BUCKETS 1 \n" +
+                                    "PROPERTIES (\n" +
+                                    "\"replication_num\"=\"1\",\n" +
+                                    "\"in_memory\"=\"false\",\n" +
+                                    "\"storage_format\"=\"DEFAULT\",\n" +
+                                    "\"enable_persistent_index\"=\"false\",\n" +
+                                    "\"compression\"=\"LZ4\"\n" +
+                                    ")", i));
+        }
+    }
+
+    @ParameterizedTest(name = "{index}-{0}")
+    @MethodSource("generateManyJoinArguments")
+    @Timeout(5)
+    public void testManyJoins(String name, String mvQuery, String query, boolean expectHitMv) throws Exception {
+        LOG.info("create mv {}", mvQuery);
+        String mvName = "mv_manyjoin";
+        String createMv = "CREATE MATERIALIZED VIEW " + mvName + "\n" +
+                "REFRESH MANUAL\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\"=\"1\"\n" +
+                ")\n" +
+                "AS " + mvQuery;
+        starRocksAssert.withMaterializedView(createMv);
+
+        Stopwatch watch = Stopwatch.createStarted();
+        // Make sure it's not empty
+        starRocksAssert.query(query).explainContains("OlapScanNode");
+        LOG.info("query takes {}ms: {}", watch.elapsed(TimeUnit.MILLISECONDS), query);
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    private static Stream<Arguments> generateManyJoinArguments() {
+        final String smallQuery = generateJoinQuery(8);
+        final String bigQuery = generateJoinQuery(20);
+        return Stream.of(
+                Arguments.of("small_query-small_mv", smallQuery, smallQuery, true),
+                Arguments.of("small_query-big_mv", smallQuery, bigQuery, false),
+                Arguments.of("big_query-small_mv", bigQuery, smallQuery, false),
+                Arguments.of("big_query-big_mv", bigQuery, bigQuery, true)
+        );
+    }
+
+    @NotNull
+    private static String generateJoinQuery(int numTables) {
+        StringBuilder query = new StringBuilder("SELECT p1.dt FROM tbl_0 AS p0 ");
+        for (int i = 1; i < numTables; i++) {
+            String alias = "p" + i;
+            String sourceTableName = String.format("tbl_%d", i);
+            query.append(String.format("LEFT OUTER JOIN %s AS %s ON %s.dt=p1.dt\n", sourceTableName, alias, alias));
+        }
+        return query.toString();
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewMultiJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewMultiJoinTest.java
@@ -22,7 +22,6 @@ import mockit.MockUp;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.jupiter.api.Timeout;
 
 public class MaterializedViewMultiJoinTest extends MaterializedViewTestBase {
 
@@ -402,39 +401,6 @@ public class MaterializedViewMultiJoinTest extends MaterializedViewTestBase {
             }
         };
         starRocksAssert.query(query).explainWithout(mvName);
-    }
-
-    @Test
-    @Timeout(value = 10)
-    public void testManyJoins() throws Exception {
-        String mvName = "mv_manyjoin";
-        String createMv = "CREATE MATERIALIZED VIEW " + mvName + "\n" +
-                "REFRESH MANUAL\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\"=\"1\"\n" +
-                ")\n" +
-                "AS ";
-        StringBuilder query = new StringBuilder("SELECT count(*) cnt " +
-                "FROM " +
-                "tbl_1 AS p1 " +
-                "INNER JOIN test_mv1 AS p5 ON p1.p1_col2=p5.p1_col2 and p1.dt=p5.dt \n" +
-                "LEFT OUTER JOIN tbl_2 AS p2 " +
-                "   ON p2.p2_col1='1' AND p1.p1_col2=p2.p2_col2 " +
-                "   AND p2.start_dt <= p1.dt AND p2.end_dt > p1.dt " +
-                "LEFT OUTER JOIN tbl_3 AS p3 ON p1.p1_col2=p3.p3_col2 AND p3.dt=p1.dt ");
-        for (int i = 6; i < 20; i++) {
-            String alias = "p" + i;
-            query.append(String.format("LEFT OUTER JOIN tbl_3 AS %s ON p1.p1_col2=%s.p3_col2 AND %s.dt=p1.dt\n",
-                    alias, alias, alias));
-        }
-        starRocksAssert.withMaterializedView(createMv + query);
-
-        starRocksAssert.query("select * from tbl_1 AS p1 " +
-                        "INNER JOIN test_mv1 AS p5 ON p1.p1_col2=p5.p1_col2 and p1.dt=p5.dt \n")
-                .explainWithout(mvName);
-
-        // FIXME: it's very slow
-        // starRocksAssert.query(query.toString()).explainContains(mvName);
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewMultiJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewMultiJoinTest.java
@@ -376,6 +376,7 @@ public class MaterializedViewMultiJoinTest extends MaterializedViewTestBase {
             }
         };
         starRocksAssert.query(query).explainWithout(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
     }
 
     @Test
@@ -401,6 +402,7 @@ public class MaterializedViewMultiJoinTest extends MaterializedViewTestBase {
             }
         };
         starRocksAssert.query(query).explainWithout(mvName);
+        starRocksAssert.dropMaterializedView(mvName);
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -45,7 +45,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class MaterializedViewTestBase extends PlanTestBase {
-    private static final Logger LOG = LogManager.getLogger(MaterializedViewTestBase.class);
+    protected static final Logger LOG = LogManager.getLogger(MaterializedViewTestBase.class);
 
     protected static final String MATERIALIZED_DB_NAME = "test_mv";
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -15,7 +15,6 @@
 package com.starrocks.planner;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
@@ -60,6 +59,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
         connectContext.getSessionVariable().setEnablePipelineEngine(true);
         connectContext.getSessionVariable().setEnableQueryCache(false);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000000);
+        connectContext.getSessionVariable().setOptimizerMaterializedViewTimeLimitMillis(3000000L);
         // connectContext.getSessionVariable().setCboPushDownAggregateMode(1);
         connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(true);
         ConnectorPlanTestBase.mockHiveCatalog(connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -107,6 +107,7 @@ public class MvRewriteTestBase {
 
         connectContext = UtFrameUtils.createDefaultCtx();
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(30000000);
+        connectContext.getSessionVariable().setOptimizerMaterializedViewTimeLimitMillis(30000000);
 
         ConnectorPlanTestBase.mockCatalog(connectContext, temp.newFolder().toURI().toString());
         starRocksAssert = new StarRocksAssert(connectContext);


### PR DESCRIPTION
Why I'm doing:
- When a query involves many tables, the MV rewrite procedure would be super slow
- E.g. A query with 30 tables, the rewrite procedure would take more than 30s

What I'm doing:
- Introduce a faster binder `MultiJoinBinder` to handle the `MULTI_JOIN` pattern
- Introduce `Rule::exhausted` mechanism to avoid some rules run too slow
- Add a limitation when permutate the join-mapping of same table in a block.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
