### PR TITLE
[Refactor] RPC requests are no longer sent to PBackendService, so PBackendService related metrics are no longer output

### DIFF
--- a/be/src/http/action/metrics_action.cpp
+++ b/be/src/http/action/metrics_action.cpp
@@ -337,7 +337,7 @@ void MetricsAction::handle(HttpRequest* req) {
         PrometheusMetricsVisitor visitor;
         _metrics->collect(&visitor);
         if (config::dump_metrics_with_bvar) {
-            bvar::Variable::dump_exposed(&visitor, nullptr);
+            bvar::Variable::dump_exposed(&visitor, &_options);
         }
 #ifdef USE_STAROS
 #ifdef BE_TEST

--- a/be/src/http/action/metrics_action.h
+++ b/be/src/http/action/metrics_action.h
@@ -34,13 +34,14 @@
 
 #pragma once
 
+#include <bvar/variable.h>
+
 #include <string>
 
 #include "http/http_handler.h"
 
 namespace starrocks {
 
-class Webserver;
 class ExecEnv;
 class HttpRequest;
 class MetricRegistry;
@@ -49,9 +50,15 @@ typedef void (*MockFunc)(const std::string&);
 
 class MetricsAction : public HttpHandler {
 public:
-    explicit MetricsAction(MetricRegistry* metrics) : _metrics(metrics), _mock_func(nullptr) {}
+    explicit MetricsAction(MetricRegistry* metrics) : _metrics(metrics), _mock_func(nullptr) {
+        // The option can be removed if PBackendService is final removed.
+        _options.black_wildcards = "*_pbackend_service*";
+    }
     // for tests
-    explicit MetricsAction(MetricRegistry* metrics, MockFunc func) : _metrics(metrics), _mock_func(func) {}
+    explicit MetricsAction(MetricRegistry* metrics, MockFunc func) : _metrics(metrics), _mock_func(func) {
+        // The option can be removed if PBackendService is final removed.
+        _options.black_wildcards = "*_pbackend_service*";
+    }
     ~MetricsAction() override = default;
 
     void handle(HttpRequest* req) override;
@@ -59,6 +66,7 @@ public:
 private:
     MetricRegistry* _metrics;
     MockFunc _mock_func;
+    bvar::DumpOptions _options;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:

RPC requests are no longer sent to PBackendService, so PBackendService related metrics are no longer output

What I'm doing:

 PBackendService related metrics are no longer output through the blacklist 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
