### PR TITLE
[BugFix] fixed issue 34320: Added a check on whether the jdbc catalog data source supports partitions information tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -67,11 +67,21 @@ public class JDBCMetadata implements ConnectorMetadata {
             LOG.warn("{} not support yet", properties.get(JDBCResource.DRIVER_CLASS));
             throw new StarRocksConnectorException(properties.get(JDBCResource.DRIVER_CLASS) + " not support yet");
         }
+        checkSupportPartitionInformation();
     }
 
     public Connection getConnection() throws SQLException {
         return DriverManager.getConnection(properties.get(JDBCResource.URI),
                 properties.get(JDBCResource.USER), properties.get(JDBCResource.PASSWORD));
+    }
+
+    public boolean checkSupportPartitionInformation() {
+        try (Connection connection = getConnection()) {
+            return schemaResolver.setSupportPartitionInformation(
+                    schemaResolver.checkSupportPartitionInformation(connection));
+        } catch (SQLException e) {
+            throw new StarRocksConnectorException(e.getMessage());
+        }
     }
 
     @Override
@@ -117,7 +127,10 @@ public class JDBCMetadata implements ConnectorMetadata {
         try (Connection connection = getConnection()) {
             ResultSet columnSet = schemaResolver.getColumns(connection, dbName, tblName);
             List<Column> fullSchema = schemaResolver.convertToSRTable(columnSet);
-            List<Column> partitionColumns = listPartitionColumns(dbName, tblName, fullSchema);
+            List<Column> partitionColumns = Lists.newArrayList();
+            if (schemaResolver.isSupportPartitionInformation()) {
+                partitionColumns = listPartitionColumns(dbName, tblName, fullSchema);
+            }
             if (fullSchema.isEmpty()) {
                 return null;
             }
@@ -126,7 +139,7 @@ public class JDBCMetadata implements ConnectorMetadata {
                 return schemaResolver.getTable(JDBCTableIdCache.getTableId(tableKey),
                         tblName, fullSchema, partitionColumns, dbName, catalogName, properties);
             } else {
-                Integer tableId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt();
+                int tableId = ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt();
                 JDBCTableIdCache.putTableId(tableKey, tableId);
                 return schemaResolver.getTable(tableId, tblName, fullSchema, partitionColumns, dbName, catalogName, properties);
             }
@@ -148,15 +161,16 @@ public class JDBCMetadata implements ConnectorMetadata {
     public List<Column> listPartitionColumns(String databaseName, String tableName, List<Column> fullSchema) {
         try (Connection connection = getConnection()) {
             Set<String> partitionColumnNames = schemaResolver.listPartitionColumns(connection, databaseName, tableName)
-                    .stream().map(columnName -> columnName.toLowerCase()).collect(Collectors.toSet());
-            if (partitionColumnNames.size() > 0) {
+                    .stream().map(String::toLowerCase).collect(Collectors.toSet());
+            if (!partitionColumnNames.isEmpty()) {
                 return fullSchema.stream().filter(column -> partitionColumnNames.contains(column.getName().toLowerCase()))
                         .collect(Collectors.toList());
             } else {
                 return Lists.newArrayList();
             }
-        } catch (SQLException e) {
-            throw new StarRocksConnectorException(e.getMessage());
+        } catch (SQLException  | StarRocksConnectorException e) {
+            LOG.warn(e.getMessage());
+            return Lists.newArrayList();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetadata.java
@@ -67,7 +67,7 @@ public class JDBCMetadata implements ConnectorMetadata {
             LOG.warn("{} not support yet", properties.get(JDBCResource.DRIVER_CLASS));
             throw new StarRocksConnectorException(properties.get(JDBCResource.DRIVER_CLASS) + " not support yet");
         }
-        checkSupportPartitionInformation();
+        checkAndSetSupportPartitionInformation();
     }
 
     public Connection getConnection() throws SQLException {
@@ -75,10 +75,9 @@ public class JDBCMetadata implements ConnectorMetadata {
                 properties.get(JDBCResource.USER), properties.get(JDBCResource.PASSWORD));
     }
 
-    public boolean checkSupportPartitionInformation() {
+    public void checkAndSetSupportPartitionInformation() {
         try (Connection connection = getConnection()) {
-            return schemaResolver.setSupportPartitionInformation(
-                    schemaResolver.checkSupportPartitionInformation(connection));
+            schemaResolver.checkAndSetSupportPartitionInformation(connection);
         } catch (SQLException e) {
             throw new StarRocksConnectorException(e.getMessage());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -99,7 +99,7 @@ public abstract class JDBCSchemaResolver {
         throw new SQLException("should not arrival here");
     }
 
-    public boolean checkSupportPartitionInformation(Connection connection) {
+    public boolean checkAndSetSupportPartitionInformation(Connection connection) {
         return false;
 
     }
@@ -108,7 +108,4 @@ public abstract class JDBCSchemaResolver {
         return supportPartitionInformation;
     }
 
-    public boolean setSupportPartitionInformation(boolean supportPartitionInformation) {
-        return this.supportPartitionInformation = supportPartitionInformation;
-    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -33,6 +33,8 @@ import java.util.Map;
 
 public abstract class JDBCSchemaResolver {
 
+    boolean supportPartitionInformation = false;
+
     public Collection<String> listSchemas(Connection connection) {
         try (ResultSet resultSet = connection.getMetaData().getSchemas()) {
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
@@ -95,5 +97,18 @@ public abstract class JDBCSchemaResolver {
 
     public Type convertColumnType(int dataType, String typeName, int columnSize, int digits) throws SQLException {
         throw new SQLException("should not arrival here");
+    }
+
+    public boolean checkSupportPartitionInformation(Connection connection) {
+        return false;
+
+    }
+
+    public boolean isSupportPartitionInformation() {
+        return supportPartitionInformation;
+    }
+
+    public boolean setSupportPartitionInformation(boolean supportPartitionInformation) {
+        return this.supportPartitionInformation = supportPartitionInformation;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -61,19 +61,18 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
     }
 
     @Override
-    public boolean checkSupportPartitionInformation(Connection connection) {
+    public boolean checkAndSetSupportPartitionInformation(Connection connection) {
         String catalogSchema = "information_schema";
         String partitionInfoTable = "partitions";
         try (ResultSet catalogSet = connection.getMetaData().getCatalogs()) {
             while (catalogSet.next()) {
                 String schemaName = catalogSet.getString("TABLE_CAT");
                 if (schemaName.equalsIgnoreCase(catalogSchema)) {
-                    try (ResultSet tableSet = connection.getMetaData().getTables(catalogSchema, null, null,
-                            new String[] {"SYSTEM TABLE", "SYSTEM VIEW"})) {
+                    try (ResultSet tableSet = connection.getMetaData().getTables(catalogSchema, null, null, null)) {
                         while (tableSet.next()) {
                             String tableName = tableSet.getString("TABLE_NAME");
                             if (tableName.equalsIgnoreCase(partitionInfoTable)) {
-                                return true;
+                                return this.supportPartitionInformation = true;
                             }
                         }
                     }
@@ -82,7 +81,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
         } catch (SQLException e) {
             throw new StarRocksConnectorException(e.getMessage());
         }
-        return false;
+        return this.supportPartitionInformation = false;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -41,9 +41,6 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
     public Collection<String> listSchemas(Connection connection) {
         try (ResultSet resultSet = connection.getMetaData().getCatalogs()) {
             ImmutableSet.Builder<String> schemaNames = ImmutableSet.builder();
-            // In unit testing, there is always a situation where the next method is false,
-            // and the beforefirst method needs to be called first
-            resultSet.beforeFirst();
             while (resultSet.next()) {
                 String schemaName = resultSet.getString("TABLE_CAT");
                 // skip internal schemas
@@ -64,6 +61,8 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
     public boolean checkAndSetSupportPartitionInformation(Connection connection) {
         String catalogSchema = "information_schema";
         String partitionInfoTable = "partitions";
+        // Different types of MySQL protocol databases have different case names for schema and table names,
+        // which need to be converted to lowercase for comparison
         try (ResultSet catalogSet = connection.getMetaData().getCatalogs()) {
             while (catalogSet.next()) {
                 String schemaName = catalogSet.getString("TABLE_CAT");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetadataTest.java
@@ -60,6 +60,7 @@ public class JDBCMetadataTest {
     @Mocked
     PreparedStatement preparedStatement;
     private MockResultSet partitionsResult;
+    MockResultSet partitionsInfoTablesResult;
 
     @Before
     public void setUp() throws SQLException {
@@ -133,6 +134,7 @@ public class JDBCMetadataTest {
     public void testListDatabaseNames() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            dbResult.beforeFirst();
             List<String> result = jdbcMetadata.listDbNames();
             List<String> expectResult = Lists.newArrayList("test");
             Assert.assertEquals(expectResult, result);
@@ -145,6 +147,7 @@ public class JDBCMetadataTest {
     public void testGetDb() {
         try {
             JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            dbResult.beforeFirst();
             Database db = jdbcMetadata.getDb("test");
             Assert.assertEquals("test", db.getOriginName());
         } catch (Exception e) {
@@ -192,13 +195,10 @@ public class JDBCMetadataTest {
                 result = partitionsResult;
                 minTimes = 0;
 
-                String catalogSchema = "information_schema";
-                String partitionInfoTable = "partitions";
-                MockResultSet piResult = new MockResultSet(partitionInfoTable);
-                piResult.addColumn("TABLE_NAME", Arrays.asList(partitionInfoTable));
-                connection.getMetaData().getTables(catalogSchema, null, null,
-                        new String[] {"SYSTEM TABLE", "SYSTEM VIEW"});
-                result = piResult;
+                partitionsInfoTablesResult = new MockResultSet("partitions");
+                partitionsInfoTablesResult.addColumn("TABLE_NAME", Arrays.asList("partitions"));
+                connection.getMetaData().getTables(anyString, null, null, null);
+                result = partitionsInfoTablesResult;
                 minTimes = 0;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -54,6 +54,8 @@ public class MysqlSchemaResolverTest {
     PreparedStatement preparedStatement;
 
     private Map<String, String> properties;
+    private MockResultSet dbResult;
+    private MockResultSet tableResult;
     private MockResultSet partitionsResult;
     private Map<JDBCTableName, Integer> tableIdCache;
 
@@ -84,6 +86,48 @@ public class MysqlSchemaResolverTest {
                 minTimes = 0;
             }
         };
+    }
+
+    @Test
+    public void testCheckPartitionWithoutPartitionsTable() {
+        try {
+            JDBCSchemaResolver schemaResolver = new MysqlSchemaResolver();
+            Assert.assertFalse(schemaResolver.checkSupportPartitionInformation(connection));
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testCheckPartitionWithPartitionsTable() throws SQLException {
+        new Expectations() {
+            {
+                String catalogSchema = "information_schema";
+
+                dbResult = new MockResultSet("catalog");
+                dbResult.addColumn("TABLE_CAT", Arrays.asList(catalogSchema));
+
+                connection.getMetaData().getCatalogs();
+                result = dbResult;
+                minTimes = 0;
+
+                String partitionInfoTable = "partitions";
+                tableResult = new MockResultSet("tables");
+                tableResult.addColumn("TABLE_NAME", Arrays.asList(partitionInfoTable));
+                connection.getMetaData().getTables(catalogSchema, null, null,
+                        new String[] {"SYSTEM TABLE", "SYSTEM VIEW"});
+                result = tableResult;
+                minTimes = 0;
+            }
+        };
+        try {
+            JDBCSchemaResolver schemaResolver = new MysqlSchemaResolver();
+            Assert.assertTrue(schemaResolver.checkSupportPartitionInformation(connection));
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -112,12 +112,10 @@ public class MysqlSchemaResolverTest {
                 result = dbResult;
                 minTimes = 0;
 
-                String partitionInfoTable = "partitions";
-                tableResult = new MockResultSet("tables");
-                tableResult.addColumn("TABLE_NAME", Arrays.asList(partitionInfoTable));
-                connection.getMetaData().getTables(catalogSchema, null, null,
-                        new String[] {"SYSTEM TABLE", "SYSTEM VIEW"});
-                result = tableResult;
+                MockResultSet piResult = new MockResultSet("partitions");
+                piResult.addColumn("TABLE_NAME", Arrays.asList("partitions"));
+                connection.getMetaData().getTables(anyString, null, null, null);
+                result = piResult;
                 minTimes = 0;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -92,7 +92,7 @@ public class MysqlSchemaResolverTest {
     public void testCheckPartitionWithoutPartitionsTable() {
         try {
             JDBCSchemaResolver schemaResolver = new MysqlSchemaResolver();
-            Assert.assertFalse(schemaResolver.checkSupportPartitionInformation(connection));
+            Assert.assertFalse(schemaResolver.checkAndSetSupportPartitionInformation(connection));
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();
@@ -123,7 +123,7 @@ public class MysqlSchemaResolverTest {
         };
         try {
             JDBCSchemaResolver schemaResolver = new MysqlSchemaResolver();
-            Assert.assertTrue(schemaResolver.checkSupportPartitionInformation(connection));
+            Assert.assertTrue(schemaResolver.checkAndSetSupportPartitionInformation(connection));
         } catch (Exception e) {
             System.out.println(e.getMessage());
             Assert.fail();


### PR DESCRIPTION
Why I'm doing:
When using SR as the data source for the jdbc catalog, the show tables command will cause an error.
What I'm doing:
Added a check on whether the jdbc catalog data source supports partitions information tables.
Fixes #34320

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
