### PR TITLE
[BugFix] Fixed potential deadlock in compaction scheduler

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -45,7 +45,7 @@ CompactionTaskCallback::CompactionTaskCallback(CompactionScheduler* scheduler, c
 }
 
 void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&& context) {
-    std::lock_guard l(_mtx);
+    std::unique_lock l(_mtx);
 
     if (!context->status.ok()) {
         // Add failed tablet for upgrade compatibility: older version FE relies on the failed tablet to determine
@@ -70,8 +70,11 @@ void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&
         _request = nullptr;
         _response = nullptr;
 
-        _scheduler->remove_states(_contexts);
-        STLClearObject(&_contexts);
+        std::vector<std::unique_ptr<CompactionTaskContext>> tmp;
+        tmp.swap(_contexts);
+
+        l.unlock();
+        _scheduler->remove_states(tmp);
     }
 }
 
@@ -250,11 +253,12 @@ bool CompactionScheduler::txn_log_exists(int64_t tablet_id, int64_t txn_id) cons
 }
 
 Status CompactionScheduler::abort(int64_t txn_id) {
-    std::lock_guard l(_contexts_lock);
+    std::unique_lock l(_contexts_lock);
     for (butil::LinkNode<CompactionTaskContext>* node = _contexts.head(); node != _contexts.end();
          node = node->next()) {
         CompactionTaskContext* context = node->value();
         if (context->txn_id == txn_id) {
+            l.unlock();
             context->callback->update_status(Status::Aborted("aborted on demand"));
             return Status::OK();
         }

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -23,6 +23,7 @@
 #include "gutil/macros.h"
 #include "storage/lake/compaction_task.h"
 #include "util/blocking_queue.hpp"
+#include "util/stack_trace_mutex.h"
 
 namespace google::protobuf {
 class RpcController;
@@ -69,7 +70,7 @@ public:
 
 private:
     CompactionScheduler* _scheduler;
-    mutable bthread::Mutex _mtx;
+    mutable StackTraceMutex<bthread::Mutex> _mtx;
     const lake::CompactRequest* _request;
     lake::CompactResponse* _response;
     ::google::protobuf::Closure* _done;
@@ -202,7 +203,7 @@ private:
 
     TabletManager* _tablet_mgr;
     Limiter _limiter;
-    bthread::Mutex _contexts_lock;
+    StackTraceMutex<bthread::Mutex> _contexts_lock;
     butil::LinkedList<CompactionTaskContext> _contexts;
     int _task_queue_count;
     TaskQueue* _task_queues;


### PR DESCRIPTION
Updated the locking mechanism in CompactionScheduler::abort() to prevent possible deadlock situation in scenarios with concurrent `CompactionScheduler::abort()` and `CompactionTaskContext::finish_task()`. Additionally, Mutex was replaced by StackTraceMutex in the CompactionTaskContext and CompactionScheduler classes for enhanced debugging.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
