### PR TITLE
[Enhancement] Supports runtime modification of some BE and Starlet params

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -177,9 +177,8 @@ void AgentServer::Impl::init_or_die() {
         BUILD_DYNAMIC_TASK_THREAD_POOL("drop", 1, config::drop_tablet_worker_count, std::numeric_limits<int>::max(),
                                        _thread_pool_drop);
 
-        BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", config::create_tablet_worker_count,
-                                       config::create_tablet_worker_count, std::numeric_limits<int>::max(),
-                                       _thread_pool_create_tablet);
+        BUILD_DYNAMIC_TASK_THREAD_POOL("create_tablet", 1, config::create_tablet_worker_count,
+                                       std::numeric_limits<int>::max(), _thread_pool_create_tablet);
 
         BUILD_DYNAMIC_TASK_THREAD_POOL("alter_tablet", 0, config::alter_tablet_worker_count,
                                        std::numeric_limits<int>::max(), _thread_pool_alter_tablet);

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -84,7 +84,7 @@ CONF_Int32(heartbeat_service_port, "9050");
 // The count of heart beat service.
 CONF_Int32(heartbeat_service_thread_count, "1");
 // The count of thread to create table.
-CONF_Int32(create_tablet_worker_count, "3");
+CONF_mInt32(create_tablet_worker_count, "3");
 // The count of thread to drop table.
 CONF_mInt32(drop_tablet_worker_count, "3");
 // The count of thread to batch load.
@@ -362,7 +362,7 @@ CONF_mInt32(periodic_counter_update_period_ms, "500");
 CONF_Int64(load_data_reserve_hours, "4");
 // log error log will be removed after this time
 CONF_mInt64(load_error_log_reserve_hours, "48");
-CONF_Int32(number_tablet_writer_threads, "16");
+CONF_mInt32(number_tablet_writer_threads, "16");
 CONF_mInt64(max_queueing_memtable_per_tablet, "2");
 // when memory limit exceed and memtable last update time exceed this time, memtable will be flushed
 CONF_mInt64(stale_memtable_flush_time_sec, "30");
@@ -688,7 +688,7 @@ CONF_mBool(enable_bitmap_union_disk_format_with_set, "false");
 
 // The number of scan threads pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_thread_num, "0");
-CONF_Double(pipeline_connector_scan_thread_num_per_cpu, "8");
+CONF_mDouble(pipeline_connector_scan_thread_num_per_cpu, "8");
 // Queue size of scan thread pool for pipeline engine.
 CONF_Int64(pipeline_scan_thread_pool_queue_size, "102400");
 // The number of execution threads for pipeline engine.
@@ -869,22 +869,22 @@ CONF_String(query_debug_trace_dir, "${STARROCKS_HOME}/query_debug_trace");
 
 #ifdef USE_STAROS
 CONF_Int32(starlet_port, "9070");
-CONF_Int32(starlet_cache_thread_num, "64");
+CONF_mInt32(starlet_cache_thread_num, "64");
 // Root dir used for cache if cache enabled.
 CONF_String(starlet_cache_dir, "");
 // Cache backend check interval (in seconds), for async write sync check and ttl clean, e.t.c.
 CONF_Int32(starlet_cache_check_interval, "900");
 // Cache backend cache evictor interval (in seconds)
-CONF_Int32(starlet_cache_evict_interval, "60");
+CONF_mInt32(starlet_cache_evict_interval, "60");
 // Cache will start evict cache files if free space belows this value(percentage)
-CONF_Double(starlet_cache_evict_low_water, "0.1");
+CONF_mDouble(starlet_cache_evict_low_water, "0.1");
 // Cache will stop evict cache files if free space is above this value(percentage)
-CONF_Double(starlet_cache_evict_high_water, "0.2");
+CONF_mDouble(starlet_cache_evict_high_water, "0.2");
 // type:Integer. cache directory allocation policy. (0:default, 1:random, 2:round-robin)
 CONF_Int32(starlet_cache_dir_allocate_policy, "0");
 // Buffer size in starlet fs buffer stream, size <= 0 means not use buffer stream.
 // Only support in S3/HDFS currently.
-CONF_Int32(starlet_fs_stream_buffer_size_bytes, "131072");
+CONF_mInt32(starlet_fs_stream_buffer_size_bytes, "131072");
 CONF_mBool(starlet_use_star_cache, "false");
 // TODO: support runtime change
 CONF_Int32(starlet_star_cache_mem_size_percent, "0");
