### PR TITLE
[Enhancement] Fix FE startup failure when encountering unknown expression partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -201,7 +201,11 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
                     if (slotRef.getColumnName().equalsIgnoreCase(partitionColumn.getName())) {
                         slotRef.setType(partitionColumn.getType());
                         slotRef.setNullable(partitionColumn.isAllowNull());
-                        PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
+                        try {
+                            PartitionExprAnalyzer.analyzePartitionExpr(expr, slotRef);
+                        } catch (SemanticException ex) {
+                            LOG.warn("Failed to analyze partition expr: {}", expr.toSql(), ex);
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -23,6 +23,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.io.DataOutputBuffer;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -37,6 +38,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInput;
+import java.io.DataInputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -561,6 +565,12 @@ public class ExpressionRangePartitionInfoTest {
         // deserialize
         OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
         Assert.assertNotNull(readTable);
+
+        DataOutputBuffer buffer = new DataOutputBuffer(1024);
+        expressionRangePartitionInfo.write(buffer);
+        DataInput input = new DataInputStream(new ByteArrayInputStream(buffer.getData()));
+        PartitionInfo deserialized = ExpressionRangePartitionInfo.read(input);
+        Assert.assertNotNull(deserialized);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/ExpressionRangePartitionInfoTest.java
@@ -559,6 +559,13 @@ public class ExpressionRangePartitionInfoTest {
         ExpressionRangePartitionInfo expressionRangePartitionInfo =
                 (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns();
+
+        DataOutputBuffer buffer = new DataOutputBuffer(1024);
+        expressionRangePartitionInfo.write(buffer);
+        DataInput input = new DataInputStream(new ByteArrayInputStream(buffer.getData()));
+        PartitionInfo deserialized = ExpressionRangePartitionInfo.read(input);
+        Assert.assertNotNull(deserialized);
+
         partitionColumns.get(0).setType(Type.VARCHAR);
         // serialize
         String json = GsonUtils.GSON.toJson(olapTable);
@@ -566,10 +573,10 @@ public class ExpressionRangePartitionInfoTest {
         OlapTable readTable = GsonUtils.GSON.fromJson(json, OlapTable.class);
         Assert.assertNotNull(readTable);
 
-        DataOutputBuffer buffer = new DataOutputBuffer(1024);
+        buffer = new DataOutputBuffer(1024);
         expressionRangePartitionInfo.write(buffer);
-        DataInput input = new DataInputStream(new ByteArrayInputStream(buffer.getData()));
-        PartitionInfo deserialized = ExpressionRangePartitionInfo.read(input);
+        input = new DataInputStream(new ByteArrayInputStream(buffer.getData()));
+        deserialized = ExpressionRangePartitionInfo.read(input);
         Assert.assertNotNull(deserialized);
     }
 


### PR DESCRIPTION
Why I'm doing:
Many new expressions may be added to the expression partition later. In terms of version compatibility, FE startup should not fail because of unfamiliar expressions.
What I'm doing:
Ignore expression parsing errors and do not parse unknown expressions when encountered. Does not affect FE
Fixes #issue

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
