### PR TITLE
[Feature] support to iceberg caching catalog

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -1,0 +1,141 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.starrocks.catalog.Database;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+public class CachingIcebergCatalog implements IcebergCatalog {
+    private static final Logger LOG = LogManager.getLogger(CachingIcebergCatalog.class);
+    private final IcebergCatalog delegate;
+    private final Cache<TableIdentifier, Table> tables;
+    private final Map<String, Database> databases = new ConcurrentHashMap<>();
+    private final Map<TableIdentifier, List<String>> partitionNames = new ConcurrentHashMap<>();
+
+    public CachingIcebergCatalog(IcebergCatalog delegate, long ttlSec) {
+        this.delegate = delegate;
+        this.tables = CacheBuilder.newBuilder().expireAfterWrite(ttlSec, SECONDS).maximumSize(100000).build();
+    }
+
+    @Override
+    public IcebergCatalogType getIcebergCatalogType() {
+        return delegate.getIcebergCatalogType();
+    }
+
+    @Override
+    public List<String> listAllDatabases() {
+        return delegate.listAllDatabases();
+    }
+
+    public void createDb(String dbName, Map<String, String> properties) {
+        delegate.createDb(dbName, properties);
+    }
+
+    public void dropDb(String dbName) throws MetaNotFoundException {
+        delegate.dropDb(dbName);
+        databases.remove(dbName);
+    }
+
+    @Override
+    public Database getDB(String dbName) {
+        if (databases.containsKey(dbName)) {
+            return databases.get(dbName);
+        }
+        Database db;
+        try {
+            db = delegate.getDB(dbName);
+        } catch (NoSuchNamespaceException e) {
+            LOG.error("Database {} not found", dbName, e);
+            return null;
+        }
+
+        databases.put(dbName, db);
+        return db;
+    }
+
+    @Override
+    public List<String> listTables(String dbName) {
+        return delegate.listTables(dbName);
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+        TableIdentifier identifier = TableIdentifier.of(dbName, tableName);
+        if (tables.getIfPresent(identifier) != null) {
+            return tables.getIfPresent(identifier);
+        }
+
+        try {
+            Table icebergTable = delegate.getTable(dbName, tableName);
+            tables.put(identifier, icebergTable);
+            return icebergTable;
+
+        } catch (StarRocksConnectorException | NoSuchTableException e) {
+            LOG.error("Failed to get iceberg table {}", identifier, e);
+            return null;
+        }
+    }
+
+    @Override
+    public boolean createTable(String dbName,
+                               String tableName,
+                               Schema schema,
+                               PartitionSpec partitionSpec,
+                               String location,
+                               Map<String, String> properties) {
+        return delegate.createTable(dbName, tableName, schema, partitionSpec, location, properties);
+    }
+
+    @Override
+    public boolean dropTable(String dbName, String tableName, boolean purge) {
+        boolean dropped = delegate.dropTable(dbName, tableName, purge);
+        tables.invalidate(TableIdentifier.of(dbName, tableName));
+        return dropped;
+    }
+
+    @Override
+    public List<String> listPartitionNames(String dbName, String tableName) {
+        TableIdentifier identifier = TableIdentifier.of(dbName, tableName);
+        if (partitionNames.containsKey(identifier)) {
+            return partitionNames.get(identifier);
+        } else {
+            List<String> partitionNames = delegate.listPartitionNames(dbName, tableName);
+            this.partitionNames.put(identifier, partitionNames);
+            return partitionNames;
+        }
+    }
+
+    @Override
+    public void deleteUncommittedDataFiles(List<String> fileLocations) {
+        delegate.deleteUncommittedDataFiles(fileLocations);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -15,15 +15,21 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.google.common.collect.Lists;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
 
 import java.util.List;
 import java.util.Map;
+
+import static com.starrocks.connector.PartitionUtil.convertIcebergPartitionToPartitionName;
 
 public interface IcebergCatalog {
 
@@ -56,8 +62,25 @@ public interface IcebergCatalog {
 
     Table getTable(String dbName, String tableName) throws StarRocksConnectorException;
 
+    default List<String> listPartitionNames(String dbName, String tableName) {
+        org.apache.iceberg.Table icebergTable = getTable(dbName, tableName);
+        List<String> partitionNames = Lists.newArrayList();
+
+        // all partitions specs are unpartitioned
+        if (icebergTable.specs().values().stream().allMatch(PartitionSpec::isUnpartitioned)) {
+            return partitionNames;
+        }
+
+        TableScan tableScan = icebergTable.newScan();
+        List<FileScanTask> tasks = Lists.newArrayList(tableScan.planFiles());
+
+        for (FileScanTask fileScanTask : tasks) {
+            StructLike partition = fileScanTask.file().partition();
+            partitionNames.add(convertIcebergPartitionToPartitionName(fileScanTask.spec(), partition));
+        }
+        return partitionNames;
+    }
 
     default void deleteUncommittedDataFiles(List<String> fileLocations) {
     }
-
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -98,7 +98,6 @@ import java.util.stream.Collectors;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static com.starrocks.common.profile.Tracers.Module.EXTERNAL;
 import static com.starrocks.connector.ColumnTypeConverter.fromIcebergType;
-import static com.starrocks.connector.PartitionUtil.convertIcebergPartitionToPartitionName;
 import static com.starrocks.connector.PartitionUtil.createPartitionKeyWithType;
 import static com.starrocks.connector.iceberg.IcebergApiConverter.parsePartitionFields;
 import static com.starrocks.connector.iceberg.IcebergApiConverter.toIcebergApiSchema;
@@ -223,7 +222,6 @@ public class IcebergMetadata implements ConnectorMetadata {
 
     @Override
     public List<String> listPartitionNames(String dbName, String tblName) {
-        org.apache.iceberg.Table icebergTable = icebergCatalog.getTable(dbName, tblName);
         IcebergCatalogType nativeType = icebergCatalog.getIcebergCatalogType();
 
         if (nativeType != HIVE_CATALOG && nativeType != REST_CATALOG && nativeType != GLUE_CATALOG) {
@@ -231,20 +229,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                     "Do not support get partitions from catalog type: " + nativeType);
         }
 
-        List<String> partitionNames = Lists.newArrayList();
-        // all partitions specs are unpartitioned
-        if (icebergTable.specs().values().stream().allMatch(PartitionSpec::isUnpartitioned)) {
-            return partitionNames;
-        }
-
-        TableScan tableScan = icebergTable.newScan();
-        List<FileScanTask> tasks = Lists.newArrayList(tableScan.planFiles());
-
-        for (FileScanTask fileScanTask : tasks) {
-            StructLike partition = fileScanTask.file().partition();
-            partitionNames.add(convertIcebergPartitionToPartitionName(fileScanTask.spec(), partition));
-        }
-        return partitionNames;
+        return icebergCatalog.listPartitionNames(dbName, tblName);
     }
 
     @Override


### PR DESCRIPTION
Why I'm doing:
Glue getTable interface is about 100ms-200ms per call. And based on iceberg mv need to get all partition names in rewrite stage. These are more or less a small part of the cost. In some t+1 user scenarios, data updates are infrequent, we can cache iceberg tables and partitionNames. And will provide refresh capability in the next pr.

What I'm doing:
support iceberg caching catalog. or support catalog level table cache and partition names cache
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
