### PR TITLE
[Enhancement] Handle timeouts in compaction

### DIFF
--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -41,12 +41,12 @@ CompactionTaskCallback::CompactionTaskCallback(CompactionScheduler* scheduler, c
         : _scheduler(scheduler), _mtx(), _request(request), _response(response), _done(done) {
     CHECK(_request != nullptr);
     CHECK(_response != nullptr);
-    _timeout_duetime = butil::gettimeofday_ms() + timeout();
+    _timeout_deadline_ms = butil::gettimeofday_ms() + timeout_ms();
     _contexts.reserve(request->tablet_ids_size());
 }
 
-int64_t CompactionTaskCallback::timeout() const {
-    return _request->has_timeout_ms() ? _request->timeout_ms() : kDefaultTimeout;
+int64_t CompactionTaskCallback::timeout_ms() const {
+    return _request->has_timeout_ms() ? _request->timeout_ms() : kDefaultTimeoutMs;
 }
 
 void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&& context) {

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -41,7 +41,12 @@ CompactionTaskCallback::CompactionTaskCallback(CompactionScheduler* scheduler, c
         : _scheduler(scheduler), _mtx(), _request(request), _response(response), _done(done) {
     CHECK(_request != nullptr);
     CHECK(_response != nullptr);
+    _timeout_duetime = butil::gettimeofday_ms() + timeout();
     _contexts.reserve(request->tablet_ids_size());
+}
+
+int64_t CompactionTaskCallback::timeout() const {
+    return _request->has_timeout_ms() ? _request->timeout_ms() : kDefaultTimeout;
 }
 
 void CompactionTaskCallback::finish_task(std::unique_ptr<CompactionTaskContext>&& context) {
@@ -206,7 +211,9 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     } else {
         auto task_or = _tablet_mgr->compact(tablet_id, version, txn_id);
         if (task_or.ok()) {
-            auto should_cancel = [&]() { return context->callback->has_error(); };
+            auto should_cancel = [&]() {
+                return context->callback->has_error() || context->callback->timeout_exceeded();
+            };
             TEST_SYNC_POINT("CompactionScheduler::do_compaction:before_execute_task");
             status.update(task_or.value()->execute(&context->progress, std::move(should_cancel)));
         } else {
@@ -229,6 +236,15 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
         VLOG_IF(3, status.ok()) << "Compacted tablet " << tablet_id << ". version=" << version << " txn_id=" << txn_id
                                 << " cost=" << cost << "s";
 
+        if (status.is_cancelled()) {
+            if (context->callback->has_error()) {
+                auto cause = context->callback->error();
+                status = Status::Cancelled(fmt::format("Cancelled due to another error: {}", cause.message()));
+            } else if (context->callback->timeout_exceeded()) {
+                auto timeout = context->callback->timeout();
+                status = Status::Cancelled(fmt::format("Cancelled due to timeout exceeded: {}", timeout));
+            }
+        }
         LOG_IF(ERROR, !status.ok()) << "Fail to compact tablet " << tablet_id << ". version=" << version
                                     << " txn_id=" << txn_id << " cost=" << cost << "s : " << status;
 

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -241,8 +241,8 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
                 auto cause = context->callback->error();
                 status = Status::Cancelled(fmt::format("Cancelled due to another error: {}", cause.message()));
             } else if (context->callback->timeout_exceeded()) {
-                auto timeout = context->callback->timeout();
-                status = Status::Cancelled(fmt::format("Cancelled due to timeout exceeded: {}", timeout));
+                auto timeout = context->callback->timeout_ms();
+                status = Status::Cancelled(fmt::format("Cancelled due to timeout exceeded: {}ms", timeout));
             }
         }
         LOG_IF(ERROR, !status.ok()) << "Fail to compact tablet " << tablet_id << ". version=" << version

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -63,18 +63,30 @@ public:
         return !_status.ok();
     }
 
+    Status error() const {
+        std::lock_guard l(_mtx);
+        return _status;
+    }
+
     void update_status(const Status& st) {
         std::lock_guard l(_mtx);
         _status.update(st);
     }
 
+    bool timeout_exceeded() const { return butil::gettimeofday_ms() >= _timeout_duetime; }
+
+    int64_t timeout() const;
+
 private:
+    const static int64_t kDefaultTimeout = 24L * 60 * 60 * 1000; // 1 day
+
     CompactionScheduler* _scheduler;
     mutable StackTraceMutex<bthread::Mutex> _mtx;
     const lake::CompactRequest* _request;
     lake::CompactResponse* _response;
     ::google::protobuf::Closure* _done;
     Status _status;
+    int64_t _timeout_duetime;
     std::vector<std::unique_ptr<CompactionTaskContext>> _contexts;
 };
 

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -73,12 +73,12 @@ public:
         _status.update(st);
     }
 
