### PR TITLE
[BugFix] fix potential deadlock when refreshing mv

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -264,7 +264,7 @@ public class StatementPlanner {
     }
 
     // Lock all database before analyze
-    private static void lock(Locker locker, Map<String, Database> dbs) {
+    public static void lock(Locker locker, Map<String, Database> dbs) {
         if (dbs == null) {
             return;
         }
@@ -276,7 +276,7 @@ public class StatementPlanner {
     }
 
     // unLock all database after analyze
-    private static void unLock(Locker locker, Map<String, Database> dbs) {
+    public static void unLock(Locker locker, Map<String, Database> dbs) {
         if (dbs == null) {
             return;
         }


### PR DESCRIPTION
Why I'm doing:
- When generating plan for MV, it would try to acquire locks of other databases meanwhile holding the lock of current database, it could introduce deadlock in this case

What I'm doing:
- Release lock of current database before invoke the `StatementPlanner.plan`, which would acquire locks for all database
- Acquire the database locks before `Analyzer.analyze`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
