### PR TITLE
[BugFix] fix alter mv refresh scheme issue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -296,9 +296,9 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
                     if (intervalLiteral != null) {
                         final IntLiteral step = (IntLiteral) intervalLiteral.getValue();
                         final MaterializedView.AsyncRefreshContext asyncRefreshContext = refreshScheme.getAsyncRefreshContext();
-                        if (asyncRefreshSchemeDesc.isDefineStartTime()) {
-                            asyncRefreshContext.setStartTime(Utils.getLongFromDateTime(asyncRefreshSchemeDesc.getStartTime()));
-                        }
+                        asyncRefreshContext.setStartTime(
+                                Utils.getLongFromDateTime(asyncRefreshSchemeDesc.getStartTime()));
+                        asyncRefreshContext.setDefineStartTime(asyncRefreshSchemeDesc.isDefineStartTime());
                         asyncRefreshContext.setStep(step.getLongValue());
                         asyncRefreshContext.setTimeUnit(intervalLiteral.getUnitIdentifier().getDescription());
                     } else {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -298,24 +298,7 @@ public class TimeUtils {
     }
 
     public static long convertTimeUnitValueToSecond(long value, TimeUnit unit) {
-        switch (unit) {
-            case DAYS:
-                return value * 60 * 60 * 24;
-            case HOURS:
-                return value * 60 * 60;
-            case MINUTES:
-                return value * 60;
-            case SECONDS:
-                return value;
-            case MILLISECONDS:
-                return value / 1000;
-            case MICROSECONDS:
-                return value / 1000 / 1000;
-            case NANOSECONDS:
-                return value / 1000 / 1000 / 1000;
-            default:
-                return 0;
-        }
+        return TimeUnit.SECONDS.convert(value, unit);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -15,8 +15,8 @@
 package com.starrocks.analysis;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
 import com.starrocks.alter.AlterJobMgr;
-import com.starrocks.alter.AlterMVJobExecutor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.AnalysisException;
@@ -27,7 +27,6 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterMaterializedViewStmt;
-import com.starrocks.sql.ast.AsyncRefreshSchemeDesc;
 import com.starrocks.sql.ast.RefreshSchemeClause;
 import com.starrocks.sql.ast.TableRenameClause;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -42,10 +41,6 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 
 public class AlterMaterializedViewTest {
     private static ConnectContext connectContext;
@@ -101,61 +96,31 @@ public class AlterMaterializedViewTest {
     }
 
     @Test
-    public void testAlterChangeRefresh() throws Exception {
-        String alterMvSql = "alter materialized view mv1 refresh async start ('2222-05-23') every (interval 1 hour)";
-        AlterMaterializedViewStmt alterMvStmt =
-                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
-        new AlterMVJobExecutor().process(alterMvStmt, ConnectContext.get());
+    public void testAlterRefreshScheme() throws Exception {
+        List<String> refreshSchemes = Lists.newArrayList(
+                "ASYNC START(\"2022-05-23 00:00:00\") EVERY(INTERVAL 1 HOUR)",
+                "ASYNC",
+                "ASYNC START(\"2022-05-23 01:02:03\") EVERY(INTERVAL 1 DAY)",
+                "ASYNC EVERY(INTERVAL 1 DAY)",
+                "ASYNC",
+                "MANUAL",
+                "ASYNC EVERY(INTERVAL 1 DAY)",
+                "MANUAL",
+                "ASYNC START(\"2022-05-23 01:02:03\") EVERY(INTERVAL 1 DAY)"
+        );
 
-        alterMvSql = "alter materialized view mv1 refresh ASYNC";
-        alterMvStmt = (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
-        new AlterMVJobExecutor().process(alterMvStmt, ConnectContext.get());
-        MaterializedView mv = (MaterializedView) currentState.getDb("test").getTable("mv1");
-        String showCreateStmt = mv.getMaterializedViewDdlStmt(false);
-        Assert.assertFalse(showCreateStmt.contains("EVERY(INTERVAL 1 HOUR)"));
-    }
+        String mvName = "mv1";
+        for (String refresh : refreshSchemes) {
+            // alter
+            String sql = String.format("alter materialized view %s refresh %s", mvName, refresh);
+            starRocksAssert.ddl(sql);
 
-    @Test
-    public void testAlterManualRefresh() throws Exception {
-        String alterMvSql = "alter materialized view mv1 refresh manual";
-        AlterMaterializedViewStmt alterMvStmt =
-                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
-        RefreshSchemeClause refreshSchemeClause = (RefreshSchemeClause) alterMvStmt.getAlterTableClause();
-        Assert.assertEquals(refreshSchemeClause.getType(), MaterializedView.RefreshType.MANUAL);
-    }
-
-    @Test
-    public void testAlterAsyncRefresh() throws Exception {
-        String alterMvSql = "alter materialized view mv1 refresh async start ('2222-05-23') every (interval 1 hour)";
-        AlterMaterializedViewStmt alterMvStmt =
-                (AlterMaterializedViewStmt) UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
-        final RefreshSchemeClause asyncRefreshSchemeDesc = (RefreshSchemeClause) alterMvStmt.getAlterTableClause();
-        assertTrue(asyncRefreshSchemeDesc instanceof AsyncRefreshSchemeDesc);
-        Assert.assertEquals(asyncRefreshSchemeDesc.getType(), MaterializedView.RefreshType.ASYNC);
-        assertNotNull(((AsyncRefreshSchemeDesc) asyncRefreshSchemeDesc).getStartTime());
-        assertEquals(((IntLiteral) ((AsyncRefreshSchemeDesc) asyncRefreshSchemeDesc).getIntervalLiteral()
-                .getValue()).getValue(), 1);
-        assertEquals(((AsyncRefreshSchemeDesc) asyncRefreshSchemeDesc).getIntervalLiteral().getUnitIdentifier()
-                .getDescription(), "HOUR");
-    }
-
-    @Test
-    public void testAlterAsyncRefreshMonth() {
-        String alterMvSql = "alter materialized view mv1 refresh async start ('2222-05-23') every (interval 1 MONTH)";
-        Assert.assertThrows(AnalysisException.class,
-                () -> UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext));
-    }
-
-    @Test
-    public void testAlterAsyncRefreshNormal() throws Exception {
-        String alterMvSql = "alter materialized view mv1 refresh async start ('2222-05-23') every (interval 1 DAY)";
-        UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
-    }
-
-    @Test
-    public void testAlterAsyncRefreshLowercase() throws Exception {
-        String alterMvSql = "alter materialized view mv1 refresh async start ('2222-05-23') every (interval 1 day)";
-        UtFrameUtils.parseStmtWithNewParser(alterMvSql, connectContext);
+            // verify
+            MaterializedView mv = starRocksAssert.getMv("test", mvName);
+            String showCreateStmt = mv.getMaterializedViewDdlStmt(false);
+            Assert.assertTrue(String.format("alter to %s \nbut got \n%s", refresh, showCreateStmt),
+                    showCreateStmt.contains(refresh));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -38,7 +38,6 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.Task;
-import com.starrocks.scheduler.persist.TaskSchedule;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -687,53 +686,6 @@ public class MaterializedViewTest {
         mv.onReload();
 
         Assert.assertFalse(mv.isActive());
-    }
-
-    @Test
-    public void testAlterAsyncMaterializedViewWithInterval() throws Exception {
-        FeConstants.runningUnitTest = true;
-        Config.enable_experimental_mv = true;
-        UtFrameUtils.createMinStarRocksCluster();
-        ConnectContext connectContext = UtFrameUtils.createDefaultCtx();
-        StarRocksAssert starRocksAssert = new StarRocksAssert(connectContext);
-        starRocksAssert.withDatabase("test").useDatabase("test")
-                .withTable("CREATE TABLE base_table\n" +
-                        "(\n" +
-                        "    k1 date,\n" +
-                        "    k2 int,\n" +
-                        "    v1 int sum\n" +
-                        ")\n" +
-                        "PARTITION BY RANGE(k1)\n" +
-                        "(\n" +
-                        "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n" +
-                        "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" +
-                        ")\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "PROPERTIES('replication_num' = '1');")
-                .withMaterializedView("CREATE MATERIALIZED VIEW base_mv\n" +
-                        "PARTITION BY k1\n" +
-                        "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" +
-                        "REFRESH async START('2122-12-31 20:45:11') EVERY(INTERVAL 1 DAY)\n" +
-                        "as select k1,k2,v1 from base_table;");
-        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-        MaterializedView baseMv = ((MaterializedView) testDb.getTable("base_mv"));
-
-        String alterMvSql = "ALTER MATERIALIZED VIEW base_mv REFRESH ASYNC EVERY(INTERVAL 2 DAY);";
-        StmtExecutor stmtExecutor = new StmtExecutor(connectContext, alterMvSql);
-        stmtExecutor.execute();
-
-        // assert context
-        MaterializedView.AsyncRefreshContext asyncRefreshContext = baseMv.getRefreshScheme().getAsyncRefreshContext();
-        // start time must equal 2022-12-31
-        Assert.assertEquals(4828164311L, asyncRefreshContext.getStartTime());
-        Assert.assertEquals(2, asyncRefreshContext.getStep());
-        Assert.assertEquals("DAY", asyncRefreshContext.getTimeUnit());
-
-        // assert task schedule
-        String mvTaskName = "mv-" + baseMv.getId();
-        TaskSchedule schedule = connectContext.getGlobalStateMgr().getTaskManager().getTask(mvTaskName).getSchedule();
-        // start time must equal 2022-12-31
-        Assert.assertEquals(4828164311L, asyncRefreshContext.getStartTime());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -246,6 +246,11 @@ public class StarRocksAssert {
         return ctx.getGlobalStateMgr().mayGetDb(dbName).map(db -> db.getTable(tableName)).orElse(null);
     }
 
+    public MaterializedView getMv(String dbName, String tableName) {
+        return (MaterializedView) ctx.getGlobalStateMgr().mayGetDb(dbName).map(db -> db.getTable(tableName))
+                .orElse(null);
+    }
+
     public StarRocksAssert withSingleReplicaTable(String sql) throws Exception {
         StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         if (statementBase instanceof CreateTableStmt) {


### PR DESCRIPTION
Why I'm doing:
- Alter refresh scheme of materialized view doesn't work in some cases
- The MV would be refreshed when altering the refresh scheme

What I'm doing:
- Fix issues about `alter materialized view <name> refresh async ...`
- Fix issue of initial refresh when altering the refresh scheme

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
