### PR TITLE
[BugFix] Fix insert and schema change concurrency issue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2625,9 +2625,6 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long mv_plan_cache_max_size = 1000;
 
-    @ConfField(mutable = true)
-    public static boolean replan_on_insert = false;
-
     /**
      * Checking the connectivity of port opened by FE,
      * mainly used for checking edit log port currently.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -104,7 +104,6 @@ import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.planner.HdfsScanNode;
 import com.starrocks.planner.HiveTableSink;
 import com.starrocks.planner.OlapScanNode;
-import com.starrocks.planner.OlapTableSink;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ScanNode;
 import com.starrocks.privilege.AccessDeniedException;
@@ -118,7 +117,6 @@ import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.rpc.RpcException;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ExplainAnalyzer;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
@@ -179,7 +177,6 @@ import com.starrocks.statistic.StatisticUtils;
 import com.starrocks.statistic.StatisticsCollectJobFactory;
 import com.starrocks.statistic.StatsConstants;
 import com.starrocks.task.LoadEtlTask;
-import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TDescriptorTable;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TLoadJobType;
@@ -221,8 +218,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-
-import static com.starrocks.sql.common.UnsupportedException.unsupportedException;
 
 // Do one COM_QUERY process.
 // first: Parse receive byte array to statement struct.
@@ -1822,70 +1817,16 @@ public class StmtExecutor {
             return;
         }
 
-        String label = DebugUtil.printId(context.getExecutionId());
-        if (stmt instanceof InsertStmt) {
-            String stmtLabel = ((InsertStmt) stmt).getLabel();
-            label = Strings.isNullOrEmpty(stmtLabel) ? "insert_" + label : stmtLabel;
-        } else if (stmt instanceof UpdateStmt) {
-            label = "update_" + label;
-        } else if (stmt instanceof DeleteStmt) {
-            label = "delete_" + label;
-        } else {
-            throw unsupportedException(
-                    "Unsupported dml statement " + parsedStmt.getClass().getSimpleName());
-        }
-
-        TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
         MetricRepo.COUNTER_LOAD_ADD.increase(1L);
-        long transactionId = -1;
+        long transactionId = stmt.getTxnId();
         TransactionState txnState = null;
-        if (targetTable instanceof ExternalOlapTable) {
-            ExternalOlapTable externalTable = (ExternalOlapTable) targetTable;
-            TAuthenticateParams authenticateParams = new TAuthenticateParams();
-            authenticateParams.setUser(externalTable.getSourceTableUser());
-            authenticateParams.setPasswd(externalTable.getSourceTablePassword());
-            authenticateParams.setHost(context.getRemoteIP());
-            authenticateParams.setDb_name(externalTable.getSourceTableDbName());
-            authenticateParams.setTable_names(Lists.newArrayList(externalTable.getSourceTableName()));
-            transactionId = transactionMgr.beginRemoteTransaction(externalTable.getSourceTableDbId(),
-                    Lists.newArrayList(externalTable.getSourceTableId()), label,
-                    externalTable.getSourceTableHost(),
-                    externalTable.getSourceTablePort(),
-                    new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
-                            FrontendOptions.getLocalHostAddress()),
-                    sourceType,
-                    context.getSessionVariable().getQueryTimeoutS(),
-                    authenticateParams);
-        } else if (targetTable instanceof SystemTable || targetTable.isIcebergTable() || targetTable.isHiveTable()
-                || targetTable.isTableFunctionTable()) {
-            // schema table and iceberg and hive table does not need txn
-        } else {
-            transactionId = transactionMgr.beginTransaction(
-                    database.getId(),
-                    Lists.newArrayList(targetTable.getId()),
-                    label,
-                    new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
-                            FrontendOptions.getLocalHostAddress()),
-                    sourceType,
-                    context.getSessionVariable().getQueryTimeoutS());
-
-            // The metadata may be changed between plan() and beginTransaction().
-            // When to beginTransaction(), the plan is not ready and the tablet is dropped by balance.
-            // So we need to get txn first, to make the dropping tablet procedure to wait.
-            // This is the re-plan of the insert to fix the issue
-
-            if (Config.replan_on_insert) {
-                execPlan = StatementPlanner.plan(stmt, context);
-            }
-
-            // add table indexes to transaction state
+        String label = DebugUtil.printId(context.getExecutionId());
+        if (targetTable instanceof OlapTable) {
             txnState = transactionMgr.getTransactionState(database.getId(), transactionId);
             if (txnState == null) {
                 throw new DdlException("txn does not exist: " + transactionId);
             }
-            if (targetTable instanceof OlapTable) {
-                txnState.addTableIndexes((OlapTable) targetTable);
-            }
+            label = txnState.getLabel();
         }
         // Every time set no send flag and clean all data in buffer
         if (context.getMysqlChannel() != null) {
@@ -1902,16 +1843,6 @@ public class StmtExecutor {
         boolean insertError = false;
         String trackingSql = "";
         try {
-            if (execPlan.getFragments().get(0).getSink() instanceof OlapTableSink) {
-                // if sink is OlapTableSink Assigned to Be execute this sql [cn execute OlapTableSink will crash]
-                context.getSessionVariable().setPreferComputeNode(false);
-                context.getSessionVariable().setUseComputeNodes(0);
-                OlapTableSink dataSink = (OlapTableSink) execPlan.getFragments().get(0).getSink();
-                dataSink.init(context.getExecutionId(), transactionId, database.getId(),
-                        ConnectContext.get().getSessionVariable().getQueryTimeoutS());
-                dataSink.complete();
-            }
-
             coord = getCoordinatorFactory().createInsertScheduler(
                     context, execPlan.getFragments(), execPlan.getScanNodes(), execPlan.getDescTbl().toThrift());
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -330,6 +330,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             insertStmt =
                     analyzeInsertStmt(insertStmt, mvToRefreshedPartitions, refTablePartitionNames, materializedView);
+            // Must set execution id before StatementPlanner.plan
+            ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
             execPlan = StatementPlanner.plan(insertStmt, ctx);
         } catch (Throwable e) {
             LOG.warn("prepareRefreshPlan for mv {} failed", materializedView.getName(), e);
@@ -1416,7 +1418,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             parentStmtExecutor.registerSubStmtExecutor(executor);
         }
         ctx.setStmtId(new AtomicInteger().incrementAndGet());
-        ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
         ctx.getSessionVariable().setEnableInsertStrict(false);
         try {
             executor.handleDMLStmtWithProfile(execPlan, insertStmt);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -15,28 +15,44 @@
 package com.starrocks.sql;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ExternalOlapTable;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.system.SystemTable;
+import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
+import com.starrocks.common.DuplicatedRequestException;
+import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.http.HttpConnectContext;
 import com.starrocks.meta.lock.LockType;
 import com.starrocks.meta.lock.Locker;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ResultSink;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.Authorizer;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DeleteStmt;
+import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.UpdateStmt;
+import com.starrocks.sql.common.MetaUtils;
+import com.starrocks.sql.common.UnsupportedException;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.OptimizerTraceUtil;
@@ -47,7 +63,11 @@ import com.starrocks.sql.optimizer.transformer.LogicalPlan;
 import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanFragmentBuilder;
+import com.starrocks.thrift.TAuthenticateParams;
 import com.starrocks.thrift.TResultSinkType;
+import com.starrocks.transaction.BeginTransactionException;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TransactionState;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -69,6 +89,12 @@ public class StatementPlanner {
                                 TResultSinkType resultSinkType) {
         if (stmt instanceof QueryStatement) {
             OptimizerTraceUtil.logQueryStatement("after parse:\n%s", (QueryStatement) stmt);
+        } else if (stmt instanceof DmlStmt) {
+            try {
+                beginTransaction((DmlStmt) stmt, session);
+            } catch (BeginTransactionException | LabelAlreadyUsedException | DuplicatedRequestException | AnalysisException e) {
+                throw new SemanticException("fail to begin transaction. " + e.getMessage());
+            }
         }
 
         Map<String, Database> dbs = AnalyzerUtils.collectAllDatabase(session, stmt);
@@ -311,5 +337,82 @@ public class StatementPlanner {
         }
         ResultSink resultSink = (ResultSink) topFragment.getSink();
         resultSink.setOutfileInfo(queryStmt.getOutFileClause(), columnOutputNames);
+    }
+
+    private static void beginTransaction(DmlStmt stmt, ConnectContext session)
+            throws BeginTransactionException, AnalysisException, LabelAlreadyUsedException, DuplicatedRequestException {
+        MetaUtils.normalizationTableName(session, stmt.getTableName());
+        String catalogName = stmt.getTableName().getCatalog();
+        String dbName = stmt.getTableName().getDb();
+        String tableName = stmt.getTableName().getTbl();
+        Database db = MetaUtils.getDatabase(catalogName, dbName);
+        Table targetTable = MetaUtils.getTable(catalogName, dbName, tableName);
+
+        // not need begin transaction here
+        // 1. explain
+        // 2. old delete
+        // 3. insert overwrite
+        if (stmt.isExplain()) {
+            return;
+        }
+        if (stmt instanceof DeleteStmt && targetTable instanceof OlapTable &&
+                ((OlapTable) targetTable).getKeysType() != KeysType.PRIMARY_KEYS) {
+            return;
+        }
+        if (stmt instanceof InsertStmt && ((InsertStmt) stmt).isOverwrite() &&
+                !((InsertStmt) stmt).hasOverwriteJob() &&
+                !(targetTable.isIcebergTable() || targetTable.isHiveTable())) {
+            return;
+        }
+
+        String label = DebugUtil.printId(session.getExecutionId());
+        if (stmt instanceof InsertStmt) {
+            String stmtLabel = ((InsertStmt) stmt).getLabel();
+            label = Strings.isNullOrEmpty(stmtLabel) ? "insert_" + label : stmtLabel;
+        } else if (stmt instanceof UpdateStmt) {
+            label = "update_" + label;
+        } else if (stmt instanceof DeleteStmt) {
+            label = "delete_" + label;
+        } else {
+            throw UnsupportedException.unsupportedException("Unsupported dml statement " + stmt.getClass().getSimpleName());
+        }
+
+        GlobalTransactionMgr transactionMgr = GlobalStateMgr.getCurrentGlobalTransactionMgr();
+        TransactionState.LoadJobSourceType sourceType = TransactionState.LoadJobSourceType.INSERT_STREAMING;
+        long txnId = -1L;
+        if (targetTable instanceof ExternalOlapTable) {
+            ExternalOlapTable tbl = (ExternalOlapTable) targetTable;
+            TAuthenticateParams authenticateParams = new TAuthenticateParams();
+            authenticateParams.setUser(tbl.getSourceTableUser());
+            authenticateParams.setPasswd(tbl.getSourceTablePassword());
+            authenticateParams.setHost(session.getRemoteIP());
+            authenticateParams.setDb_name(tbl.getSourceTableDbName());
+            authenticateParams.setTable_names(Lists.newArrayList(tbl.getSourceTableName()));
+            txnId = transactionMgr.beginRemoteTransaction(tbl.getSourceTableDbId(), Lists.newArrayList(tbl.getSourceTableId()),
+                    label, tbl.getSourceTableHost(), tbl.getSourceTablePort(),
+                    new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, FrontendOptions.getLocalHostAddress()),
+                    sourceType, session.getSessionVariable().getQueryTimeoutS(), authenticateParams);
+        } else if (targetTable instanceof SystemTable || targetTable.isIcebergTable() || targetTable.isHiveTable()
+                || targetTable.isTableFunctionTable()) {
+            // schema table and iceberg and hive table does not need txn
+        } else {
+            long dbId = db.getId();
+            txnId = transactionMgr.beginTransaction(
+                    dbId,
+                    Lists.newArrayList(targetTable.getId()),
+                    label,
+                    new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE,
+                            FrontendOptions.getLocalHostAddress()),
+                    sourceType,
+                    session.getSessionVariable().getQueryTimeoutS());
+
+            // add table indexes to transaction state
+            if (targetTable instanceof OlapTable) {
+                TransactionState txnState = transactionMgr.getTransactionState(dbId, txnId);
+                txnState.addTableIndexes((OlapTable) targetTable);
+            }
+        }
+
+        stmt.setTxnId(txnId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DmlStmt.java
@@ -21,7 +21,7 @@ import com.starrocks.sql.parser.NodePosition;
 import java.util.Map;
 
 public abstract class DmlStmt extends StatementBase {
-
+    private long txnId;
     private Map<String, String> optHints;
 
     protected DmlStmt(NodePosition pos) {
@@ -34,6 +34,14 @@ public abstract class DmlStmt extends StatementBase {
     }
 
     public abstract TableName getTableName();
+
+    public long getTxnId() {
+        return txnId;
+    }
+
+    public void setTxnId(long txnId) {
+        this.txnId = txnId;
+    }
 
     public Map<String, String> getOptHints() {
         return optHints;

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/InsertIntoValuesDecimalV3Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/InsertIntoValuesDecimalV3Test.java
@@ -18,6 +18,7 @@ package com.starrocks.analysis;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.common.Config;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.sql.StatementPlanner;
 import com.starrocks.sql.ast.InsertStmt;
@@ -28,6 +29,7 @@ import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -44,7 +46,7 @@ public class InsertIntoValuesDecimalV3Test {
     private static ConnectContext ctx;
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void beforeClass() throws Exception {
         UtFrameUtils.createMinStarRocksCluster();
         String createTblStmtStr =
                 "CREATE TABLE if not exists test_table (\n" +
@@ -72,6 +74,12 @@ public class InsertIntoValuesDecimalV3Test {
                 "\"replication_num\" = \"1\",\n" +
                 "\"in_memory\" = \"false\"\n" +
                 ");");
+    }
+
+    @Before
+    public void setUp() {
+        ctx.setQueryId(UUIDUtil.genUUID());
+        ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowMaterializedViewTest.java
@@ -234,8 +234,10 @@ public class ShowMaterializedViewTest {
         TaskManager tm = GlobalStateMgr.getCurrentState().getTaskManager();
         TaskRunManager trm = tm.getTaskRunManager();
 
+        ctx.setQueryId(UUIDUtil.genUUID());
         String insertSql = "insert into tbl6 partition(p1) values('2022-01-02',2,10);";
         new StmtExecutor(ctx, insertSql).execute();
+        ctx.setQueryId(UUIDUtil.genUUID());
         insertSql = "insert into tbl6 partition(p2) values('2022-02-02',2,10);";
         new StmtExecutor(ctx, insertSql).execute();
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
@@ -21,9 +21,8 @@ import org.junit.Test;
 
 public class MaterializedViewHiveTPCHTest extends MaterializedViewTestBase {
     @BeforeClass
-    public static void setUp() throws Exception {
-        PlanTestBase.beforeClass();
-        MaterializedViewTestBase.setUp();
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 
         executeSqlFile("sql/materialized-view/tpch-hive/ddl_tpch_mv1.sql");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -20,8 +20,8 @@ import org.junit.Test;
 public class MaterializedViewManualTest extends MaterializedViewTestBase {
 
     @BeforeClass
-    public static void setUp() throws Exception {
-        MaterializedViewTestBase.setUp();
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManyJoinTest.java
@@ -35,8 +35,8 @@ import java.util.stream.Stream;
 public class MaterializedViewManyJoinTest extends MaterializedViewTestBase {
 
     @BeforeAll
-    public static void setUp() throws Exception {
-        MaterializedViewTestBase.setUp();
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
         starRocksAssert.withTable(
                 "CREATE TABLE tbl_0 (\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewMultiJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewMultiJoinTest.java
@@ -28,8 +28,8 @@ import org.junit.Test;
 public class MaterializedViewMultiJoinTest extends MaterializedViewTestBase {
 
     @BeforeClass
-    public static void setUp() throws Exception {
-        MaterializedViewTestBase.setUp();
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
         prepareDatas();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewPrimaryKeySSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewPrimaryKeySSBTest.java
@@ -21,9 +21,9 @@ import org.junit.Test;
 
 public class MaterializedViewPrimaryKeySSBTest extends MaterializedViewTestBase {
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void beforeClass() throws Exception {
         FeConstants.USE_MOCK_DICT_MANAGER = true;
-        MaterializedViewTestBase.setUp();
+        MaterializedViewTestBase.beforeClass();
 
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewSSBTest.java
@@ -22,9 +22,9 @@ import org.junit.Test;
 
 public class MaterializedViewSSBTest extends MaterializedViewTestBase {
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void beforeClass() throws Exception {
         FeConstants.USE_MOCK_DICT_MANAGER = true;
-        MaterializedViewTestBase.setUp();
+        MaterializedViewTestBase.beforeClass();
 
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -25,9 +25,9 @@ import org.junit.Test;
 
 public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void beforeClass() throws Exception {
         PlanTestBase.beforeClass();
-        MaterializedViewTestBase.setUp();
+        MaterializedViewTestBase.beforeClass();
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 
         executeSqlFile("sql/materialized-view/tpch/ddl_tpch.sql");

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -34,8 +34,8 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     private static final List<String> outerJoinTypes = ImmutableList.of("left", "right");
 
     @BeforeClass
-    public static void setUp() throws Exception {
-        MaterializedViewTestBase.setUp();
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
 
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
         Config.default_replication_num = 1;

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -64,7 +64,9 @@ public class MaterializedViewTestBase extends PlanTestBase {
     }
 
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+
         FeConstants.runningUnitTest = true;
         Config.enable_experimental_mv = true;
         UtFrameUtils.createMinStarRocksCluster();

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewUniqueKeySSBTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewUniqueKeySSBTest.java
@@ -21,9 +21,9 @@ import org.junit.Test;
 
 public class MaterializedViewUniqueKeySSBTest extends MaterializedViewTestBase {
     @BeforeClass
-    public static void setUp() throws Exception {
+    public static void beforeClass() throws Exception {
         FeConstants.USE_MOCK_DICT_MANAGER = true;
-        MaterializedViewTestBase.setUp();
+        MaterializedViewTestBase.beforeClass();
 
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewWithPartitionTest.java
@@ -21,8 +21,8 @@ import org.junit.Test;
 public class MaterializedViewWithPartitionTest extends MaterializedViewTestBase {
 
     @BeforeClass
-    public static void setUp() throws Exception {
-        MaterializedViewTestBase.setUp();
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
 
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/CoordinatorTest.java
@@ -66,7 +66,8 @@ public class CoordinatorTest extends PlanTestBase {
     CoordinatorPreprocessor coordinatorPreprocessor;
 
     @Before
-    public void setUp() throws IOException {
+    public void setUp() {
+        super.setUp();
         ctx = UtFrameUtils.createDefaultCtx();
         ctx.setExecutionId(new TUniqueId(0xdeadbeef, 0xdeadbeef));
         ConnectContext.threadLocalInfo.set(ctx);

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/QueryQueueManagerTest.java
@@ -129,8 +129,8 @@ public class QueryQueueManagerTest extends SchedulerTestBase {
 
         GlobalVariable.setEnableGroupLevelQueryQueue(true);
 
-        GlobalVariable.setQueryQueuePendingTimeoutSecond(1000_000);
-        connectContext.getSessionVariable().setQueryTimeoutS(1000_000);
+        GlobalVariable.setQueryQueuePendingTimeoutSecond(Config.max_load_timeout_second);
+        connectContext.getSessionVariable().setQueryTimeoutS(Config.max_load_timeout_second);
 
         mockFrontends(FRONTENDS);
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -338,20 +338,28 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         }
     }
 
+    private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
+        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+        taskRun.executeTaskRun();
+    }
+
+    private static void executeInsertSql(ConnectContext ctx, String insertSql) throws Exception {
+        ctx.setQueryId(UUIDUtil.genUUID());
+        new StmtExecutor(ctx, insertSql).execute();
+    }
+
     @Test
     public void testUnionAllMvWithPartition() {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("union_all_mv"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         try {
             // base table partition insert data
             String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -370,37 +378,35 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv1"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         try {
             // first sync partition
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             Collection<Partition> partitions = materializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
             // add tbl1 partition p5
             String addPartitionSql = "ALTER TABLE test.tbl1 ADD\n" +
                     "PARTITION p5 VALUES [('2022-05-01'),('2022-06-01'))";
             new StmtExecutor(connectContext, addPartitionSql).execute();
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             partitions = materializedView.getPartitions();
             Assert.assertEquals(6, partitions.size());
             // drop tbl2 partition p5
             String dropPartitionSql = "ALTER TABLE test.tbl1 DROP PARTITION p5\n";
             new StmtExecutor(connectContext, dropPartitionSql).execute();
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             partitions = materializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
             // add tbl2 partition p3
             addPartitionSql = "ALTER TABLE test.tbl2 ADD PARTITION p3 values less than('2022-04-01')";
             new StmtExecutor(connectContext, addPartitionSql).execute();
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             partitions = materializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
             // drop tbl2 partition p3
             dropPartitionSql = "ALTER TABLE test.tbl2 DROP PARTITION p3";
             new StmtExecutor(connectContext, dropPartitionSql).execute();
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             partitions = materializedView.getPartitions();
             Assert.assertEquals(5, partitions.size());
 
@@ -433,12 +439,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_without_partition"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-
         try {
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail("refresh failed");
@@ -468,7 +471,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         MaterializedView materializedView = refreshMaterializedView("mv2", "2022-01-03", "2022-02-05");
 
         String insertSql = "insert into tbl4 partition(p1) values('2022-01-02',2,10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
         refreshMVRange(materializedView.getName(), null, null, false);
         Assert.assertEquals(1, materializedView.getPartition("p202112_202201").getVisibleVersion());
@@ -485,9 +488,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Assert.assertEquals(2, materializedView.getPartition("p202204_202205").getVisibleVersion());
 
         insertSql = "insert into tbl4 partition(p3) values('2022-03-02',21,102);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
         insertSql = "insert into tbl4 partition(p0) values('2021-12-02',81,182);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
         refreshMVRange(materializedView.getName(), "2021-12-03", "2022-03-01", false);
         Assert.assertEquals(2, materializedView.getPartition("p202112_202201").getVisibleVersion());
@@ -519,16 +522,15 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         TaskRunManager trm = tm.getTaskRunManager();
 
         String insertSql = "insert into tbl6 partition(p1) values('2022-01-02',2,10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
         insertSql = "insert into tbl6 partition(p2) values('2022-02-02',2,10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
         HashMap<String, String> taskRunProperties = new HashMap<>();
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(true));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
 
         long taskId = tm.getTask(TaskBuilder.getMvTaskName(materializedView.getId())).getId();
         TaskRun run = tm.getTaskRunManager().getRunnableTaskRun(taskId);
@@ -558,8 +560,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         task.setType(Constants.TaskType.PERIODICAL);
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
 
         Collection<Partition> partitions = materializedView.getPartitions();
         Assert.assertEquals(6, partitions.size());
@@ -574,7 +575,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                         getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         Assert.assertEquals(1, materializedView.getPartition("p19980101").getVisibleVersion());
         Assert.assertEquals(1, materializedView.getPartition("p19980102").getVisibleVersion());
         Assert.assertEquals(1, materializedView.getPartition("p19980103").getVisibleVersion());
@@ -583,8 +584,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         task.setType(Constants.TaskType.MANUAL);
         taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
 
         Assert.assertEquals(6, partitions.size());
         Assert.assertEquals(2, materializedView.getPartition("p19980101").getVisibleVersion());
@@ -603,8 +603,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -663,8 +662,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             throws Exception {
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
     }
 
     @Test
@@ -762,8 +760,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // refresh only one partition
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -783,8 +780,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // add new row and refresh again
         mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-01");
         taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -818,8 +814,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -832,7 +827,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                         getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
         mockedHiveMetadata.addPartition("partitioned_db", "lineitem_par", "l_shipdate=1998-01-06");
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -864,8 +859,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -879,7 +873,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "t1_par",
                 ImmutableList.of("par_col=0/par_date=2020-01-03"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -888,7 +882,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "t1",
                 ImmutableList.of("par_col=0"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -914,8 +908,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -929,7 +922,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=1998-01-04"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -939,7 +932,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         mockedHiveMetadata.updateTable("tpch", "orders");
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -963,8 +956,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -977,7 +969,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                         getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
         mockedHiveMetadata.updateTable("tpch", "nation");
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -1007,8 +999,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1023,7 +1014,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -1058,8 +1049,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1073,7 +1063,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -1104,8 +1094,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1119,7 +1108,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -1150,8 +1139,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1165,7 +1153,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -1201,8 +1189,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1216,7 +1203,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db", "lineitem_par",
                 ImmutableList.of("l_shipdate=1998-01-02", "l_shipdate=1998-01-03"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -1253,8 +1240,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1268,7 +1254,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         mockedHiveMetadata.updatePartitions("partitioned_db2", "t2",
                 ImmutableList.of("par_col=0"));
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         mvContext = processor.getMvContext();
         execPlan = mvContext.getExecPlan();
@@ -1293,8 +1279,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(false));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(taskRunProperties).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         Collection<Partition> partitions = materializedView.getPartitions();
 
         Assert.assertEquals(2, partitions.size());
@@ -1321,8 +1306,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1344,8 +1328,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).properties(mvProperties).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
 
@@ -1581,14 +1564,14 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_without_partition"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
         String insertSql = "insert into tbl3 values('2021-12-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
+
         try {
             for (int i = 0; i < 2; i++) {
-                taskRun.executeTaskRun();
+                initAndExecuteTaskRun(taskRun);
             }
             Assert.assertEquals(1, taskRunCounter.get());
         } catch (Exception e) {
@@ -1618,7 +1601,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             }
         };
         String insertSql = "insert into tbl3 values('2021-12-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
         refreshMVRange(materializedView.getName(), false);
         System.out.println("unregister query id: " + DebugUtil.printId(connectContext.getExecutionId()));
         Assert.assertNull(QeProcessorImpl.INSTANCE.getCoordinator(connectContext.getExecutionId()));
@@ -1627,12 +1610,12 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
     private void testBaseTablePartitionInsertData(Database testDb, MaterializedView materializedView, TaskRun taskRun)
             throws Exception {
         String insertSql = "insert into tbl1 partition(p0) values('2021-12-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
         insertSql = "insert into tbl1 partition(p1) values('2022-01-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         MaterializedView.BasePartitionInfo basePartitionInfo = baseTableVisibleVersionMap.get(tbl1.getId()).get("p0");
@@ -1640,9 +1623,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // insert new data into tbl1's p0 partition
         // update base table tbl1's p0 version to 2
         insertSql = "insert into tbl1 partition(p0) values('2021-12-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap2 =
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         MaterializedView.BasePartitionInfo newP0PartitionInfo = baseTableVisibleVersionMap2.get(tbl1.getId()).get("p0");
@@ -1658,7 +1641,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // insert new data into tbl1's p0 partition
         // update base table tbl1's p0 version to 3
         String insertSql = "insert into tbl1 partition(p0) values('2021-12-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
@@ -1667,7 +1650,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             }
         };
         try {
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -1720,9 +1703,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // insert new data into tbl1's p1 partition
         // update base table tbl1's p1 version to 2
         String insertSql = "insert into tbl1 partition(p1) values('2022-01-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
         try {
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
         } catch (Exception e) {
             Assert.assertTrue(e.getMessage().contains("is not active, skip sync partition and data with base tables"));
         }
@@ -1767,7 +1750,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                                     ");";
                     new StmtExecutor(connectContext, replacePartitionSql).execute();
                     String insertSql = "insert into tbl1 partition(p3) values('2021-03-01', 2, 10);";
-                    new StmtExecutor(connectContext, insertSql).execute();
+                    executeInsertSql(connectContext, insertSql);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -1780,8 +1763,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                 "ALTER TABLE test.tbl1 ADD TEMPORARY PARTITION tp3 values [('2022-03-01'),('2022-04-01'))";
         new StmtExecutor(connectContext, createTempPartitionSql).execute();
         String insertSql = "insert into tbl1 partition(p3) values('2021-03-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
-        taskRun.executeTaskRun();
+        executeInsertSql(connectContext, insertSql);
+        initAndExecuteTaskRun(taskRun);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         MaterializedView.BasePartitionInfo basePartitionInfo = baseTableVisibleVersionMap.get(tbl1.getId()).get("p3");
@@ -1825,9 +1808,10 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
+
                 String insertSql = "insert into tbl1 partition(p99) values('9999-03-01', 2, 10);";
                 try {
-                    new StmtExecutor(connectContext, insertSql).execute();
+                    executeInsertSql(connectContext, insertSql);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -1837,8 +1821,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         // insert new data into tbl1's p3 partition
         String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 2, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
-        taskRun.executeTaskRun();
+        executeInsertSql(connectContext, insertSql);
+        initAndExecuteTaskRun(taskRun);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assert.assertEquals(3, baseTableVisibleVersionMap.get(tbl1.getId()).get("p3").getVersion());
@@ -1860,7 +1844,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                 String insertSql = "insert into tbl1 partition(p100) values('9999-04-01', 3, 10);";
                 try {
                     new StmtExecutor(connectContext, addPartitionSql).execute();
-                    new StmtExecutor(connectContext, insertSql).execute();
+                    executeInsertSql(connectContext, insertSql);
                 } catch (Exception e) {
                     e.printStackTrace();
                 }
@@ -1877,9 +1861,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         // insert new data into tbl1's p3 partition
         String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 3, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assert.assertEquals(4, baseTableVisibleVersionMap.get(tbl1.getId()).get("p3").getVersion());
@@ -1928,8 +1912,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         // insert new data into tbl1's p3 partition
         String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 3, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
-        taskRun.executeTaskRun();
+        executeInsertSql(connectContext, insertSql);
+
+        initAndExecuteTaskRun(taskRun);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assert.assertNull(baseTableVisibleVersionMap.get(tbl1.getId()).get("p4"));
@@ -1963,8 +1948,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         // insert new data into tbl1's p3 partition
         String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 3, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
-        taskRun.executeTaskRun();
+        executeInsertSql(connectContext, insertSql);
+
+        initAndExecuteTaskRun(taskRun);
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
                 materializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
         Assert.assertNotNull(baseTableVisibleVersionMap.get(tbl1.getId()).get("p100"));
@@ -1977,8 +1963,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_with_test_refresh"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         materializedView.getTableProperty().setPartitionRefreshNumber(3);
         PartitionBasedMvRefreshProcessor processor = new PartitionBasedMvRefreshProcessor();
 
@@ -1991,7 +1976,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Assert.assertEquals("2022-03-01", mvContext.getNextPartitionStart());
         Assert.assertEquals("2022-05-01", mvContext.getNextPartitionEnd());
 
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
 
         processor.filterPartitionByRefreshNumber(Sets.newHashSet(), materializedView);
         mvContext = processor.getMvContext();
@@ -2014,15 +1999,14 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_config1"));
 
         String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 3, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
 
         // by default, enable spill
         {
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2035,8 +2019,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             Config.enable_materialized_view_spill = false;
 
             // insert again.
-            new StmtExecutor(connectContext, insertSql).execute();
-            taskRun.executeTaskRun();
+            executeInsertSql(connectContext, insertSql);
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2062,13 +2046,11 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_config2"));
 
         String insertSql = "insert into tbl1 partition(p3) values('2022-03-01', 3, 10);";
-        new StmtExecutor(connectContext, insertSql).execute();
+        executeInsertSql(connectContext, insertSql);
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
-
-        taskRun.executeTaskRun();
+        initAndExecuteTaskRun(taskRun);
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                 taskRun.getProcessor();
         MvTaskRunContext mvContext = processor.getMvContext();
@@ -2143,13 +2125,12 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
 
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
 
         // run 1
         {
             // just refresh to avoid dirty data
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2161,9 +2142,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // run 2
         {
             String insertSql = "INSERT INTO list_partition_tbl1 VALUES (1, 1, '2023-08-15', 'beijing');";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2177,7 +2158,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // run 3
         {
             // just refresh to avoid dirty data
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2206,22 +2187,21 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("partition_prune_non_ref_tables1"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
         // run 1
         {
             // just refresh to avoid dirty data
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
         }
 
         // run 2
         {
             // base table partition insert data
             String insertSql = "insert into tbl4 partition(p4) values('2022-04-01', 3, 10);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2238,9 +2218,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         {
             // TODO: non-ref base table partition's updated will cause the materialized view's refresh all partitions
             String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2272,22 +2252,21 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("partition_prune_non_ref_tables2"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
         // run 1
         {
             // just refresh to avoid dirty data
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
         }
 
         // run 2
         {
             // base table partition insert data
             String insertSql = "insert into tbl4 partition(p4) values('2022-04-01', 3, 10);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2304,9 +2283,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         {
             // TODO: non-ref base table partition's updated will cause the materialized view's refresh all partitions
             String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2338,22 +2317,21 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("partition_prune_non_ref_tables1"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+
         // run 1
         {
             // just refresh to avoid dirty data
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
         }
 
         // run 2
         {
             // base table partition insert data
             String insertSql = "insert into tbl4 partition(p4) values('2022-04-01', 3, 10);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2371,9 +2349,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         {
             // TODO: non-ref base table partition's updated will cause the materialized view's refresh all partitions
             String insertSql = "insert into tbl5 partition(p4) values('2022-04-01', '2021-04-01 00:02:11', 3, 10);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2410,11 +2388,10 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                 ((MaterializedView) testDb.getTable("hive_partition_prune_non_ref_tables2"));
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
 
         // run 1
         {
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2436,7 +2413,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                             getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
             mockedHiveMetadata.addPartition("partitioned_db", "part_tbl1", "par_date=2020-01-05");
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2458,7 +2435,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                             getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
             mockedHiveMetadata.addPartition("partitioned_db", "part_tbl2", "par_date=2020-01-05");
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
             MvTaskRunContext mvContext = processor.getMvContext();
@@ -2479,7 +2456,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                             getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
             mockedHiveMetadata.dropPartition("partitioned_db", "part_tbl1", "par_date=2020-01-05");
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2495,7 +2472,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                             getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
             mockedHiveMetadata.dropPartition("partitioned_db", "part_tbl2", "par_date=2020-01-05");
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2534,13 +2511,11 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                 ((MaterializedView) testDb.getTable("hive_partition_prune_non_ref_tables1"));
 
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
 
         // run 1
         {
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2562,7 +2537,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                             getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
             mockedHiveMetadata.addPartition("partitioned_db", "t1_par", "par_col=4/par_date=2020-01-05");
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2585,7 +2560,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                             getOptionalMetadata(MockedHiveMetadata.MOCKED_HIVE_CATALOG_NAME).get();
             mockedHiveMetadata.addPartition("partitioned_db", "t2_par", "par_col=4/par_date=2020-01-05");
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2610,7 +2585,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             mockedHiveMetadata.dropPartition("partitioned_db", "t1_par", "par_col=3/par_date=2020-01-05");
             mockedHiveMetadata.dropPartition("partitioned_db", "t2_par", "par_col=3/par_date=2020-01-05");
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2662,15 +2637,14 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
 
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
-        taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
 
         // run 1
         {
             String insertSql = "INSERT INTO test_partition_prune_tbl1 VALUES (\"2020-11-10\",1,1);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2687,9 +2661,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // run 2
         {
             String insertSql = "INSERT INTO test_partition_prune_tbl2 VALUES (\"2020-11-10\",1,1);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 
@@ -2706,9 +2680,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // run 3
         {
             String insertSql = "INSERT INTO test_partition_prune_tbl1 VALUES (\"2020-11-10\",1,1);";
-            new StmtExecutor(connectContext, insertSql).execute();
+            executeInsertSql(connectContext, insertSql);
 
-            taskRun.executeTaskRun();
+            initAndExecuteTaskRun(taskRun);
             PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
                     taskRun.getProcessor();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DeletePlanTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.StatementPlanner;
@@ -43,6 +44,8 @@ public class DeletePlanTest extends PlanTestBase {
     }
 
     private void testExplain(String explainStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.getState().reset();
         List<StatementBase> statements =
                 com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
@@ -52,6 +55,8 @@ public class DeletePlanTest extends PlanTestBase {
     }
 
     private static String getDeleteExecPlan(String originStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
         StatementBase statementBase =
                 com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -26,8 +26,13 @@ import java.util.List;
 
 public class HivePartitionPruneTest extends ConnectorPlanTestBase {
     @Before
-    public void setUp() throws DdlException {
-        GlobalStateMgr.getCurrentState().changeCatalogDb(connectContext, "hive0.partitioned_db");
+    public void setUp() {
+        super.setUp();
+        try {
+            GlobalStateMgr.getCurrentState().changeCatalogDb(connectContext, "hive0.partitioned_db");
+        } catch (DdlException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/InsertPlanTest.java
@@ -21,6 +21,7 @@ import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.InsertPlanner;
@@ -370,6 +371,8 @@ public class InsertPlanTest extends PlanTestBase {
     }
 
     public static String getInsertExecPlan(String originStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
         StatementBase statementBase =
                 com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())
@@ -888,5 +891,14 @@ public class InsertPlanTest extends PlanTestBase {
         // parse it again
         var stmts2 = SqlParser.parse(genSql, new SessionVariable());
         Assert.assertEquals(genSql, AstToSQLBuilder.toSQL(stmts2.get(0)));
+    }
+
+    @Test
+    public void testInsertNotExistTable() {
+        try {
+            getInsertExecPlan("insert into not_exist_table values (1)");
+        } catch (Exception e) {
+            Assert.assertTrue(e.getMessage().contains("Table not_exist_table is not found"));
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PipelineParallelismTest.java
@@ -37,6 +37,8 @@ public class PipelineParallelismTest extends PlanTestBase {
 
     @Before
     public void setUp() {
+        super.setUp();
+
         mockedBackendCoreStat = new MockUp<BackendCoreStat>() {
             @Mock
             public int getAvgNumOfHardwareCoresOfBe() {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -28,6 +28,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -42,6 +43,7 @@ import kotlin.text.Charsets;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.ErrorCollector;
@@ -92,6 +94,12 @@ public class PlanTestNoneDBBase {
         FeConstants.showJoinLocalShuffleInExplain = false;
     }
 
+    @Before
+    public void setUp() {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+    }
+
     public static void assertContains(String text, String... pattern) {
         for (String s : pattern) {
             Assert.assertTrue(text, text.contains(s));
@@ -140,10 +148,14 @@ public class PlanTestNoneDBBase {
     }
 
     public ExecPlan getExecPlan(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         return UtFrameUtils.getPlanAndFragment(connectContext, sql).second;
     }
 
     public String getFragmentPlan(String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
                 getExplainString(TExplainLevel.NORMAL);
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -91,6 +91,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
 
     @Before
     public void setUp() {
+        super.setUp();
         connectContext.getSessionVariable().setCboPruneSubfield(true);
         connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayFromDumpTestBase.java
@@ -19,6 +19,7 @@ import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Writable;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.EditLog;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.qe.ConnectContext;
@@ -81,6 +82,8 @@ public class ReplayFromDumpTestBase {
     public void before() {
         BackendCoreStat.reset();
         connectContext.getSessionVariable().setCboPushDownAggregateMode(-1);
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
     }
 
     @AfterClass

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDS1TTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDS1TTestBase.java
@@ -70,7 +70,8 @@ public class TPCDS1TTestBase extends TPCDSPlanTestBase {
     }
 
     @BeforeEach
-    public void setUp() throws Exception {
+    public void setUp() {
+        super.setUp();
         origin = GlobalStateMgr.getCurrentStatisticStorage();
         connectContext.getGlobalStateMgr().setStatisticStorage(new MockTPCDSStatisticStorage());
         setTPCDSTableStats(ROW_COUNT_MAP);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TPCDSPlanTest.java
@@ -34,6 +34,7 @@ public class TPCDSPlanTest extends TPCDSPlanTestBase {
 
     @Before
     public void setUp() {
+        super.setUp();
         tpcdsStats = getTPCDSTableStats();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/TracerMVTest.java
@@ -24,8 +24,8 @@ import org.junit.Test;
 public class TracerMVTest extends MaterializedViewTestBase {
 
     @BeforeClass
-    public static void setUp() throws Exception {
-        MaterializedViewTestBase.setUp();
+    public static void beforeClass() throws Exception {
+        MaterializedViewTestBase.beforeClass();
         starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
         Config.default_replication_num = 1;
         String mv = "CREATE MATERIALIZED VIEW `test_distinct_mv1`\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/UpdatePlanTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.plan;
 
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.StatementPlanner;
@@ -50,6 +51,8 @@ public class UpdatePlanTest extends PlanTestBase {
     }
 
     private void testExplain(String explainStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.getState().reset();
         List<StatementBase> statements =
                 com.starrocks.sql.parser.SqlParser.parse(explainStmt, connectContext.getSessionVariable().getSqlMode());
@@ -59,6 +62,8 @@ public class UpdatePlanTest extends PlanTestBase {
     }
 
     private static String getUpdateExecPlan(String originStmt) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
         StatementBase statementBase =
                 com.starrocks.sql.parser.SqlParser.parse(originStmt, connectContext.getSessionVariable().getSqlMode())

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -191,6 +191,7 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
     @Before
     public void setUp() {
+        super.setUp();
         GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().clear();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -57,6 +57,7 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.LogUtil;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.connector.hive.ReplayMetadataMgr;
 import com.starrocks.ha.FrontendNodeType;
 import com.starrocks.journal.JournalEntity;
@@ -412,6 +413,8 @@ public class UtFrameUtils {
 
     private static <R> R buildPlan(ConnectContext connectContext, String originStmt,
                                    GetPlanHook<R> returnedSupplier) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
         originStmt = LogUtil.removeLineSeparator(originStmt);
 


### PR DESCRIPTION
## Why I'm doing:

currently, source and sink in insert plan are not atomic and may be inconsistent, which may cause BE crash.

## What I'm doing:

1. make insert plan atomic in db lock
2. begin transaction before insert plan

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
