### PR TITLE
[BugFix][branch-3.2] Fix bucket colocate agg error when enable spill 

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.cpp
@@ -40,7 +40,7 @@ bool SpillableAggregateBlockingSinkOperator::is_finished() const {
 
 Status SpillableAggregateBlockingSinkOperator::set_finishing(RuntimeState* state) {
     auto defer_set_finishing = DeferOp([this]() {
-        _aggregator->spill_channel()->set_finishing();
+        _aggregator->spill_channel()->set_finishing_if_not_reuseable();
         _is_finished = true;
     });
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h
@@ -18,6 +18,7 @@
 #include "common/object_pool.h"
 #include "exec/aggregator.h"
 #include "exec/pipeline/operator.h"
+#include "exec/pipeline/spill_process_channel.h"
 #include "exec/sorted_streaming_aggregator.h"
 #include "runtime/runtime_state.h"
 
@@ -41,6 +42,7 @@ public:
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
     bool spillable() const override { return true; }
+
     void set_execute_mode(int performance_level) override {
         _spill_strategy = spill::SpillStrategy::SPILL_ALL;
         TRACE_SPILL_LOG << "AggregateBlockingSink, mark spill " << (void*)this;
@@ -57,6 +59,9 @@ public:
     }
 
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+
+    // only the prepare/open phase calls are valid.
+    SpillProcessChannelPtr spill_channel() { return _aggregator->spill_channel(); }
 
 private:
     bool spilled() const { return _aggregator->spiller()->spilled(); }

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -30,7 +30,7 @@ bool SpillableAggregateDistinctBlockingSinkOperator::is_finished() const {
 
 Status SpillableAggregateDistinctBlockingSinkOperator::set_finishing(RuntimeState* state) {
     auto defer_set_finishing = DeferOp([this]() {
-        _aggregator->spill_channel()->set_finishing();
+        _aggregator->spill_channel()->set_finishing_if_not_reuseable();
         _is_finished = true;
     });
 

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h
@@ -24,7 +24,6 @@
 #include "storage/chunk_helper.h"
 
 namespace starrocks::pipeline {
-// TODO: implements reset_state
 class SpillableAggregateDistinctBlockingSinkOperator : public AggregateDistinctBlockingSinkOperator {
 public:
     template <class... Args>
@@ -59,6 +58,9 @@ public:
     }
 
     Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+
+    // only the prepare/open phase calls are valid.
+    SpillProcessChannelPtr spill_channel() { return _aggregator->spill_channel(); }
 
 private:
     Status _spill_all_inputs(RuntimeState* state, const ChunkPtr& chunk);
@@ -96,7 +98,6 @@ private:
     SpillProcessChannelFactoryPtr _spill_channel_factory;
 };
 
-// TODO: implements reset_state
 class SpillableAggregateDistinctBlockingSourceOperator : public AggregateDistinctBlockingSourceOperator {
 public:
     template <class... Args>

--- a/be/src/exec/pipeline/bucket_process_operator.cpp
+++ b/be/src/exec/pipeline/bucket_process_operator.cpp
@@ -1,8 +1,26 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "exec/pipeline/bucket_process_operator.h"
 
+#include "exec/pipeline/aggregate/spillable_aggregate_blocking_sink_operator.h"
+#include "exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.h"
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_fwd.h"
+#include "exec/pipeline/spill_process_channel.h"
 #include "runtime/runtime_state.h"
+#include "util/defer_op.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks::pipeline {
@@ -35,6 +53,11 @@ bool BucketProcessSinkOperator::is_finished() const {
 }
 
 Status BucketProcessSinkOperator::set_finishing(RuntimeState* state) {
+    auto defer = DeferOp([&]() {
+        if (_ctx->spill_channel != nullptr) {
+            _ctx->spill_channel->set_finishing();
+        }
+    });
     _ctx->all_input_finishing = true;
     bool token = _ctx->token;
     if (!token && _ctx->token.compare_exchange_strong(token, true)) {
@@ -105,6 +128,16 @@ StatusOr<ChunkPtr> BucketProcessSourceOperator::pull_chunk(RuntimeState* state) 
     return chunk;
 }
 
+// TODO: put the spill channel in operator.
+SpillProcessChannelPtr get_spill_channel(const OperatorPtr& op) {
+    if (auto raw = dynamic_cast<SpillableAggregateBlockingSinkOperator*>(op.get()); raw != nullptr) {
+        return raw->spill_channel();
+    } else if (auto raw = dynamic_cast<SpillableAggregateDistinctBlockingSinkOperator*>(op.get()); raw != nullptr) {
+        return raw->spill_channel();
+    }
+    return nullptr;
+}
+
 BucketProcessSinkOperatorFactory::BucketProcessSinkOperatorFactory(
         int32_t id, int32_t plan_node_id, const BucketProcessContextFactoryPtr& context_factory,
         const OperatorFactoryPtr& factory)
@@ -115,6 +148,8 @@ BucketProcessSinkOperatorFactory::BucketProcessSinkOperatorFactory(
 OperatorPtr BucketProcessSinkOperatorFactory::create(int32_t degree_of_parallelism, int32_t driver_sequence) {
     auto ctx = _ctx_factory->get_or_create(driver_sequence);
     ctx->sink = _factory->create(degree_of_parallelism, driver_sequence);
+    ctx->spill_channel = get_spill_channel(ctx->sink);
+    ctx->spill_channel->set_reuseable(true);
     auto bucket_source_operator =
             std::make_shared<BucketProcessSinkOperator>(this, _id, _plan_node_id, driver_sequence, ctx);
     return bucket_source_operator;

--- a/be/src/exec/pipeline/bucket_process_operator.h
+++ b/be/src/exec/pipeline/bucket_process_operator.h
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #pragma once
 
 #include <memory>
@@ -6,6 +20,7 @@
 #include "exec/pipeline/operator.h"
 #include "exec/pipeline/pipeline_fwd.h"
 #include "exec/pipeline/source_operator.h"
+#include "exec/pipeline/spill_process_channel.h"
 #include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
@@ -20,6 +35,7 @@ struct BucketProcessContext {
 
     OperatorPtr source;
     OperatorPtr sink;
+    SpillProcessChannelPtr spill_channel;
 
     Status reset_operator_state(RuntimeState* state);
 };

--- a/be/src/exec/spill/input_stream.cpp
+++ b/be/src/exec/spill/input_stream.cpp
@@ -242,9 +242,11 @@ private:
     std::shared_ptr<BlockReader> _current_reader;
     size_t _current_idx = 0;
     SerdePtr _serde;
+    DECLARE_RACE_DETECTOR(detect_get_next)
 };
 
 StatusOr<ChunkUniquePtr> UnorderedInputStream::get_next(SerdeContext& ctx) {
+    RACE_DETECT(detect_get_next, var1);
     if (_current_idx >= _input_blocks.size()) {
         return Status::EndOfFile("end of reading spilled UnorderedInputStream");
     }

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -196,7 +196,7 @@ Status SpillerReader::trigger_restore(RuntimeState* state, TaskExecutor&& execut
     // if all is well and input stream enable prefetch and not eof
     if (!_stream->eof()) {
         _running_restore_tasks++;
-        auto restore_task = [this, guard, trace = TraceInfo(state)]() {
+        auto restore_task = [this, guard, trace = TraceInfo(state), _stream = _stream]() {
             SCOPED_SET_TRACE_INFO({}, trace.query_id, trace.fragment_id);
             RETURN_IF(!guard.scoped_begin(), Status::OK());
             DEFER_GUARD_END(guard);


### PR DESCRIPTION
If the spill process channel finished and we re-add the task, it will be ignored.
ASAN stack:
```
PC: @     0x7fec06af69fc pthread_kill
*** SIGABRT (@0x3eb001d7389) received by PID 1930121 (TID 0x7feae0957640) from PID 1930121; stack trace: ***
    @         0x1a5262ba google::(anonymous namespace)::FailureSignalHandler()
    @     0x7fec06aa2520 (unknown)
    @     0x7fec06af69fc pthread_kill
    @     0x7fec06aa2476 raise
    @     0x7fec06a887f3 abort
    @          0xe5a72d5 starrocks::failure_function()
    @         0x1a514851 google::LogMessage::Fail()
    @         0x1a516eaf google::LogMessage::SendToLog()
    @         0x1a514390 google::LogMessage::Flush()
    @         0x1a51751d google::LogMessageFatal::~LogMessageFatal()
    @         0x1595413c starrocks::SpillProcessChannel::add_spill_task()
    @         0x15950ca3 starrocks::SpillProcessChannel::execute()
    @         0x16ebe497 starrocks::pipeline::SpillableAggregateBlockingSinkOperator::set_finishing()
    @         0x16f7f5e5 starrocks::pipeline::BucketProcessSinkOperator::set_finishing()
    @          0xea7cab0 starrocks::pipeline::PipelineDriver::_mark_operator_finishing()
    @          0xea73f5e starrocks::pipeline::PipelineDriver::process()
    @         0x178c1d21 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @         0x178c059c _ZZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiENKUlvE_clEv
    @         0x178cb6cc _ZSt13__invoke_implIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEET_St14__invoke_otherOT0_DpOT1_
    @         0x178caabd _ZSt10__invoke_rIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @         0x178c9bd1 _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE_E9_M_invokeERKSt9_Any_data
    @          0xe47af0e std::function<>::operator()()
    @         0x18582c50 starrocks::FunctionRunnable::run()
    @         0x1857f451 starrocks::ThreadPool::dispatch_thread()
    @         0x1859e4fe std::__invoke_impl<>()
    @         0x1859df8d std::__invoke<>()
    @         0x1859ce4a _ZNSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @         0x1859bb99 std::_Bind<>::operator()<>()
    @         0x1859936a std::__invoke_impl<>()
    @         0x18595500 _ZSt10__invoke_rIvRSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
    @         0x18591393 std::_Function_handler<>::_M_invoke()
    @          0xe47af0e std::function<>::operator()()
```