@@ -898,9 +898,9 @@ CONF_Int32(starlet_s3_client_max_cache_capacity, "8");
 // number of instances per cache item
 CONF_Int32(starlet_s3_client_num_instances_per_cache, "1");
 // whether turn on read prefetch feature
-CONF_Bool(starlet_fs_read_prefetch_enable, "false");
+CONF_mBool(starlet_fs_read_prefetch_enable, "false");
 // prefetch threadpool size
-CONF_Int32(starlet_fs_read_prefetch_threadpool_size, "128");
+CONF_mInt32(starlet_fs_read_prefetch_threadpool_size, "128");
 #endif
 
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -44,8 +44,10 @@
 #include "agent/agent_common.h"
 #include "agent/agent_server.h"
 #include "common/configbase.h"
+#include "common/gflags_utils.h"
 #include "common/logging.h"
 #include "common/status.h"
+#include "exec/workgroup/scan_executor.h"
 #include "gutil/strings/substitute.h"
 #include "http/http_channel.h"
 #include "http/http_headers.h"
@@ -61,6 +63,7 @@
 #include "storage/segment_replicate_executor.h"
 #include "storage/storage_engine.h"
 #include "storage/update_manager.h"
+#include "util/bthreads/executor.h"
 #include "util/priority_thread_pool.hpp"
 
 #ifdef USE_STAROS
@@ -171,6 +174,61 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::RELEASE_SNAPSHOT);
             (void)thread_pool->update_max_threads(config::release_snapshot_worker_count);
         });
+        _config_callback.emplace("pipeline_connector_scan_thread_num_per_cpu", [&]() {
+            LOG(INFO) << "set pipeline_connector_scan_thread_num_per_cpu:"
+                      << config::pipeline_connector_scan_thread_num_per_cpu;
+            ExecEnv::GetInstance()->connector_scan_executor()->change_num_threads(
+                    config::pipeline_connector_scan_thread_num_per_cpu);
+        });
+        _config_callback.emplace("create_tablet_worker_count", [&]() {
+            LOG(INFO) << "set create_tablet_worker_count:" << config::create_tablet_worker_count;
+            auto thread_pool = ExecEnv::GetInstance()->agent_server()->get_thread_pool(TTaskType::CREATE);
+            (void)thread_pool->update_max_threads(config::create_tablet_worker_count);
+        });
+        _config_callback.emplace("number_tablet_writer_threads", [&]() {
+            LOG(INFO) << "set number_tablet_writer_threads:" << config::number_tablet_writer_threads;
+            bthreads::ThreadPoolExecutor* executor = static_cast<bthreads::ThreadPoolExecutor*>(
+                    StorageEngine::instance()->async_delta_writer_executor());
+            (void)executor->get_thread_pool()->update_max_threads(config::number_tablet_writer_threads);
+        });
+#ifdef USE_STAROS
+        _config_callback.emplace("starlet_cache_thread_num", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_threadpool_size", value).empty()) {
+                LOG(WARNING) << "Failed to update cachemgr_threadpool_size";
+            }
+        });
+        _config_callback.emplace("starlet_cache_evict_low_water", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_low_water", value).empty()) {
+                LOG(WARNING) << "Failed to update cachemgr_evict_low_water";
+            }
+        });
+        _config_callback.emplace("starlet_cache_evict_high_water", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_high_water", value).empty()) {
+                LOG(WARNING) << "Failed to update cachemgr_evict_high_water";
+            }
+        });
+        _config_callback.emplace("starlet_fs_stream_buffer_size_bytes", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_stream_buffer_size_bytes", value).empty()) {
+                LOG(WARNING) << "Failed to update fs_stream_buffer_size_bytes";
+            }
+        });
+        _config_callback.emplace("starlet_fs_read_prefetch_enable", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_enable_buffer_prefetch", value).empty()) {
+                LOG(WARNING) << "Failed to update fs_enable_buffer_prefetch";
+            }
+        });
+        _config_callback.emplace("starlet_fs_read_prefetch_threadpool_size", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_buffer_prefetch_threadpool_size", value)
+                        .empty()) {
+                LOG(WARNING) << "Failed to update fs_buffer_prefetch_threadpool_size";
+            }
+        });
+        _config_callback.emplace("starlet_cache_evict_interval", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_interval", value).empty()) {
+                LOG(WARNING) << "Failed to update cachemgr_evict_interval";
+            }
+        });
+#endif // USE_STAROS
     });
 
     Status s = config::set_config(name, value);

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -21,6 +21,7 @@
 
 #include "absl/strings/str_format.h"
 #include "common/config.h"
