### PR TITLE
[BugFix] split limit directly in some rules 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -51,12 +51,14 @@ public class LogicalLimitOperator extends LogicalOperator {
         super(OperatorType.LOGICAL_LIMIT);
     }
 
-    // use init LogicalLimitOperator only when the SplitLimitRule can be applied in the further step!
+    // use init LogicalLimitOperator only when the split and merge limit rule can be applied
+    // in the further step
     public static LogicalLimitOperator init(long limit) {
         return new LogicalLimitOperator(limit, DEFAULT_OFFSET, Phase.INIT);
     }
 
-    // use init LogicalLimitOperator only when the SplitLimitRule can be applied in the further step!
+    // use init LogicalLimitOperator only when the split and merge limit rule can be applied
+    // in the further step
     public static LogicalLimitOperator init(long limit, long offset) {
         return new LogicalLimitOperator(limit, offset, Phase.INIT);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/logical/LogicalLimitOperator.java
@@ -51,10 +51,12 @@ public class LogicalLimitOperator extends LogicalOperator {
         super(OperatorType.LOGICAL_LIMIT);
     }
 
+    // use init LogicalLimitOperator only when the SplitLimitRule can be applied in the further step!
     public static LogicalLimitOperator init(long limit) {
         return new LogicalLimitOperator(limit, DEFAULT_OFFSET, Phase.INIT);
     }
 
+    // use init LogicalLimitOperator only when the SplitLimitRule can be applied in the further step!
     public static LogicalLimitOperator init(long limit, long offset) {
         return new LogicalLimitOperator(limit, offset, Phase.INIT);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/MergeLimitWithSortRule.java
@@ -38,7 +38,7 @@ public class MergeLimitWithSortRule extends TransformationRule {
 
         // Merge Init-Limit/Local-limit and Sort
         // Local-limit may be generate at MergeLimitWithLimitRule
-        return (limit.isInit() || limit.isLocal()) && !topN.hasLimit();
+        return limit.isInit() || limit.isLocal();
     }
 
     @Override
@@ -47,6 +47,10 @@ public class MergeLimitWithSortRule extends TransformationRule {
         LogicalLimitOperator limit = (LogicalLimitOperator) input.getOp();
         LogicalTopNOperator sort = (LogicalTopNOperator) input.getInputs().get(0).getOp();
 
+        long minLimit = limit.getLimit();
+        if (sort.hasLimit()) {
+            minLimit = Math.min(minLimit, sort.getLimit());
+        }
         OptExpression result = new OptExpression(
                 new LogicalTopNOperator(sort.getOrderByElements(), limit.getLimit(), limit.getOffset()));
         result.getInputs().addAll(input.getInputs().get(0).getInputs());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
@@ -40,8 +40,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static com.starrocks.sql.optimizer.operator.Operator.DEFAULT_OFFSET;
-
 // for aggregate queries with group by keys like `group by col,expr(col),constant` or `group by constant`,
 // these expr and constant won't affect the effect of aggregation grouping, we can remove them
 public class PruneGroupByKeysRule extends TransformationRule {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
@@ -150,11 +150,10 @@ public class PruneGroupByKeysRule extends TransformationRule {
                 // for queries with all constant in project and group by keys,
                 // like `select 'a','b' from table group by 'c','d'`,
                 // we can remove agg node and rewrite it to `select 'a','b' from table limit 1`
-                OptExpression childInput = OptExpression.create(projectOperator, input.getInputs().get(0).getInputs());
-                LogicalLimitOperator local = LogicalLimitOperator.local(1);
-                LogicalLimitOperator global = LogicalLimitOperator.global(1, DEFAULT_OFFSET);
                 OptExpression result = OptExpression.create(
-                        global, OptExpression.create(local, childInput));
+                        LogicalLimitOperator.init(1),
+                        OptExpression.create(
+                                projectOperator, input.getInputs().get(0).getInputs()));
                 return Lists.newArrayList(result);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -734,7 +734,7 @@ public class LimitTest extends PlanTestBase {
                 "LIMIT \n" +
                 "  61202;";
         String plan = getFragmentPlan(sql);
-        assertContains(plan, "5:MERGING-EXCHANGE\n" +
+        assertContains(plan, "7:MERGING-EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
         assertContains(plan, "4:TOP-N\n" +
@@ -767,7 +767,7 @@ public class LimitTest extends PlanTestBase {
                 "  |  order by: <slot 9> 9: expr ASC, <slot 4> 4: S_NATIONKEY ASC\n" +
                 "  |  offset: 0\n" +
                 "  |  limit: 21");
-        assertContains(plan, "3:MERGING-EXCHANGE\n" +
+        assertContains(plan, "5:MERGING-EXCHANGE\n" +
                 "     offset: 6\n" +
                 "     limit: 15");
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -874,4 +874,21 @@ public class LimitTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "0:EMPTYSET");
     }
+
+    @Test
+    public void testMergeLimitInCte() throws Exception {
+        String sql = "with with_t_0 as (select v1 from t0 where EXISTS (select v4 from t1)) \n" +
+                "select distinct 1 from with_t_0, (select v7, v8 from t2) subt right SEMI join t0 on subt.v8 = v2 \n" +
+                "union all \n" +
+                "select distinct 2 from with_t_0, (select v10, v11 from t3) subt right SEMI join t0 on subt.v11 = v3;";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+        assertContains(plan, "7:UNION\n" +
+                "  |  \n" +
+                "  |----33:EXCHANGE\n" +
+                "  |       limit: 1\n" +
+                "  |    \n" +
+                "  20:EXCHANGE\n" +
+                "     limit: 1");
+    }
 }


### PR DESCRIPTION
Why I'm doing:
If a rule yeilds a new OptExpression like `limit(init) -> child`, it may skip the splitLimit rule which makes the final plan is illegal.
```
 private void rewrite(OptExpression parent, int childIndex, OptExpression root) {
        SessionVariable sessionVariable = context.getOptimizerContext().getSessionVariable();

        for (Rule rule : rules) {
            .....
        }

        // prune cte column depend on prune right child first
        for (int i = root.getInputs().size() - 1; i >= 0; i--) {
            rewrite(root, i, root.getInputs().get(i));
        }
    }
```

What I'm doing:
Directly split the new generated init limit like `limit(global) -> limit(local) -> child`. When process this op's child `limit(local) -> child` the further rule in MERGE_LIMIT ruleset would merge the limit(local) to its child.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/4815

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
