### PR TITLE
[BugFix] limit lake table publish version thread pool size

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2328,6 +2328,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int lake_compaction_fail_history_size = 12;
 
+    @ConfField(mutable = true, comment = "the max number of threads for lake table publishing version")
+    public static int lake_publish_version_max_threads = 128;
+
     @ConfField(mutable = true, comment = "the max number of previous version files to keep")
     public static int lake_autovacuum_max_previous_versions = 0;
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -48,6 +48,7 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.lake.Utils;
@@ -75,8 +76,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import javax.validation.constraints.NotNull;
 
 public class PublishVersionDaemon extends FrontendDaemon {
@@ -85,7 +85,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
 
     private static final long RETRY_INTERVAL_MS = 1000;
 
-    private Executor lakeTaskExecutor;
+    private ThreadPoolExecutor lakeTaskExecutor;
     private Set<Long> publishingLakeTransactions;
 
     private Set<Long> publishingLakeTransactionsBatchTableId;
@@ -154,9 +154,21 @@ public class PublishVersionDaemon extends FrontendDaemon {
         }
     }
 
-    private @NotNull Executor getLakeTaskExecutor() {
+    private @NotNull ThreadPoolExecutor getLakeTaskExecutor() {
         if (lakeTaskExecutor == null) {
-            lakeTaskExecutor = Executors.newCachedThreadPool();
+            // Create a new thread for every task if there is no idle threads available.
+            // Idle threads will be cleaned after `KEEP_ALIVE_TIME` seconds, which is 60 seconds by default.
+            lakeTaskExecutor = ThreadPoolManager.newDaemonCacheThreadPool(Config.lake_publish_version_max_threads,
+                    "lake-publish-task", true);
+
+            // register ThreadPool config change listener
+            GlobalStateMgr.getCurrentState().getConfigRefreshDaemon().registerListener(() -> {
+                int newMaxThreads = Config.lake_publish_version_max_threads;
+                if (lakeTaskExecutor != null && newMaxThreads > 0
+                        && lakeTaskExecutor.getMaximumPoolSize() != newMaxThreads) {
+                    lakeTaskExecutor.setMaximumPoolSize(Config.lake_publish_version_max_threads);
+                }
+            });
         }
         return lakeTaskExecutor;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/PublishVersionDaemonTest.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.transaction;
+
+import com.starrocks.common.Config;
+import com.starrocks.common.ConfigRefreshDaemon;
+import com.starrocks.server.GlobalStateMgr;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class PublishVersionDaemonTest {
+    public int oldValue;
+
+    @Before
+    public void setUp() {
+        oldValue = Config.lake_publish_version_max_threads;
+    }
+
+    @After
+    public void tearDown() {
+        Config.lake_publish_version_max_threads = oldValue;
+    }
+
+    @Test
+    public void testUpdateLakeExecutorThreads()
+            throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
+        PublishVersionDaemon daemon = new PublishVersionDaemon();
+
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) MethodUtils.invokeMethod(daemon, true, "getLakeTaskExecutor");
+        Assert.assertNotNull(executor);
+        Assert.assertEquals(Config.lake_publish_version_max_threads, executor.getMaximumPoolSize());
+
+        Config.lake_publish_version_max_threads += 10;
+        // manual trigger the configVar listener refresh
+
+        ConfigRefreshDaemon configDaemon = GlobalStateMgr.getCurrentState().getConfigRefreshDaemon();
+        // force run one cycle to update config listeners
+        MethodUtils.invokeMethod(configDaemon, true, "runAfterCatalogReady");
+        // after configVar refresh, the threadPool size is changed.
+        Assert.assertEquals(Config.lake_publish_version_max_threads, executor.getMaximumPoolSize());
+    }
+}


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [X] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [X] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
