### PR TITLE
[Enhancement] percentile_cont performance enhance

### DIFF
--- a/be/src/exprs/agg/percentile_cont.h
+++ b/be/src/exprs/agg/percentile_cont.h
@@ -40,10 +40,119 @@ template <LogicalType LT, typename = guard::Guard>
 struct PercentileState {
     using CppType = RunTimeCppType<LT>;
     void update(CppType item) { items.emplace_back(item); }
-
+    void update_batch(const std::vector<CppType>& vec) {
+        size_t old_size = items.size();
+        items.resize(old_size + vec.size());
+        memcpy(items.data() + old_size, vec.data(), vec.size() * sizeof(CppType));
+    }
     std::vector<CppType> items;
+    std::vector<std::vector<CppType>> grid;
     double rate = 0.0;
 };
+
+template <LogicalType LT, typename CppType, bool reverse>
+void kWayMergeSort(const std::vector<std::vector<CppType>>& grid, std::vector<CppType>& b, std::vector<int>& ls,
+                   std::map<int, int>& mp, size_t goal, int k, CppType& junior_elm, CppType& senior_elm) {
+    CppType minV = RunTimeTypeLimits<LT>::min_value();
+    CppType maxV = RunTimeTypeLimits<LT>::max_value();
+
+    b.resize(k + 1);
+    ls.resize(k);
+    for (int i = 0; i < k; ++i) {
+        if constexpr (reverse) {
+            mp[i] = grid[i].size() - 2;
+        } else {
+            mp[i] = 1;
+        }
+    }
+    for (int i = 0; i < k; ++i) {
+        b[i] = grid[i][mp[i]];
+        if constexpr (reverse) {
+            mp[i]--;
+        } else {
+            mp[i]++;
+        }
+    }
+    b[k] = reverse ? maxV : minV;
+    for (int i = 0; i < k; ++i) {
+        ls[i] = k;
+    }
+
+    for (int i = k - 1; i >= 0; --i) {
+        int q = i;
+        int t = (q + k) / 2;
+        while (t > 0) {
+            if constexpr (reverse) {
+                if (b[q] < b[ls[t]]) {
+                    std::swap(q, ls[t]);
+                }
+            } else if (b[q] > b[ls[t]]) {
+                std::swap(q, ls[t]);
+            }
+            t = t / 2;
+        }
+        ls[0] = q;
+    }
+
+    CppType tp = reverse ? minV : maxV;
+    size_t cnt = 0;
+
+    while (b[ls[0]] != tp) {
+        int q = ls[0];
+        if (UNLIKELY(cnt >= goal)) {
+            if (cnt == goal) {
+                if constexpr (reverse)
+                    senior_elm = b[q];
+                else
+                    junior_elm = b[q];
+            }
+            if (cnt == goal + 1) {
+                if constexpr (reverse)
+                    junior_elm = b[q];
+                else
+                    senior_elm = b[q];
+                break;
+            }
+        }
+        cnt++;
+        b[q] = grid[q][mp[q]];
+
+        if constexpr (reverse) {
+            mp[q]--;
+        } else {
+            mp[q]++;
+        }
+        int t = (q + k) / 2;
+        while (t > 0) {
+            if constexpr (reverse) {
+                if (b[q] < b[ls[t]]) {
+                    std::swap(q, ls[t]);
+                }
+            } else if (b[q] > b[ls[t]]) {
+                std::swap(q, ls[t]);
+            }
+            t = t / 2;
+        }
+        ls[0] = q;
+    }
+}
+
+template <LogicalType LT, typename CppType, typename ResultType>
+ResultType calculateResult(CppType junior_elm, CppType senior_elm, double u, size_t index) {
+    [[maybe_unused]] ResultType result;
+    if constexpr (lt_is_datetime<LT>) {
+        result.from_unix_second(junior_elm.to_unix_second() +
+                                (u - (float)index) * (senior_elm.to_unix_second() - junior_elm.to_unix_second()));
+    } else if constexpr (lt_is_date<LT>) {
+        result._julian = junior_elm._julian + (u - (double)index) * (senior_elm._julian - junior_elm._julian);
+    } else if constexpr (lt_is_arithmetic<LT>) {
+        result = junior_elm + (u - (double)index) * (senior_elm - junior_elm);
+    } else {
+        // won't go there if percentile_cont is registered correctly
+        throw std::runtime_error("Invalid PrimitiveTypes: " + type_to_string(LT) + " for percentile_cont function");
+    }
+    return result;
+}
 
 template <LogicalType LT, typename = guard::Guard>
 class PercentileContDiscAggregateFunction
