### PR TITLE
[Feature] support background sync cloud table meta info

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/SyncCloudTableMetaAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/SyncCloudTableMetaAction.java
@@ -21,9 +21,9 @@ import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.IllegalArgException;
-import com.starrocks.lake.StarMgrMetaSyncer;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.UserIdentity;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
@@ -74,7 +74,7 @@ public class SyncCloudTableMetaAction extends RestBaseAction {
                     "both database and table should be provided.");
         }
 
-        StarMgrMetaSyncer.syncTableMeta(dbName, tableName, force);
+        GlobalStateMgr.getCurrentStarMgrMetaSyncer().syncTableMeta(dbName, tableName, force);
         response.appendContent("OK");
         sendResult(request, response);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarMgrMetaSyncer.java
@@ -236,72 +236,151 @@ public class StarMgrMetaSyncer extends FrontendDaemon {
         return cnt;
     }
 
-    @Override
-    protected void runAfterCatalogReady() {
-        deleteUnusedShardAndShardGroup();
-        deleteUnusedWorker();
+    public void syncTableMetaAndColocationInfo() {
+        List<Long> dbIds = GlobalStateMgr.getCurrentState().getDbIds();
+        for (Long dbId : dbIds) {
+            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            if (db == null) {
+                continue;
+            }
+            if (db.isSystemDatabase()) {
+                continue;
+            }
+
+            List<Table> tables = db.getTables();
+            for (Table table : tables) {
+                if (!table.isCloudNativeTableOrMaterializedView()) {
+                    continue;
+                }
+                try {
+                    syncTableMetaAndColocationInfoInternal(db, (OlapTable) table, true /* forceDeleteData */);
+                } catch (Exception e) {
+                    LOG.info("fail to sync table {} meta, {}", table.getName(), e.getMessage());
+                }
+            }
+        }
     }
 
-    // do a one time sync, delete all shards from this table that exist in starmgr but not in fe
-    public static void syncTableMeta(String dbName, String tableName, boolean forceDeleteData) throws DdlException {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-        if (db == null) {
-            throw new DdlException(String.format("db %s does not exist.", dbName));
-        }
-
-        HashMap<Long, List<Long>> feGroupToShards = new HashMap<>();
+    // return true if starmgr shard meta changed
+    private boolean syncTableMetaInternal(Database db, OlapTable table, boolean forceDeleteData) throws DdlException {
+        StarOSAgent starOSAgent = GlobalStateMgr.getCurrentStarOSAgent();
+        HashMap<Long, Set<Long>> redundantGroupToShards = new HashMap<>();
+        List<PhysicalPartition> physicalPartitions = new ArrayList<>();
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.READ);
         try {
-            Table table = db.getTable(tableName);
-            if (table == null) {
-                throw new DdlException(String.format("table %s does not exist.", tableName));
+            if (db.getTable(table.getId()) == null) {
+                return false; // table might be dropped
             }
-            if (!table.isCloudNativeTableOrMaterializedView()) {
-                throw new DdlException("only support cloud table or cloud mv.");
-            }
-
-            OlapTable olapTable = (OlapTable) table;
-            for (Partition partition : olapTable.getAllPartitions()) {
-                for (PhysicalPartition physicalPartition : partition.getSubPartitions()) {
-                    long groupId = physicalPartition.getShardGroupId();
-                    List<Long> feShardIds = new ArrayList<>();
-                    for (MaterializedIndex materializedIndex :
-                            physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
-                        for (Tablet tablet : materializedIndex.getTablets()) {
-                            feShardIds.add(tablet.getId());
-                        }
-                    }
-                    if (!feShardIds.isEmpty()) {
-                        feGroupToShards.put(groupId, feShardIds);
-                    }
-                }
-            }
-        } catch (Exception e) {
-            throw new DdlException(e.getMessage());
+            GlobalStateMgr.getCurrentState()
+                    .getAllPartitionsIncludeRecycleBin(table)
+                    .stream()
+                    .map(Partition::getSubPartitions)
+                    .forEach(physicalPartitions::addAll);
         } finally {
             locker.unLockDatabase(db, LockType.READ);
         }
 
-        // delete tablet meta and data, outside db lock
-        StarOSAgent starOSAgent = GlobalStateMgr.getCurrentStarOSAgent();
+        for (PhysicalPartition physicalPartition : physicalPartitions) {
+            locker.lockDatabase(db, LockType.READ);
+            try {
+                if (table.getState() != OlapTable.OlapTableState.NORMAL) {
+                    return false; // table might be in schema change
+                }
+                // no need to check db/table/partition again, everything still works
+                long groupId = physicalPartition.getShardGroupId();
+                List<Long> starmgrShardIds = starOSAgent.listShard(groupId);
+                Set<Long> starmgrShardIdsSet = new HashSet<>(starmgrShardIds);
+                for (MaterializedIndex materializedIndex :
+                        physicalPartition.getMaterializedIndices(MaterializedIndex.IndexExtState.ALL)) {
+                    for (Tablet tablet : materializedIndex.getTablets()) {
+                        starmgrShardIdsSet.remove(tablet.getId());
+                    }
+                }
+                // collect shard in starmgr but not in fe
+                redundantGroupToShards.put(groupId, starmgrShardIdsSet);
+            } finally {
+                locker.unLockDatabase(db, LockType.READ);
+            }
+        }
+
+        // try to delete data, if fail, still delete redundant shard meta in starmgr
         Set<Long> shardToDelete = new HashSet<>();
-        for (Map.Entry<Long, List<Long>> entry : feGroupToShards.entrySet()) {
-            List<Long> starmgrShardIds = starOSAgent.listShard(entry.getKey());
-            starmgrShardIds.removeAll(entry.getValue());
+        for (Map.Entry<Long, Set<Long>> entry : redundantGroupToShards.entrySet()) {
             if (forceDeleteData) {
                 try {
-                    // delete shard in starmgr but not in fe
-                    dropTabletAndDeleteShard(starmgrShardIds, starOSAgent);
+                    List<Long> shardIds = new ArrayList<>();
+                    shardIds.addAll(entry.getValue());
+                    dropTabletAndDeleteShard(shardIds, starOSAgent);
                 } catch (Exception e) {
                     // ignore exception
                     LOG.info(e.getMessage());
                 }
             }
-            shardToDelete.addAll(starmgrShardIds);
+            shardToDelete.addAll(entry.getValue());
         }
 
         // do final meta delete, regardless whether above tablet deleted or not
-        starOSAgent.deleteShards(shardToDelete);
+        if (!shardToDelete.isEmpty()) {
+            starOSAgent.deleteShards(shardToDelete);
+        }
+        return !shardToDelete.isEmpty();
+    }
+
+    private void syncTableColocationInfo(Database db, OlapTable table) throws DdlException {
+        // quick check
+        if (!GlobalStateMgr.getCurrentColocateIndex().isLakeColocateTable(table.getId())) {
+            return;
+        }
+        Locker locker = new Locker();
+        locker.lockDatabase(db, LockType.WRITE);
+        try {
+            // check db and table again
+            if (GlobalStateMgr.getCurrentState().getDb(db.getId()) == null) {
+                return;
+            }
+            if (db.getTable(table.getId()) == null) {
+                return;
+            }
+            GlobalStateMgr.getCurrentColocateIndex().updateLakeTableColocationInfo(table, true /* isJoin */,
+                        null /* expectGroupId */);
+        } finally {
+            locker.unLockDatabase(db, LockType.WRITE);
+        }
+    }
+
+    // delete all shards from this table that exist in starmgr but not in fe(mostly from schema change),
+    // and update colocation info
+    private void syncTableMetaAndColocationInfoInternal(Database db, OlapTable table, boolean forceDeleteData)
+            throws DdlException {
+        boolean changed = syncTableMetaInternal(db, table, forceDeleteData);
+        // if meta is changed, need to sync colocation info
+        if (changed) {
+            syncTableColocationInfo(db, table);
+        }
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        deleteUnusedShardAndShardGroup();
+        deleteUnusedWorker();
+        syncTableMetaAndColocationInfo();
+    }
+
+    public void syncTableMeta(String dbName, String tableName, boolean forceDeleteData) throws DdlException {
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
+        if (db == null) {
+            throw new DdlException(String.format("db %s does not exist.", dbName));
+        }
+
+        Table table = db.getTable(tableName);
+        if (table == null) {
+            throw new DdlException(String.format("table %s does not exist.", tableName));
+        }
+        if (!table.isCloudNativeTableOrMaterializedView()) {
+            throw new DdlException("only support cloud table or cloud mv.");
+        }
+
+        syncTableMetaAndColocationInfoInternal(db, (OlapTable) table, forceDeleteData);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -919,6 +919,10 @@ public class GlobalStateMgr {
         return getCurrentState().getStarOSAgent();
     }
 
+    public static StarMgrMetaSyncer getCurrentStarMgrMetaSyncer() {
+        return getCurrentState().getStarMgrMetaSyncer();
+    }
+
     public static WarehouseManager getCurrentWarehouseMgr() {
         return getCurrentState().getWarehouseMgr();
     }
@@ -976,6 +980,10 @@ public class GlobalStateMgr {
 
     public StarOSAgent getStarOSAgent() {
         return starOSAgent;
+    }
+
+    public StarMgrMetaSyncer getStarMgrMetaSyncer() {
+        return starMgrMetaSyncer;
     }
 
     public CatalogMgr getCatalogMgr() {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -1448,8 +1448,12 @@ public class LocalMetastore implements ConnectorMetadata {
                 // update partition info
                 updatePartitionInfo(partitionInfo, newPartitions, existPartitionNameSet, addPartitionClause, olapTable);
 
-                colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */,
-                        null /* expectGroupId */);
+                try {
+                    colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */,
+                            null /* expectGroupId */);
+                } catch (DdlException e) {
+                    LOG.info("table {} update colocation info failed when add partition, {}", olapTable.getId(), e.getMessage());
+                }
 
                 // add partition log
                 addPartitionLog(db, olapTable, partitionDescs, addPartitionClause, partitionInfo, partitionList,
@@ -4873,7 +4877,12 @@ public class LocalMetastore implements ConnectorMetadata {
             // replace
             truncateTableInternal(olapTable, newPartitions, truncateEntireTable, false);
 
-            colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */, null /* expectGroupId */);
+            try {
+                colocateTableIndex.updateLakeTableColocationInfo(olapTable, true /* isJoin */,
+                        null /* expectGroupId */);
+            } catch (DdlException e) {
+                LOG.info("table {} update colocation info failed when truncate table, {}", olapTable.getId(), e.getMessage());
+            }
 
             // write edit log
             TruncateTableInfo info = new TruncateTableInfo(db.getId(), olapTable.getId(), newPartitions,

--- a/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/StarMgrMetaSyncerTest.java
@@ -18,6 +18,8 @@ package com.starrocks.lake;
 import com.google.common.collect.Lists;
 import com.staros.client.StarClientException;
 import com.staros.proto.ShardGroupInfo;
+import com.starrocks.catalog.ColocateTableIndex;
+import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DistributionInfo;
@@ -28,6 +30,7 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
+import com.starrocks.catalog.PhysicalPartition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
@@ -48,6 +51,7 @@ import org.junit.jupiter.api.Assertions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,6 +68,9 @@ public class StarMgrMetaSyncerTest {
     @Mocked
     private StarOSAgent starOSAgent;
 
+    @Mocked
+    private ColocateTableIndex colocateTableIndex;
+
     @Before
     public void setUp() throws Exception {
         long dbId = 1L;
@@ -75,6 +82,11 @@ public class StarMgrMetaSyncerTest {
             @Mock
             public SystemInfoService getCurrentSystemInfo() {
                 return systemInfoService;
+            }
+
+            @Mock
+            public ColocateTableIndex getCurrentColocateIndex() {
+                return colocateTableIndex;
             }
 
             @Mock
@@ -203,21 +215,32 @@ public class StarMgrMetaSyncerTest {
     }
 
     @Test
-    public void testSyncTabletMetaDbNotExist() throws Exception {
+    public void testSyncTableMetaDbNotExist() throws Exception {
         new MockUp<GlobalStateMgr>() {
             @Mock
             public Database getDb(String dbName) {
                 return null;
+            }
+
+            @Mock
+            public Database getDb(long dbId) {
+                return null;
+            }
+
+            @Mock
+            public List<Long> getDbIds() {
+                return Lists.newArrayList(1000L);
             }
         };
 
         Exception exception = Assertions.assertThrows(DdlException.class, () -> {
             starMgrMetaSyncer.syncTableMeta("db", "table", true);
         });
+        starMgrMetaSyncer.syncTableMetaAndColocationInfo();
     }
 
     @Test
-    public void testSyncTabletMetaTableNotExist() throws Exception {
+    public void testSyncTableMetaTableNotExist() throws Exception {
         new MockUp<GlobalStateMgr>() {
             @Mock
             public Database getDb(String dbName) {
@@ -238,39 +261,48 @@ public class StarMgrMetaSyncerTest {
     }
 
     @Test
-    public void testSyncTabletMeta() throws Exception {
+    public void testSyncTableMeta() throws Exception {
+        long dbId = 100;
+        long tableId = 1000;
         List<Long> shards = new ArrayList<>();
-        shards.add(111L);
-        shards.add(222L);
-        shards.add(333L);
 
         new MockUp<GlobalStateMgr>() {
             @Mock
             public Database getDb(String dbName) {
-                return new Database(100, dbName);
+                return new Database(dbId, dbName);
+            }
+
+            @Mock
+            public Database getDb(long id) {
+                return new Database(id, "aaa");
+            }
+
+            @Mock
+            public List<Long> getDbIds() {
+                return Lists.newArrayList(dbId);
             }
         };
+
+        List<Column> baseSchema = new ArrayList<>();
+        KeysType keysType = KeysType.AGG_KEYS;
+        PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
+        DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
+        Table table = new LakeTable(tableId, "bbb", baseSchema, keysType, partitionInfo, defaultDistributionInfo);
 
         new MockUp<Database>() {
             @Mock
             public Table getTable(String tableName) {
-                List<Column> baseSchema = new ArrayList<>();
-                KeysType keysType = KeysType.AGG_KEYS;
-                PartitionInfo partitionInfo = new PartitionInfo(PartitionType.RANGE);
-                DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
-                Table table = new LakeTable(1000, tableName, baseSchema, keysType, partitionInfo, defaultDistributionInfo);
                 return table;
             }
-        };
 
-        new MockUp<OlapTable>() {
             @Mock
-            public Collection<Partition> getAllPartitions() {
-                List<Partition> partitions = new ArrayList<>();
-                DistributionInfo defaultDistributionInfo = new HashDistributionInfo();
-                MaterializedIndex baseIndex = new MaterializedIndex();
-                partitions.add(new Partition(2000, "aaa", baseIndex, defaultDistributionInfo));
-                return partitions;
+            public Table getTable(long tableId) {
+                return table;
+            }
+
+            @Mock
+            public List<Table> getTables() {
+                return Lists.newArrayList(table);
             }
         };
 
@@ -285,7 +317,7 @@ public class StarMgrMetaSyncerTest {
             }
         };
 
-        new MockUp<Partition>() {
+        new MockUp<PhysicalPartition>() {
             @Mock
             public long getShardGroupId() {
                 return 444;
@@ -294,17 +326,52 @@ public class StarMgrMetaSyncerTest {
 
         new MockUp<StarOSAgent>() {
             @Mock
-            public List<Long> listShard(long groupId) {
+            public List<Long> listShard(long groupId) throws DdlException {
                 return shards;
             }
 
             @Mock
-            public void deleteShards(List<Long> shardIds) {
+            public void deleteShards(Set<Long> shardIds) throws DdlException {
                 shards.removeAll(shardIds);
             }
         };
 
+        new MockUp<ColocateTableIndex>() {
+            @Mock
+            public boolean isLakeColocateTable(long tableId) {
+                return true;
+            }
+
+            @Mock
+            public void updateLakeTableColocationInfo(OlapTable olapTable, boolean isJoin,
+                    GroupId expectGroupId) throws DdlException {
+                return;
+            }
+        };
+
+        new MockUp<SystemInfoService>() {
+            @Mock
+            public ComputeNode getBackendOrComputeNode(long nodeId) {
+                return null;
+            }
+        };
+
+        shards.clear();
+        shards.add(111L);
+        shards.add(222L);
+        shards.add(333L);
         starMgrMetaSyncer.syncTableMeta("db", "table", true);
-        Assert.assertEquals(0, shards.size());
+        Assert.assertEquals(3, shards.size());
+
+        shards.clear();
+        shards.add(111L);
+        shards.add(222L);
+        shards.add(333L);
+        shards.add(444L);
+        starMgrMetaSyncer.syncTableMetaAndColocationInfo();
+        Assert.assertEquals(3, shards.size());
+        Assert.assertEquals((long) shards.get(0), 111L);
+        Assert.assertEquals((long) shards.get(1), 222L);
+        Assert.assertEquals((long) shards.get(2), 333L);
     }
 }


### PR DESCRIPTION
Why I'm doing:
in some situation schema change will lead to un-deleted tablets/shards, that will cause colocation info update for cloud table failure

What I'm doing:
ignore some update failure, and introduce a background mechanism to update colocation info for cloud table

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
