### PR TITLE
[BugFix] fix inaccurate data caused by limit after show export sorting

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -176,6 +176,7 @@ public class ExportMgr {
 
         long resultNum = limit == -1L ? Integer.MAX_VALUE : limit;
         LinkedList<List<Comparable>> exportJobInfos = new LinkedList<List<Comparable>>();
+        boolean isLimitBreak = orderByPairs == null;
         readLock();
         try {
             int counter = 0;
@@ -270,7 +271,7 @@ public class ExportMgr {
 
                 exportJobInfos.add(jobInfo);
 
-                if (++counter >= resultNum) {
+                if (isLimitBreak && ++counter >= resultNum) {
                     break;
                 }
             }
@@ -278,23 +279,24 @@ public class ExportMgr {
             readUnlock();
         }
 
-        // TODO: fix order by first, then limit
         // order by
-        ListComparator<List<Comparable>> comparator = null;
+        ListComparator<List<Comparable>> comparator;
         if (orderByPairs != null) {
             OrderByPair[] orderByPairArr = new OrderByPair[orderByPairs.size()];
-            comparator = new ListComparator<List<Comparable>>(orderByPairs.toArray(orderByPairArr));
+            comparator = new ListComparator<>(orderByPairs.toArray(orderByPairArr));
         } else {
             // sort by id asc
-            comparator = new ListComparator<List<Comparable>>(0);
+            comparator = new ListComparator<>(0);
         }
         Collections.sort(exportJobInfos, comparator);
 
         List<List<String>> results = Lists.newArrayList();
-        for (List<Comparable> list : exportJobInfos) {
-            results.add(list.stream().map(e -> e.toString()).collect(Collectors.toList()));
+        for (int i = 0; i < exportJobInfos.size(); i++) {
+            results.add(exportJobInfos.get(i).stream().map(Object::toString).collect(Collectors.toList()));
+            if (i > resultNum - 1) {
+                break;
+            }
         }
-
         return results;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
@@ -1,9 +1,15 @@
 // This file is licensed under the Elastic License 2.0. Copyright 2021-present, StarRocks Inc.
 package com.starrocks.load;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.TableName;
+import com.starrocks.analysis.UserIdentity;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeMetaVersion;
+import com.starrocks.common.util.OrderByPair;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -15,7 +21,11 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class ExportMgrTest {
     @Mocked
@@ -90,5 +100,65 @@ public class ExportMgrTest {
         Assert.assertEquals(saveChecksum, loadChecksum);
 
         tempFile.delete();
+    }
+
+    @Test
+    public void testShowExpiredJob() throws Exception {
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+            }
+        };
+        new Expectations(globalStateMgr) {
+            {
+                globalStateMgr.getCurrentStateJournalVersion();
+                minTimes = 0;
+                result = FeMetaVersion.VERSION_CURRENT;
+            }
+        };
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+        connectContext.setThreadLocalInfo();
+        GlobalStateMgr.getCurrentState().initAuth(true);
+        ExportMgr mgr = new ExportMgr();
+        int limit = 5;
+        List<Integer> jobIds = Lists.newArrayList();
+        jobIds.add(299948218);
+        jobIds.add(299948214);
+        jobIds.add(299948190);
+        jobIds.add(299948188);
+        jobIds.add(299948183);
+        jobIds.add(299948087);
+        jobIds.add(299943362);
+        jobIds.add(299943118);
+        jobIds.add(299943014);
+        jobIds.add(299943012);
+        jobIds.add(299942987);
+        jobIds = jobIds.stream().sorted(Collections.reverseOrder()).collect(Collectors.toList()).subList(0, Math.min(limit, jobIds.size()));
+        for (Integer jobId : jobIds) {
+            ExportJob job1 = new ExportJob(jobId, new UUID(1, 1));
+            job1.setTableName(new TableName("DUMMY" + jobId, "DUMMY" + jobId));
+            job1.setBrokerDesc(new BrokerDesc("DUMMY", Maps.newHashMap()));
+            mgr.replayCreateExportJob(job1);
+        }
+        ArrayList<OrderByPair> orderByPairs = new ArrayList<>();
+        OrderByPair pair = new OrderByPair(0, true);
+        orderByPairs.add(pair);
+        List<List<String>> exportJobInfosByIdOrState = mgr.getExportJobInfosByIdOrState(-1, 0, null, null, orderByPairs, limit);
+        List<Integer> resultJobIds = Lists.newArrayList();
+        for (List<String> infos : exportJobInfosByIdOrState) {
+            resultJobIds.add(Integer.valueOf(infos.get(0)));
+        }
+        Assert.assertArrayEquals(jobIds.toArray(new Integer[0]), resultJobIds.toArray(new Integer[0]));
+
+        resultJobIds.clear();
+        List<List<String>> exportJobInfosByIdOrState1 = mgr.getExportJobInfosByIdOrState(-1, 0, null, null, null, limit);
+        for (List<String> infos : exportJobInfosByIdOrState1) {
+            resultJobIds.add(Integer.valueOf(infos.get(0)));
+        }
+        Assert.assertEquals(limit, exportJobInfosByIdOrState1.size());
+
     }
 }


### PR DESCRIPTION
Why I'm doing:
  Inaccurate limit data after show export sorting
  show export from alg ORDER BY JobId DESC
  ![image](https://github.com/StarRocks/starrocks/assets/48077349/2b6c82f1-6c6f-4a44-90ad-e1fd63a9766d)
  show export from alg ORDER BY JobId DESC limit 20
  ![image](https://github.com/StarRocks/starrocks/assets/48077349/a9f3f73f-2995-46ee-8a2e-9cd5f50fcb19)

What I'm doing:
  Sort first and then limit
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [x] 2.5
