### PR TITLE
[Enhancement] cache iceberg scan task schema to reduce 'toJson' cost

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AlreadyExistsException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.connector.ConnectorMetadata;
@@ -90,6 +91,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -119,6 +121,9 @@ public class IcebergMetadata implements ConnectorMetadata {
     private final Map<String, Database> databases = new ConcurrentHashMap<>();
     private final Map<IcebergFilter, List<FileScanTask>> splitTasks = new ConcurrentHashMap<>();
     private final Set<IcebergFilter> scannedTables = new HashSet<>();
+
+    // FileScanTaskSchema -> Pair<schemaId, specId>
+    private final Map<FileScanTaskSchema, Pair<String, String>> fileScanTaskSchemas = new ConcurrentHashMap<>();
 
     public IcebergMetadata(String catalogName, HdfsEnvironment hdfsEnvironment, IcebergCatalog icebergCatalog) {
         this.catalogName = catalogName;
@@ -429,7 +434,7 @@ public class IcebergMetadata implements ConnectorMetadata {
 
             FileScanTask icebergSplitScanTask = scanTask;
             if (enableCollectColumnStatistics()) {
-                icebergSplitScanTask = buildIcebergSplitScanTask(scanTask, icebergPredicate);
+                icebergSplitScanTask = buildIcebergSplitScanTask(scanTask, icebergPredicate, key);
             }
             icebergScanTasks.add(icebergSplitScanTask);
 
@@ -488,16 +493,31 @@ public class IcebergMetadata implements ConnectorMetadata {
         return statisticProvider.getTableStatistics(icebergTable, columns, session, predicate);
     }
 
-    private IcebergSplitScanTask buildIcebergSplitScanTask(FileScanTask fileScanTask, Expression icebergPredicate) {
+    private IcebergSplitScanTask buildIcebergSplitScanTask(
+            FileScanTask fileScanTask, Expression icebergPredicate, IcebergFilter filter) {
         long offset = fileScanTask.start();
         long length = fileScanTask.length();
         DataFile dataFileWithoutStats = fileScanTask.file().copyWithoutStats();
         DeleteFile[] deleteFiles = fileScanTask.deletes().stream()
                 .map(DeleteFile::copyWithoutStats)
                 .toArray(DeleteFile[]::new);
-        String schemaString = SchemaParser.toJson(fileScanTask.spec().schema());
-        String partitionString = PartitionSpecParser.toJson(fileScanTask.spec());
-        ResidualEvaluator residualEvaluator = ResidualEvaluator.of(fileScanTask.spec(), icebergPredicate, true);
+
+        PartitionSpec taskSpec = fileScanTask.spec();
+        Schema taskSchema = fileScanTask.spec().schema();
+        String schemaString;
+        String partitionString;
+        FileScanTaskSchema schemaKey = new FileScanTaskSchema(filter, taskSchema.schemaId(), taskSpec.specId());
+        Pair<String, String> schema = fileScanTaskSchemas.get(schemaKey);
+        if (schema == null) {
+            schemaString = SchemaParser.toJson(fileScanTask.spec().schema());
+            partitionString = PartitionSpecParser.toJson(fileScanTask.spec());
+            fileScanTaskSchemas.put(schemaKey, Pair.create(schemaString, partitionString));
+        } else {
+            schemaString = schema.first;
+            partitionString = schema.second;
+        }
+
+        ResidualEvaluator residualEvaluator = ResidualEvaluator.of(taskSpec, icebergPredicate, true);
 
         BaseFileScanTask baseFileScanTask = new BaseFileScanTask(
                 dataFileWithoutStats,
@@ -767,5 +787,34 @@ public class IcebergMetadata implements ConnectorMetadata {
     @Override
     public CloudConfiguration getCloudConfiguration() {
         return hdfsEnvironment.getCloudConfiguration();
+    }
+
+    private static class FileScanTaskSchema {
+        private final IcebergFilter icebergFilter;
+        private final int schemaId;
+        private final int specId;
+
+        public FileScanTaskSchema(IcebergFilter icebergFilter, int schemaId, int specId) {
+            this.icebergFilter = icebergFilter;
+            this.schemaId = schemaId;
+            this.specId = specId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            FileScanTaskSchema that = (FileScanTaskSchema) o;
+            return schemaId == that.schemaId && specId == that.specId && Objects.equals(icebergFilter, that.icebergFilter);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(icebergFilter, schemaId, specId);
+        }
     }
 }


### PR DESCRIPTION
Why I'm doing:
Each file to read will to do `SchemaParser.toJson` and `PartitionSpecParser.toJson` when iceberg job planning with column statistics. The cost is relatively high, we need to reduce the time.

What I'm doing:
reduce iceberg job planning cost.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
