### PR TITLE
[Enhancement] Use standalone lake compaction txn timeout config

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -879,7 +879,7 @@ public class Config extends ConfigBase {
     public static int prepared_transaction_default_timeout_second = 86400; // 1day
 
     /**
-     * Max load timeout applicable to all type of load except for stream load
+     * Max load timeout applicable to all type of load except for stream load and lake compaction
      */
     @ConfField(mutable = true)
     public static int max_load_timeout_second = 259200; // 3days
@@ -2369,6 +2369,19 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true, comment = "the max number of threads for lake table delete txnLog when enable batch publish")
     public static int lake_publish_delete_txnlog_max_threads = 16;
+
+    /**
+     * Default lake compaction txn timeout
+     */
+    @ConfField(mutable = true)
+    public static int lake_compaction_default_timeout_second = 86400; // 1 day
+
+    /**
+     * Max timeout for lake compaction transaction.
+     * This value should always be greater than `lake_compaction_default_timeout_second`
+     */
+    @ConfField(mutable = true)
+    public static int max_lake_compaction_timeout_second = 259200; // 3days
 
     @ConfField(mutable = true, comment = "the max number of previous version files to keep")
     public static int lake_autovacuum_max_previous_versions = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2376,12 +2376,6 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int lake_compaction_default_timeout_second = 86400; // 1 day
 
-    /**
-     * Max timeout for lake compaction transaction.
-     * This value should always be greater than `lake_compaction_default_timeout_second`
-     */
-    @ConfField(mutable = true)
-    public static int max_lake_compaction_timeout_second = 259200; // 3days
 
     @ConfField(mutable = true, comment = "the max number of previous version files to keep")
     public static int lake_autovacuum_max_previous_versions = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -154,6 +154,10 @@ public class GlobalTransactionMgr implements Writable {
                 checkValidTimeoutSecond(timeoutSecond, Config.max_stream_load_timeout_second,
                         Config.min_load_timeout_second);
                 break;
+            case LAKE_COMPACTION:
+                checkValidTimeoutSecond(timeoutSecond, Config.max_lake_compaction_timeout_second,
+                        Config.min_load_timeout_second);
+                break;
             default:
                 checkValidTimeoutSecond(timeoutSecond, Config.max_load_timeout_second, Config.min_load_timeout_second);
         }
