### PR TITLE
[BugFix] fix logic when query some non-partition columns in jni connector

### DIFF
--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -457,11 +457,16 @@ Status JniScanner::fill_empty_chunk(RuntimeState* runtime_state, ChunkPtr* chunk
 Status HiveJniScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     // fill chunk with all wanted column exclude partition columns
     Status status = fill_empty_chunk(runtime_state, chunk, _scanner_params.materialize_slots);
-
-    // ====== conjunct evaluation ======
-    // important to add columns before evaluation
-    // because ctxs_by_slot maybe refers to some non-existed slot or partition slot.
     size_t chunk_size = (*chunk)->num_rows();
+    if (!_scanner_params.materialize_slots.empty()) {
+        // when the chunk has partition column and non partition column
+        // fill_empty_chunk will only fill partition column for HiveJniScanner
+        // In this situation, Chunk.num_rows() is not reliable  temporally
+        auto slot_desc = _scanner_params.materialize_slots[0];
+        ColumnPtr& first_non_partition_column = (*chunk)->get_column_by_slot_id(slot_desc->id());
+        chunk_size = first_non_partition_column->size();
+    }
+
     _scanner_ctx.append_not_existed_columns_to_chunk(chunk, chunk_size);
     // right now only hive table need append partition columns explictly, paimon and hudi reader will append partition columns in Java side
     _scanner_ctx.append_or_update_partition_column_to_chunk(chunk, chunk_size);

--- a/test/sql/test_external_file/R/test_hive_jni_format
+++ b/test/sql/test_external_file/R/test_hive_jni_format
@@ -2,7 +2,7 @@
 [UC]shell: avro_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/avro_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/22d31c2544de4459a5f36c20b49cf1d2/avro_format/
+oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/18b53aff8c6f422e87ef9e3b4a3219e5/avro_format/
 -- !result
 shell: ossutil64 mkdir ${avro_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -56,6 +56,11 @@ select * from test_hive_avro_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
 1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k1":3,"k2":5}	{"name":"chandler","age":54}
 -- !result
+select col_tinyint,col_decimal,col_array from test_hive_avro_format;
+-- result:
+7	57.30	["A","B","C"]
+1	100.50	["D","E","F"]
+-- !result
 shell: ossutil64 rm -rf ${avro_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -65,7 +70,7 @@ shell: ossutil64 rm -rf ${avro_prefix[1]}  >/dev/null || echo "exit 0" >/dev/nul
 [UC]shell: rcbinary_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/rcbinary_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/9173a3116080493998b40261430e4fc3/rcbinary_format/
+oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/ed0414200602437987c7771c55e98b05/rcbinary_format/
 -- !result
 shell: ossutil64 mkdir ${rcbinary_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -119,6 +124,11 @@ select * from test_hive_rcbinary_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
 1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 02:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
 -- !result
+select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format;
+-- result:
+7	57.30	["A","B","C"]
+1	100.50	["D","E","F"]
+-- !result
 shell: ossutil64 rm -rf ${rcbinary_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -128,7 +138,7 @@ shell: ossutil64 rm -rf ${rcbinary_prefix[1]}  >/dev/null || echo "exit 0" >/dev
 [UC]shell: rctext_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/rctext_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/1b45b0945f744e4fbe9efddc0fe7021d/rctext_format/
+oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/ac2c404dfb8e4a17ace8e3aa6d2c0e47/rctext_format/
 -- !result
 shell: ossutil64 mkdir ${rctext_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -182,6 +192,11 @@ select * from test_hive_rctext_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
 1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
 -- !result
+select col_tinyint,col_decimal,col_array from test_hive_rctext_format;
+-- result:
+7	57.30	["A","B","C"]
+1	100.50	["D","E","F"]
+-- !result
 shell: ossutil64 rm -rf ${rctext_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:
 0
@@ -191,7 +206,7 @@ shell: ossutil64 rm -rf ${rctext_prefix[1]}  >/dev/null || echo "exit 0" >/dev/n
 [UC]shell: sequence_prefix=echo "oss://${oss_bucket}/test_hive_format/${uuid0}/sequence_format/"
 -- result:
 0
-oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/59a32058171440509022e4f4baa1cc61/sequence_format/
+oss://starrocks-sql-data-zhangjiakou/jiangyangjun/test_hive_format/7847f5f081e54501a414380f71600937/sequence_format/
 -- !result
 shell: ossutil64 mkdir ${sequence_prefix[1]} > /dev/null || echo "exit 0" >/dev/null
 -- result:
@@ -244,6 +259,11 @@ select * from test_hive_sequence_format where col_string = 'world';
 select * from test_hive_sequence_format where abs(col_float - 1.23) < 0.01 ;
 -- result:
 1	2	3	10000000000	1.23	3.14	100.50	you	are       	beautiful	0	2023-10-29 10:00:00	2023-10-29	["D","E","F"]	{"k2":5,"k1":3}	{"name":"chandler","age":54}
+-- !result
+select col_tinyint,col_decimal,col_array from test_hive_sequence_format;
+-- result:
+7	57.30	["A","B","C"]
+1	100.50	["D","E","F"]
 -- !result
 shell: ossutil64 rm -rf ${sequence_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 -- result:

--- a/test/sql/test_external_file/T/test_hive_jni_format
+++ b/test/sql/test_external_file/T/test_hive_jni_format
@@ -41,6 +41,7 @@ PROPERTIES
 
 select * from test_hive_avro_format where col_string = 'world';
 select * from test_hive_avro_format where abs(col_float - 1.23) < 0.01 ;
+select col_tinyint,col_decimal,col_array from test_hive_avro_format;
 
 shell: ossutil64 rm -rf ${avro_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 
@@ -82,6 +83,7 @@ PROPERTIES
 
 select * from test_hive_rcbinary_format where col_string = 'world';
 select * from test_hive_rcbinary_format where abs(col_float - 1.23) < 0.01 ;
+select col_tinyint,col_decimal,col_array from test_hive_rcbinary_format;
 
 shell: ossutil64 rm -rf ${rcbinary_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 
@@ -122,6 +124,7 @@ PROPERTIES
 
 select * from test_hive_rctext_format where col_string = 'world';
 select * from test_hive_rctext_format where abs(col_float - 1.23) < 0.01 ;
+select col_tinyint,col_decimal,col_array from test_hive_rctext_format;
 
 shell: ossutil64 rm -rf ${rctext_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null
 
@@ -162,5 +165,6 @@ PROPERTIES
 
 select * from test_hive_sequence_format where col_string = 'world';
 select * from test_hive_sequence_format where abs(col_float - 1.23) < 0.01 ;
+select col_tinyint,col_decimal,col_array from test_hive_sequence_format;
 
 shell: ossutil64 rm -rf ${sequence_prefix[1]}  >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
Why I'm doing:
when query some non-partition columns , jni connector may return empty result, because chunk->num_rows rely on the first column in chunk, and that column could be partition column. At that time, partition column still empty, so jni connector just return immediately.

What I'm doing:
fix this bug.

before this pr:

```
create external catalog hive_catalog PROPERTIES("type" = "hive","hive.metastore.uris" = "xxx");
use hive_catalog.hive_extbl_test;

mysql> select col_date,col_smallint,col_int from hive_hdfs_par_avro_deflate;
Empty set (0.05 sec)
```

after this pr:
```
mysql> select col_date,col_smallint,col_int from hive_hdfs_par_avro_deflate;
+------------+--------------+---------+
| col_date   | col_smallint | col_int |
+------------+--------------+---------+
| 2021-10-01 |           10 |      10 |
| 2022-01-01 |           13 |      13 |
| 2021-02-01 |            2 |       2 |
| 2021-01-01 |            1 |       1 |
| 2021-11-01 |           11 |      11 |
| 2021-12-01 |           12 |      12 |
| 2021-04-01 |            4 |       4 |
| 2021-09-01 |            9 |       9 |
| 2021-06-01 |            6 |       6 |
| 2021-03-01 |            3 |       3 |
| 2021-05-01 |            5 |       5 |
| 2021-08-01 |            8 |       8 |
| 2021-07-01 |            7 |       7 |
+------------+--------------+---------+
13 rows in set (0.18 sec)
```


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
