### PR TITLE
[BugFix] Fix inconsistent tablet schema in tablet reader

### DIFF
--- a/be/src/exec/olap_meta_scanner.cpp
+++ b/be/src/exec/olap_meta_scanner.cpp
@@ -52,6 +52,7 @@ Status OlapMetaScanner::_init_meta_reader_params() {
         for (auto& column : _parent->_meta_scan_node.columns) {
             tablet_schema->append_column(TabletColumn(column));
         }
+        tablet_schema->generate_sort_key_idxes();
     }
     _reader_params.tablet_schema = std::move(tablet_schema);
     _reader_params.desc_tbl = &_parent->_desc_tbl;

--- a/be/src/exec/pipeline/scan/morsel.cpp
+++ b/be/src/exec/pipeline/scan/morsel.cpp
@@ -450,9 +450,9 @@ Status PhysicalSplitMorselQueue::_init_segment() {
         if (0 == _rowset_idx) {
             _tablet_seek_ranges.clear();
             _mempool.clear();
-            RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx], _range_start_op, _range_end_op,
-                                                           _range_start_key, _range_end_key, &_tablet_seek_ranges,
-                                                           &_mempool));
+            RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
+                                                           _range_end_op, _range_start_key, _range_end_key,
+                                                           &_tablet_seek_ranges, &_mempool));
         }
         // Read a new rowset.
         RETURN_IF_ERROR(_cur_rowset()->load());
@@ -777,9 +777,9 @@ Status LogicalSplitMorselQueue::_init_tablet() {
 
     if (_tablet_idx == 0) {
         // All the tablets have the same schema, so parse seek range with the first table schema.
-        RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx], _range_start_op, _range_end_op,
-                                                       _range_start_key, _range_end_key, &_tablet_seek_ranges,
-                                                       &_mempool));
+        RETURN_IF_ERROR(TabletReader::parse_seek_range(_tablets[_tablet_idx]->tablet_schema(), _range_start_op,
+                                                       _range_end_op, _range_start_key, _range_end_key,
+                                                       &_tablet_seek_ranges, &_mempool));
     }
 
     _largest_rowset = _find_largest_rowset(_tablet_rowsets[_tablet_idx]);

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -328,6 +328,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
         for (const auto& column_desc : _scan_node->thrift_olap_scan_node().columns_desc) {
             _tablet_schema->append_column(TabletColumn(column_desc));
         }
+        _tablet_schema->generate_sort_key_idxes();
     }
 
     RETURN_IF_ERROR(_init_global_dicts(&_params));

--- a/be/src/exec/tablet_scanner.cpp
+++ b/be/src/exec/tablet_scanner.cpp
@@ -58,6 +58,7 @@ Status TabletScanner::init(RuntimeState* runtime_state, const TabletScannerParam
         for (const auto& column_desc : _parent->_olap_scan_node.columns_desc) {
             _tablet_schema->append_column(TabletColumn(column_desc));
         }
+        _tablet_schema->generate_sort_key_idxes();
     }
 
     RETURN_IF_ERROR(_init_unused_output_columns(*params.unused_output_columns));
