### PR TITLE
[BugFix] mark using parameter as assignment expr in update statement not supported

### DIFF
--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -209,11 +209,12 @@ Status OlapTableSink::prepare(RuntimeState* state) {
         for (int i = 0; i < _output_expr_ctxs.size(); ++i) {
             if (!is_type_compatible(_output_expr_ctxs[i]->root()->type().type,
                                     _output_tuple_desc->slots()[i]->type().type)) {
-                LOG(WARNING) << "type of exprs is not match slot's, expr_type="
-                             << _output_expr_ctxs[i]->root()->type().type
-                             << ", slot_type=" << _output_tuple_desc->slots()[i]->type().type
-                             << ", slot_name=" << _output_tuple_desc->slots()[i]->col_name();
-                return Status::InternalError("expr's type is not same with slot's");
+                auto msg = fmt::format("type of exprs is not match slot's, expr_type={}, slot_type={}, slot_name={}",
+                                       _output_expr_ctxs[i]->root()->type().type,
+                                       _output_tuple_desc->slots()[i]->type().type,
+                                       _output_tuple_desc->slots()[i]->col_name());
+                LOG(WARNING) << msg;
+                return Status::InternalError(msg);
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PrepareAnalyzer.java
@@ -20,6 +20,7 @@ import com.starrocks.sql.ast.DeallocateStmt;
 import com.starrocks.sql.ast.ExecuteStmt;
 import com.starrocks.sql.ast.PrepareStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UpdateStmt;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.optimizer.validate.ValidateException;
 
@@ -32,9 +33,16 @@ public class PrepareAnalyzer {
 
     public void analyze(PrepareStmt prepareStmt) {
         StatementBase innerStmt = prepareStmt.getInnerStmt();
-        if (innerStmt instanceof PrepareStmt || innerStmt instanceof  ExecuteStmt
+        if (innerStmt instanceof PrepareStmt || innerStmt instanceof ExecuteStmt
                 || innerStmt instanceof DeallocateStmt) {
             throw new ValidateException("Invalid statement type for prepared statement", ErrorType.USER_ERROR);
+        }
+        if (innerStmt instanceof UpdateStmt) {
+            UpdateStmt updateStmt = (UpdateStmt) innerStmt;
+            if (updateStmt.assignmentsContainsParameter()) {
+                throw new ValidateException("using parameter(?) as assignment expr in update statement is not supported",
+                        ErrorType.USER_ERROR);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/UpdateStmt.java
@@ -16,6 +16,7 @@ package com.starrocks.sql.ast;
 
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.Parameter;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Table;
 import com.starrocks.sql.parser.NodePosition;
@@ -67,6 +68,15 @@ public class UpdateStmt extends DmlStmt {
 
     public List<ColumnAssignment> getAssignments() {
         return assignments;
+    }
+
+    public boolean assignmentsContainsParameter() {
+        for (ColumnAssignment assignment : assignments) {
+            if (assignment.getExpr().contains(Parameter.class)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public List<Relation> getFromRelations() {

--- a/test/sql/test_preparestatement/R/test_preprare_statement
+++ b/test/sql/test_preparestatement/R/test_preprare_statement
@@ -24,7 +24,11 @@ PREPARE stmt2 FROM select * from prepare_stmt where k1 = ? and k2 = ?;
 -- result:
 []
 -- !result
-PREPARE stmt3 FROM 'update prepare_stmt set v8 = ?, v10 = ? where k1 = ? and k2 = ?';
+PREPARE stmt3_err FROM update prepare_stmt set v8 = ?, v10 = ? where k1 = ? and k2 = ?;
+-- result:
+E: (1064, 'using parameter(?) as assignment expr in update statement is not supported')
+-- !result
+PREPARE stmt3 FROM update prepare_stmt set v8 = '2', v10 = '2' where k1 = ? and k2 = ?;
 -- result:
 []
 -- !result
@@ -84,7 +88,7 @@ execute stmt2 using @i2, @i;
 -- result:
 2	1	1	1	1	1	2021-02-01	1	2021-02-01 00:00:12	1	1.00
 -- !result
-execute stmt3 using @v2, @v2, @i, @i;
+execute stmt3 using @i, @i;
 -- result:
 []
 -- !result
@@ -103,10 +107,9 @@ execute stmt6 using @i, @v2;
 2	1
 1	1
 -- !result
-execute stmt6 using @i, @i2;
+execute stmt7 using @i, @i2;
 -- result:
-2	1
-1	1
+[]
 -- !result
 drop prepare stmt1;
 -- result:

--- a/test/sql/test_preparestatement/T/test_preprare_statement
+++ b/test/sql/test_preparestatement/T/test_preprare_statement
@@ -16,7 +16,8 @@ CREATE TABLE IF NOT EXISTS prepare_stmt (
 
 PREPARE stmt1 FROM insert into prepare_stmt values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);
 PREPARE stmt2 FROM select * from prepare_stmt where k1 = ? and k2 = ?;
-PREPARE stmt3 FROM 'update prepare_stmt set v8 = ?, v10 = ? where k1 = ? and k2 = ?';
+PREPARE stmt3_err FROM update prepare_stmt set v8 = ?, v10 = ? where k1 = ? and k2 = ?;
+PREPARE stmt3 FROM update prepare_stmt set v8 = '2', v10 = '2' where k1 = ? and k2 = ?;
 PREPARE stmt4 FROM 'select * from prepare_stmt';
 PREPARE stmt5 FROM select * from prepare_stmt;
 PREPARE stmt6 FROM select k1, k2 from prepare_stmt order by ?, ? desc;
@@ -35,7 +36,7 @@ execute stmt1 using @i2, @i, @i, @i, @v, @b, @t, @v, @t, @v, @i;
 execute stmt2 using @i, @i;
 execute stmt2 using @i2, @i;
 
-execute stmt3 using @v2, @v2, @i, @i;
+execute stmt3 using @i, @i;
 
 execute stmt4;
 execute stmt5;


### PR DESCRIPTION
Why I'm doing:

some of the assignment analyzing are not working in preparedstmt, mark it as not supported for now.

What I'm doing:

mark using parameter as assignment expr in update statement not supported

Fixes #34550

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
