### PR TITLE
[Feature] Implement Pulsar exactly-once consume #32086

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -508,6 +508,9 @@ CONF_Int32(routine_load_kafka_timeout_second, "10");
 // pulsar request timeout
 CONF_Int32(routine_load_pulsar_timeout_second, "10");
 
+// pulsar receiver queue size, default 10000 for better performance
+CONF_mInt32(routine_load_pulsar_receiver_queue_size, "10000");
+
 // Is set to true, index loading failure will not cause BE exit,
 // and the tablet will be marked as bad, so that FE will try to repair it.
 // CONF_Bool(auto_recover_index_loading_failure, "false");

--- a/be/src/runtime/routine_load/data_consumer.h
+++ b/be/src/runtime/routine_load/data_consumer.h
@@ -172,6 +172,9 @@ public:
 
     ~PulsarDataConsumer() override {
         VLOG(3) << "deconstruct pulsar client";
+        if (_p_reader.isConnected()) {
+            _p_reader.close();
+        }
         if (_p_client) {
             _p_client->close();
             delete _p_client;
@@ -179,18 +182,15 @@ public:
         }
     }
 
-    enum InitialPosition { LATEST, EARLIEST };
-
     Status init(StreamLoadContext* ctx) override;
-    Status assign_partition(const std::string& partition, StreamLoadContext* ctx, int64_t initial_position = -1);
+    Status assign_partition(const std::string& partition, StreamLoadContext* ctx,
+                            pulsar::MessageId begin_position=pulsar::MessageId::latest());
     // TODO(cmy): currently do not implement single consumer start method, using group_consume
     Status consume(StreamLoadContext* ctx) override { return Status::OK(); }
     Status cancel(StreamLoadContext* ctx) override;
     // reassign partition topics
     Status reset() override;
     bool match(StreamLoadContext* ctx) override;
-    // acknowledge pulsar message
-    Status acknowledge_cumulative(pulsar::MessageId& message_id);
 
     // start the consumer and put msgs to queue
     Status group_consume(TimedBlockingQueue<pulsar::Message*>* queue, int64_t max_running_time_ms);
@@ -198,10 +198,8 @@ public:
     // get the partitions of the topic
     Status get_topic_partition(std::vector<std::string>* partitions);
 
-    // get backlog num of partition
-    Status get_partition_backlog(int64_t* backlog);
-
-    const std::string& get_partition();
+    // get last message id
+    Status get_partition_last_message_id(pulsar::MessageId& messageId);
 
 private:
     std::string _service_url;
@@ -210,8 +208,10 @@ private:
     std::unordered_map<std::string, std::string> _custom_properties;
 
     pulsar::Client* _p_client = nullptr;
-    pulsar::Consumer _p_consumer;
+    pulsar::Reader _p_reader;
     std::shared_ptr<PulsarConsumerPipe> _p_consumer_pipe;
+    bool _p_start_from_real_id;
+    pulsar::MessageId _p_start_message_id;
 };
 
 } // end namespace starrocks

--- a/be/src/runtime/routine_load/data_consumer_group.h
+++ b/be/src/runtime/routine_load/data_consumer_group.h
@@ -114,8 +114,6 @@ private:
     void actual_consume(const std::shared_ptr<DataConsumer>& consumer, TimedBlockingQueue<pulsar::Message*>* queue,
                         int64_t max_running_time_ms, const ConsumeFinishCallback& cb);
 
-    void get_backlog_nums(StreamLoadContext* ctx);
-
 private:
     // blocking queue to receive msgs from all consumers
     TimedBlockingQueue<pulsar::Message*> _queue;

--- a/be/src/runtime/routine_load/routine_load_task_executor.cpp
+++ b/be/src/runtime/routine_load/routine_load_task_executor.cpp
@@ -208,8 +208,8 @@ Status RoutineLoadTaskExecutor::get_pulsar_partition_meta(const PPulsarMetaProxy
     return st;
 }
 
