### PR TITLE
[Enhancement] Add more jvm stats into /metrics http api

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/MonitorProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/MonitorProcDir.java
@@ -58,7 +58,7 @@ public class MonitorProcDir implements ProcDirInterface {
         }
 
         if (name.equalsIgnoreCase("jvm")) {
-            return new JvmProcDir();
+            return new JvmMonitorProcDir();
         } else {
             throw new AnalysisException("unknown name: " + name);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
@@ -38,14 +38,11 @@ import com.codahale.metrics.Histogram;
 import com.starrocks.monitor.jvm.GcNames;
 import com.starrocks.monitor.jvm.JvmStats;
 
-import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
 
 public class JsonMetricVisitor extends MetricVisitor {
-
     private boolean isFirstElement;
-    private StringBuilder sb;
+    private final StringBuilder sb;
 
     public JsonMetricVisitor(String prefix) {
         super(prefix);
@@ -53,53 +50,76 @@ public class JsonMetricVisitor extends MetricVisitor {
         sb = new StringBuilder();
     }
 
+    private void addGcMetric(String metricName, JvmStats.GarbageCollector gc) {
+        buildMetric(metricName, "nounit", String.valueOf(gc.getCollectionCount()),
+                List.of(new MetricLabel("type", "count")));
+        buildMetric(metricName, "milliseconds", String.valueOf(gc.getCollectionTime().getMillis()),
+                List.of(new MetricLabel("type", "time")));
+    }
+
+    private void addMemPoolMetric(String metricName, JvmStats.MemoryPool memPool) {
+        buildMetric(metricName, "bytes", String.valueOf(memPool.getCommitted()),
+                List.of(new MetricLabel("type", "committed")));
+        buildMetric(metricName, "bytes", String.valueOf(memPool.getUsed()),
+                List.of(new MetricLabel("type", "used")));
+    }
+
     @Override
     public void visitJvm(JvmStats jvmStats) {
-
-        List<MetricLabel> labels = new ArrayList<>();
-        //gc
-        Iterator<JvmStats.GarbageCollector> gcIter = jvmStats.getGc().iterator();
-        while (gcIter.hasNext()) {
-            JvmStats.GarbageCollector gc = gcIter.next();
+        // gc
+        for (JvmStats.GarbageCollector gc : jvmStats.getGc()) {
             if (gc.getName().equalsIgnoreCase(GcNames.YOUNG)) {
-                labels.clear();
-                labels.add(new MetricLabel("type", "count"));
-                buildMetric("jvm_young_gc", "nounit", String.valueOf(gc.getCollectionCount()), labels);
-
-                labels.clear();
-                labels.add(new MetricLabel("type", "time"));
-                buildMetric("jvm_young_gc", "milliseconds", String.valueOf(gc.getCollectionTime().getMillis()), labels);
+                addGcMetric("jvm_young_gc", gc);
             } else if (gc.getName().equalsIgnoreCase(GcNames.OLD)) {
-                labels.clear();
-                labels.add(new MetricLabel("type", "count"));
-                buildMetric("jvm_old_gc", "nounit", String.valueOf(gc.getCollectionCount()), labels);
-
-                labels.clear();
-                labels.add(new MetricLabel("type", "time"));
-                buildMetric("jvm_old_gc", "milliseconds", String.valueOf(gc.getCollectionTime().getMillis()), labels);
+                addGcMetric("jvm_old_gc", gc);
             }
         }
 
+        // mem overall
+        JvmStats.Mem mem = jvmStats.getMem();
+        buildMetric("jvm_heap_size_bytes", "bytes", String.valueOf(mem.getHeapMax()),
+                List.of(new MetricLabel("type", "max")));
+        buildMetric("jvm_heap_size_bytes", "bytes", String.valueOf(mem.getHeapCommitted()),
+                List.of(new MetricLabel("type", "committed")));
+        buildMetric("jvm_heap_size_bytes", "bytes", String.valueOf(mem.getHeapUsed()),
+                List.of(new MetricLabel("type", "used")));
+
         // mem pool
-        Iterator<JvmStats.MemoryPool> memIter = jvmStats.getMem().iterator();
-        while (memIter.hasNext()) {
-            JvmStats.MemoryPool memPool = memIter.next();
+        for (JvmStats.MemoryPool memPool : jvmStats.getMem()) {
             if (memPool.getName().equalsIgnoreCase(GcNames.PERM)) {
                 double percent = 0.0;
                 if (memPool.getCommitted().getBytes() > 0) {
                     percent = 100 * ((double) memPool.getUsed().getBytes() / memPool.getCommitted().getBytes());
                 }
-                labels.clear();
-                labels.add(new MetricLabel("type", GcNames.PERM));
-                buildMetric("jvm_size_percent", "percent", String.valueOf(percent), labels);
+                buildMetric("jvm_size_percent", "percent", String.valueOf(percent),
+                        List.of(new MetricLabel("type", GcNames.PERM)));
             } else if (memPool.getName().equalsIgnoreCase(GcNames.OLD)) {
                 double percent = 0.0;
                 if (memPool.getCommitted().getBytes() > 0) {
                     percent = 100 * ((double) memPool.getUsed().getBytes() / memPool.getCommitted().getBytes());
                 }
-                labels.clear();
-                labels.add(new MetricLabel("type", GcNames.OLD));
-                buildMetric("jvm_size_percent", "percent", String.valueOf(percent), labels);
+                // **NOTICE**: We shouldn't use 'jvm_size_percent' as a metric name, it should be a type,
+                // but for compatibility reason, we won't remove it.
+                buildMetric("jvm_size_percent", "percent", String.valueOf(percent),
+                        List.of(new MetricLabel("type", GcNames.OLD)));
+
+                // {"metric":"jvm_old_size_bytes","type":"committed","unit":"bytes"}
+                // {"metric":"jvm_old_size_bytes","type":"used","unit":"bytes"}
+                addMemPoolMetric("jvm_old_size_bytes", memPool);
+            } else if (memPool.getName().equalsIgnoreCase(GcNames.YOUNG)) {
+                // {"metric":"jvm_young_size_bytes","type":"committed","unit":"bytes"}
+                // {"metric":"jvm_young_size_bytes","type":"used","unit":"bytes"}
+                addMemPoolMetric("jvm_young_size_bytes", memPool);
+            }
+        }
+
+        // buffer pool
+        for (JvmStats.BufferPool pool : jvmStats.getBufferPools()) {
+            if (pool.getName().equalsIgnoreCase("direct")) {
+                buildMetric("jvm_direct_buffer_pool_size_bytes", "bytes", String.valueOf(pool.getTotalCapacity()),
+                        List.of(new MetricLabel("type", "capacity")));
+                buildMetric("jvm_direct_buffer_pool_size_bytes", "bytes", String.valueOf(pool.getUsed()),
+                        List.of(new MetricLabel("type", "used")));
             }
         }
     }
@@ -114,12 +134,10 @@ public class JsonMetricVisitor extends MetricVisitor {
 
     @Override
     public void visitHistogram(String name, Histogram histogram) {
-        return;
     }
 
     @Override
     public void getNodeInfo() {
-        return;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -65,7 +65,7 @@ import com.starrocks.load.routineload.RoutineLoadJob;
 import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.metric.Metric.MetricType;
 import com.starrocks.metric.Metric.MetricUnit;
-import com.starrocks.monitor.jvm.JvmService;
+import com.starrocks.monitor.jvm.JvmStatCollector;
 import com.starrocks.monitor.jvm.JvmStats;
 import com.starrocks.proto.PKafkaOffsetProxyRequest;
 import com.starrocks.proto.PKafkaOffsetProxyResult;
@@ -876,8 +876,8 @@ public final class MetricRepo {
         updateMetrics();
 
         // jvm
-        JvmService jvmService = new JvmService();
-        JvmStats jvmStats = jvmService.stats();
+        JvmStatCollector jvmStatCollector = new JvmStatCollector();
+        JvmStats jvmStats = jvmStatCollector.stats();
         visitor.visitJvm(jvmStats);
 
         // starrocks metrics

--- a/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
@@ -45,7 +45,6 @@ import com.starrocks.monitor.jvm.JvmStats.Threads;
 import com.starrocks.server.GlobalStateMgr;
 
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -70,8 +69,8 @@ public class PrometheusMetricVisitor extends MetricVisitor {
     private static final String HELP = "# HELP ";
     private static final String TYPE = "# TYPE ";
 
-    private StringBuilder sb;
-    private Set<String> metricNames = new HashSet();
+    private final StringBuilder sb;
+    private final Set<String> metricNames = new HashSet<>();
 
     public PrometheusMetricVisitor(String prefix) {
         super(prefix);
@@ -98,34 +97,16 @@ public class PrometheusMetricVisitor extends MetricVisitor {
                 .append(jvmStats.getMem().getNonHeapUsed().getBytes()).append("\n");
 
         // mem pool
-        Iterator<MemoryPool> memIter = jvmStats.getMem().iterator();
-        while (memIter.hasNext()) {
-            MemoryPool memPool = memIter.next();
+        for (MemoryPool memPool : jvmStats.getMem()) {
             if (memPool.getName().equalsIgnoreCase("young")) {
-                sb.append(Joiner.on(" ").join(HELP, JVM_YOUNG_SIZE_BYTES, "jvm young mem pool stat\n"));
-                sb.append(Joiner.on(" ").join(TYPE, JVM_YOUNG_SIZE_BYTES, "gauge\n"));
-                sb.append(JVM_YOUNG_SIZE_BYTES).append("{type=\"used\"} ").append(memPool.getUsed().getBytes())
-                        .append("\n");
-                sb.append(JVM_YOUNG_SIZE_BYTES).append("{type=\"peak_used\"} ").append(memPool.getPeakUsed().getBytes())
-                        .append("\n");
-                sb.append(JVM_YOUNG_SIZE_BYTES).append("{type=\"max\"} ").append(memPool.getMax().getBytes())
-                        .append("\n");
+                addMemPoolMetrics(memPool, JVM_YOUNG_SIZE_BYTES, "jvm young mem pool stat\n");
             } else if (memPool.getName().equalsIgnoreCase("old")) {
-                sb.append(Joiner.on(" ").join(HELP, JVM_OLD_SIZE_BYTES, "jvm old mem pool stat\n"));
-                sb.append(Joiner.on(" ").join(TYPE, JVM_OLD_SIZE_BYTES, "gauge\n"));
-                sb.append(JVM_OLD_SIZE_BYTES).append("{type=\"used\"} ").append(memPool.getUsed().getBytes())
-                        .append("\n");
-                sb.append(JVM_OLD_SIZE_BYTES).append("{type=\"peak_used\"} ").append(memPool.getPeakUsed().getBytes())
-                        .append("\n");
-                sb.append(JVM_OLD_SIZE_BYTES).append("{type=\"max\"} ").append(memPool.getMax().getBytes())
-                        .append("\n");
+                addMemPoolMetrics(memPool, JVM_OLD_SIZE_BYTES, "jvm old mem pool stat\n");
             }
         }
 
         // direct buffer pool
-        Iterator<BufferPool> poolIter = jvmStats.getBufferPools().iterator();
-        while (poolIter.hasNext()) {
-            BufferPool pool = poolIter.next();
+        for (BufferPool pool : jvmStats.getBufferPools()) {
             if (pool.getName().equalsIgnoreCase("direct")) {
                 sb.append(Joiner.on(" ").join(HELP, JVM_DIRECT_BUFFER_POOL_SIZE_BYTES,
                         "jvm direct buffer pool stat\n"));
@@ -140,21 +121,11 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         }
 
         // gc
-        Iterator<GarbageCollector> gcIter = jvmStats.getGc().iterator();
-        while (gcIter.hasNext()) {
-            GarbageCollector gc = gcIter.next();
+        for (GarbageCollector gc : jvmStats.getGc()) {
             if (gc.getName().equalsIgnoreCase("young")) {
-                sb.append(Joiner.on(" ").join(HELP, JVM_YOUNG_GC, "jvm young gc stat\n"));
-                sb.append(Joiner.on(" ").join(TYPE, JVM_YOUNG_GC, "gauge\n"));
-                sb.append(JVM_YOUNG_GC).append("{type=\"count\"} ").append(gc.getCollectionCount()).append("\n");
-                sb.append(JVM_YOUNG_GC).append("{type=\"time\"} ").append(gc.getCollectionTime().getMillis())
-                        .append("\n");
+                addGcMetrics(gc, JVM_YOUNG_GC, "jvm young gc stat\n");
             } else if (gc.getName().equalsIgnoreCase("old")) {
-                sb.append(Joiner.on(" ").join(HELP, JVM_OLD_GC, "jvm old gc stat\n"));
-                sb.append(Joiner.on(" ").join(TYPE, JVM_OLD_GC, "gauge\n"));
-                sb.append(JVM_OLD_GC).append("{type=\"count\"} ").append(gc.getCollectionCount()).append("\n");
-                sb.append(JVM_OLD_GC).append("{type=\"time\"} ").append(gc.getCollectionTime().getMillis())
-                        .append("\n");
+                addGcMetrics(gc, JVM_OLD_GC, "jvm old gc stat\n");
             }
         }
 
@@ -164,14 +135,35 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         sb.append(Joiner.on(" ").join(TYPE, JVM_THREAD, "gauge\n"));
         sb.append(JVM_THREAD).append("{type=\"count\"} ").append(threads.getCount()).append("\n");
         sb.append(JVM_THREAD).append("{type=\"peak_count\"} ").append(threads.getPeakCount()).append("\n");
-        return;
+    }
+
+    private void addGcMetrics(GarbageCollector gc, String metricName, String desc) {
+        sb.append(Joiner.on(" ").join(HELP, metricName, desc));
+        sb.append(Joiner.on(" ").join(TYPE, metricName, "gauge\n"));
+        sb.append(metricName).append("{type=\"count\"} ").append(gc.getCollectionCount()).append("\n");
+        sb.append(metricName).append("{type=\"time\"} ").append(gc.getCollectionTime().getMillis())
+                .append("\n");
+
+    }
+
+    private void addMemPoolMetrics(MemoryPool memPool, String metricName, String desc) {
+        sb.append(Joiner.on(" ").join(HELP, metricName, desc));
+        sb.append(Joiner.on(" ").join(TYPE, metricName, "gauge\n"));
+        sb.append(metricName).append("{type=\"committed\"} ").append(memPool.getCommitted().getBytes())
+                .append("\n");
+        sb.append(metricName).append("{type=\"used\"} ").append(memPool.getUsed().getBytes())
+                .append("\n");
+        sb.append(metricName).append("{type=\"peak_used\"} ").append(memPool.getPeakUsed().getBytes())
+                .append("\n");
+        sb.append(metricName).append("{type=\"max\"} ").append(memPool.getMax().getBytes())
+                .append("\n");
     }
 
     @Override
     public void visit(@SuppressWarnings("rawtypes") Metric metric) {
         // title
         final String fullName = prefix + "_" + metric.getName();
-        // SR-57 : Fix prometheus parse error : 'second HELP line for metric name ..'
+        // SR-57 : Fix prometheus parse error : 'second HELP line for metric name ...'
         if (!metricNames.contains(fullName)) {
             sb.append(HELP).append(fullName).append(" ").append(metric.getDescription()).append("\n");
             sb.append(TYPE).append(fullName).append(" ").append(metric.getType().name().toLowerCase()).append("\n");
@@ -184,15 +176,14 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         List<MetricLabel> labels = metric.getLabels();
         if (!labels.isEmpty()) {
             sb.append("{");
-            List<String> labelStrs = labels.stream().map(l -> l.getKey() + "=\"" + l.getValue()
+            List<String> labelStrings = labels.stream().map(l -> l.getKey() + "=\"" + l.getValue()
                     + "\"").collect(Collectors.toList());
-            sb.append(Joiner.on(", ").join(labelStrs));
+            sb.append(Joiner.on(", ").join(labelStrings));
             sb.append("}");
         }
 
         // value
         sb.append(" ").append(metric.getValue().toString()).append("\n");
-        return;
     }
 
     @Override
@@ -209,7 +200,6 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         sb.append(fullName).append("{quantile=\"0.999\"} ").append(snapshot.get999thPercentile()).append("\n");
         sb.append(fullName).append("_sum ").append(histogram.getCount() * snapshot.getMean()).append("\n");
         sb.append(fullName).append("_count ").append(histogram.getCount()).append("\n");
-        return;
     }
 
     @Override
@@ -233,7 +223,6 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         if (GlobalStateMgr.getCurrentState().isLeader()) {
             sb.append(NODE_INFO).append("{type=\"is_master\"} ").append(1).append("\n");
         }
-        return;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmInfo.java
@@ -36,7 +36,7 @@ import java.util.Map;
 
 public class JvmInfo {
 
-    private static JvmInfo INSTANCE;
+    private static final JvmInfo INSTANCE;
 
     static {
         RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();

--- a/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmStatCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmStatCollector.java
@@ -30,16 +30,16 @@ import org.apache.logging.log4j.Logger;
 import java.util.List;
 
 /**
- * Obtain JVMInfo and JvmStats
+ * Obtain JvmInfo and JvmStats periodically.
  */
-public class JvmService {
-    private static final Logger LOG = LogManager.getLogger(JvmService.class);
+public class JvmStatCollector {
+    private static final Logger LOG = LogManager.getLogger(JvmStatCollector.class);
 
     private final JvmInfo jvmInfo;
 
     private JvmStats jvmStats;
 
-    public JvmService() {
+    public JvmStatCollector() {
         this.jvmInfo = JvmInfo.jvmInfo();
         this.jvmStats = JvmStats.jvmStats();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmStats.java
@@ -36,6 +36,7 @@ package com.starrocks.monitor.jvm;
 
 import com.starrocks.monitor.unit.ByteSizeValue;
 import com.starrocks.monitor.unit.TimeValue;
+import org.jetbrains.annotations.NotNull;
 
 import java.lang.management.BufferPoolMXBean;
 import java.lang.management.ClassLoadingMXBean;
@@ -82,7 +83,7 @@ public class JvmStats {
                 MemoryUsage usage = memoryPoolMXBean.getUsage();
                 MemoryUsage peakUsage = memoryPoolMXBean.getPeakUsage();
                 String name = GcNames.getByMemoryPoolName(memoryPoolMXBean.getName(), null);
-                if (name == null) { // if we can't resolve it, its not interesting.... (Per Gen, Code Cache)
+                if (name == null) { // if we can't resolve it, it's not interesting.... (Per Gen, Code Cache)
                     continue;
                 }
                 pools.add(new MemoryPool(name,
@@ -239,6 +240,7 @@ public class JvmStats {
             return this.collectors;
         }
 
+        @NotNull
         @Override
         public Iterator<GarbageCollector> iterator() {
             return Arrays.stream(collectors).iterator();
@@ -375,6 +377,7 @@ public class JvmStats {
             this.pools = pools;
         }
 
+        @NotNull
         @Override
         public Iterator<MemoryPool> iterator() {
             return pools.iterator();

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -17,7 +17,9 @@
 
 package com.starrocks.metric;
 
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.proc.JvmMonitorProcDir;
 import com.starrocks.monitor.jvm.JvmStatCollector;
 import com.starrocks.monitor.jvm.JvmStats;
 import org.junit.Assert;
@@ -81,6 +83,7 @@ public class MetricsTest {
     public void testPrometheusJvmStats() {
         PrometheusMetricVisitor prometheusMetricVisitor = new PrometheusMetricVisitor("sr_fe_jvm_stat_test");
         JvmStatCollector jvmStatCollector = new JvmStatCollector();
+        System.out.println(jvmStatCollector.toString());
         JvmStats jvmStats = jvmStatCollector.stats();
         prometheusMetricVisitor.visitJvm(jvmStats);
         String output = prometheusMetricVisitor.build();
@@ -95,6 +98,35 @@ public class MetricsTest {
         );
         for (String metricName : metricNames) {
             Assert.assertTrue(output.contains(metricName));
+        }
+    }
+
+    private boolean jvmProcDirResultRowsContains(List<List<String>> rows, String metricName) {
+        for (List<String> row : rows) {
+            if (row.contains(metricName)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Test
+    public void testProcDirJvmStats() throws AnalysisException {
+        JvmMonitorProcDir jvmMonitorProcDir = new JvmMonitorProcDir();
+        List<List<String>> rows = jvmMonitorProcDir.fetchResult().getRows();
+        System.out.println(rows);
+        List<String> metricNames = Arrays.asList(
+                "gc old collection count",
+                "gc old collection time",
+                "gc young collection time",
+                "gc young collection time",
+                "mem pool old committed",
+                "mem pool old used"
+        );
+        for (String metricName : metricNames) {
+            System.out.println(metricName);
+            Assert.assertTrue(jvmProcDirResultRowsContains(rows, metricName));
         }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/metric/MetricsTest.java
@@ -18,10 +18,13 @@
 package com.starrocks.metric;
 
 import com.starrocks.common.FeConstants;
+import com.starrocks.monitor.jvm.JvmStatCollector;
+import com.starrocks.monitor.jvm.JvmStats;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class MetricsTest {
@@ -50,6 +53,48 @@ public class MetricsTest {
             } else {
                 Assert.fail();
             }
+        }
+    }
+
+    @Test
+    public void testJsonJvmStats() {
+        JsonMetricVisitor jsonMetricVisitor = new JsonMetricVisitor("sr_fe_jvm_stat_test");
+        JvmStatCollector jvmStatCollector = new JvmStatCollector();
+        JvmStats jvmStats = jvmStatCollector.stats();
+        jsonMetricVisitor.visitJvm(jvmStats);
+        String output = jsonMetricVisitor.build();
+        System.out.println(output);
+        List<String> metricNames = Arrays.asList(
+                "jvm_old_gc",
+                "jvm_young_gc",
+                "jvm_young_size_bytes",
+                "jvm_heap_size_bytes",
+                "jvm_old_size_bytes",
+                "jvm_direct_buffer_pool_size_bytes"
+        );
+        for (String metricName : metricNames) {
+            Assert.assertTrue(output.contains(metricName));
+        }
+    }
+
+    @Test
+    public void testPrometheusJvmStats() {
+        PrometheusMetricVisitor prometheusMetricVisitor = new PrometheusMetricVisitor("sr_fe_jvm_stat_test");
+        JvmStatCollector jvmStatCollector = new JvmStatCollector();
+        JvmStats jvmStats = jvmStatCollector.stats();
+        prometheusMetricVisitor.visitJvm(jvmStats);
+        String output = prometheusMetricVisitor.build();
+        System.out.println(output);
+        List<String> metricNames = Arrays.asList(
+                "jvm_old_gc",
+                "jvm_young_gc",
+                "jvm_young_size_bytes",
+                "jvm_heap_size_bytes",
+                "jvm_old_size_bytes",
+                "jvm_direct_buffer_pool_size_bytes"
+        );
+        for (String metricName : metricNames) {
+            Assert.assertTrue(output.contains(metricName));
         }
     }
 }


### PR DESCRIPTION
Why I'm doing:
Some of the key jvm stats, like yound/old heap metrics are not output in the `/metrics` http api.
And the metrics are not aligned between prometheus and json format.

What I'm doing:
Add those missing metrics, and refactor some code to make it easy to maintain and read.

Fixes SR-22790

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
