### PR TITLE
[BugFix] remain pruned predicate cols in olapScan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -487,21 +487,31 @@ public class Optimizer {
 
     private OptExpression pushDownAggregation(OptExpression tree, TaskContext rootTaskContext,
                                               ColumnRefSet requiredColumns) {
+        boolean pushDistinctFlag = false;
+        boolean pushAggFlag = false;
         if (context.getSessionVariable().isCboPushDownDistinctBelowWindow()) {
             // TODO(by satanson): in future, PushDownDistinctAggregateRule and PushDownAggregateRule should be
             //  fused one rule to tackle with all scenarios of agg push-down.
-            tree = new PushDownDistinctAggregateRule().rewrite(tree, rootTaskContext);
+            PushDownDistinctAggregateRule rule = new PushDownDistinctAggregateRule(rootTaskContext);
+            tree = rule.rewrite(tree, rootTaskContext);
+            pushDistinctFlag = rule.getRewriter().hasRewrite();
         }
 
-        if (context.getSessionVariable().getCboPushDownAggregateMode() == -1) {
-            return tree;
+        if (context.getSessionVariable().getCboPushDownAggregateMode() != -1) {
+            PushDownAggregateRule rule = new PushDownAggregateRule(rootTaskContext);
+            rule.getRewriter().collectRewriteContext(tree);
+            if(rule.getRewriter().isNeedRewrite()) {
+                pushAggFlag = true;
+                tree = rule.rewrite(tree, rootTaskContext);
+            }
         }
 
-        tree = new PushDownAggregateRule().rewrite(tree, rootTaskContext);
-        deriveLogicalProperty(tree);
+        if (pushDistinctFlag || pushAggFlag) {
+            deriveLogicalProperty(tree);
+            rootTaskContext.setRequiredColumns(requiredColumns.clone());
+            ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
+        }
 
-        rootTaskContext.setRequiredColumns(requiredColumns.clone());
-        ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
         return tree;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -500,7 +500,7 @@ public class Optimizer {
         if (context.getSessionVariable().getCboPushDownAggregateMode() != -1) {
             PushDownAggregateRule rule = new PushDownAggregateRule(rootTaskContext);
             rule.getRewriter().collectRewriteContext(tree);
-            if(rule.getRewriter().isNeedRewrite()) {
+            if (rule.getRewriter().isNeedRewrite()) {
                 pushAggFlag = true;
                 tree = rule.rewrite(tree, rootTaskContext);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -27,7 +27,9 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.RuleType;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -54,6 +56,7 @@ public class PruneScanColumnRule extends TransformationRule {
         LogicalScanOperator scanOperator = (LogicalScanOperator) input.getOp();
         ColumnRefSet requiredOutputColumns = context.getTaskContext().getRequiredColumns();
 
+
         // The `outputColumns`s are some columns required but not specified by `requiredOutputColumns`.
         // including columns in predicate or some specialized columns defined by scan operator.
         Set<ColumnRefOperator> outputColumns =
@@ -79,7 +82,7 @@ public class PruneScanColumnRule extends TransformationRule {
                     .collect(Collectors.toMap(identity(), scanOperator.getColRefToColumnMetaMap()::get));
             if (scanOperator instanceof LogicalOlapScanOperator) {
                 LogicalOlapScanOperator olapScanOperator = (LogicalOlapScanOperator) scanOperator;
-
+                fillPrunedPredicateCols(newColumnRefMap, olapScanOperator);
                 LogicalOlapScanOperator.Builder builder = new LogicalOlapScanOperator.Builder();
                 LogicalOlapScanOperator newScanOperator = builder.withOperator(olapScanOperator)
                         .setColRefToColumnMetaMap(newColumnRefMap).build();
@@ -91,6 +94,18 @@ public class PruneScanColumnRule extends TransformationRule {
                         builder.withOperator(scanOperator).setColRefToColumnMetaMap(newColumnRefMap).build();
                 return Lists.newArrayList(new OptExpression(newScanOperator));
             }
+        }
+    }
+
+    private void fillPrunedPredicateCols(Map<ColumnRefOperator, Column> newColumnRefMap,
+                                         LogicalOlapScanOperator olapScanOperator) {
+        if (CollectionUtils.isEmpty(olapScanOperator.getPrunedPartitionPredicates())) {
+            return;
+        }
+
+        for (ScalarOperator predicate : olapScanOperator.getPrunedPartitionPredicates()) {
+            Utils.extractColumnRef(predicate).stream()
+                    .forEach( e -> newColumnRefMap.put(e, olapScanOperator.getColRefToColumnMetaMap().get(e)));
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneScanColumnRule.java
@@ -105,7 +105,7 @@ public class PruneScanColumnRule extends TransformationRule {
 
         for (ScalarOperator predicate : olapScanOperator.getPrunedPartitionPredicates()) {
             Utils.extractColumnRef(predicate).stream()
-                    .forEach( e -> newColumnRefMap.put(e, olapScanOperator.getColRefToColumnMetaMap().get(e)));
+                    .forEach(e -> newColumnRefMap.put(e, olapScanOperator.getColRefToColumnMetaMap().get(e)));
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownAggregateRule.java
@@ -21,9 +21,18 @@ import com.starrocks.sql.optimizer.task.TaskContext;
 
 public class PushDownAggregateRule implements TreeRewriteRule {
 
+    private final PushDownAggregateRewriter rewriter;
+
+    public PushDownAggregateRule(TaskContext taskContext) {
+        this.rewriter = new PushDownAggregateRewriter(taskContext);
+    }
+
+    public PushDownAggregateRewriter getRewriter() {
+        return rewriter;
+    }
+
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
-        PushDownAggregateRewriter rewriter = new PushDownAggregateRewriter(taskContext);
         return rewriter.rewrite(root);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownDistinctAggregateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/PushDownDistinctAggregateRule.java
@@ -18,9 +18,18 @@ import com.starrocks.sql.optimizer.rule.tree.pdagg.PushDownDistinctAggregateRewr
 import com.starrocks.sql.optimizer.task.TaskContext;
 
 public class PushDownDistinctAggregateRule implements TreeRewriteRule {
+
+    public final PushDownDistinctAggregateRewriter rewriter;
+
+    public PushDownDistinctAggregateRule(TaskContext context) {
+        rewriter = new PushDownDistinctAggregateRewriter(context);
+    }
+
+    public PushDownDistinctAggregateRewriter getRewriter() {
+        return rewriter;
+    }
     @Override
     public OptExpression rewrite(OptExpression root, TaskContext taskContext) {
-        PushDownDistinctAggregateRewriter rewriter = new PushDownDistinctAggregateRewriter(taskContext);
         return rewriter.rewrite(root);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
@@ -42,6 +42,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
 import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.commons.collections4.MapUtils;
 
 import java.util.Collection;
 import java.util.List;
@@ -77,14 +78,19 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
         this.sessionVariable = taskContext.getOptimizerContext().getSessionVariable();
     }
 
-    public OptExpression rewrite(OptExpression root) {
+    public void collectRewriteContext(OptExpression root) {
         collector.collect(root);
         allRewriteContext = collector.getAllRewriteContext();
+    }
 
-        if (allRewriteContext.isEmpty()) {
+    public boolean isNeedRewrite() {
+        return MapUtils.isNotEmpty(allRewriteContext);
+    }
+
+    public OptExpression rewrite(OptExpression root) {
+        if(!isNeedRewrite()) {
             return root;
         }
-
         allPushDownGroupBys = new ColumnRefSet();
         allRewriteContext.values().stream()
                 .flatMap(Collection::stream)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownAggregateRewriter.java
@@ -88,7 +88,7 @@ public class PushDownAggregateRewriter extends OptExpressionVisitor<OptExpressio
     }
 
     public OptExpression rewrite(OptExpression root) {
-        if(!isNeedRewrite()) {
+        if (!isNeedRewrite()) {
             return root;
         }
         allPushDownGroupBys = new ColumnRefSet();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/pdagg/PushDownDistinctAggregateRewriter.java
@@ -66,6 +66,8 @@ public class PushDownDistinctAggregateRewriter {
     private final ColumnRefFactory factory;
     private final SessionVariable sessionVariable;
 
+    private boolean hasRewrite;
+
     private static final Set<String> SUPPORT_WINDOW_FUNC = ImmutableSet.of(FunctionSet.SUM);
 
     public PushDownDistinctAggregateRewriter(TaskContext taskContext) {
@@ -76,7 +78,12 @@ public class PushDownDistinctAggregateRewriter {
     }
 
     public OptExpression rewrite(OptExpression tree) {
-        return process(tree, AggregatePushDownContext.EMPTY).getOp().orElse(tree);
+        Optional<OptExpression> res = process(tree, AggregatePushDownContext.EMPTY).getOp();
+        return res.orElse(tree);
+    }
+
+    public boolean hasRewrite() {
+        return hasRewrite;
     }
 
     // After rewrite, the post-rewrite tree must replace the old slotId with the new one,
@@ -487,6 +494,7 @@ public class PushDownDistinctAggregateRewriter {
         if (newContext == AggregatePushDownContext.EMPTY) {
             return Optional.empty();
         } else {
+            hasRewrite = true;
             return Optional.of(newContext);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -24,15 +24,19 @@ import com.starrocks.sql.optimizer.operator.ColumnOutputInfo;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalCTEConsumeOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalSetOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalSetOperation;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalValuesOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.task.TaskContext;
+import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
 
@@ -91,6 +95,21 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
                 for (ColumnOutputInfo col : rowOutputInfo.getCommonColInfo()) {
                     usedCols.except(col.getColumnRef().getUsedColumns());
                 }
+
+                if (operator.getPredicate() != null) {
+                    usedCols.union(operator.getPredicate().getUsedColumns());
+                }
+
+                if (operator instanceof LogicalOlapScanOperator) {
+                    LogicalOlapScanOperator olapScanOperator = operator.cast();
+                    fillPrunedPredicateCols(usedCols, olapScanOperator.getPrunedPartitionPredicates());
+                }
+
+                if (operator instanceof PhysicalOlapScanOperator) {
+                    PhysicalOlapScanOperator olapScanOperator = operator.cast();
+                    fillPrunedPredicateCols(usedCols, olapScanOperator.getPrunedPartitionPredicates());
+                }
+
                 checkInputCols(inputCols, usedCols, optExpression);
             }
         }
@@ -104,6 +123,9 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             }
             ColumnRefSet inputCols = optExpression.inputAt(0).getRowOutputInfo().getOutputColumnRefSet();
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
+            if (optExpression.getOp().getPredicate() != null) {
+                usedCols.union(optExpression.getOp().getPredicate().getUsedColumns());
+            }
             checkInputCols(inputCols, usedCols, optExpression);
         }
 
@@ -188,6 +210,16 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
                 String message = String.format("Invalid plan:%s%s%s. The required number of children is %d but found %d.",
                         System.lineSeparator(), optExpression.debugString(), PREFIX, requiredSize, inputSize);
                 throw new StarRocksPlannerException(message, ErrorType.INTERNAL_ERROR);
+            }
+        }
+
+        private void fillPrunedPredicateCols(ColumnRefSet usedCols, List<ScalarOperator> prunedPredicates) {
+            if(CollectionUtils.isEmpty(prunedPredicates)) {
+                return;
+            }
+
+            for (ScalarOperator predicate : prunedPredicates) {
+                usedCols.union(predicate.getUsedColumns());
             }
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -123,9 +123,6 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
             }
             ColumnRefSet inputCols = optExpression.inputAt(0).getRowOutputInfo().getOutputColumnRefSet();
             ColumnRefSet usedCols = optExpression.getRowOutputInfo().getUsedColumnRefSet();
-            if (optExpression.getOp().getPredicate() != null) {
-                usedCols.union(optExpression.getOp().getPredicate().getUsedColumns());
-            }
             checkInputCols(inputCols, usedCols, optExpression);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/InputDependenciesChecker.java
@@ -214,7 +214,7 @@ public class InputDependenciesChecker implements PlanValidator.Checker {
         }
 
         private void fillPrunedPredicateCols(ColumnRefSet usedCols, List<ScalarOperator> prunedPredicates) {
-            if(CollectionUtils.isEmpty(prunedPredicates)) {
+            if (CollectionUtils.isEmpty(prunedPredicates)) {
                 return;
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -170,4 +170,17 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "  |  \n" +
                 "  1:EXCHANGE");
     }
+
+    @Test
+    public void testPruneColsAfterPushdownAgg() throws Exception {
+        String sql = "select L_PARTKEY from lineitem_partition where L_SHIPDATE >= '1992-01-01' and L_SHIPDATE < '1993-01-01'";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "1:Project\n" +
+                "  |  <slot 2> : 2: L_PARTKEY\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: lineitem_partition\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/7");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregatePushDownTest.java
@@ -172,7 +172,7 @@ public class AggregatePushDownTest extends PlanTestBase {
     }
 
     @Test
-    public void testPruneColsAfterPushdownAgg() throws Exception {
+    public void testPruneColsAfterPushdownAgg_1() throws Exception {
         String sql = "select L_PARTKEY from lineitem_partition where L_SHIPDATE >= '1992-01-01' and L_SHIPDATE < '1993-01-01'";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "1:Project\n" +
@@ -182,5 +182,40 @@ public class AggregatePushDownTest extends PlanTestBase {
                 "     TABLE: lineitem_partition\n" +
                 "     PREAGGREGATION: ON\n" +
                 "     partitions=1/7");
+    }
+
+    @Test
+    public void testPruneColsAfterPushdownAgg_2() throws Exception {
+        String sql = "select max(L_ORDERKEY), sum(2), L_PARTKEY from lineitem_partition " +
+                "join t0 on L_PARTKEY = v1 " +
+                "where L_SHIPDATE >= '1992-01-01' and L_SHIPDATE < '1993-01-01' group by L_PARTKEY";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "1:Project\n" +
+                "  |  <slot 1> : 1: L_ORDERKEY\n" +
+                "  |  <slot 2> : 2: L_PARTKEY\n" +
+                "  |  <slot 26> : 2\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: lineitem_partition\n" +
+                "     PREAGGREGATION: ON\n" +
+                "     partitions=1/7",
+                "7:HASH JOIN\n" +
+                        "  |  join op: INNER JOIN (BROADCAST)\n" +
+                        "  |  colocate: false, reason: \n" +
+                        "  |  equal join conjunct: 23: cast = 18: v1\n" +
+                        "  |  \n" +
+                        "  |----6:EXCHANGE\n" +
+                        "  |    \n" +
+                        "  4:Project\n" +
+                        "  |  <slot 2> : 2: L_PARTKEY\n" +
+                        "  |  <slot 23> : CAST(2: L_PARTKEY AS BIGINT)\n" +
+                        "  |  <slot 24> : 24: max\n" +
+                        "  |  <slot 25> : 25: sum\n" +
+                        "  |  \n" +
+                        "  3:AGGREGATE (update finalize)\n" +
+                        "  |  output: sum(26: expr), max(1: L_ORDERKEY)\n" +
+                        "  |  group by: 2: L_PARTKEY\n" +
+                        "  |  \n" +
+                        "  2:EXCHANGE");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTest.java
@@ -492,7 +492,7 @@ public class ReplayFromDumpTest extends ReplayFromDumpTestBase {
                 "  |  \n" +
                 "  95:Project\n" +
                 "  |  output columns:\n" +
-                "  |  548 <-> 1\n" +
+                "  |  549 <-> 1\n" +
                 "  |  hasNullableGenerateChild: true\n" +
                 "  |  cardinality: 1\n" +
                 "  |  column statistics: \n" +


### PR DESCRIPTION
Why I'm doing:
remain pruned predicate cols in olapScan, or it will fail to transform these predicate to expr when building fragment.
```
for (ScalarOperator predicate : node.getPrunedPartitionPredicates()) {
                scanNode.getPrunedPartitionPredicates()
                        .add(ScalarOperatorToExpr.buildExecExpression(predicate, formatterContext));
            }
```

What I'm doing:
- union pruned predicate cols in required cols when prune scan cols.
- check these cols from input cols when using InputDependenciesChecker
- skip some operation like logical property derive and prune cols when `PushDownDistinctAggregateRule` or  `PushDownAggregateRule` doesn't rewrite the optExpression

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
