### PR TITLE
[BugFix] Only support olap tables/materaizlied views without related mvs for non lock optimization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -347,7 +347,7 @@ public class OlapTable extends Table {
             olapTable.tableProperty = this.tableProperty.copy();
         }
 
-        // Shadow copy shared data to check whether the copied table has changed or not.
+        // Shallow copy shared data to check whether the copied table has changed or not.
         olapTable.lastSchemaUpdateTime = this.lastSchemaUpdateTime;
         olapTable.lastVersionUpdateStartTime = this.lastVersionUpdateStartTime;
         olapTable.lastVersionUpdateEndTime = this.lastVersionUpdateEndTime;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -346,6 +346,11 @@ public class OlapTable extends Table {
         if (this.tableProperty != null) {
             olapTable.tableProperty = this.tableProperty.copy();
         }
+
+        // Shadow copy shared data to check whether the copied table has changed or not.
+        olapTable.lastSchemaUpdateTime = this.lastSchemaUpdateTime;
+        olapTable.lastVersionUpdateStartTime = this.lastVersionUpdateStartTime;
+        olapTable.lastVersionUpdateEndTime = this.lastVersionUpdateEndTime;
     }
 
     public BinlogConfig getCurBinlogConfig() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -1115,6 +1115,17 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_backup_materialized_view = true;
 
