### PR TITLE
[Refactor] Change the default stub of serivce

### DIFF
--- a/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_sink_operator.cpp
@@ -118,7 +118,7 @@ private:
     PassThroughContext _pass_through_context;
 
     bool _is_first_chunk = true;
-    doris::PBackendService_Stub* _brpc_stub = nullptr;
+    PInternalService_Stub* _brpc_stub = nullptr;
 
     // If pipeline level shuffle is enable, the size of the _chunks
     // equals with dop of dest pipeline

--- a/be/src/exec/pipeline/exchange/sink_buffer.h
+++ b/be/src/exec/pipeline/exchange/sink_buffer.h
@@ -49,7 +49,7 @@ struct TransmitChunkInfo {
     // a same exchange source fragment instance, so we should use fragment_instance_id
     // of the destination as the key of destination instead of channel_id.
     TUniqueId fragment_instance_id;
-    doris::PBackendService_Stub* brpc_stub;
+    PInternalService_Stub* brpc_stub;
     PTransmitChunkParamsPtr params;
     butil::IOBuf attachment;
     int64_t attachment_physical_bytes;

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -202,7 +202,7 @@ private:
 
     std::unique_ptr<RowDescriptor> _row_desc;
 
-    doris::PBackendService_Stub* _stub = nullptr;
+    PInternalService_Stub* _stub = nullptr;
     std::vector<RefCountClosure<PTabletWriterOpenResult>*> _open_closures;
 
     std::map<int64_t, std::vector<PTabletWithPartition>> _index_tablets_map;

--- a/be/src/runtime/data_stream_sender.cpp
+++ b/be/src/runtime/data_stream_sender.cpp
@@ -179,7 +179,7 @@ private:
 
     size_t _current_request_bytes = 0;
 
-    doris::PBackendService_Stub* _brpc_stub = nullptr;
+    PInternalService_Stub* _brpc_stub = nullptr;
 
     int32_t _brpc_timeout_ms = 500;
     // whether the dest can be treated as query statistics transfer chain.

--- a/be/src/runtime/runtime_filter_worker.cpp
+++ b/be/src/runtime/runtime_filter_worker.cpp
@@ -49,7 +49,7 @@ static inline std::shared_ptr<MemTracker> get_mem_tracker(const PUniqueId& query
 
 static void send_rpc_runtime_filter(const TNetworkAddress& dest, RuntimeFilterRpcClosure* rpc_closure, int timeout_ms,
                                     int64_t http_min_size, const PTransmitRuntimeFilterParams& request) {
-    doris::PBackendService_Stub* stub = nullptr;
+    PInternalService_Stub* stub = nullptr;
     bool via_http = request.data().size() >= http_min_size;
     if (via_http) {
         if (auto res = HttpBrpcStubCache::getInstance()->get_http_stub(dest); res.ok()) {
@@ -77,6 +77,7 @@ void RuntimeFilterPort::add_listener(RuntimeFilterProbeDescriptor* rf_desc) {
     auto& wait_list = _listeners.find(rf_id)->second;
     wait_list.emplace_back(rf_desc);
 }
+
 std::string RuntimeFilterPort::listeners(int32_t filter_id) {
     std::stringstream ss;
     if (!_listeners.count(filter_id)) {

--- a/be/src/runtime/schema_table_sink.cpp
+++ b/be/src/runtime/schema_table_sink.cpp
@@ -70,7 +70,7 @@ static Status set_config_remote(const StarRocksNodesInfo& nodes_info, int64_t be
     if (node_info == nullptr) {
         return Status::InternalError(strings::Substitute("set_config fail: be $0 not found", be_id));
     }
-    doris::PBackendService_Stub* stub =
+    PInternalService_Stub* stub =
             ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(node_info->host, node_info->brpc_port);
     if (stub == nullptr) {
         return Status::InternalError(strings::Substitute("set_config fail to get brpc stub for $0:$1", node_info->host,

--- a/be/src/storage/segment_replicate_executor.h
+++ b/be/src/storage/segment_replicate_executor.h
@@ -69,7 +69,7 @@ private:
     const int64_t _node_id;
 
     ReusableClosure<PTabletWriterAddSegmentResult>* _closure = nullptr;
-    doris::PBackendService_Stub* _stub = nullptr;
+    PInternalService_Stub* _stub = nullptr;
     MemTracker* _mem_tracker = nullptr;
 
     bool _inited = false;

--- a/be/src/storage/table_reader.cpp
+++ b/be/src/storage/table_reader.cpp
@@ -220,7 +220,7 @@ Status TableReader::_tablet_multi_get_remote(int64_t tablet_id, int64_t version,
             LOG(WARNING) << msg;
             st = Status::InternalError(msg);
         } else {
-            doris::PBackendService_Stub* stub =
+            PInternalService_Stub* stub =
                     ExecEnv::GetInstance()->brpc_stub_cache()->get_stub(node_info->host, node_info->brpc_port);
             if (stub == nullptr) {
                 string msg = strings::Substitute("multi_get fail to get brpc stub for $0:$1 tablet:$2", node_info->host,
@@ -238,9 +238,9 @@ Status TableReader::_tablet_multi_get_remote(int64_t tablet_id, int64_t version,
     return st;
 }
 
-Status TableReader::_tablet_multi_get_rpc(doris::PBackendService_Stub* stub, int64_t tablet_id, int64_t version,
-                                          Chunk& keys, const std::vector<std::string>& value_columns,
-                                          std::vector<bool>& found, Chunk& values, SchemaPtr& value_schema) {
+Status TableReader::_tablet_multi_get_rpc(PInternalService_Stub* stub, int64_t tablet_id, int64_t version, Chunk& keys,
+                                          const std::vector<std::string>& value_columns, std::vector<bool>& found,
+                                          Chunk& values, SchemaPtr& value_schema) {
     PTabletReaderMultiGetRequest request;
     request.set_tablet_id(tablet_id);
     request.set_version(version);

--- a/be/src/storage/table_reader.h
+++ b/be/src/storage/table_reader.h
@@ -22,16 +22,13 @@
 #include "storage/column_predicate.h"
 #include "storage/tablet.h"
 
-namespace doris {
-class PBackendService_Stub;
-}
-
 namespace starrocks {
 
 class OlapTablePartitionParam;
 class OlapTableLocationParam;
 class StarRocksNodesInfo;
 class LocalTabletReader;
+class PInternalService_Stub;
 
 namespace serde {
 struct ProtobufChunkMeta;
@@ -123,7 +120,7 @@ private:
                                     const std::vector<std::string>& value_columns, std::vector<bool>& found,
                                     Chunk& values, SchemaPtr& value_schema);
 
-    Status _tablet_multi_get_rpc(doris::PBackendService_Stub* stub, int64_t tablet_id, int64_t version, Chunk& keys,
+    Status _tablet_multi_get_rpc(PInternalService_Stub* stub, int64_t tablet_id, int64_t version, Chunk& keys,
                                  const std::vector<std::string>& value_columns, std::vector<bool>& found, Chunk& values,
                                  SchemaPtr& value_schema);
     // fields for local tablet reader


### PR DESCRIPTION
Why I'm doing:

Since the pr https://github.com/StarRocks/starrocks/pull/717 , the function of PInternalService is the same as that of PBackendService, the  PBackendService is reserved only for compatibility, so now it is necessary to use PInternalService_Stub uniformly. After multiple major versions, PBackendService can be finally removed.

What I'm doing:

Replace PBackendService_Stub with PInternalService_Stub.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
