### PR TITLE
[Enhancement] Assign a new schema id after finish fast schema evolution

### DIFF
--- a/be/src/exec/tablet_info.h
+++ b/be/src/exec/tablet_info.h
@@ -44,6 +44,7 @@ struct OlapTableColumnParam {
 struct OlapTableIndexSchema {
     int64_t index_id;
     std::vector<SlotDescriptor*> slots;
+    int64_t schema_id;
     int32_t schema_hash;
     OlapTableColumnParam* column_param;
     ExprContext* where_clause = nullptr;

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -562,9 +562,6 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
         _tablet_schema = ori_tablet_schema;
     }
 
-    LOG(INFO) << "tablet:" << _tablet->tablet_id() << " schema id:" << _tablet_schema->id()
-              << " use count:" << _tablet_schema.use_count();
-
     return st;
 }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -562,6 +562,8 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
         _tablet_schema = ori_tablet_schema;
     }
 
+    LOG(INFO) << "tablet:" << _tablet->tablet_id() << " schema id:" << _tablet_schema->id() << " use count:" << _tablet_schema.use_count();
+
     return st;
 }
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -562,7 +562,8 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
         _tablet_schema = ori_tablet_schema;
     }
 
-    LOG(INFO) << "tablet:" << _tablet->tablet_id() << " schema id:" << _tablet_schema->id() << " use count:" << _tablet_schema.use_count();
+    LOG(INFO) << "tablet:" << _tablet->tablet_id() << " schema id:" << _tablet_schema->id()
+              << " use count:" << _tablet_schema.use_count();
 
     return st;
 }
@@ -627,7 +628,6 @@ Status DeltaWriter::commit() {
         return res.status();
     }
 