-    bool timeout_exceeded() const { return butil::gettimeofday_ms() >= _timeout_duetime; }
+    bool timeout_exceeded() const { return butil::gettimeofday_ms() >= _timeout_deadline_ms; }
 
-    int64_t timeout() const;
+    int64_t timeout_ms() const;
 
 private:
-    const static int64_t kDefaultTimeout = 24L * 60 * 60 * 1000; // 1 day
+    const static int64_t kDefaultTimeoutMs = 24L * 60 * 60 * 1000; // 1 day
 
     CompactionScheduler* _scheduler;
     mutable StackTraceMutex<bthread::Mutex> _mtx;
@@ -86,7 +86,7 @@ private:
     lake::CompactResponse* _response;
     ::google::protobuf::Closure* _done;
     Status _status;
-    int64_t _timeout_duetime;
+    int64_t _timeout_deadline_ms;
     std::vector<std::unique_ptr<CompactionTaskContext>> _contexts;
 };
 

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionJob.java
@@ -23,6 +23,7 @@ import com.starrocks.transaction.VisibleStateWaiter;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 public class CompactionJob {
@@ -82,7 +83,7 @@ public class CompactionJob {
     }
 
     public int getNumTabletCompactionTasks() {
-        return tasks.stream().mapToInt(CompactionTask::tabletCount).sum();
+        return tasks.stream().filter(Predicate.not(CompactionTask::isDone)).mapToInt(CompactionTask::tabletCount).sum();
     }
 
     public long getStartTs() {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionScheduler.java
@@ -338,6 +338,7 @@ public class CompactionScheduler extends Daemon {
             request.tabletIds = entry.getValue();
             request.txnId = txnId;
             request.version = currentVersion;
+            request.timeoutMs = LakeService.TIMEOUT_COMPACT;
 
             CompactionTask task = new CompactionTask(node.getId(), service, request);
             tasks.add(task);

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/LakeService.java
@@ -48,34 +48,50 @@ import com.starrocks.proto.VacuumResponse;
 
 import java.util.concurrent.Future;
 
-public interface LakeService {
-    long TIMEOUT_GET_TABLET_STATS = 15 * 60 * 1000L;
+import static org.joda.time.DateTimeConstants.MILLIS_PER_DAY;
+import static org.joda.time.DateTimeConstants.MILLIS_PER_HOUR;
+import static org.joda.time.DateTimeConstants.MILLIS_PER_MINUTE;
+import static org.joda.time.DateTimeConstants.MILLIS_PER_SECOND;
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = /*1m=*/60000)
+public interface LakeService {
+    long TIMEOUT_PUBLISH_VERSION = MILLIS_PER_MINUTE;
+    long TIMEOUT_GET_TABLET_STATS = 15 * MILLIS_PER_MINUTE;
+    long TIMEOUT_COMPACT = MILLIS_PER_DAY;
+    long TIMEOUT_ABORT = 5 * MILLIS_PER_SECOND;
+    long TIMEOUT_DELETE_TABLET = 10 * MILLIS_PER_MINUTE;
+    long TIMEOUT_DELETE_DATA = 5 * MILLIS_PER_MINUTE;
+    long TIMEOUT_DROP_TABLE = 5 * MILLIS_PER_MINUTE;
+    long TIMEOUT_PUBLISH_LOG_VERSION = MILLIS_PER_MINUTE;
+    long TIMEOUT_PUBLISH_LOG_VERSION_BATCH = MILLIS_PER_MINUTE;
+    long TIMEOUT_ABORT_COMPACTION = 5 * MILLIS_PER_SECOND;
+    long TIMEOUT_VACUUM = MILLIS_PER_HOUR;
+
+    @ProtobufRPC(serviceName = "LakeService", methodName = "publish_version", onceTalkTimeout = TIMEOUT_PUBLISH_VERSION)
     Future<PublishVersionResponse> publishVersion(PublishVersionRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "abort_txn", onceTalkTimeout = 5000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "abort_txn", onceTalkTimeout = TIMEOUT_ABORT)
     Future<AbortTxnResponse> abortTxn(AbortTxnRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "compact", onceTalkTimeout = /*24H=*/86400000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "compact", onceTalkTimeout = TIMEOUT_COMPACT)
     Future<CompactResponse> compact(CompactRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "delete_tablet", onceTalkTimeout = /*10m=*/600000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "delete_tablet", onceTalkTimeout = TIMEOUT_DELETE_TABLET)
     Future<DeleteTabletResponse> deleteTablet(DeleteTabletRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "delete_data", onceTalkTimeout = 300000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "delete_data", onceTalkTimeout = TIMEOUT_DELETE_DATA)
     Future<DeleteDataResponse> deleteData(DeleteDataRequest request);
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "get_tablet_stats", onceTalkTimeout = TIMEOUT_GET_TABLET_STATS)
     Future<TabletStatResponse> getTabletStats(TabletStatRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "drop_table", onceTalkTimeout = /*5m=*/300000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "drop_table", onceTalkTimeout = TIMEOUT_DROP_TABLE)
     Future<DropTableResponse> dropTable(DropTableRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "publish_log_version", onceTalkTimeout = /*1m=*/60000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "publish_log_version", onceTalkTimeout = TIMEOUT_PUBLISH_LOG_VERSION)
     Future<PublishLogVersionResponse> publishLogVersion(PublishLogVersionRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "publish_log_version_batch", onceTalkTimeout = /*1m=*/60000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "publish_log_version_batch",
+            onceTalkTimeout = TIMEOUT_PUBLISH_LOG_VERSION_BATCH)
     Future<PublishLogVersionResponse> publishLogVersionBatch(PublishLogVersionBatchRequest request);
 
     @ProtobufRPC(serviceName = "LakeService", methodName = "lock_tablet_metadata", onceTalkTimeout = 5000)
@@ -90,10 +106,10 @@ public interface LakeService {
     @ProtobufRPC(serviceName = "LakeService", methodName = "restore_snapshots", onceTalkTimeout = 5000)
     Future<RestoreSnapshotsResponse> restoreSnapshots(RestoreSnapshotsRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "abort_compaction", onceTalkTimeout = 5000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "abort_compaction", onceTalkTimeout = TIMEOUT_ABORT_COMPACTION)
     Future<AbortCompactionResponse> abortCompaction(AbortCompactionRequest request);
 
-    @ProtobufRPC(serviceName = "LakeService", methodName = "vacuum", onceTalkTimeout = /*1h=*/3600000)
+    @ProtobufRPC(serviceName = "LakeService", methodName = "vacuum", onceTalkTimeout = TIMEOUT_VACUUM)
     Future<VacuumResponse> vacuum(VacuumRequest request);
 }
 

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -66,6 +66,7 @@ message CompactRequest {
     repeated int64 tablet_ids = 1;
     optional int64 txn_id = 2;
     optional int64 version = 3;
+    optional int64 timeout_ms = 4;
 }
 
 message CompactResponse {


### PR DESCRIPTION
Implemented timeout processing in compaction_scheduler by setting a default timeout and adding a timeout check function. This helps to improve robustness of compaction in cases of unexpected long execution times.

Also made constants for timeout values in LakeService.java for more clear reading and maintainability.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