@@ -150,7 +151,7 @@ Status TabletScanner::_init_reader_params(const std::vector<OlapScanRange*>* key
     // to avoid the unnecessary SerDe and improve query performance
     _params.need_agg_finalize = _need_agg_finalize;
     _params.use_page_cache = _runtime_state->use_page_cache();
-    auto parser = _pool.add(new PredicateParser(_tablet->tablet_schema()));
+    auto parser = _pool.add(new PredicateParser(_tablet_schema));
     std::vector<PredicatePtr> preds;
     RETURN_IF_ERROR(_parent->_conjuncts_manager.get_column_predicates(parser, &preds));
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -198,7 +198,7 @@ Status DeltaWriter::_init() {
 
     // build tablet schema in request level
     auto tablet_schema_ptr = _tablet->tablet_schema();
-    RETURN_IF_ERROR(_build_current_tablet_schema(_opt.index_id, _opt.ptable_schema_param, _tablet->tablet_schema()));
+    RETURN_IF_ERROR(_build_current_tablet_schema(_opt.index_id, _opt.ptable_schema_param, tablet_schema_ptr));
     size_t real_num_columns = _tablet_schema->num_columns();
     if (_tablet->is_column_with_row_store()) {
         if (_tablet_schema->columns().back().name() != "__row") {
@@ -264,11 +264,11 @@ Status DeltaWriter::_init() {
         writer_context.tablet_schema = _tablet_schema;
     }
 
-    auto sort_key_idxes = _tablet->tablet_schema()->sort_key_idxes();
+    auto sort_key_idxes = tablet_schema_ptr->sort_key_idxes();
     std::sort(sort_key_idxes.begin(), sort_key_idxes.end());
     bool auto_increment_in_sort_key = false;
     for (auto& idx : sort_key_idxes) {
-        auto& col = _tablet->tablet_schema()->column(idx);
+        auto& col = tablet_schema_ptr->column(idx);
         if (col.is_auto_increment()) {
             auto_increment_in_sort_key = true;
             break;
@@ -619,7 +619,6 @@ Status DeltaWriter::commit() {
         return res.status();
     }
 
-    _cur_rowset->set_schema(_tablet->tablet_schema());
     if (_tablet->keys_type() == KeysType::PRIMARY_KEYS) {
         auto st = _storage_engine->update_manager()->on_rowset_finished(_tablet.get(), _cur_rowset.get());
         if (!st.ok()) {

--- a/be/src/storage/local_tablet_reader.cpp
+++ b/be/src/storage/local_tablet_reader.cpp
@@ -206,7 +206,7 @@ Status handle_tablet_multi_get_rpc(const PTabletReaderMultiGetRequest& request, 
         }
         value_column_ids.push_back(cid);
     }
-    Schema values_schema(tablet->tablet_schema()->schema(), value_column_ids);
+    Schema values_schema(tablet_schema->schema(), value_column_ids);
     auto keys_st = serde::deserialize_chunk_pb_with_schema(key_schema, keys_pb.data());
     if (!keys_st.ok()) {
         return keys_st.status();

--- a/be/src/storage/push_handler.cpp
+++ b/be/src/storage/push_handler.cpp
@@ -109,6 +109,7 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
                 for (const auto& column_desc : request.columns_desc) {
                     tablet_schema->append_column(TabletColumn(column_desc));
                 }
+                tablet_schema->generate_sort_key_idxes();
             }
             res = del_cond_handler.generate_delete_predicate(*tablet_schema, request.delete_conditions, &del_pred);
             del_preds.push(del_pred);
@@ -127,6 +128,7 @@ Status PushHandler::_do_streaming_ingestion(TabletSharedPtr tablet, const TPushR
         for (const auto& column_desc : request.columns_desc) {
             tablet_schema->append_column(TabletColumn(column_desc));
         }
+        tablet_schema->generate_sort_key_idxes();
     }
 
     Status st = Status::OK();

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -307,8 +307,8 @@ void RowsetUpdateState::plan_read_by_rssid(const vector<uint64_t>& rowids, size_
 }
 // update_column_ids needed read by rowset
 Status RowsetUpdateState::_prepare_partial_update_value_columns(Tablet* tablet, Rowset* rowset, uint32_t idx,
-                                                                const std::vector<uint32_t>& update_column_ids) {
-    auto tablet_schema = tablet->tablet_schema();
+                                                                const std::vector<uint32_t>& update_column_ids,
+                                                                const TabletSchemaCSPtr& tablet_schema) {
     if (_partial_update_value_column_ids.empty()) {
         // need to init
         for (uint32_t cid : update_column_ids) {
@@ -422,7 +422,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
     }
 
     if (tablet->is_column_with_row_store()) {
-        RETURN_IF_ERROR(_prepare_partial_update_value_columns(tablet, rowset, idx, update_column_uids));
+        RETURN_IF_ERROR(_prepare_partial_update_value_columns(tablet, rowset, idx, update_column_uids, tablet_schema));
     }
     int64_t t_end = MonotonicMillis();
     _partial_update_states[idx].update_byte_size();

--- a/be/src/storage/rowset_update_state.h
+++ b/be/src/storage/rowset_update_state.h
@@ -142,7 +142,8 @@ private:
     Status _do_load(Tablet* tablet, Rowset* rowset);
 
     Status _prepare_partial_update_value_columns(Tablet* tablet, Rowset* rowset, uint32_t idx,
-                                                 const std::vector<uint32_t>& update_column_ids);
+                                                 const std::vector<uint32_t>& update_column_ids,
+                                                 const TabletSchemaCSPtr& tablet_schema);
 
     // `need_lock` means whether the `_index_lock` in TabletUpdates needs to held.
     // `index_lock` is used to avoid access the PrimaryIndex at the same time as the apply thread.

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -701,6 +701,7 @@ Status SchemaChangeHandler::_do_process_alter_tablet_v2(const TAlterTabletReqV2&
         for (const auto& column : request.columns) {
             base_tablet_schema->append_column(TabletColumn(column));
         }
+        base_tablet_schema->generate_sort_key_idxes();
     }
     auto new_tablet_schema = new_tablet->tablet_schema();
 

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -570,7 +570,7 @@ Status TabletReader::_to_seek_tuple(const TabletSchemaCSPtr& tablet_schema, cons
 }
 
 // convert vector<OlapTuple> to vector<SeekRange>
-Status TabletReader::parse_seek_range(TabletSchemaCSPtr tablet_schema,
+Status TabletReader::parse_seek_range(const TabletSchemaCSPtr& tablet_schema,
                                       TabletReaderParams::RangeStartOperation range_start_op,
                                       TabletReaderParams::RangeEndOperation range_end_op,
                                       const std::vector<OlapTuple>& range_start_key,

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -128,7 +128,7 @@ Status TabletReader::open(const TabletReaderParams& read_params) {
 Status TabletReader::_init_collector_for_pk_index_read() {
     DCHECK(_reader_params != nullptr);
     // get pk eq predicates, and convert these predicates to encoded pk column
-    const auto& tablet_schema = _tablet->tablet_schema();
+    const auto& tablet_schema = _tablet_schema;
     vector<ColumnId> pk_column_ids;
     for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
         pk_column_ids.emplace_back(i);
@@ -195,7 +195,7 @@ Status TabletReader::_init_collector_for_pk_index_read() {
     rs_opts.runtime_state = _reader_params->runtime_state;
     rs_opts.profile = _reader_params->profile;
     rs_opts.use_page_cache = _reader_params->use_page_cache;
-    rs_opts.tablet_schema = _tablet->tablet_schema();
+    rs_opts.tablet_schema = _tablet_schema;
     rs_opts.global_dictmaps = _reader_params->global_dictmaps;
     rs_opts.unused_output_column_ids = _reader_params->unused_output_column_ids;
     rs_opts.runtime_range_pruner = _reader_params->runtime_range_pruner;
@@ -254,7 +254,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     KeysType keys_type = _tablet_schema->keys_type();
     RETURN_IF_ERROR(_init_predicates(params));
     RETURN_IF_ERROR(_init_delete_predicates(params, &_delete_predicates));
-    RETURN_IF_ERROR(parse_seek_range(_tablet, params.range, params.end_range, params.start_key, params.end_key,
+    RETURN_IF_ERROR(parse_seek_range(_tablet_schema, params.range, params.end_range, params.start_key, params.end_key,
                                      &rs_opts.ranges, &_mempool));
     rs_opts.predicates = _pushdown_predicates;
     RETURN_IF_ERROR(ZonemapPredicatesRewriter::rewrite_predicate_map(&_obj_pool, rs_opts.predicates,
@@ -570,7 +570,7 @@ Status TabletReader::_to_seek_tuple(const TabletSchemaCSPtr& tablet_schema, cons
 }
 
 // convert vector<OlapTuple> to vector<SeekRange>
-Status TabletReader::parse_seek_range(const TabletSharedPtr& tablet,
+Status TabletReader::parse_seek_range(TabletSchemaCSPtr tablet_schema,
                                       TabletReaderParams::RangeStartOperation range_start_op,
                                       TabletReaderParams::RangeEndOperation range_end_op,
                                       const std::vector<OlapTuple>& range_start_key,
@@ -592,8 +592,8 @@ Status TabletReader::parse_seek_range(const TabletSharedPtr& tablet,
     for (size_t i = 0; i < n; i++) {
         SeekTuple lower;
         SeekTuple upper;
-        RETURN_IF_ERROR(_to_seek_tuple(tablet->tablet_schema(), range_start_key[i], &lower, mempool));
-        RETURN_IF_ERROR(_to_seek_tuple(tablet->tablet_schema(), range_end_key[i], &upper, mempool));
+        RETURN_IF_ERROR(_to_seek_tuple(tablet_schema, range_start_key[i], &lower, mempool));
+        RETURN_IF_ERROR(_to_seek_tuple(tablet_schema, range_end_key[i], &upper, mempool));
         ranges->emplace_back(SeekRange{std::move(lower), std::move(upper)});
         ranges->back().set_inclusive_lower(lower_inclusive);
         ranges->back().set_inclusive_upper(upper_inclusive);

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -60,7 +60,7 @@ public:
 
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
 
-    static Status parse_seek_range(TabletSchemaCSPtr tablet_schema,
+    static Status parse_seek_range(const TabletSchemaCSPtr& tablet_schema,
                                    TabletReaderParams::RangeStartOperation range_start_op,
                                    TabletReaderParams::RangeEndOperation range_end_op,
                                    const std::vector<OlapTuple>& range_start_key,

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -60,7 +60,7 @@ public:
 
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
 
-    static Status parse_seek_range(const TabletSharedPtr& tablet,
+    static Status parse_seek_range(TabletSchemaCSPtr tablet_schema,
                                    TabletReaderParams::RangeStartOperation range_start_op,
                                    TabletReaderParams::RangeEndOperation range_end_op,
                                    const std::vector<OlapTuple>& range_start_key,

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -288,7 +288,7 @@ void TabletSchema::append_column(TabletColumn column) {
     }
     _unique_id_to_index[column.unique_id()] = _num_columns;
     _cols.push_back(std::move(column));
-    if (_sort_key_idxes_set.count(_num_columns) > 0) {
+    if (_sort_key_uids_set.count(column.unique_id()) > 0) {
         _cols[_num_columns].set_is_sort_key(true);
     }
     _num_columns++;
@@ -299,6 +299,7 @@ void TabletSchema::clear_columns() {
     _num_columns = 0;
     _num_key_columns = 0;
     _cols.clear();
+    _sort_key_idxes.clear();
 }
 
 void TabletSchema::copy_from(const std::shared_ptr<const TabletSchema>& tablet_schema) {
@@ -433,18 +434,20 @@ void TabletSchema::_init_from_pb(const TabletSchemaPB& schema) {
         for (auto uid : schema.sort_key_unique_ids()) {
             _sort_key_uids.emplace_back(uid);
             _sort_key_idxes.emplace_back(_unique_id_to_index.at(uid));
+            _sort_key_uids_set.emplace(uid);
         }
     } else if (!schema.sort_key_idxes().empty()) {
         _sort_key_idxes.reserve(schema.sort_key_idxes_size());
         for (auto i = 0; i < schema.sort_key_idxes_size(); ++i) {
-            _sort_key_idxes.push_back(schema.sort_key_idxes(i));
-            _sort_key_idxes_set.emplace(schema.sort_key_idxes(i));
+            ColumnId cid = schema.sort_key_idxes(i);
+            _sort_key_idxes.push_back(cid);
+            _sort_key_uids_set.emplace(schema.column(cid).unique_id());
         }
     } else {
         _sort_key_idxes.reserve(_num_key_columns);
         for (auto i = 0; i < _num_key_columns; ++i) {
             _sort_key_idxes.push_back(i);
-            _sort_key_idxes_set.emplace(i);
+            _sort_key_uids_set.emplace(schema.column(i).unique_id());
         }
     }
 
@@ -570,6 +573,21 @@ size_t TabletSchema::field_index(std::string_view field_name) const {
 int32_t TabletSchema::field_index(int32_t col_unique_id) const {
     const auto& found = _unique_id_to_index.find(col_unique_id);
     return (found == _unique_id_to_index.end()) ? -1 : found->second;
+}
+
+void TabletSchema::generate_sort_key_idxes() {
+    if (!_sort_key_idxes.empty()) {
+        return;
+    }
+    if (!_sort_key_uids.empty()) {
+        for (auto uid : _sort_key_uids) {
+            _sort_key_idxes.emplace_back(_unique_id_to_index.at(uid));
+        }
+    } else {
+        for (int32_t i = 0; i < _num_key_columns; i++) {
+            _sort_key_idxes.emplace_back(i);
+        }
+    }
 }
 
 const std::vector<TabletColumn>& TabletSchema::columns() const {

--- a/be/src/storage/tablet_schema.h
+++ b/be/src/storage/tablet_schema.h
@@ -262,6 +262,7 @@ public:
     size_t field_index(std::string_view field_name) const;
     const TabletColumn& column(size_t ordinal) const;
     const std::vector<TabletColumn>& columns() const;
+    void generate_sort_key_idxes();
     const std::vector<ColumnId> sort_key_idxes() const { return _sort_key_idxes; }
 
     size_t num_columns() const { return _cols.size(); }
@@ -345,8 +346,8 @@ private:
     mutable uint16_t _num_key_columns = 0;
     uint16_t _num_short_key_columns = 0;
     std::vector<ColumnId> _sort_key_idxes;
-    std::unordered_set<ColumnId> _sort_key_idxes_set;
     std::vector<ColumnUID> _sort_key_uids;
+    std::unordered_set<ColumnUID> _sort_key_uids_set;
 
     uint8_t _keys_type = static_cast<uint8_t>(DUP_KEYS);
     CompressionTypePB _compression_type = CompressionTypePB::LZ4_FRAME;


### PR DESCRIPTION
Why I'm doing:

Tablet schema maybe update after support fast schema evolution, so we need to capture the tablet schema first and read data according the tablet schema during the whole process. But when we init `tablet_reader`,  we may access different version tablet schema.

What I'm doing:

Keep the tablet schema consistency during the whole process.

Fixes https://github.com/StarRocks/StarRocksTest/issues/4975

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
