### PR TITLE
[BugFix] fix large binary column overflow when column writer append

### DIFF
--- a/be/src/column/binary_column.cpp
+++ b/be/src/column/binary_column.cpp
@@ -291,7 +291,7 @@ void BinaryColumnBase<T>::append_value_multiple_times(const void* value, size_t 
 template <typename T>
 void BinaryColumnBase<T>::_build_slices() const {
     if constexpr (std::is_same_v<T, uint32_t>) {
-        CHECK_LT(_bytes.size(), (size_t)UINT32_MAX) << "BinaryColumn size overflow";
+        DCHECK_LT(_bytes.size(), (size_t)UINT32_MAX) << "BinaryColumn size overflow";
     }
 
     DCHECK(_offsets.size() > 0);

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -719,4 +719,87 @@ TEST_F(ColumnReaderWriterTest, test_scalar_column_total_mem_footprint) {
     }
 }
 
+TEST_F(ColumnReaderWriterTest, test_large_varchar_column_writer) {
+    auto fs = std::make_shared<MemoryFileSystem>();
+    ASSERT_TRUE(fs->create_dir(TEST_DIR).ok());
+    const std::string fname = strings::Substitute("$0/test_large_varchar_column_writer.data", TEST_DIR);
+    // write data
+    {
+        int32_t old_config = config::dictionary_speculate_min_chunk_size;
+        const int TEST_N = 100;
+        // Test 3 different dictionary_speculate_min_chunk_size.
+        int32_t dict_chunk_sizes[3] = {TEST_N - 1, TEST_N, TEST_N + 1};
+        for (int32_t dict_chunk_size : dict_chunk_sizes) {
+            fs->delete_file(fname);
+            ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(fname));
+            ColumnMetaPB meta;
+            ColumnWriterOptions writer_opts;
+            writer_opts.page_format = 2;
+            writer_opts.meta = &meta;
+            writer_opts.meta->set_column_id(0);
+            writer_opts.meta->set_unique_id(0);
+            writer_opts.meta->set_type(TYPE_VARCHAR);
+            writer_opts.meta->set_length(1024 * 1024);
+            writer_opts.meta->set_encoding(PLAIN_ENCODING);
+            writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
+            writer_opts.meta->set_is_nullable(true);
+            writer_opts.need_zone_map = true;
+
+            TabletColumn column(STORAGE_AGGREGATE_NONE, TYPE_VARCHAR);
+            column = create_varchar_key(1, true, 1024 * 1024);
+            ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &column, wfile.get()));
+            ASSERT_OK(writer->init());
+            config::dictionary_speculate_min_chunk_size = dict_chunk_size;
+            auto col = ChunkHelper::column_from_field_type(TYPE_VARCHAR, true);
+            config::dictionary_speculate_min_chunk_size = 4096;
+            std::vector<Slice> col_slices;
+            std::vector<std::string> col_strs;
+            col_strs.resize(TEST_N);
+            for (int i = 0; i < TEST_N; i++) {
+                col_strs[i] = strings::Substitute("test_$0", i);
+                col_slices.push_back(Slice(col_strs[i]));
+            }
+            col->reserve(TEST_N);
+            col->append_strings(col_slices);
+            ASSERT_TRUE(writer->append(*col).ok());
+
+            ASSERT_TRUE(writer->finish().ok());
+            ASSERT_TRUE(writer->write_data().ok());
+            ASSERT_TRUE(writer->write_ordinal_index().ok());
+            ASSERT_TRUE(writer->write_zone_map().ok());
+
+            // close the file
+            ASSERT_TRUE(wfile->close().ok());
+            // read and check result
+            auto segment = create_dummy_segment(fs, fname);
+            auto res = ColumnReader::create(&meta, segment.get());
+            ASSERT_TRUE(res.ok());
+            auto reader = std::move(res).value();
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator());
+            ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
+            ColumnIteratorOptions iter_opts;
+            OlapReaderStatistics stats;
+            iter_opts.stats = &stats;
+            iter_opts.read_file = read_file.get();
+            iter_opts.use_page_cache = true;
+            auto st = iter->init(iter_opts);
+            ASSERT_TRUE(st.ok());
+            ASSERT_TRUE(iter->seek_to_first().ok());
+            ColumnPtr dst = ChunkHelper::column_from_field_type(TYPE_VARCHAR, true);
+            dst->reserve(TEST_N);
+            size_t rows_read = TEST_N;
+            ASSERT_TRUE(iter->next_batch(&rows_read, dst.get()).ok());
+            ASSERT_EQ(dst->size(), TEST_N);
+
+            TypeInfoPtr type_info = get_type_info(TYPE_VARCHAR);
+            for (size_t i = 0; i < TEST_N; i++) {
+                ASSERT_EQ(0, type_info->cmp(col->get(i), dst->get(i)))
+                        << " row " << i << ": " << datum_to_string(type_info.get(), col->get(i)) << " vs "
+                        << datum_to_string(type_info.get(), dst->get(i));
+            }
+        }
+        config::dictionary_speculate_min_chunk_size = old_config;
+    }
+}
+
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:
In BinaryColumn, we use `vector<uint32_t> _offset` to store each rows offset in `vector<uint8_t> _bytes`. But if `_bytes` is large than 4GB, which means that offset will large than UINT32_MAX, offset overflow in `uint32`.  To prevent this overflow, we add this check in pr #33521, and because overflow happens, check fail with BE crash.
```
template <typename T>
void BinaryColumnBase<T>::_build_slices() const {
    if constexpr (std::is_same_v<T, uint32_t>) {
        CHECK_LT(_bytes.size(), (size_t)UINT32_MAX) << "BinaryColumn size overflow";
    }
```
BE crash:
```
   @          0x5e50559 google::LogMessageFatal::~LogMessageFatal()
    @          0x27ecfaf starrocks::BinaryColumnBase<>::_build_slices()
    @          0x2757dd5 starrocks::BinaryColumnBase<>::raw_data()
    @          0x480a0da starrocks::ScalarColumnWriter::append()
    @          0x480a33c starrocks::StringColumnWriter::append()
    @          0x43a2806 starrocks::SegmentWriter::append_chunk()
    @          0x4a98da0 starrocks::VerticalRowsetWriter::add_columns()
    @          0x4a73ac7 starrocks::VerticalCompactionTask::_compact_data()
    @          0x4a74d0f starrocks::VerticalCompactionTask::_compact_column_group()
    @          0x4a75632 starrocks::VerticalCompactionTask::_vertical_compaction_data()
    @          0x4a76129 starrocks::VerticalCompactionTask::run_impl()
    @          0x4a6b6fc starrocks::CompactionTask::run()
    @          0x44d30d3 _ZNSt17_Function_handlerIFvvEZN9starrocks17CompactionManager9_scheduleEvEUlvE_E9_M_invokeERKSt9_Any_data
    @          0x4cc33d2 starrocks::ThreadPool::dispatch_thread()
    @          0x4cbde6a starrocks::Thread::supervise_thread()
    @     0x7f4658c6644b start_thread
    @     0x7f465803f40f __GI___clone
    @                0x0 (unknown)
```

What I'm doing:
Add byte size limit to dictionary speculate, and make sure dictionary speculate will not batch too large column and cause overflow.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
