### PR TITLE
[BugFix] Check the disk size configuration for datacache to avoid BE starting failed.

### DIFF
--- a/be/src/service/starrocks_main.cpp
+++ b/be/src/service/starrocks_main.cpp
@@ -179,15 +179,17 @@ int main(int argc, char** argv) {
         cache_options.mem_space_size = starrocks::config::block_cache_mem_size;
 
         std::vector<std::string> paths;
-        auto parse_res = starrocks::parse_conf_block_cache_paths(starrocks::config::block_cache_disk_path, &paths);
-        if (!parse_res.ok()) {
-            LOG(FATAL) << "parse config block cache disk path failed, path="
-                       << starrocks::config::block_cache_disk_path;
-            exit(-1);
-        }
-        for (auto& p : paths) {
-            cache_options.disk_spaces.push_back(
-                    {.path = p, .size = static_cast<size_t>(starrocks::config::block_cache_disk_size)});
+        if (starrocks::config::block_cache_disk_size > 0) {
+            auto parse_res = starrocks::parse_conf_block_cache_paths(starrocks::config::block_cache_disk_path, &paths);
+            if (!parse_res.ok()) {
+                LOG(FATAL) << "parse config block cache disk path failed, path="
+                           << starrocks::config::block_cache_disk_path;
+                exit(-1);
+            }
+            for (auto& p : paths) {
+                cache_options.disk_spaces.push_back(
+                        {.path = p, .size = static_cast<size_t>(starrocks::config::block_cache_disk_size)});
+            }
         }
         cache_options.meta_path = starrocks::config::block_cache_meta_path;
         cache_options.block_size = starrocks::config::block_cache_block_size;


### PR DESCRIPTION

Why I'm doing:
We forgot to check the disk size for datacache once the disk path is configured, which will cause the BE start failed.

What I'm doing:
Check the disk size before initialize the datacache.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
