### PR TITLE
[BugFix]check spillable before decompose to spillable aggregate operator

### DIFF
--- a/be/src/exec/aggregate/aggregate_base_node.cpp
+++ b/be/src/exec/aggregate/aggregate_base_node.cpp
@@ -116,4 +116,17 @@ void AggregateBaseNode::push_down_join_runtime_filter(RuntimeState* state, Runti
     }
 }
 
+bool AggregateBaseNode::_grouping_exprs_spillable() const {
+    if (!_tnode.agg_node.__isset.grouping_exprs) {
+        return true;
+    }
+
+    for (const auto& expr : _tnode.agg_node.grouping_exprs) {
+        if (!expr.nodes.empty() && !TypeDescriptor::from_thrift(expr.nodes.at(0).type).support_orderby()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 } // namespace starrocks

--- a/be/src/exec/aggregate/aggregate_base_node.h
+++ b/be/src/exec/aggregate/aggregate_base_node.h
@@ -31,6 +31,8 @@ public:
     void push_down_join_runtime_filter(RuntimeState* state, RuntimeFilterProbeCollector* collector) override;
 
 protected:
+    bool _grouping_exprs_spillable() const;
+
     const TPlanNode& _tnode;
     // _group_by_expr_ctxs used by the pipeline execution engine to push down rf to children nodes before
     // pipeline decomposition.

--- a/be/src/exec/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/aggregate/aggregate_blocking_node.cpp
@@ -293,7 +293,8 @@ pipeline::OpFactories AggregateBlockingNode::decompose_to_pipeline(pipeline::Pip
                 _decompose_to_pipeline<StreamingAggregatorFactory, SortedAggregateStreamingSourceOperatorFactory,
                                        SortedAggregateStreamingSinkOperatorFactory>(ops_with_sink, context, false);
     } else {
-        if (runtime_state()->enable_spill() && runtime_state()->enable_agg_spill() && has_group_by_keys) {
+        if (runtime_state()->enable_spill() && runtime_state()->enable_agg_spill() && has_group_by_keys &&
+            _grouping_exprs_spillable()) {
             ops_with_source = _decompose_to_pipeline<AggregatorFactory, SpillableAggregateBlockingSourceOperatorFactory,
                                                      SpillableAggregateBlockingSinkOperatorFactory>(
                     ops_with_sink, context, use_per_bucket_optimize && has_group_by_keys);

--- a/be/src/exec/aggregate/distinct_blocking_node.cpp
+++ b/be/src/exec/aggregate/distinct_blocking_node.cpp
@@ -229,7 +229,8 @@ pipeline::OpFactories DistinctBlockingNode::decompose_to_pipeline(pipeline::Pipe
                 _decompose_to_pipeline<StreamingAggregatorFactory, SortedAggregateStreamingSourceOperatorFactory,
                                        SortedAggregateStreamingSinkOperatorFactory>(ops_with_sink, context, false);
     } else {
-        if (runtime_state()->enable_spill() && runtime_state()->enable_agg_distinct_spill()) {
+        if (runtime_state()->enable_spill() && runtime_state()->enable_agg_distinct_spill() &&
+            _grouping_exprs_spillable()) {
             ops_with_source =
                     _decompose_to_pipeline<AggregatorFactory, SpillableAggregateDistinctBlockingSourceOperatorFactory,
                                            SpillableAggregateDistinctBlockingSinkOperatorFactory>(

--- a/test/sql/test_spill/R/test_spill_aggregate
+++ b/test/sql/test_spill/R/test_spill_aggregate
@@ -5,6 +5,24 @@ set enable_spill=true;
 set spill_mode="auto";
 -- result:
 -- !result
+CREATE TABLE t_struct(
+    k1 INT,
+    k2 STRUCT<k3 INT, k4 INT>)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t_struct values (1, named_struct('k3', 1, 'k4', 1));
+-- result:
+-- !result
+select min(k1), k2 from t_struct group by k2;
+-- result:
+1	{"k3":1,"k4":1}
+-- !result
+select k1, k2 from t_struct group by k1, k2;
+-- result:
+1	{"k3":1,"k4":1}
+-- !result
 CREATE TABLE t1 (
     k1 INT,
     k2 VARCHAR(20))

--- a/test/sql/test_spill/T/test_spill_aggregate
+++ b/test/sql/test_spill/T/test_spill_aggregate
@@ -1,6 +1,17 @@
 -- name: test_spill_agg
 set enable_spill=true;
 set spill_mode="auto";
+--
+-- aggregation group by struct is not supported on spill mode
+CREATE TABLE t_struct(
+    k1 INT,
+    k2 STRUCT<k3 INT, k4 INT>)
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+insert into t_struct values (1, named_struct('k3', 1, 'k4', 1));
+select min(k1), k2 from t_struct group by k2;
+select k1, k2 from t_struct group by k1, k2;
+--
 -- 
 -- for issue: https://github.com/StarRocks/starrocks/issues/23491
 CREATE TABLE t1 (


### PR DESCRIPTION
Why I'm doing:
spillable aggregate blocking sink operator need groupby exprs support orderby, 
otherwise it will return error so that the sql could not run.
What I'm doing:
check spillable before decompose to spillable operator, if spillable operator does not work,
just use non-spillable operator.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