@@ -64,26 +173,33 @@ public:
         }
     }
 
+    void update_batch_single_state(FunctionContext* ctx, size_t chunk_size, const Column** columns,
+                                   AggDataPtr __restrict state) const override {
+        const auto& column = down_cast<const InputColumnType&>(*columns[0]);
+        this->data(state).update_batch(column.get_data());
+
+        if (ctx->get_num_args() == 2) {
+            const auto* rate = down_cast<const ConstColumn*>(columns[1]);
+            this->data(state).rate = rate->get(0).get_double();
+        }
+    }
+
     void merge(FunctionContext* ctx, const Column* column, AggDataPtr __restrict state, size_t row_num) const override {
         DCHECK(column->is_binary());
 
         const Slice slice = column->get(row_num).get_slice();
         double rate = *reinterpret_cast<double*>(slice.data);
-        size_t second_size = *reinterpret_cast<size_t*>(slice.data + sizeof(double));
+        size_t items_size = *reinterpret_cast<size_t*>(slice.data + sizeof(double));
         auto data_ptr = slice.data + sizeof(double) + sizeof(size_t);
+        std::vector<std::vector<InputCppType>>& grid = this->data(state).grid;
 
-        auto second_start = reinterpret_cast<InputCppType*>(data_ptr);
-        auto second_end = reinterpret_cast<InputCppType*>(data_ptr + second_size * sizeof(InputCppType));
+        std::vector<InputCppType> vec;
+        vec.resize(items_size + 2);
+        memcpy(vec.data() + 1, data_ptr, items_size * sizeof(InputCppType));
+        vec[0] = RunTimeTypeLimits<LT>::min_value();
+        vec[vec.size() - 1] = RunTimeTypeLimits<LT>::max_value();
 
-        // TODO(murphy) reduce the copy overhead of merge algorithm
-        auto& output = this->data(state).items;
-        size_t first_size = output.size();
-        output.resize(first_size + second_size);
-        auto first_end = output.begin() + first_size;
-        std::copy(second_start, second_end, first_end);
-        // TODO: optimize it with SIMD bitonic merge
-        std::inplace_merge(output.begin(), first_end, output.end());
-
+        grid.emplace_back(std::move(vec));
         this->data(state).rate = rate;
     }
 
@@ -92,18 +208,29 @@ public:
         Bytes& bytes = column->get_bytes();
         size_t old_size = bytes.size();
         size_t items_size = this->data(state).items.size();
+        size_t grid_items_size = 0;
+        for (const auto& vec : this->data(state).grid) {
+            grid_items_size += vec.size() - 2;
+        }
+        size_t total_items_size = items_size + grid_items_size;
 
         // should serialize: rate_size, vector_size, all vector element.
-        size_t new_size = old_size + sizeof(double) + sizeof(size_t) + items_size * sizeof(InputCppType);
+        size_t new_size = old_size + sizeof(double) + sizeof(size_t) + total_items_size * sizeof(InputCppType);
         bytes.resize(new_size);
 
         memcpy(bytes.data() + old_size, &(this->data(state).rate), sizeof(double));
-        memcpy(bytes.data() + old_size + sizeof(double), &items_size, sizeof(size_t));
+        memcpy(bytes.data() + old_size + sizeof(double), &total_items_size, sizeof(size_t));
         memcpy(bytes.data() + old_size + sizeof(double) + sizeof(size_t), this->data(state).items.data(),
                items_size * sizeof(InputCppType));
