### PR TITLE
[Feature] disable iceberg column statistics when iceberg job planning

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -407,21 +407,6 @@ public class IcebergMetadata implements ConnectorMetadata {
             fileScanTasks = fileScanTaskIterator;
         }
 
-        List<Types.NestedField> fullColumns = nativeTbl.schema().columns();
-        Map<Integer, Type.PrimitiveType> idToTypeMapping = fullColumns.stream()
-                .filter(column -> column.type().isPrimitiveType())
-                .collect(Collectors.toMap(Types.NestedField::fieldId, column -> column.type().asPrimitiveType()));
-
-        Set<Integer> identityPartitionIds = nativeTbl.spec().fields().stream()
-                .filter(x -> x.transform().isIdentity())
-                .map(PartitionField::sourceId)
-                .collect(Collectors.toSet());
-
-        List<Types.NestedField> nonPartitionPrimitiveColumns = fullColumns.stream()
-                .filter(column -> !identityPartitionIds.contains(column.fieldId()) &&
-                        column.type().isPrimitiveType())
-                .collect(toImmutableList());
-
         List<FileScanTask> icebergScanTasks = Lists.newArrayList();
         long totalReadCount = 0;
 
@@ -429,12 +414,36 @@ public class IcebergMetadata implements ConnectorMetadata {
         Set<String> filePaths = new HashSet<>();
         while (fileScanTasks.hasNext()) {
             FileScanTask scanTask = fileScanTaskIterator.next();
-            statisticProvider.updateIcebergFileStats(
-                    icebergTable, scanTask, idToTypeMapping, nonPartitionPrimitiveColumns, key);
 
             FileScanTask icebergSplitScanTask = scanTask;
             if (enableCollectColumnStatistics()) {
-                icebergSplitScanTask = buildIcebergSplitScanTask(scanTask, icebergPredicate, key);
+                try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.buildSplitScanTask")) {
+                    icebergSplitScanTask = buildIcebergSplitScanTask(scanTask, icebergPredicate, key);
+                }
+
+                List<Types.NestedField> fullColumns = nativeTbl.schema().columns();
+                Map<Integer, Type.PrimitiveType> idToTypeMapping = fullColumns.stream()
+                        .filter(column -> column.type().isPrimitiveType())
+                        .collect(Collectors.toMap(Types.NestedField::fieldId, column -> column.type().asPrimitiveType()));
+
+                Set<Integer> identityPartitionIds = nativeTbl.spec().fields().stream()
+                        .filter(x -> x.transform().isIdentity())
+                        .map(PartitionField::sourceId)
+                        .collect(Collectors.toSet());
+
+                List<Types.NestedField> nonPartitionPrimitiveColumns = fullColumns.stream()
+                        .filter(column -> !identityPartitionIds.contains(column.fieldId()) &&
+                                column.type().isPrimitiveType())
+                        .collect(toImmutableList());
+
+                try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.updateIcebergFileStats")) {
+                    statisticProvider.updateIcebergFileStats(
+                            icebergTable, scanTask, idToTypeMapping, nonPartitionPrimitiveColumns, key);
+                }
+            } else {
+                try (Timer ignored = Tracers.watchScope(EXTERNAL, "ICEBERG.updateCardinality")) {
+                    statisticProvider.updateIcebergCardinality(key, scanTask);
+                }
             }
             icebergScanTasks.add(icebergSplitScanTask);
 
