### PR TITLE
[BugFix] reuse deleteconditions in DeleteMgr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/delete/LakeDeleteJob.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.lake.delete;
 
 import com.google.common.base.Preconditions;
@@ -47,7 +46,6 @@ import com.starrocks.qe.QueryStateException;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.rpc.LakeService;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.DeleteAnalyzer;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
@@ -98,7 +96,7 @@ public class LakeDeleteJob extends DeleteJob {
         }
 
         // create delete predicate
-        List<Predicate> conditions = DeleteAnalyzer.replaceParameterInExpr(stmt.getDeleteConditions());
+        List<Predicate> conditions = getDeleteConditions();
         DeletePredicatePB deletePredicate = createDeletePredicate(conditions);
 
         // send delete data request to BE

--- a/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/DeleteJob.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.load;
 
+import com.starrocks.analysis.Predicate;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -69,6 +70,7 @@ public abstract class DeleteJob extends AbstractTxnStateChangeCallback {
     protected String label;
     protected DeleteState state;
     protected MultiDeleteInfo deleteInfo;
+    List<Predicate> deleteConditions;
 
     public DeleteJob(long id, long transactionId, String label, MultiDeleteInfo deleteInfo) {
         this.id = id;
@@ -101,6 +103,14 @@ public abstract class DeleteJob extends AbstractTxnStateChangeCallback {
 
     public MultiDeleteInfo getDeleteInfo() {
         return deleteInfo;
+    }
+
+    public List<Predicate> getDeleteConditions() {
+        return deleteConditions;
+    }
+
+    public void setDeleteConditions(List<Predicate> deleteConditions) {
+        this.deleteConditions = deleteConditions;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/OlapDeleteJob.java
@@ -61,7 +61,6 @@ import com.starrocks.meta.lock.LockType;
 import com.starrocks.meta.lock.Locker;
 import com.starrocks.qe.QueryStateException;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.DeleteAnalyzer;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.task.AgentBatchTask;
 import com.starrocks.task.AgentTaskExecutor;
@@ -114,7 +113,7 @@ public class OlapDeleteJob extends DeleteJob {
         Preconditions.checkState(table.isOlapTable());
         OlapTable olapTable = (OlapTable) table;
         MarkedCountDownLatch<Long, Long> countDownLatch;
-        List<Predicate> conditions = DeleteAnalyzer.replaceParameterInExpr(stmt.getDeleteConditions());
+        List<Predicate> conditions = getDeleteConditions();
 
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);


### PR DESCRIPTION
Why I'm doing:

ci failed https://github.com/StarRocks/StarRocksTest/issues/4904 because of https://github.com/StarRocks/starrocks/pull/35305
This is because deleteconditions gets copied each time calling stmt.getDeleteConditions() , but in the process the content of the conditions may be modified, those modifications are lost.

What I'm doing:

store deleteconditions in DeleteJob and all use this one.

Fixes [#issue](https://github.com/StarRocks/StarRocksTest/issues/4904)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
