### PR TITLE
[Enhancement] support mysql key words in where caluse

### DIFF
--- a/be/src/connector/jdbc_connector.cpp
+++ b/be/src/connector/jdbc_connector.cpp
@@ -49,13 +49,12 @@ const TupleDescriptor* JDBCDataSourceProvider::tuple_descriptor(RuntimeState* st
 
 static std::string get_jdbc_sql(const Slice jdbc_url, const std::string& table, const std::vector<std::string>& columns,
                                 const std::vector<std::string>& filters, int64_t limit) {
-    std::string object_identifier = jdbc_url.starts_with("jdbc:mysql") ? "`" : "";
     std::ostringstream oss;
     oss << "SELECT";
     for (size_t i = 0; i < columns.size(); i++) {
-        oss << (i == 0 ? "" : ",") << " " << object_identifier << columns[i] << object_identifier;
+        oss << (i == 0 ? "" : ",") << " " << columns[i];
     }
-    oss << " FROM " << object_identifier << table << object_identifier;
+    oss << " FROM " << table;
     if (!filters.empty()) {
         oss << " WHERE ";
         for (size_t i = 0; i < filters.size(); i++) {
@@ -147,7 +146,7 @@ Status JDBCDataSource::_create_scanner(RuntimeState* state) {
     scan_ctx.jdbc_url = jdbc_table->jdbc_url();
     scan_ctx.user = jdbc_table->jdbc_user();
     scan_ctx.passwd = jdbc_table->jdbc_passwd();
-    scan_ctx.sql = get_jdbc_sql(scan_ctx.jdbc_url, jdbc_table->jdbc_table(), jdbc_scan_node.columns,
+    scan_ctx.sql = get_jdbc_sql(scan_ctx.jdbc_url, jdbc_scan_node.table_name, jdbc_scan_node.columns,
                                 jdbc_scan_node.filters, _read_limit);
     _scanner = _pool->add(new JDBCScanner(scan_ctx, _tuple_desc, _runtime_profile));
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -792,7 +792,7 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return toSql();
     }
 
-    public String toJDBCSQL(boolean isMySQL) {
+    public String toJDBCSQL() {
         return toSql();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/SlotRef.java
@@ -316,11 +316,11 @@ public class SlotRef extends Expr {
     }
 
     @Override
-    public String toJDBCSQL(boolean isMySQL) {
+    public String toJDBCSQL() {
         if (label == null) {
             throw new IllegalArgumentException("should set label for cols in JDBCScanNode. SlotRef: " + debugString());
         }
-        return isMySQL ? "`" + label + "`" : label;
+        return label;
     }
 
     public TableName getTableName() {

--- a/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/JDBCScanNode.java
@@ -50,8 +50,9 @@ public class JDBCScanNode extends ScanNode {
 
     public JDBCScanNode(PlanNodeId id, TupleDescriptor desc, JDBCTable tbl) {
         super(id, desc, "SCAN JDBC");
-        tableName = "`" + tbl.getJdbcTable() + "`";
         table = tbl;
+        String objectIdentifier = getIdentifierSymbol();
+        tableName = objectIdentifier + tbl.getJdbcTable() + objectIdentifier;
     }
 
     @Override
@@ -94,17 +95,31 @@ public class JDBCScanNode extends ScanNode {
     }
 
     private void createJDBCTableColumns() {
+        String objectIdentifier = getIdentifierSymbol();
         for (SlotDescriptor slot : desc.getSlots()) {
             if (!slot.isMaterialized()) {
                 continue;
             }
             Column col = slot.getColumn();
-            columns.add(col.getName());
+            columns.add(objectIdentifier + col.getName() + objectIdentifier);
         }
         // this happends when count(*)
         if (0 == columns.size()) {
             columns.add("*");
         }
+    }
+
+    private boolean isMysql() {
+        JDBCResource resource = (JDBCResource) GlobalStateMgr.getCurrentState().getResourceMgr()
+                .getResource(table.getResourceName());
+        // Compatible with jdbc catalog
+        String jdbcURI = resource != null ? resource.getProperty(JDBCResource.URI) : table.getProperty(JDBCResource.URI);
+        return jdbcURI.startsWith("jdbc:mysql");
+    }
+
+    private String getIdentifierSymbol() {
+        //TODO: for other jdbc table we need different objectIdentifier to support reserved key words
+        return isMysql() ? "`" : "";
     }
 
     private void createJDBCTableFilters() {
@@ -114,23 +129,17 @@ public class JDBCScanNode extends ScanNode {
         List<SlotRef> slotRefs = Lists.newArrayList();
         Expr.collectList(conjuncts, SlotRef.class, slotRefs);
         ExprSubstitutionMap sMap = new ExprSubstitutionMap();
-        JDBCResource resource = (JDBCResource) GlobalStateMgr.getCurrentState().getResourceMgr()
-                .getResource(table.getResourceName());
-        // Compatible with jdbc catalog
-        String jdbcURI = resource != null ? resource.getProperty(JDBCResource.URI) : table.getProperty(JDBCResource.URI);
-        boolean isMySQL = jdbcURI.startsWith("jdbc:mysql");
+        String identifier = getIdentifierSymbol();
         for (SlotRef slotRef : slotRefs) {
             SlotRef tmpRef = (SlotRef) slotRef.clone();
             tmpRef.setTblName(null);
-            if (isMySQL && tmpRef.getLabel() != null && !tmpRef.getLabel().startsWith("`")) {
-                tmpRef.setLabel("`" + tmpRef.getLabel() + "`");
-            }
+            tmpRef.setLabel(identifier + tmpRef.getLabel() + identifier);
             sMap.put(slotRef, tmpRef);
         }
 
-        ArrayList<Expr> mysqlConjuncts = Expr.cloneList(conjuncts, sMap);
-        for (Expr p : mysqlConjuncts) {
-            filters.add(p.toJDBCSQL(isMySQL));
+        ArrayList<Expr> jdbcConjuncts = Expr.cloneList(conjuncts, sMap);
+        for (Expr p : jdbcConjuncts) {
+            filters.add(p.toJDBCSQL());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -22,11 +22,37 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
+import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.utframe.StarRocksAssert;
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class ExternalTableTest extends PlanTestBase {
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
+        FeConstants.runningUnitTest = true;
+        starRocksAssert.withTable("create external table test.jdbc_key_words_test\n" +
+                "(a int, `schema` varchar(20))\n" +
+                "ENGINE=jdbc\n" +
+                "PROPERTIES (\n" +
+                "\"resource\"=\"jdbc_test\",\n" +
+                "\"table\"=\"test_table\"\n" +
+                ");");
+        FeConstants.runningUnitTest = false;
+    }
+
+    @Test
+    public void testKeyWordWhereCaluse() throws Exception {
+        String sql = "select * from test.jdbc_key_words_test where `schema` = \"test\"";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "`schema` = 'test'");
+    }
+
     @Test
     public void testMysqlTableFilter() throws Exception {
         String sql = "select * from ods_order where order_dt = '2025-08-07' and order_no = 'p' limit 10;";
@@ -160,7 +186,7 @@ public class ExternalTableTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan, plan.contains("0:SCAN JDBC\n" +
                 "     TABLE: `test_table`\n" +
-                "     QUERY: SELECT a, b, c FROM `test_table` WHERE (a > 10) AND (b < 'abc')\n" +
+                "     QUERY: SELECT a, b, c FROM `test_table` WHERE (`a` > 10) AND (`b` < 'abc')\n" +
                 "     limit: 10"));
         sql = "select * from test.jdbc_test where a > 10 and length(b) < 20 limit 10";
         plan = getFragmentPlan(sql);
@@ -171,7 +197,7 @@ public class ExternalTableTest extends PlanTestBase {
                         "  |  \n" +
                         "  0:SCAN JDBC\n" +
                         "     TABLE: `test_table`\n" +
-                        "     QUERY: SELECT a, b, c FROM `test_table` WHERE (a > 10)"));
+                        "     QUERY: SELECT a, b, c FROM `test_table` WHERE (`a` > 10)"));
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExternalTableTest.java
@@ -186,7 +186,7 @@ public class ExternalTableTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan, plan.contains("0:SCAN JDBC\n" +
                 "     TABLE: `test_table`\n" +
-                "     QUERY: SELECT a, b, c FROM `test_table` WHERE (`a` > 10) AND (`b` < 'abc')\n" +
+                "     QUERY: SELECT `a`, `b`, `c` FROM `test_table` WHERE (`a` > 10) AND (`b` < 'abc')\n" +
                 "     limit: 10"));
         sql = "select * from test.jdbc_test where a > 10 and length(b) < 20 limit 10";
         plan = getFragmentPlan(sql);
@@ -197,7 +197,7 @@ public class ExternalTableTest extends PlanTestBase {
                         "  |  \n" +
                         "  0:SCAN JDBC\n" +
                         "     TABLE: `test_table`\n" +
-                        "     QUERY: SELECT a, b, c FROM `test_table` WHERE (`a` > 10)"));
+                        "     QUERY: SELECT `a`, `b`, `c` FROM `test_table` WHERE (`a` > 10)"));
 
     }
 
@@ -212,7 +212,7 @@ public class ExternalTableTest extends PlanTestBase {
                         "  |  \n" +
                         "  0:SCAN JDBC\n" +
                         "     TABLE: `test_table`\n" +
-                        "     QUERY: SELECT a, b FROM `test_table`"));
+                        "     QUERY: SELECT `a`, `b` FROM `test_table`"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -828,7 +828,7 @@ public class PlanTestBase extends PlanTestNoneDBBase {
                         "\"password\"=\"test_passwd\",\n" +
                         "\"driver_url\"=\"test_driver_url\",\n" +
                         "\"driver_class\"=\"test.driver.class\",\n" +
-                        "\"jdbc_uri\"=\"test_uri\"\n" +
+                        "\"jdbc_uri\"=\"jdbc:mysql://127.0.0.1:3306\"\n" +
                         ");")
                 .withTable("create external table test.jdbc_test\n" +
                         "(a int, b varchar(20), c float)\n" +


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
support mysql key words in where caluse

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
