### PR TITLE
[BugFix] fix the issue of inaccurate limit data after show export sorting

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -69,7 +69,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -204,7 +203,10 @@ public class ExportMgr implements MemoryTrackable {
             ArrayList<OrderByPair> orderByPairs, long limit) {
 
         long resultNum = limit == -1L ? Integer.MAX_VALUE : limit;
-        LinkedList<List<Comparable>> exportJobInfos = new LinkedList<List<Comparable>>();
+        LinkedList<List<Comparable>> exportJobInfos = new LinkedList<>();
+        //If sorting is required, all data needs to be obtained before limiting it
+        //If not needed, directly obtain the limit quantity and then sort it
+        boolean isLimitBreak = orderByPairs == null;
         readLock();
         try {
             int counter = 0;
@@ -217,20 +219,16 @@ public class ExportMgr implements MemoryTrackable {
                 }
 
                 // filter job
-                if (jobId != 0) {
-                    if (id != jobId) {
-                        continue;
-                    }
+                if (jobId != 0 && (id != jobId)) {
+                    continue;
                 }
 
-                if (states != null) {
-                    if (!states.contains(state)) {
-                        continue;
-                    }
+                if (states != null && (!states.contains(state))) {
+                    continue;
                 }
 
                 UUID jobQueryId = job.getQueryId();
-                if (queryId != null && (jobQueryId == null || !queryId.equals(jobQueryId))) {
+                if (queryId != null && (!queryId.equals(jobQueryId))) {
                     continue;
                 }
 
@@ -260,7 +258,7 @@ public class ExportMgr implements MemoryTrackable {
                     }
                 }
 
-                List<Comparable> jobInfo = new ArrayList<Comparable>();
+                List<Comparable> jobInfo = new ArrayList<>();
 
                 jobInfo.add(id);
                 // query id
@@ -305,7 +303,7 @@ public class ExportMgr implements MemoryTrackable {
 
                 exportJobInfos.add(jobInfo);
 
-                if (++counter >= resultNum) {
+                if (isLimitBreak && ++counter >= resultNum) {
                     break;
                 }
             }
@@ -313,23 +311,24 @@ public class ExportMgr implements MemoryTrackable {
             readUnlock();
         }
 
-        // TODO: fix order by first, then limit
         // order by
-        ListComparator<List<Comparable>> comparator = null;
+        ListComparator<List<Comparable>> comparator;
         if (orderByPairs != null) {
             OrderByPair[] orderByPairArr = new OrderByPair[orderByPairs.size()];
-            comparator = new ListComparator<List<Comparable>>(orderByPairs.toArray(orderByPairArr));
+            comparator = new ListComparator<>(orderByPairs.toArray(orderByPairArr));
         } else {
             // sort by id asc
-            comparator = new ListComparator<List<Comparable>>(0);
+            comparator = new ListComparator<>(0);
         }
-        Collections.sort(exportJobInfos, comparator);
+        exportJobInfos.sort(comparator);
 
         List<List<String>> results = Lists.newArrayList();
-        for (List<Comparable> list : exportJobInfos) {
-            results.add(list.stream().map(e -> e.toString()).collect(Collectors.toList()));
+        for (int i = 0; i < exportJobInfos.size(); i++) {
+            results.add(exportJobInfos.get(i).stream().map(Object::toString).collect(Collectors.toList()));
+            if (i > resultNum - 1) {
+                break;
+            }
         }
-
         return results;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportMgr.java
@@ -219,16 +219,16 @@ public class ExportMgr implements MemoryTrackable {
                 }
 
                 // filter job
-                if (jobId != 0 && (id != jobId)) {
+                if (jobId != 0 && id != jobId) {
                     continue;
                 }
 
-                if (states != null && (!states.contains(state))) {
+                if (states != null && !states.contains(state)) {
                     continue;
                 }
 
                 UUID jobQueryId = job.getQueryId();
-                if (queryId != null && (!queryId.equals(jobQueryId))) {
+                if (queryId != null && !queryId.equals(jobQueryId)) {
                     continue;
                 }
 
@@ -323,11 +323,10 @@ public class ExportMgr implements MemoryTrackable {
         exportJobInfos.sort(comparator);
 
         List<List<String>> results = Lists.newArrayList();
-        for (int i = 0; i < exportJobInfos.size(); i++) {
+        //The maximum return value of Math.min(resultNum, exportJobInfos.size()) is Integer.MAX_VALUE
+        int upperBound = (int) Math.min(resultNum, exportJobInfos.size());
+        for (int i = 0; i < upperBound; i++) {
             results.add(exportJobInfos.get(i).stream().map(Object::toString).collect(Collectors.toList()));
-            if (i > resultNum - 1) {
-                break;
-            }
         }
         return results;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportMgrTest.java
@@ -14,10 +14,16 @@
 
 package com.starrocks.load;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.TableName;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.OrderByPair;
 import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -29,7 +35,11 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class ExportMgrTest {
     @Mocked
@@ -125,5 +135,62 @@ public class ExportMgrTest {
         reader.close();
 
         Assert.assertEquals(1, followerMgr.getIdToJob().size());
+    }
+
+
+    @Test
+    public void testShowExpiredJob() throws Exception {
+        new Expectations(globalStateMgr) {
+            {
+                GlobalStateMgr.getCurrentState();
+                minTimes = 0;
+                result = globalStateMgr;
+            }
+        };
+        ConnectContext connectContext = new ConnectContext();
+        connectContext.setCurrentUserIdentity(UserIdentity.ROOT);
+        connectContext.setThreadLocalInfo();
+        GlobalStateMgr currentState = GlobalStateMgr.getCurrentState();
+        currentState.initAuth(true);
+        connectContext.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        ExportMgr mgr = new ExportMgr();
+        int limit = 5;
+        List<Integer> jobIds = Lists.newArrayList();
+        jobIds.add(299948218);
+        jobIds.add(299948214);
+        jobIds.add(299948190);
+        jobIds.add(299948188);
+        jobIds.add(299948183);
+        jobIds.add(299948087);
+        jobIds.add(299943362);
+        jobIds.add(299943118);
+        jobIds.add(299943014);
+        jobIds.add(299943012);
+        jobIds.add(299942987);
+        jobIds = jobIds.stream().sorted(Collections.reverseOrder())
+                .collect(Collectors.toList()).subList(0, Math.min(limit, jobIds.size()));
+        for (Integer jobId : jobIds) {
+            ExportJob job1 = new ExportJob(jobId, new UUID(1, 1));
+            job1.setTableName(new TableName("*", "DUMMY" + jobId));
+            job1.setBrokerDesc(new BrokerDesc("DUMMY", Maps.newHashMap()));
+            mgr.replayCreateExportJob(job1);
+        }
+        ArrayList<OrderByPair> orderByPairs = new ArrayList<>();
+        OrderByPair pair = new OrderByPair(0, true);
+        orderByPairs.add(pair);
+        List<List<String>> exportJobInfosByIdOrState = mgr.getExportJobInfosByIdOrState(-1, 0, null, null, orderByPairs, limit);
+        List<Integer> resultJobIds = Lists.newArrayList();
+        for (List<String> infos : exportJobInfosByIdOrState) {
+            resultJobIds.add(Integer.valueOf(infos.get(0)));
+        }
+        Assert.assertArrayEquals(jobIds.toArray(new Integer[0]), resultJobIds.toArray(new Integer[0]));
+
+        resultJobIds.clear();
+        List<List<String>> exportJobInfosByIdOrState1 = mgr.getExportJobInfosByIdOrState(-1, 0, null, null, null, limit);
+        for (List<String> infos : exportJobInfosByIdOrState1) {
+            resultJobIds.add(Integer.valueOf(infos.get(0)));
+        }
+        Assert.assertEquals(Math.min(limit, resultJobIds.size()), exportJobInfosByIdOrState1.size());
+
     }
 }


### PR DESCRIPTION
Why I'm doing:
    Inaccurate limit data after show export sorting
    show export from alg order by jobId desc
    ![image](https://github.com/StarRocks/starrocks/assets/48077349/d58a9bb5-a323-4d42-81e0-74f2c7b4ba99)
    show export from alg order by jobId desc limit 20
    ![image](https://github.com/StarRocks/starrocks/assets/48077349/81292d9f-fade-4439-abd4-4de08c92a4e3)
What I'm doing:
    Sort first and then limit

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5