### PR TITLE
[Refactor] Send to PInternalService instead of PBackendService

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
@@ -37,52 +37,52 @@ import com.starrocks.proto.PUpdateFailPointStatusResponse;
 import java.util.concurrent.Future;
 
 public interface PBackendService {
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "exec_plan_fragment",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "exec_plan_fragment",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 60000)
     Future<PExecPlanFragmentResult> execPlanFragmentAsync(PExecPlanFragmentRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "exec_batch_plan_fragments",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "exec_batch_plan_fragments",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 60000)
     Future<PExecBatchPlanFragmentsResult> execBatchPlanFragmentsAsync(PExecBatchPlanFragmentsRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "cancel_plan_fragment",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "cancel_plan_fragment",
             onceTalkTimeout = 5000)
     Future<PCancelPlanFragmentResult> cancelPlanFragmentAsync(PCancelPlanFragmentRequest request);
 
     // we set timeout to 1 day, because now there is no way to give different timeout for each RPC call
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "fetch_data",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "fetch_data",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 86400000)
     Future<PFetchDataResult> fetchDataAsync(PFetchDataRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "trigger_profile_report",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "trigger_profile_report",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 10000)
     Future<PTriggerProfileReportResult> triggerProfileReport(PTriggerProfileReportRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "collect_query_statistics",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "collect_query_statistics",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 10000)
     Future<PCollectQueryStatisticsResult> collectQueryStatistics(PCollectQueryStatisticsRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "get_info", onceTalkTimeout = 600000)
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "get_info", onceTalkTimeout = 600000)
     Future<PProxyResult> getInfo(PProxyRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "get_pulsar_info", onceTalkTimeout = 600000)
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "get_pulsar_info", onceTalkTimeout = 600000)
     Future<PPulsarProxyResult> getPulsarInfo(PPulsarProxyRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "get_file_schema",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "get_file_schema",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 600000)
     Future<PGetFileSchemaResult> getFileSchema(PGetFileSchemaRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "submit_mv_maintenance_task", onceTalkTimeout = 60000,
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "submit_mv_maintenance_task", onceTalkTimeout = 60000,
             attachmentHandler = ThriftClientAttachmentHandler.class)
     Future<PMVMaintenanceTaskResult> submitMVMaintenanceTaskAsync(PMVMaintenanceTaskRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "execute_command", onceTalkTimeout = 60000)
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "execute_command", onceTalkTimeout = 60000)
     Future<ExecuteCommandResultPB> executeCommandAsync(ExecuteCommandRequestPB request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "update_fail_point_status", onceTalkTimeout = 60000)
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "update_fail_point_status", onceTalkTimeout = 60000)
     Future<PUpdateFailPointStatusResponse> updateFailPointStatusAsync(PUpdateFailPointStatusRequest request);
 
-    @ProtobufRPC(serviceName = "PBackendService", methodName = "list_fail_point",
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "list_fail_point",
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 60000)
     Future<PListFailPointResponse> listFailPointAsync(PListFailPointRequest request);
 }


### PR DESCRIPTION
Why I'm doing:

Since the pr https://github.com/StarRocks/starrocks/pull/717 , the function of PInternalService is the same as that of PBackendService, the PBackendService is reserved only for compatibility, so now it is necessary to send to PInternalService instead of PBackendService. After multiple major versions, PBackendService can be finally removed.

What I'm doing:

send to PInternalService instead of PBackendService.

The class name `PBackendService` is easier to understand, so we did not change the class name.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