-    _cur_rowset->set_schema(_tablet_schema);
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
         if (!st.ok()) {

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -538,7 +538,7 @@ Status DeltaWriter::_flush_memtable() {
 Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTableSchemaParam& ptable_schema_param,
                                                  const TabletSchemaCSPtr& ori_tablet_schema) {
     Status st;
-    _tablet_schema->copy_from(ori_tablet_schema);
+    TabletSchemaSPtr new_schema = std::make_shared<TabletSchema>();
 
     // new tablet schema if new table
     // find the right index id
@@ -549,14 +549,17 @@ Status DeltaWriter::_build_current_tablet_schema(int64_t index_id, const POlapTa
     if (i < ptable_schema_param.indexes_size()) {
         if (ptable_schema_param.indexes_size() > 0 && ptable_schema_param.indexes(i).has_column_param() &&
             ptable_schema_param.indexes(i).column_param().columns_desc_size() != 0 &&
-            ptable_schema_param.indexes(i).column_param().columns_desc(0).unique_id() >= 0) {
-            RETURN_IF_ERROR(_tablet_schema->build_current_tablet_schema(
-                    index_id, ptable_schema_param.version(), ptable_schema_param.indexes(i), ori_tablet_schema));
+            ptable_schema_param.indexes(i).column_param().columns_desc(0).unique_id() >= 0 &&
+            ptable_schema_param.version() > ori_tablet_schema->schema_version()) {
+            new_schema->copy_from(ori_tablet_schema);
+            RETURN_IF_ERROR(new_schema->build_current_tablet_schema(index_id, ptable_schema_param.version(),
+                                                                    ptable_schema_param.indexes(i), ori_tablet_schema));
         }
     }
-
-    if (_tablet_schema->schema_version() > ori_tablet_schema->schema_version()) {
-        _tablet->update_max_version_schema(_tablet_schema);
+    if (new_schema->schema_version() > ori_tablet_schema->schema_version()) {
+        _tablet_schema = _tablet->update_max_version_schema(new_schema);
+    } else {
+        _tablet_schema = ori_tablet_schema;
     }
 
     return st;
@@ -567,7 +570,7 @@ void DeltaWriter::_reset_mem_table() {
         _vectorized_schema = MemTable::convert_schema(_tablet_schema, _opt.slots);
         _schema_initialized = true;
     }
-    if (_tablet->tablet_schema()->keys_type() == KeysType::PRIMARY_KEYS && !_opt.merge_condition.empty()) {
+    if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS && !_opt.merge_condition.empty()) {
         _mem_table = std::make_unique<MemTable>(_tablet->tablet_id(), &_vectorized_schema, _opt.slots,
                                                 _mem_table_sink.get(), _opt.merge_condition, _mem_tracker);
     } else {
@@ -622,7 +625,7 @@ Status DeltaWriter::commit() {
         return res.status();
     }
 
-    _cur_rowset->set_schema(_tablet->tablet_schema());
+    _cur_rowset->set_schema(_tablet_schema);
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
         if (!st.ok()) {

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -196,7 +196,7 @@ private:
     // tablet schema owned by delta writer, all write will use this tablet schema
     // it's build from unsafe_tablet_schema_ref（stored when create tablet） and OlapTableSchema
     // every request will have it's own tablet schema so simple schema change can work
-    TabletSchemaSPtr _tablet_schema;
+    TabletSchemaCSPtr _tablet_schema;
 
     std::unique_ptr<FlushToken> _flush_token;
     std::unique_ptr<ReplicateToken> _replicate_token;

--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -237,6 +237,8 @@ public:
     bool has_data_files() const { return num_segments() > 0 || num_delete_files() > 0 || num_update_files() > 0; }
     KeysType keys_type() const { return _keys_type; }
 
+    const TabletSchemaCSPtr tablet_schema() { return rowset_meta()->tablet_schema(); }
+
     // remove all files in this rowset
     // TODO should we rename the method to remove_files() to be more specific?
     Status remove();

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -259,19 +259,12 @@ private:
                 _schema = TabletSchema::create(_rowset_meta_pb->tablet_schema());
             }
         }
-        if (_schema != nullptr) {
-            LOG(INFO) << "tablet:" << tablet_id() << " rowset:" << rowset_id() << " schema id:" << _schema->id()
-                      << " use count:" << _schema.use_count();
-        }
     }
 
     int64_t _calc_mem_usage() const {
         int64_t size = sizeof(RowsetMeta);
         if (_rowset_meta_pb != nullptr) {
             size += static_cast<int64_t>(_rowset_meta_pb->SpaceUsedLong());
-        }
-        if (_schema != nullptr && _schema.use_count() <= 1) {
-            size += _schema->mem_usage();
         }
         return size;
     }

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -259,12 +259,18 @@ private:
                 _schema = TabletSchema::create(_rowset_meta_pb->tablet_schema());
             }
         }
+        if (_schema != nullptr) {
+            LOG(INFO) << "tablet:" << tablet_id() << " rowset:" << rowset_id() << " schema id:" << _schema->id() << " use count:" << _schema.use_count();
+        }
     }
 
     int64_t _calc_mem_usage() const {
         int64_t size = sizeof(RowsetMeta);
         if (_rowset_meta_pb != nullptr) {
             size += static_cast<int64_t>(_rowset_meta_pb->SpaceUsedLong());
+        }
+        if (_schema != nullptr && _schema.use_count() <= 1) {
+            size += _schema->mem_usage();
         }
         return size;
     }

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -260,7 +260,8 @@ private:
             }
         }
         if (_schema != nullptr) {
-            LOG(INFO) << "tablet:" << tablet_id() << " rowset:" << rowset_id() << " schema id:" << _schema->id() << " use count:" << _schema.use_count();
+            LOG(INFO) << "tablet:" << tablet_id() << " rowset:" << rowset_id() << " schema id:" << _schema->id()
+                      << " use count:" << _schema.use_count();
         }
     }
 

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1722,7 +1722,7 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
     return _max_version_schema;
 }
 
-void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
+TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
     std::lock_guard l0(_meta_lock);
     std::lock_guard l1(_schema_lock);
     // Double Check for concurrent update
@@ -1735,6 +1735,7 @@ void Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
     }
 
     _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
