### PR TITLE
[BugFix] fix millisecond behaviour of jodatime_parse

### DIFF
--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -384,7 +384,13 @@ bool JodaFormat::prepare(std::string_view format) {
                 if (!str_to_int64(val, &tmp, &int_value)) {
                     return false;
                 }
-                _microsecond = int_value * 1000;
+                // The exact number of fractional digits. If more millisecond digits are available then specified the number
+                // will be truncated, if there are fewer than specified then the number will be zero-padded to the right.
+                // When parsing, only the exact number of digits are accepted.
+                for (int actual_count = tmp - val; actual_count < 6; actual_count++) {
+                    int_value *= 10;
+                }
+                _microsecond = int_value;
                 val = tmp;
                 time_part_used = true;
                 frac_part_used = true;
@@ -1052,6 +1058,19 @@ static char* append_with_prefix(const char* str, int str_len, char prefix, int f
     return to;
 }
 
+static char* append_with_suffix(const char* str, int str_len, char suffix, int full_len, char* to) {
+    int len = (str_len > full_len) ? str_len : full_len;
+    len -= str_len;
+    while (str_len-- > 0) {
+        *to++ = *str++;
+    }
+    while (len-- > 0) {
+        *to++ = suffix;
+    }
+
+    return to;
+}
+
 int DateTimeValue::compute_format_len(const char* format, int len) {
     int size = 0;
     const char* ptr = format;
@@ -1355,14 +1374,20 @@ bool DateTimeValue::to_joda_format_string(const char* format, int len, char* to)
             if (write_size + actual_size >= buffer_size) return false;
             to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
             break;
-        case 'S':
+        case 'S': {
             // fraction of second
-            pos = int_to_str(_microsecond / 1000, buf);
+            RETURN_IF(same_ch_size > 6, false);
+            uint64_t val = _microsecond;
+            for (int i = 0; i < 6 - same_ch_size; i++) {
+                val /= 10;
+            }
+            pos = int_to_str(val, buf);
             buf_size = pos - buf;
             actual_size = std::max(buf_size, same_ch_size);
             if (write_size + actual_size >= buffer_size) return false;
-            to = append_with_prefix(buf, pos - buf, '0', actual_size, to);
+            to = append_with_suffix(buf, pos - buf, '0', actual_size, to);
             break;
+        }
         case 'z':
         case 'Z':
             // sr do not support datetime with timezone type， just ignore

--- a/be/test/runtime/datetime_value_test.cpp
+++ b/be/test/runtime/datetime_value_test.cpp
@@ -1476,6 +1476,8 @@ INSTANTIATE_TEST_SUITE_P(
 
                 // Second
                 TestParseDatetimeParam("1994-09-09 01:02:03.123", "yyyy-MM-dd HH:mm:ss.SSS"),
+                TestParseDatetimeParam("1994-09-09 01:02:03.12", "yyyy-MM-dd HH:mm:ss.SS"),
+                TestParseDatetimeParam("1994-09-09 01:02:03.1234", "yyyy-MM-dd HH:mm:ss.SSSS"),
 
                 // Timezone
                 TestParseDatetimeParam("1994-09-09 01:02:03 CST", "yyyy-MM-dd HH:mm:ss zzz"),
@@ -1533,7 +1535,15 @@ INSTANTIATE_TEST_SUITE_P(
                 SpecialTestParseDatetimeParam("1994-09-09 24:02:03", "yyyy-MM-dd HH:mm:ss", "NULL"),
                 SpecialTestParseDatetimeParam("1994-09-09 24:02:03", "yyyy-MM-dd kk:mm:ss", "NULL"),
                 SpecialTestParseDatetimeParam("1994-09-09 00:02:03", "yyyy-MM-dd HH:mm:ss", "1994-09-09 00:02:03"),
-                SpecialTestParseDatetimeParam("1994-09-09 00:02:03", "yyyy-MM-dd kk:mm:ss", "1994-09-09 24:02:03")
+                SpecialTestParseDatetimeParam("1994-09-09 00:02:03", "yyyy-MM-dd kk:mm:ss", "1994-09-09 24:02:03"),
+
+                // Millisecond
+                SpecialTestParseDatetimeParam("1994-09-09 01:02:03.123", "yyyy-MM-dd HH:mm:ss.SS",
+                                              "1994-09-09 01:02:03.12"),
+                SpecialTestParseDatetimeParam("1994-09-09 01:02:03.12", "yyyy-MM-dd HH:mm:ss.SSS",
+                                              "1994-09-09 01:02:03.120"),
+                SpecialTestParseDatetimeParam("1994-09-09 01:02:03.12345", "yyyy-MM-dd HH:mm:ss.SSSS",
+                                              "1994-09-09 01:02:03.1234")
 
                 // clang-format: on
                 ));


### PR DESCRIPTION
Why I'm doing:
- Parsing the milliseconds should truncate to right instead of left

What I'm doing:
- `jodatime_parse("01:02:03.123", "HH:mm:ss.SS")` => `01:02:03.12`
- `jodatime_parse("01:02:03.123", "HH:mm:ss.SSSS")` => `01:02:03.1230`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
