### PR TITLE
[UT] Fix primary key backup table ut

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/common/util/UnitTestUtil.java
@@ -91,6 +91,90 @@ public class UnitTestUtil {
         return db;
     }
 
+    public static Database createDbByName(long dbId, long tableId, long partitionId, long indexId,
+                                    long tabletId, long backendId, long version, KeysType type, String dbName,
+                                    String tableName) {
+        // GlobalStateMgr.getCurrentInvertedIndex().clear();
+
+        // table
+        OlapTable table = createOlapTableByName(dbId, tableId, partitionId, indexId, tabletId,
+                backendId, version, type, Table.TableType.OLAP, tableName);
+
+        // db
+        Database db = new Database(dbId, dbName);
+        db.registerTableUnlocked(table);
+        return db;
+    }
+
+    public static OlapTable createOlapTableByName(long dbId, long tableId, long partitionId, long indexId,
+                                            long tabletId, long backendId, long version, KeysType type,
+                                            Table.TableType tableType, String tableName) {
+        // replica
+        long replicaId = 0;
+        Replica replica1 = new Replica(replicaId, backendId, ReplicaState.NORMAL, version, 0);
+        Replica replica2 = new Replica(replicaId + 1, backendId + 1, ReplicaState.NORMAL, version, 0);
+        Replica replica3 = new Replica(replicaId + 2, backendId + 2, ReplicaState.NORMAL, version, 0);
+
+        // tablet
+        LocalTablet tablet = new LocalTablet(tabletId);
+
+        // index
+        MaterializedIndex index = new MaterializedIndex(indexId, IndexState.NORMAL);
+        TabletMeta tabletMeta = new TabletMeta(dbId, tableId, partitionId, indexId, 0, TStorageMedium.HDD);
+        index.addTablet(tablet, tabletMeta);
+
+        tablet.addReplica(replica1);
+        tablet.addReplica(replica2);
+        tablet.addReplica(replica3);
+
+        // partition
+        RandomDistributionInfo distributionInfo = new RandomDistributionInfo(10);
+        Partition partition = new Partition(partitionId, PARTITION_NAME, index, distributionInfo);
+
+        // columns
+        List<Column> columns = new ArrayList<Column>();
+        Column temp = new Column("k1", Type.INT);
+        temp.setIsKey(true);
+        columns.add(temp);
+        temp = new Column("k2", Type.INT);
+        temp.setIsKey(true);
+        columns.add(temp);
+        columns.add(new Column("v", Type.DOUBLE, false, AggregateType.SUM, "0", ""));
+
+        List<Column> keysColumn = new ArrayList<Column>();
+        temp = new Column("k1", Type.INT);
+        temp.setIsKey(true);
+        keysColumn.add(temp);
+        temp = new Column("k2", Type.INT);
+        temp.setIsKey(true);
+        keysColumn.add(temp);
+
+        // table
+        PartitionInfo partitionInfo = new SinglePartitionInfo();
+        partitionInfo.setDataProperty(partitionId, DataProperty.DEFAULT_DATA_PROPERTY);
+        partitionInfo.setReplicationNum(partitionId, (short) 3);
+        partitionInfo.setIsInMemory(partitionId, false);
+        partitionInfo.setTabletType(partitionId, TTabletType.TABLET_TYPE_DISK);
+        if (tableType == Table.TableType.MATERIALIZED_VIEW) {
+            MaterializedView.MvRefreshScheme mvRefreshScheme = new MaterializedView.MvRefreshScheme();
+            MaterializedView mv = new MaterializedView(tableId, dbId, MATERIALIZED_VIEW_NAME, columns,
+                    type, partitionInfo, distributionInfo, mvRefreshScheme);
+            Deencapsulation.setField(mv, "baseIndexId", indexId);
+            mv.addPartition(partition);
+            mv.setIndexMeta(indexId, tableName, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
+                    type);
+            return mv;
+        } else {
+            OlapTable table = new OlapTable(tableId, tableName, columns,
+                    type, partitionInfo, distributionInfo);
+            Deencapsulation.setField(table, "baseIndexId", indexId);
+            table.addPartition(partition);
+            table.setIndexMeta(indexId, tableName, columns, 0, SCHEMA_HASH, (short) 1, TStorageType.COLUMN,
+                    type);
+            return table;
+        }
+    }
+
     public static OlapTable createOlapTable(long dbId, long tableId, long partitionId, long indexId,
                                             long tabletId, long backendId, long version, KeysType type,
                                             Table.TableType tableType) {


### PR DESCRIPTION
Why I'm doing:
The unit tests for non-PK table and PK table backup use the same label, table name, and database name, which may cause conflicts and failure in a concurrent execution environment.

What I'm doing:
change the label, table name, database name

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
