### PR TITLE
[BugFix] Correct error message for query mem_limit exceeding parent

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -119,10 +119,6 @@ int64_t QueryContext::compute_query_mem_limit(int64_t parent_mem_limit, int64_t 
         }
     }
 
-    if (parent_mem_limit > 0 && mem_limit > parent_mem_limit) {
-        return -1;
-    }
-
     return mem_limit;
 }
 

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -119,8 +119,11 @@ int64_t QueryContext::compute_query_mem_limit(int64_t parent_mem_limit, int64_t 
         }
     }
 
-    // query's mem_limit never exceeds its parent's limit if it exists
-    return parent_mem_limit == -1 ? mem_limit : std::min(parent_mem_limit, mem_limit);
+    if (parent_mem_limit > 0 && mem_limit > parent_mem_limit) {
+        return -1;
+    }
+
+    return mem_limit;
 }
 
 void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent, int64_t big_query_mem_limit,

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -129,7 +129,8 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
         auto* mem_tracker_counter =
                 ADD_COUNTER_SKIP_MERGE(_profile.get(), "MemoryLimit", TUnit::BYTES, TCounterMergeType::SKIP_ALL);
         mem_tracker_counter->set(query_mem_limit);
-        if (wg != nullptr && big_query_mem_limit > 0 && big_query_mem_limit < query_mem_limit) {
+        if (wg != nullptr && big_query_mem_limit > 0 &&
+            (query_mem_limit <= 0 || big_query_mem_limit < query_mem_limit)) {
             std::string label = "Group=" + wg->name() + ", " + _profile->name();
             _mem_tracker = std::make_shared<MemTracker>(MemTracker::RESOURCE_GROUP_BIG_QUERY, big_query_mem_limit,
                                                         std::move(label), parent);

--- a/be/test/exec/pipeline/query_context_test.cpp
+++ b/be/test/exec/pipeline/query_context_test.cpp
@@ -35,17 +35,17 @@ TEST_P(ComputeQueryMemLimitTestFixture, compute_query_mem_limit) {
     ASSERT_EQ(expected_result, result);
 }
 
-INSTANTIATE_TEST_SUITE_P(QueryContextTest, ComputeQueryMemLimitTestFixture,
-                         ::testing::Values(
-                                 // Not set per_instance_mem_limit and option_query_mem_limit.
-                                 std::make_tuple(100, -1, 4, -1, -1),
-                                 // Set option_query_mem_limit.
-                                 std::make_tuple(100, 2, 16, 4, 4), std::make_tuple(100, 2, 16, 101, 100),
-                                 // Set per_instance_mem_limit.
-                                 std::make_tuple(100, 2, 16, -1, 96), std::make_tuple(100, 4, 16, -1, 100),
-                                 // Set per_instance_mem_limit, and exceed MAX_INT64.
-                                 std::make_tuple(100, std::numeric_limits<int64_t>::max(), 16, -1, 100),
-                                 std::make_tuple(-1, std::numeric_limits<int64_t>::max(), 16, -1,
-                                                 std::numeric_limits<int64_t>::max())));
+INSTANTIATE_TEST_SUITE_P(
+        QueryContextTest, ComputeQueryMemLimitTestFixture,
+        ::testing::Values(
+                // Not set per_instance_mem_limit and option_query_mem_limit.
+                std::make_tuple(100, -1, 4, -1, -1),
+                // Set option_query_mem_limit.
+                std::make_tuple(100, 2, 16, 4, 4), std::make_tuple(100, 2, 16, 101, 101),
+                // Set per_instance_mem_limit.
+                std::make_tuple(100, 2, 16, -1, 96), std::make_tuple(100, 4, 16, -1, 192),
+                // Set per_instance_mem_limit, and exceed MAX_INT64.
+                std::make_tuple(100, std::numeric_limits<int64_t>::max(), 16, -1, std::numeric_limits<int64_t>::max()),
+                std::make_tuple(-1, std::numeric_limits<int64_t>::max(), 16, -1, std::numeric_limits<int64_t>::max())));
 
 } // namespace starrocks::pipeline

--- a/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
@@ -1,0 +1,44 @@
+-- name: test_resource_group_lt_query_mem_limit
+create table t1 (
+    k1 int
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 32
+properties("replication_num" = "1");
+-- result:
+-- !result
+insert into t1 select generate_series FROM TABLE(generate_series(1, 65535));
+-- result:
+-- !result
+insert into t1 select k1 + 65535 from t1;
+-- result:
+-- !result
+insert into t1 select k1 + 65535*2 from t1;
+-- result:
+-- !result
+insert into t1 select k1 + 65535*3 from t1;
+-- result:
+-- !result
+create resource group rg_${uuid0} 
+    to ( user='user_${uuid0}' ) 
+    with ('cpu_core_limit' = '1', 'mem_limit' = '0.0000000000001', 'concurrency_limit'='2');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824,resource_group='rg_${uuid0}')*/ count(1) from t1;
+-- result:
+[REGEX].*Mem usage has exceed the limit of the resource group.*
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,resource_group='rg_${uuid0}')*/ count(1) from t1;
+-- result:
+[REGEX].*Mem usage has exceed the limit of single query.*
+-- !result
+select /*+SET_VAR(query_mem_limit=107374182400,resource_group='rg_${uuid0}')*/ count(1) from t1;
+-- result:
+524280
+-- !result
+drop resource group rg_${uuid0};
+-- result:
+-- !result