+    /**
+     * To avoid too many related materialized view causing too much fe memory and decreasing performance, set N
+     * to determine which strategy you choose:
+     *  N <0      : always use non lock optimization and no copy related materialized views which
+     *      may cause metadata concurrency problem but can reduce many lock conflict time and metadata memory-copy consume.
+     *  N = 0    : always not use non lock optimization
+     *  N > 0    : use non lock optimization when related mvs's num <= N, otherwise don't use non lock optimization
+     */
+    @ConfField(mutable = true)
+    public static int skip_whole_phase_lock_mv_limit = 5;
+
     @ConfField
     public static boolean enable_udf = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -75,6 +75,8 @@ public class FeConstants {
     public static boolean showScanNodeLocalShuffleColumnsInExplain = true;
     // set to true when replay from query dump
     public static boolean isReplayFromQueryDump = false;
+    // Whether to canonize predicate after mv rewrite which make uts more stable
+    public static boolean isCanonizePredicateAfterMVRewrite = false;
     // set false to resolve ut
     public static boolean enablePruneEmptyOutputScan = true;
     public static boolean showJoinLocalShuffleInExplain = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -200,6 +200,9 @@ public class StatementPlanner {
             try (Timer ignored = Tracers.watchScope("Optimizer")) {
                 // 2. Optimize logical plan and build physical plan
                 Optimizer optimizer = new Optimizer();
+                // FIXME: refactor this into Optimizer.optimize() method.
+                // set query tables into OptimizeContext so can be added for mv rewrite
+                optimizer.setQueryTables(olapTables);
                 optimizedPlan = optimizer.optimize(
                         session,
                         logicalPlan.getRoot(),
@@ -207,6 +210,7 @@ public class StatementPlanner {
                         new ColumnRefSet(logicalPlan.getOutputColumn()),
                         columnRefFactory);
             }
+
             try (Timer ignored = Tracers.watchScope("ExecPlanBuild")) {
                 // 3. Build fragment exec plan
                 /*

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -202,7 +202,9 @@ public class StatementPlanner {
                 Optimizer optimizer = new Optimizer();
                 // FIXME: refactor this into Optimizer.optimize() method.
                 // set query tables into OptimizeContext so can be added for mv rewrite
-                optimizer.setQueryTables(olapTables);
+                if (Config.skip_whole_phase_lock_mv_limit >= 0) {
+                    optimizer.setQueryTables(olapTables);
+                }
                 optimizedPlan = optimizer.optimize(
                         session,
                         logicalPlan.getRoot(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -609,7 +609,8 @@ public class AnalyzerUtils {
             if (!tables.isEmpty()) {
                 return null;
             }
-            if (!node.getTable().isNativeTableOrMaterializedView()) {
+
+            if (!node.getTable().isOlapTableOrMaterializedView()) {
                 tables.put(node.getName(), node.getTable());
             }
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -610,7 +610,10 @@ public class AnalyzerUtils {
                 return null;
             }
 
-            if (!node.getTable().isOlapTableOrMaterializedView()) {
+            int relatedMVCount = node.getTable().getRelatedMaterializedViews().size();
+            boolean useNonLockOptimization = Config.skip_whole_phase_lock_mv_limit < 0 ||
+                    relatedMVCount <= Config.skip_whole_phase_lock_mv_limit;
+            if (!(node.getTable().isOlapTableOrMaterializedView() && useNonLockOptimization)) {
                 tables.put(node.getName(), node.getTable());
             }
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -40,7 +40,10 @@ import com.starrocks.catalog.RandomDistributionInfo;
 import com.starrocks.catalog.SinglePartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.common.profile.Timer;
+import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionNames;
@@ -71,25 +74,128 @@ public class MvRewritePreprocessor {
     private final ConnectContext connectContext;
     private final ColumnRefFactory queryColumnRefFactory;
     private final OptimizerContext context;
-    private final OptExpression logicOperatorTree;
 
     public MvRewritePreprocessor(ConnectContext connectContext,
                                  ColumnRefFactory queryColumnRefFactory,
-                                 OptimizerContext context,
-                                 OptExpression logicOperatorTree) {
+                                 OptimizerContext context) {
         this.connectContext = connectContext;
         this.queryColumnRefFactory = queryColumnRefFactory;
         this.context = context;
-        this.logicOperatorTree = logicOperatorTree;
     }
 
-    public Set<MaterializedView> getRelatedAsyncMVs(Set<Table> queryTables) {
+    public void prepare(OptExpression optExpression) {
+        try (Timer ignored = Tracers.watchScope("preprocessMvs")) {
+            Set<Table> queryTables = MvUtils.getAllTables(optExpression).stream().collect(Collectors.toSet());
+            logMVPrepare(connectContext, "Query input tables: {}", queryTables);
+
+            try {
+                Set<MaterializedView> relatedMVs =
+                        getRelatedMVs(connectContext, queryTables, context.getOptimizerConfig().isRuleBased());
+                Set<Pair<MaterializedView, MvPlanContext>> validMVs = filterValidMVs(connectContext, relatedMVs);
+                prepareRelatedMVs(queryTables, validMVs);
+            } catch (Exception e) {
+                // MV's prepare should not affect query's process, this may be caused by MV's concurrent process.
+                List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
+                LOG.warn("Prepare query tables {} for mv failed: {}", tableNames, e);
+            }
+        }
+    }
+
+    private MaterializedView copyOnlyMaterializedView(MaterializedView mv) {
+        // TODO: add read lock?
+        // Query will not lock dbs in the optimizer stage, so use a shadow copy of mv to avoid
+        // metadata race for different operations.
+        // Ensure to re-optimize if the mv's version has changed after the optimization.
+        MaterializedView copiedMV = new MaterializedView();
+        mv.copyOnlyForQuery(copiedMV);
+        return copiedMV;
+    }
+
+    private static Set<MaterializedView> getRelatedMVs(ConnectContext connectContext,
+                                                       Set<Table> queryTables,
+                                                       boolean isRuleBased) {
+        if (Config.enable_experimental_mv
+                && connectContext.getSessionVariable().isEnableMaterializedViewRewrite()
+                && !isRuleBased) {
+            Set<MaterializedView> relatedMVs = getRelatedAsyncMVs(connectContext, queryTables);
+            if (connectContext.getSessionVariable().isEnableSyncMaterializedViewRewrite()) {
+                relatedMVs.addAll(getRelatedSyncMVs(connectContext, queryTables));
+            }
+            return relatedMVs;
+        } else {
+            if (!isRuleBased) {
+                logMVPrepare(connectContext, "Do not prepare materialized views, " +
+                                "enable_experimental_mv:{}, enable_materialized_view_rewrite:{}",
+                        Config.enable_experimental_mv,
+                        connectContext.getSessionVariable().isEnableMaterializedViewRewrite());
+            }
+            return Sets.newHashSet();
+        }
+    }
+
+    private static Set<Pair<MaterializedView, MvPlanContext>> filterValidMVs(ConnectContext connectContext,
+                                                                             Set<MaterializedView> relatedMVs) {
+        // filter mvs by including/excluding settings
+        String queryExcludingMVNames = connectContext.getSessionVariable().getQueryExcludingMVNames();
+        String queryIncludingMVNames = connectContext.getSessionVariable().getQueryIncludingMVNames();
+        if (!Strings.isNullOrEmpty(queryExcludingMVNames) || !Strings.isNullOrEmpty(queryIncludingMVNames)) {
+            logMVPrepare(connectContext, "queryExcludingMVNames:{}, queryIncludingMVNames:{}",
+                    Strings.nullToEmpty(queryExcludingMVNames), Strings.nullToEmpty(queryIncludingMVNames));
+
+            final Set<String> queryExcludingMVNamesSet = Strings.isNullOrEmpty(queryExcludingMVNames) ? Sets.newHashSet()
+                    : Arrays.stream(queryExcludingMVNames.split(",")).map(String::trim).collect(Collectors.toSet());
+
+            final Set<String> queryIncludingMVNamesSet = Strings.isNullOrEmpty(queryIncludingMVNames) ? Sets.newHashSet()
+                    : Arrays.stream(queryIncludingMVNames.split(",")).map(String::trim).collect(Collectors.toSet());
+            relatedMVs = relatedMVs.stream()
+                    .filter(mv -> queryIncludingMVNamesSet.isEmpty() || queryIncludingMVNamesSet.contains(mv.getName()))
+                    .filter(mv -> queryExcludingMVNamesSet.isEmpty() || !queryExcludingMVNamesSet.contains(mv.getName()))
+                    .collect(Collectors.toSet());
+        }
+
+        // filter mvs which are active and have valid plans
+        Set<Pair<MaterializedView, MvPlanContext>> filteredMVs = Sets.newHashSet();
+        for (MaterializedView mv : relatedMVs) {
+            if (!mv.isActive()) {
+                logMVPrepare(connectContext, mv, "MV is not active: {}", mv.getName());
+                continue;
+            }
+
+            MvPlanContext mvPlanContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv,
+                    connectContext.getSessionVariable().isEnableMaterializedViewPlanCache());
+            if (mvPlanContext == null) {
+                logMVPrepare(connectContext, mv, "MV plan is not valid: {}, cannot generate plan for rewrite",
+                        mv.getName());
+                continue;
+            }
+            if (!mvPlanContext.isValidMvPlan()) {
+                if (mvPlanContext.getLogicalPlan() != null) {
+                    logMVPrepare(connectContext, mv, "MV plan is not valid: {}, plan:\n {}",
+                            mv.getName(), mvPlanContext.getLogicalPlan().debugString());
+                } else {
+                    logMVPrepare(connectContext, mv, "MV plan is not valid: {}",
+                            mv.getName());
+                }
+                continue;
+            }
+
+            filteredMVs.add(Pair.create(mv, mvPlanContext));
+        }
+        if (filteredMVs.isEmpty()) {
+            logMVPrepare(connectContext, "There are no valid related mvs for the query plan");
+        }
+        return filteredMVs;
+    }
+
+    private static Set<MaterializedView> getRelatedAsyncMVs(ConnectContext connectContext,
+                                                            Set<Table> queryTables) {
         // get all related materialized views, include nested mvs
         return MvUtils.getRelatedMvs(connectContext,
                 connectContext.getSessionVariable().getNestedMvRewriteMaxLevel(), queryTables);
     }
 
-    public Set<MaterializedView> getRelatedSyncMVs(Set<Table> queryTables) {
+    private static Set<MaterializedView> getRelatedSyncMVs(ConnectContext connectContext,
+                                                           Set<Table> queryTables) {
         Set<MaterializedView> relatedMvs = Sets.newHashSet();
         // get all related materialized views, include nested mvs
         for (Table table : queryTables) {
@@ -97,14 +203,14 @@ public class MvRewritePreprocessor {
                 continue;
             }
             OlapTable olapTable = (OlapTable) table;
-            relatedMvs.addAll(getTableRelatedSyncMVs(olapTable));
+            relatedMvs.addAll(getTableRelatedSyncMVs(connectContext, olapTable));
         }
         return relatedMvs;
     }
 
-    private Set<MaterializedView> getTableRelatedSyncMVs(OlapTable olapTable) {
+    private static Set<MaterializedView> getTableRelatedSyncMVs(ConnectContext connectContext,
+                                                                OlapTable olapTable) {
         Set<MaterializedView> relatedMvs = Sets.newHashSet();
-
         for (MaterializedIndexMeta indexMeta : olapTable.getVisibleIndexMetas()) {
             long indexId = indexMeta.getIndexId();
             if (indexMeta.getIndexId() == olapTable.getBaseIndexId()) {
@@ -171,38 +277,24 @@ public class MvRewritePreprocessor {
                 relatedMvs.add(mv);
             } catch (Exception e) {
                 logMVPrepare(connectContext, "Fail to get the related sync materialized views from table:{}, " +
-                                "exception:{}", olapTable.getName(), e);
+                        "exception:{}", olapTable.getName(), e);
             }
         }
         return relatedMvs;
     }
 
-    public void prepareRelatedMVs(Set<Table> queryTables, Set<MaterializedView> relatedMvs) {
-        String queryExcludingMVNames = connectContext.getSessionVariable().getQueryExcludingMVNames();
-        String queryIncludingMVNames = connectContext.getSessionVariable().getQueryIncludingMVNames();
-        if (!Strings.isNullOrEmpty(queryExcludingMVNames) || !Strings.isNullOrEmpty(queryIncludingMVNames)) {
-            logMVPrepare(connectContext, "queryExcludingMVNames:{}, queryIncludingMVNames:{}",
-                    Strings.nullToEmpty(queryExcludingMVNames), Strings.nullToEmpty(queryIncludingMVNames));
-
-            final Set<String> queryExcludingMVNamesSet = Strings.isNullOrEmpty(queryExcludingMVNames) ? Sets.newHashSet()
-                    : Arrays.stream(queryExcludingMVNames.split(",")).map(String::trim).collect(Collectors.toSet());
-
-            final Set<String> queryIncludingMVNamesSet = Strings.isNullOrEmpty(queryIncludingMVNames) ? Sets.newHashSet()
-                    : Arrays.stream(queryIncludingMVNames.split(",")).map(String::trim).collect(Collectors.toSet());
-            relatedMvs = relatedMvs.stream()
-                    .filter(mv -> queryIncludingMVNamesSet.isEmpty() || queryIncludingMVNamesSet.contains(mv.getName()))
-                    .filter(mv -> queryExcludingMVNamesSet.isEmpty() || !queryExcludingMVNamesSet.contains(mv.getName()))
-                    .collect(Collectors.toSet());
-        }
+    public void prepareRelatedMVs(Set<Table> queryTables,
+                                  Set<Pair<MaterializedView, MvPlanContext>> relatedMvs) {
         if (relatedMvs.isEmpty()) {
-            logMVPrepare(connectContext, "There are no related mvs for the query plan");
             return;
         }
 
         Set<ColumnRefOperator> originQueryColumns = Sets.newHashSet(queryColumnRefFactory.getColumnRefs());
-        for (MaterializedView mv : relatedMvs) {
+        for (Pair<MaterializedView, MvPlanContext> pair : relatedMvs) {
+            MaterializedView mv = pair.first;
+            MvPlanContext mvPlanContext = pair.second;
             try {
-                preprocessMv(mv, queryTables, originQueryColumns);
+                preprocessMv(mv, mvPlanContext, queryTables, originQueryColumns);
             } catch (Exception e) {
                 List<String> tableNames = queryTables.stream().map(Table::getName).collect(Collectors.toList());
                 logMVPrepare(connectContext, "Preprocess MV {} failed: {}", mv.getName(), e.getMessage());
@@ -210,39 +302,22 @@ public class MvRewritePreprocessor {
             }
         }
         // all base table related mvs
-        List<String> relatedMvNames = relatedMvs.stream().map(mv -> mv.getName()).collect(Collectors.toList());
+        List<String> relatedMvNames =
+                relatedMvs.stream().map(pair -> pair.first.getName()).collect(Collectors.toList());
         // all mvs that match SPJG pattern and can ben used to try mv rewrite
         List<String> candidateMvNames = context.getCandidateMvs().stream()
-                .map(materializationContext -> materializationContext.getMv().getName()).collect(Collectors.toList());
-
+                .map(materializationContext -> materializationContext.getMv().getName())
+                .collect(Collectors.toList());
         logMVPrepare(connectContext, "RelatedMVs: {}, CandidateMVs: {}", relatedMvNames,
                 candidateMvNames);
     }
 
-    private void preprocessMv(MaterializedView mv, Set<Table> queryTables,
+    private void preprocessMv(MaterializedView mv, MvPlanContext mvPlanContext,
+                              Set<Table> queryTables,
                               Set<ColumnRefOperator> originQueryColumns) throws AnalysisException {
-        if (!mv.isActive()) {
-            logMVPrepare(connectContext, mv, "MV is not active: {}", mv.getName());
-            return;
-        }
-
-        MvPlanContext mvPlanContext = CachingMvPlanContextBuilder.getInstance().getPlanContext(mv,
-                connectContext.getSessionVariable().isEnableMaterializedViewPlanCache());
-        if (mvPlanContext == null) {
-            logMVPrepare(connectContext, mv, "MV plan is not valid: {}, cannot generate plan for rewrite",
-                        mv.getName());
-            return;
-        }
-        if (!mvPlanContext.isValidMvPlan()) {
-            if (mvPlanContext.getLogicalPlan() != null) {
-                logMVPrepare(connectContext, mv, "MV plan is not valid: {}, plan:\n {}",
-                        mv.getName(), mvPlanContext.getLogicalPlan().debugString());
-            } else {
-                logMVPrepare(connectContext, mv, "MV plan is not valid: {}",
-                        mv.getName());
-            }
-            return;
-        }
+        Preconditions.checkState(mvPlanContext != null);
+        OptExpression mvPlan = mvPlanContext.getLogicalPlan();
+        Preconditions.checkState(mvPlan != null);
 
         Set<String> partitionNamesToRefresh = Sets.newHashSet();
         if (!mv.getPartitionNamesToRefreshForMv(partitionNamesToRefresh, true)) {
@@ -276,10 +351,6 @@ public class MvRewritePreprocessor {
             return;
         }
 
-        Preconditions.checkState(mvPlanContext != null);
-        OptExpression mvPlan = mvPlanContext.getLogicalPlan();
-        Preconditions.checkState(mvPlan != null);
-
         ScalarOperator mvPartialPartitionPredicates = null;
         if (mv.getPartitionInfo() instanceof ExpressionRangePartitionInfo && !partitionNamesToRefresh.isEmpty()) {
             // when mv is partitioned and there are some refreshed partitions,
@@ -310,8 +381,15 @@ public class MvRewritePreprocessor {
             refTableUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfTable(refBaseTable, true);
         }
 
+        MaterializedView copiedMV = mv;
+        if (context.getQueryTables() != null) {
+            // If query tables are set which means use related mv for non lock optimization,
+            // copy mv's metadata into a ready-only object.
+            copiedMV = copyOnlyMaterializedView(mv);
+        }
+
         MaterializationContext materializationContext =
-                new MaterializationContext(context, mv, mvPlan, queryColumnRefFactory,
+                new MaterializationContext(context, copiedMV, mvPlan, queryColumnRefFactory,
                         mvPlanContext.getRefFactory(), partitionNamesToRefresh,
                         baseTables, originQueryColumns, intersectingTables,
                         mvPartialPartitionPredicates, refTableUpdatedPartitionNames);
@@ -321,7 +399,7 @@ public class MvRewritePreprocessor {
         materializationContext.setScanMvOperator(scanMvOp);
         // should keep the sequence of schema
         List<ColumnRefOperator> scanMvOutputColumns = Lists.newArrayList();
-        for (Column column : mv.getBaseSchema()) {
+        for (Column column : copiedMV.getBaseSchema()) {
             scanMvOutputColumns.add(scanMvOp.getColumnReference(column));
         }
         Preconditions.checkState(mvOutputColumns.size() == scanMvOutputColumns.size());
@@ -338,7 +416,7 @@ public class MvRewritePreprocessor {
         }
         materializationContext.setOutputMapping(outputMapping);
         context.addCandidateMvs(materializationContext);
-        logMVPrepare(connectContext, mv, "Prepare MV {} success", mv.getName());
+        logMVPrepare(connectContext, copiedMV, "Prepare MV {} success", copiedMV.getName());
     }
 
     /**
@@ -439,5 +517,4 @@ public class MvRewritePreprocessor {
 
         return distributionSpec;
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -18,9 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.JoinOperator;
-import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.Table;
-import com.starrocks.common.Config;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
@@ -95,7 +93,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
 import static com.starrocks.sql.optimizer.rule.RuleType.TF_MATERIALIZED_VIEW;
 
 /**
@@ -107,6 +104,8 @@ public class Optimizer {
     private final OptimizerConfig optimizerConfig;
 
     private long updateTableId = -1;
+
+    private Set<OlapTable> queryTables;
 
     public Optimizer() {
         this(OptimizerConfig.defaultConfig());
@@ -131,12 +130,16 @@ public class Optimizer {
                                   ColumnRefSet requiredColumns,
                                   ColumnRefFactory columnRefFactory) {
         prepare(connectContext, logicOperatorTree, columnRefFactory);
-        context.setUpdateTableId(updateTableId);
+
         if (optimizerConfig.isRuleBased()) {
             return optimizeByRule(connectContext, logicOperatorTree, requiredProperty, requiredColumns);
         } else {
             return optimizeByCost(connectContext, logicOperatorTree, requiredProperty, requiredColumns);
         }
+    }
+
+    public void setQueryTables(Set<OlapTable> queryTables) {
+        this.queryTables = queryTables;
     }
 
     public void setUpdateTableId(long updateTableId) {
@@ -241,28 +244,11 @@ public class Optimizer {
         }
 
         context = new OptimizerContext(memo, columnRefFactory, connectContext, optimizerConfig);
-        if (Config.enable_experimental_mv
-                && connectContext.getSessionVariable().isEnableMaterializedViewRewrite()
-                && !optimizerConfig.isRuleBased()) {
-            MvRewritePreprocessor preprocessor =
-                    new MvRewritePreprocessor(connectContext, columnRefFactory, context, logicOperatorTree);
-            try (Timer ignored = Tracers.watchScope("preprocessMvs")) {
-                Set<Table> queryTables = MvUtils.getAllTables(logicOperatorTree).stream().collect(Collectors.toSet());
-                logMVPrepare(connectContext, "Query input tables: {}", queryTables);
-                Set<MaterializedView> relatedMVs = preprocessor.getRelatedAsyncMVs(queryTables);
-                if (connectContext.getSessionVariable().isEnableSyncMaterializedViewRewrite()) {
-                    relatedMVs.addAll(preprocessor.getRelatedSyncMVs(queryTables));
-                }
-                preprocessor.prepareRelatedMVs(queryTables, relatedMVs);
-            }
-        } else {
-            if (!optimizerConfig.isRuleBased()) {
-                logMVPrepare(connectContext, "Do not prepare materialized views, " +
-                                "enable_experimental_mv:{}, enable_materialized_view_rewrite:{}",
-                        Config.enable_experimental_mv,
-                        connectContext.getSessionVariable().isEnableMaterializedViewRewrite());
-            }
-        }
+        context.setQueryTables(queryTables);
+        context.setUpdateTableId(updateTableId);
+
+        // prepare related mvs if needed
+        new MvRewritePreprocessor(connectContext, columnRefFactory, context).prepare(logicOperatorTree);
     }
 
     private void pruneTables(OptExpression tree, TaskContext rootTaskContext, ColumnRefSet requiredColumns) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.catalog.OlapTable;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.VariableMgr;
@@ -34,6 +35,7 @@ import com.starrocks.sql.optimizer.task.TaskScheduler;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
@@ -50,6 +52,8 @@ public class OptimizerContext {
     private TaskContext currentTaskContext;
     private final OptimizerConfig optimizerConfig;
     private final List<MaterializationContext> candidateMvs;
+
+    private Set<OlapTable>  queryTables;
 
     private long updateTableId = -1;
     private boolean enableLeftRightJoinEquivalenceDerive = true;
@@ -187,6 +191,14 @@ public class OptimizerContext {
     public boolean reachTimeout() {
         long timeout = getSessionVariable().getOptimizerExecuteTimeout();
         return optimizerElapsedMs() > timeout;
+    }
+
+    public Set<OlapTable> getQueryTables() {
+        return queryTables;
+    }
+
+    public void setQueryTables(Set<OlapTable> queryTables) {
+        this.queryTables = queryTables;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -39,6 +39,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UniqueConstraint;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.StringUtils;
@@ -1274,8 +1275,14 @@ public class MaterializedViewRewriter {
                 }
                 final Operator.Builder newScanOpBuilder = OperatorBuilderFactory.build(mvScanOptExpression.getOp());
                 newScanOpBuilder.withOperator(mvScanOptExpression.getOp());
-                final ScalarOperator normalizedPredicate = normalizePredicate(finalCompensationPredicate);
+
+                ScalarOperator normalizedPredicate = normalizePredicate(finalCompensationPredicate);
+                // Canonize predicates to make uts more stable.
+                if (FeConstants.runningUnitTest && FeConstants.isCanonizePredicateAfterMVRewrite) {
+                    normalizedPredicate = MvUtils.canonizePredicateForRewrite(normalizedPredicate);
+                }
                 newScanOpBuilder.setPredicate(normalizedPredicate);
+
                 mvScanOptExpression = OptExpression.create(newScanOpBuilder.build());
                 mvScanOptExpression.setLogicalProperty(null);
                 deriveLogicalProperty(mvScanOptExpression);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/MVRewriteValidator.java
@@ -122,6 +122,11 @@ public class MVRewriteValidator {
         List<MaterializedView> diffMVs = mvs.stream()
                 .filter(mv -> !beforeTableIds.contains(mv.getId()))
                 .collect(Collectors.toList());
+
+        if (taskContext.getOptimizerContext().getQueryTables() != null) {
+            taskContext.getOptimizerContext().getQueryTables().addAll(diffMVs);
+        }
+
         if (diffMVs.isEmpty()) {
             boolean hasRewriteSuccess = Tracers.getAllVars().stream()
                     .anyMatch(var -> StringUtils.contains(var.getValue().toString(),

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.planner;
 
+import com.starrocks.common.FeConstants;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,7 +62,9 @@ public class MaterializedViewHiveTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery7() {
+        FeConstants.isCanonizePredicateAfterMVRewrite = true;
         runFileUnitTest("materialized-view/tpch-hive/q7");
+        FeConstants.isCanonizePredicateAfterMVRewrite = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.planner;
 
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.MockTpchStatisticStorage;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -76,7 +77,9 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery7() {
+        FeConstants.isCanonizePredicateAfterMVRewrite = true;
         runFileUnitTest("materialized-view/tpch/q7");
+        FeConstants.isCanonizePredicateAfterMVRewrite = false;
     }
 
     @Test

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q7.sql
@@ -41,9 +41,9 @@ order by
 [result]
 TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
     TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{370: sum=sum(370: sum)}] group by [[105: n_name1, 106: n_name2, 107: l_shipyear]] having [null]
-            EXCHANGE SHUFFLE[105, 106, 107]
-                AGGREGATE ([LOCAL] aggregate [{370: sum=sum(108: sum_saleprice)}] group by [[105: n_name1, 106: n_name2, 107: l_shipyear]] having [null]
-                    SCAN (mv[lineitem_mv_agg_mv2] columns[104: l_shipdate, 105: n_name1, 106: n_name2, 107: l_shipyear, 108: sum_saleprice] predicate[104: l_shipdate >= 1995-01-01 AND 104: l_shipdate <= 1996-12-31 AND 105: n_name1 = CANADA AND 106: n_name2 = IRAN OR 105: n_name1 = IRAN AND 106: n_name2 = CANADA])
+        AGGREGATE ([GLOBAL] aggregate [{364: sum=sum(364: sum)}] group by [[152: n_name1, 153: n_name2, 154: l_shipyear]] having [null]
+            EXCHANGE SHUFFLE[152, 153, 154]
+                AGGREGATE ([LOCAL] aggregate [{364: sum=sum(155: sum_saleprice)}] group by [[152: n_name1, 153: n_name2, 154: l_shipyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv2] columns[151: l_shipdate, 152: n_name1, 153: n_name2, 154: l_shipyear, 155: sum_saleprice] predicate[151: l_shipdate <= 1996-12-31 AND 151: l_shipdate >= 1995-01-01 AND 152: n_name1 = CANADA AND 153: n_name2 = IRAN OR 152: n_name1 = IRAN AND 153: n_name2 = CANADA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q7.sql
@@ -41,9 +41,9 @@ order by
 [result]
 TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
     TOP-N (order by [[42: n_name ASC NULLS FIRST, 46: n_name ASC NULLS FIRST, 49: year ASC NULLS FIRST]])
-        AGGREGATE ([GLOBAL] aggregate [{363: sum=sum(363: sum)}] group by [[136: n_name1, 137: n_name2, 138: l_shipyear]] having [null]
-            EXCHANGE SHUFFLE[136, 137, 138]
-                AGGREGATE ([LOCAL] aggregate [{363: sum=sum(139: sum_saleprice)}] group by [[136: n_name1, 137: n_name2, 138: l_shipyear]] having [null]
-                    SCAN (mv[lineitem_mv_agg_mv2] columns[135: l_shipdate, 136: n_name1, 137: n_name2, 138: l_shipyear, 139: sum_saleprice] predicate[136: n_name1 = CANADA AND 137: n_name2 = IRAN OR 136: n_name1 = IRAN AND 137: n_name2 = CANADA AND 135: l_shipdate <= 1996-12-31 AND 135: l_shipdate >= 1995-01-01])
+        AGGREGATE ([GLOBAL] aggregate [{467: sum=sum(467: sum)}] group by [[151: n_name1, 152: n_name2, 153: l_shipyear]] having [null]
+            EXCHANGE SHUFFLE[151, 152, 153]
+                AGGREGATE ([LOCAL] aggregate [{467: sum=sum(154: sum_saleprice)}] group by [[151: n_name1, 152: n_name2, 153: l_shipyear]] having [null]
+                    SCAN (mv[lineitem_mv_agg_mv2] columns[150: l_shipdate, 151: n_name1, 152: n_name2, 153: l_shipyear, 154: sum_saleprice] predicate[150: l_shipdate <= 1996-12-31 AND 150: l_shipdate >= 1995-01-01 AND 151: n_name1 = CANADA AND 152: n_name2 = IRAN OR 151: n_name1 = IRAN AND 152: n_name2 = CANADA])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q8.sql
@@ -42,6 +42,5 @@ TOP-N (order by [[61: year ASC NULLS FIRST]])
         AGGREGATE ([GLOBAL] aggregate [{65: sum=sum(65: sum), 64: sum=sum(64: sum)}] group by [[61: year]] having [null]
             EXCHANGE SHUFFLE[61]
                 AGGREGATE ([LOCAL] aggregate [{65: sum=sum(62: expr), 64: sum=sum(63: case)}] group by [[61: year]] having [null]
-                    SCAN (mv[lineitem_mv] columns[116: o_orderdate, 125: p_type, 129: l_saleprice, 132: o_orderyear, 133: n_name1, 138: r_name2] predicate[125: p_type = ECONOMY ANODIZED STEEL AND 138: r_name2 = MIDDLE EAST AND 116: o_orderdate >= 1995-01-01 AND 116: o_orderdate <= 1996-12-31])
+                    SCAN (mv[lineitem_mv] columns[87: o_orderdate, 96: p_type, 100: l_saleprice, 103: o_orderyear, 104: n_name1, 109: r_name2] predicate[109: r_name2 = MIDDLE EAST AND 87: o_orderdate <= 1996-12-31 AND 87: o_orderdate >= 1995-01-01 AND 96: p_type = ECONOMY ANODIZED STEEL])
 [end]
-


### PR DESCRIPTION
Fixes #4777

Why I'm doing:

After PR https://github.com/StarRocks/starrocks/pull/34569/files, olap/native olaptable/materialized view can use non lock optimization, but query tables' related mvs have not 
copy its metadata, so optimization may be corrupted in the concurrent scenes.


What I'm doing:

- Support copy-only for queries' related materialized views.
- Add `skip_whole_phase_lock_mv_limit` to control strategies:
```
    /**
     * To avoid too many related materialized view causing too much fe memory and decreasing performance, set N
     * to determine which strategy you choose:
     *  N <0      : always use non lock optimization and no copy related materialized views which
     *      may cause metadata concurrency problem but can reduce many lock conflict time and metadata memory-copy consume.
     *  N = 0    : always not use non lock optimization
     *  N > 0    : use non lock optimization when related mvs's num <= N, otherwise don't use non lock optimization
     */
    @ConfField(mutable = true)
    public static int skip_whole_phase_lock_mv_limit = 5;
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
