### PR TITLE
[Enhancement] Add source progress to result of `show routine load`

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletChecker.java
@@ -58,6 +58,7 @@ import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.meta.lock.LockType;
 import com.starrocks.meta.lock.Locker;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.AdminStmtAnalyzer;
 import com.starrocks.sql.ast.AdminCancelRepairTableStmt;
 import com.starrocks.sql.ast.AdminRepairTableStmt;
@@ -195,6 +196,9 @@ public class TabletChecker extends FrontendDaemon {
      */
     @Override
     protected void runAfterCatalogReady() {
+        if (RunMode.isSharedDataMode()) {
+            return;
+        }
         int pendingNum = tabletScheduler.getPendingNum();
         int runningNum = tabletScheduler.getRunningNum();
         if (pendingNum > Config.tablet_sched_max_scheduling_tablets

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -126,6 +126,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     private List<Pair<Integer, Long>> customeKafkaPartitionOffsets = null;
     boolean useDefaultGroupId = true;
 
+    private Map<Integer, Long> latestPartitionOffsets = Maps.newHashMap();
+
     public KafkaRoutineLoadJob() {
         // for serialization, id is dummy
         super(-1, LoadDataSourceType.KAFKA);
@@ -157,6 +159,22 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
     public Map<String, String> getConvertedCustomProperties() {
         return convertedCustomProperties;
+    }
+
+    @Override
+    protected String getSourceProgressString() {
+        // To be compatible with progress format, we convert the Map<Integer, Long> to Map<String, String>
+        Map<String, String> partitionOffsets = Maps.newHashMap();
+        for (Map.Entry<Integer, Long> entry : latestPartitionOffsets.entrySet()) {
+            partitionOffsets.put(entry.getKey().toString(), entry.getValue().toString());
+        }
+
+        Gson gson = new Gson();
+        return gson.toJson(partitionOffsets);
+    }
+
+    public void setPartitionOffset(int partition, long offset) {
+        latestPartitionOffsets.put(Integer.valueOf(partition), Long.valueOf(offset));
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -107,6 +107,10 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 ImmutableMap.copyOf(kafkaRoutineLoadJob.getConvertedCustomProperties()),
                 new ArrayList<>(partitionIdToOffset.keySet()));
         for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
+            kafkaRoutineLoadJob.setPartitionOffset(entry.getKey(), entry.getValue());
+        }
+
+        for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
             int partitionId = entry.getKey();
             Long latestOffset = latestOffsets.get(partitionId);
             Long consumeOffset = entry.getValue();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -106,7 +106,7 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
                 kafkaRoutineLoadJob.getTopic(),
                 ImmutableMap.copyOf(kafkaRoutineLoadJob.getConvertedCustomProperties()),
                 new ArrayList<>(partitionIdToOffset.keySet()));
-        for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
+        for (Map.Entry<Integer, Long> entry : latestOffsets.entrySet()) {
             kafkaRoutineLoadJob.setPartitionOffset(entry.getKey(), entry.getValue());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -130,6 +130,12 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
     }
 
     @Override
+    protected String getSourceProgressString() {
+        // empty implement.
+        return "";
+    }
+
+    @Override
     public void prepare() throws UserException {
         super.prepare();
         // should reset converted properties each time the job being prepared.

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -599,6 +599,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         return progress;
     }
 
+    protected abstract String getSourceProgressString();
+
     public double getMaxFilterRatio() {
         return maxFilterRatio;
     }
@@ -1423,6 +1425,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     protected abstract String getStatistic();
 
+
     public List<String> getShowInfo() {
         Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
         Table tbl = null;
@@ -1454,6 +1457,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             row.add(customPropertiesJsonToString());
             row.add(getStatistic());
             row.add(getProgress().toJsonString());
+            row.add(getSourceProgressString());
             switch (state) {
                 case PAUSED:
                     row.add(pauseReason == null ? "" : pauseReason.toString());

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -1457,7 +1457,6 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             row.add(customPropertiesJsonToString());
             row.add(getStatistic());
             row.add(getProgress().toJsonString());
-            row.add(getSourceProgressString());
             switch (state) {
                 case PAUSED:
                     row.add(pauseReason == null ? "" : pauseReason.toString());
@@ -1477,6 +1476,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
                 row.add("");
             }
             row.add(otherMsg);
+            row.add(getSourceProgressString());
             return row;
         } finally {
             readUnlock();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadStmt.java
@@ -80,11 +80,11 @@ public class ShowRoutineLoadStmt extends ShowStmt {
                     .add("CustomProperties")
                     .add("Statistic")
                     .add("Progress")
-                    .add("SourceProgress")
                     .add("ReasonOfStateChanged")
                     .add("ErrorLogUrls")
                     .add("TrackingSQL")
                     .add("OtherMsg")
+                    .add("LatestSourcePosition")
                     .build();
 
     private final LabelName labelName;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadStmt.java
@@ -80,6 +80,7 @@ public class ShowRoutineLoadStmt extends ShowStmt {
                     .add("CustomProperties")
                     .add("Statistic")
                     .add("Progress")
+                    .add("SourceProgress")
                     .add("ReasonOfStateChanged")
                     .add("ErrorLogUrls")
                     .add("TrackingSQL")

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRoutineLoadStmtTest.java
@@ -46,7 +46,7 @@ public class ShowRoutineLoadStmtTest {
         Assert.assertEquals("label", stmt.getName());
         Assert.assertEquals("testDb", stmt.getDbFullName());
         Assert.assertFalse(stmt.isIncludeHistory());
-        Assert.assertEquals(19, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(20, stmt.getMetaData().getColumnCount());
         Assert.assertEquals("Id", stmt.getMetaData().getColumn(0).getName());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -158,16 +158,20 @@ public class RoutineLoadJobTest {
 
     @Test
     public void testGetShowInfo(@Mocked KafkaProgress kafkaProgress) {
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+        KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
         ErrorReason errorReason = new ErrorReason(InternalErrorCode.INTERNAL_ERR,
                 TransactionState.TxnStatusChangeReason.OFFSET_OUT_OF_RANGE.toString());
         Deencapsulation.setField(routineLoadJob, "pauseReason", errorReason);
         Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
 
+        routineLoadJob.setPartitionOffset(0, 12345);
+
         List<String> showInfo = routineLoadJob.getShowInfo();
         Assert.assertEquals(true, showInfo.stream().filter(entity -> !Strings.isNullOrEmpty(entity))
                 .anyMatch(entity -> entity.equals(errorReason.toString())));
+
+        Assert.assertEquals("{\"0\":\"12345\"}", showInfo.get(15));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -171,7 +171,7 @@ public class RoutineLoadJobTest {
         Assert.assertEquals(true, showInfo.stream().filter(entity -> !Strings.isNullOrEmpty(entity))
                 .anyMatch(entity -> entity.equals(errorReason.toString())));
 
-        Assert.assertEquals("{\"0\":\"12345\"}", showInfo.get(15));
+        Assert.assertEquals("{\"0\":\"12345\"}", showInfo.get(19));
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
We need a easy way to check the lag of routine load job.
What I'm doing:
This PR adds `SourceProgress` to the result of `show routine load`, which denotes the producer's progress. In this way, we can check the lag of routine load job easily. Meanwhile, little overhead is added to the `show routine load`.
```
MySQL [db0]> show routine load\G;
*************************** 1. row ***************************
                  Id: 15008
                Name: rl_simple
          CreateTime: 2023-11-27 16:31:18
           PauseTime: NULL
             EndTime: NULL
              DbName: db0
           TableName: tbl_simple
               State: RUNNING
      DataSourceType: KAFKA
      CurrentTaskNum: 1
       JobProperties: {"partitions":"*","partial_update":"false","columnToColumnExpr":"key1,key2","maxBatchIntervalS":"10","partial_update_mode":"null","whereExpr":"*","dataFormat":"json","timezone":"GMT+08:00","format":"json","log_rejected_record_num":"0","taskTimeoutSecond":"60","json_root":"","maxFilterRatio":"1.0","strict_mode":"false","jsonpaths":"","taskConsumeSecond":"15","desireTaskConcurrentNum":"5","maxErrorNum":"0","strip_outer_array":"false","currentTaskConcurrentNum":"1","maxBatchRows":"200000"}
DataSourceProperties: {"topic":"topic-simple-json-continuous1","currentKafkaPartitions":"0","brokerList":"127.0.0.1:49092"}
    CustomProperties: {"group.id":"rl_simple_6dd18de6-a46d-4d43-8f36-4c71433cd5c5"}
           Statistic: {"receivedBytes":0,"errorRows":0,"committedTaskNum":0,"loadedRows":0,"loadRowsRate":0,"abortedTaskNum":13,"totalRows":0,"unselectedRows":0,"receivedBytesRate":0,"taskExecuteTimeMs":1}
            Progress: {"0":"1007861"}
ReasonOfStateChanged: 
        ErrorLogUrls: 
         TrackingSQL: 
            OtherMsg: 
LatestSourcePosition: {"0":"2053532"}


```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
