### PR TITLE
[Doc] remove docusaurus build from CI

### DIFF
--- a/.github/workflows/ci-doc-checker.yml
+++ b/.github/workflows/ci-doc-checker.yml
@@ -105,33 +105,6 @@ jobs:
             --config docs/lychee.toml
             --offline "docs/**/*.md"
 
-      # To run a Docusaurus build on the docs as a final check
-      # checkout the test-harness
-      - uses: actions/checkout@v4
-        with:
-          repository: 'StarRocks/docusaurus-build'
-          path: 'docusaurus'
-      # mv the docs into the docusaurus dir where the
-      # docusaurus build job expects them to be
-      - run: mv docs/en docusaurus/docs
-      - run: mkdir -p docusaurus/i18n/zh/docusaurus-plugin-content-docs/current
-      - run: mv docs/zh docusaurus/i18n/zh/docusaurus-plugin-content-docs/current
-      - run: mv docs/docusaurus/sidebars.json docusaurus/
-      # The README and contrib files have some sample markdown that fails
-      # link checking. StarRocks_intro.md uses a Gatsby component and will
-      # be replaced when we switch Gatsby off. Release notes we grab from
-      # main, so don't check in PRs.
-      - run: rm -f docusaurus/docs/README.md
-      - run: rm -f docusaurus/docs/feedback-and-contribute.md
-      - run: rm -f docusaurus/docs/TOC.md
-      - run: rm -rf docusaurus/docs/release_notes
-
-      - name: Run Docusaurus build
-        working-directory: ./docusaurus
-        run: |
-          yarn install --frozen-lockfile
-          yarn build
-
   behavior-unchange:
     runs-on: ubuntu-latest
     needs: add-doc-label


### PR DESCRIPTION
Removes build check for Docs.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
