### PR TITLE
[BugFix] Fix NullableColumn::remove_first_n_values not maintaining has_null field

### DIFF
--- a/be/src/column/nullable_column.cpp
+++ b/be/src/column/nullable_column.cpp
@@ -58,6 +58,12 @@ size_t NullableColumn::null_count(size_t offset, size_t count) const {
     return SIMD::count_nonzero(_null_column->raw_data() + offset, count);
 }
 
+void NullableColumn::remove_first_n_values(size_t count) {
+    _data_column->remove_first_n_values(count);
+    _null_column->remove_first_n_values(count);
+    _has_null = SIMD::contain_nonzero(_null_column->get_data(), 0, _null_column->size());
+}
+
 void NullableColumn::append_datum(const Datum& datum) {
     if (datum.is_null()) {
         append_nulls(1);

--- a/be/src/column/nullable_column.h
+++ b/be/src/column/nullable_column.h
@@ -129,10 +129,7 @@ public:
         _null_column->assign(n, idx);
     }
 
-    void remove_first_n_values(size_t count) override {
-        _data_column->remove_first_n_values(count);
-        _null_column->remove_first_n_values(count);
-    }
+    void remove_first_n_values(size_t count) override;
 
     void append_datum(const Datum& datum) override;
 

--- a/be/test/column/nullable_column_test.cpp
+++ b/be/test/column/nullable_column_test.cpp
@@ -380,4 +380,19 @@ PARALLEL_TEST(NullableColumnTest, test_replicate) {
     ASSERT_EQ(4, c2->get(6).get_int32());
 }
 
+PARALLEL_TEST(NullableColumnTest, test_remove_first_n_values) {
+    auto column = NullableColumn::create(Int32Column::create(), NullColumn::create());
+    column->append_datum((int32_t)1);
+    column->append_datum({});
+    column->append_datum((int32_t)4);
+
+    ASSERT_TRUE(column->has_null());
+    column->remove_first_n_values(1);
+    ASSERT_TRUE(column->has_null());
+    column->remove_first_n_values(1);
+    ASSERT_FALSE(column->has_null());
+    column->remove_first_n_values(1);
+    ASSERT_FALSE(column->has_null());
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:
The implementation of NullableColumn::remove_first_n_values is wrong, it does not maintain the has_null field.

What I'm doing:
Fix it.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