+        size_t current_pos = old_size + sizeof(double) + sizeof(size_t) + items_size * sizeof(InputCppType);
+        for (const auto& vec : this->data(state).grid) {
+            memcpy(bytes.data() + current_pos, vec.data() + 1, (vec.size() - 2) * sizeof(InputCppType));
+            current_pos += (vec.size() - 2) * sizeof(InputCppType);
+        }
+
         pdqsort(reinterpret_cast<InputCppType*>(bytes.data() + old_size + sizeof(double) + sizeof(size_t)),
                 reinterpret_cast<InputCppType*>(bytes.data() + old_size + sizeof(double) + sizeof(size_t) +
-                                                items_size * sizeof(InputCppType)));
+                                                total_items_size * sizeof(InputCppType)));
 
         column->get_offset().emplace_back(new_size);
     }
@@ -255,36 +382,72 @@ class PercentileContAggregateFunction final : public PercentileContDiscAggregate
     using ResultColumnType = RunTimeColumnType<ResultLT>;
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        using CppType = RunTimeCppType<LT>;
-        std::vector<CppType> new_vector = std::move(this->data(state).items);
-        pdqsort(new_vector.begin(), new_vector.end());
+        const std::vector<std::vector<InputCppType>>& grid = this->data(state).grid;
         const double& rate = this->data(state).rate;
 
