### PR TITLE
[BugFix] fix constant check issue in RewriteSumByAssociativeRule

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/RewriteSumByAssociativeRule.java
@@ -229,7 +229,8 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
                             List<ScalarOperator> arguments = callOperator.getArguments();
                             Preconditions.checkState(arguments.size() == 2);
                             // there is at least one constant in arguments
-                            if (arguments.get(0).isConstant() || arguments.get(1).isConstant()) {
+                            if (arguments.get(0) instanceof ConstantOperator ||
+                                    arguments.get(1) instanceof ConstantOperator) {
                                 // sometimes expr need to be cast before evaluating ADD/SUB operation.
                                 // for example, suppose the type of expr is SMALLINT,
                                 // sum(expr + 1) will translate to sum(add(cast(expr as INT), 1)),
@@ -237,6 +238,7 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
                                 // we can remove it and get sum(expr) + count() * 1
                                 ScalarOperator newArg0 = rewriteCastForAggExpr(arguments.get(0));
                                 ScalarOperator newArg1 = rewriteCastForAggExpr(arguments.get(1));
+                                // @TODO what if cast cannot evaul on FE
 
                                 ScalarOperator agg0 = createNewAggFunction(
                                         newArg0, newArg1, aggFunction.getType());
@@ -305,7 +307,7 @@ public class RewriteSumByAssociativeRule extends TransformationRule {
         }
 
         private ScalarOperator createNewAggFunction(ScalarOperator arg0, ScalarOperator arg1, Type returnType) {
-            if (arg0.isConstant()) {
+            if (arg0 instanceof ConstantOperator) {
                 // generate count(arg1) * arg0
                 List<ScalarOperator> countArguments = Lists.newArrayList(createColumnRefForAggArgument(arg1));
                 List<Type> argTypes = Lists.newArrayList(arg1.getType());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/AggregateTest.java
@@ -2037,6 +2037,11 @@ public class AggregateTest extends PlanTestBase {
                 "args: SMALLINT; result: BIGINT; args nullable: true; result nullable: true]\n" +
                 "  |  hasNullableGenerateChild: true");
 
+        sql = "select sum(cast(t1b as int) + cast('1.1' as int)) from test_all_type";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "  2:AGGREGATE (update finalize)\n" +
+                "  |  aggregate: sum[(cast([2: t1b, SMALLINT, true] as BIGINT) + cast(cast('1.1' as INT) as BIGINT)); " +
+                "args: BIGINT; result: BIGINT; args nullable: true; result nullable: true]");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:

in RewriteSumByAssociativeRule, we use `ScalarOperator::isConstant` to check if one of the arguments of `sum(arg0 + arg1)` is constant, and rewrite it to `sum(arg0) + count() * arg1` if arg1 is constant.

when rewriting happens, we will create some const operator from the string representation of arg1, like the following
![image](https://github.com/StarRocks/starrocks/assets/3675229/cb1d4c6f-94cb-4217-a687-7d78ff6cf52f)



for some cast operator like `cast(1.1 as INT)`, `isConstant` returns true but it cannot be evaluated in FE, if we create a const operator from its string representation, an exception happens.

so we should use `instance of ConstantOperator` to check if it is constant.

What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/3274

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
