### PR TITLE
[Enhancement] Use trino sql dialect as default dialect when query trino view

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveView.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.catalog;
 
-import com.google.common.base.Preconditions;
 import com.starrocks.analysis.ParseNode;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
@@ -32,43 +31,74 @@ import static java.util.Objects.requireNonNull;
 
 public class HiveView extends Table {
     private static final Logger LOG = LogManager.getLogger(HiveView.class);
+
+    public enum Type {
+        Trino,
+        Hive
+    }
+
     private final String catalogName;
     private final String inlineViewDef;
+    private final Type viewType;
 
     public static final String PRESTO_VIEW_PREFIX = "/* Presto View: ";
     public static final String PRESTO_VIEW_SUFFIX = " */";
 
-    public HiveView(long id, String catalogName, String name, List<Column> schema, String definition) {
+    public HiveView(long id, String catalogName, String name, List<Column> schema, String definition, Type type) {
         super(id, name, TableType.HIVE_VIEW, schema);
         this.catalogName = requireNonNull(catalogName, "Hive view catalog name is null");
         this.inlineViewDef = requireNonNull(definition, "Hive view text is null");
+        this.viewType = requireNonNull(type, "Hive view type is null");
     }
 
-    public QueryStatement getQueryStatementWithSRParser() throws StarRocksPlannerException {
-        Preconditions.checkNotNull(inlineViewDef);
+    public QueryStatement getQueryStatementWithTrinoParser(SessionVariable sessionVariable)
+            throws StarRocksPlannerException {
+        sessionVariable.setSqlDialect("trino");
+        return getQueryStatementImpl(sessionVariable);
+    }
+
+    public QueryStatement getQueryStatementWithDefaultParser(SessionVariable sessionVariable)
+            throws StarRocksPlannerException {
+        return getQueryStatementImpl(sessionVariable);
+    }
+
+    private QueryStatement getQueryStatementImpl(SessionVariable sessionVariable) {
         ParseNode node;
-        SessionVariable sessionVariable = ConnectContext.get() != null ? ConnectContext.get().getSessionVariable()
-                : new SessionVariable();
         try {
             node = com.starrocks.sql.parser.SqlParser.parse(inlineViewDef, sessionVariable).get(0);
         } catch (Exception e) {
             LOG.warn("stmt is {}", inlineViewDef);
             LOG.warn("exception because: ", e);
-            throw new StarRocksPlannerException(
-                    String.format("Failed to parse view-definition statement of view: %s", name),
-                    ErrorType.INTERNAL_ERROR);
+            if (viewType == Type.Trino) {
+                // try to parse with starrocks sql dialect
+                sessionVariable.setSqlDialect("starrocks");
+                node = com.starrocks.sql.parser.SqlParser.parse(inlineViewDef, sessionVariable).get(0);
+            } else {
+                throw new StarRocksPlannerException(
+                        String.format("Failed to parse view-definition statement of view: %s", name),
+                        ErrorType.INTERNAL_ERROR);
+            }
         }
         // Make sure the view definition parses to a query statement.
         if (!(node instanceof QueryStatement)) {
             throw new StarRocksPlannerException(String.format("View definition of %s " +
                     "is not a query statement", name), ErrorType.INTERNAL_ERROR);
         }
-
         return (QueryStatement) node;
     }
 
     public QueryStatement getQueryStatement() throws StarRocksPlannerException {
-        QueryStatement queryStatement = getQueryStatementWithSRParser();
+        SessionVariable sessionVariable = ConnectContext.get() != null ? ConnectContext.get().getSessionVariable()
+                : new SessionVariable();
+        String sqlDialect = sessionVariable.getSqlDialect();
+        QueryStatement queryStatement;
+        if (viewType == Type.Trino) {
+            queryStatement = getQueryStatementWithTrinoParser(sessionVariable);
+        } else {
+            queryStatement = getQueryStatementWithDefaultParser(sessionVariable);
+        }
+        sessionVariable.setSqlDialect(sqlDialect);
+
         List<TableRelation> tableRelations = AnalyzerUtils.collectTableRelations(queryStatement);
         for (TableRelation tableRelation : tableRelations) {
             tableRelation.getName().setCatalog(catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -237,14 +237,16 @@ public class HiveMetastoreApiConverter {
                     TrinoViewDefinition.class);
             hiveViewText = trinoViewDefinition.getOriginalSql();
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition), hiveViewText);
+                    table.getTableName(), toFullSchemasForTrinoView(table, trinoViewDefinition), hiveViewText,
+                    HiveView.Type.Trino);
         } else {
             hiveView = new HiveView(ConnectorTableId.CONNECTOR_ID_GENERATOR.getNextId().asInt(), catalogName,
-                    table.getTableName(), toFullSchemasForHiveTable(table), table.getViewExpandedText());
+                    table.getTableName(), toFullSchemasForHiveTable(table), table.getViewExpandedText(),
+                    HiveView.Type.Hive);
         }
 
         try {
-            hiveView.getQueryStatementWithSRParser();
+            hiveView.getQueryStatement();
         } catch (StarRocksPlannerException e) {
             throw new StarRocksConnectorException("failed to parse hive view text", e);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveViewTest.java
@@ -81,10 +81,10 @@ public class HiveViewTest extends PlanTestBase {
                  "    t1b,t1a\n" +
                  "from\n" +
                  "    test_all_type\n" +
-                 "    lateral view explode(split(t1a,',')) t1a");
+                 "    lateral view explode(split(t1a,',')) t1a", HiveView.Type.Hive);
         expectedException.expect(StarRocksPlannerException.class);
         expectedException.expectMessage("Failed to parse view-definition statement of view");
-        hiveView.getQueryStatementWithSRParser();
+        hiveView.getQueryStatement();
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
For trino view, it will use default parser to parse
What I'm doing:
use trino parser to parse trino view
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
