### PR TITLE
[BugFix] dict_mapping crash if dictionary table is not local (#36229)

### DIFF
--- a/be/src/exprs/dict_query_expr.cpp
+++ b/be/src/exprs/dict_query_expr.cpp
@@ -19,6 +19,7 @@
 #include "column/column.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
+#include "exec/tablet_info.h"
 #include "gutil/casts.h"
 #include "runtime/client_cache.h"
 #include "storage/chunk_helper.h"
@@ -42,11 +43,14 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
             column = ColumnHelper::unpack_and_duplicate_const_column(size, column);
         }
     }
-    ChunkPtr key_chunk = ChunkHelper::new_chunk(_key_slots, size);
+    ChunkPtr key_chunk = ChunkHelper::new_chunk(_key_schema, size);
     key_chunk->reset();
     for (int i = 0; i < _dict_query_expr.key_fields.size(); ++i) {
         ColumnPtr key_column = columns[1 + i];
         key_chunk->update_column_by_index(key_column, i);
+    }
+    for (size_t i = 0; i < key_chunk->num_columns(); ++i) {
+        key_chunk->set_slot_id_to_index(_key_slot_ids[i], i);
     }
 
     for (auto& column : key_chunk->columns()) {
@@ -56,7 +60,8 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
     }
 
     std::vector<bool> found;
-    ChunkPtr value_chunk = ChunkHelper::new_chunk(_value_slot, key_chunk->num_rows());
+    ChunkPtr value_chunk = ChunkHelper::new_chunk(_value_schema, key_chunk->num_rows());
+    value_chunk->set_slot_id_to_index(_value_slot_id, 0);
 
     Status status = _table_reader->multi_get(*key_chunk, {_dict_query_expr.value_field}, found, *value_chunk);
     if (!status.ok()) {
@@ -64,7 +69,11 @@ StatusOr<ColumnPtr> DictQueryExpr::evaluate_checked(ExprContext* context, Chunk*
         LOG(WARNING) << "fail to execute multi get: " << status.detailed_message();
         return status;
     }
-    res = ColumnHelper::create_column(_value_slot[0]->type(), true);
+    res = value_chunk->get_column_by_index(0)->clone_empty();
+    if (!res->is_nullable()) {
+        auto null_column = UInt8Column::create(0, 0);
+        res = NullableColumn::create(res, null_column);
+    }
 
     int res_idx = 0;
     for (int idx = 0; idx < size; ++idx) {
@@ -114,21 +123,39 @@ Status DictQueryExpr::open(RuntimeState* state, ExprContext* context, FunctionCo
     _table_reader = std::make_shared<TableReader>();
     RETURN_IF_ERROR(_table_reader->init(params));
 
-    _key_slots.resize(_dict_query_expr.key_fields.size());
+    auto schema_param = std::make_shared<OlapTableSchemaParam>();
+    RETURN_IF_ERROR(schema_param->init(params.schema));
+    const auto& tcolumns = schema_param->indexes()[0]->column_param->columns;
     for (int i = 0; i < _dict_query_expr.key_fields.size(); ++i) {
-        vector<TSlotDescriptor>& slot_descs = response.schema.slot_descs;
-        for (auto& slot : slot_descs) {
-            if (slot.colName == _dict_query_expr.key_fields[i]) {
-                _key_slots[i] = state->obj_pool()->add(new SlotDescriptor(slot));
+        for (const auto& tcolumn : tcolumns) {
+            if (tcolumn->name() == _dict_query_expr.key_fields[i]) {
+                auto f = std::make_shared<Field>(ChunkHelper::convert_field(i, *tcolumn));
+                _key_schema.append(f);
             }
         }
     }
-    _value_slot.resize(1);
-    for (auto& slot : response.schema.slot_descs) {
-        if (slot.colName == _dict_query_expr.value_field) {
-            _value_slot[0] = state->obj_pool()->add(new SlotDescriptor(slot));
+
+    for (const auto& tcolumn : tcolumns) {
+        if (tcolumn->name() == _dict_query_expr.value_field) {
+            auto f = std::make_shared<Field>(ChunkHelper::convert_field(0, *tcolumn));
+            _value_schema.append(f);
+            break; /* only single column */
         }
     }
+
+    for (size_t i = 0; i < params.schema.slot_descs.size(); ++i) {
+        const auto& slot = params.schema.slot_descs[i];
+        for (const auto& field : _key_schema.fields()) {
+            if (field->name() == slot.colName) {
+                _key_slot_ids.emplace_back(slot.id);
+                break;
+            }
+        }
+        if (_dict_query_expr.value_field == slot.colName) {
+            _value_slot_id = slot.id;
+        }
+    }
+    DCHECK(_key_slot_ids.size() == _key_schema.fields().size());
 
     return Status::OK();
 }

--- a/be/src/exprs/dict_query_expr.h
+++ b/be/src/exprs/dict_query_expr.h
@@ -37,8 +37,9 @@ private:
     TDictQueryExpr _dict_query_expr;
 
     Schema _key_schema;
-    std::vector<SlotDescriptor*> _key_slots;
-    std::vector<SlotDescriptor*> _value_slot;
+    Schema _value_schema;
+    std::vector<SlotId> _key_slot_ids;
+    SlotId _value_slot_id;
     std::shared_ptr<TableReader> _table_reader;
 };
 } // namespace starrocks

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -220,7 +220,7 @@ Status handle_tablet_multi_get_rpc(const PTabletReaderMultiGetRequest& request, 
         found_pb->Add(f);
     }
     StatusOr<ChunkPB> values_pb;
-    TRY_CATCH_BAD_ALLOC(values_pb = serde::ProtobufChunkSerde::serialize(*values, nullptr));
+    TRY_CATCH_BAD_ALLOC(values_pb = serde::ProtobufChunkSerde::serialize_without_meta(*values, nullptr));
     if (!values_pb.ok()) {
         return values_pb.status();
     }


### PR DESCRIPTION
Why I'm doing:
There are two crash may happen when execute `dict_mapping` function:

In release mode and debug/asan mode:
If `dict_mapping` need to pull data from other BE nodes when querying the dictionary table, a crash will be triggered. This is because the `value_chunk` constructed by `dict_query_expr` does not contain valid schema information, causing deserialization of `chunkPB` to fail.

In debug/asan mode only:
In `ProtobufChunkSerde::serialize` BE crash cause by `DCHECK_EQ(columns.size(), slot_id_to_index.size())` when executing `multi_get`. This is because the chunk constructed by `multi_get` does not initialize the data structure related to the slot index map. However, since `multi_get` uses `deserialize_chunk_pb_with_schema`, a function that has nothing to do with other metadata of the chunk for deserialization, other serialization functions can be used to avoid this problem.

What I'm doing:
1. construct valid schema for value_chunk in `dict_query_expr`
2. use `serialize_without_meta` instead of `ProtobufChunkSerde::serialize` to serialize chunk in `multi_get`

Fixes #36229

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