-        auto* column = down_cast<ResultColumnType*>(to);
-        DCHECK(!new_vector.empty());
-        if (new_vector.size() == 1 || rate == 1) {
-            column->append(new_vector.back());
+        // for group by
+        if (grid.size() == 0) {
+            ResultColumnType* column = down_cast<ResultColumnType*>(to);
+            auto& items = const_cast<std::vector<InputCppType>&>(this->data(state).items);
+            std::sort(items.begin(), items.end());
+
+            if (items.size() == 0) {
+                return;
+            }
+            if (items.size() == 1 || rate == 1) {
+                column->append(items.back());
+                return;
+            }
+
+            double u = (items.size() - 1) * rate;
+            auto index = (size_t)u;
+
+            ResultType result = calculateResult<LT, InputCppType, ResultType>(items[index], items[index + 1], u, index);
+            column->append(result);
             return;
         }
 
-        double u = (new_vector.size() - 1) * rate;
-        int index = (int)u;
+        std::vector<InputCppType> b;
+        std::vector<int> ls;
+        std::map<int, int> mp;
 
-        [[maybe_unused]] ResultType result;
-        if constexpr (lt_is_datetime<LT>) {
-            result.from_unix_second(
-                    new_vector[index].to_unix_second() +
-                    (u - (float)index) * (new_vector[index + 1].to_unix_second() - new_vector[index].to_unix_second()));
-        } else if constexpr (lt_is_date<LT>) {
-            result._julian = new_vector[index]._julian +
-                             (u - (double)index) * (new_vector[index + 1]._julian - new_vector[index]._julian);
-        } else if constexpr (lt_is_arithmetic<LT>) {
-            result = new_vector[index] + (u - (double)index) * (new_vector[index + 1] - new_vector[index]);
-        } else {
-            // won't go there if percentile_cont is registered correctly
-            throw std::runtime_error("Invalid PrimitiveTypes for percentile_cont function");
+        size_t k = grid.size();
+        size_t rowsNum = 0;
+        for (int i = 0; i < k; i++) {
+            rowsNum += grid[i].size() - 2;
+        }
+        if (rowsNum == 0) return;
+
+        bool reverse = false;
+        if (rate > 0.5 && rowsNum > 2) reverse = true;
+
+        double u = ((double)rowsNum - 1) * rate;
+        auto index = (size_t)u;
+        size_t goal = reverse ? (size_t)ceil((double)rowsNum - 2 - u) : (size_t)u;
+        if (rate == 1) {
+            goal = 0;
         }
 
+        InputCppType junior_elm;
+        InputCppType senior_elm;
+
+        if (reverse) {
+            kWayMergeSort<LT, InputCppType, true>(grid, b, ls, mp, goal, k, junior_elm, senior_elm);
+        } else {
+            kWayMergeSort<LT, InputCppType, false>(grid, b, ls, mp, goal, k, junior_elm, senior_elm);
+        }
+
+        ResultColumnType* column = down_cast<ResultColumnType*>(to);
+
+        if (rate == 0) {
+            column->append(junior_elm);
+            return;
+        } else if (rate == 1) {
+            column->append(senior_elm);
+            return;
+        }
+
+        ResultType result = calculateResult<LT, InputCppType, ResultType>(junior_elm, senior_elm, u, index);
         column->append(result);
     }
 
@@ -300,12 +463,15 @@ class PercentileDiscAggregateFunction final : public PercentileContDiscAggregate
     using ResultColumnType = RunTimeColumnType<ResultLT>;
 
     void finalize_to_column(FunctionContext* ctx, ConstAggDataPtr __restrict state, Column* to) const override {
-        using CppType = RunTimeCppType<LT>;
-        std::vector<CppType> new_vector = std::move(this->data(state).items);
+        std::vector<InputCppType> new_vector = std::move(this->data(state).items);
+        for (auto& innerData : this->data(state).grid) {
+            std::move(innerData.begin() + 1, innerData.end() - 1, std::back_inserter(new_vector));
+        }
+
         pdqsort(new_vector.begin(), new_vector.end());
         const double& rate = this->data(state).rate;
 
-        auto* column = down_cast<ResultColumnType*>(to);
+        ResultColumnType* column = down_cast<ResultColumnType*>(to);
         DCHECK(!new_vector.empty());
         if (new_vector.size() == 1 || rate == 1) {
             column->append(new_vector.back());

--- a/be/test/exprs/agg/aggregate_test.cpp
+++ b/be/test/exprs/agg/aggregate_test.cpp
@@ -1355,42 +1355,137 @@ TEST_F(AggregateTest, test_percentile_cont) {
 
     const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DOUBLE, TYPE_DOUBLE, false);
 
+    auto data_column1 = DoubleColumn::create();
+    data_column1->append(2.0);
+    data_column1->append(3.0);
+    data_column1->append(4.0);
+
+    auto data_column2 = DoubleColumn::create();
+    data_column2->append(5.0);
+    data_column2->append(6.0);
+
     // update input column 1
     auto state1 = ManagedAggrState::create(ctx, func);
-
-    auto data_column1 = DoubleColumn::create();
-    auto const_colunm1 = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.1, 1);
-    data_column1->append(3.0);
-    data_column1->append(3.0);
-
+    auto const_colunm1 = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.25, 1);
     std::vector<const Column*> raw_columns1;
     raw_columns1.resize(2);
     raw_columns1[0] = data_column1.get();
     raw_columns1[1] = const_colunm1.get();
-
     func->update_batch_single_state(local_ctx.get(), data_column1->size(), raw_columns1.data(), state1->state());
 
     // update input column 2
     auto state2 = ManagedAggrState::create(ctx, func);
-
-    auto data_column2 = DoubleColumn::create();
-    auto const_colunm2 = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.1, 1);
-    data_column2->append(6.0);
-
+    auto const_colunm2 = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.25, 1);
     std::vector<const Column*> raw_columns2;
     raw_columns2.resize(2);
     raw_columns2[0] = data_column2.get();
     raw_columns2[1] = const_colunm2.get();
-
     func->update_batch_single_state(local_ctx.get(), data_column2->size(), raw_columns2.data(), state2->state());
 
-    // merge column 1 and column 2
-    ColumnPtr serde_column = BinaryColumn::create();
-    auto result_column = DoubleColumn::create();
-    func->serialize_to_column(local_ctx.get(), state1->state(), serde_column.get());
-    func->merge(local_ctx.get(), serde_column.get(), state2->state(), 0);
-    func->finalize_to_column(local_ctx.get(), state2->state(), result_column.get());
+    // state3
+    auto state3 = ManagedAggrState::create(ctx, func);
 
