### PR TITLE
[BugFix] split limit directly in some rules  (#35875)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
@@ -149,6 +149,9 @@ public class PruneGroupByKeysRule extends TransformationRule {
                 // for queries with all constant in project and group by keys,
                 // like `select 'a','b' from table group by 'c','d'`,
                 // we can remove agg node and rewrite it to `select 'a','b' from table limit 1`
+                // This rule may be invoked after MERGE_LIMIT rule. So we need split the init limitOperator
+                // and merge the local limit its child here to avoid not processing init limitOperator
+                // in the plan.
                 Operator op = input.inputAt(0).inputAt(0).getOp();
                 if (!op.hasLimit() || op.getLimit() > 1) {
                     op.setLimit(1);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/PruneGroupByKeysRule.java
@@ -24,6 +24,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalLimitOperator;
@@ -148,10 +149,14 @@ public class PruneGroupByKeysRule extends TransformationRule {
                 // for queries with all constant in project and group by keys,
                 // like `select 'a','b' from table group by 'c','d'`,
                 // we can remove agg node and rewrite it to `select 'a','b' from table limit 1`
+                Operator op = input.inputAt(0).inputAt(0).getOp();
+                if (!op.hasLimit() || op.getLimit() > 1) {
+                    op.setLimit(1);
+                }
                 OptExpression result = OptExpression.create(
-                        LogicalLimitOperator.init(1),
+                        LogicalLimitOperator.global(1, 0),
                         OptExpression.create(
-                                projectOperator, input.getInputs().get(0).getInputs()));
+                                projectOperator, input.inputAt(0).getInputs()));
                 return Lists.newArrayList(result);
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LimitTest.java
@@ -891,4 +891,21 @@ public class LimitTest extends PlanTestBase {
                 "  20:EXCHANGE\n" +
                 "     limit: 1");
     }
+
+    @Test
+    public void testTransformGroupByToLimit() throws Exception {
+        String sql = "select distinct v1 from (select t0.* from t0 join (select * from t1 where false) t1 " +
+                "right join t2 on t0.v1 = t2.v7) t";
+        String plan = getFragmentPlan(sql);
+        assertCContains(plan, "1:Project\n" +
+                "  |  <slot 1> : NULL\n" +
+                "  |  limit: 1\n" +
+                "  |  \n" +
+                "  0:OlapScanNode\n" +
+                "     TABLE: t2",
+                "RESULT SINK\n" +
+                        "\n" +
+                        "  2:EXCHANGE\n" +
+                        "     limit: 1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/NestLoopJoinTest.java
@@ -138,13 +138,11 @@ public class NestLoopJoinTest extends PlanTestBase {
                 " on substr(cast(sub1.v7 as string), 1) = substr(cast(sub2.v10 as string), 1)";
         assertPlanContains(sql, "13:Project\n" +
                 "  |  <slot 20> : 1\n" +
-                "  |  limit: 1\n" +
                 "  |  \n" +
                 "  12:HASH JOIN\n" +
                 "  |  join op: LEFT ANTI JOIN (BROADCAST)\n" +
                 "  |  colocate: false, reason: \n" +
-                "  |  equal join conjunct: 14: substr = 15: substr\n" +
-                "  |  limit: 1");
+                "  |  equal join conjunct: 14: substr = 15: substr");
 
         // RIGHT ANTI JOIN + AGGREGATE count(*)
         sql = "select count(*) from (select t2.id_char, t2.id_varchar " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -588,7 +588,7 @@ public class PlanTestNoneDBBase {
         String explainString = getFragmentPlan(sql);
 
         for (String expected : explain) {
-            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
+            Assert.assertTrue("expected is:\n" + expected + "\n but plan is \n" + explainString,
                     StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -237,7 +237,6 @@ public class SubqueryTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "18:Project\n" +
                     "  |  <slot 15> : 1\n" +
-                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  17:NESTLOOP JOIN\n" +
                     "  |  join op: INNER JOIN\n" +
@@ -257,7 +256,6 @@ public class SubqueryTest extends PlanTestBase {
             String plan = getFragmentPlan(sql);
             assertContains(plan, "18:Project\n" +
                     "  |  <slot 15> : 1\n" +
-                    "  |  limit: 1\n" +
                     "  |  \n" +
                     "  17:NESTLOOP JOIN\n" +
                     "  |  join op: INNER JOIN\n" +


### PR DESCRIPTION
Why I'm doing:
The #35875 missed processing `PruneGroupByKeysRule`.

What I'm doing:
split limit directly in `PruneGroupByKeysRule`.

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/4979
The old code also exists the above problem if `set cbo_push_down_aggregate_mode = 0;`. The https://github.com/StarRocks/starrocks/pull/35912 invoke `PRUNE_COLUMN` rules if any `PushDownDistinctAggregateRule` or `PushDownAggregateRule` may work. This lead the daily case failed.
The root case is if we use the `PRUNE_COLUMN` rules again, we still may have a init LoigcialLimitOperator not being processed.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
