### PR TITLE
[Enhancement] Reduce database lock holding time in TabletStatMgr

### DIFF
--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -478,6 +478,7 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                                        const ::starrocks::lake::TabletStatRequest* request,
                                        ::starrocks::lake::TabletStatResponse* response,
                                        ::google::protobuf::Closure* done) {
+    static constexpr int64_t kDefaultTimeout = 5 * 60 * 1000L; // 5 minutes
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -485,21 +486,30 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
         cntl->SetFailed("missing tablet_infos");
         return;
     }
-
+    int64_t timeout_ms = request->has_timeout_ms() ? request->timeout_ms() : kDefaultTimeout;
+    int64_t due_time = butil::gettimeofday_ms() + timeout_ms;
     auto thread_pool = get_tablet_stats_thread_pool(_env);
     auto latch = BThreadCountDownLatch(request->tablet_infos_size());
     bthread::Mutex response_mtx;
     for (const auto& tablet_info : request->tablet_infos()) {
         auto task = [&, tablet_info]() {
             DeferOp defer([&] { latch.count_down(); });
+
             int64_t tablet_id = tablet_info.tablet_id();
+            int64_t version = tablet_info.version();
+            int64_t now = butil::gettimeofday_ms();
+            if (now >= due_time) {
+                LOG(WARNING) << "Cancelled tablet stat collection task due to timeout exceeded. tablet_id: "
+                             << tablet_id << ", version: " << version;
+                return;
+            }
+
             auto tablet = _tablet_mgr->get_tablet(tablet_id);
             if (!tablet.ok()) {
                 LOG(WARNING) << "Fail to get tablet " << tablet_id << ": " << tablet.status();
                 return;
             }
 
-            int64_t version = tablet_info.version();
             auto tablet_metadata = tablet->get_metadata(version);
             if (!tablet_metadata.ok()) {
                 LOG(WARNING) << "Fail to get tablet metadata. tablet_id: " << tablet_id << ", version: " << version
@@ -523,6 +533,7 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
             tablet_stat->set_num_rows(num_rows);
             tablet_stat->set_data_size(data_size);
         };
+        TEST_SYNC_POINT_CALLBACK("LakeServiceImpl::get_tablet_stats:before_submit", nullptr);
         if (auto st = thread_pool->submit_func(std::move(task)); !st.ok()) {
             LOG(WARNING) << "Fail to get tablet stats task: " << st;
             latch.count_down();

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -478,7 +478,6 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
                                        const ::starrocks::lake::TabletStatRequest* request,
                                        ::starrocks::lake::TabletStatResponse* response,
                                        ::google::protobuf::Closure* done) {
-    static constexpr int64_t kDefaultTimeout = 5 * 60 * 1000L; // 5 minutes
     brpc::ClosureGuard guard(done);
     auto cntl = static_cast<brpc::Controller*>(controller);
 
@@ -486,7 +485,7 @@ void LakeServiceImpl::get_tablet_stats(::google::protobuf::RpcController* contro
         cntl->SetFailed("missing tablet_infos");
         return;
     }
-    int64_t timeout_ms = request->has_timeout_ms() ? request->timeout_ms() : kDefaultTimeout;
+    int64_t timeout_ms = request->has_timeout_ms() ? request->timeout_ms() : kDefaultTimeoutForGetTabletStat;
     int64_t due_time = butil::gettimeofday_ms() + timeout_ms;
     auto thread_pool = get_tablet_stats_thread_pool(_env);
     auto latch = BThreadCountDownLatch(request->tablet_infos_size());

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -103,6 +103,8 @@ private:
                                           ::starrocks::lake::PublishLogVersionResponse* response);
 
 private:
+    static constexpr int64_t kDefaultTimeoutForGetTabletStat = 5 * 60 * 1000L; // 5 minutes
+
     ExecEnv* _env;
     lake::TabletManager* _tablet_mgr;
 };

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1027,7 +1027,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
     {
         lake::TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(2001);
+        txnlog.set_txn_id(1001);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
         txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(101);
         txnlog.mutable_op_write()->mutable_rowset()->set_data_size(4096);
@@ -1037,7 +1037,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
 
         lake::TxnLog txnlog2;
         txnlog2.set_tablet_id(_tablet_id);
-        txnlog2.set_txn_id(2002);
+        txnlog2.set_txn_id(1002);
         txnlog2.mutable_op_write()->mutable_rowset()->set_overlapped(true);
         txnlog2.mutable_op_write()->mutable_rowset()->set_num_rows(101);
         txnlog2.mutable_op_write()->mutable_rowset()->set_data_size(4096);
@@ -1066,7 +1066,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         lake::PublishLogVersionBatchRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(2001);
+        request.add_txn_ids(1001);
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
@@ -1076,8 +1076,8 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         lake::PublishLogVersionBatchRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(2001);
-        request.add_txn_ids(2002);
+        request.add_txn_ids(1001);
+        request.add_txn_ids(1002);
         request.add_versions(10);
         request.add_versions(11);
         brpc::Controller cntl;
@@ -1087,26 +1087,26 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
 
         _tablet_mgr->prune_metacache();
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2001).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 2001).status();
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2002).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 2002).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 1001).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1002).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 1002).status();
 
         ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_vlog(_tablet_id, 10));
         ASSERT_EQ(_tablet_id, txn_log->tablet_id());
-        ASSERT_EQ(2001, txn_log->txn_id());
+        ASSERT_EQ(1001, txn_log->txn_id());
 
         ASSIGN_OR_ABORT(auto txn_log2, _tablet_mgr->get_txn_vlog(_tablet_id, 11));
         ASSERT_EQ(_tablet_id, txn_log2->tablet_id());
-        ASSERT_EQ(2002, txn_log2->txn_id());
+        ASSERT_EQ(1002, txn_log2->txn_id());
     }
     // duplicate request
     {
         lake::PublishLogVersionBatchRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(2001);
-        request.add_txn_ids(2002);
+        request.add_txn_ids(1001);
+        request.add_txn_ids(1002);
         request.add_versions(10);
         request.add_versions(11);
         brpc::Controller cntl;
@@ -1116,19 +1116,19 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
 
         _tablet_mgr->prune_metacache();
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2001).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 2001).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 1001).status();
 
         ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_vlog(_tablet_id, 10));
         ASSERT_EQ(_tablet_id, txn_log->tablet_id());
