### PR TITLE
[Enhancement] show persistent index disk cost in be_tablets (backport #35615)

### DIFF
--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.cpp
@@ -34,7 +34,7 @@ SchemaScanner::ColumnDesc SchemaBeTabletsScanner::_s_columns[] = {
         {"INDEX_MEM", TYPE_BIGINT, sizeof(int64_t), false},     {"CREATE_TIME", TYPE_BIGINT, sizeof(int64_t), false},
         {"STATE", TYPE_VARCHAR, sizeof(StringValue), false},    {"TYPE", TYPE_VARCHAR, sizeof(StringValue), false},
         {"DATA_DIR", TYPE_VARCHAR, sizeof(StringValue), false}, {"SHARD_ID", TYPE_BIGINT, sizeof(int64_t), false},
-        {"SCHEMA_HASH", TYPE_BIGINT, sizeof(int64_t), false},
+        {"SCHEMA_HASH", TYPE_BIGINT, sizeof(int64_t), false},   {"INDEX_DISK", TYPE_BIGINT, sizeof(int64_t), false},
 };
 
 SchemaBeTabletsScanner::SchemaBeTabletsScanner()
@@ -92,7 +92,7 @@ Status SchemaBeTabletsScanner::fill_chunk(ChunkPtr* chunk) {
     for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
-            if (slot_id < 1 || slot_id > 17) {
+            if (slot_id < 1 || slot_id > 18) {
                 return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
             }
             ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
@@ -170,16 +170,24 @@ Status SchemaBeTabletsScanner::fill_chunk(ChunkPtr* chunk) {
                 break;
             }
             case 15: {
+                // DATA_DIR
                 Slice type = Slice(info.data_dir);
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&type);
                 break;
             }
             case 16: {
+                // SHARD_ID
                 fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.shard_id);
                 break;
             }
             case 17: {
+                // SCHEMA_HASH
                 fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.schema_hash);
+                break;
+            }
+            case 18: {
+                // INDEX_DISK
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.index_disk_usage);
                 break;
             }
             default:

--- a/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
+++ b/be/src/exec/schema_scanner/schema_be_tablets_scanner.h
@@ -38,6 +38,7 @@ struct TabletBasicInfo {
     std::string data_dir;
     int64_t shard_id{0};
     int64_t schema_hash{0};
+    int64_t index_disk_usage{0};
 };
 
 class SchemaBeTabletsScanner : public SchemaScanner {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2743,10 +2743,14 @@ Status TabletUpdates::_get_extra_file_size(int64_t* pindex_size, int64_t* col_si
                 std::string filename = entry.path().filename().string();
 
                 if (HasPrefixString(filename, "index.l")) {
-                    *pindex_size += std::filesystem::file_size(entry);
+                    if (pindex_size != nullptr) {
+                        *pindex_size += std::filesystem::file_size(entry);
+                    }
                 } else if (HasSuffixString(filename, ".cols")) {
                     // TODO skip the expired cols file
-                    *col_size += std::filesystem::file_size(entry);
+                    if (col_size != nullptr) {
+                        *col_size += std::filesystem::file_size(entry);
+                    }
                 }
             }
         }
@@ -3878,6 +3882,16 @@ void TabletUpdates::get_basic_info_extra(TabletBasicInfo& info) {
     if (index_entry != nullptr) {
         info.index_mem = index_entry->size();
         index_cache.release(index_entry);
+    }
+    int64_t pindex_size = 0;
+    auto st = _get_extra_file_size(&pindex_size, nullptr);
+    if (!st.ok()) {
+        // Ignore error status here, because we don't to break up get basic info because of get pk index disk usage failure.
+        // So just print error log and keep going.
+        LOG(ERROR) << "get persistent index disk usage fail, tablet_id: " << _tablet.tablet_id()
+                   << ", error: " << st.get_error_msg();
+    } else {
+        info.index_disk_usage = pindex_size;
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeTabletsSystemTable.java
@@ -46,6 +46,7 @@ public class BeTabletsSystemTable {
                         .column("DATA_DIR", ScalarType.createVarchar(NAME_CHAR_LEN))
                         .column("SHARD_ID", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("SCHEMA_HASH", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("INDEX_DISK", ScalarType.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_BE_TABLETS);
     }
 }


### PR DESCRIPTION
We can't get the persistent index disk usage from system table now. Add each tablet's persistent index disk usage `INDEX_DISK` to `be_tablets`.

```
mysql> select * from be_tablets where tablet_id = 10121\G
*************************** 1. row ***************************
       BE_ID: 10004
    TABLE_ID: 10119
PARTITION_ID: 10118
   TABLET_ID: 10121
 NUM_VERSION: 4
 MAX_VERSION: 6
 MIN_VERSION: 4
  NUM_ROWSET: 1
     NUM_ROW: 5
   DATA_SIZE: 710
   INDEX_MEM: 119
 CREATE_TIME: 1700701817
       STATE: RUNNING
        TYPE: PRIMARY
    DATA_DIR: /home/disk5/luoyixin/starrocks-4/starrocks/output/be/storage
    SHARD_ID: 48
 SCHEMA_HASH: 1872891624
  INDEX_DISK: 152
1 row in set (0.02 sec)
```
backport #35615

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
