### PR TITLE
[BugFix] spillable partition sort sink use-after-free

### DIFF
--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -69,13 +69,16 @@ Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
     // if has spill task. we should wait all spill task finished then to call finished
     // TODO: test cancel case
     auto io_executor = _chunks_sorter->spill_channel()->io_executor();
-    auto set_call_back_function = [this](RuntimeState* state, auto io_executor) {
+    auto chunk_sorter = _chunks_sorter;
+    _sort_context->ref();
+    auto set_call_back_function = [this, chunk_sorter](RuntimeState* state, auto io_executor) {
         return _chunks_sorter->spiller()->set_flush_all_call_back(
-                [this]() {
+                [this, chunk_sorter]() {
                     // Current partition sort is ended, and
                     // the last call will drive LocalMergeSortSourceOperator to work.
-                    TRACE_SPILL_LOG << "finish partition rows:" << _chunks_sorter->get_output_rows();
-                    _sort_context->finish_partition(_chunks_sorter->get_output_rows());
+                    TRACE_SPILL_LOG << "finish partition rows:" << chunk_sorter->get_output_rows();
+                    _sort_context->finish_partition(chunk_sorter->get_output_rows());
+                    _sort_context->unref(runtime_state());
                     _is_finished = true;
                     return Status::OK();
                 },

--- a/be/src/exec/pipeline/spill_process_channel.h
+++ b/be/src/exec/pipeline/spill_process_channel.h
@@ -25,6 +25,7 @@
 #include "exec/spill/spiller.h"
 #include "runtime/runtime_state.h"
 #include "util/blocking_queue.hpp"
+#include "util/defer_op.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -87,7 +88,7 @@ public:
     bool add_last_task(SpillProcessTask&& task) {
         DCHECK(!_is_finishing);
         _is_working = true;
-        set_finishing();
+        auto defer = DeferOp([this]() { set_finishing(); });
         return _spill_tasks.put(std::move(task));
     }
 

--- a/test/sql/test_spill/R/test_short_circuit
+++ b/test/sql/test_spill/R/test_short_circuit
@@ -1,0 +1,74 @@
+-- name: test_short_circuit
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="force";
+-- result:
+-- !result
+set pipeline_dop=1;
+-- result:
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 4 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  6553500));
+-- result:
+-- !result
+create table t1 like t0;
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+-- result:
+-- !result
+select count(*) from t0;
+-- result:
+6553500
+-- !result
+select count(*) from t1;
+-- result:
+4097
+-- !result
+create table empty_t like t0;
+-- result:
+-- !result
+insert into empty_t values (-1,-1);
+-- result:
+-- !result
+select count(*) from ( select l.c0,r.c1 from (select c0, c1, row_number() over (partition by c1) as rn from t0) l join empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- result:
+0
+-- !result
+select count(*) from ( select l.c0,r.c1 from (select c0, c1, row_number() over (partition by c1) as rn from t0) l join [shuffle] empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- result:
+0
+-- !result
+select count(*) from ( select * from (select c0,c1,max(c0),max(c1) from t0 group by c0,c1) l join empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- result:
+0
+-- !result
+select count(*) from ( select * from (select c0,c1,max(c0),max(c1) from t0 group by c0,c1) l join [shuffle] empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- result:
+0
+-- !result
+select count(*) from ( select * from (select t0.c0 as c0, t1.c1 as c1 from t0 join t1 on t0.c0=t1.c0) l join [shuffle] empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- result:
+0
+-- !result
+set query_timeout=5;
+-- result:
+-- !result
+select count(*), count(rn) from (select c0, c0, row_number() over (partition by c0) as rn from TABLE(generate_series(1, 1000000000)) t(c0)) tb;
+-- result:
+E: (1064, 'Query exceeded time limit of 5 seconds')
+-- !result
+select count(*), count(c0), count(mc0) from (select max(c0) mc0, c0 from TABLE(generate_series(1, 1000000000)) t(c0) group by c0) tb;
+-- result:
+E: (1064, 'Query exceeded time limit of 5 seconds')
+-- !result
+select count(*) from ( select * from (select c0 from TABLE(generate_series(1, 1000000000)) t(c0)) l join [broadcast] (select c1 from TABLE(generate_series(1, 1000000000)) t(c1)) r on l.c0 = r.c1 )tb;
+-- result:
+E: (1064, 'Query exceeded time limit of 5 seconds')
+-- !result

--- a/test/sql/test_spill/T/test_short_circuit
+++ b/test/sql/test_spill/T/test_short_circuit
@@ -1,0 +1,32 @@
+-- name: test_short_circuit
+set enable_spill=true;
+set spill_mode="force";
+set pipeline_dop=1;
+
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 4 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  6553500));
+create table t1 like t0;
+insert into t1 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(4096,  8192));
+select count(*) from t0;
+select count(*) from t1;
+create table empty_t like t0;
+insert into empty_t values (-1,-1);
+-- full sort
+select count(*) from ( select l.c0,r.c1 from (select c0, c1, row_number() over (partition by c1) as rn from t0) l join empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+select count(*) from ( select l.c0,r.c1 from (select c0, c1, row_number() over (partition by c1) as rn from t0) l join [shuffle] empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- agg
+select count(*) from ( select * from (select c0,c1,max(c0),max(c1) from t0 group by c0,c1) l join empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+select count(*) from ( select * from (select c0,c1,max(c0),max(c1) from t0 group by c0,c1) l join [shuffle] empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- join
+select count(*) from ( select * from (select t0.c0 as c0, t1.c1 as c1 from t0 join t1 on t0.c0=t1.c0) l join [shuffle] empty_t r on l.c0=r.c0 and l.c1=r.c1 where r.c1 > 0) tb;
+-- test timeout case
+set query_timeout=5;
+-- timeout with spill full sort
+select count(*), count(rn) from (select c0, c0, row_number() over (partition by c0) as rn from TABLE(generate_series(1, 1000000000)) t(c0)) tb;
+-- timeout with spill agg
+select count(*), count(c0), count(mc0) from (select max(c0) mc0, c0 from TABLE(generate_series(1, 1000000000)) t(c0) group by c0) tb;
+-- timeout with join
+select count(*) from ( select * from (select c0 from TABLE(generate_series(1, 1000000000)) t(c0)) l join [broadcast] (select c1 from TABLE(generate_series(1, 1000000000)) t(c1)) r on l.c0 = r.c1 )tb;


### PR DESCRIPTION
Why I'm doing:
when call PartitionSortSink::close, the _chunks_sorter will be reset to null. when spill call ball called. it may cause a NPE

What I'm doing:
capture the chunks_sort in callback function

Fix stack :
```
*** Aborted at 1700718528 (unix time) try "date -d @1700718528" if you are using GNU date ***
PC: @          0x36106b2 _ZNSt17_Function_handlerIFN9starrocks6StatusEvEZZNS0_8pipeline34SpillablePartitionSortSinkOperator13set_finishingEPNS0_12RuntimeStateEENKUlS6_T_E0_clISt10shared_ptrINS0_5spill14IOTaskExecutorEEEEDaS6_S7_EUlvE_E9_M_invokeERKSt9_Any_data
*** SIGSEGV (@0x0) received by PID 114639 (TID 0x7fadddc59700) from PID 0; stack trace: ***
    @          0x6641b82 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7faeae4ec630 (unknown)
    @          0x36106b2 _ZNSt17_Function_handlerIFN9starrocks6StatusEvEZZNS0_8pipeline34SpillablePartitionSortSinkOperator13set_finishingEPNS0_12RuntimeStateEENKUlS6_T_E0_clISt10shared_ptrINS0_5spill14IOTaskExecutorEEEEDaS6_S7_EUlvE_E9_M_invokeERKSt9_Any_data
    @          0x35de057 _ZNSt17_Function_handlerIFN9starrocks6StatusEvEZNS0_5spill7Spiller23set_flush_all_call_backINS3_23ResourceMemTrackerGuardIJSt8weak_ptrINS0_8pipeline12QueryContextEEEEEEES1_RKSt8functionIS2_EPNS0_12RuntimeStateERNS3_14IOTaskExecutorERKT_EUlvE_E9_M_invokeERKSt9_Any_data
    @          0x3675d25 starrocks::spill::SpillerWriter::_decrease_running_flush_tasks()
    @          0x35d57cb _ZZZN9starrocks5spill16RawSpillerWriter5flushIRNS0_14IOTaskExecutorERNS0_23ResourceMemTrackerGuardIJSt8weak_ptrINS_8pipeline12QueryContextEEEEEEENS_6StatusEPNS_12RuntimeStateEOT_OT0_ENKUlvE0_clEvENKUlvE0_clEv
    @          0x35d5b55 _ZNSt17_Function_handlerIFvvEZN9starrocks5spill16RawSpillerWriter5flushIRNS2_14IOTaskExecutorERNS2_23ResourceMemTrackerGuardIJSt8weak_ptrINS1_8pipeline12QueryContextEEEEEEENS1_6StatusEPNS1_12RuntimeStateEOT_OT0_EUlvE0_E9_M_invokeERKSt9_Any_data
    @          0x5221fc0 starrocks::PriorityThreadPool::work_thread()
    @          0x6601547 thread_proxy
    @     0x7faeae4e4ea5 start_thread
    @     0x7faeadaffb2d __clone
    @                0x0 (unknown)
```

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
