### PR TITLE
[BugFix] Fix exchange may hang when grayscale upgrade

### DIFF
--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -216,7 +216,7 @@ private:
     seconds _query_expire_seconds = seconds(DEFAULT_EXPIRE_SECONDS);
     bool _is_runtime_filter_coordinator = false;
     std::once_flag _init_mem_tracker_once;
-    bool _enable_pipeline_level_shuffle = false;
+    bool _enable_pipeline_level_shuffle = true;
     std::shared_ptr<RuntimeProfile> _profile;
     bool _enable_profile = false;
     int64_t _big_query_profile_threshold_ns = 0;


### PR DESCRIPTION
Why I'm doing:

This issue is introduced by https://github.com/StarRocks/starrocks/pull/35486

in branch-3.2 introduce session variable `enable_pipeline_level_shuffle`. the default value for BE is false. but when grayscale upgrade one BE. other BE will always use enable_pipeline_level_shuffle. wich may cause exchange hang.

What I'm doing:
change _enable_pipeline_level_shuffle default value to false


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
