### PR TITLE
[BugFix] Support union rewrite by pulling up query's extra predicates

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -93,6 +93,7 @@ public class MvRewritePreprocessor {
                     Config.enable_experimental_mv,
                     connectContext.getSessionVariable().isEnableMaterializedViewRewrite(),
                     context.getOptimizerConfig().isRuleBased());
+            logMVPrepare(connectContext, "QueryID:", context.getQueryId());
             try {
                 Set<MaterializedView> relatedMVs =
                         getRelatedMVs(connectContext, queryTables, context.getOptimizerConfig().isRuleBased());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -55,12 +55,11 @@ public class OptimizerTraceUtil {
         MaterializationContext mvContext = mvRewriteContext.getMaterializationContext();
         Tracers.log(Tracers.Module.MV, input -> {
             Object[] args = new Object[] {
-                    mvContext.getOptimizerContext().getQueryId(),
                     mvRewriteContext.getRule().type().name(),
                     mvContext.getMv().getName(),
                     MessageFormatter.arrayFormat(format, object).getMessage()
             };
-            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {} {} {}] {}", args).getMessage();
+            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {} {}] {}", args).getMessage();
         });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -481,7 +481,6 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         }
         OptExpression result = createNewAggregate(rewriteContext, queryAgg, newAggregations, aggregateMapping,
                 unionExpr, newProjection);
