### PR TITLE
[Feature] Add support datacache.partition_duration for mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3433,6 +3433,12 @@ public class LocalMetastore implements ConnectorMetadata {
                 setLakeStorageInfo(materializedView, storageVolumeId, properties);
             }
 
+            // datacache.partition_duration
+            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)) {
+                PeriodDuration duration = PropertyAnalyzer.analyzeDataCachePartitionDuration(properties);
+                materializedView.setDataCachePartitionDuration(duration);
+            }
+
             // session properties
             if (!properties.isEmpty()) {
                 // analyze properties

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3434,9 +3434,11 @@ public class LocalMetastore implements ConnectorMetadata {
             }
 
             // datacache.partition_duration
-            if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)) {
-                PeriodDuration duration = PropertyAnalyzer.analyzeDataCachePartitionDuration(properties);
-                materializedView.setDataCachePartitionDuration(duration);
+            if (materializedView.isCloudNativeMaterializedView()) {
+                if (properties.containsKey(PropertyAnalyzer.PROPERTIES_DATACACHE_PARTITION_DURATION)) {
+                    PeriodDuration duration = PropertyAnalyzer.analyzeDataCachePartitionDuration(properties);
+                    materializedView.setDataCachePartitionDuration(duration);
+                }
             }
 
             // session properties

--- a/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/LakeMaterializedViewTest.java
@@ -311,7 +311,8 @@ public class LakeMaterializedViewTest {
                         "distributed by hash(k2) buckets 3\n" +
                         "PROPERTIES(\n" +
                         "   'datacache.enable' = 'true',\n" +
-                        "   'enable_async_write_back' = 'false'\n" +
+                        "   'enable_async_write_back' = 'false',\n" +
+                        "   'datacache.partition_duration' = '6 day'\n" +
                         ")\n" +
                         "refresh async\n" +
                         "as select k2, sum(k3) as total from base_table group by k2;");
@@ -340,6 +341,7 @@ public class LakeMaterializedViewTest {
         Assert.assertTrue(ddlStmt.contains("\"datacache.enable\" = \"true\""));
         Assert.assertTrue(ddlStmt.contains("\"enable_async_write_back\" = \"false\""));
         Assert.assertTrue(ddlStmt.contains("\"storage_volume\" = \"builtin_storage_volume\""));
+        Assert.assertTrue(ddlStmt.contains("\"datacache.partition_duration\" = \"6 days\""));
 
         // check task
         String mvTaskName = "mv-" + mv.getId();


### PR DESCRIPTION
Why I'm doing:
Materialized view doesn't support to set datacache.partition_duration so far.

What I'm doing:
Add support datacache.partition_duration property for materialized view to
control the validity time of its datacache.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