@@ -312,6 +316,10 @@ public class GlobalTransactionMgr implements Writable {
         switch (sourceType) {
             case BACKEND_STREAMING:
                 checkValidTimeoutSecond(timeoutSecond, Config.max_stream_load_timeout_second,
+                        Config.min_load_timeout_second);
+                break;
+            case LAKE_COMPACTION:
+                checkValidTimeoutSecond(timeoutSecond, Config.max_lake_compaction_timeout_second,
                         Config.min_load_timeout_second);
                 break;
             default:

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -315,8 +315,7 @@ public class GlobalTransactionMgr implements Writable {
                         Config.min_load_timeout_second);
                 break;
             case LAKE_COMPACTION:
-                checkValidTimeoutSecond(timeoutSecond, Config.max_lake_compaction_timeout_second,
-                        Config.min_load_timeout_second);
+                // skip transaction timeout range check for lake compaction
                 break;
             default:
                 checkValidTimeoutSecond(timeoutSecond, Config.max_load_timeout_second, Config.min_load_timeout_second);

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -72,7 +72,6 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import scala.util.control.Exception;
 
 import java.io.DataInput;
 import java.io.DataInputStream;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -72,6 +72,7 @@ import org.apache.commons.lang3.time.StopWatch;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import scala.util.control.Exception;
 
 import java.io.DataInput;
 import java.io.DataInputStream;
@@ -152,10 +153,6 @@ public class GlobalTransactionMgr implements Writable {
         switch (sourceType) {
             case BACKEND_STREAMING:
                 checkValidTimeoutSecond(timeoutSecond, Config.max_stream_load_timeout_second,
-                        Config.min_load_timeout_second);
-                break;
-            case LAKE_COMPACTION:
-                checkValidTimeoutSecond(timeoutSecond, Config.max_lake_compaction_timeout_second,
                         Config.min_load_timeout_second);
                 break;
             default:

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -61,8 +61,6 @@ public class CompactionSchedulerTest {
 
         // default value
         Config.lake_compaction_default_timeout_second = 86400;
-        // default value, and greater than `lake_compaction_default_timeout_second`
-        Config.max_lake_compaction_timeout_second = 259200;
         // value smaller than `lake_compaction_default_timeout_second`
         // expect not affect lake compaction's  transaction operation
         Config.max_stream_load_timeout_second = 64800;
@@ -84,9 +82,6 @@ public class CompactionSchedulerTest {
         Config.lake_compaction_default_timeout_second = 86400;
         // default value
         Config.max_stream_load_timeout_second = 259200;
-        // value smaller than `lake_compaction_default_timeout_second`
-        // expect to affect lake compaction's transaction operation
-        Config.max_lake_compaction_timeout_second = 64800;
 
         CompactionMgr compactionManager = new CompactionMgr();
         CompactionScheduler compactionScheduler =

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -1,0 +1,128 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is based on code available under the Apache license here:
+//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
+
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.lake.compaction;
+
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TUniqueId;
+import com.starrocks.transaction.DatabaseTransactionMgr;
+import com.starrocks.transaction.TransactionState;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author xiaolong
+ * @date 2023/12/08/06:52
+ */
+public class CompactionSchedulerTest {
+
+    private final long dbId = 9000L;
+    private final long transactionId = 12345L;
+
+    @Mocked
+    private DatabaseTransactionMgr dbTransactionMgr;
+
+    @Before
+    public void setUp() {
+    }
+
+    @Test
+    public void testBeginTransactionSucceedWithSmallerStreamLoadTimeout() {
+        GlobalStateMgr.getCurrentGlobalTransactionMgr().addDatabaseTransactionMgr(dbId);
+        new Expectations() {
+            {
+                try {
+                    dbTransactionMgr.beginTransaction(
+                            (List<Long>) any, anyString, (TUniqueId) any, (TransactionState.TxnCoordinator) any,
+                            (TransactionState.LoadJobSourceType) any, anyLong, anyLong
+                    );
+                } catch (Exception e) {
+                    // skip
+                }
+                result = transactionId;
+            }
+        };
+
+        // default value
+        Config.lake_compaction_default_timeout_second = 86400;
+        // default value, and greater than `lake_compaction_default_timeout_second`
+        Config.max_lake_compaction_timeout_second = 259200;
+        // value smaller than `lake_compaction_default_timeout_second`
+        // expect not affect lake compaction's  transaction operation
+        Config.max_stream_load_timeout_second = 64800;
+        CompactionMgr compactionManager = new CompactionMgr();
+        CompactionScheduler compactionScheduler =
+                new CompactionScheduler(compactionManager, GlobalStateMgr.getCurrentSystemInfo(),
+                        GlobalStateMgr.getCurrentGlobalTransactionMgr(), GlobalStateMgr.getCurrentState());
+        PartitionIdentifier partitionIdentifier = new PartitionIdentifier(dbId, 2, 3);
+        try {
+            assertEquals(transactionId, compactionScheduler.beginTransaction(partitionIdentifier));
+        } catch (Exception e) {
+            Assert.fail("Transaction failed for lake compaction");
+        }
+    }
+
+    @Test
+    public void testBeginTransactionFailWithSmallerLakeCompactionTimeout() {
+        // default value
+        Config.lake_compaction_default_timeout_second = 86400;
+        // default value
+        Config.max_stream_load_timeout_second = 259200;
+        // value smaller than `lake_compaction_default_timeout_second`
+        // expect to affect lake compaction's transaction operation
+        Config.max_lake_compaction_timeout_second = 64800;
+
+        CompactionMgr compactionManager = new CompactionMgr();
+        CompactionScheduler compactionScheduler =
+                new CompactionScheduler(compactionManager, GlobalStateMgr.getCurrentSystemInfo(),
+                        GlobalStateMgr.getCurrentGlobalTransactionMgr(), GlobalStateMgr.getCurrentState());
+        PartitionIdentifier partitionIdentifier = new PartitionIdentifier(dbId, 2, 3);
+        try {
+            Assert.assertThrows(AnalysisException.class, () -> {
+                compactionScheduler.beginTransaction(partitionIdentifier);
+            });
+        } catch (Exception e) {
+            Assert.fail("Transaction failed for lake compaction");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.lake.compaction;
 
-import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TUniqueId;
@@ -71,27 +70,6 @@ public class CompactionSchedulerTest {
         PartitionIdentifier partitionIdentifier = new PartitionIdentifier(dbId, 2, 3);
         try {
             assertEquals(transactionId, compactionScheduler.beginTransaction(partitionIdentifier));
-        } catch (Exception e) {
-            Assert.fail("Transaction failed for lake compaction");
-        }
-    }
-
-    @Test
-    public void testBeginTransactionFailWithSmallerLakeCompactionTimeout() {
-        // default value
-        Config.lake_compaction_default_timeout_second = 86400;
-        // default value
-        Config.max_stream_load_timeout_second = 259200;
-
-        CompactionMgr compactionManager = new CompactionMgr();
-        CompactionScheduler compactionScheduler =
-                new CompactionScheduler(compactionManager, GlobalStateMgr.getCurrentSystemInfo(),
-                        GlobalStateMgr.getCurrentGlobalTransactionMgr(), GlobalStateMgr.getCurrentState());
-        PartitionIdentifier partitionIdentifier = new PartitionIdentifier(dbId, 2, 3);
-        try {
-            Assert.assertThrows(AnalysisException.class, () -> {
-                compactionScheduler.beginTransaction(partitionIdentifier);
-            });
         } catch (Exception e) {
             Assert.fail("Transaction failed for lake compaction");
         }

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -50,10 +50,6 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * @author xiaolong
- * @date 2023/12/08/06:52
- */
 public class CompactionSchedulerTest {
 
     private final long dbId = 9000L;

--- a/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/lake/compaction/CompactionSchedulerTest.java
@@ -12,26 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/transaction/GlobalTransactionMgrTest.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 package com.starrocks.lake.compaction;
 
 import com.starrocks.common.AnalysisException;


### PR DESCRIPTION
Why I'm doing:
Fixes #36242

What I'm doing:

add two fe configs related with transaction timeout for lake compaction 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
