### PR TITLE
[Enhancement] Use runtime filter on non-slotref expression

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/NestLoopJoinNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/NestLoopJoinNode.java
@@ -96,9 +96,6 @@ public class NestLoopJoinNode extends JoinNode implements RuntimeFilterBuildNode
         PlanNode leftChild = getChild(0);
         PlanNode rightChild = getChild(1);
 
-        if (!(leftExpr instanceof SlotRef)) {
-            return false;
-        }
         if (joinExpr instanceof BinaryPredicate && ((BinaryPredicate) joinExpr).getOp().isUnequivalence()) {
             return false;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -331,7 +331,7 @@ public class NestLoopJoinTest extends PlanTestBase {
         assertVerbosePlanNotContains(sql, "  |  build runtime filters:");
 
         sql = "select * from t0 a join t0 b where a.v1 + 1 < b.v1";
-        assertVerbosePlanNotContains(sql, "  |  build runtime filters:");
+        assertVerbosePlanContains(sql, "  |  build runtime filters:");
 
         sql = "select * from t0 a join t0 b where a.v1 + b.v1 < b.v1";
         assertVerbosePlanNotContains(sql, "  |  build runtime filters:");


### PR DESCRIPTION
Why I'm doing:

Use runtime filter when left expr is not a slotref. This is ok as long as left/right expr is fully bound by left/right plan tree.

```
select count(1) from customer join customer_address on  c_birth_country + 1 < ca_country;
```

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
