### PR TITLE
[Enhancement] Some perfomance optimizations for parquet reader.

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -61,8 +61,7 @@ Status ColumnChunkReader::init(int chunk_size) {
 }
 
 Status ColumnChunkReader::load_header() {
-    RETURN_IF_ERROR(_parse_page_header());
-    return Status::OK();
+    return _parse_page_header();
 }
 
 Status ColumnChunkReader::load_page() {

--- a/be/src/formats/parquet/encoding_dict.h
+++ b/be/src/formats/parquet/encoding_dict.h
@@ -90,7 +90,6 @@ public:
     // initialize dictionary
     Status set_dict(int chunk_size, size_t num_values, Decoder* decoder) override {
         _dict.resize(num_values);
-        _indexes.resize(chunk_size);
         RETURN_IF_ERROR(decoder->next_batch(num_values, (uint8_t*)&_dict[0]));
         return Status::OK();
     }

--- a/be/src/formats/parquet/meta_helper.cpp
+++ b/be/src/formats/parquet/meta_helper.cpp
@@ -20,8 +20,9 @@ namespace starrocks::parquet {
 
 void ParquetMetaHelper::set_existed_column_names(std::unordered_set<std::string>* names) const {
     names->clear();
+    names->reserve(_file_metadata->schema().get_fields_size());
     for (size_t i = 0; i < _file_metadata->schema().get_fields_size(); i++) {
-        names->emplace(_file_metadata->schema().get_stored_column_by_field_idx(i)->name);
+        names->insert(_file_metadata->schema().get_stored_column_by_field_idx(i)->name);
     }
 }
 
@@ -76,12 +77,13 @@ void IcebergMetaHelper::set_existed_column_names(std::unordered_set<std::string>
     names->clear();
     // build column name set from iceberg schema
     const auto& fields = _t_iceberg_schema->fields;
+    names->reserve(fields.size());
     for (const auto& field : fields) {
         if (_file_metadata->schema().contain_field_id(field.field_id)) {
             // We can't use _file_metadata->schema()'s column name, because column name from
             // _file_metadata->schema() was set by parquet metadata, it may not the same as column name from FE.
             // names->emplace(_file_metadata->schema().get_stored_column_by_field_id(field.field_id)->name);
-            names->emplace(_case_sensitive ? field.name : boost::algorithm::to_lower_copy(field.name));
+            names->insert(_case_sensitive ? field.name : boost::algorithm::to_lower_copy(field.name));
         }
     }
 }

--- a/be/src/formats/parquet/metadata.cpp
+++ b/be/src/formats/parquet/metadata.cpp
@@ -24,7 +24,7 @@ Status FileMetaData::init(tparquet::FileMetaData& t_metadata, bool case_sensitiv
     // construct schema from thrift
     RETURN_IF_ERROR(_schema.from_thrift(t_metadata.schema, case_sensitive));
     _num_rows = t_metadata.num_rows;
-    _t_metadata = std::move(t_metadata);
+    tparquet::swap(_t_metadata, t_metadata);
     if (_t_metadata.__isset.created_by) {
         _writer_version = ApplicationVersion(_t_metadata.created_by);
     } else {


### PR DESCRIPTION


Why I'm doing:
To further improve parquet reader performance.

What I'm doing:
* Swap the FileMetaData instance directly because the class has no a movable assignment operator.
* Skip `_indexes.resize` in dict decoder because it's useless.
* Reserve the hashtable size before inserting element in `set_existed_column_names`.
* Replace `RETURN_IF_ERROR` in some high-frequency operations because it introduces higher overhead in some cases.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
