### PR TITLE
[BugFix] fix not processing exception when castToStrictly

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/DecimalLiteralTest.java
@@ -369,11 +369,7 @@ public class DecimalLiteralTest {
         };
         ScalarType decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
         for (BigDecimal dec32 : decimal32Values) {
-            try {
-                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4);
-                Assert.fail("should throw exception");
-            } catch (Exception ignored) {
-            }
+            Assert.assertFalse(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4));
         }
 
         BigDecimal decimal64Values[] = {
@@ -384,11 +380,7 @@ public class DecimalLiteralTest {
         };
         ScalarType decimal64p18s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
         for (BigDecimal dec64 : decimal64Values) {
-            try {
-                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6);
-                Assert.fail("should throw exception");
-            } catch (Exception ignored) {
-            }
+            Assert.assertFalse(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6));
         }
 
         BigDecimal decimal128Values[] = {
@@ -399,11 +391,7 @@ public class DecimalLiteralTest {
         };
         ScalarType decimal128p38s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
         for (BigDecimal dec128 : decimal128Values) {
-            try {
-                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11);
-                Assert.fail("should throw exception");
-            } catch (Exception ignored) {
-            }
+            Assert.assertFalse(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11));
         }
     }
 
@@ -422,11 +410,7 @@ public class DecimalLiteralTest {
         };
         ScalarType decimal32p9s4 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL32, 9, 4);
         for (BigDecimal dec32 : decimal32Values) {
-            try {
-                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4);
-            } catch (Exception ignored) {
-                Assert.fail("should not throw exception");
-            }
+            Assert.assertTrue(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec32, decimal32p9s4));
         }
 
         BigDecimal decimal64Values[] = {
@@ -442,11 +426,7 @@ public class DecimalLiteralTest {
         };
         ScalarType decimal64p18s6 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL64, 18, 6);
         for (BigDecimal dec64 : decimal64Values) {
-            try {
-                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6);
-            } catch (Exception ignored) {
-                Assert.fail("should not throw exception");
-            }
+            Assert.assertTrue(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec64, decimal64p18s6));
         }
 
         BigDecimal decimal128Values[] = {
@@ -462,11 +442,7 @@ public class DecimalLiteralTest {
         };
         ScalarType decimal128p38s11 = ScalarType.createDecimalV3Type(PrimitiveType.DECIMAL128, 38, 11);
         for (BigDecimal dec128 : decimal128Values) {
-            try {
-                DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11);
-            } catch (Exception ignored) {
-                Assert.fail("should not throw exception");
-            }
+            Assert.assertTrue(DecimalLiteral.checkLiteralOverflowInDecimalStyle(dec128, decimal128p38s11));
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DecimalTypeTest.java
@@ -267,4 +267,12 @@ public class DecimalTypeTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "'12.56'");
     }
+
+    @Test
+    public void testDateToDecimal() throws Exception {
+        String sql = "select '1969-12-10 23:46:53' > c_0_0 from tab0";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  <slot 16> : CAST(1: c_0_0 AS VARCHAR) < '1969-12-10 23:46:53'");
+    }
 }


### PR DESCRIPTION
Why I'm doing:
Not catch exception when castToStrictly lead to expction being thrown to outer code

What I'm doing:
catch the exception and return empty.
Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/4884

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
