### PR TITLE
[BugFix] Stop execution thread pool and poller thread on BE graceful stop

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -42,7 +42,6 @@ PipelineDriver::~PipelineDriver() noexcept {
     if (_workgroup != nullptr) {
         _workgroup->decr_num_running_drivers();
     }
-    check_operator_close_states("deleting pipeline drivers");
 }
 
 void PipelineDriver::check_operator_close_states(std::string func_name) {

--- a/be/src/exec/pipeline/pipeline_driver.cpp
+++ b/be/src/exec/pipeline/pipeline_driver.cpp
@@ -42,6 +42,7 @@ PipelineDriver::~PipelineDriver() noexcept {
     if (_workgroup != nullptr) {
         _workgroup->decr_num_running_drivers();
     }
+    check_operator_close_states("deleting pipeline drivers");
 }
 
 void PipelineDriver::check_operator_close_states(std::string func_name) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -49,6 +49,7 @@ GlobalDriverExecutor::~GlobalDriverExecutor() {
 
 void GlobalDriverExecutor::close() {
     _driver_queue->close();
+    _blocked_driver_poller->shutdown();
 }
 
 void GlobalDriverExecutor::initialize(int num_threads) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -49,6 +49,7 @@ GlobalDriverExecutor::~GlobalDriverExecutor() {
 
 void GlobalDriverExecutor::close() {
     _driver_queue->close();
+    _thread_pool->wait();
     _blocked_driver_poller->shutdown();
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -43,10 +43,6 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                                     [this]() { return _blocked_driver_poller->blocked_driver_queue_len(); });
 }
 
-GlobalDriverExecutor::~GlobalDriverExecutor() {
-    close();
-}
-
 void GlobalDriverExecutor::close() {
     _driver_queue->close();
     _thread_pool->wait();

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -70,7 +70,7 @@ protected:
 class GlobalDriverExecutor final : public FactoryMethod<DriverExecutor, GlobalDriverExecutor> {
 public:
     GlobalDriverExecutor(const std::string& name, std::unique_ptr<ThreadPool> thread_pool, bool enable_resource_group);
-    ~GlobalDriverExecutor() override;
+    ~GlobalDriverExecutor() override = default;
     void initialize(int32_t num_threads) override;
     void change_num_threads(int32_t num_threads) override;
     void submit(DriverRawPtr driver) override;


### PR DESCRIPTION
Why I'm doing:

On graceful stopping, global components will be stopped and destroyed. But the active poller thread may still visit unfinished drivers, which leads to invalid memory accesses.

What I'm doing:

Stop the poller thread when stopping `DriverExecutor` 

Also, the execution threads pool is stoped.

Fixes https://github.com/StarRocks/StarRocksTest/issues/4940

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