-        ASSERT_EQ(2001, txn_log->txn_id());
+        ASSERT_EQ(1001, txn_log->txn_id());
 
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2002).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 2002).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1002).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 1002).status();
 
         ASSIGN_OR_ABORT(auto txn_log2, _tablet_mgr->get_txn_vlog(_tablet_id, 11));
         ASSERT_EQ(_tablet_id, txn_log2->tablet_id());
-        ASSERT_EQ(2002, txn_log2->txn_id());
+        ASSERT_EQ(1002, txn_log2->txn_id());
     }
 
     // not existing txnId

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -1027,7 +1027,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
     {
         lake::TxnLog txnlog;
         txnlog.set_tablet_id(_tablet_id);
-        txnlog.set_txn_id(1001);
+        txnlog.set_txn_id(2001);
         txnlog.mutable_op_write()->mutable_rowset()->set_overlapped(true);
         txnlog.mutable_op_write()->mutable_rowset()->set_num_rows(101);
         txnlog.mutable_op_write()->mutable_rowset()->set_data_size(4096);
@@ -1037,7 +1037,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
 
         lake::TxnLog txnlog2;
         txnlog2.set_tablet_id(_tablet_id);
-        txnlog2.set_txn_id(1002);
+        txnlog2.set_txn_id(2002);
         txnlog2.mutable_op_write()->mutable_rowset()->set_overlapped(true);
         txnlog2.mutable_op_write()->mutable_rowset()->set_num_rows(101);
         txnlog2.mutable_op_write()->mutable_rowset()->set_data_size(4096);
@@ -1066,7 +1066,7 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         lake::PublishLogVersionBatchRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1001);
+        request.add_txn_ids(2001);
         brpc::Controller cntl;
         _lake_service.publish_log_version_batch(&cntl, &request, &response, nullptr);
         ASSERT_TRUE(cntl.Failed());
@@ -1076,8 +1076,8 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         lake::PublishLogVersionBatchRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1001);
-        request.add_txn_ids(1002);
+        request.add_txn_ids(2001);
+        request.add_txn_ids(2002);
         request.add_versions(10);
         request.add_versions(11);
         brpc::Controller cntl;
@@ -1087,26 +1087,26 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
 
         _tablet_mgr->prune_metacache();
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 1001).status();
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1002).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 1002).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2001).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 2001).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2002).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 2002).status();
 
         ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_vlog(_tablet_id, 10));
         ASSERT_EQ(_tablet_id, txn_log->tablet_id());
-        ASSERT_EQ(1001, txn_log->txn_id());
+        ASSERT_EQ(2001, txn_log->txn_id());
 
         ASSIGN_OR_ABORT(auto txn_log2, _tablet_mgr->get_txn_vlog(_tablet_id, 11));
         ASSERT_EQ(_tablet_id, txn_log2->tablet_id());
-        ASSERT_EQ(1002, txn_log2->txn_id());
+        ASSERT_EQ(2002, txn_log2->txn_id());
     }
     // duplicate request
     {
         lake::PublishLogVersionBatchRequest request;
         lake::PublishLogVersionResponse response;
         request.add_tablet_ids(_tablet_id);
-        request.add_txn_ids(1001);
-        request.add_txn_ids(1002);
+        request.add_txn_ids(2001);
+        request.add_txn_ids(2002);
         request.add_versions(10);
         request.add_versions(11);
         brpc::Controller cntl;
@@ -1116,19 +1116,19 @@ TEST_F(LakeServiceTest, test_publish_log_version_batch) {
         ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
 
         _tablet_mgr->prune_metacache();
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1001).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 1001).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2001).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 2001).status();
 
         ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_vlog(_tablet_id, 10));
         ASSERT_EQ(_tablet_id, txn_log->tablet_id());
-        ASSERT_EQ(1001, txn_log->txn_id());
+        ASSERT_EQ(2001, txn_log->txn_id());
 
-        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 1002).status().is_not_found())
-                << _tablet_mgr->get_txn_log(_tablet_id, 1002).status();
+        ASSERT_TRUE(_tablet_mgr->get_txn_log(_tablet_id, 2002).status().is_not_found())
+                << _tablet_mgr->get_txn_log(_tablet_id, 2002).status();
 
         ASSIGN_OR_ABORT(auto txn_log2, _tablet_mgr->get_txn_vlog(_tablet_id, 11));
         ASSERT_EQ(_tablet_id, txn_log2->tablet_id());
-        ASSERT_EQ(1002, txn_log2->txn_id());
+        ASSERT_EQ(2002, txn_log2->txn_id());
     }
 
     // not existing txnId