+#include "common/gflags_utils.h"
 #include "common/logging.h"
 #include "common/shutdown_hook.h"
 #include "file_store.pb.h"
@@ -343,20 +344,28 @@ void init_staros_worker() {
     // skip staros reinit aws sdk
     staros::starlet::fslib::skip_aws_init_api = true;
 
-    FLAGS_cachemgr_threadpool_size = config::starlet_cache_thread_num;
+    staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_threadpool_size",
+                                                          std::to_string(config::starlet_cache_thread_num));
+    staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_low_water",
+                                                          std::to_string(config::starlet_cache_evict_low_water));
+    staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_high_water",
+                                                          std::to_string(config::starlet_cache_evict_high_water));
+    staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_stream_buffer_size_bytes",
+                                                          std::to_string(config::starlet_fs_stream_buffer_size_bytes));
+    staros::starlet::common::GFlagsUtils::UpdateFlagValue("fs_enable_buffer_prefetch",
+                                                          std::to_string(config::starlet_fs_read_prefetch_enable));
+    staros::starlet::common::GFlagsUtils::UpdateFlagValue(
+            "fs_buffer_prefetch_threadpool_size", std::to_string(config::starlet_fs_read_prefetch_threadpool_size));
+    staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_interval",
+                                                          std::to_string(config::starlet_cache_evict_interval));
+
     FLAGS_cachemgr_check_interval = config::starlet_cache_check_interval;
-    FLAGS_cachemgr_evict_interval = config::starlet_cache_evict_interval;
-    FLAGS_cachemgr_evict_low_water = config::starlet_cache_evict_low_water;
-    FLAGS_cachemgr_evict_high_water = config::starlet_cache_evict_high_water;
     FLAGS_cachemgr_dir_allocate_policy = config::starlet_cache_dir_allocate_policy;
-    FLAGS_fs_stream_buffer_size_bytes = config::starlet_fs_stream_buffer_size_bytes;
     FLAGS_fslib_s3_virtual_address_domainlist = config::starlet_s3_virtual_address_domainlist;
     // use the same configuration as the external query
     FLAGS_fslib_s3client_max_connections = config::object_storage_max_connection;
     FLAGS_fslib_s3client_max_items = config::starlet_s3_client_max_cache_capacity;
     FLAGS_fslib_s3client_max_instance_per_item = config::starlet_s3_client_num_instances_per_cache;
-    FLAGS_fs_enable_buffer_prefetch = config::starlet_fs_read_prefetch_enable;
-    FLAGS_fs_buffer_prefetch_threadpool_size = config::starlet_fs_read_prefetch_threadpool_size;
 
     fslib::FLAGS_use_star_cache = config::starlet_use_star_cache;
     fslib::FLAGS_star_cache_mem_size_percent = config::starlet_star_cache_mem_size_percent;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -207,7 +207,7 @@ Status StorageEngine::_open(const EngineOptions& options) {
 
     std::unique_ptr<ThreadPool> thread_pool;
     RETURN_IF_ERROR(ThreadPoolBuilder("delta_writer")
-                            .set_min_threads(config::number_tablet_writer_threads / 2)
+                            .set_min_threads(1)
                             .set_max_threads(std::max<int>(1, config::number_tablet_writer_threads))
                             .set_max_queue_size(40960 /*a random chosen number that should big enough*/)
                             .set_idle_timeout(MonoDelta::FromMilliseconds(/*5 minutes=*/5 * 60 * 1000))


### PR DESCRIPTION
## Why I'm doing:
Some BE and Starlet parameters cannot be modified in runtime and are inconvenient to use.

## What I'm doing:
The supported parameters are as follows:
Four BE parameters:
1. pipeline_connector_scan_thread_num_per_cpu
2. disable_column_pool
3. create_tablet_worker_count
4. number_tablet_writer_threads

Seven Starlet parameters:
1. starlet_cache_thread_num
2. starlet_cache_evict_low_water
3. starlet_cache_evict_high_water
4. starlet_fs_stream_buffer_size_bytes
5. starlet_fs_read_prefetch_enable
6. starlet_fs_read_prefetch_threadpool_size
7. starlet_cache_evict_interval

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
