### PR TITLE
[BugFix] Reset all fields of runtime filter when exceeding global build size  (#35776)

### DIFF
--- a/be/src/exprs/vectorized/runtime_filter.h
+++ b/be/src/exprs/vectorized/runtime_filter.h
@@ -145,9 +145,9 @@ private:
 
     // Common:
     // log_num_buckets_ is the log (base 2) of the number of buckets in the directory:
-    int _log_num_buckets;
+    int _log_num_buckets = 0;
     // directory_mask_ is (1 << log_num_buckets_) - 1
-    uint32_t _directory_mask;
+    uint32_t _directory_mask = 0;
     Bucket* _directory = nullptr;
 };
 

--- a/test/sql/test_runtime_filter/R/test_global_runtime_filter_exceed_limit
+++ b/test/sql/test_runtime_filter/R/test_global_runtime_filter_exceed_limit
@@ -1,0 +1,29 @@
+-- name: test_global_runtime_filter_exceed_limit
+create table t1 (
+    k1 int
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 32
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t1 select generate_series FROM TABLE(generate_series(1, 65535));
+-- result:
+-- !result
+insert into t1 select k1 + 65535 from t1;
+-- result:
+-- !result
+insert into t1 select k1 + 65535*2 from t1;
+-- result:
+-- !result
+insert into t1 select k1 + 65535*3 from t1;
+-- result:
+-- !result
+with tw1 as (
+    select t1.k1 from t1 join [broadcast] t1 t2 using(k1)
+)
+select /*+SET_VAR(global_runtime_filter_build_max_size=1,global_runtime_filter_probe_min_size=0)*/ 
+    count(1) from tw1 join [broadcast] t1 t3 using(k1);
+-- result:
+917490
+-- !result

--- a/test/sql/test_runtime_filter/T/test_global_runtime_filter_exceed_limit
+++ b/test/sql/test_runtime_filter/T/test_global_runtime_filter_exceed_limit
@@ -1,0 +1,18 @@
+-- name: test_global_runtime_filter_exceed_limit
+create table t1 (
+    k1 int
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 32
+properties("replication_num" = "1");
+
+insert into t1 select generate_series FROM TABLE(generate_series(1, 65535));
+insert into t1 select k1 + 65535 from t1;
+insert into t1 select k1 + 65535*2 from t1;
+insert into t1 select k1 + 65535*3 from t1;
+
+with tw1 as (
+    select t1.k1 from t1 join [broadcast] t1 t2 using(k1)
+)
+select /*+SET_VAR(global_runtime_filter_build_max_size=1,global_runtime_filter_probe_min_size=0)*/ 
+    count(1) from tw1 join [broadcast] t1 t3 using(k1);


### PR DESCRIPTION
CP from #35776.

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
