### PR TITLE
[BugFix] upgrade lake persistent index version

### DIFF
--- a/be/src/storage/lake/lake_local_persistent_index.cpp
+++ b/be/src/storage/lake/lake_local_persistent_index.cpp
@@ -24,6 +24,7 @@
 
 namespace starrocks::lake {
 
+// TODO refactor load from lake tablet, use same path with load from local tablet.
 Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* tablet, const TabletMetadata& metadata,
                                                        int64_t base_version, const MetaFileBuilder* builder) {
     if (!is_primary_key(metadata)) {
@@ -70,12 +71,12 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
         // here just use version.major_number so that PersistentIndexMetaPB need't to be modified,
         // the minor_number is meaningless
         if (version.major_number() == base_version) {
-            // If format version is not equal to PERSISTENT_INDEX_VERSION_3, this maybe upgrade from
-            // PERSISTENT_INDEX_VERSION_2.
             // We need to rebuild persistent index because the meta structure is changed
             if (index_meta.format_version() != PERSISTENT_INDEX_VERSION_2 &&
-                index_meta.format_version() != PERSISTENT_INDEX_VERSION_3) {
-                LOG(WARNING) << "different format version, we need to rebuild persistent index";
+                index_meta.format_version() != PERSISTENT_INDEX_VERSION_3 &&
+                index_meta.format_version() != PERSISTENT_INDEX_VERSION_4) {
+                LOG(WARNING) << "different format version, we need to rebuild persistent index, version: "
+                             << index_meta.format_version();
                 status = Status::InternalError("different format version");
             } else {
                 status = load(index_meta);
@@ -182,7 +183,7 @@ Status LakeLocalPersistentIndex::load_from_lake_tablet(starrocks::lake::Tablet* 
     index_meta.clear_l2_versions();
     index_meta.clear_l2_version_merged();
     index_meta.set_key_size(_key_size);
-    index_meta.set_format_version(PERSISTENT_INDEX_VERSION_3);
+    index_meta.set_format_version(PERSISTENT_INDEX_VERSION_4);
     _version.to_pb(index_meta.mutable_version());
     MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
     l0_meta->clear_wals();


### PR DESCRIPTION
Why I'm doing:
To support persistent index compression, we already upgrade persistent index's format version to 4. But when load from lake tablet, miss check this version.

What I'm doing:
check format version 4 when load from lake tablet.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