@@ -1407,6 +1407,21 @@ TEST_F(LakeServiceTest, test_get_tablet_stats) {
     ASSERT_EQ(_tablet_id, response.tablet_stats(0).tablet_id());
     ASSERT_EQ(0, response.tablet_stats(0).num_rows());
     ASSERT_EQ(0, response.tablet_stats(0).data_size());
+
+    // test timeout
+    response.clear_tablet_stats();
+    request.set_timeout_ms(5);
+
+    SyncPoint::GetInstance()->SetCallBack("LakeServiceImpl::get_tablet_stats:before_submit",
+                                          [](void*) { std::this_thread::sleep_for(std::chrono::milliseconds(10)); });
+    SyncPoint::GetInstance()->EnableProcessing();
+    DeferOp defer([&]() {
+        SyncPoint::GetInstance()->ClearCallBack("LakeServiceImpl::get_tablet_stats:before_submit");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    _lake_service.get_tablet_stats(nullptr, &request, &response, nullptr);
+    ASSERT_EQ(0, response.tablet_stats_size());
 }
 
 // NOLINTNEXTLINE

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -138,7 +138,7 @@ public class TabletStatMgr extends FrontendDaemon {
     }
 
     private void updateLocalTabletStat() {
-        if (RunMode.isSharedDataMode()) {
+        if (!RunMode.isSharedNothingMode()) {
             return;
         }
         ImmutableMap<Long, Backend> backends = GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
@@ -195,7 +195,7 @@ public class TabletStatMgr extends FrontendDaemon {
     }
 
     private void updateLakeTabletStat() {
-        if (RunMode.isSharedNothingMode()) {
+        if (!RunMode.isSharedDataMode()) {
             return;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -227,7 +227,7 @@ public class TabletStatMgr extends FrontendDaemon {
     }
 
     @NotNull
-    private PartitionSnapshot craetePartitionSnapshot(@NotNull Database db,
+    private PartitionSnapshot createPartitionSnapshot(@NotNull Database db,
                                                       @NotNull OlapTable table,
                                                       @NotNull PhysicalPartition partition) {
         String dbName = db.getFullName();
@@ -248,7 +248,7 @@ public class TabletStatMgr extends FrontendDaemon {
     @Nullable
     private CollectTabletStatJob createCollectTabletStatJob(@NotNull Database db, @NotNull OlapTable table,
                                                             @NotNull PhysicalPartition partition) {
-        PartitionSnapshot snapshot = craetePartitionSnapshot(db, table, partition);
+        PartitionSnapshot snapshot = createPartitionSnapshot(db, table, partition);
         long visibleVersionTime = snapshot.visibleVersionTime;
         snapshot.tablets.removeIf(t -> ((LakeTablet) t).getDataSizeUpdateTime() >= visibleVersionTime);
         if (snapshot.tablets.isEmpty()) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -253,6 +253,7 @@ public class TabletStatMgr extends FrontendDaemon {
         long visibleVersionTime = snapshot.visibleVersionTime;
         snapshot.tablets.removeIf(t -> ((LakeTablet) t).getDataSizeUpdateTime() >= visibleVersionTime);
         if (snapshot.tablets.isEmpty()) {
+            LOG.debug("Skipped tablet stat collection of partition {}", snapshot.debugName());
             return null;
         }
         return new CollectTabletStatJob(snapshot);
@@ -285,6 +286,10 @@ public class TabletStatMgr extends FrontendDaemon {
             this.visibleVersion = visibleVersion;
             this.visibleVersionTime = visibleVersionTime;
             this.tablets = Objects.requireNonNull(tablets);
+        }
+
+        private String debugName() {
+            return String.format("%s.%s.%d version %d", dbName, tableName, partitionId, visibleVersion);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -246,9 +246,8 @@ public class TabletStatMgr extends FrontendDaemon {
     }
 
     @Nullable
-    private CollectTabletStatJob createCollectTabletStatJobs(@NotNull Database db,
-                                                             @NotNull OlapTable table,
-                                                             @NotNull PhysicalPartition partition) {
+    private CollectTabletStatJob createCollectTabletStatJob(@NotNull Database db, @NotNull OlapTable table,
+                                                            @NotNull PhysicalPartition partition) {
         PartitionSnapshot snapshot = craetePartitionSnapshot(db, table, partition);
         long visibleVersionTime = snapshot.visibleVersionTime;
         snapshot.tablets.removeIf(t -> ((LakeTablet) t).getDataSizeUpdateTime() >= visibleVersionTime);
@@ -262,7 +261,7 @@ public class TabletStatMgr extends FrontendDaemon {
     private void updateLakeTableTabletStat(@NotNull Database db, @NotNull OlapTable table) {
         Collection<PhysicalPartition> partitions = getPartitions(db, table);
         for (PhysicalPartition partition : partitions) {
-            CollectTabletStatJob job = createCollectTabletStatJobs(db, table, partition);
+            CollectTabletStatJob job = createCollectTabletStatJob(db, table, partition);
             if (job == null) {
                 continue;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -36,7 +36,6 @@ package com.starrocks.catalog;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.common.ClientPool;
 import com.starrocks.common.Config;
@@ -52,9 +51,9 @@ import com.starrocks.proto.TabletStatResponse.TabletStat;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
-import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.BackendService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TTabletStat;
@@ -63,9 +62,16 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 
 /*
  * TabletStatMgr is for collecting tablet(replica) statistics from backends.
@@ -74,14 +80,10 @@ import java.util.concurrent.Future;
 public class TabletStatMgr extends FrontendDaemon {
     private static final Logger LOG = LogManager.getLogger(TabletStatMgr.class);
 
-    // for lake table
-    private final Map<Long, Long> partitionToUpdatedVersion;
-
     private LocalDateTime lastWorkTimestamp = LocalDateTime.MIN;
 
     public TabletStatMgr() {
         super("tablet stat mgr", Config.tablet_stat_update_interval_second * 1000L);
-        partitionToUpdatedVersion = Maps.newHashMap();
     }
 
     public LocalDateTime getLastWorkTimestamp() {
@@ -113,7 +115,8 @@ public class TabletStatMgr extends FrontendDaemon {
                     for (Partition partition : olapTable.getAllPartitions()) {
                         for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
                             long version = physicalPartition.getVisibleVersion();
-                            for (MaterializedIndex index : physicalPartition.getMaterializedIndices(IndexExtState.VISIBLE)) {
+                            for (MaterializedIndex index : physicalPartition.getMaterializedIndices(
+                                    IndexExtState.VISIBLE)) {
                                 long indexRowCount = 0L;
                                 for (Tablet tablet : index.getTablets()) {
                                     indexRowCount += tablet.getRowCount(version);
@@ -135,6 +138,9 @@ public class TabletStatMgr extends FrontendDaemon {
     }
 
     private void updateLocalTabletStat() {
+        if (RunMode.isSharedDataMode()) {
+            return;
+        }
         ImmutableMap<Long, Backend> backends = GlobalStateMgr.getCurrentSystemInfo().getIdToBackend();
 
         long start = System.currentTimeMillis();
@@ -189,6 +195,10 @@ public class TabletStatMgr extends FrontendDaemon {
     }
 
     private void updateLakeTabletStat() {
+        if (RunMode.isSharedNothingMode()) {
+            return;
+        }
+
         List<Long> dbIds = GlobalStateMgr.getCurrentState().getDbIds();
         for (Long dbId : dbIds) {
             Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
@@ -196,135 +206,166 @@ public class TabletStatMgr extends FrontendDaemon {
                 continue;
             }
 
-            List<OlapTable> tables = Lists.newArrayList();
-            Locker locker = new Locker();
-            locker.lockDatabase(db, LockType.READ);
-            try {
-                for (Table table : db.getTables()) {
-                    if (table.isCloudNativeTableOrMaterializedView()) {
-                        tables.add((OlapTable) table);
-                    }
+            List<Table> tables = db.getTables();
+            for (Table table : tables) {
+                if (table.isCloudNativeTableOrMaterializedView()) {
+                    updateLakeTableTabletStat(db, (OlapTable) table);
                 }
-            } finally {
-                locker.unLockDatabase(db, LockType.READ);
-            }
-
-            for (OlapTable table : tables) {
-                updateLakeTableTabletStat(db, table);
             }
         }
     }
 
-    @java.lang.SuppressWarnings("squid:S2142")  // allow catch InterruptedException
-    private void updateLakeTableTabletStat(Database db, OlapTable table) {
-        // prepare tablet infos
-        Map<Long, List<TabletInfo>> beToTabletInfos = Maps.newHashMap();
-        Map<Long, Long> partitionToVersion = Maps.newHashMap();
+    @NotNull
+    private Collection<PhysicalPartition> getPartitions(@NotNull Database db, @NotNull OlapTable table) {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            for (PhysicalPartition partition : table.getPhysicalPartitions()) {
-                long partitionId = partition.getId();
-                long version = partition.getVisibleVersion();
-                // partition init version is 1
-                if (version <= partitionToUpdatedVersion.getOrDefault(partitionId, 1L)) {
-                    continue;
-                }
-
-                partitionToVersion.put(partitionId, version);
-                for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                    for (Tablet tablet : index.getTablets()) {
-                        Long beId = Utils.chooseBackend((LakeTablet) tablet);
-                        if (beId == null) {
-                            continue;
-                        }
-                        TabletInfo tabletInfo = new TabletInfo();
-                        tabletInfo.tabletId = tablet.getId();
-                        tabletInfo.version = version;
-                        beToTabletInfos.computeIfAbsent(beId, k -> Lists.newArrayList()).add(tabletInfo);
-                    }
-                }
-            }
+            return table.getPhysicalPartitions();
         } finally {
             locker.unLockDatabase(db, LockType.READ);
         }
+    }
 
-        if (beToTabletInfos.isEmpty()) {
-            return;
+    @NotNull
+    private PartitionSnapshot craetePartitionSnapshot(@NotNull Database db,
+                                                      @NotNull OlapTable table,
+                                                      @NotNull PhysicalPartition partition) {
+        String dbName = db.getFullName();
+        String tableName = table.getName();
+        long partitionId = partition.getId();
+        Locker locker = new Locker();
+        locker.lockDatabase(db, LockType.READ);
+        try {
+            long visibleVersion = partition.getVisibleVersion();
+            long visibleVersionTime = partition.getVisibleVersionTime();
+            List<Tablet> tablets = new ArrayList<>(partition.getBaseIndex().getTablets());
+            return new PartitionSnapshot(dbName, tableName, partitionId, visibleVersion, visibleVersionTime, tablets);
+        } finally {
+            locker.unLockDatabase(db, LockType.READ);
+        }
+    }
+
+    @Nullable
+    private CollectTabletStatJob createCollectTabletStatJobs(@NotNull Database db,
+                                                             @NotNull OlapTable table,
+                                                             @NotNull PhysicalPartition partition) {
+        PartitionSnapshot snapshot = craetePartitionSnapshot(db, table, partition);
+        long visibleVersionTime = snapshot.visibleVersionTime;
+        snapshot.tablets.removeIf(t -> ((LakeTablet) t).getDataSizeUpdateTime() >= visibleVersionTime);
+        if (snapshot.tablets.isEmpty()) {
+            return null;
+        }
+        return new CollectTabletStatJob(snapshot);
+    }
+
+    private void updateLakeTableTabletStat(@NotNull Database db, @NotNull OlapTable table) {
+        Collection<PhysicalPartition> partitions = getPartitions(db, table);
+        for (PhysicalPartition partition : partitions) {
+            CollectTabletStatJob job = createCollectTabletStatJobs(db, table, partition);
+            if (job == null) {
+                continue;
+            }
+            job.execute();
+        }
+    }
+
+    private static class PartitionSnapshot {
+        private final String dbName;
+        private final String tableName;
+        private final long partitionId;
+        private final long visibleVersion;
+        private final long visibleVersionTime;
+        private final List<Tablet> tablets;
+
+        PartitionSnapshot(String dbName, String tableName, long partitionId, long visibleVersion,
+                          long visibleVersionTime, List<Tablet> tablets) {
+            this.dbName = dbName;
+            this.tableName = tableName;
+            this.partitionId = partitionId;
+            this.visibleVersion = visibleVersion;
+            this.visibleVersionTime = visibleVersionTime;
+            this.tablets = Objects.requireNonNull(tablets);
+        }
+    }
+
+    private static class CollectTabletStatJob {
+        private final String dbName;
+        private final String tableName;
+        private final long partitionId;
+        private final long version;
+        private final Map<Long, Tablet> tablets;
+        private List<Future<TabletStatResponse>> responseList;
+
+        CollectTabletStatJob(PartitionSnapshot snapshot) {
+            this.dbName = Objects.requireNonNull(snapshot.dbName, "dbName is null");
+            this.tableName = Objects.requireNonNull(snapshot.tableName, "tableName is null");
+            this.partitionId = snapshot.partitionId;
+            this.version = snapshot.visibleVersion;
+            this.tablets = new HashMap<>();
+            for (Tablet tablet : snapshot.tablets) {
+                this.tablets.put(tablet.getId(), tablet);
+            }
         }
 
-        // get tablet stats from be
-        List<Future<TabletStatResponse>> responseList = Lists.newArrayListWithCapacity(beToTabletInfos.size());
-        SystemInfoService systemInfoService = GlobalStateMgr.getCurrentSystemInfo();
-        Map<Long, TabletStat> idToStat = Maps.newHashMap();
-        long start = System.currentTimeMillis();
-        try {
-            for (Map.Entry<Long, List<TabletInfo>> entry : beToTabletInfos.entrySet()) {
-                ComputeNode node = systemInfoService.getBackendOrComputeNode(entry.getKey());
+        void execute() {
+            sendTasks();
+            waitResponse();
+        }
+
+        private String debugName() {
+            return String.format("%s.%s.%d", dbName, tableName, partitionId);
+        }
+
+        private void sendTasks() {
+            Map<ComputeNode, List<TabletInfo>> beToTabletInfos = new HashMap<>();
+            for (Tablet tablet : tablets.values()) {
+                ComputeNode node = Utils.chooseNode((LakeTablet) tablet);
                 if (node == null) {
-                    continue;
+                    LOG.warn("Stop sending tablet stat task for partition {} because no alive node", debugName());
+                    return;
                 }
+                TabletInfo tabletInfo = new TabletInfo();
+                tabletInfo.tabletId = tablet.getId();
+                tabletInfo.version = version;
+                beToTabletInfos.computeIfAbsent(node, k -> Lists.newArrayList()).add(tabletInfo);
+            }
+
+            responseList = Lists.newArrayListWithCapacity(beToTabletInfos.size());
+            for (Map.Entry<ComputeNode, List<TabletInfo>> entry : beToTabletInfos.entrySet()) {
+                ComputeNode node = entry.getKey();
                 TabletStatRequest request = new TabletStatRequest();
                 request.tabletInfos = entry.getValue();
-
-                LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
-                Future<TabletStatResponse> responseFuture = lakeService.getTabletStats(request);
-                responseList.add(responseFuture);
+                request.timeoutMs = LakeService.TIMEOUT_GET_TABLET_STATS;
+                try {
+                    LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
+                    Future<TabletStatResponse> responseFuture = lakeService.getTabletStats(request);
+                    responseList.add(responseFuture);
+                } catch (Throwable e) {
+                    LOG.warn("Fail to send tablet stat task to host {} for partition {}: {}", node.getHost(), debugName(),
+                            e.getMessage());
+                }
             }
+        }
 
+        private void waitResponse() {
             for (Future<TabletStatResponse> responseFuture : responseList) {
-                TabletStatResponse response = responseFuture.get();
-                if (response != null && response.tabletStats != null) {
-                    for (TabletStat tabletStat : response.tabletStats) {
-                        idToStat.put(tabletStat.tabletId, tabletStat);
-                    }
-                }
-            }
-        } catch (Throwable e) {
-            LOG.warn("failed to get lake tablet stats. table id: {}", table.getId(), e);
-            return;
-        }
-        LOG.info("finished to get lake tablet stats. db id: {}, table id: {}, cost: {} ms", db.getId(), table.getId(),
-                (System.currentTimeMillis() - start));
-
-        if (idToStat.isEmpty()) {
-            return;
-        }
-
-        // update tablet stats
-        locker.lockDatabase(db, LockType.WRITE);
-        try {
-            for (PhysicalPartition partition : table.getPhysicalPartitions()) {
-                long partitionId = partition.getId();
-                if (!partitionToVersion.containsKey(partitionId)) {
-                    continue;
-                }
-
-                boolean allTabletsUpdated = true;
-                for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
-                    for (Tablet tablet : index.getTablets()) {
-                        TabletStat stat = idToStat.get(tablet.getId());
-                        if (stat == null) {
-                            allTabletsUpdated = false;
-                            continue;
+                try {
+                    TabletStatResponse response = responseFuture.get();
+                    long now = System.currentTimeMillis();
+                    if (response != null && response.tabletStats != null) {
+                        for (TabletStat stat : response.tabletStats) {
+                            LakeTablet tablet = (LakeTablet) tablets.get(stat.tabletId);
+                            tablet.setDataSize(stat.dataSize);
+                            tablet.setRowCount(stat.numRows);
+                            tablet.setDataSizeUpdateTime(now);
                         }
-
-                        LakeTablet lakeTablet = (LakeTablet) tablet;
-                        lakeTablet.setRowCount(stat.numRows);
-                        lakeTablet.setDataSize(stat.dataSize);
-                        LOG.debug("update lake tablet info. tablet id: {}, num rows: {}, data size: {}", stat.tabletId,
-                                stat.numRows, stat.dataSize);
                     }
-                }
-                if (allTabletsUpdated) {
-                    long version = partitionToVersion.get(partitionId);
-                    partitionToUpdatedVersion.put(partitionId, version);
-                    LOG.info("update lake tablet stats. db id: {}, table id: {}, partition id: {}, version: {}",
-                            db.getId(), table.getId(), partitionId, version);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (ExecutionException e) {
+                    LOG.warn("Fail to collect tablet stat for partition {}: {}", debugName(), e.getMessage());
                 }
             }
-        } finally {
-            locker.unLockDatabase(db, LockType.WRITE);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -340,6 +340,8 @@ public class TabletStatMgr extends FrontendDaemon {
                     LakeService lakeService = BrpcProxy.getLakeService(node.getHost(), node.getBrpcPort());
                     Future<TabletStatResponse> responseFuture = lakeService.getTabletStats(request);
                     responseList.add(responseFuture);
+                    LOG.debug("Sent tablet stat collection task to node {} for partition {} of version {}. tablet count={}",
+                                node.getHost(), debugName(), version, entry.getValue().size());
                 } catch (Throwable e) {
                     LOG.warn("Fail to send tablet stat task to host {} for partition {}: {}", node.getHost(), debugName(),
                             e.getMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -53,11 +53,14 @@ public class LakeTablet extends Tablet {
 
     private static final String JSON_KEY_DATA_SIZE = "dataSize";
     private static final String JSON_KEY_ROW_COUNT = "rowCount";
+    private static final String JSON_KEY_DATA_SIZE_UPDATE_TIME = "dataSizeUpdateTime";
 
     @SerializedName(value = JSON_KEY_DATA_SIZE)
-    private long dataSize = 0L;
+    private volatile long dataSize = 0L;
     @SerializedName(value = JSON_KEY_ROW_COUNT)
-    private long rowCount = 0L;
+    private volatile long rowCount = 0L;
+    @SerializedName(value = JSON_KEY_DATA_SIZE_UPDATE_TIME)
+    private volatile long dataSizeUpdateTime = 0L;
 
     public LakeTablet(long id) {
         super(id);
@@ -75,6 +78,14 @@ public class LakeTablet extends Tablet {
 
     public void setDataSize(long dataSize) {
         this.dataSize = dataSize;
+    }
+
+    public void setDataSizeUpdateTime(long dataSizeUpdateTime) {
+        this.dataSizeUpdateTime = dataSizeUpdateTime;
+    }
+
+    public long getDataSizeUpdateTime() {
+        return dataSizeUpdateTime;
     }
 
     // version is not used

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -49,6 +49,8 @@ import com.starrocks.proto.VacuumResponse;
 import java.util.concurrent.Future;
 
 public interface LakeService {
+    long TIMEOUT_GET_TABLET_STATS = 15 * 60 * 1000L;
+
     @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = /*1m=*/60000)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);
 
@@ -64,7 +66,7 @@ public interface LakeService {
     @ProtobufRPC(serviceName = "LakeService", methodName = "delete_data", onceTalkTimeout = 300000)
     Future<DeleteDataResponse> deleteData(DeleteDataRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "get_tablet_stats", onceTalkTimeout = /*5m=*/300000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "get_tablet_stats", onceTalkTimeout = TIMEOUT_GET_TABLET_STATS)
     Future<TabletStatResponse> getTabletStats(TabletStatRequest request);
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "drop_table", onceTalkTimeout = /*5m=*/300000)

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
@@ -27,7 +27,7 @@ import com.starrocks.proto.TabletStatResponse.TabletStat;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.system.Backend;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TStorageMedium;
@@ -35,6 +35,7 @@ import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTabletStat;
 import com.starrocks.thrift.TTabletStatResult;
 import com.starrocks.thrift.TTabletType;
+import mockit.Delegate;
 import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
@@ -46,17 +47,19 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
 public class TabletStatMgrTest {
+    private static final long DB_ID = 1;
+    private static final long TABLE_ID = 2;
+    private static final long PARTITION_ID = 3;
+    private static final long INDEX_ID = 4;
+
     @Test
     public void testUpdateLocalTabletStat(@Mocked GlobalStateMgr globalStateMgr, @Mocked Utils utils,
                                           @Mocked SystemInfoService systemInfoService) {
-        long dbId = 1L;
-        long tableId = 2L;
-        long partitionId = 3L;
-        long indexId = 4L;
         long tablet2Id = 11L;
         long backendId = 20L;
         TabletInvertedIndex invertedIndex = new TabletInvertedIndex();
@@ -69,7 +72,7 @@ public class TabletStatMgrTest {
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
 
         // Tablet2 is LocalTablet
-        TabletMeta tabletMeta2 = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD);
+        TabletMeta tabletMeta2 = new TabletMeta(DB_ID, TABLE_ID, PARTITION_ID, INDEX_ID, 0, TStorageMedium.HDD);
         invertedIndex.addTablet(tablet2Id, tabletMeta2);
         Replica replica = new Replica(tablet2Id + 1, backendId, 0, Replica.ReplicaState.NORMAL);
         invertedIndex.addReplica(tablet2Id, replica);
@@ -77,18 +80,18 @@ public class TabletStatMgrTest {
         // Partition info and distribution info
         DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
         PartitionInfo partitionInfo = new SinglePartitionInfo();
-        partitionInfo.setDataProperty(partitionId, new DataProperty(TStorageMedium.HDD));
-        partitionInfo.setIsInMemory(partitionId, false);
-        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
-        partitionInfo.setReplicationNum(partitionId, (short) 3);
+        partitionInfo.setDataProperty(PARTITION_ID, new DataProperty(TStorageMedium.HDD));
+        partitionInfo.setIsInMemory(PARTITION_ID, false);
+        partitionInfo.setTabletType(PARTITION_ID, TTabletType.TABLET_TYPE_DISK);
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 3);
 
         // Table
-        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        OlapTable table = new OlapTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
-        Deencapsulation.setField(table, "baseIndexId", indexId);
+        MaterializedIndex index = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        Partition partition = new Partition(PARTITION_ID, "p1", index, distributionInfo);
+        OlapTable table = new OlapTable(TABLE_ID, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+        Deencapsulation.setField(table, "baseIndexId", INDEX_ID);
         table.addPartition(partition);
-        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(INDEX_ID, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
 
         // Db
         Database db = new Database();
@@ -115,19 +118,11 @@ public class TabletStatMgrTest {
         Assert.assertEquals(201L, replica.getRowCount());
     }
 
-    @Test
-    public void testUpdateLakeTabletStat(@Mocked SystemInfoService systemInfoService,
-                                         @Mocked LakeService lakeService) {
-        long dbId = 1L;
-        long tableId = 2L;
-        long partitionId = 3L;
-        long indexId = 4L;
+    private LakeTable createLakeTableForTest() {
         long tablet1Id = 10L;
         long tablet2Id = 11L;
-        long tablet1NumRows = 20L;
-        long tablet2NumRows = 21L;
-        long tablet1DataSize = 30L;
-        long tablet2DataSize = 31L;
+        long tablet3Id = 12L;
+
 
         // Schema
         List<Column> columns = Lists.newArrayList();
@@ -136,31 +131,48 @@ public class TabletStatMgrTest {
         columns.add(new Column("k2", Type.BIGINT, true, null, "", ""));
         columns.add(new Column("v", Type.BIGINT, false, AggregateType.SUM, "0", ""));
 
+        long visibleVersionTime = System.currentTimeMillis();
+
         // Tablet
-        Tablet tablet1 = new LakeTablet(tablet1Id);
-        Tablet tablet2 = new LakeTablet(tablet2Id);
+        LakeTablet tablet1 = new LakeTablet(tablet1Id);
+        LakeTablet tablet2 = new LakeTablet(tablet2Id);
+        LakeTablet tablet3 = new LakeTablet(tablet3Id);
+        tablet1.setDataSizeUpdateTime(0);
+        tablet2.setDataSizeUpdateTime(0);
+        tablet3.setDataSizeUpdateTime(visibleVersionTime);
 
         // Index
-        MaterializedIndex index = new MaterializedIndex(indexId, MaterializedIndex.IndexState.NORMAL);
-        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD, true);
+        MaterializedIndex index = new MaterializedIndex(INDEX_ID, MaterializedIndex.IndexState.NORMAL);
+        TabletMeta tabletMeta = new TabletMeta(DB_ID,     TABLE_ID, PARTITION_ID, INDEX_ID, 0, TStorageMedium.HDD, true);
         index.addTablet(tablet1, tabletMeta);
         index.addTablet(tablet2, tabletMeta);
 
         // Partition
         DistributionInfo distributionInfo = new HashDistributionInfo(10, Lists.newArrayList(k1));
         PartitionInfo partitionInfo = new SinglePartitionInfo();
-        partitionInfo.setReplicationNum(partitionId, (short) 3);
-        Partition partition = new Partition(partitionId, "p1", index, distributionInfo);
-        partition.setVisibleVersion(2L, System.currentTimeMillis());
+        partitionInfo.setReplicationNum(PARTITION_ID, (short) 3);
+        Partition partition = new Partition(PARTITION_ID, "p1", index, distributionInfo);
+        partition.setVisibleVersion(2L, visibleVersionTime);
 
         // Lake table
-        LakeTable table = new LakeTable(tableId, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
-        Deencapsulation.setField(table, "baseIndexId", indexId);
+        LakeTable table = new LakeTable(TABLE_ID, "t1", columns, KeysType.AGG_KEYS, partitionInfo, distributionInfo);
+        Deencapsulation.setField(table, "baseIndexId", INDEX_ID);
         table.addPartition(partition);
-        table.setIndexMeta(indexId, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
+        table.setIndexMeta(INDEX_ID, "t1", columns, 0, 0, (short) 3, TStorageType.COLUMN, KeysType.AGG_KEYS);
+
+        return table;
+    }
+
+    @Test
+    public void testUpdateLakeTabletStat(@Mocked SystemInfoService systemInfoService,
+                                         @Mocked LakeService lakeService) {
+        LakeTable table = createLakeTableForTest();
+
+        long tablet1Id = table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(0).getId();
+        long tablet2Id = table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(1).getId();
 
         // db
-        Database db = new Database(dbId, "db");
+        Database db = new Database(DB_ID, "db");
         db.registerTableUnlocked(table);
 
         new MockUp<BrpcProxy>() {
@@ -179,53 +191,210 @@ public class TabletStatMgrTest {
             public Long chooseBackend(LakeTablet tablet) {
                 return 1000L;
             }
+            @Mock
+            public ComputeNode chooseNode(LakeTablet tablet) {
+                return new ComputeNode();
+            }
         };
+
+        long tablet1NumRows = 20L;
+        long tablet2NumRows = 21L;
+        long tablet1DataSize = 30L;
+        long tablet2DataSize = 31L;
+
         new Expectations() {
             {
-                systemInfoService.getBackendOrComputeNode(anyLong);
-                result = new Backend(1000L, "", 123);
-
                 lakeService.getTabletStats((TabletStatRequest) any);
                 minTimes = 1;
                 maxTimes = 1;
-                result = new Future<TabletStatResponse>() {
-                    @Override
-                    public boolean cancel(boolean mayInterruptIfRunning) {
-                        return false;
+                result = new Delegate() {
+                    Future<TabletStatResponse> getTabletStats(TabletStatRequest request) {
+                        Assert.assertEquals(LakeService.TIMEOUT_GET_TABLET_STATS, (long) request.timeoutMs);
+                        Assert.assertEquals(2, request.tabletInfos.size());
+                        Assert.assertEquals(tablet1Id, (long) request.tabletInfos.get(0).tabletId);
+                        Assert.assertEquals(tablet2Id, (long) request.tabletInfos.get(1).tabletId);
+
+                        return new Future<TabletStatResponse>() {
+                            @Override
+                            public boolean cancel(boolean mayInterruptIfRunning) {
+                                return false;
+                            }
+
+                            @Override
+                            public boolean isCancelled() {
+                                return false;
+                            }
+
+                            @Override
+                            public boolean isDone() {
+                                return true;
+                            }
+
+                            @Override
+                            public TabletStatResponse get() {
+                                List<TabletStat> stats = Lists.newArrayList();
+                                TabletStat stat1 = new TabletStat();
+                                stat1.tabletId = tablet1Id;
+                                stat1.numRows = tablet1NumRows;
+                                stat1.dataSize = tablet1DataSize;
+                                stats.add(stat1);
+                                TabletStat stat2 = new TabletStat();
+                                stat2.tabletId = tablet2Id;
+                                stat2.numRows = tablet2NumRows;
+                                stat2.dataSize = tablet2DataSize;
+                                stats.add(stat2);
+
+                                TabletStatResponse response = new TabletStatResponse();
+                                response.tabletStats = stats;
+                                return response;
+                            }
+
+                            @Override
+                            public TabletStatResponse get(long timeout, @NotNull TimeUnit unit) {
+                                return null;
+                            }
+                        };
                     }
+                };
+            }
+        };
 
-                    @Override
-                    public boolean isCancelled() {
-                        return false;
-                    }
+        long t1 = System.currentTimeMillis();
+        TabletStatMgr tabletStatMgr = new TabletStatMgr();
+        Deencapsulation.invoke(tabletStatMgr, "updateLakeTableTabletStat", db, table);
+        long t2 = System.currentTimeMillis();
 
-                    @Override
-                    public boolean isDone() {
-                        return true;
-                    }
+        LakeTablet tablet1 = (LakeTablet) table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(0);
+        LakeTablet tablet2 = (LakeTablet) table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(1);
 
-                    @Override
-                    public TabletStatResponse get() {
-                        List<TabletStat> stats = Lists.newArrayList();
-                        TabletStat stat1 = new TabletStat();
-                        stat1.tabletId = tablet1Id;
-                        stat1.numRows = tablet1NumRows;
-                        stat1.dataSize = tablet1DataSize;
-                        stats.add(stat1);
-                        TabletStat stat2 = new TabletStat();
-                        stat2.tabletId = tablet2Id;
-                        stat2.numRows = tablet2NumRows;
-                        stat2.dataSize = tablet2DataSize;
-                        stats.add(stat2);
+        Assert.assertEquals(tablet1.getRowCount(-1), tablet1NumRows);
+        Assert.assertEquals(tablet1.getDataSize(true), tablet1DataSize);
+        Assert.assertEquals(tablet2.getRowCount(-1), tablet2NumRows);
+        Assert.assertEquals(tablet2.getDataSize(true), tablet2DataSize);
+        Assert.assertTrue(tablet1.getDataSizeUpdateTime() >= t1 && tablet1.getDataSizeUpdateTime() <= t2);
+        Assert.assertTrue(tablet2.getDataSizeUpdateTime() >= t1 && tablet2.getDataSizeUpdateTime() <= t2);
+    }
 
-                        TabletStatResponse response = new TabletStatResponse();
-                        response.tabletStats = stats;
-                        return response;
-                    }
+    @Test
+    public void testUpdateLakeTabletStat2(@Mocked SystemInfoService systemInfoService,
+                                         @Mocked LakeService lakeService) {
+        LakeTable table = createLakeTableForTest();
 
-                    @Override
-                    public TabletStatResponse get(long timeout, @NotNull TimeUnit unit) {
-                        return null;
+        long tablet1Id = table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(0).getId();
+        long tablet2Id = table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(1).getId();
+
+        // db
+        Database db = new Database(DB_ID, "db");
+        db.registerTableUnlocked(table);
+
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(TNetworkAddress addr) {
+                throw new RuntimeException("injected exception");
+            }
+
+            @Mock
+            public LakeService getLakeService(String host, int port) {
+                throw new RuntimeException("injected exception");
+            }
+        };
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1000L;
+            }
+            @Mock
+            public ComputeNode chooseNode(LakeTablet tablet) {
+                return new ComputeNode();
+            }
+        };
+
+        TabletStatMgr tabletStatMgr = new TabletStatMgr();
+        Deencapsulation.invoke(tabletStatMgr, "updateLakeTableTabletStat", db, table);
+
+        LakeTablet tablet1 = (LakeTablet) table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(0);
+        LakeTablet tablet2 = (LakeTablet) table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(1);
+
+        Assert.assertEquals(0, tablet1.getRowCount(-1));
+        Assert.assertEquals(0, tablet1.getDataSize(true));
+        Assert.assertEquals(0, tablet2.getRowCount(-1));
+        Assert.assertEquals(0, tablet2.getDataSize(true));
+        Assert.assertEquals(0L, tablet1.getDataSizeUpdateTime());
+        Assert.assertEquals(0L, tablet2.getDataSizeUpdateTime());
+    }
+
+    @Test
+    public void testUpdateLakeTabletStat3(@Mocked SystemInfoService systemInfoService,
+                                         @Mocked LakeService lakeService) {
+        LakeTable table = createLakeTableForTest();
+
+        long tablet1Id = table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(0).getId();
+        long tablet2Id = table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(1).getId();
+
+        // db
+        Database db = new Database(DB_ID, "db");
+        db.registerTableUnlocked(table);
+
+        new MockUp<BrpcProxy>() {
+            @Mock
+            public LakeService getLakeService(TNetworkAddress addr) {
+                return lakeService;
+            }
+
+            @Mock
+            public LakeService getLakeService(String host, int port) {
+                return lakeService;
+            }
+        };
+        new MockUp<Utils>() {
+            @Mock
+            public Long chooseBackend(LakeTablet tablet) {
+                return 1000L;
+            }
+            @Mock
+            public ComputeNode chooseNode(LakeTablet tablet) {
+                return new ComputeNode();
+            }
+        };
+
+        long tablet1NumRows = 20L;
+        long tablet2NumRows = 21L;
+        long tablet1DataSize = 30L;
+        long tablet2DataSize = 31L;
+
+        new Expectations() {
+            {
+                lakeService.getTabletStats((TabletStatRequest) any);
+                minTimes = 1;
+                maxTimes = 1;
+                result = new Delegate() {
+                    Future<TabletStatResponse> getTabletStats(TabletStatRequest request) {
+                        return new Future<TabletStatResponse>() {
+                            @Override
+                            public boolean cancel(boolean mayInterruptIfRunning) {
+                                return false;
+                            }
+
+                            @Override
+                            public boolean isCancelled() {
+                                return false;
+                            }
+
+                            @Override
+                            public boolean isDone() {
+                                return true;
+                            }
+
+                            @Override
+                            public TabletStatResponse get() throws ExecutionException {
+                                throw new ExecutionException(new RuntimeException("injected"));
+                            }
+
+                            @Override
+                            public TabletStatResponse get(long timeout, @NotNull TimeUnit unit) {
+                                return null;
+                            }
+                        };
                     }
                 };
             }
@@ -234,12 +403,14 @@ public class TabletStatMgrTest {
         TabletStatMgr tabletStatMgr = new TabletStatMgr();
         Deencapsulation.invoke(tabletStatMgr, "updateLakeTableTabletStat", db, table);
 
-        Assert.assertEquals(tablet1.getRowCount(-1), tablet1NumRows);
-        Assert.assertEquals(tablet1.getDataSize(true), tablet1DataSize);
-        Assert.assertEquals(tablet2.getRowCount(-1), tablet2NumRows);
-        Assert.assertEquals(tablet2.getDataSize(true), tablet2DataSize);
-        Map<Long, Long> partitionToUpdatedVersion =
-                Deencapsulation.getField(tabletStatMgr, "partitionToUpdatedVersion");
-        Assert.assertEquals(2L, (long) partitionToUpdatedVersion.get(partitionId));
+        LakeTablet tablet1 = (LakeTablet) table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(0);
+        LakeTablet tablet2 = (LakeTablet) table.getPartition(PARTITION_ID).getBaseIndex().getTablets().get(1);
+
+        Assert.assertEquals(0, tablet1.getRowCount(-1));
+        Assert.assertEquals(0, tablet1.getDataSize(true));
+        Assert.assertEquals(0, tablet2.getRowCount(-1));
+        Assert.assertEquals(0, tablet2.getDataSize(true));
+        Assert.assertEquals(0L, tablet1.getDataSizeUpdateTime());
+        Assert.assertEquals(0L, tablet2.getDataSizeUpdateTime());
     }
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -105,6 +105,7 @@ message TabletStatRequest {
     }
 
     repeated TabletInfo tablet_infos = 1;
+    optional int64 timeout_ms = 2;
 }
 
 message TabletStatResponse {


### PR DESCRIPTION
Reduce database lock holding time in TabletStatMgr and add timeout for tablet stat collection tasks.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
