### PR TITLE
[BugFix][Branch-2.5] Force using timestamp without timezone in orc reader

### DIFF
--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -95,7 +95,7 @@ public:
         // Harding coding, we assume people is using timestamp type
         // This bug fixed in sr >=3.0
         cctz::time_zone new_tz = cctz::utc_time_zone();
-        int64_t new_tzoffset=0;
+        int64_t new_tzoffset = 0;
         if (seconds >= 0) {
             orc_ts_to_native_ts_after_unix_epoch(tv, seconds + new_tzoffset, nanoseconds);
         } else {

--- a/be/src/formats/orc/utils.h
+++ b/be/src/formats/orc/utils.h
@@ -92,10 +92,14 @@ public:
     }
     static void orc_ts_to_native_ts(vectorized::TimestampValue* tv, const cctz::time_zone& tz, int64_t tzoffset,
                                     int64_t seconds, int64_t nanoseconds) {
+        // Harding coding, we assume people is using timestamp type
+        // This bug fixed in sr >=3.0
+        cctz::time_zone new_tz = cctz::utc_time_zone();
+        int64_t new_tzoffset=0;
         if (seconds >= 0) {
-            orc_ts_to_native_ts_after_unix_epoch(tv, seconds + tzoffset, nanoseconds);
+            orc_ts_to_native_ts_after_unix_epoch(tv, seconds + new_tzoffset, nanoseconds);
         } else {
-            orc_ts_to_native_ts_before_unix_epoch(tv, tz, seconds, nanoseconds);
+            orc_ts_to_native_ts_before_unix_epoch(tv, new_tz, seconds, nanoseconds);
         }
     }
 };

--- a/be/test/exec/vectorized/hdfs_scanner_test.cpp
+++ b/be/test/exec/vectorized/hdfs_scanner_test.cpp
@@ -970,10 +970,10 @@ TEST_F(HdfsScannerTest, DecodeMinMaxDateTime) {
     };
     std::vector<Case> cases = {
             {timzone_datetime_shanghai_orc_file, "2022-04-09 07:13:00", "Asia/Shanghai", 1},
-            {timzone_datetime_shanghai_orc_file, "2022-04-09 07:13:00", "UTC", 0},
-            {timzone_datetime_shanghai_orc_file, "2022-04-08 23:13:00", "UTC", 1},
-            {timzone_datetime_utc_orc_file, "2022-04-09 07:13:00", "Asia/Shanghai", 0},
-            {timzone_datetime_utc_orc_file, "2022-04-09 15:13:00", "Asia/Shanghai", 1},
+            {timzone_datetime_shanghai_orc_file, "2022-04-09 07:13:00", "UTC", 1},
+            {timzone_datetime_shanghai_orc_file, "2022-04-08 23:13:00", "UTC", 0},
+            {timzone_datetime_utc_orc_file, "2022-04-09 07:13:00", "Asia/Shanghai", 1},
+            {timzone_datetime_utc_orc_file, "2022-04-09 15:13:00", "Asia/Shanghai", 0},
             {timzone_datetime_utc_orc_file, "2022-04-09 07:13:00", "UTC", 1},
     };
 

--- a/be/test/formats/orc/orc_chunk_reader_test.cpp
+++ b/be/test/formats/orc/orc_chunk_reader_test.cpp
@@ -904,9 +904,9 @@ TEST_F(OrcChunkReaderTest, TestTimestamp) {
         -8444232248
     };
     const std::vector<std::string> exp_values = {
-        "2021-05-25 09:18:40",
-        "1970-01-01 08:00:00",
-        "1702-06-01 04:01:35",
+        "2021-05-25 01:18:40",
+        "1970-01-01 00:00:00",
+        "1702-05-31 19:55:52",
     };
     // clang-format on
     ObjectPool pool;


### PR DESCRIPTION
We already fixed orc's timestamp problem in >= 3.0 version. But it's hard to cherry-pick bugfix to branch2.5, so we just hard coding here because almost 99% of the user is using orc timestamp type.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