@@ -490,7 +499,11 @@ public class IcebergMetadata implements ConnectorMetadata {
 
         triggerIcebergPlanFilesIfNeeded(key, icebergTable, predicate, limit);
 
-        return statisticProvider.getTableStatistics(icebergTable, columns, session, predicate);
+        if (!session.getSessionVariable().enableIcebergColumnStatistics()) {
+            return statisticProvider.getCardinalityStats(icebergTable, columns, predicate);
+        } else {
+            return statisticProvider.getTableStatistics(icebergTable, columns, session, predicate);
+        }
     }
 
     private IcebergSplitScanTask buildIcebergSplitScanTask(

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/cost/IcebergStatisticProvider.java
@@ -17,7 +17,6 @@ package com.starrocks.connector.iceberg.cost;
 
 import com.google.common.collect.AbstractSequentialIterator;
 import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Multimap;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -71,9 +70,32 @@ public class IcebergStatisticProvider {
     // table uuid -> <partition column id -> partition column values>
     private final Map<String, HashMultimap<Integer, Object>> uuidToPartitionFieldIdToValues = new HashMap<>();
     private final Map<IcebergFilter, IcebergFileStats> icebergFileStatistics = new HashMap<>();
-    private final Multimap<IcebergFilter, String> scannedFiles = HashMultimap.create();
+    private final Map<IcebergFilter, Set<String>> scannedFiles = new HashMap<>();
+
+    // only used for iceberg job planning without column statistics.
+    private final Map<IcebergFilter, Long> icebergCardinality = new HashMap<>();
 
     public IcebergStatisticProvider() {
+    }
+
+    public Statistics getCardinalityStats(IcebergTable icebergTable,
+                                          Map<ColumnRefOperator, Column> colRefToColumnMetaMap,
+                                          ScalarOperator predicate) {
+        Statistics.Builder statisticsBuilder = Statistics.builder();
+        Optional<Snapshot> snapshot = icebergTable.getSnapshot();
+        if (snapshot.isPresent()) {
+            IcebergFilter key = IcebergFilter.of(icebergTable.getRemoteDbName(), icebergTable.getRemoteTableName(),
+                    snapshot.get().snapshotId(), predicate);
+            if (icebergCardinality.containsKey(key)) {
+                statisticsBuilder.setOutputRowCount(icebergCardinality.get(key));
+            } else {
+                statisticsBuilder.setOutputRowCount(1);
+            }
+        } else {
+            statisticsBuilder.setOutputRowCount(1);
+        }
+        statisticsBuilder.addColumnStatistics(buildUnknownColumnStatistics(colRefToColumnMetaMap.keySet()));
+        return statisticsBuilder.build();
     }
 
     public Statistics getTableStatistics(IcebergTable icebergTable,
@@ -129,6 +151,18 @@ public class IcebergStatisticProvider {
         return columns.stream().collect(Collectors.toMap(column -> column, column -> ColumnStatistic.unknown()));
     }
 
+    public void updateIcebergCardinality(IcebergFilter key, FileScanTask fileScanTask) {
+        DataFile dataFile = fileScanTask.file();
+        Set<String> files = scannedFiles.computeIfAbsent(key, ignored -> new HashSet<>());
+        if (files.contains(dataFile.path().toString())) {
+            return;
+        }
+
+        files.add(dataFile.path().toString());
+        long rowNum = fileScanTask.file().recordCount();
+        icebergCardinality.compute(key, (k, v) -> (v == null) ? rowNum : v + rowNum);
+    }
+
     public void updateIcebergFileStats(IcebergTable icebergTable, FileScanTask fileScanTask,
                                        Map<Integer, Type.PrimitiveType> idToTypeMapping,
                                        List<Types.NestedField> nonPartitionPrimitiveColumns,
@@ -145,11 +179,12 @@ public class IcebergStatisticProvider {
             return;
         }
 
-        if (scannedFiles.containsEntry(key, dataFile.path().toString())) {
+        Set<String> files = scannedFiles.computeIfAbsent(key, ignored -> new HashSet<>());
+        if (files.contains(dataFile.path().toString())) {
             return;
         }
 
-        scannedFiles.put(key, dataFile.path().toString());
+        files.add(dataFile.path().toString());
 
         PartitionData partitionData = (PartitionData) fileScanTask.file().partition();
         for (int i = 0; i < partitionData.size(); i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1480,7 +1480,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private boolean enableReadIcebergPuffinNdv = true;
 
     @VarAttr(name = ENABLE_ICEBERG_COLUMN_STATISTICS)
-    private boolean enableIcebergColumnStatistics = true;
+    private boolean enableIcebergColumnStatistics = false;
 
     @VarAttr(name = LARGE_DECIMAL_UNDERLYING_TYPE)
     private String largeDecimalUnderlyingType = SessionVariableConstants.PANIC;


### PR DESCRIPTION
Why I'm doing:
An 8MB iceberg manifest avro file deserialized to about 1GB of memory.  file metrics like column statistics accounts for about 95% in them. And we need to cache iceberg split from avro  in order to reduce the cost of multiple iceberg job planning in one query.  So we need to remove the metrics then cache the iceberg split for building iceberg scan ranges. However, single-thread build splits and update iceberg statistics based on iceberg scan tasks are much slower than multi-threaded iceberg job planning.  This will lead to two issues.
1. FE optimizer takes longer
2. Fe increases full gc probability according to iceberg job planning production consumption model.
So we need to disable iceberg file metrics when job planning. and use to analyze external table to replace it.

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
