### PR TITLE
[BugFix] Fix lake update manager graceful shutdown problem

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -43,6 +43,7 @@ UpdateManager::UpdateManager(LocationProvider* location_provider, MemTracker* me
     _compaction_state_mem_tracker = std::make_unique<MemTracker>(-1, "compaction_state_cache", mem_tracker);
     _index_cache.set_mem_tracker(_index_cache_mem_tracker.get());
     _update_state_cache.set_mem_tracker(_update_state_mem_tracker.get());
+    _compaction_cache.set_mem_tracker(_compaction_state_mem_tracker.get());
 
     int64_t byte_limits = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -43,11 +43,16 @@ UpdateManager::UpdateManager(LocationProvider* location_provider, MemTracker* me
     _compaction_state_mem_tracker = std::make_unique<MemTracker>(-1, "compaction_state_cache", mem_tracker);
     _index_cache.set_mem_tracker(_index_cache_mem_tracker.get());
     _update_state_cache.set_mem_tracker(_update_state_mem_tracker.get());
-    _compaction_cache.set_mem_tracker(_compaction_state_mem_tracker.get());
 
     int64_t byte_limits = ParseUtil::parse_mem_spec(config::mem_limit, MemInfo::physical_mem());
     int32_t update_mem_percent = std::max(std::min(100, config::update_memory_limit_percent), 0);
     _index_cache.set_capacity(byte_limits * update_mem_percent);
+}
+
+UpdateManager::~UpdateManager() {
+    _index_cache.clear();
+    _update_state_cache.clear();
+    _compaction_cache.clear();
 }
 
 inline std::string cache_key(uint32_t tablet_id, int64_t txn_id) {

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -183,8 +183,6 @@ private:
 
     // rowset cache
     DynamicCache<string, RowsetUpdateState> _update_state_cache;
-    // compaction cache
-    DynamicCache<string, CompactionState> _compaction_cache;
     std::atomic<int64_t> _last_clear_expired_cache_millis = 0;
     LocationProvider* _location_provider = nullptr;
     TabletManager* _tablet_mgr = nullptr;
@@ -194,6 +192,9 @@ private:
     std::unique_ptr<MemTracker> _index_cache_mem_tracker;
     std::unique_ptr<MemTracker> _update_state_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_state_mem_tracker;
+
+    // compaction cache
+    DynamicCache<string, CompactionState> _compaction_cache;
 
     std::vector<PkIndexShard> _pk_index_shards;
 };

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -54,7 +54,7 @@ private:
 class UpdateManager {
 public:
     UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker = nullptr);
-    ~UpdateManager() {}
+    ~UpdateManager();
     void set_tablet_mgr(TabletManager* tablet_mgr) { _tablet_mgr = tablet_mgr; }
     void set_cache_expire_ms(int64_t expire_ms) { _cache_expire_ms = expire_ms; }
 
@@ -183,6 +183,8 @@ private:
 
     // rowset cache
     DynamicCache<string, RowsetUpdateState> _update_state_cache;
+    // compaction cache
+    DynamicCache<string, CompactionState> _compaction_cache;
     std::atomic<int64_t> _last_clear_expired_cache_millis = 0;
     LocationProvider* _location_provider = nullptr;
     TabletManager* _tablet_mgr = nullptr;
@@ -192,9 +194,6 @@ private:
     std::unique_ptr<MemTracker> _index_cache_mem_tracker;
     std::unique_ptr<MemTracker> _update_state_mem_tracker;
     std::unique_ptr<MemTracker> _compaction_state_mem_tracker;
-
-    // compaction cache
-    DynamicCache<string, CompactionState> _compaction_cache;
 
     std::vector<PkIndexShard> _pk_index_shards;
 };


### PR DESCRIPTION
Why I'm doing:
`_compaction_state_mem_tracker` will be destructed before `_compaction_cache`. When `_compaction_cache` is destructed, `_compaction_state_mem_tracker` maybe nullptr.
What I'm doing:
Make `_compaction_state_mem_tracker` be destructed after `_compaction_cache`.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
