### PR TITLE
[BugFix] `files()` returns unkown error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -306,15 +306,14 @@ public class TableFunctionTable extends Table {
 
         PGetFileSchemaResult result;
         try {
-            // TODO(fw): more format support.
             PGetFileSchemaRequest request = getGetFileSchemaRequest(fileStatuses);
             Future<PGetFileSchemaResult> future = BackendServiceClient.getInstance().getFileSchema(address, request);
             result = future.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new DdlException("failed to get file schema", e);
+            throw new DdlException("failed to get file schema: " + e.getMessage());
         } catch (Exception e) {
-            throw new DdlException("failed to get file schema", e);
+            throw new DdlException("failed to get file schema: " + e.getMessage());
         }
 
         if (TStatusCode.findByValue(result.status.statusCode) != TStatusCode.OK) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -311,7 +311,7 @@ public class TableFunctionTable extends Table {
             result = future.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new DdlException("failed to get file schema: ", e);
+            throw new DdlException("failed to get file schema", e);
         } catch (Exception e) {
             throw new DdlException("failed to get file schema: " + e.getMessage());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunctionTable.java
@@ -311,7 +311,7 @@ public class TableFunctionTable extends Table {
             result = future.get();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
-            throw new DdlException("failed to get file schema: " + e.getMessage());
+            throw new DdlException("failed to get file schema: ", e);
         } catch (Exception e) {
             throw new DdlException("failed to get file schema: " + e.getMessage());
         }


### PR DESCRIPTION
Why I'm doing:
When the be is crashed due to oom killer, the `files()` would return `Unkown Error`, which is confusing.
What I'm doing:
This PR returns the accurate error message in the result of `files()`.
Fixes https://github.com/StarRocks/StarRocksTest/issues/4863

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