+    return _max_version_schema;
 }
 
 const TabletSchema& Tablet::unsafe_tablet_schema_ref() const {

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1725,7 +1725,8 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
 TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
     std::lock_guard l0(_meta_lock);
     std::lock_guard l1(_schema_lock);
-    LOG(INFO) << "origin schema id:" << _max_version_schema->id() << ", origin schema version:" << _max_version_schema->schema_version();
+    LOG(INFO) << "origin schema id:" << _max_version_schema->id()
+              << ", origin schema version:" << _max_version_schema->schema_version();
     // Double Check for concurrent update
     if (!_max_version_schema || tablet_schema->schema_version() > _max_version_schema->schema_version()) {
         if (tablet_schema->id() == TabletSchema::invalid_id()) {
@@ -1734,7 +1735,8 @@ TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tab
             _max_version_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_schema).first;
         }
     }
-    LOG(INFO) << "update schema id:" << _max_version_schema->id() << ", update schema version:" << _max_version_schema->schema_version();
+    LOG(INFO) << "update schema id:" << _max_version_schema->id()
+              << ", update schema version:" << _max_version_schema->schema_version();
 
     _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
     return _max_version_schema;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1725,8 +1725,6 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
 TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
     std::lock_guard l0(_meta_lock);
     std::lock_guard l1(_schema_lock);
-    LOG(INFO) << "origin schema id:" << _max_version_schema->id()
-              << ", origin schema version:" << _max_version_schema->schema_version();
     // Double Check for concurrent update
     if (!_max_version_schema || tablet_schema->schema_version() > _max_version_schema->schema_version()) {
         if (tablet_schema->id() == TabletSchema::invalid_id()) {
@@ -1735,8 +1733,6 @@ TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tab
             _max_version_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_schema).first;
         }
     }
-    LOG(INFO) << "update schema id:" << _max_version_schema->id()
-              << ", update schema version:" << _max_version_schema->schema_version();
 
     _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
     return _max_version_schema;

