### PR TITLE
[Enhancement] Add Iceberg planFiles method runtime defensive check

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2106,10 +2106,10 @@ public class Config extends ConfigBase {
     public static long iceberg_query_fe_reserved_mem_percentage = 10;
 
     /**
-     * iceberg planFiles method runtime defensive check divisor, default 1000
+     * iceberg planFiles method runtime defensive check threshold, default 1000
      */
     @ConfField(mutable = true)
-    public static long iceberg_plan_files_defensive_check_divisor = 1000;
+    public static long iceberg_plan_files_defensive_check_threshold = 1000;
 
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2025,7 +2025,7 @@ public class Config extends ConfigBase {
      * excessive machine load and triggering node anomalies.
      */
     @ConfField(mutable = true)
-    public static long iceberg_reserved_num_of_processors = 2;
+    public static int iceberg_reserved_num_of_processors = 2;
 
     /**
      * size of iceberg table refresh pool

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2082,35 +2082,16 @@ public class Config extends ConfigBase {
     public static long iceberg_metadata_cache_max_entry_size = 8388608L;
 
     /**
-     * enable iceberg ScanTasks number limit, default false
+     * iceberg ScanTasks number limit, default -1(no limit)
      */
     @ConfField(mutable = true)
-    public static boolean enable_iceberg_scan_tasks_limit = false;
-
-    /**
-     * iceberg ScanTasks number limit, default 500 * 1000
-     */
-    @ConfField(mutable = true)
-    public static long iceberg_scan_tasks_num = 500L * 1000L;
+    public static long iceberg_scan_tasks_num = -1;
 
     /**
      * enable iceberg query reserved memory defense, default false
      */
     @ConfField(mutable = true)
     public static boolean enable_iceberg_query_memory_defense = false;
-
-    /**
-     * iceberg table query FE reserved memory percentage, default 10
-     */
-    @ConfField(mutable = true)
-    public static long iceberg_query_fe_reserved_mem_percentage = 10;
-
-    /**
-     * iceberg planFiles method runtime defensive check threshold, default 1000
-     */
-    @ConfField(mutable = true)
-    public static long iceberg_plan_files_defensive_check_threshold = 1000;
-
 
     /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2020,6 +2020,14 @@ public class Config extends ConfigBase {
     public static long iceberg_worker_num_threads = Runtime.getRuntime().availableProcessors();
 
     /**
+     * To prevent the entire Frontend (fe) node's CPU resources from being fully occupied
+     * by the Iceberg planner when querying extremely large Iceberg tables, causing
+     * excessive machine load and triggering node anomalies.
+     */
+    @ConfField(mutable = true)
+    public static long iceberg_reserved_num_of_processors = 2;
+
+    /**
      * size of iceberg table refresh pool
      */
     @ConfField(mutable = true)
@@ -2072,6 +2080,37 @@ public class Config extends ConfigBase {
      */
     @ConfField(mutable = true)
     public static long iceberg_metadata_cache_max_entry_size = 8388608L;
+
+    /**
+     * enable iceberg ScanTasks number limit, default false
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_iceberg_scan_tasks_limit = false;
+
+    /**
+     * iceberg ScanTasks number limit, default 500 * 1000
+     */
+    @ConfField(mutable = true)
+    public static long iceberg_scan_tasks_num = 500L * 1000L;
+
+    /**
+     * enable iceberg query reserved memory defense, default false
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_iceberg_query_memory_defense = false;
+
+    /**
+     * iceberg table query FE reserved memory percentage, default 10
+     */
+    @ConfField(mutable = true)
+    public static long iceberg_query_fe_reserved_mem_percentage = 10;
+
+    /**
+     * iceberg planFiles method runtime defensive check divisor, default 1000
+     */
+    @ConfField(mutable = true)
+    public static long iceberg_plan_files_defensive_check_divisor = 1000;
+
 
     /**
      * fe will call es api to get es index shard info every es_state_sync_interval_secs

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -40,7 +40,6 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.common.TimeoutException;
 import com.starrocks.sql.analyzer.SemanticException;
 import org.apache.logging.log4j.LogManager;
@@ -77,6 +76,9 @@ public class Util {
 
     private static final String[] ORDINAL_SUFFIX =
             new String[] {"th", "st", "nd", "rd", "th", "th", "th", "th", "th", "th"};
+
+    // Iceberg tables query FE reserved memory percentage
+    private static final int ICEBERG_QUERY_FE_RESERVED_MEM_PERCENTAGE = 10;
 
     static {
         TYPE_STRING_MAP.put(PrimitiveType.TINYINT, "tinyint(4)");
@@ -484,7 +486,7 @@ public class Util {
         long maxMemory = r.maxMemory();
 
         double memoryReservedPercentage = ((double) (maxMemory - usedMemory) / maxMemory) * 100;
-        return memoryReservedPercentage < Config.iceberg_query_fe_reserved_mem_percentage;
+        return memoryReservedPercentage < ICEBERG_QUERY_FE_RESERVED_MEM_PERCENTAGE;
     }
 
     private static String formatBytes(long sizeInBytes) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -491,8 +491,11 @@ public class Util {
         if (sizeInBytes <= 0) {
             return "0B";
         }
-        final String[] units = new String[] {"B", "KB", "MB", "GB", "TB"};
+        final String[] units = new String[] {"B", "KB", "MB", "GB", "TB", "PB"};
         int digitGroups = (int) (Math.log10(sizeInBytes) / Math.log10(1024));
+        if (digitGroups >= units.length) {
+            digitGroups = units.length - 1;
+        }
         return String.format("%.1f%s", sizeInBytes / Math.pow(1024, digitGroups), units[digitGroups]);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergConnector.java
@@ -70,6 +70,12 @@ public class IcebergConnector implements Connector {
             LOG.info("Default iceberg worker thread number changed " + Config.iceberg_worker_num_threads);
             Properties props = System.getProperties();
             props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP, String.valueOf(Config.iceberg_worker_num_threads));
+        } else {
+            String number = String.valueOf(Math.max(2,
+                    Runtime.getRuntime().availableProcessors() - Config.iceberg_reserved_num_of_processors));
+            LOG.info("The default number for the Iceberg WORKER_POOL is set to " + number);
+            Properties props = System.getProperties();
+            props.setProperty(ThreadPools.WORKER_THREAD_POOL_SIZE_PROP, number);
         }
 
         switch (nativeCatalogType) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -446,9 +446,11 @@ public class IcebergMetadata implements ConnectorMetadata {
 
             icebergScanTasks.add(icebergSplitScanTask);
 
-            if (++loopCount % Config.iceberg_plan_files_defensive_check_divisor == 0) {
+            if (++loopCount >= Config.iceberg_plan_files_defensive_check_threshold) {
                 performIcebergPlanFilesDefensiveCheck(key, icebergScanTasks);
+                loopCount = 0L;
             }
+
 
             String filePath = icebergSplitScanTask.file().path().toString();
             if (!filePaths.contains(filePath)) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -415,7 +415,7 @@ public class IcebergMetadata implements ConnectorMetadata {
         Set<String> filePaths = new HashSet<>();
         long loopCount = 0L;
         while (fileScanTasks.hasNext()) {
-            FileScanTask scanTask = fileScanTaskIterator.next();
+            FileScanTask scanTask = fileScanTasks.next();
 
             FileScanTask icebergSplitScanTask = scanTask;
             if (enableCollectColumnStatistics()) {


### PR DESCRIPTION
Recently, I have been conducting tests and preparations for an internally
large Iceberg v1 table using StarRocks in ad-hoc scenarios. The table
details and the identified issues, as well as optimizations made, are
outlined below:

Information:
- Daily incremental data size for the Iceberg table is 50 TB in Parquet
files, with 450,000 DataFiles, 300 to 500 columns, and 20 to 30 columns
for write metadata metrics (`write.metadata.metrics.column.colx`).
- Queries on this table typically cover a time range of approximately
one week, with 80% of skipping data files.
- Frontend (FE) machine specifications: 8 cores, 64 GB RAM.

Issues:
- When a single query is executed, CPU utilization reaches 800%, FE JVM
memory usage exceeds 90%, but the query eventually produces results.
- With more than two concurrent queries, FE nodes crash, primarily due
to out-of-memory (OOM) issues and secondarily due to CPU reaching 800%.

Objectives:
To ensure that FE nodes do not crash or experience unusually high loads
due to queries on this table.

Enhancements:
1. Set the default Iceberg WORKER_POOL size to CPU number - 2, leaving
two CPU cores for FE non-Iceberg plan files runtime.
2. Introduce a configuration to limit the final ScanTasks data volume for
plan files. Exceeding this limit will trigger a timely
INTERNAL_ERROR, causing the query to fallback to the offline engine.
3. Introduce a configuration to trigger INTERNAL_ERROR when the available
memory in the cluster drops below 10% during the Iceberg plan files
process. Users can then choose to retry later or fallback to the offline
engine.

Results:
1. ScanTasks for Iceberg plan files are within the specified limit.
Queries with FE memory never exceeding 90% during the Iceberg plan files
process execute quickly, achieving the intended ad-hoc performance.
2. Even with extremely large concurrent queries, the FE node does not
crash due to memory and CPU pressure. With concurrent queries, the
cluster CPU utilization ranges from 600% to 800%, and memory usage is
controlled within 90%.

fe.conf:
`enable_iceberg_scan_tasks_limit=true`
`iceberg_scan_tasks_num=800000`
`enable_iceberg_query_memory_defense=true`
`iceberg_query_fe_reserved_mem_percentage=10`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5