### PR TITLE
Using cgroup to automatically set BE's CPU hard limit

### DIFF
--- a/conf/cgroup.conf
+++ b/conf/cgroup.conf
@@ -1,0 +1,14 @@
+# use cgroup: IF_USE_CPU_CGROUP=0
+# not use cgroup: IF_USE_CPU_CGROUP=1 (default)
+IF_USE_CPU_CGROUP=1
+
+# cgroup name, default set to starrocks
+CPU_CGROUP_NAME=starrocks
+
+# cpu cgroup default cfs_period_us, default set to 100000
+CPU_CFS_PERIOD_US=100000
+
+# cpu cgroup default cfs_quota_us, default set to -1
+# CPU_CFS_QUOTA_US = ceiling(BE's CPU hard limit percent * BE's CPU cores)*CPU_CFS_PERIOD_US
+# i.e. BE's server has 64 cores, BE should not use more than 80% of total CPU cores, then CPU_CFS_QUOTA_US = ceiling(64*0.8)*100000=5100000
+CPU_CFS_QUOTA_US=-1


### PR DESCRIPTION
Why I'm doing:
StarRocks does not have a hard limit of CPU usage for backend, which might lead to 100% of CPU occupation when loading tons of data via broker load and querying at the same time. This phenomenon might have side effects to other services running on the same backend nodes. 
What I'm doing:
1. Adding a configuration file to starrocks be's conf dir, including a switch to decide whether to use cgroup to control be's cpu usage, cgroup's name , system's cpu.cfs_period_us and cpu usage limit for backend.
2. Modifying start_backend.sh, read from cgroup.conf to check whether to set limit or not. If switch is set to 0, then it should get the current be's pid to the created cgroup, or create the cgroup then do the rest. These operation can be done automatically every time the BEis restarted.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [x] 2.5
