### PR TITLE
[Enhancement] Support transform distinct function in trino parser

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
@@ -35,13 +35,11 @@
 package com.starrocks.analysis;
 
 import com.google.common.collect.Lists;
-import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.io.Writable;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -49,6 +49,15 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select count_if(v1) from t0;";
         assertPlanContains(sql, "  2:AGGREGATE (update finalize)\n" +
                 "  |  output: count(if(CAST(1: v1 AS BOOLEAN), 1, NULL))");
+
+        sql = "select count(distinct ('a', 'b', 'c'))";
+        assertPlanContains(sql, "count('abc')");
+
+        sql = "select count(distinct row('a', 'b', 'c'));";
+        assertPlanContains(sql, "count('abc')");
+
+        sql = "select count(distinct (v1, v2, 'a')) from t0;";
+        assertPlanContains(sql, "count(concat(CAST(1: v1 AS VARCHAR), CAST(2: v2 AS VARCHAR), 'a'))");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
Trino:
```sql
presto> select count(distinct ('a', 'b', 'c'));
 _col0
-------
     1
(1 row)
```

But StarRocks:
```sql
mysql> select count(distinct ('a', 'b', 'c'));
ERROR 1064 (HY000): Getting analyzing error. Detail message: No matching function with signature: multi_distinct_count(struct<col1 varchar, col2 varchar, col3 varchar>).
```


What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
