### PR TITLE
[Enhancement] Support bitmap binary field from hive in spark load (backport #32830)

### DIFF
--- a/docs/en/loading/SparkLoad.md
+++ b/docs/en/loading/SparkLoad.md
@@ -421,6 +421,12 @@ Currently, to use a Hive table in the import process, you need to create an exte
   
 In the load command, you can specify the required fields for building the global dictionary in the following format: `StarRocks field name=bitmap_dict(hive table field name)` Note that currently **the global dictionary is only supported when the upstream data source is a Hive table**.
 
+- **Import of bitmap binary type columns**
+
+The data type applicable to the StarRocks table aggregate column is bitmap type, and the data type of the corresponding column in the data source Hive table or HDFS file type is binary (through com.starrocks.load.loadv2.dpp.BitmapValue in spark-dpp in FE class serialization) type.
+
+There is no need to build a global dictionary, just specify the corresponding fields in the load command. The format is: ```StarRocks field name=bitmap_from_binary(Hive table field name)```
+
 ## Viewing Import Jobs
 
 The Spark load import is asynchronous, as is the broker load. The user must record the label of the import job and use it in the `SHOW LOAD` command to view the import results. The command to view the import is common to all import methods. The example is as follows.

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -269,6 +269,7 @@ public class FunctionSet {
     public static final String BITMAP_UNION_INT = "bitmap_union_int";
     public static final String INTERSECT_COUNT = "intersect_count";
     public static final String BITMAP_DICT = "bitmap_dict";
+    public static final String BITMAP_FROM_BINARY = "bitmap_from_binary";
     public static final String EXCHANGE_BYTES = "exchange_bytes";
     public static final String EXCHANGE_SPEED = "exchange_speed";
     // Array functions:

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -623,7 +623,8 @@ public class SparkLoadPendingTask extends LoadTask {
         }
 
         String msg = "BITMAP column must use bitmap function, like " + columnName + "=to_bitmap(xxx) or "
-                + columnName + "=bitmap_hash() or " + columnName + "=bitmap_dict()";
+                + columnName + "=bitmap_hash() or " + columnName + "=bitmap_dict() or "
+                + columnName + "=bitmap_from_binary()";
         if (!(expr instanceof FunctionCallExpr)) {
             throw new LoadException(msg);
         }
@@ -631,7 +632,8 @@ public class SparkLoadPendingTask extends LoadTask {
         String functionName = fn.getFnName().getFunction();
         if (!functionName.equalsIgnoreCase(FunctionSet.TO_BITMAP)
                 && !functionName.equalsIgnoreCase(FunctionSet.BITMAP_HASH)
-                && !functionName.equalsIgnoreCase(FunctionSet.BITMAP_DICT)) {
+                && !functionName.equalsIgnoreCase(FunctionSet.BITMAP_DICT)
+                && !functionName.equalsIgnoreCase(FunctionSet.BITMAP_FROM_BINARY)) {
             throw new LoadException(msg);
         }
 

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/DppUtils.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/DppUtils.java
@@ -37,6 +37,7 @@ import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.CRC32;
 
 public class DppUtils {
@@ -401,5 +402,20 @@ public class DppUtils {
                     "Reason: Fail to parse columnsFromPath, expected: " + columnsFromPath + ", filePath: " + filePath);
         }
         return Lists.newArrayList(columns);
+    }
+
+    public static StructType replaceBinaryColumnsInSchema(Set<String> binaryColumns, StructType dstSchema) {
+        List<StructField> fields = new ArrayList<>();
+        for (StructField originField : dstSchema.fields()) {
+            if (binaryColumns.contains(originField.name())) {
+                fields.add(DataTypes.createStructField(originField.name(),
+                        DataTypes.BinaryType, originField.nullable()));
+            } else {
+                fields.add(DataTypes.createStructField(originField.name(),
+                        originField.dataType(), originField.nullable()));
+            }
+        }
+        StructType ret = DataTypes.createStructType(fields);
+        return ret;
     }
 }

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkDpp.java
@@ -120,16 +120,21 @@ public final class SparkDpp implements java.io.Serializable {
     private SerializableConfiguration serializableHadoopConf;
     private DppResult dppResult = new DppResult();
     private Map<Long, Set<String>> tableToBitmapDictColumns = new HashMap<>();
+    private Map<Long, Set<String>> tableToBitmapBinaryColumns = new HashMap<>();
 
     // just for ut
     public SparkDpp() {
     }
 
-    public SparkDpp(SparkSession spark, EtlJobConfig etlJobConfig, Map<Long, Set<String>> tableToBitmapDictColumns) {
+    public SparkDpp(SparkSession spark, EtlJobConfig etlJobConfig, Map<Long, Set<String>> tableToBitmapDictColumns,
+                    Map<Long, Set<String>> tableToBinaryBitmapColumns) {
         this.spark = spark;
         this.etlJobConfig = etlJobConfig;
         if (tableToBitmapDictColumns != null) {
             this.tableToBitmapDictColumns = tableToBitmapDictColumns;
+        }
+        if (tableToBinaryBitmapColumns != null) {
+            this.tableToBitmapBinaryColumns = tableToBinaryBitmapColumns;
         }
     }
 
@@ -1175,6 +1180,7 @@ public final class SparkDpp implements java.io.Serializable {
                 Long tableId = entry.getKey();
                 EtlJobConfig.EtlTable etlTable = entry.getValue();
                 Set<String> dictBitmapColumnSet = tableToBitmapDictColumns.getOrDefault(tableId, new HashSet<>());
+                Set<String> bitmapBinaryColumnSet = tableToBitmapBinaryColumns.getOrDefault(tableId, new HashSet<>());
 
                 // get the base index meta
                 EtlJobConfig.EtlIndex baseIndex = null;
@@ -1213,7 +1219,8 @@ public final class SparkDpp implements java.io.Serializable {
                         createPartitionRangeKeys(partitionInfo, partitionKeySchema);
                 List<StarRocksListPartitioner.PartitionListKey> partitionListKeys =
                         createPartitionListKeys(partitionInfo, partitionKeySchema);
-                StructType dstTableSchema = DppUtils.createDstTableSchema(baseIndex.columns, false, false);
+                StructType dstTableSchema = DppUtils.createDstTableSchema(baseIndex.columns, false, true);
+                dstTableSchema = DppUtils.replaceBinaryColumnsInSchema(bitmapBinaryColumnSet, dstTableSchema);
                 RollupTreeBuilder rollupTreeParser = new MinimumCoverageRollupTreeBuilder();
                 RollupTreeNode rootNode = rollupTreeParser.build(etlTable);
                 LOG.info("Start to process rollup tree:" + rootNode);


### PR DESCRIPTION
Why I'm doing:
cherry-pick: https://github.com/StarRocks/starrocks/pull/32830/files

backport #32830 

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
