### PR TITLE
[Enhancement] Supports struct and null arguments in function expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/TypeManager.java
@@ -104,18 +104,25 @@ public class TypeManager {
     }
 
     private static Type getCommonStructType(StructType t1, StructType t2) {
-        if (t1.getFields().size() != t2.getFields().size()) {
-            return Type.INVALID;
-        }
         ArrayList<StructField> fields = Lists.newArrayList();
-        for (int i = 0; i < t1.getFields().size(); ++i) {
-            Type fieldCommon = getCommonSuperType(t1.getField(i).getType(), t2.getField(i).getType());
+        int maxFieldSize = Math.max(t1.getFields().size(), t2.getFields().size());
+        for (int i = 0; i < maxFieldSize; ++i) {
+            Type fieldCommon = null;
+            if (i < t1.getFields().size() && i < t2.getFields().size()) {
+                fieldCommon = getCommonSuperType(t1.getField(i).getType(), t2.getField(i).getType());
+                // default t1's field name
+                fields.add(new StructField(t1.getField(i).getName(), fieldCommon));
+            } else if (i < t1.getFields().size()) {
+                fieldCommon = t1.getField(i).getType();
+                fields.add(new StructField(t1.getField(i).getName(), fieldCommon));
+            } else {
+                fieldCommon = t2.getField(i).getType();
+                fields.add(new StructField(t2.getField(i).getName(), fieldCommon));
+            }
+
             if (!fieldCommon.isValid()) {
                 return Type.INVALID;
             }
-
-            // default t1's field name
-            fields.add(new StructField(t1.getField(i).getName(), fieldCommon));
         }
         return new StructType(fields);
     }

--- a/test/sql/test_semi/R/test_struct
+++ b/test/sql/test_semi/R/test_struct
@@ -295,3 +295,27 @@ select cast(named_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c
 -- result:
 {"a":1,"b":"2","c":3}
 -- !result
+select count(distinct if(v1>3, map1, null)) from sc2;
+-- result:
+5
+-- !result
+select count(distinct if(v1>3, null, st1)) from sc2;
+-- result:
+3
+-- !result
+select count(distinct if(v1>3, st2, null)) from sc2;
+-- result:
+5
+-- !result
+select count(distinct if(v1>2, row(v2, v3), row(v1, v2))) from t1;
+-- result:
+5
+-- !result
+select count(distinct if(v1>2, row(v2, v3), null)) from t1;
+-- result:
+3
+-- !result
+select count(distinct if(v1>2, null, row(v1, v2))) from t1;
+-- result:
+2
+-- !result

--- a/test/sql/test_semi/T/test_struct
+++ b/test/sql/test_semi/T/test_struct
@@ -74,3 +74,10 @@ select named_struct('a', st1, 'b', st2)[1].sm2 from sc2;
 
 select cast(row(1,2,3) as STRUCT<a double, b string, c BIGINT>);
 select cast(named_struct('1', 1, '2', 2, '3', 3) as STRUCT<a double, b string, c BIGINT>);
+
+select count(distinct if(v1>3, map1, null)) from sc2;
+select count(distinct if(v1>3, null, st1)) from sc2;
+select count(distinct if(v1>3, st2, null)) from sc2;
+select count(distinct if(v1>2, row(v2, v3), row(v1, v2))) from t1;
+select count(distinct if(v1>2, row(v2, v3), null)) from t1;
+select count(distinct if(v1>2, null, row(v1, v2))) from t1;


### PR DESCRIPTION
Why I'm doing:
An error is reported when the `struct` type is used with `null` as an argument to the `if` function.

```sql
MySQL [ssb]> select count(distinct if(lo_quantity > 10, row(lo_orderkey, lo_linenumber), row(lo_orderkey, lo_custkey))) from lineorder;
+-----------------------------------------------------------------------------------------------------+
| count(DISTINCT if(lo_quantity > 10, row(lo_orderkey, lo_linenumber), row(lo_orderkey, lo_custkey))) |
+-----------------------------------------------------------------------------------------------------+
|                                                                                            56772832 |
+-----------------------------------------------------------------------------------------------------+
1 row in set (3.20 sec)

MySQL [ssb]> select count(distinct if(lo_quantity > 10, row(lo_orderkey, lo_linenumber), null)) from lineorder;
ERROR 1064 (HY000): Getting analyzing error from line 1, column 22 to line 1, column 92. Detail message: No matching function with signature: if(boolean, struct<col1 int(11), col2 int(11)>, NULL_TYPE).
```
After repair:
```sql
MySQL [ssb]> select count(distinct if(lo_quantity > 10, row(lo_orderkey, lo_linenumber), null)) from lineorder;
+-----------------------------------------------------------------------------+
| count(DISTINCT if(lo_quantity > 10, row(lo_orderkey, lo_linenumber), NULL)) |
+-----------------------------------------------------------------------------+
|                                                                    48465645 |
+-----------------------------------------------------------------------------+
1 row in set (3.36 sec)
```

What I'm doing:
In the `resolveArgTypes` method, `fn.getArgs()` if the type is `AnyStructType` and `inputArgTypes` is `NULL_TYPE`, `resolvedTypes` will be converted to `StructType(boolean)`. This causes the struct common type to return `type.invalid`, resulting in an error.
So I modified the struct common type logic, regardless of the length of the struct, to support `null` scenarios.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
