### PR TITLE
[BugFix] fix PassThroughChunkBuffer reference leak

### DIFF
--- a/be/src/runtime/data_stream_mgr.cpp
+++ b/be/src/runtime/data_stream_mgr.cpp
@@ -74,6 +74,8 @@ DataStreamMgr::~DataStreamMgr() {
             }
         }
     }
+    // explicitly call close to release PassThroughChunkBufferManager resources
+    _pass_through_chunk_buffer_manager.close();
 }
 
 inline uint32_t DataStreamMgr::get_bucket(const TUniqueId& fragment_instance_id) {
@@ -200,7 +202,7 @@ void DataStreamMgr::deregister_recvr(const TUniqueId& fragment_instance_id, Plan
 }
 
 void DataStreamMgr::close() {
-    for (size_t i = 0; i < _receiver_map->size(); i++) {
+    for (size_t i = 0; i < BUCKET_NUM; i++) {
         std::lock_guard<Mutex> l(_lock[i]);
         for (auto& iter : _receiver_map[i]) {
             for (auto& sub_iter : *iter.second) {
@@ -208,7 +210,9 @@ void DataStreamMgr::close() {
             }
         }
     }
-    _pass_through_chunk_buffer_manager.close();
+    // NOTE: delay _pass_through_chunk_buffer_manager's close action until DataStreamMgr is destroyed
+    // Let all the fragments take chances to cancel/close its PassThroughChunkBuffer asynchronously
+    // from other threads.
 }
 
 void DataStreamMgr::cancel(const TUniqueId& fragment_instance_id) {

--- a/be/src/runtime/local_pass_through_buffer.cpp
+++ b/be/src/runtime/local_pass_through_buffer.cpp
@@ -98,7 +98,10 @@ PassThroughChunkBuffer::PassThroughChunkBuffer(const TUniqueId& query_id)
         : _mutex(), _query_id(query_id), _ref_count(1) {}
 
 PassThroughChunkBuffer::~PassThroughChunkBuffer() {
-    DCHECK(_ref_count == 0);
+    if (UNLIKELY(_ref_count != 0)) {
+        LOG(WARNING) << "PassThroughChunkBuffer reference leak detected! query_id=" << print_id(_query_id)
+                     << ", _ref_count=" << _ref_count;
+    }
     for (auto& it : _key_to_channel) {
         delete it.second;
     }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -293,6 +293,7 @@ set(EXEC_FILES
         ./storage/get_use_pk_index_test.cpp
         ./storage/meta_reader_test.cpp
         ./runtime/buffer_control_block_test.cpp
+        ./runtime/data_stream_mgr_test.cpp
         ./runtime/datetime_value_test.cpp
         ./runtime/decimalv2_value_test.cpp
         ./runtime/decimalv3_test.cpp

--- a/be/test/runtime/data_stream_mgr_test.cpp
+++ b/be/test/runtime/data_stream_mgr_test.cpp
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "runtime/data_stream_mgr.h"
+
+#include <gtest/gtest.h>
+
+namespace starrocks {
+
+TEST(DataStreamMgr, pass_through_buffer_test) {
+    auto mgr = std::make_unique<DataStreamMgr>();
+
+    TUniqueId query_id;
+    query_id.lo = 1121;
+    query_id.hi = 2023;
+
+    // register the same query_id twice
+    mgr->prepare_pass_through_chunk_buffer(query_id);
+    mgr->prepare_pass_through_chunk_buffer(query_id);
+
+    // unregister one
+    mgr->destroy_pass_through_chunk_buffer(query_id);
+    // close with no issue
+    mgr->close();
+    // unregister for the second
+    mgr->destroy_pass_through_chunk_buffer(query_id);
+    // no issue, all resources released
+    mgr.reset();
+}
+
+} // namespace starrocks


### PR DESCRIPTION
* delay PassThroughChunkBufferManager's close action, allows all the executors to close/cancel the pass_through_chunk_buffer
* Fix DataStreamMgr::close() typo, should use `BUCKET_NUM` to iterate _receiver_map

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
