### PR TITLE
[BugFix] No merge string partition range keys

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -153,6 +153,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     TABLE: part_tbl1\n" +
                     "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
         }
+        starRocksAssert.dropMaterializedView(mvName);
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -28,10 +28,131 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
-
     @BeforeClass
     public static void beforeClass() throws Exception {
         MvRewriteTestBase.beforeClass();
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewriteSingleTable_UnionRewrite() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select a, b, d, bitmap_union(to_bitmap(t1.c))" +
+                " from iceberg0.partitioned_db.part_tbl1 as t1 " +
+                " group by a, b, d;");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        {
+            String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " where t1.d in ('2023-08-01')\n" +
+                    " group by t1.a, t2.b, t1.d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "test_mv1");
+        }
+
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        {
+            String query = "select a, b, d, count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " where d='2023-08-01'" +
+                    " group by a, b, d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        {
+            String query = "select a, b, d, count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " where t1.d >= '2023-08-01' \n" +
+                    " group by a, b, d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+
+            PlanTestBase.assertContains(plan, "OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+            PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
+                    "     TABLE: part_tbl1\n" +
+                    "     PREDICATES: 13: d != '2023-08-01'");
+        }
+        {
+            String query = "select a, b, d, count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " group by a, b, d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+
+            PlanTestBase.assertContains(plan, "OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+            PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
+                    "     TABLE: part_tbl1\n" +
+                    "     PREDICATES: 13: d != '2023-08-01'");
+        }
+
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-02') " +
+                "end ('2023-08-03') force with sync mode");
+        partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802", "p20230802_20230803"), partitions);
+
+        {
+            String query = "select a, b, d, count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " where t1.d >= '2023-08-01' \n" +
+                    " group by a, b, d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+
+            PlanTestBase.assertContains(plan, "OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
+                    "     TABLE: part_tbl1\n" +
+                    "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
+        }
+        {
+            String query = "select a, b, d, count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " group by a, b, d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+
+            PlanTestBase.assertContains(plan, "OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=2/2");
+            PlanTestBase.assertContains(plan, "IcebergScanNode\n" +
+                    "     TABLE: part_tbl1\n" +
+                    "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
+        }
     }
 
     @Test
@@ -966,6 +1087,24 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         }
 
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        {
+            String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
+                    " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " left join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d \n" +
+                    " left join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
+                    " group by t1.a, t2.b, t1.d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertContains(plan, "UNION");
+
+            PlanTestBase.assertContains(plan, "OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+            PlanTestBase.assertContains(plan, "5:IcebergScanNode\n" +
+                    "     TABLE: part_tbl3\n" +
+                    "     PREDICATES: 27: d != '2023-08-01'");
+        }
+
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
                     " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +


### PR DESCRIPTION
Why I'm doing:

After PR(https://github.com/StarRocks/starrocks/pull/35095), start to treat the string type partition range key as a list point. but this PR will result in incorrect results which is because `mergeRanges` will merge string partition keys before converting them to predicates.


What I'm doing:
- No merge string partition range keys.
- Add more tests.

Fixes https://github.com/StarRocks/StarRocksTest/issues/4978

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