+    // merge column 1 and column 2
+    auto result_column = DoubleColumn::create();
+    ColumnPtr serde_column1 = BinaryColumn::create();
+    func->serialize_to_column(local_ctx.get(), state1->state(), serde_column1.get());
+    ColumnPtr serde_column2 = BinaryColumn::create();
+    func->serialize_to_column(local_ctx.get(), state2->state(), serde_column2.get());
+
+    func->merge(local_ctx.get(), serde_column1.get(), state3->state(), 0);
+    func->merge(local_ctx.get(), serde_column2.get(), state3->state(), 0);
+
+    func->finalize_to_column(local_ctx.get(), state3->state(), result_column.get());
+
+    // [2,3,4,5,6], rate = 0.25 -> 3
+    ASSERT_EQ(3, result_column->get_data()[0]);
+}
+
+TEST_F(AggregateTest, test_percentile_cont_1) {
+    std::vector<FunctionContext::TypeDesc> arg_types = {
+            AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_logical_type(TYPE_DOUBLE)),
+            AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_logical_type(TYPE_DOUBLE))};
+    auto return_type = AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_logical_type(TYPE_DOUBLE));
+    std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+
+    const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DOUBLE, TYPE_DOUBLE, false);
+
+    auto data_column1 = DoubleColumn::create();
+    data_column1->append(2.0);
+    data_column1->append(3.0);
+    data_column1->append(4.0);
+
+    auto data_column2 = DoubleColumn::create();
+    data_column2->append(5.0);
+    data_column2->append(6.0);
+
+    // update input column 1
+    auto state1 = ManagedAggrState::create(ctx, func);
+    auto const_colunm1 = ColumnHelper::create_const_column<TYPE_DOUBLE>(1, 1);
+    std::vector<const Column*> raw_columns1;
+    raw_columns1.resize(2);
+    raw_columns1[0] = data_column1.get();
+    raw_columns1[1] = const_colunm1.get();
+    func->update_batch_single_state(local_ctx.get(), data_column1->size(), raw_columns1.data(), state1->state());
+
+    // update input column 2
+    auto state2 = ManagedAggrState::create(ctx, func);
+    auto const_colunm2 = ColumnHelper::create_const_column<TYPE_DOUBLE>(1, 1);
+    std::vector<const Column*> raw_columns2;
+    raw_columns2.resize(2);
+    raw_columns2[0] = data_column2.get();
+    raw_columns2[1] = const_colunm2.get();
+    func->update_batch_single_state(local_ctx.get(), data_column2->size(), raw_columns2.data(), state2->state());
+
+    // state3
+    auto state3 = ManagedAggrState::create(ctx, func);
+
+    // merge column 1 and column 2
+    auto result_column = DoubleColumn::create();
+    ColumnPtr serde_column1 = BinaryColumn::create();
+    func->serialize_to_column(local_ctx.get(), state1->state(), serde_column1.get());
+    ColumnPtr serde_column2 = BinaryColumn::create();
+    func->serialize_to_column(local_ctx.get(), state2->state(), serde_column2.get());
+
+    func->merge(local_ctx.get(), serde_column1.get(), state3->state(), 0);
+    func->merge(local_ctx.get(), serde_column2.get(), state3->state(), 0);
+
+    func->finalize_to_column(local_ctx.get(), state3->state(), result_column.get());
+
+    // [2,3,4,5,6], rate = 1 -> 6
+    ASSERT_EQ(6, result_column->get_data()[0]);
+}
+
+TEST_F(AggregateTest, test_percentile_cont_2) {
+    std::vector<FunctionContext::TypeDesc> arg_types = {
+            AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_logical_type(TYPE_DOUBLE)),
+            AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_logical_type(TYPE_DOUBLE))};
+    auto return_type = AnyValUtil::column_type_to_type_desc(TypeDescriptor::from_logical_type(TYPE_DOUBLE));
+    std::unique_ptr<FunctionContext> local_ctx(FunctionContext::create_test_context(std::move(arg_types), return_type));
+
+    const AggregateFunction* func = get_aggregate_function("percentile_cont", TYPE_DOUBLE, TYPE_DOUBLE, false);
+
+    auto data_column1 = DoubleColumn::create();
+    data_column1->append(2.0);
+    data_column1->append(3.0);
+    data_column1->append(4.0);
+    data_column1->append(5.0);
+    data_column1->append(6.0);
+
+    // update input column 1
+    auto state1 = ManagedAggrState::create(ctx, func);
+    auto const_colunm1 = ColumnHelper::create_const_column<TYPE_DOUBLE>(0.25, 1);
+    std::vector<const Column*> raw_columns1;
+    raw_columns1.resize(2);
+    raw_columns1[0] = data_column1.get();
+    raw_columns1[1] = const_colunm1.get();
+    func->update_batch_single_state(local_ctx.get(), data_column1->size(), raw_columns1.data(), state1->state());
+
+    // merge column 1 and column 2
+    auto result_column = DoubleColumn::create();
+    func->finalize_to_column(local_ctx.get(), state1->state(), result_column.get());
+
+    // [2,3,4,5,6], rate = 0.25 -> 3
     ASSERT_EQ(3, result_column->get_data()[0]);
 }
 