--- a/be/src/storage/tablet.cpp
+++ b/be/src/storage/tablet.cpp
@@ -1725,6 +1725,7 @@ const TabletSchemaCSPtr Tablet::thread_safe_get_tablet_schema() const {
 TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tablet_schema) {
     std::lock_guard l0(_meta_lock);
     std::lock_guard l1(_schema_lock);
+    LOG(INFO) << "origin schema id:" << _max_version_schema->id() << ", origin schema version:" << _max_version_schema->schema_version();
     // Double Check for concurrent update
     if (!_max_version_schema || tablet_schema->schema_version() > _max_version_schema->schema_version()) {
         if (tablet_schema->id() == TabletSchema::invalid_id()) {
@@ -1733,6 +1734,7 @@ TabletSchemaCSPtr Tablet::update_max_version_schema(const TabletSchemaCSPtr& tab
             _max_version_schema = GlobalTabletSchemaMap::Instance()->emplace(tablet_schema).first;
         }
     }
+    LOG(INFO) << "update schema id:" << _max_version_schema->id() << ", update schema version:" << _max_version_schema->schema_version();
 
     _tablet_meta->save_tablet_schema(_max_version_schema, _data_dir);
     return _max_version_schema;

--- a/be/src/storage/tablet.h
+++ b/be/src/storage/tablet.h
@@ -306,7 +306,7 @@ public:
 
     const TabletSchemaCSPtr thread_safe_get_tablet_schema() const;
 
-    void update_max_version_schema(const TabletSchemaCSPtr& tablet_schema);
+    TabletSchemaCSPtr update_max_version_schema(const TabletSchemaCSPtr& tablet_schema);
 
     int64_t data_size();
 

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -506,6 +506,7 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
     _sort_key_uids.clear();
 
     _schema_version = version;
+    _id = index.schema_id();
     if (index.id() == index_id) {
         for (auto& pcolumn : index.column_param().columns_desc()) {
             TabletColumn column;

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -261,6 +261,7 @@ public:
 
     // Caller should always check the returned value with `invalid_id()`.
     SchemaId id() const { return _id; }
+    void set_id(SchemaId id) { _id = id; }
     size_t estimate_row_size(size_t variable_len) const;
     int32_t field_index(int32_t col_unique_id) const;
     size_t field_index(std::string_view field_name) const;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -317,6 +317,7 @@ set(EXEC_FILES_PART2
         ./storage/del_vector_test.cpp
         ./storage/delete_handler_test.cpp
         ./storage/delta_column_group_test.cpp
+        ./storage/fast_schema_evolution_test.cpp
         ./storage/file_utils_test.cpp
         ./storage/tablet_schema_map_test.cpp
         ./storage/hll_test.cpp

--- a/be/test/storage/fast_schema_evolution_test.cpp
+++ b/be/test/storage/fast_schema_evolution_test.cpp
@@ -1,0 +1,141 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+
+#include "fs/fs_memory.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/persistent_index_compaction_manager.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset_update_state.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+#include "testutil/parallel_test.h"
+#include "util/coding.h"
+#include "util/faststring.h"
+
+namespace starrocks {
+
+class FastSchemaEvolutionTest : public testing::Test {
+public:
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.__set_version_hash(0);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.__set_id(1);
+        request.tablet_schema.__set_schema_version(1);
+        request.tablet_schema.keys_type = TKeysType::PRIMARY_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        TColumn k1;
+        k1.column_name = "pk";
+        k1.__set_is_key(true);
+        k1.column_type.type = TPrimitiveType::BIGINT;
+        request.tablet_schema.columns.push_back(k1);
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                  Column* one_delete = nullptr) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        size_t size = keys.size();
+        for (size_t i = 0; i < size; i++) {
+            cols[0]->append_datum(Datum(keys[i]));
+            cols[1]->append_datum(Datum((int16_t)(keys[i] % size + 1)));
+            cols[2]->append_datum(Datum((int32_t)(keys[i] % size + 2)));
+        }
+        if (one_delete == nullptr && !keys.empty()) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        } else if (one_delete == nullptr) {
+            CHECK_OK(writer->flush());
+        } else if (one_delete != nullptr) {
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+        }
+        return *writer->build();
+    }
+};
+
+TEST_F(FastSchemaEvolutionTest, update_schema_id_test) {
+    TabletSharedPtr tablet = create_tablet(rand(), rand());
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    const size_t N = 100;
+    std::vector<int64_t> keys(N);
+    std::vector<Slice> key_slices;
+    key_slices.reserve(N);
+    for (int64_t i = 0; i < N; ++i) {
+        keys[i] = i;
+        key_slices.emplace_back((uint8_t*)(&keys[i]), sizeof(uint64_t));
+    }
+    TabletSchemaCSPtr ori_tablet_schema = tablet->tablet_schema();
+    RowsetSharedPtr rowset = create_rowset(tablet, keys);
+    EXPECT_EQ(ori_tablet_schema->id(), 1);
+    EXPECT_EQ(tablet->tablet_schema().get(), rowset->tablet_schema().get());
+    EXPECT_EQ(ori_tablet_schema.get(), tablet->tablet_schema().get());
+
+    TabletSchemaSPtr new_schema = std::make_shared<TabletSchema>();
+    new_schema->copy_from(ori_tablet_schema);
+    new_schema->set_schema_version(ori_tablet_schema->schema_version() + 1);
+    new_schema->set_id(100);
+    tablet->update_max_version_schema(new_schema);
+
+    RowsetSharedPtr rowset2 = create_rowset(tablet, keys);
+
+    EXPECT_EQ(tablet->tablet_schema().get(), rowset2->tablet_schema().get());
+    EXPECT_NE(rowset->tablet_schema().get(), rowset2->tablet_schema().get());
+    EXPECT_EQ(ori_tablet_schema.get(), rowset->tablet_schema().get());
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/RollupJobV2.java
@@ -358,7 +358,7 @@ public class RollupJobV2 extends AlterJobV2 implements GsonPostProcessable {
             }
         }
 
-        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, 0 /* initial schema version */,
+        tbl.setIndexMeta(rollupIndexId, rollupIndexName, rollupSchema, rollupSchemaVersion /* initial schema version */,
                 rollupSchemaHash, rollupShortKeyColumnCount, TStorageType.COLUMN, rollupKeysType, origStmt);
         MaterializedIndexMeta indexMeta = tbl.getIndexMetaByIndexId(rollupIndexId);
         Preconditions.checkNotNull(indexMeta);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1621,14 +1621,20 @@ public class SchemaChangeHandler extends AlterHandler {
                 fastSchemaEvolution);
 
         if (fastSchemaEvolution) {
-            long jobId = GlobalStateMgr.getCurrentState().getNextId();
+            GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+            long jobId = globalStateMgr.getNextId();
             long txnId = GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
             long startTime = ConnectContext.get().getStartTime();
             // for schema change add/drop value column optimize, direct modify table meta.
             // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
             // try to copy first before modifying, avoiding in-place changes.
+            Map<Long, Long> indexToNewSchemaId = new HashMap<Long, Long>();
+            for (Long alterIndexId : indexSchemaMap.keySet()) {
+                indexToNewSchemaId.put(alterIndexId, globalStateMgr.getNextId());
+            }
+            //for schema change add/drop value column optimize, direct modify table meta.
             modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, newIndexes, jobId, txnId, startTime,
-                                        addColumnsName, false);
+                                        addColumnsName, indexToNewSchemaId, false);
             return null;
         } else {
             return createJob(db.getId(), olapTable, indexSchemaMap, propertyMap, newIndexes);
@@ -2387,7 +2393,8 @@ public class SchemaChangeHandler extends AlterHandler {
     public void modifyTableAddOrDropColumns(Database db, OlapTable olapTable,
                                             Map<Long, LinkedList<Column>> indexSchemaMap,
                                             List<Index> indexes, long jobId, long txnId, long startTime,
-                                            Set<String> addColumnsName, boolean isReplay)
+                                            Set<String> addColumnsName, Map<Long, Long> indexToNewSchemaId, 
+                                            boolean isReplay)
             throws DdlException, NotImplementedException {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.WRITE);
@@ -2418,7 +2425,12 @@ public class SchemaChangeHandler extends AlterHandler {
                 List<Column> alterSchema = indexSchemaMap.get(alterIndexId);
 
                 LOG.debug("index[{}] is changed. start checking...", alterIndexId);
-                // 1. check order: a) has key; b) value after key
+                // 1. check new schema id
+                if (indexToNewSchemaId != null && !indexToNewSchemaId.containsKey(alterIndexId)) {
+                    throw new DdlException("index[" + olapTable.getIndexNameById(alterIndexId) + "] does not assign" +
+                                           " new schema id");
+                }
+                // 2. check order: a) has key; b) value after key
                 boolean meetValue = false;
                 boolean hasKey = false;
                 for (Column column : alterSchema) {
@@ -2437,7 +2449,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     throw new DdlException("No key column left. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
                 }
 
-                // 2. check partition key
+                // 3. check partition key
                 PartitionInfo partitionInfo = olapTable.getPartitionInfo();
                 if (partitionInfo.getType() == PartitionType.RANGE || partitionInfo.getType() == PartitionType.LIST) {
                     List<Column> partitionColumns = partitionInfo.getPartitionColumns();
@@ -2459,7 +2471,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     } // end for partitionColumns
                 }
 
-                // 3. check distribution key:
+                // 4. check distribution key:
                 DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
                 if (distributionInfo.getType() == DistributionInfoType.HASH) {
                     List<Column> distributionColumns = ((HashDistributionInfo) distributionInfo).getDistributionColumns();
@@ -2553,6 +2565,11 @@ public class SchemaChangeHandler extends AlterHandler {
                 // update the indexIdToMeta
                 olapTable.getIndexIdToMeta().put(idx, currentIndexMeta);
                 currentIndexMeta.setSchemaId(GlobalStateMgr.getCurrentState().getNextId());
+                // if FE upgrade from old version and replay journal, the indexToNewSchemaId maybe null
+                if (indexToNewSchemaId != null) {
+                    currentIndexMeta.setSchemaId(indexToNewSchemaId.get(idx));
+                }
+
                 schemaChangeJob.addIndexSchema(idx, idx, olapTable.getIndexNameById(idx), newSchemaVersion,
                                                currentIndexMeta.getSchemaHash(), currentIndexMeta.getShortKeyColumnCount(),
                                                indexSchema);
@@ -2574,7 +2591,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
             if (!isReplay) {
                 TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),
-                        indexSchemaMap, indexes, jobId, txnId, startTime, addColumnsName);
+                        indexSchemaMap, indexes, jobId, txnId, startTime, addColumnsName, indexToNewSchemaId);
                 LOG.debug("logModifyTableAddOrDropColumns info:{}", info);
                 GlobalStateMgr.getCurrentState().getEditLog().logModifyTableAddOrDropColumns(info);
             }
@@ -2598,6 +2615,7 @@ public class SchemaChangeHandler extends AlterHandler {
         long dbId = info.getDbId();
         long tableId = info.getTableId();
         Map<Long, LinkedList<Column>> indexSchemaMap = info.getIndexSchemaMap();
+        Map<Long, Long> indexToNewSchemaId = info.getIndexToNewSchemaId();
         List<Index> indexes = info.getIndexes();
         long jobId = info.getJobId();
 
@@ -2609,8 +2627,9 @@ public class SchemaChangeHandler extends AlterHandler {
         Locker locker = new Locker();
         try {
             locker.lockDatabase(db, LockType.WRITE);
-            modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, indexes, jobId, info.getTxnId(), 
-                                        info.getStartTime(), info.getAddColumnsName(), true);
+            modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, indexes, jobId, info.getTxnId(),
+                                        info.getStartTime(), info.getAddColumnsName(), indexToNewSchemaId, 
+                                        true);
         } catch (DdlException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop columns", e);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2564,7 +2564,6 @@ public class SchemaChangeHandler extends AlterHandler {
                 currentIndexMeta.setSchemaVersion(newSchemaVersion);
                 // update the indexIdToMeta
                 olapTable.getIndexIdToMeta().put(idx, currentIndexMeta);
-                currentIndexMeta.setSchemaId(GlobalStateMgr.getCurrentState().getNextId());
                 // if FE upgrade from old version and replay journal, the indexToNewSchemaId maybe null
                 if (indexToNewSchemaId != null) {
                     currentIndexMeta.setSchemaId(indexToNewSchemaId.get(idx));

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2552,6 +2552,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 currentIndexMeta.setSchemaVersion(newSchemaVersion);
                 // update the indexIdToMeta
                 olapTable.getIndexIdToMeta().put(idx, currentIndexMeta);
+                currentIndexMeta.setSchemaId(GlobalStateMgr.getCurrentState().getNextId());
                 schemaChangeJob.addIndexSchema(idx, idx, olapTable.getIndexNameById(idx), newSchemaVersion,
                                                currentIndexMeta.getSchemaHash(), currentIndexMeta.getShortKeyColumnCount(),
                                                indexSchema);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -69,6 +69,8 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     private int schemaVersion;
     @SerializedName(value = "schemaHash")
     private int schemaHash;
+    @SerializedName(value = "schemaId")
+    private long schemaId;
     @SerializedName(value = "shortKeyColumnCount")
     private short shortKeyColumnCount;
     @SerializedName(value = "storageType")
@@ -99,6 +101,7 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
         this.schema = schema;
         this.schemaVersion = schemaVersion;
         this.schemaHash = schemaHash;
+        this.schemaId = indexId;
         this.shortKeyColumnCount = shortKeyColumnCount;
         Preconditions.checkState(storageType != null);
         this.storageType = storageType;
@@ -168,6 +171,14 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     public int getSchemaVersion() {
         return schemaVersion;
+    }
+
+    public void setSchemaId(long schemaId) {
+        this.schemaId = schemaId;
+    }
+
+    public long getSchemaId() {
+        return schemaId;
     }
 
     public List<Column> getNonAggregatedColumns() {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/TableAddOrDropColumnsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/TableAddOrDropColumnsInfo.java
@@ -72,10 +72,13 @@ public class TableAddOrDropColumnsInfo implements Writable {
     private long startTime;
     @SerializedName(value = "addColumnsName")
     private Set<String> addColumnsName;
+    @SerializedName(value = "indexToNewSchemaId")
+    private Map<Long, Long> indexToNewSchemaId;
 
     public TableAddOrDropColumnsInfo(long dbId, long tableId,
             Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes, long jobId,
-            long txnId, long startTime, Set<String> addColumnsName) {
+            long txnId, long startTime, Set<String> addColumnsName,
+            Map<Long, Long> indexToNewSchemaId) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.indexSchemaMap = indexSchemaMap;
@@ -84,6 +87,7 @@ public class TableAddOrDropColumnsInfo implements Writable {
         this.txnId = txnId;
         this.startTime = startTime;
         this.addColumnsName = addColumnsName;
+        this.indexToNewSchemaId = indexToNewSchemaId;
     }
 
     public long getDbId() {
@@ -108,6 +112,10 @@ public class TableAddOrDropColumnsInfo implements Writable {
 
     public long getTxnId() {
         return txnId;
+    }
+    
+    public Map<Long, Long> getIndexToNewSchemaId() {
+        return indexToNewSchemaId;
     }
 
     public long getStartTime() {
@@ -160,6 +168,7 @@ public class TableAddOrDropColumnsInfo implements Writable {
         sb.append(" txnId: ").append(txnId);
         sb.append(" startTime: ").append(startTime);
         sb.append(" addColumnsName: ").append(addColumnsName);
+        sb.append(" indexToNewSchemaId: ").append(indexToNewSchemaId);
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -312,6 +312,7 @@ public class OlapTableSink extends DataSink {
             TOlapTableIndexSchema indexSchema = new TOlapTableIndexSchema(pair.getKey(), columns,
                     indexMeta.getSchemaHash());
             indexSchema.setColumn_param(columnParam);
+            indexSchema.setSchema_id(indexMeta.getSchemaId());
             schemaParam.addToIndexes(indexSchema);
             if (indexMeta.getWhereClause() != null) {
                 String dbName = MetaUtils.getDatabase(dbId).getFullName();

--- a/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
@@ -24,7 +24,7 @@ public class TableAddOrDropColumnsInfoTest {
     public void test() {
         TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(1, 1,
                 Collections.emptyMap(), Collections.emptyList(), 0, 1, 0,
-                Collections.emptySet());
+                Collections.emptySet(), Collections.emptyMap());
 
         Assert.assertEquals(1, info.getDbId());
         Assert.assertEquals(1, info.getTableId());
@@ -37,7 +37,7 @@ public class TableAddOrDropColumnsInfoTest {
 
         TableAddOrDropColumnsInfo info2 = new TableAddOrDropColumnsInfo(1, 1,
                 Collections.emptyMap(), Collections.emptyList(), 0, 1, 0,
-                Collections.emptySet());
+                Collections.emptySet(), Collections.emptyMap());
 
         Assert.assertEquals(info.hashCode(), info2.hashCode());
         Assert.assertEquals(info, info2);

--- a/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
@@ -34,6 +34,7 @@ public class TableAddOrDropColumnsInfoTest {
         Assert.assertEquals(1, info.getTxnId());
         Assert.assertEquals(0, info.getStartTime());
         Assert.assertEquals(0, info.getAddColumnsName().size());
+        Assert.assertEquals(0, info.getIndexToNewSchemaId().size());
 
         TableAddOrDropColumnsInfo info2 = new TableAddOrDropColumnsInfo(1, 1,
                 Collections.emptyMap(), Collections.emptyList(), 0, 1, 0,

--- a/gensrc/proto/descriptors.proto
+++ b/gensrc/proto/descriptors.proto
@@ -74,6 +74,7 @@ message POlapTableIndexSchema {
     repeated string columns = 2;
     required int32 schema_hash = 3;
     optional POlapTableColumnParam column_param = 4;
+    optional int64 schema_id = 5;
 };
 
 message POlapTableSchemaParam {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -269,11 +269,12 @@ struct TOlapTableColumnParam {
 }
 
 struct TOlapTableIndexSchema {
-    1: required i64 id
+    1: required i64 id // index id
     2: required list<string> columns
     3: required i32 schema_hash
     4: optional TOlapTableColumnParam column_param
     5: optional Exprs.TExpr where_clause
+    6: optional i64 schema_id // schema id
 }
 
 struct TOlapTableSchemaParam {


### PR DESCRIPTION
Why I'm doing:
After support fast schema evolution, one tablet's rowsets may have different tablet schemas which has the same schema id and it may cause each rowset keep one tablet schema causing memory wastage. The reason is different schema have the same schema id so we can not only keep one tablet schema in schema map cache.

What I'm doing:

This pr assign a new schema id after finish fast schema evolution but not only update the schema version and it ensures that only identical schemas will have the same schema ID.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
