### PR TITLE
[BugFix] Fix the case sensitivity issue in the analyze

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -91,8 +91,9 @@ public class AnalyzeStmtAnalyzer {
 
             // Analyze columns mentioned in the statement.
             Set<String> mentionedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-
             List<String> columnNames = statement.getColumnNames();
+            // The actual column name, avoiding case sensitivity issues
+            List<String> realColumnNames = Lists.newArrayList();
             if (columnNames != null) {
                 for (String colName : columnNames) {
                     Column col = analyzeTable.getColumn(colName);
@@ -102,8 +103,10 @@ public class AnalyzeStmtAnalyzer {
                     if (!mentionedColumns.add(colName)) {
                         throw new SemanticException("Column '%s' specified twice", colName);
                     }
+                    realColumnNames.add(col.getName());
                 }
             }
+            statement.setColumnNames(realColumnNames);
 
             analyzeProperties(statement.getProperties());
             analyzeAnalyzeTypeDesc(session, statement, statement.getAnalyzeTypeDesc());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -173,6 +173,8 @@ public class AnalyzeStmtAnalyzer {
                     Set<String> mentionedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
 
                     List<String> columnNames = statement.getColumnNames();
+                    // The actual column name, avoiding case sensitivity issues
+                    List<String> realColumnNames = Lists.newArrayList();
                     if (columnNames != null && !columnNames.isEmpty()) {
                         for (String colName : columnNames) {
                             Column col = analyzeTable.getColumn(colName);
@@ -183,7 +185,9 @@ public class AnalyzeStmtAnalyzer {
                             if (!mentionedColumns.add(colName)) {
                                 throw new SemanticException("Column '%s' specified twice", colName);
                             }
+                            realColumnNames.add(col.getName());
                         }
+                        statement.setColumnNames(realColumnNames);
                     }
 
                     statement.setDbId(db.getId());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -121,6 +121,8 @@ public class AnalyzeStmtAnalyzer {
                             statement.getTableName().toString());
                 }
                 statement.setExternal(true);
+            } else if (CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(analyzeTable.getCatalogName())) {
+                throw new SemanticException("Don't support analyze external table created by resource mapping");
             }
             return null;
         }
@@ -168,6 +170,10 @@ public class AnalyzeStmtAnalyzer {
                     MetaUtils.normalizationTableName(session, statement.getTableName());
                     Database db = MetaUtils.getDatabase(session, statement.getTableName());
                     Table analyzeTable = MetaUtils.getTable(session, statement.getTableName());
+
+                    if (CatalogMgr.ResourceMappingCatalog.isResourceMappingCatalog(analyzeTable.getCatalogName())) {
+                        throw new SemanticException("Don't support analyze external table created by resource mapping");
+                    }
 
                     // Analyze columns mentioned in the statement.
                     Set<String> mentionedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzeStmtAnalyzer.java
@@ -105,8 +105,8 @@ public class AnalyzeStmtAnalyzer {
                     }
                     realColumnNames.add(col.getName());
                 }
+                statement.setColumnNames(realColumnNames);
             }
-            statement.setColumnNames(realColumnNames);
 
             analyzeProperties(statement.getProperties());
             analyzeAnalyzeTypeDesc(session, statement, statement.getAnalyzeTypeDesc());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateAnalyzeJobStmt.java
@@ -29,7 +29,7 @@ public class CreateAnalyzeJobStmt extends DdlStmt {
     private long dbId;
     private long tableId;
     private final TableName tbl;
-    private final List<String> columnNames;
+    private List<String> columnNames;
     private final boolean isSample;
     private Map<String, String> properties;
 
@@ -75,6 +75,10 @@ public class CreateAnalyzeJobStmt extends DdlStmt {
 
     public List<String> getColumnNames() {
         return columnNames;
+    }
+
+    public void setColumnNames(List<String> columnNames) {
+        this.columnNames = columnNames;
     }
 
     public boolean isSample() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeCreateAnalyzeJobTest.java
@@ -19,6 +19,7 @@ import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Table;
 import com.starrocks.qe.DDLStmtExecutor;
 import com.starrocks.sql.ast.CreateAnalyzeJobStmt;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
@@ -27,6 +28,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.analyzeSuccess;
+import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getConnectContext;
 import static com.starrocks.sql.analyzer.AnalyzeTestUtil.getStarRocksAssert;
 
 public class AnalyzeCreateAnalyzeJobTest {
@@ -37,6 +39,7 @@ public class AnalyzeCreateAnalyzeJobTest {
         UtFrameUtils.createMinStarRocksCluster();
         AnalyzeTestUtil.init();
         starRocksAssert = getStarRocksAssert();
+        ConnectorPlanTestBase.mockHiveCatalog(getConnectContext());
 
         String createTblStmtStr = "create table db.tbl(kk1 int, kk2 varchar(32), kk3 int, kk4 int) "
                 + "AGGREGATE KEY(kk1, kk2,kk3,kk4) distributed by hash(kk1) buckets 3 properties('replication_num' = "
@@ -87,5 +90,9 @@ public class AnalyzeCreateAnalyzeJobTest {
         DDLStmtExecutor.execute(analyzeStmt, starRocksAssert.getCtx());
         Assert.assertEquals(1,
                 starRocksAssert.getCtx().getGlobalStateMgr().getAnalyzeMgr().getAllAnalyzeJobList().size());
+
+        sql = "create analyze table hive0.tpch.customer(C_NAME, C_PHONE)";
+        analyzeStmt = (CreateAnalyzeJobStmt) analyzeSuccess(sql);
+        Assert.assertEquals("[c_name, c_phone]", analyzeStmt.getColumnNames().toString());
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -128,6 +128,10 @@ public class AnalyzeStmtTest {
         AnalyzeStmt analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
 
         Assert.assertTrue(analyzeStmt.isExternal());
+
+        sql = "analyze table hive0.tpch.customer(C_NAME, C_PHONE)";
+        analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
+        Assert.assertEquals("[c_name, c_phone]", analyzeStmt.getColumnNames().toString());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -17,13 +17,17 @@ package com.starrocks.sql.analyzer;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AnalyzeHistogramDesc;
 import com.starrocks.sql.ast.AnalyzeStmt;
@@ -39,6 +43,7 @@ import com.starrocks.sql.ast.ShowBasicStatsMetaStmt;
 import com.starrocks.sql.ast.ShowHistogramStatsMetaStmt;
 import com.starrocks.sql.ast.ShowUserPropertyStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.statistic.AnalyzeStatus;
 import com.starrocks.statistic.BasicStatsMeta;
@@ -53,6 +58,8 @@ import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -132,6 +139,21 @@ public class AnalyzeStmtTest {
         sql = "analyze table hive0.tpch.customer(C_NAME, C_PHONE)";
         analyzeStmt = (AnalyzeStmt) analyzeSuccess(sql);
         Assert.assertEquals("[c_name, c_phone]", analyzeStmt.getColumnNames().toString());
+    }
+
+    @Test
+    public void testAnalyzeHiveResource() {
+        new MockUp<MetaUtils>() {
+            @Mock
+            public Table getTable(ConnectContext session, TableName tableName) {
+                return new HiveTable(1, "customer", Lists.newArrayList(), "resource_name",
+                        CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName("resource_name", "hive"),
+                        "hive", "tpch", "", 0, Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap(),
+                        null, null);
+            }
+        };
+        String sql = "analyze table tpch.customer";
+        analyzeFail(sql, "Don't support analyze external table created by resource mapping.");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
analyze table (K1) will insert column name "K1" into external_column_statistics table
What I'm doing:
use actual column name, avoiding case sensitivity issues
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
