### PR TITLE
[Enhancement] Lightweight kafka comsume lag

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarTaskInfo.java
@@ -95,7 +95,7 @@ public class PulsarTaskInfo extends RoutineLoadTaskInfo {
     // TODO(chen9t) there's no way to find out how many backlogs have been consumed in this round,
     // the bellowing method will preempt the slots of BEs. So return ture until we find a better way.
     @Override
-    public boolean isProgressKeepUp(RoutineLoadProgress progress) {
+    public boolean isProgressKeepUp(RoutineLoadProgress progress, Map<String, Long> consumeLagsRowNum) {
         // PulsarProgress pProgress = (PulsarProgress) progress;
         // for (Long backLogNum : pProgress.getBacklogNums()) {
         //     if (backLogNum > 0) {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -133,6 +133,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     protected static final String STAR_STRING = "*";
 
+    private Map<String, Long> rowNumConsumeLags = Maps.newHashMap();
+
     /*
                      +-----------------+
     fe schedule job  |  NEED_SCHEDULE  |  user resume job
@@ -661,6 +663,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         }
     }
 
+    public Map<String, Long> getRowNumConsumeLags() {
+        return rowNumConsumeLags;
+    }
+
     // RoutineLoadScheduler will run this method at fixed interval, and renew the timeout tasks
     public void processTimeoutTasks() {
         writeLock();
@@ -1050,7 +1056,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                     (RLTaskTxnCommitAttachment) txnState.getTxnCommitAttachment();
             // isProgressKeepUp returns false means there is too much data in kafka/pulsar stream,
             // we set timeToExecuteMs to now, so that data not accumulated in kafka/pulsar
-            if (!routineLoadTaskInfo.isProgressKeepUp(rlTaskTxnCommitAttachment.getProgress())) {
+            if (!routineLoadTaskInfo.isProgressKeepUp(rlTaskTxnCommitAttachment.getProgress(), rowNumConsumeLags)) {
                 timeToExecuteMs = System.currentTimeMillis();
             } else {
                 timeToExecuteMs = System.currentTimeMillis() + taskSchedIntervalS * 1000;

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskInfo.java
@@ -53,6 +53,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -204,7 +205,7 @@ public abstract class RoutineLoadTaskInfo {
 
     abstract boolean readyToExecute() throws UserException;
 
-    public abstract boolean isProgressKeepUp(RoutineLoadProgress progress);
+    public abstract boolean isProgressKeepUp(RoutineLoadProgress progress, Map<String, Long> consumeLagsRowNum);
 
     // begin the txn of this task
     // throw exception if unrecoverable errors happen.

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -146,6 +146,7 @@ public class MetricCalculator extends TimerTask {
         if (Config.enable_routine_load_lag_metrics)  {
             MetricRepo.updateRoutineLoadProcessMetrics();
         }
+        MetricRepo.updateRoutineLoadRowNumLagMetrics();
 
         MetricRepo.GAUGE_SAFE_MODE.setValue(GlobalStateMgr.getCurrentState().isSafeMode() ? 1 : 0);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -27,6 +27,7 @@ import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -107,15 +108,22 @@ public class KafkaTaskInfoTest {
         // call readyExecute to cache latestPartOffset
         kafkaTaskInfo.readyToExecute();
 
+        Map<String, Long> consumeLagsRowNum = new HashMap<>();
         KafkaProgress kafkaProgress = new KafkaProgress();
         kafkaProgress.addPartitionOffset(new Pair<>(0, 98L));
         kafkaProgress.addPartitionOffset(new Pair<>(1, 98L));
-        Assert.assertFalse(kafkaTaskInfo.isProgressKeepUp(kafkaProgress));
+        Assert.assertFalse(kafkaTaskInfo.isProgressKeepUp(kafkaProgress, consumeLagsRowNum));
+        Assert.assertEquals(1, consumeLagsRowNum.get("0").longValue());
+        Assert.assertEquals(1, consumeLagsRowNum.get("1").longValue());
 
         kafkaProgress.modifyOffset(Lists.newArrayList(new Pair<>(0, 99L)));
-        Assert.assertFalse(kafkaTaskInfo.isProgressKeepUp(kafkaProgress));
+        Assert.assertFalse(kafkaTaskInfo.isProgressKeepUp(kafkaProgress, consumeLagsRowNum));
+        Assert.assertEquals(0, consumeLagsRowNum.get("0").longValue());
+        Assert.assertEquals(1, consumeLagsRowNum.get("1").longValue());
 
         kafkaProgress.modifyOffset(Lists.newArrayList(new Pair<>(1, 99L)));
-        Assert.assertTrue(kafkaTaskInfo.isProgressKeepUp(kafkaProgress));
+        Assert.assertTrue(kafkaTaskInfo.isProgressKeepUp(kafkaProgress, consumeLagsRowNum));
+        Assert.assertEquals(0, consumeLagsRowNum.get("0").longValue());
+        Assert.assertEquals(0, consumeLagsRowNum.get("1").longValue());
     }
 }


### PR DESCRIPTION
The current kafka routine load lag is controlled by this config:
```
    /**
     * Whether to collect routine load process metrics.
     * Be careful to turn this on, because this will call kafka api to get the partition's latest offset.
     */
    @ConfField(mutable = true)
    public static boolean enable_routine_load_lag_metrics = false;
```
And it tasks long when we got a lot of jobs with many partitions.

This PR implemented a lightweight kafka consume lag, the lag was calculated when progress was updated, no extra impacts.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
