### PR TITLE
[Enhancement] Support transform isnull function in trino parse

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/ComplexFunctionCallTransformer.java
@@ -24,9 +24,11 @@ import com.starrocks.analysis.CollectionElementExpr;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
+import com.starrocks.analysis.IsNullPredicate;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.TimestampArithmeticExpr;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.MapExpr;
@@ -103,6 +105,16 @@ public class ComplexFunctionCallTransformer {
                 ArithmeticExpr addExpr = new ArithmeticExpr(ArithmeticExpr.Operator.ADD, mulExpr, args[0]);
                 return new FunctionCallExpr("floor", ImmutableList.of(addExpr));
             }
+        } else if (functionName.equalsIgnoreCase(FunctionSet.ISNULL)) {
+            if (args.length != 1) {
+                throw new SemanticException("isnull function must have 1 argument");
+            }
+            return new IsNullPredicate(args[0], false);
+        } else if (functionName.equalsIgnoreCase(FunctionSet.ISNOTNULL)) {
+            if (args.length != 1) {
+                throw new SemanticException("isnotnull function must have 1 argument");
+            }
+            return new IsNullPredicate(args[0], true);
         }
         return null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -383,6 +383,9 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         sql = "select isnull(null)";
         assertPlanContains(sql, "<slot 2> : TRUE");
 
+        sql = "select isnull(1, 2)";
+        analyzeFail(sql, "isnull function must have 1 argument");
+
         sql = "select isnotnull(1)";
         assertPlanContains(sql, "<slot 2> : TRUE");
 
@@ -391,5 +394,8 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select isnotnull(null)";
         assertPlanContains(sql, "<slot 2> : FALSE");
+
+        sql = "select isnotnull(1, 2)";
+        analyzeFail(sql, "isnotnull function must have 1 argument");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -372,4 +372,24 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
         assertPlanContains(sql, "<slot 12> : CURRENT_ROLE()");
     }
 
+    @Test
+    public void testIsNullFunction() throws Exception {
+        String sql = "select isnull(1)";
+        assertPlanContains(sql, "<slot 2> : FALSE");
+
+        sql = "select isnull('aaa')";
+        assertPlanContains(sql, "<slot 2> : FALSE");
+
+        sql = "select isnull(null)";
+        assertPlanContains(sql, "<slot 2> : TRUE");
+
+        sql = "select isnotnull(1)";
+        assertPlanContains(sql, "<slot 2> : TRUE");
+
+        sql = "select isnotnull('aaa')";
+        assertPlanContains(sql, "<slot 2> : TRUE");
+
+        sql = "select isnotnull(null)";
+        assertPlanContains(sql, "<slot 2> : FALSE");
+    }
 }


### PR DESCRIPTION
Why I'm doing:
The `isnull` function reported an error in Trino mode.

```sql
MySQL [(none)]> set sql_dialect='starrocks';
Query OK, 0 rows affected (0.00 sec)

MySQL [(none)]> select isnull(1);
+-----------+
| 1 IS NULL |
+-----------+
|         0 |
+-----------+
1 row in set (0.01 sec)

MySQL [(none)]> set sql_dialect='trino';
Query OK, 0 rows affected (0.00 sec)

MySQL [(none)]> select isnull(1);
ERROR 1064 (HY000): Getting analyzing error. Detail message: No matching function with signature: isnull(tinyint(4)).
```


What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
