### PR TITLE
[BugFix] forget to choose cn when starosAgent returned "failed to get primary backend" (backport #34317)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -32,7 +32,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.warehouse.Warehouse;
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -58,12 +57,12 @@ public class Utils {
             return tablet.getPrimaryComputeNodeId(workerGroupId);
         } catch (UserException ex) {
             LOG.info("Ignored error {}", ex.getMessage());
+            try {
+                return GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendOrComputeId();
+            } catch (UserException e) {
+                return null;
+            }
         }
-        List<Long> backendIds = GlobalStateMgr.getCurrentSystemInfo().seqChooseBackendIds(1, true, false);
-        if (CollectionUtils.isEmpty(backendIds)) {
-            return null;
-        }
-        return backendIds.get(0);
     }
 
     public static ComputeNode chooseNode(LakeTablet tablet) {

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -736,6 +736,21 @@ public class SystemInfoService implements GsonPostProcessable {
                 v -> !v.diskExceedLimitByStorageMedium(storageMedium));
     }
 
+    public Long seqChooseBackendOrComputeId() throws UserException {
+        List<Long> backendIds = seqChooseBackendIds(1, true, false);
+        if (CollectionUtils.isNotEmpty(backendIds)) {
+            return backendIds.get(0);
+        }
+        if (RunMode.getCurrentRunMode() == RunMode.SHARED_NOTHING) {
+            throw new UserException("No backend alive.");
+        }
+        List<Long> computeNodes = seqChooseComputeNodes(1, true, false);
+        if (CollectionUtils.isNotEmpty(computeNodes)) {
+            return computeNodes.get(0);
+        }
+        throw new UserException("No backend or compute node alive.");
+    }
+
     public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable, boolean isCreate) {
 
         return seqChooseBackendIds(backendNum, needAvailable, isCreate, v -> !v.diskExceedLimit());

--- a/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/UtilsTest.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.lake;
+
+import com.starrocks.common.UserException;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.SystemInfoService;
+import mockit.Mock;
+import mockit.MockUp;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class UtilsTest {
+
+    @Mocked
+    GlobalStateMgr globalStateMgr;
+
+    @Mocked
+    SystemInfoService systemInfoService;
+
+    @Test
+    public void testChooseBackend() {
+
+        new MockUp<GlobalStateMgr>() {
+            @Mock
+            public SystemInfoService getCurrentSystemInfo() {
+                return systemInfoService;
+            }
+        };
+
+        new MockUp<LakeTablet>() {
+            @Mock
+            public long getPrimaryComputeNodeId(long clusterId) throws UserException {
+                throw new UserException("Failed to get primary backend");
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public Long seqChooseBackendOrComputeId() throws UserException {
+                throw new UserException("No backend or compute node alive.");
+            }
+        };
+
+        Assert.assertNull(Utils.chooseBackend(new LakeTablet(1000L)));
+    }
+}


### PR DESCRIPTION
Why I'm doing:

forget backport pr : https://github.com/StarRocks/starrocks/pull/34317 to branch-3.2

What I'm doing:

manually backport pr : https://github.com/StarRocks/starrocks/pull/34317 to branch-3.2

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
