### PR TITLE
[BugFix] Fix refresh for mv with complex name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -119,7 +119,7 @@ public class TaskBuilder {
 
         task.setProperties(taskProperties);
         task.setDefinition(
-                "insert overwrite " + materializedView.getName() + " " + materializedView.getViewDefineSql());
+                "insert overwrite `" + materializedView.getName() + "` " + materializedView.getViewDefineSql());
         task.setPostRun(getAnalyzeMVStmt(materializedView.getName()));
         task.setExpireTime(0L);
         return task;

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.scheduler;
+
+import com.starrocks.catalog.MaterializedView;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TaskBuilderTest {
+
+    @Test
+    public void testTaskBuilderForMv(@Mocked MaterializedView mv) {
+        new Expectations() {
+            {
+                mv.getViewDefineSql();
+                result = "select * from table1";
+
+                mv.getName();
+                result = "aa.bb.cc";
+
+                mv.getId();
+                result = 1;
+            }
+        };
+        Task task = TaskBuilder.buildMvTask(mv, "test");
+        Assert.assertEquals("insert overwrite `aa.bb.cc` select * from table1", task.getDefinition());
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class MvRefreshTest extends MvRewriteTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+        MvRewriteTestBase.prepareDefaultDatas();
+    }
+
+    @Test
+    public void testMvWithComplexNameRefresh() throws Exception {
+        createAndRefreshMv("test", "`aa.bb.cc`",
+                "create materialized view `aa.bb.cc`" +
+                        " partition by id_date" +
+                        " distributed by hash(`t1a`)" +
+                        " as" +
+                        " select t1a, id_date, t1b from table_with_partition");
+
+        createAndRefreshMv("test",
+                "`LEAF_NO_ACC_CUBE_SHADOW_VIEW_.default.luchen_order_8e2c65ba-1c30`",
+                "create materialized view `LEAF_NO_ACC_CUBE_SHADOW_VIEW_.default.luchen_order_8e2c65ba-1c30`" +
+                        " partition by id_date" +
+                        " distributed by hash(`t1a`)" +
+                        " as" +
+                        " select t1a, id_date, t1b from table_with_partition");
+    }
+}


### PR DESCRIPTION
Why I'm doing:
Fix mv with complex name refresh failed bug, this bug comes from that parsing mv name throws exception.
What I'm doing:
generate mv refresh statement with mv name quoted by '`' to avoid parsing exception.
Fix #36270

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
