### PR TITLE
[BugFix] fix encoding error when reading t_r_test files

### DIFF
--- a/test/lib/choose_cases.py
+++ b/test/lib/choose_cases.py
@@ -161,7 +161,7 @@ class ChooseCase(object):
 
     def read_t_r_file(self, file, case_regex):
         """read t r file and get case & result"""
-        with open(file, "r") as f:
+        with open(file, "r", encoding='utf8') as f:
             f_lines = f.readlines()
 
         file = os.path.abspath(file)[len(os.path.abspath(self.sr_lib_obj.root_path)):].lstrip("/")


### PR DESCRIPTION
Why I'm doing:

The current sql-tester script shows the following error, indicating that encoding is not correctly set when running 
`python3 run.py`

`/root/starrocks/test/sql/test_rbac/R/test_grants_to_system_table
/root/starrocks/test/sql/test_rbac/R/test_is_role_in_session
/root/starrocks/test/sql/test_external_file/R/test_parquet_struct_in_struct
/root/starrocks/test/sql/test_external_file/R/test_parquet_optional_column_levels
/root/starrocks/test/sql/test_external_file/R/test_parquet_bool_decoder
/root/starrocks/test/sql/test_external_file/R/test_parquet_count_star_opt
/root/starrocks/test/sql/test_external_file/R/test_csv_compression_format
/root/starrocks/test/sql/test_external_file/R/test_query_external_file
/root/starrocks/test/sql/test_external_file/R/test_parquet_dict_null_predicate
/root/starrocks/test/sql/test_external_file/R/test_parquet_compression_format
/root/starrocks/test/sql/test_external_file/R/test_orc_count_star_opt
/root/starrocks/test/sql/test_add_column/R/test_add_column
/root/starrocks/test/sql/test_task/R/test_drop
/root/starrocks/test/sql/test_function/R/test_translate
Failure: UnicodeDecodeError ('ascii' codec can't decode byte 0xe6 in position 187: ordinal not in range(128)) ... ERROR

======================================================================
ERROR: Failure: UnicodeDecodeError ('ascii' codec can't decode byte 0xe6 in position 187: ordinal not in range(128))
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/nose/failure.py", line 39, in runTest
    raise self.exc_val.with_traceback(self.tb)
  File "/usr/local/lib/python3.6/site-packages/nose/loader.py", line 418, in loadTestsFromName
    addr.filename, addr.module)
  File "/usr/local/lib/python3.6/site-packages/nose/importer.py", line 47, in importFromPath
    return self.importFromDir(dir_path, fqname)
  File "/usr/local/lib/python3.6/site-packages/nose/importer.py", line 94, in importFromDir
    mod = load_module(part_fqname, fh, filename, desc)
  File "/usr/lib64/python3.6/imp.py", line 235, in load_module
    return load_source(name, filename, file)
  File "/usr/lib64/python3.6/imp.py", line 172, in load_source
    module = _load(spec)
  File "<frozen importlib._bootstrap>", line 684, in _load
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/root/starrocks/test/test_sql_cases.py", line 45, in <module>
    case_list = choose_cases.choose_cases(record_mode).case_list
  File "/root/starrocks/test/lib/choose_cases.py", line 302, in choose_cases
    cases = ChooseCase(confirm_case_dir, record_mode, filename_regex, case_name_regex)
  File "/root/starrocks/test/lib/choose_cases.py", line 103, in __init__
    self.get_cases(record_mode, case_regex)
  File "/root/starrocks/test/lib/choose_cases.py", line 158, in get_cases
    self.read_t_r_file(file, case_regex)
  File "/root/starrocks/test/lib/choose_cases.py", line 166, in read_t_r_file
    f_lines = f.readlines()
  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 187: ordinal not in range(128)`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
