### PR TITLE
[BugFix] fix epoch finish make olap table sink close twice

### DIFF
--- a/be/src/exec/pipeline/olap_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/olap_table_sink_operator.cpp
@@ -99,37 +99,6 @@ bool OlapTableSinkOperator::pending_finish() const {
     return false;
 }
 
-bool OlapTableSinkOperator::is_epoch_finishing() const {
-    return pending_finish();
-}
-
-Status OlapTableSinkOperator::set_epoch_finishing(RuntimeState* state) {
-    _is_epoch_finished = true;
-    if (_is_open_done && !_automatic_partition_chunk) {
-        // sink's open already finish, we can try_close
-        return _sink->try_close(state);
-    } else {
-        // sink's open not finish, we need check in pending_finish() before close
-        return Status::OK();
-    }
-}
-
-Status OlapTableSinkOperator::reset_epoch(RuntimeState* state) {
-    if (!_sink->is_close_done()) {
-        RETURN_IF_ERROR(_sink->close(state, Status::OK()));
-    }
-
-    _is_epoch_finished = false;
-
-    RETURN_IF_ERROR(_sink->reset_epoch(state));
-
-    RETURN_IF_ERROR(_sink->prepare(state));
-
-    RETURN_IF_ERROR(_sink->try_open(state));
-
-    return Status::OK();
-}
-
 Status OlapTableSinkOperator::set_cancelled(RuntimeState* state) {
     _is_cancelled = true;
     return _sink->close(state, Status::Cancelled("Cancelled by pipeline engine"));

--- a/be/src/exec/pipeline/olap_table_sink_operator.h
+++ b/be/src/exec/pipeline/olap_table_sink_operator.h
@@ -60,11 +60,6 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
-    bool is_epoch_finished() const override { return _is_epoch_finished; }
-    bool is_epoch_finishing() const override;
-    Status set_epoch_finishing(RuntimeState* state) override;
-    Status reset_epoch(RuntimeState* state) override;
-
 private:
     starrocks::stream_load::OlapTableSink* _sink;
     FragmentContext* const _fragment_ctx;
@@ -74,9 +69,6 @@ private:
     mutable bool _is_open_done = false;
     int32_t _sender_id;
     bool _is_cancelled = false;
-
-    // STREAM MV
-    bool _is_epoch_finished = false;
 
     // temporarily save chunk during automatic partition creation
     mutable ChunkPtr _automatic_partition_chunk;


### PR DESCRIPTION
## Why I'm doing:
`is_epoch_finishing` and `is_finishing` both use `pending_finish`, it will make OlapTableSink close twice.

## What I'm doing:
remove epoch relate function since it's not use now

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
