### PR TITLE
[Enhancement] Add a config to enable/disable mv active checker

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2580,7 +2580,7 @@ public class Config extends ConfigBase {
      * Whether enable to active inactive materialized views automatically by the daemon thread or not.
      */
     @ConfField(mutable = true)
-    public static boolean enable_mv_automatic_active_check = false;
+    public static boolean enable_mv_automatic_active_check = true;
 
     /**
      * Whether analyze the mv after refresh in async mode.

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2577,6 +2577,12 @@ public class Config extends ConfigBase {
     public static long mv_active_checker_interval_seconds = 60;
 
     /**
+     * Whether enable to active inactive materialized views automatically by the daemon thread or not.
+     */
+    @ConfField(mutable = true)
+    public static boolean enable_mv_automatic_active_check = false;
+
+    /**
      * Whether analyze the mv after refresh in async mode.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -117,6 +117,7 @@ public class MVActiveChecker extends FrontendDaemon {
         boolean activeOk = false;
         String mvFullName = new TableName(dbName.get(), mv.getName()).toString();
         String sql = String.format("ALTER MATERIALIZED VIEW %s active", mvFullName);
+        LOG.info("[MVActiveChecker] Start to activate MV {} because of its inactive reason: {}", mvFullName, reason);
         try {
             ConnectContext connect = StatisticUtils.buildConnectContext();
             connect.setStatisticsContext(false);

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.util.FrontendDaemon;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
@@ -55,6 +56,10 @@ public class MVActiveChecker extends FrontendDaemon {
     protected void runAfterCatalogReady() {
         // reset if the interval has been changed
         setInterval(Config.mv_active_checker_interval_seconds * 1000L);
+
+        if (!Config.enable_mv_automatic_active_check || FeConstants.runningUnitTest) {
+            return;
+        }
 
         try {
             process();


### PR DESCRIPTION
Why I'm doing:

- When SR's cluster already has many inactive materialized views, mv-active-checker may cause all mvs' restart which will cause the instance cpu's load very high and unusable.

What I'm doing:
- Add a config to control whether to enable/disable mv active checker.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
