### PR TITLE
[BugFix] cloud native duplicate and primary table scheme change will cause short key unorder (backport #35666)

### DIFF
--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -135,6 +135,7 @@ Status ConvertedSchemaChange::init() {
     _read_params.chunk_size = config::vector_chunk_size;
     _read_params.use_page_cache = false;
     _read_params.fill_data_cache = false;
+    _read_params.sorted_by_keys_per_tablet = true;
 
     ASSIGN_OR_RETURN(auto base_tablet_schema, _base_tablet->get_schema());
     _base_schema = ChunkHelper::convert_schema(*base_tablet_schema, _chunk_changer->get_selected_column_indexes());


### PR DESCRIPTION
Why I'm doing:
In cloud native duplicate and primary table, after schema change like add/del/modify columns, if the segment are overlap in source rowset, the new convert rowset's segment file may contains unorder short key index.

What I'm doing:
set `sorted_by_keys_per_tablet` = true , so we can generate segment file with correct short key index.

Fixes #35666

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