--- a/test/sql/test_agg_function/R/test_percentile_cont
+++ b/test/sql/test_agg_function/R/test_percentile_cont
@@ -1,0 +1,119 @@
+-- name: test_percentile_cont
+CREATE TABLE `test_pc` (
+  `date` date NULL COMMENT "",
+  `datetime` datetime NULL COMMENT "",
+  `db` double NULL COMMENT "",
+  `id` int(11) NULL COMMENT "",
+  `name` varchar(255) NULL COMMENT "",
+  `subject` varchar(255) NULL COMMENT "",
+  `score` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`date`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into test_pc values ("2018-01-01","2018-01-01 00:00:01",11.1,1,"Tom","English",90);
+-- result:
+-- !result
+insert into test_pc values ("2019-01-01","2019-01-01 00:00:01",11.2,1,"Tom","English",91);
+-- result:
+-- !result
+insert into test_pc values ("2020-01-01","2020-01-01 00:00:01",11.3,1,"Tom","English",92);
+-- result:
+-- !result
+insert into test_pc values ("2021-01-01","2021-01-01 00:00:01",11.4,1,"Tom","English",93);
+-- result:
+-- !result
+insert into test_pc values ("2022-01-01","2022-01-01 00:00:01",11.5,1,"Tom","English",94);
+-- result:
+-- !result
+insert into test_pc values (NULL,NULL,NULL,NULL,"Tom","English",NULL);
+-- result:
+-- !result
+select percentile_cont(score, 0) from test_pc;
+-- result:
+90.0
+-- !result
+select percentile_cont(score, 0.25) from test_pc;
+-- result:
+91.0
+-- !result
+select percentile_cont(score, 0.5) from test_pc;
+-- result:
+92.0
+-- !result
+select percentile_cont(score, 0.75) from test_pc;
+-- result:
+93.0
+-- !result
+select percentile_cont(score, 1) from test_pc;
+-- result:
+94.0
+-- !result
+select percentile_cont(date, 0) from test_pc;
+-- result:
+2018-01-01
+-- !result
+select percentile_cont(date, 0.25) from test_pc;
+-- result:
+2019-01-01
+-- !result
+select percentile_cont(date, 0.5) from test_pc;
+-- result:
+2020-01-01
+-- !result
+select percentile_cont(date, 0.75) from test_pc;
+-- result:
+2021-01-01
+-- !result
+select percentile_cont(date, 1) from test_pc;
+-- result:
+2022-01-01
+-- !result
+select percentile_cont(datetime, 0) from test_pc;
+-- result:
+2018-01-01 00:00:01
+-- !result
+select percentile_cont(datetime, 0.25) from test_pc;
+-- result:
+2019-01-01 00:00:01
+-- !result
+select percentile_cont(datetime, 0.5) from test_pc;
+-- result:
+2020-01-01 00:00:01
+-- !result
+select percentile_cont(datetime, 0.75) from test_pc;
+-- result:
+2021-01-01 00:00:01
+-- !result
+select percentile_cont(datetime, 1) from test_pc;
+-- result:
+2022-01-01 00:00:01
+-- !result
+select percentile_cont(db, 0) from test_pc;
+-- result:
+11.1
+-- !result
+select percentile_cont(db, 0.25) from test_pc;
+-- result:
+11.2
+-- !result
+select percentile_cont(db, 0.5) from test_pc;
+-- result:
+11.3
+-- !result
+select percentile_cont(db, 0.75) from test_pc;
+-- result:
+11.4
+-- !result
+select percentile_cont(db, 1) from test_pc;
+-- result:
+11.5
+-- !result

--- a/test/sql/test_agg_function/T/test_percentile_cont
+++ b/test/sql/test_agg_function/T/test_percentile_cont
@@ -1,0 +1,50 @@
+-- name: test_percentile_cont
+
+CREATE TABLE `test_pc` (
+  `date` date NULL COMMENT "",
+  `datetime` datetime NULL COMMENT "",
+  `db` double NULL COMMENT "",
+  `id` int(11) NULL COMMENT "",
+  `name` varchar(255) NULL COMMENT "",
+  `subject` varchar(255) NULL COMMENT "",
+  `score` int(11) NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`date`)
+DISTRIBUTED BY HASH(`id`) BUCKETS 4
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into test_pc values ("2018-01-01","2018-01-01 00:00:01",11.1,1,"Tom","English",90);
+insert into test_pc values ("2019-01-01","2019-01-01 00:00:01",11.2,1,"Tom","English",91);
+insert into test_pc values ("2020-01-01","2020-01-01 00:00:01",11.3,1,"Tom","English",92);
+insert into test_pc values ("2021-01-01","2021-01-01 00:00:01",11.4,1,"Tom","English",93);
+insert into test_pc values ("2022-01-01","2022-01-01 00:00:01",11.5,1,"Tom","English",94);
+insert into test_pc values (NULL,NULL,NULL,NULL,"Tom","English",NULL);
+
+
+select percentile_cont(score, 0) from test_pc;
+select percentile_cont(score, 0.25) from test_pc;
+select percentile_cont(score, 0.5) from test_pc;
+select percentile_cont(score, 0.75) from test_pc;
+select percentile_cont(score, 1) from test_pc;
+select percentile_cont(date, 0) from test_pc;
+select percentile_cont(date, 0.25) from test_pc;
+select percentile_cont(date, 0.5) from test_pc;
+select percentile_cont(date, 0.75) from test_pc;
+select percentile_cont(date, 1) from test_pc;
+select percentile_cont(datetime, 0) from test_pc;
+select percentile_cont(datetime, 0.25) from test_pc;
+select percentile_cont(datetime, 0.5) from test_pc;
+select percentile_cont(datetime, 0.75) from test_pc;
+select percentile_cont(datetime, 1) from test_pc;
+select percentile_cont(db, 0) from test_pc;
+select percentile_cont(db, 0.25) from test_pc;
+select percentile_cont(db, 0.5) from test_pc;
+select percentile_cont(db, 0.75) from test_pc;
+select percentile_cont(db, 1) from test_pc;


### PR DESCRIPTION
Why I'm doing:
percentile_cont performance enhance

What I'm doing:
Detailed information about this enhancement has been put in issue below:
https://github.com/StarRocks/starrocks/issues/36160

Test on the same cluster and the same data set, and record the performance before and after optimization.

8506500 items —— 0.54 sec --> 0.20 sec

54387164 items —— 5.15 sec --> 0.80 sec

109610515 items —— 8.65 sec --> 1.50 sec

251414166 items —— 20.10 sec --> 3.42 sec

742991422 items —— 1 min 14.80 sec --> 10.88 sec

1106646823 items —— 2 min 55.81 sec --> 16.16 sec

The test shows that the processing performance has been significantly improved.
Especially the processing performance under large data volume is close to 10 times that before optimization.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.


## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