-Status RoutineLoadTaskExecutor::get_pulsar_partition_backlog(const PPulsarBacklogProxyRequest& request,
-                                                             std::vector<int64_t>* backlog_num) {
+Status RoutineLoadTaskExecutor::get_pulsar_partition_message_id(const PPulsarMessageIdProxyRequest& request,
+                                                             std::vector<PPulsarMessageId>* message_ids) {
     DCHECK(request.has_pulsar_info());
 
     // This context is meaningless, just for unifing the interface
@@ -239,18 +239,22 @@ Status RoutineLoadTaskExecutor::get_pulsar_partition_backlog(const PPulsarBacklo
     for (const auto& p : request.partitions()) {
         partitions.push_back(p);
     }
-
-    backlog_num->reserve(partitions.size());
+    message_ids->reserve(partitions.size());
 
     Status st;
     std::shared_ptr<DataConsumer> consumer;
     RETURN_IF_ERROR(_data_consumer_pool.get_consumer(&ctx, &consumer));
     for (const auto& p : partitions) {
-        int64_t backlog = 0;
+        pulsar::MessageId message_id;
         RETURN_IF_ERROR(std::static_pointer_cast<PulsarDataConsumer>(consumer)->assign_partition(p, &ctx));
-        st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->get_partition_backlog(&backlog);
+        st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->get_partition_last_message_id(message_id);
         std::static_pointer_cast<PulsarDataConsumer>(consumer).reset();
-        backlog_num->push_back(backlog);
+        PPulsarMessageId p_msg_id;
+        p_msg_id.set_entry_id(message_id.entryId());
+        p_msg_id.set_batch_index(message_id.batchIndex());
+        p_msg_id.set_partition(message_id.partition());
+        p_msg_id.set_ledger_id(message_id.ledgerId());
+        message_ids->push_back(p_msg_id);
     }
 
     if (st.ok()) {
@@ -477,14 +481,6 @@ void RoutineLoadTaskExecutor::exec_task(StreamLoadContext* ctx, DataConsumerPool
 
             // assign partition for consumer
             st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->assign_partition(kv.first, ctx);
-            if (!st.ok()) {
-                // Pulsar Offset Acknowledgement is idempotent, Failure should not block the normal process
-                // So just print a warning
-                LOG(WARNING) << st.get_error_msg();
-            }
-
-            // do ack
-            st = std::static_pointer_cast<PulsarDataConsumer>(consumer)->acknowledge_cumulative(kv.second);
             if (!st.ok()) {
                 // Pulsar Offset Acknowledgement is idempotent, Failure should not block the normal process
                 // So just print a warning

--- a/be/src/runtime/routine_load/routine_load_task_executor.h
+++ b/be/src/runtime/routine_load/routine_load_task_executor.h
@@ -78,8 +78,8 @@ public:
 
     Status get_pulsar_partition_meta(const PPulsarMetaProxyRequest& request, std::vector<std::string>* partitions);
 
-    Status get_pulsar_partition_backlog(const PPulsarBacklogProxyRequest& request, std::vector<int64_t>* backlog_num);
-
+    Status get_pulsar_partition_message_id(const PPulsarMessageIdProxyRequest& request,
+                                           std::vector<PPulsarMessageId>* message_ids);
 private:
     // execute the task
     void exec_task(StreamLoadContext* ctx, DataConsumerPool* pool, const ExecFinishCallback& cb);

--- a/be/src/runtime/stream_load/stream_load_context.cpp
+++ b/be/src/runtime/stream_load/stream_load_context.cpp
@@ -221,7 +221,7 @@ std::string StreamLoadContext::brief(bool detail) const {
                     ss << partition << ",";
                 }
                 ss << "], initial positions: [";
-                for (const auto& [key, value] : pulsar_info->initial_positions) {
+                for (const auto& [key, value] : pulsar_info->begin_positions) {
                     ss << key << ":" << value << ",";
                 }
                 ss << "], properties: [";

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -104,8 +104,11 @@ public:
               subscription(t_info.subscription),
               partitions(t_info.partitions),
               properties(t_info.properties) {
-        if (t_info.__isset.initial_positions) {
-            initial_positions = t_info.initial_positions;
+        if (t_info.__isset.begin_positions) {
+            for (auto const& [key, val] : t_info.begin_positions) {
+                auto message_id = pulsar::MessageId(val.partition, val.ledgerId, val.entryId, val.batchIndex);
+                begin_positions.insert(std::pair<std::string, pulsar::MessageId>(key, message_id));
+            }
         }
     }
 
@@ -119,7 +122,7 @@ public:
     std::string topic;
     std::string subscription;
     std::vector<std::string> partitions;
-    std::map<std::string, int64_t> initial_positions;
+    std::map<std::string, pulsar::MessageId> begin_positions;
 
     // partition -> acknowledge offset, inclusive.
     std::map<std::string, pulsar::MessageId> ack_offset;

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -724,33 +724,33 @@ void PInternalServiceImplBase<T>::_get_pulsar_info_impl(const PPulsarProxyReques
         st.to_protobuf(response->mutable_status());
         return;
     }
-    if (request->has_pulsar_backlog_request()) {
-        std::vector<int64_t> backlog_nums;
-        Status st = _exec_env->routine_load_task_executor()->get_pulsar_partition_backlog(
-                request->pulsar_backlog_request(), &backlog_nums);
+    if (request->has_pulsar_message_id_request()) {
+        std::vector<PPulsarMessageId> message_ids;
+        Status st = _exec_env->routine_load_task_executor()->get_pulsar_partition_message_id(
+                request->pulsar_message_id_request(), &message_ids);
         if (st.ok()) {
-            auto result = response->mutable_pulsar_backlog_result();
-            for (int i = 0; i < backlog_nums.size(); i++) {
-                result->add_partitions(request->pulsar_backlog_request().partitions(i));
-                result->add_backlog_nums(backlog_nums[i]);
+            auto result = response->mutable_pulsar_message_id_result();
+            for (int i = 0; i < message_ids.size(); i++) {
+                result->add_partitions(request->pulsar_message_id_request().partitions(i));
+                *result->add_message_ids() = message_ids[i];
             }
         }
         st.to_protobuf(response->mutable_status());
         return;
     }
-    if (request->has_pulsar_backlog_batch_request()) {
-        for (const auto& backlog_req : request->pulsar_backlog_batch_request().requests()) {
-            std::vector<int64_t> backlog_nums;
+    if (request->has_pulsar_message_id_batch_request()) {
+        for (const auto& message_id_req : request->pulsar_message_id_batch_request().requests()) {
+            std::vector<PPulsarMessageId> message_ids;
             Status st =
-                    _exec_env->routine_load_task_executor()->get_pulsar_partition_backlog(backlog_req, &backlog_nums);
-            auto backlog_result = response->mutable_pulsar_backlog_batch_result()->add_results();
+                    _exec_env->routine_load_task_executor()->get_pulsar_partition_message_id(message_id_req, &message_ids);
+            auto message_id_result = response->mutable_pulsar_message_id_batch_result()->add_results();
             if (st.ok()) {
-                for (int i = 0; i < backlog_nums.size(); i++) {
-                    backlog_result->add_partitions(backlog_req.partitions(i));
-                    backlog_result->add_backlog_nums(backlog_nums[i]);
+                for (int i = 0; i < message_ids.size(); i++) {
+                    message_id_result->add_partitions(message_id_req.partitions(i));
+                    *message_id_result->add_message_ids() = message_ids[i];
                 }
             } else {
-                response->clear_pulsar_backlog_batch_result();
+                response->clear_pulsar_message_id_batch_result();
                 st.to_protobuf(response->mutable_status());
                 return;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/common/StarRocksFEMetaVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/StarRocksFEMetaVersion.java
@@ -27,7 +27,9 @@ public class StarRocksFEMetaVersion {
 
     //change all serialize format to json
     public static final int VERSION_4 = 4;
+    //pulsar consume position change to message id
+    public static final int VERSION_5 = 5;
 
     // note: when increment meta version, should assign the latest version to VERSION_CURRENT
-    public static final int VERSION_CURRENT = VERSION_4;
+    public static final int VERSION_CURRENT = VERSION_5;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.load.routineload;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
@@ -30,39 +29,37 @@ import com.starrocks.thrift.TFileFormatType;
 import com.starrocks.thrift.TLoadSourceType;
 import com.starrocks.thrift.TPlanFragment;
 import com.starrocks.thrift.TPulsarLoadInfo;
+import com.starrocks.thrift.TPulsarMessageId;
 import com.starrocks.thrift.TRoutineLoadTask;
 import com.starrocks.thrift.TUniqueId;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 public class PulsarTaskInfo extends RoutineLoadTaskInfo {
     private RoutineLoadMgr routineLoadManager = GlobalStateMgr.getCurrentState().getRoutineLoadMgr();
-
-    private List<String> partitions;
-    private Map<String, Long> initialPositions = Maps.newHashMap();
+    private Map<String, TPulsarMessageId> beginPositions;
+    private Map<String, TPulsarMessageId> latestPartMessageId;
 
     public PulsarTaskInfo(UUID id, long jobId, long taskScheduleIntervalMs, long timeToExecuteMs,
-                          List<String> partitions, Map<String, Long> initialPositions, long tastTimeoutMs) {
+                          Map<String, TPulsarMessageId> beginPositions, long tastTimeoutMs) {
         super(id, jobId, taskScheduleIntervalMs, timeToExecuteMs, tastTimeoutMs);
-        this.partitions = partitions;
-        this.initialPositions.putAll(initialPositions);
+        this.beginPositions.putAll(beginPositions);
     }
 
-    public PulsarTaskInfo(long timeToExecuteMs, PulsarTaskInfo pulsarTaskInfo, Map<String, Long> initialPositions) {
+    public PulsarTaskInfo(long timeToExecuteMs, PulsarTaskInfo pulsarTaskInfo,
+                          Map<String, TPulsarMessageId> beginPositions) {
         super(UUID.randomUUID(), pulsarTaskInfo.getJobId(), pulsarTaskInfo.getTaskScheduleIntervalMs(),
                 timeToExecuteMs, pulsarTaskInfo.getBeId());
-        this.partitions = pulsarTaskInfo.getPartitions();
-        this.initialPositions.putAll(initialPositions);
+        this.beginPositions.putAll(beginPositions);
     }
 
     public List<String> getPartitions() {
-        return partitions;
-    }
-
-    public Map<String, Long> getInitialPositions() {
-        return initialPositions;
+        return new ArrayList<>(beginPositions.keySet());
     }
 
     @Override
@@ -72,36 +69,48 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
             return false;
         }
 
-        // Got initialPositions, we need to execute even there's no backlogs
-        if (!initialPositions.isEmpty()) {
-            return true;
-        }
-
         PulsarRoutineLoadJob pulsarRoutineLoadJob = (PulsarRoutineLoadJob) routineLoadJob;
-        Map<String, Long> backlogNums = PulsarUtil.getBacklogNums(pulsarRoutineLoadJob.getServiceUrl(),
+        Map<String, TPulsarMessageId> lastMessageIds = PulsarUtil.getLatestMessageIds(pulsarRoutineLoadJob.getServiceUrl(),
                 pulsarRoutineLoadJob.getTopic(), pulsarRoutineLoadJob.getSubscription(),
                 ImmutableMap.copyOf(pulsarRoutineLoadJob.getConvertedCustomProperties()),
-                partitions);
-        for (String partition : partitions) {
-            Long backlogNum = backlogNums.get(partition);
-            if (backlogNum != null && backlogNum > 0) {
-                return true;
+                getPartitions());
+
+        for (Map.Entry<String, TPulsarMessageId> entry : beginPositions.entrySet()) {
+            String partition = entry.getKey();
+            TPulsarMessageId latestPosition = lastMessageIds.get(partition);
+            TPulsarMessageId consumedPosition = entry.getValue();
+
+            if (latestMessageId != null && PulsarUtil.isMessageValid(latestMessageId)) {
+                if (PulsarUtil.messageIdGt(latestPosition, consumedPosition)) {
+                    this.latestPartMessageId = lastMessageIds;
+                    return true;
+                } else if (PulsarUtil.messageIdLt(latestPosition, consumedPosition)) {
+                    LOG.warn("partition: {}, latest message id: {} less then consumed message id {}, it shouldn't be happened",
+                            partition, latestMessageId, consumeMessageId);
+                    throw new RoutineLoadPauseException(
+                            "partition " + partition + " position " + consumedPosition + " has no data");
+                }
             }
         }
 
         return false;
     }
 
-    // TODO(chen9t) there's no way to find out how many backlogs have been consumed in this round,
-    // the bellowing method will preempt the slots of BEs. So return ture until we find a better way.
     @Override
     public boolean isProgressKeepUp(RoutineLoadProgress progress) {
-        // PulsarProgress pProgress = (PulsarProgress) progress;
-        // for (Long backLogNum : pProgress.getBacklogNums()) {
-        //     if (backLogNum > 0) {
-        //         return false;
-        //     }
-        // }
+        PulsarProgress pProgress = (PulsarProgress) progress;
+        if (latestPartMessageId == null) {
+            return true;
+        }
+
+        for (Map.Entry<String, TPulsarMessageId> entry : latestPartMessageId.entrySet()) {
+            String part = entry.getKey();
+            TPulsarMessageId latestPosition = entry.getValue();
+            TPulsarMessageId consumedPosition = pProgress.getPositionByPartition(part);
+            if (consumedPosition != null && PulsarUtil.messageIdLt(consumedPosition, latestPosition)) {
+                return false;
+            }
+        }
         return true;
     }
 
@@ -132,8 +141,8 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
         tPulsarLoadInfo.setTopic((routineLoadJob).getTopic());
         tPulsarLoadInfo.setSubscription((routineLoadJob).getSubscription());
         tPulsarLoadInfo.setPartitions(getPartitions());
-        if (!initialPositions.isEmpty()) {
-            tPulsarLoadInfo.setInitial_positions(getInitialPositions());
+        if (!beginPositions.isEmpty()) {
+            tPulsarLoadInfo.setBegin_positions(beginPositions);
         }
         tPulsarLoadInfo.setProperties(routineLoadJob.getConvertedCustomProperties());
         tRoutineLoadTask.setPulsar_load_info(tPulsarLoadInfo);
@@ -158,17 +167,15 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
         StringBuilder result = new StringBuilder();
 
         Gson gson = new Gson();
-        result.append("Partitions: " + gson.toJson(partitions));
-        if (!initialPositions.isEmpty()) {
-            result.append("InitialPositisons: " + gson.toJson(initialPositions));
-        }
-
+        result.append("Progress:").append(gson.toJson(beginPositions));
+        result.append(",");
+        result.append("LatestMessageId:").append(gson.toJson(latestPartMessageId));
         return result.toString();
     }
 
     @Override
     public String toString() {
-        return "Task id: " + getId() + ", partitions: " + partitions + ", initial positions: " + initialPositions;
+        return "Task id: " + getId() + ", begin positions: " + beginPositions;
     }
 
     private TExecPlanFragmentParams plan(RoutineLoadJob routineLoadJob) throws UserException {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -903,7 +903,7 @@ struct TKafkaRLTaskProgress {
 }
 
 struct TPulsarRLTaskProgress {
-    1: required map<string,i64> partitionBacklogNum
+    1: required map<string, InternalService.TPulsarMessageId> partitionCmtPosition;
 }
 
 struct TRLTaskTxnCommitAttachment {

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -474,3 +474,11 @@ struct TGetFileSchemaRequest {
   1: required PlanNodes.TScanRange scan_range
   2: optional i32 volume_id = -1
 }
+
+// https://pulsar.apache.org/api/python/3.0.x/pulsar.MessageId.html
+struct TPulsarMessageId {
+    1: required i64 ledgerId
+    2: required i64 entryId
+    3: required i32 batchIndex
+    4: required i32 partition
+}


### PR DESCRIPTION
Why I'm doing:

Implement Pulsar exactly-once consume #32086

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
