### PR TITLE
[BugFix] Fix pindex background compaction bug

### DIFF
--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4915,7 +4915,7 @@ Status PersistentIndex::major_compaction(Tablet* tablet) {
         const MutableIndexMetaPB& l0_meta = index_meta.l0_meta();
         EditVersion l0_version = l0_meta.snapshot().version();
         RETURN_IF_ERROR(_delete_expired_index_file(
-                l0_vesion, _l1_version,
+                l0_version, _l1_version,
                 _l2_versions.size() > 0 ? _l2_versions[0] : EditVersionWithMerge(INT64_MAX, INT64_MAX, true)));
     }
     (void)_delete_major_compaction_tmp_index_file();

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4606,7 +4606,7 @@ Status PersistentIndex::_merge_compaction() {
     if (_usage != writer->total_kv_size()) {
         _usage = writer->total_kv_size();
     }
-    if (_size != writer->total_kv_num()) {
+    if (_l2_vec.size() == 0 && _size != writer->total_kv_num()) {
         std::string msg =
                 strings::Substitute("inconsistent kv num after merge compaction, actual:$0, expect:$1, index_file:$2",
                                     writer->total_kv_num(), _size, writer->index_file());

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3325,6 +3325,7 @@ Status PersistentIndex::load_from_tablet(Tablet* tablet) {
     index_meta.clear_l0_meta();
     index_meta.clear_l1_version();
     index_meta.clear_l2_versions();
+    index_meta.clear_l2_version_merged();
     index_meta.set_key_size(_key_size);
     index_meta.set_format_version(PERSISTENT_INDEX_VERSION_4);
     lastest_applied_version.to_pb(index_meta.mutable_version());
@@ -4911,8 +4912,10 @@ Status PersistentIndex::major_compaction(Tablet* tablet) {
         // reload new l2 versions
         RETURN_IF_ERROR(_reload(index_meta));
         // delete useless files
+        const MutableIndexMetaPB& l0_meta = index_meta.l0_meta();
+        EditVersion l0_version = l0_meta.snapshot().version();
         RETURN_IF_ERROR(_delete_expired_index_file(
-                _version, _l1_version,
+                l0_vesion, _l1_version,
                 _l2_versions.size() > 0 ? _l2_versions[0] : EditVersionWithMerge(INT64_MAX, INT64_MAX, true)));
     }
     (void)_delete_major_compaction_tmp_index_file();

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4897,7 +4897,7 @@ Status PersistentIndex::major_compaction(Tablet* tablet) {
     // 1. load current l2 vec
     std::vector<EditVersion> l2_versions;
     std::vector<std::unique_ptr<ImmutableIndex>> l2_vec;
-    DCHECK(index_meta.l2_versions_size() == index_meta.l2_version_merged_size());
+    DCHECK(prev_index_meta.l2_versions_size() == prev_index_meta.l2_version_merged_size());
     for (int i = 0; i < prev_index_meta.l2_versions_size(); i++) {
         l2_versions.emplace_back(prev_index_meta.l2_versions(i));
         auto l2_block_path = strings::Substitute(

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -3180,7 +3180,7 @@ bool PersistentIndex::_need_rebuild_index(const PersistentIndexMetaPB& index_met
     if (index_meta.l2_versions_size() > 0 && !config::enable_pindex_minor_compaction) {
         // When l2 exist, and we choose to disable minor compaction, then we need to rebuild index.
         return true;
-    }    
+    }
     if (index_meta.l2_versions_size() != index_meta.l2_version_merged_size()) {
         // Make sure l2 version equal to l2 version merged flag
         return true;


### PR DESCRIPTION
Why I'm doing:
There are two bugs in pindex background compaction:
1. As the code shown:
   ```
   Status PersistentIndex::major_compaction(Tablet* tablet) {
        ...
        ASSIGN_OR_RETURN(EditVersion new_l2_version, _major_compaction_impl(l2_versions, l2_vec));
        // 3. modify PersistentIndexMetaPB and reload index, protected by index lock
        {
             std::lock_guard lg(*tablet->updates()->get_index_lock());
             PersistentIndexMetaPB index_meta;
             RETURN_IF_ERROR(
                    TabletMetaManager::get_persistent_index_meta(tablet->data_dir(), tablet->tablet_id(), &index_meta));
             modify_l2_versions(l2_versions, new_l2_version, index_meta);
             RETURN_IF_ERROR(
                     TabletMetaManager::write_persistent_index_meta(tablet->data_dir(), tablet->tablet_id(), index_meta));
             // reload new l2 versions
             RETURN_IF_ERROR(_reload(index_meta));
             // delete useless files
             RETURN_IF_ERROR(_delete_expired_index_file(
                     _version, _l1_version,
                     _l2_versions.size() > 0 ? _l2_versions[0] : EditVersionWithMerge(INT64_MAX, INT64_MAX, true)));
         }
         (void)_delete_major_compaction_tmp_index_file();
         return Status::OK();
   }
   ```
   After major compaction finished, we will delete expired pindex file. However, the l0 index file version is not always the 
   latest. For example, if we dump a new snapshot of version 1, we will create a new l0 file l0.1.0 and we append WAL in 
   version 2, the l0 file is still l0.1.0 but the `_version` is update to 2. So we will delete the l0 index file.

2. When we try to rebuild pindex, we need to clear the old persistent index meta but we don't clear the   `l2_version_merge` during rebuild which may result in subsequent inability to locate the correct index files. 
e.g.
    + We finished a major compaction and generate a new l2 file index.l2.3.0.merged
    +  If we rebuild pindex and we generate a new l2 file index.l2.3.0 but we don't clear the `l2_version_merge`
    +  We will try to find the pindex file index.l2.3.0.merged which not exist because we mark the pindex file index.l2.3.0 should be end with `.merged`.

What I'm doing:

Fix the above bugs.
1. Get the correct l0 file version.
2. Clear the pindex meta during rebuiling.
3. Add more check


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
