### PR TITLE
[BugFix] Fix core in call hdfs scan function

### DIFF
--- a/be/src/udf/java/utils.cpp
+++ b/be/src/udf/java/utils.cpp
@@ -21,6 +21,7 @@
 #include "common/compiler_util.h"
 #include "exec/workgroup/scan_executor.h"
 #include "exec/workgroup/scan_task_queue.h"
+#include "exec/workgroup/work_group.h"
 #include "runtime/current_thread.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
@@ -46,6 +47,7 @@ PromiseStatusPtr call_hdfs_scan_function_in_pthread(const std::function<Status()
     PromiseStatusPtr ms = std::make_unique<PromiseStatus>();
     if (bthread_self()) {
         ExecEnv::GetInstance()->connector_scan_executor()->submit(workgroup::ScanTask(
+                workgroup::WorkGroupManager::instance()->get_default_workgroup().get(),
                 [promise = ms.get(), func](workgroup::YieldContext&) { promise->set_value(func()); }));
     } else {
         ms->set_value(func());


### PR DESCRIPTION
Why I'm doing:
`connector_scan_executor` uses WorkGroupTaskQueue, workgroup is necessary.
What I'm doing:
Fix core in call hdfs scan function
Fixes #36252

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
