### PR TITLE
[Enhancement]Support delete txn_log when publish batch succeed

### DIFF
--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -43,6 +43,10 @@ public:
                        const ::starrocks::lake::DeleteTabletRequest* request,
                        ::starrocks::lake::DeleteTabletResponse* response, ::google::protobuf::Closure* done) override;
 
+    void delete_txn_log(::google::protobuf::RpcController* controller,
+                        const ::starrocks::lake::DeleteTxnLogRequest* request,
+                        ::starrocks::lake::DeleteTxnLogResponse* response, ::google::protobuf::Closure* done) override;
+
     void compact(::google::protobuf::RpcController* controller, const ::starrocks::lake::CompactRequest* request,
                  ::starrocks::lake::CompactResponse* response, ::google::protobuf::Closure* done) override;
 

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -38,6 +38,8 @@ void vacuum_full(TabletManager* tablet_mgr, const VacuumFullRequest& request, Va
 //  - response != NULL
 void delete_tablets(TabletManager* tablet_mgr, const DeleteTabletRequest& request, DeleteTabletResponse* response);
 
+void delete_txn_log(TabletManager* tablet_mgr, const DeleteTxnLogRequest& request, DeleteTxnLogResponse* response);
+
 // Batch delete files.
 // REQUIRE: All files in |paths| have the same file system scheme.
 Status delete_files(const std::vector<std::string>& paths);

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -818,6 +818,50 @@ TEST_F(LakeServiceTest, test_delete_tablet) {
 }
 
 // NOLINTNEXTLINE
+TEST_F(LakeServiceTest, test_delete_txn_log) {
+    // missing tablet_ids
+    {
+        brpc::Controller cntl;
+        lake::DeleteTxnLogRequest request;
+        lake::DeleteTxnLogResponse response;
+        _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ("missing tablet_ids", cntl.ErrorText());
+    }
+
+    // missing txn_ids
+    {
+        brpc::Controller cntl;
+        lake::DeleteTxnLogRequest request;
+        lake::DeleteTxnLogResponse response;
+        request.add_tablet_ids(_tablet_id);
+        _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
+        ASSERT_TRUE(cntl.Failed());
+        ASSERT_EQ("missing txn_ids", cntl.ErrorText());
+    }
+
+    // test normal
+    {
+        std::vector<lake::TxnLog> logs;
+
+        // TxnLog with 2 segments
+        logs.emplace_back(generate_write_txn_log(2, 101, 4096));
+        ASSERT_OK(_tablet_mgr->put_txn_log(logs.back()));
+
+        brpc::Controller cntl;
+        lake::DeleteTxnLogRequest request;
+        lake::DeleteTxnLogResponse response;
+        request.add_tablet_ids(_tablet_id);
+        request.add_txn_ids(logs.back().txn_id());
+        _lake_service.delete_txn_log(&cntl, &request, &response, nullptr);
+
+        ExecEnv::GetInstance()->delete_file_thread_pool()->wait();
+        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_id));
+        ASSERT_TRUE(tablet.get_txn_log(logs[0].txn_id()).status().is_not_found());
+    }
+}
+
+// NOLINTNEXTLINE
 TEST_F(LakeServiceTest, test_delete_tablet_dir_not_exit) {
     ASSERT_OK(fs::remove_all(kRootLocation));
     brpc::Controller cntl;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2356,6 +2356,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true, comment = "the max number of threads for lake table publishing version")
     public static int lake_publish_version_max_threads = 512;
 