--- a/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
@@ -24,31 +24,357 @@ create resource group rg_${uuid0}
     with ('cpu_core_limit' = '1', 'mem_limit' = '0.0000000000001', 'concurrency_limit'='2');
 -- result:
 -- !result
-select /*+SET_VAR(query_mem_limit=1073741824,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
 -- result:
-[REGEX].*Mem usage has exceed the limit of the resource group.*
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
 -- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0.99');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 8795ad5e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
-select /*+SET_VAR(query_mem_limit=1024,resource_group='rg_${uuid0}')*/ count(1) from t1;
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-[REGEX].*Mem usage has exceed the limit of single query.*
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 8797f750-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
-select /*+SET_VAR(query_mem_limit=107374182400,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
 524280
 -- !result
-alter resource group rg_${uuid0} with ('big_query_mem_limit'='1024');
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+524280
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
-select /*+SET_VAR(query_mem_limit=1073741824000,resource_group='rg_${uuid0}')*/ count(1) from t1;
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-[REGEX].*Mem usage has exceed the big query limit of the resource group.*
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87a341f6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
-select /*+SET_VAR(query_mem_limit=1022,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
-[REGEX].*Mem usage has exceed the limit of single query.*
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+524280
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+524280
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ae176c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87afec2e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87afec2e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87afec2e-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b1c0f0-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b1c0f0-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b1c0f0-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b395b2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b71824-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b71824-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b71824-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b8ece6-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b8ece6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b8ece6-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87bac1a8-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+524280
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+524280
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87c12a4e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+524280
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+524280
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87c792f4-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87c940a6-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87c940a6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87c940a6-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87caee58-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87caee58-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87caee58-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87cc9c0a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ce70cc-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ce70cc-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ce70cc-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87cff76e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87cff76e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87d1cc30-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d1cc30-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87d3a0f2-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d3a0f2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87d52794-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d52794-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87d6ae36-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d6ae36-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87d834d8-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d834d8-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87d9946a-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d9946a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87db421c-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87db421c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87dcc8be-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87dcc8be-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87de0140-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87de0140-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87df87e2-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87df87e2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87e10e84-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e10e84-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87e29526-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e29526-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87e442d8-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e442d8-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87e6179a-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e6179a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87e7772c-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e7772c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87e924de-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e924de-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87ead290-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ead290-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87ec3222-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ec3222-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87edb8c4-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87edb8c4-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ef6676-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ef6676-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ef6676-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87f11428-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87f11428-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87f11428-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87f2e8ea-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87f2e8ea-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+-- !result
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+-- result:
+E: (1064, 'Memory of Query87f4bdac-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87f4bdac-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 drop resource group rg_${uuid0};
 -- result:

--- a/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
@@ -39,6 +39,17 @@ select /*+SET_VAR(query_mem_limit=107374182400,resource_group='rg_${uuid0}')*/ c
 -- result:
 524280
 -- !result
+alter resource group rg_${uuid0} with ('big_query_mem_limit'='1024');
+-- result:
+-- !result
+select /*+SET_VAR(query_mem_limit=1073741824000,resource_group='rg_${uuid0}')*/ count(1) from t1;
+-- result:
+[REGEX].*Mem usage has exceed the big query limit of the resource group.*
+-- !result
+select /*+SET_VAR(query_mem_limit=1022,resource_group='rg_${uuid0}')*/ count(1) from t1;
+-- result:
+[REGEX].*Mem usage has exceed the limit of single query.*
+-- !result
 drop resource group rg_${uuid0};
 -- result:
 -- !result

