### PR TITLE
[Feature] Provide sql interface to check Datacache metrics

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -82,7 +82,7 @@ option(WITH_COMPRESS "Build binary with compresss debug section" ON)
 
 option(WITH_CACHELIB "Build binary with cachelib library" OFF)
 
-option(WITH_STARCACHE "Build binary with starcache library" OFF)
+option(WITH_STARCACHE "Build binary with starcache library" ON)
 
 option(WITH_BENCH "Build binary with bench" OFF)
 

--- a/be/src/block_cache/block_cache.cpp
+++ b/be/src/block_cache/block_cache.cpp
@@ -166,6 +166,11 @@ void BlockCache::record_read_cache(size_t size, int64_t lateny_us) {
     _kv_cache->record_read_cache(size, lateny_us);
 }
 
+
+const starcache::CacheMetrics BlockCache::cache_metrics() const {
+    return _kv_cache->cache_metrics();
+}
+
 Status BlockCache::shutdown() {
     Status st = _kv_cache->shutdown();
     _kv_cache = nullptr;

--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -61,6 +61,8 @@ public:
 
     void record_read_cache(size_t size, int64_t lateny_us);
 
+    const starcache::CacheMetrics cache_metrics() const;
+
     // Shutdown the cache instance to save some state meta
     Status shutdown();
 

--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -92,9 +92,10 @@ Status CacheLibWrapper::remove(const std::string& key) {
     return Status::OK();
 }
 
-std::unordered_map<std::string, double> CacheLibWrapper::cache_stats() {
-    const auto navy_stats = _cache->getNvmCacheStatsMap().toMap();
-    return navy_stats;
+const starcache::CacheMetrics CacheLibWrapper::cache_metrics() {
+    // not implemented
+    starcache::CacheMetrics metrics{};
+    return metrics;
 }
 
 Status CacheLibWrapper::write_object(const std::string& key, const void* ptr, size_t size,

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -56,7 +56,7 @@ public:
 
     Status remove(const std::string& key) override;
 
-    std::unordered_map<std::string, double> cache_stats() override;
+    const starcache::CacheMetrics cache_metrics() override;
 
     void record_read_remote(size_t size, int64_t lateny_us) override;
 

--- a/be/src/block_cache/kv_cache.h
+++ b/be/src/block_cache/kv_cache.h
@@ -18,6 +18,7 @@
 #include "block_cache/cache_options.h"
 #include "block_cache/io_buffer.h"
 #include "common/status.h"
+#include "starcache/star_cache.h"
 
 namespace starrocks {
 
@@ -44,7 +45,7 @@ public:
     // Remove data from cache. The offset must be aligned by block size
     virtual Status remove(const std::string& key) = 0;
 
-    virtual std::unordered_map<std::string, double> cache_stats() = 0;
+    virtual const starcache::CacheMetrics cache_metrics() = 0;
 
     virtual void record_read_remote(size_t size, int64_t lateny_us) = 0;
 

--- a/be/src/block_cache/starcache_wrapper.cpp
+++ b/be/src/block_cache/starcache_wrapper.cpp
@@ -102,10 +102,8 @@ Status StarCacheWrapper::remove(const std::string& key) {
     return Status::OK();
 }
 
-std::unordered_map<std::string, double> StarCacheWrapper::cache_stats() {
-    // TODO: fill some statistics information
-    std::unordered_map<std::string, double> stats;
-    return stats;
+const starcache::CacheMetrics StarCacheWrapper::cache_metrics() {
+    return _cache->metrics();
 }
 
 void StarCacheWrapper::record_read_remote(size_t size, int64_t lateny_us) {

--- a/be/src/block_cache/starcache_wrapper.h
+++ b/be/src/block_cache/starcache_wrapper.h
@@ -40,7 +40,7 @@ public:
 
     Status remove(const std::string& key) override;
 
-    std::unordered_map<std::string, double> cache_stats() override;
+    const starcache::CacheMetrics cache_metrics() override;
 
     void record_read_remote(size_t size, int64_t lateny_us) override;
 

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -147,6 +147,7 @@ set(EXEC_FILES
     schema_scanner/schema_routine_load_jobs_scanner.cpp
     schema_scanner/schema_stream_loads_scanner.cpp
     schema_scanner/sys_object_dependencies.cpp
+    schema_scanner/schema_datacache_metrics_scanner.cpp
     jdbc_scanner.cpp
     sorting/compare_column.cpp
     sorting/merge_column.cpp

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -43,6 +43,7 @@
 #include "exec/schema_scanner/schema_tables_config_scanner.h"
 #include "exec/schema_scanner/schema_tables_scanner.h"
 #include "exec/schema_scanner/schema_task_runs_scanner.h"
+#include "exec/schema_scanner/schema_datacache_metrics_scanner.h"
 #include "exec/schema_scanner/schema_tasks_scanner.h"
 #include "exec/schema_scanner/schema_user_privileges_scanner.h"
 #include "exec/schema_scanner/schema_variables_scanner.h"
@@ -177,6 +178,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaTablePipeFiles>();
     case TSchemaTableType::SCH_PIPES:
         return std::make_unique<SchemaTablePipes>();
+    case TSchemaTableType::SCH_DATACACHE_METRICS:
+        return std::make_unique<SchemaDataCacheMetricsScanner>();
     default:
         return std::make_unique<SchemaDummyScanner>();
     }

--- a/be/src/exec/schema_scanner/schema_datacache_metrics_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_datacache_metrics_scanner.cpp
@@ -1,0 +1,48 @@
+//
+// Created by Smith on 2023/11/30.
+//
+
+#include "exec/schema_scanner/schema_datacache_metrics_scanner.h"
+
+
+namespace starrocks {
+
+SchemaScanner::ColumnDesc SchemaDataCacheMetricsScanner::_s_columns[] = {
+    {"DATABASE_NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"PIPE_ID", TYPE_BIGINT, sizeof(int64_t), false},
+    {"PIPE_NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"TABLE_NAME", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"LOAD_STATUS", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"LAST_ERROR", TYPE_VARCHAR, sizeof(StringValue), false},
+    {"CREATED_TIME", TYPE_DATETIME, sizeof(DateTimeValue), false},
+};
+
+
+SchemaDataCacheMetricsScanner::SchemaDataCacheMetricsScanner() : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
+
+
+DatumArray SchemaDataCacheMetricsScanner::_build_row() {
+    return {
+        Slice("1")
+    };
+}
+
+
+
+Status SchemaDataCacheMetricsScanner::get_next(ChunkPtr* chunk, bool* eos) {
+    auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
+    auto datum_array = _build_row();
+    for (const auto& [slot_id, index] : slot_id_map) {
+        Column* column = (*chunk)->get_column_by_slot_id(slot_id).get();
+        column->append_datum(datum_array[slot_id - 1]);
+    }
+    *eos = true;
+    return Status::OK();
+}
+
+
+
+
+}
+

--- a/be/src/exec/schema_scanner/schema_datacache_metrics_scanner.h
+++ b/be/src/exec/schema_scanner/schema_datacache_metrics_scanner.h
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <column/datum.h>
+
+#include "exec/schema_scanner.h"
+#include "runtime/datetime_value.h"
+#include "runtime/runtime_state.h"
+#include "runtime/string_value.h"
+
+namespace starrocks {
+
+
+
+class SchemaDataCacheMetricsScanner final  : public SchemaScanner {
+public:
+    SchemaDataCacheMetricsScanner();
+    ~SchemaDataCacheMetricsScanner() override = default;
+
+    Status get_next(ChunkPtr* chunk, bool* eos) override;
+
+private:
+    DatumArray _build_row();
+
+    static SchemaScanner::ColumnDesc _s_columns[];
+};
+
+}
+
+
+

--- a/be/src/service/service_be/starrocks_be.cpp
+++ b/be/src/service/service_be/starrocks_be.cpp
@@ -24,7 +24,6 @@
 #include "block_cache/block_cache.h"
 #include "common/config.h"
 #include "common/daemon.h"
-#include "common/logging.h"
 #include "common/status.h"
 #include "exec/pipeline/query_context.h"
 #include "runtime/exec_env.h"

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/SystemId.java
@@ -108,6 +108,7 @@ public class SystemId {
     public static final long GRANTS_TO_ROLES_ID = 102L;
     public static final long GRANTS_TO_USERS_ID = 103L;
     public static final long OBJECT_DEPENDENCIES = 104L;
+    public static final long DATACACHE_METRICS = 105L;
 
     public static final long PIPE_FILES_ID = 120L;
     public static final long PIPES_ID = 121L;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/DataCacheMetricsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/DataCacheMetricsTable.java
@@ -1,0 +1,40 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.information;
+
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemId;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.thrift.TSchemaTableType;
+
+public class DataCacheMetricsTable {
+    public static final String NAME = "datacache_metrics";
+
+    public static SystemTable create() {
+        return new SystemTable(SystemId.DATACACHE_METRICS, NAME, Table.TableType.SCHEMA,
+                SystemTable.builder()
+                        .column("DATABASE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("PIPE_ID", ScalarType.BIGINT)
+                        .column("PIPE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("STATE", ScalarType.createVarcharType(8))
+                        .column("TABLE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("LOAD_STATUS", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("LAST_ERROR", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
+                        .column("CREATED_TIME", ScalarType.DATETIME)
+                        .build(),
+                TSchemaTableType.SCH_DATACACHE_METRICS);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/DataCacheMetricsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/DataCacheMetricsTable.java
@@ -21,19 +21,12 @@ import com.starrocks.catalog.system.SystemTable;
 import com.starrocks.thrift.TSchemaTableType;
 
 public class DataCacheMetricsTable {
-    public static final String NAME = "datacache_metrics";
+    public static final String NAME = "be_datacache_metrics";
 
     public static SystemTable create() {
         return new SystemTable(SystemId.DATACACHE_METRICS, NAME, Table.TableType.SCHEMA,
                 SystemTable.builder()
                         .column("DATABASE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("PIPE_ID", ScalarType.BIGINT)
-                        .column("PIPE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("STATE", ScalarType.createVarcharType(8))
-                        .column("TABLE_NAME", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("LOAD_STATUS", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("LAST_ERROR", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
-                        .column("CREATED_TIME", ScalarType.DATETIME)
                         .build(),
                 TSchemaTableType.SCH_DATACACHE_METRICS);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/InfoSchemaDb.java
@@ -85,6 +85,7 @@ public class InfoSchemaDb extends Database {
             super.registerTableUnlocked(BeCloudNativeCompactionsSystemTable.create());
             super.registerTableUnlocked(PipeFileSystemTable.create());
             super.registerTableUnlocked(PipesSystemTable.create());
+            super.registerTableUnlocked(DataCacheMetricsTable.create());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheMetrics.java
+++ b/fe/fe-core/src/main/java/com/starrocks/datacache/DataCacheMetrics.java
@@ -1,0 +1,134 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.datacache;
+
+import com.google.api.client.util.Lists;
+import com.google.common.base.Preconditions;
+import com.starrocks.thrift.TDataCacheDiskDirSpace;
+import com.starrocks.thrift.TDataCacheMetrics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class DataCacheMetrics {
+    public enum Status {
+
+        NORMAL("Normal"), UPDATING("Updating"), ABNORMAL("Abnormal");
+
+        private final String name;
+
+        private Status(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+    }
+
+    static class DiskDirSpace {
+        String path;
+        long quotaBytes;
+
+        public DiskDirSpace(String path, long quotaBytes) {
+            this.path = path;
+            this.quotaBytes = quotaBytes;
+        }
+    }
+
+    private final Status status;
+    private final long memQuoteBytes;
+    private final long memUsedBytes;
+    private final long diskQuotaBytes;
+    private final long diskUsedBytes;
+    private final long metaUsedBytes;
+    private final List<DiskDirSpace> diskDirSpaces;
+
+    private DataCacheMetrics(Status status, long memQuoteBytes, long memUsedBytes, long diskQuotaBytes,
+                             long diskUsedBytes,
+                             long metaUsedBytes, List<DiskDirSpace> diskDirSpaces) {
+        this.status = status;
+        this.memQuoteBytes = memQuoteBytes;
+        this.memUsedBytes = memUsedBytes;
+        this.diskQuotaBytes = diskQuotaBytes;
+        this.diskUsedBytes = diskUsedBytes;
+        this.metaUsedBytes = metaUsedBytes;
+        Preconditions.checkNotNull(diskDirSpaces, "Don't use null list here");
+        this.diskDirSpaces = diskDirSpaces;
+    }
+
+    public static DataCacheMetrics buildFromThrift(TDataCacheMetrics tMetrics) {
+        Status status = Status.ABNORMAL;
+        if (tMetrics.isSetStatus()) {
+            switch (tMetrics.status) {
+                case NORMAL:
+                    status = Status.NORMAL;
+                    break;
+                case UPDATING:
+                    status = Status.UPDATING;
+                    break;
+                default:
+            }
+        }
+
+        long memQuoteBytes = tMetrics.isSetMem_quota_bytes() ? tMetrics.mem_quota_bytes : 0;
+        long memUsedBytes = tMetrics.isSetMem_used_bytes() ? tMetrics.mem_used_bytes : 0;
+        long diskQuotaBytes = tMetrics.isSetDisk_quota_bytes() ? tMetrics.disk_quota_bytes : 0;
+        long diskUsedBytes = tMetrics.isSetDisk_used_bytes() ? tMetrics.disk_used_bytes : 0;
+        long metaUsedBytes = tMetrics.isSetMeta_used_bytes() ? tMetrics.meta_used_bytes : 0;
+
+        List<DiskDirSpace> diskDirSpaces = Lists.newArrayList();
+        if (tMetrics.isSetDisk_dir_spaces()) {
+            for (TDataCacheDiskDirSpace tDataCacheDiskDirSpace : tMetrics.disk_dir_spaces) {
+                String path = tDataCacheDiskDirSpace.isSetPath() ? tDataCacheDiskDirSpace.path : "";
+                long quotaBytes = tDataCacheDiskDirSpace.isSetQuota_bytes() ? tDataCacheDiskDirSpace.quota_bytes : 0;
+                diskDirSpaces.add(new DiskDirSpace(path, quotaBytes));
+            }
+        }
+
+        return new DataCacheMetrics(status, memQuoteBytes, memUsedBytes, diskQuotaBytes, diskUsedBytes, metaUsedBytes,
+                diskDirSpaces);
+    }
+
+    public String getMemUsage() {
+        return String.format("%s/%s", convertSize(memUsedBytes), convertSize(memQuoteBytes));
+    }
+
+    public String getDiskUsage() {
+        return String.format("%s/%s", convertSize(diskUsedBytes), convertSize(diskQuotaBytes));
+    }
+
+    public String getMetaUsage() {
+        return String.format("%s", convertSize(metaUsedBytes));
+    }
+
+    public String getDiskInfo() {
+        List<String> spaces = new ArrayList<>(diskDirSpaces.size());
+        for (DiskDirSpace space : diskDirSpaces) {
+            spaces.add(String.format("[Path: %s, Quota: %s]", space.path, convertSize(space.quotaBytes)));
+        }
+        return String.join(", ", spaces);
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    private static String convertSize(long size) {
+        double base1Gigabytes = 1024 * 1024 * 1024;
+        double res = size / base1Gigabytes;
+        return String.format("%.2fGb", res);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -750,6 +750,10 @@ public abstract class AstVisitor<R, C> {
         return visitStatement(statement, context);
     }
 
+    public R visitShowDataCacheMetricsStatement(ShowDataCacheMetricsStmt statement, C context) {
+        return visitStatement(statement, context);
+    }
+
     // --------------------------------------- Export Statement --------------------------------------------------------
 
     public R visitExportStatement(ExportStmt statement, C context) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDataCacheMetricsStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowDataCacheMetricsStmt.java
@@ -1,0 +1,84 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.ast;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.ScalarType;
+import com.starrocks.datacache.DataCacheMetrics;
+import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.sql.parser.NodePosition;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class ShowDataCacheMetricsStmt extends ShowStmt {
+
+    private static final ShowResultSetMetaData META_DATA =
+            ShowResultSetMetaData.builder()
+                    .addColumn(new Column("BackendId", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("BackendIP", ScalarType.createVarchar(30)))
+                    .addColumn(new Column("Status", ScalarType.createVarchar(30)))
+                    .addColumn(new Column("DiskUsage", ScalarType.createVarchar(30)))
+                    .addColumn(new Column("MemUsage", ScalarType.createVarchar(30)))
+                    .addColumn(new Column("MetaSize", ScalarType.createVarchar(20)))
+                    .addColumn(new Column("DiskInfo", ScalarType.createVarchar(30)))
+                    .build();
+
+    public ShowDataCacheMetricsStmt(NodePosition nodePosition) {
+        super(nodePosition);
+    }
+
+    public static List<String> convertDataCacheMetricsToRows(long backendId, String backendIP,
+                                                             DataCacheMetrics metrics) {
+        List<String> row = new ArrayList<>(META_DATA.getColumnCount());
+        row.add(String.valueOf(backendId));
+        row.add(backendIP);
+        if (metrics == null) {
+            for (int i = 0; i < META_DATA.getColumnCount() - 2; i++) {
+                row.add("N/A");
+            }
+        } else {
+            row.add(metrics.getStatus().getName());
+            row.add(metrics.getDiskUsage());
+            row.add(metrics.getMemUsage());
+            row.add(metrics.getMetaUsage());
+            row.add(metrics.getDiskInfo());
+        }
+        return row;
+    }
+
+    @Override
+    public ShowResultSetMetaData getMetaData() {
+        return META_DATA;
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitShowDataCacheMetricsStatement(this, context);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/BackendHbResponse.java
@@ -36,10 +36,12 @@ package com.starrocks.system;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Writable;
+import com.starrocks.datacache.DataCacheMetrics;
 
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * Backend heartbeat response contains Backend's be port, http port and brpc port
@@ -63,6 +65,7 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
     private int cpuCores;
     @SerializedName(value = "rebootTime")
     private long rebootTime = -1L;
+    private DataCacheMetrics dataCacheMetrics = null;
     private boolean isSetStoragePath = false;
 
     public BackendHbResponse() {
@@ -102,6 +105,14 @@ public class BackendHbResponse extends HeartbeatResponse implements Writable {
 
     public void setRebootTime(long rebootTime) {
         this.rebootTime = rebootTime * 1000;
+    }
+
+    public void setDataCacheMetrics(DataCacheMetrics dataCacheMetrics) {
+        this.dataCacheMetrics = dataCacheMetrics;
+    }
+
+    public Optional<DataCacheMetrics> getDataCacheMetrics() {
+        return Optional.ofNullable(dataCacheMetrics);
     }
 
     public long getBeId() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/ComputeNode.java
@@ -23,6 +23,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.DnsCache;
+import com.starrocks.datacache.DataCacheMetrics;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.CoordinatorMonitor;
 import com.starrocks.qe.GlobalVariable;
@@ -40,6 +41,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -107,6 +109,8 @@ public class ComputeNode implements IComputable, Writable {
     // It must be true for Backend
     @SerializedName("isSetStoragePath")
     private volatile boolean isSetStoragePath = false;
+
+    private DataCacheMetrics dataCacheMetrics = null;
 
     private volatile int numRunningQueries = 0;
     private volatile long memLimitBytes = 0;
@@ -533,6 +537,10 @@ public class ComputeNode implements IComputable, Writable {
                 }
             }
 
+            if (hbResponse.getDataCacheMetrics().isPresent()) {
+                this.dataCacheMetrics = hbResponse.getDataCacheMetrics().get();
+            }
+
             heartbeatErrMsg = "";
             this.heartbeatRetryTimes = 0;
         } else {
@@ -575,6 +583,10 @@ public class ComputeNode implements IComputable, Writable {
         }
 
         return isChanged;
+    }
+
+    public Optional<DataCacheMetrics> getDataCacheMetrics() {
+        return Optional.of(dataCacheMetrics);
     }
 
     public boolean isResourceUsageFresh() {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -45,6 +45,7 @@ import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.Version;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.Util;
+import com.starrocks.datacache.DataCacheMetrics;
 import com.starrocks.http.rest.BootstrapFinishAction;
 import com.starrocks.persist.HbPackage;
 import com.starrocks.server.GlobalStateMgr;
@@ -304,6 +305,9 @@ public class HeartbeatMgr extends FrontendDaemon {
                             System.currentTimeMillis(), version, cpuCores, isSetStoragePath);
                     if (tBackendInfo.isSetReboot_time()) {
                         backendHbResponse.setRebootTime(tBackendInfo.getReboot_time());
+                    }
+                    if (tBackendInfo.isSetDatacache_metrics()) {
+                        backendHbResponse.setDataCacheMetrics(DataCacheMetrics.buildFromThrift(tBackendInfo.datacache_metrics));
                     }
                     return backendHbResponse;
                 } else {

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -163,6 +163,7 @@ enum TSchemaTableType {
     SCH_PIPES,
     SCH_FE_METRICS,
     STARROCKS_OBJECT_DEPENDENCIES,
+    SCH_DATACACHE_METRICS,
 }
 
 enum THdfsCompression {

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -33,6 +33,30 @@ struct TMasterInfo {
     10: optional Types.TRunMode run_mode
 }
 
+enum TDataCacheStatus {
+    NORMAL,
+    UPDATING,
+    ABNORMAL
+}
+
+struct TDataCacheDiskDirSpace {
+    1: optional string path
+    2: optional i64 quota_bytes
+}
+
+struct TDataCacheMetrics {
+    1: optional TDataCacheStatus status
+    2: optional i64 mem_quota_bytes
+    3: optional i64 mem_used_bytes
+    4: optional i64 disk_quota_bytes
+    5: optional i64 disk_used_bytes
+    6: optional i64 meta_used_bytes
+
+    // space for numeric metrics
+
+    100: optional list<TDataCacheDiskDirSpace> disk_dir_spaces
+}
+
 struct TBackendInfo {
     1: required Types.TPort be_port
     2: required Types.TPort http_port
@@ -43,6 +67,7 @@ struct TBackendInfo {
     7: optional Types.TPort starlet_port
     8: optional i64 reboot_time
     9: optional bool is_set_storage_path
+    10: optional TDataCacheMetrics datacache_metrics
 }
 
 struct THeartbeatResult {


### PR DESCRIPTION
Why I'm doing:
Improve datacache observability, FE need knows DataCache's status for make decision in warmup

What I'm doing:
Provide below grammar:
```sql
mysql> show datacache metrics;
+-----------+---------------+--------+---------------+---------------+----------+----------------------------------------------------------------------------------+
| BackendId | BackendIP     | Status | DiskUsage     | MemUsage      | MetaSize | DiskInfo                                                                         |
+-----------+---------------+--------+---------------+---------------+----------+----------------------------------------------------------------------------------+
| 10004     | 172.26.92.227 | Normal | 0.00Gb/0.00Gb | 0.00Gb/2.93Gb | 0.00Gb   | [Path: /home/disk1/dingchao/code/starrocks/output/be/block_cache, Quota: 0.00Gb] |
+-----------+---------------+--------+---------------+---------------+----------+----------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