+    @ConfField(mutable = true, comment = "the max number of threads for lake table delete txnLog when enable batch publish")
+    public static int lake_publish_delete_txnlog_max_threads = 16;
+
     @ConfField(mutable = true, comment = "the max number of previous version files to keep")
     public static int lake_autovacuum_max_previous_versions = 0;
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/Utils.java
@@ -104,9 +104,12 @@ public class Utils {
 
     public static void publishVersionBatch(@NotNull List<Tablet> tablets, List<Long> txnIds,
                                       long baseVersion, long newVersion, long commitTimeInSecond,
-                                      Map<Long, Double> compactionScores)
+                                      Map<Long, Double> compactionScores, Map<ComputeNode, List<Long>> nodeToTablets)
             throws NoAliveBackendException, RpcException {
-        Map<ComputeNode, List<Long>> nodeToTablets = new HashMap<>();
+        if (nodeToTablets == null) {
+            nodeToTablets = new HashMap<>();
+        }
+
         for (Tablet tablet : tablets) {
             ComputeNode node = Utils.chooseNode((LakeTablet) tablet);
             if (node == null) {
@@ -154,7 +157,7 @@ public class Utils {
                                       long commitTimeInSecond, Map<Long, Double> compactionScores)
             throws NoAliveBackendException, RpcException {
         List<Long> txnIds = Lists.newArrayList(txnId);
-        publishVersionBatch(tablets, txnIds, baseVersion, newVersion, commitTimeInSecond, compactionScores);
+        publishVersionBatch(tablets, txnIds, baseVersion, newVersion, commitTimeInSecond, compactionScores, null);
     }
 
     public static void publishLogVersion(@NotNull List<Tablet> tablets, long txnId, long version)

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -26,6 +26,8 @@ import com.starrocks.proto.DeleteDataRequest;
 import com.starrocks.proto.DeleteDataResponse;
 import com.starrocks.proto.DeleteTabletRequest;
 import com.starrocks.proto.DeleteTabletResponse;
+import com.starrocks.proto.DeleteTxnLogRequest;
+import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
 import com.starrocks.proto.LockTabletMetadataRequest;
@@ -80,6 +82,9 @@ public interface LakeService {
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "delete_data", onceTalkTimeout = TIMEOUT_DELETE_DATA)
     Future<DeleteDataResponse> deleteData(DeleteDataRequest request);
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "delete_txn_log", onceTalkTimeout = /*10m=*/600000)
+    Future<DeleteTxnLogResponse> deleteTxnLog(DeleteTxnLogRequest request);
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "get_tablet_stats", onceTalkTimeout = TIMEOUT_GET_TABLET_STATS)
     Future<TabletStatResponse> getTabletStats(TabletStatRequest request);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -244,7 +244,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
         if (deleteTxnLogExecutor == null) {
             // Create a new thread for every task if there is no idle threads available.
             // Idle threads will be cleaned after `KEEP_ALIVE_TIME` seconds, which is 60 seconds by default.
-            deleteTxnLogExecutor = ThreadPoolManager.newDaemonCacheThreadPool(Config.lake_publish_delete_txnlog_max_threads,
+            int numThreads = Math.max(Config.lake_publish_delete_txnlog_max_threads, 1);
+            deleteTxnLogExecutor = ThreadPoolManager.newDaemonCacheThreadPool(numThreads,
                     "lake-publish-delete-txnLog", true);
 
             // register ThreadPool config change listener

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -34,6 +34,8 @@ import com.starrocks.proto.DeleteDataRequest;
 import com.starrocks.proto.DeleteDataResponse;
 import com.starrocks.proto.DeleteTabletRequest;
 import com.starrocks.proto.DeleteTabletResponse;
+import com.starrocks.proto.DeleteTxnLogRequest;
+import com.starrocks.proto.DeleteTxnLogResponse;
 import com.starrocks.proto.DropTableRequest;
 import com.starrocks.proto.DropTableResponse;
 import com.starrocks.proto.ExecuteCommandRequestPB;
@@ -1082,6 +1084,11 @@ public class PseudoBackend {
 
         @Override
         public Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request) {
+            return CompletableFuture.completedFuture(null);
+        }
+
+        @Override
+        public Future<DeleteTxnLogResponse> deleteTxnLog(DeleteTxnLogRequest request) {
             return CompletableFuture.completedFuture(null);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
@@ -120,12 +120,13 @@ public class TransactionStateBatchTest {
         nodeToTablets1.put(node1, Lists.newArrayList(1L, 2L));
         nodeToTablets1.put(node2, Lists.newArrayList(3L, 4L));
         Map<ComputeNode, List<Long>> nodeToTablets2 = new HashMap<>();
-        nodeToTablets2.put(node1, Lists.newArrayList(3L, 4L, 5L));
+        nodeToTablets2.put(node1, Lists.newArrayList(2L, 3L, 4L));
 
         stateBatch.putBeTablets(partitionId1, nodeToTablets1);
         stateBatch.putBeTablets(partitionId1, nodeToTablets2);
         Assert.assertEquals(1, stateBatch.getPartitionToTablets().size());
-        Assert.assertEquals(3, stateBatch.getPartitionToTablets().get(partitionId1).get(node2).size());
+        Assert.assertEquals(4, stateBatch.getPartitionToTablets().get(partitionId1).get(node1).size());
+        Assert.assertEquals(2, stateBatch.getPartitionToTablets().get(partitionId1).get(node2).size());
 
         stateBatch.putBeTablets(partitionId2, nodeToTablets2);
         Assert.assertEquals(2, stateBatch.getPartitionToTablets().size());

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateBatchTest.java
@@ -16,6 +16,7 @@ package com.starrocks.transaction;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.UserException;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TUniqueId;
 import org.junit.After;
 import org.junit.Assert;
@@ -28,7 +29,9 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public class TransactionStateBatchTest {
@@ -86,6 +89,46 @@ public class TransactionStateBatchTest {
         Assert.assertEquals(TransactionStatus.VISIBLE, state.getTransactionStatus());
 
         in.close();
+    }
+
+    @Test
+    public void testPutBeTablets() {
+        Long dbId = 1000L;
+        Long tableId = 20000L;
+        UUID uuid = UUID.randomUUID();
+        List<TransactionState> transactionStateList = new ArrayList<TransactionState>();
+        TransactionState transactionState1 = new TransactionState(dbId, Lists.newArrayList(tableId),
+                3000, "label1", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
+                60 * 1000L);
+        uuid = UUID.randomUUID();
+        TransactionState transactionState2 = new TransactionState(dbId, Lists.newArrayList(tableId),
+                3001, "label2", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+                TransactionState.LoadJobSourceType.BACKEND_STREAMING,
+                new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.BE, "127.0.0.1"), 50000L,
+                60 * 1000L);
+        transactionStateList.add(transactionState1);
+        transactionStateList.add(transactionState2);
+        TransactionStateBatch stateBatch = new TransactionStateBatch(transactionStateList);
+
+        long partitionId1 = 1;
+        long partitionId2 = 2;
+        Map<ComputeNode, List<Long>> nodeToTablets1 = new HashMap<>();
+        ComputeNode node1 = new ComputeNode(1, "host", 9050);
+        ComputeNode node2 = new ComputeNode(2, "host", 9050);
+        nodeToTablets1.put(node1, Lists.newArrayList(1L, 2L));
+        nodeToTablets1.put(node2, Lists.newArrayList(3L, 4L));
+        Map<ComputeNode, List<Long>> nodeToTablets2 = new HashMap<>();
+        nodeToTablets2.put(node1, Lists.newArrayList(3L, 4L, 5L));
+
+        stateBatch.putBeTablets(partitionId1, nodeToTablets1);
+        stateBatch.putBeTablets(partitionId1, nodeToTablets2);
+        Assert.assertEquals(1, stateBatch.getPartitionToTablets().size());
+        Assert.assertEquals(3, stateBatch.getPartitionToTablets().get(partitionId1).get(node2).size());
+
+        stateBatch.putBeTablets(partitionId2, nodeToTablets2);
+        Assert.assertEquals(2, stateBatch.getPartitionToTablets().size());
     }
 
 }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -64,6 +64,15 @@ message DeleteTabletResponse {
     optional StatusPB status = 2;
 }
 
+message DeleteTxnLogRequest {
+    repeated int64 tablet_ids = 1;
+    repeated int64 txn_ids = 2;
+}
+
+message DeleteTxnLogResponse {
+    optional StatusPB status = 1;
+}
+
 message CompactRequest {
     repeated int64 tablet_ids = 1;
     optional int64 txn_id = 2;
@@ -246,6 +255,7 @@ service LakeService {
     rpc publish_version(PublishVersionRequest) returns (PublishVersionResponse);
     rpc publish_log_version(PublishLogVersionRequest) returns (PublishLogVersionResponse);
     rpc publish_log_version_batch(PublishLogVersionBatchRequest) returns (PublishLogVersionResponse);
+    rpc delete_txn_log(DeleteTxnLogRequest) returns (DeleteTxnLogResponse);
     rpc abort_txn(AbortTxnRequest) returns (AbortTxnResponse);
     rpc compact(CompactRequest) returns (CompactResponse);
     rpc delete_tablet(DeleteTabletRequest) returns (DeleteTabletResponse);


### PR DESCRIPTION
Why I'm doing:
Pr #28789 will not delete remove txn_log when enable publish batch, and let the vacuum do the work. 

What I'm doing:
The pr will delete the txn_log when publish succeed by send a rpc to Be to alleviate the pressure of vacuum,
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