--- a/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
@@ -29,7 +29,7 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea736e46-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
@@ -43,7 +43,7 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea7a732a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
@@ -57,35 +57,35 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea80669e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea826270-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea826270-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea826270-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+[REGEX].*Mem usage has exceed the big query limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea84fa82-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea86f654-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea86f654-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea86f654-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+[REGEX].*Mem usage has exceed the big query limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea88cb16-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
@@ -99,7 +99,7 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea8ce9ca-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
@@ -113,140 +113,140 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea90e16e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea92b630-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea92b630-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea92b630-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+[REGEX].*Mem usage has exceed the big query limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea948af2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
+[REGEX].*Mem usage has exceed the limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea965fb4-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea965fb4-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea965fb4-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+[REGEX].*Mem usage has exceed the big query limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryea980d66-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea980d66-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryea99bb18-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea99bb18-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryea9b41ba-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9b41ba-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryea9cc85c-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9cc85c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryea9e760e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9e760e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryea9ffcb0-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9ffcb0-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaa18352-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa18352-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaa33104-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa33104-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaa4b7a6-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa4b7a6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaa66558-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa66558-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaa8130a-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa8130a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaa9c0bc-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa9c0bc-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaab6e6e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaab6e6e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryeaad1c20-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaad1c20-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryeaad1c20-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+[REGEX].*Mem usage has exceed the big query limit of the resource group.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeaaec9d2-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaaec9d2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Queryeab07784-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eab07784-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+[REGEX].*Mem usage has exceed the limit of single query.*
 -- !result
 drop resource group rg_${uuid0};
 -- result:

--- a/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/R/test_resource_group_lt_query_mem_limit
@@ -24,31 +24,15 @@ create resource group rg_${uuid0}
     with ('cpu_core_limit' = '1', 'mem_limit' = '0.0000000000001', 'concurrency_limit'='2');
 -- result:
 -- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 8795ad5e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
--- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 8797f750-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea736e46-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
--- !result
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-524280
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
@@ -59,18 +43,10 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87a341f6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea7a732a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
--- !result
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-524280
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
@@ -81,62 +57,38 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ae176c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea80669e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87afec2e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87afec2e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87afec2e-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b1c0f0-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b1c0f0-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b1c0f0-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea826270-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea826270-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea826270-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b395b2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea84fa82-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b71824-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b71824-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b71824-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b8ece6-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87b8ece6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87b8ece6-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea86f654-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea86f654-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea86f654-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87bac1a8-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea88cb16-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
--- !result
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-524280
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
@@ -147,7 +99,7 @@ alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87c12a4e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea8ce9ca-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
@@ -156,225 +108,145 @@ select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group=
 -- result:
 524280
 -- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-524280
--- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87c792f4-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea90e16e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87c940a6-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87c940a6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87c940a6-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87caee58-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87caee58-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87caee58-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea92b630-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea92b630-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea92b630-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of rg_01857680cae4464dacae02f21b2be7dc exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87cc9c0a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_01857680cae4464dacae02f21b2be7dc]. You can change the limit by modifying [mem_limit] of this group')
+E: (1064, 'Memory of rg_6a1d1474629c459b9de7e924f273ce6d exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea948af2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 0. Mem usage has exceed the limit of the resource group [rg_6a1d1474629c459b9de7e924f273ce6d]. You can change the limit by modifying [mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ce70cc-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ce70cc-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ce70cc-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Query87cff76e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87cff76e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea965fb4-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea965fb4-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryea965fb4-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87d1cc30-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d1cc30-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryea980d66-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea980d66-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87d3a0f2-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d3a0f2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Query87d52794-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d52794-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryea99bb18-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea99bb18-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87d6ae36-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d6ae36-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryea9b41ba-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9b41ba-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87d834d8-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d834d8-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Query87d9946a-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87d9946a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryea9cc85c-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9cc85c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87db421c-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87db421c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryea9e760e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9e760e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87dcc8be-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87dcc8be-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Query87de0140-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87de0140-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryea9ffcb0-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: ea9ffcb0-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87df87e2-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87df87e2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaa18352-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa18352-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87e10e84-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e10e84-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Query87e29526-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e29526-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaa33104-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa33104-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87e442d8-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e442d8-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaa4b7a6-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa4b7a6-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87e6179a-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e6179a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Query87e7772c-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e7772c-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaa66558-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa66558-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87e924de-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87e924de-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaa8130a-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa8130a-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87ead290-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ead290-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Query87ec3222-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ec3222-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaa9c0bc-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaa9c0bc-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87edb8c4-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87edb8c4-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaab6e6e-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaab6e6e-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ef6676-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87ef6676-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87ef6676-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
--- !result
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
--- result:
-E: (1064, 'Getting analyzing error. Detail message: mem_limit should range from 0.00(exclude) to 1.00(exclude).')
--- !result
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
--- result:
-E: (1064, 'Memory of Group=rg_01857680cae4464dacae02f21b2be7dc, Query87f11428-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87f11428-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_01857680cae4464dacae02f21b2be7dc, Query87f11428-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
+E: (1064, 'Memory of Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryeaad1c20-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaad1c20-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1020. Mem usage has exceed the big query limit of the resource group [Group=rg_6a1d1474629c459b9de7e924f273ce6d, Queryeaad1c20-8cfa-11ee-a48e-3a680bfb1cc8]. You can change the limit by modifying [big_query_mem_limit] of this group')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87f2e8ea-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87f2e8ea-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeaaec9d2-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eaaec9d2-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 -- result:
 -- !result
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 -- result:
-E: (1064, 'Memory of Query87f4bdac-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: 87f4bdac-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
+E: (1064, 'Memory of Queryeab07784-8cfa-11ee-a48e-3a680bfb1cc8 exceed limit. Pipeline Backend: 172.26.92.195, fragment: eab07784-8cfa-11ee-a48e-3a680bfb1cca Used: 6480, Limit: 1024. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.')
 -- !result
 drop resource group rg_${uuid0};
 -- result:

--- a/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
@@ -1,0 +1,28 @@
+-- name: test_resource_group_lt_query_mem_limit
+create table t1 (
+    k1 int
+)
+duplicate key(k1)
+distributed by hash(k1) buckets 32
+properties("replication_num" = "1");
+
+insert into t1 select generate_series FROM TABLE(generate_series(1, 65535));
+insert into t1 select k1 + 65535 from t1;
+insert into t1 select k1 + 65535*2 from t1;
+insert into t1 select k1 + 65535*3 from t1;
+
+create resource group rg_${uuid0} 
+    to ( user='user_${uuid0}' ) 
+    with ('cpu_core_limit' = '1', 'mem_limit' = '0.0000000000001', 'concurrency_limit'='2');
+
+-- group.mem_limit < query_mem_limit and exceed memory limit.
+select /*+SET_VAR(query_mem_limit=1073741824,resource_group='rg_${uuid0}')*/ count(1) from t1;
+
+-- group.mem_limit > query_mem_limit and exceed memory limit.
+alter resource group rg_${uuid0} with ('mem_limit'='0.99');
+select /*+SET_VAR(query_mem_limit=1024,resource_group='rg_${uuid0}')*/ count(1) from t1;
+
+-- Does not exceed memory limit.
+select /*+SET_VAR(query_mem_limit=107374182400,resource_group='rg_${uuid0}')*/ count(1) from t1;
+
+drop resource group rg_${uuid0};

--- a/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
@@ -15,14 +15,21 @@ create resource group rg_${uuid0}
     to ( user='user_${uuid0}' ) 
     with ('cpu_core_limit' = '1', 'mem_limit' = '0.0000000000001', 'concurrency_limit'='2');
 
--- group.mem_limit < query_mem_limit and exceed memory limit.
+-- Trigger group.mem_limit: group.mem_limit < query_mem_limit and exceed memory limit.
 select /*+SET_VAR(query_mem_limit=1073741824,resource_group='rg_${uuid0}')*/ count(1) from t1;
 
--- group.mem_limit > query_mem_limit and exceed memory limit.
+-- Trigger query_mem_limit: group.mem_limit > query_mem_limit and exceed memory limit.
 alter resource group rg_${uuid0} with ('mem_limit'='0.99');
 select /*+SET_VAR(query_mem_limit=1024,resource_group='rg_${uuid0}')*/ count(1) from t1;
 
 -- Does not exceed memory limit.
-select /*+SET_VAR(query_mem_limit=107374182400,resource_group='rg_${uuid0}')*/ count(1) from t1;
+select /*+SET_VAR(query_mem_limit=1073741824000,resource_group='rg_${uuid0}')*/ count(1) from t1;
+
+-- Trigger group.big_query_mem_limit: group.big_query_mem_limit < group.mem_limit < query_mem_limit and exceed memory limit.
+alter resource group rg_${uuid0} with ('big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1073741824000,resource_group='rg_${uuid0}')*/ count(1) from t1;
+
+-- Trigger query_mem_limit: group.big_query_mem_limit > query_mem_limit and exceed memory limit.
+select /*+SET_VAR(query_mem_limit=1022,resource_group='rg_${uuid0}')*/ count(1) from t1;
 
 drop resource group rg_${uuid0};

--- a/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
@@ -15,21 +15,148 @@ create resource group rg_${uuid0}
     to ( user='user_${uuid0}' ) 
     with ('cpu_core_limit' = '1', 'mem_limit' = '0.0000000000001', 'concurrency_limit'='2');
 
--- Trigger group.mem_limit: group.mem_limit < query_mem_limit and exceed memory limit.
-select /*+SET_VAR(query_mem_limit=1073741824,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
--- Trigger query_mem_limit: group.mem_limit > query_mem_limit and exceed memory limit.
-alter resource group rg_${uuid0} with ('mem_limit'='0.99');
-select /*+SET_VAR(query_mem_limit=1024,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
--- Does not exceed memory limit.
-select /*+SET_VAR(query_mem_limit=1073741824000,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
--- Trigger group.big_query_mem_limit: group.big_query_mem_limit < group.mem_limit < query_mem_limit and exceed memory limit.
-alter resource group rg_${uuid0} with ('big_query_mem_limit'='1024');
-select /*+SET_VAR(query_mem_limit=1073741824000,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
--- Trigger query_mem_limit: group.big_query_mem_limit > query_mem_limit and exceed memory limit.
-select /*+SET_VAR(query_mem_limit=1022,resource_group='rg_${uuid0}')*/ count(1) from t1;
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
+
+alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
+select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 drop resource group rg_${uuid0};

--- a/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
+++ b/test/sql/test_resource_group/T/test_resource_group_lt_query_mem_limit
@@ -15,16 +15,10 @@ create resource group rg_${uuid0}
     to ( user='user_${uuid0}' ) 
     with ('cpu_core_limit' = '1', 'mem_limit' = '0.0000000000001', 'concurrency_limit'='2');
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
@@ -33,16 +27,10 @@ select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
@@ -51,16 +39,10 @@ select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 select /*+SET_VAR(query_mem_limit=0,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
@@ -69,16 +51,10 @@ select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group=
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
@@ -87,16 +63,10 @@ select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group=
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 select /*+SET_VAR(query_mem_limit=1073741824000,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
@@ -105,16 +75,10 @@ select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uui
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');
@@ -123,16 +87,10 @@ select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uui
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1024');
 select /*+SET_VAR(query_mem_limit=1020,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='0');
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='0');
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1073741824000');
@@ -141,16 +99,10 @@ select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uui
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1073741824000');
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1020');
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.99','big_query_mem_limit'='1020');
-select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
-
-alter resource group rg_${uuid0} with ('mem_limit'='0','big_query_mem_limit'='1024');
 select /*+SET_VAR(query_mem_limit=1024,exec_mem_limit=0,resource_group='rg_${uuid0}')*/ count(1) from t1 where k1 > 0;
 
 alter resource group rg_${uuid0} with ('mem_limit'='0.0000000000001','big_query_mem_limit'='1024');


### PR DESCRIPTION
### Why I'm doing:
When the `parent.mem_limit` is less than `query.mem_limit`, the `query.mem_limit` will be constrained to `min(parent.mem_limit, query.mem_limit)`. 
For example, `parent.mem_limit` is 16 and `query.mem_limit` is 32. When the query exceeds memory limit, it will throw `Limit: 16. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.`, which is misunderstanding.

### What I'm doing:
Do not constrain `query.mem_limit` to `min(parent.mem_limit, query.mem_limit)`.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
