### PR TITLE
[Enhancement] use lightweight iceberg fileScanTask schema key

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergFilter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergFilter.java
@@ -36,6 +36,14 @@ public class IcebergFilter {
         this.predicate = predicate;
     }
 
+    public String getDatabaseName() {
+        return databaseName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -491,7 +491,8 @@ public class IcebergMetadata implements ConnectorMetadata {
         Schema taskSchema = fileScanTask.spec().schema();
         String schemaString;
         String partitionString;
-        FileScanTaskSchema schemaKey = new FileScanTaskSchema(filter, taskSchema.schemaId(), taskSpec.specId());
+        FileScanTaskSchema schemaKey = new FileScanTaskSchema(filter.getDatabaseName(), filter.getTableName(),
+                taskSchema.schemaId(), taskSpec.specId());
         Pair<String, String> schema = fileScanTaskSchemas.get(schemaKey);
         if (schema == null) {
             schemaString = SchemaParser.toJson(fileScanTask.spec().schema());
@@ -775,12 +776,14 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     private static class FileScanTaskSchema {
-        private final IcebergFilter icebergFilter;
+        private final String dbName;
+        private final String tableName;
         private final int schemaId;
         private final int specId;
 
-        public FileScanTaskSchema(IcebergFilter icebergFilter, int schemaId, int specId) {
-            this.icebergFilter = icebergFilter;
+        public FileScanTaskSchema(String dbName, String tableName, int schemaId, int specId) {
+            this.dbName = dbName;
+            this.tableName = tableName;
             this.schemaId = schemaId;
             this.specId = specId;
         }
@@ -793,13 +796,15 @@ public class IcebergMetadata implements ConnectorMetadata {
             if (o == null || getClass() != o.getClass()) {
                 return false;
             }
+
             FileScanTaskSchema that = (FileScanTaskSchema) o;
-            return schemaId == that.schemaId && specId == that.specId && Objects.equals(icebergFilter, that.icebergFilter);
+            return schemaId == that.schemaId && specId == that.specId &&
+                    Objects.equals(dbName, that.dbName) && Objects.equals(tableName, that.tableName);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(icebergFilter, schemaId, specId);
+            return Objects.hash(dbName, tableName, schemaId, specId);
         }
     }
 }


### PR DESCRIPTION
Why I'm doing:
iceberg snapshot id and iceberg predicate have no effect on matching the schema string and partition spec string of a table

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