-
         if (rewriteContext.getUnionRewriteQueryExtraPredicate() != null) {
             LogicalFilterOperator filter =
                     new LogicalFilterOperator(rewriteContext.getUnionRewriteQueryExtraPredicate());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -42,6 +42,9 @@ public class MVColumnPruner {
     private ColumnRefSet requiredOutputColumns;
 
     public OptExpression pruneColumns(OptExpression queryExpression) {
+        if (queryExpression.getOp() instanceof LogicalFilterOperator) {
+            queryExpression = queryExpression.inputAt(0);
+        }
         Projection projection = queryExpression.getOp().getProjection();
         // OptExpression after mv rewrite must have projection.
         Preconditions.checkState(projection != null);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1555,7 +1555,9 @@ public class MaterializedViewRewriter {
         PredicateSplit mvPredicateSplit = rewriteContext.getMvPredicateSplit();
         PredicateSplit queryPredicateSplit = rewriteContext.getQueryPredicateSplit();
         Set<ColumnRefOperator> mvPredicateUsedColRefs = Utils.compoundAnd(mvPredicateSplit.getPredicates())
-                .getColumnRefs().stream().collect(Collectors.toSet());
+                .getColumnRefs().stream()
+                .map(colRef -> (ColumnRefOperator) columnRewriter.rewriteViewToQuery(colRef))
+                .collect(Collectors.toSet());
 
         // filter out query's predicates that its column refs are not contained in mv's predicate:
         // when column ref is not contained in mv's predicates, query's predicate cannot be rewritten.
@@ -1623,7 +1625,6 @@ public class MaterializedViewRewriter {
         final PredicateSplit mvCompensationToQuery = getUnionRewriteQueryCompensation(rewriteContext,
                 columnRewriter);
         if (mvCompensationToQuery == null) {
-            // filter all predicates that
             logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot get compensation from view to query");
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
@@ -67,6 +67,10 @@ public class PredicateSplit {
         return Lists.newArrayList(equalPredicates, rangePredicates, residualPredicates);
     }
 
+    public List<ScalarOperator> getNonEqualPredicates() {
+        return Lists.newArrayList(rangePredicates, residualPredicates);
+    }
+
     // split predicate into three parts: equal columns predicates, range predicates, and residual predicates
     public static PredicateSplit splitPredicate(ScalarOperator predicate) {
         if (predicate == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
@@ -67,10 +67,6 @@ public class PredicateSplit {
         return Lists.newArrayList(equalPredicates, rangePredicates, residualPredicates);
     }
 
-    public List<ScalarOperator> getNonEqualPredicates() {
-        return Lists.newArrayList(rangePredicates, residualPredicates);
-    }
-
     // split predicate into three parts: equal columns predicates, range predicates, and residual predicates
     public static PredicateSplit splitPredicate(ScalarOperator predicate) {
         if (predicate == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/RewriteContext.java
@@ -28,7 +28,7 @@ import java.util.Set;
 
 public class RewriteContext {
     private final OptExpression queryExpression;
-    private final PredicateSplit queryPredicateSplit;
+    private PredicateSplit queryPredicateSplit;
     private EquivalenceClasses queryEquivalenceClasses;
     // key is table relation id
     private final Map<Integer, Map<String, ColumnRefOperator>> queryRelationIdToColumns;
@@ -41,10 +41,10 @@ public class RewriteContext {
     private final ColumnRefFactory mvRefFactory;
     private EquivalenceClasses queryBasedViewEquivalenceClasses;
     private final ReplaceColumnRefRewriter mvColumnRefRewriter;
-
     private final Map<ColumnRefOperator, ColumnRefOperator> outputMapping;
     private final Set<ColumnRefOperator> queryColumnSet;
     private BiMap<Integer, Integer> queryToMvRelationIdMapping;
+    private ScalarOperator unionRewriteQueryExtraPredicate;
 
     public RewriteContext(OptExpression queryExpression,
                           PredicateSplit queryPredicateSplit,
@@ -88,6 +88,10 @@ public class RewriteContext {
 
     public PredicateSplit getQueryPredicateSplit() {
         return queryPredicateSplit;
+    }
+
+    public void setQueryPredicateSplit(PredicateSplit queryPredicateSplit) {
+        this.queryPredicateSplit = queryPredicateSplit;
     }
 
     public EquivalenceClasses getQueryEquivalenceClasses() {
@@ -148,5 +152,13 @@ public class RewriteContext {
 
     public Map<ColumnRefOperator, ScalarOperator> getMVColumnRefToScalarOp() {
         return MvUtils.getColumnRefMap(getMvExpression(), getMvRefFactory());
+    }
+
+    public ScalarOperator getUnionRewriteQueryExtraPredicate() {
+        return unionRewriteQueryExtraPredicate;
+    }
+
+    public void setUnionRewriteQueryExtraPredicate(ScalarOperator unionRewriteQueryExtraPredicate) {
+        this.unionRewriteQueryExtraPredicate = unionRewriteQueryExtraPredicate;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -46,6 +46,8 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class MaterializedViewTestBase extends PlanTestBase {
     protected static final Logger LOG = LogManager.getLogger(MaterializedViewTestBase.class);
@@ -278,7 +280,7 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 LOG.warn("test rewrite failed:", e);
                 this.exception = e;
             } finally {
-                if (Strings.isNullOrEmpty(traceLogModule)) {
+                if (!Strings.isNullOrEmpty(traceLogModule)) {
                     System.out.println(traceLog);
                 }
                 if (mv != null && !mv.isEmpty()) {
@@ -327,15 +329,35 @@ public class MaterializedViewTestBase extends PlanTestBase {
             return this;
         }
 
-        public MVRewriteChecker contains(String expect) {
+        private MVRewriteChecker contains(String expect, boolean isIgnoreColRef) {
             Assert.assertTrue(this.rewritePlan != null);
-            boolean contained = this.rewritePlan.contains(expect);
+            boolean contained = false;
+            if (isIgnoreColRef) {
+                expect = Stream.of(expect.split("\n")).filter(s -> !s.contains("tabletList"))
+                        .map(str -> str.replaceAll("\\d+", "").trim())
+                        .collect(Collectors.joining("\n"));
+                String actual = Stream.of(this.rewritePlan.split("\n")).filter(s -> !s.contains("tabletList"))
+                        .map(str -> str.replaceAll("\\d+", "").trim())
+                        .collect(Collectors.joining("\n"));
+                contained = actual.contains(expect);
+            } else {
+                contained = this.rewritePlan.contains(expect);
+            }
+
             if (!contained) {
                 LOG.warn("rewritePlan: \n{}", rewritePlan);
                 LOG.warn("expect: \n{}", expect);
             }
             Assert.assertTrue(contained);
             return this;
+        }
+
+        public MVRewriteChecker containsIgnoreColRefs(String expect) {
+            return contains(expect, true);
+        }
+
+        public MVRewriteChecker contains(String expect) {
+            return contains(expect, false);
         }
 
         public MVRewriteChecker notContain(String expect) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -174,10 +174,14 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     PREDICATES: 9: c2 >= 2000\n" +
                         "     partitions=5/5");
 
+        setTracLogModule("MV");
         sql("select c1, c3, c2 from test_base_part where c2 < 3000 and c3 < 3000")
-                .contains("PREDICATES: 2: c2 < 3000\n" +
-                        "     partitions=5/5\n" +
-                        "     rollup: test_base_part");
+                .contains("partial_mv_6")
+                .contains("TABLE: test_base_part\n" +
+                        "     PREAGGREGATION: ON\n" +
+                        "     PREDICATES: 9: c2 < 3000, 9: c2 >= 2000\n" +
+                        "     partitions=5/5");
+        setTracLogModule("");
 
         // test query delta
         sql("select c1, c3, c2 from test_base_part where c2 < 1000 and c3 < 1000")
@@ -259,30 +263,19 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     rollup: partial_mv_6\n" +
                         "     tabletRatio=6/6");
 
-        // test union all
         // TODO: MV can be rewritten but cannot bingo(because cost?)!
-        /*
+        // test union all
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         sql(
                 " select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
                         " inner join test_base_part2 t2 \n" +
                         " on t1.c1 = t2.c1 and t1.c3=t2.c3 \n" +
                         " where t1.c3 < 3000")
-                .contains("TABLE: test_base_part\n" +
+                .contains("UNION")
+                .contains("7:OlapScanNode\n" +
+                        "     TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 3: c3 < 3000\n" +
-                        "     partitions=5/5\n" +
-                        "     rollup: test_base_part\n" +
-                        "     tabletRatio=10/10")
-                .contains("OlapScanNode\n" +
-                        "     TABLE: test_base_part2\n" +
-                        "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 7: c3 < 3000\n" +
-                        "     partitions=5/5\n" +
-                        "     rollup: test_base_part2\n" +
-                        "     tabletRatio=10/10");
-
-
-         */
+                        "     partitions=4/5");
         sql(
                 " select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
                         " inner join test_base_part2 t2 \n" +
@@ -296,6 +289,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     PREDICATES: 15: c1 IS NOT NULL, 16: c3 IS NOT NULL\n" +
                         "     partitions=1/5");
 
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView("partial_mv_6");
     }
 
@@ -359,32 +353,20 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     partitions=1/1");
 
         // test union all
-        // TODO: MV can be rewritten but cannot bingo(because cost?)!
-        /*
-        sql(
-                " select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
-                        " inner join test_base_part2 t2 \n" +
-                        " on t1.c1 = t2.c1 and t1.c3=t2.c3 \n" +
-                        " where t1.c3 < 3000")
-                .contains("TABLE: test_base_part\n" +
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        sql(" select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
+                " inner join test_base_part2 t2 \n" +
+                " on t1.c1 = t2.c1 and t1.c3=t2.c3 \n" +
+                " where t1.c3 < 3000")
+                .contains("UNION")
+                .contains("7:OlapScanNode\n" +
+                        "     TABLE: partial_mv_6\n" +
                         "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 3: c3 < 3000\n" +
-                        "     partitions=5/5\n" +
-                        "     rollup: test_base_part\n" +
-                        "     tabletRatio=10/10")
-                .contains("TABLE: test_base_part2\n" +
-                        "     PREAGGREGATION: ON\n" +
-                        "     PREDICATES: 7: c3 < 3000\n" +
-                        "     partitions=5/5\n" +
-                        "     rollup: test_base_part2\n" +
-                        "     tabletRatio=10/10");
+                        "     partitions=1/1");
 
-         */
-
-        sql(
-                " select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
-                        " inner join test_base_part2 t2 \n" +
-                        " on t1.c1=t2.c1 and t1.c3=t2.c3 ")
+        sql(" select t1.c1, t1.c3, t2.c2 from test_base_part t1 \n" +
+                " inner join test_base_part2 t2 \n" +
+                " on t1.c1=t2.c1 and t1.c3=t2.c3 ")
                 .contains("TABLE: test_base_part\n" +
                         "     PREAGGREGATION: ON\n" +
                         "     PREDICATES: 15: c1 IS NOT NULL, 16: c3 IS NOT NULL\n" +
@@ -395,6 +377,7 @@ public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase 
                         "     PREDICATES: 19: c1 IS NOT NULL, 21: c3 IS NOT NULL\n" +
                         "     partitions=1/5");
 
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView("partial_mv_6");
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -908,6 +908,40 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
             PlanTestBase.assertNotContains(plan, "test_mv1");
         }
 
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-02') " +
+                "end ('2023-08-03') force with sync mode");
+        partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803"), partitions);
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "3:IcebergScanNode\n" +
+                    "     TABLE: part_tbl1\n" +
+                    "     PREDICATES: 19: d >= '2023-08-01'");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d in ('2023-08-01', '2023-08-02') " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
         starRocksAssert.dropMaterializedView(mvName);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -741,6 +741,194 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     }
 
     @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_ExtraCompensate() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(b) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+        connectContext.getSessionVariable().setFollowerQueryForwardMode("force");
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            System.out.println(plan);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            System.out.println(plan);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null and t2.b in ('xxx') " +
+                    " and t3.c in ('xxx') " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            System.out.println(plan);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_LeftJoin_ExtraCompensate() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(b) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+        connectContext.getSessionVariable().setFollowerQueryForwardMode("force");
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            System.out.println(plan);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            System.out.println(plan);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null and t2.b in ('xxx') " +
+                    " and t3.c in ('xxx') " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            System.out.println(plan);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+    
+    @Test
     public void testStr2DateMVRefreshRewriteInnerJoinAggregatePartialRefreshUnion() throws Exception {
         String mvName = "test_mv1";
         starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -789,7 +789,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " where t1.d>='2023-08-01' " +
                     " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
@@ -805,7 +804,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
                     " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
@@ -823,7 +821,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " and t3.c in ('xxx') " +
                     " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
@@ -831,6 +828,166 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     partitions=1/1\n" +
                     "     rollup: test_mv1");
         }
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_LeftJoin_OnPredicates_ExtraCompensate() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(b) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d in ('2023-08-01', '2023-08-02') " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewrite_InnerJoin_OnPredicates_ExtraCompensate() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(b) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select  t1.d, t2.b, t3.c, count(t1.a) " +
+                " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
+                " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                " group by t1.d, t2.b, t3.c;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b is not null " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d>='2023-08-01' " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
+        {
+            String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
+                    " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d and t2.b != '' " +
+                    " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
+                    " where t1.d in ('2023-08-01', '2023-08-02') " +
+                    " group by t1.d, t2.b, t3.c;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "test_mv1");
+        }
+
         starRocksAssert.dropMaterializedView(mvName);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -927,7 +927,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         }
         starRocksAssert.dropMaterializedView(mvName);
     }
-    
+
     @Test
     public void testStr2DateMVRefreshRewriteInnerJoinAggregatePartialRefreshUnion() throws Exception {
         String mvName = "test_mv1";


### PR DESCRIPTION
Why I'm doing:

- it cannot be rewritten for query below:
```
-- MV
create materialized view ? 
partition by str2date(d,'%Y-%m-%d') 
distributed by hash(b) 
REFRESH DEFERRED MANUAL 
PROPERTIES (
'replication_num' = '1'
) 
as select  t1.d, t2.b, t3.c, count(t1.a) 
 from  iceberg0.partitioned_db.part_tbl1 as t1 
 left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d 
 left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d 
 group by t1.d, t2.b, t3.c;

-- refresh mv by using dt='2023-08-01'

-- Query: can rewrite 
select * (
select  t1.d, t2.b, t3.c, count(t1.a) 
 from  iceberg0.partitioned_db.part_tbl1 as t1 
 left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d 
 left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d 
 where t1.d>='2023-08-01' 
 and t3.c in ('xxx') 
 group by t1.d, t2.b, t3.c
) x where t2.b != '' and t2.b is not null and t2.b in ('xxx') ;

-- Query: cannot rewrite
select  t1.d, t2.b, t3.c, count(t1.a) 
 from  iceberg0.partitioned_db.part_tbl1 as t1 
 left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d 
 left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d 
 where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null and t2.b in ('xxx') 
 and t3.c in ('xxx') 
 group by t1.d, t2.b, t3.c;
```

What I'm doing:
- Try to  pull up query's extra predicates from original query predicates if query based mv compensate failed.
- Predicates that can be pulled up:
  - predicates that are not contained in mv's predicates
  - predicates that are not contained in the query's non-(inner/cross)join predicates

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
