### PR TITLE
[Enhancement] Add crc32c checksum to persistent index's l0 & persistent index compression (backport #30841) (backport #32112)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1036,7 +1036,7 @@ CONF_mInt64(pindex_major_compaction_schedule_interval_seconds, "15");
 // control the local persistent index in shared_data gc interval
 CONF_mInt64(pindex_shard_data_gc_interval_seconds, "18000"); // 5 hour
 // enable persistent index compression
-CONF_mBool(enable_pindex_compression, "true");
+CONF_mBool(enable_pindex_compression, "false");
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1035,6 +1035,8 @@ CONF_mInt64(pindex_major_compaction_schedule_interval_seconds, "15");
 
 // control the local persistent index in shared_data gc interval
 CONF_mInt64(pindex_shard_data_gc_interval_seconds, "18000"); // 5 hour
+// enable persistent index compression
+CONF_mBool(enable_pindex_compression, "true");
 
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -787,7 +787,7 @@ public:
     }
 
     Status append_wal(const Slice* keys, const IndexValue* values, const std::vector<size_t>& idxes,
-                      std::unique_ptr<WritableFile>& index_file, uint64_t* page_size) override {
+                      std::unique_ptr<WritableFile>& index_file, uint64_t* page_size, uint32_t* checksum) override {
         faststring fixed_buf;
         fixed_buf.reserve(sizeof(size_t) + sizeof(size_t) + idxes.size() * (KeySize + sizeof(IndexValue)));
         put_fixed32_le(&fixed_buf, KeySize);
@@ -799,6 +799,8 @@ public:
         }
         RETURN_IF_ERROR(index_file->append(fixed_buf));
         *page_size += fixed_buf.size();
+        // incremental calc crc32
+        *checksum = crc32c::Extend(*checksum, (const char*)fixed_buf.data(), fixed_buf.size());
         return Status::OK();
     }
 
@@ -1110,7 +1112,7 @@ public:
     }
 
     Status append_wal(const Slice* keys, const IndexValue* values, const std::vector<size_t>& idxes,
-                      std::unique_ptr<WritableFile>& index_file, uint64_t* page_size) override {
+                      std::unique_ptr<WritableFile>& index_file, uint64_t* page_size, uint32_t* checksum) override {
         faststring fixed_buf;
         size_t keys_size = 0;
         auto n = idxes.size();
@@ -1130,6 +1132,8 @@ public:
         }
         RETURN_IF_ERROR(index_file->append(fixed_buf));
         *page_size += fixed_buf.size();
+        // incremental calc crc32
+        *checksum = crc32c::Extend(*checksum, (const char*)fixed_buf.data(), fixed_buf.size());
         return Status::OK();
     }
 
@@ -1720,8 +1724,8 @@ Status ShardByLengthMutableIndex::append_wal(size_t n, const Slice* keys, const 
         const auto [shard_offset, shard_size] = _shard_info_by_key_size[_fixed_key_size];
         const auto idxes_by_shard = split_keys_by_shard(shard_size, keys, 0, n);
         for (size_t i = 0; i < shard_size; ++i) {
-            RETURN_IF_ERROR(
-                    _shards[shard_offset + i]->append_wal(keys, values, idxes_by_shard[i], _index_file, &_page_size));
+            RETURN_IF_ERROR(_shards[shard_offset + i]->append_wal(keys, values, idxes_by_shard[i], _index_file,
+                                                                  &_page_size, &_checksum));
         }
     } else {
         DCHECK(_fixed_key_size == 0);
@@ -1739,7 +1743,7 @@ Status ShardByLengthMutableIndex::append_wal(size_t n, const Slice* keys, const 
             const auto idxes_by_shard = split_keys_by_shard(shard_size, keys, idxes);
             for (size_t i = 0; i < shard_size; ++i) {
                 RETURN_IF_ERROR(_shards[shard_offset + i]->append_wal(keys, values, idxes_by_shard[i], _index_file,
-                                                                      &_page_size));
+                                                                      &_page_size, &_checksum));
             }
         }
     }
@@ -1753,8 +1757,8 @@ Status ShardByLengthMutableIndex::append_wal(const Slice* keys, const IndexValue
         const auto [shard_offset, shard_size] = _shard_info_by_key_size[_fixed_key_size];
         const auto idxes_by_shard = split_keys_by_shard(shard_size, keys, idxes);
         for (size_t i = 0; i < shard_size; ++i) {
-            RETURN_IF_ERROR(
-                    _shards[shard_offset + i]->append_wal(keys, values, idxes_by_shard[i], _index_file, &_page_size));
+            RETURN_IF_ERROR(_shards[shard_offset + i]->append_wal(keys, values, idxes_by_shard[i], _index_file,
+                                                                  &_page_size, &_checksum));
         }
     } else {
         DCHECK(_fixed_key_size == 0);
@@ -1772,7 +1776,7 @@ Status ShardByLengthMutableIndex::append_wal(const Slice* keys, const IndexValue
             const auto idxes_by_shard = split_keys_by_shard(shard_size, keys, idxes);
             for (size_t i = 0; i < shard_size; ++i) {
                 RETURN_IF_ERROR(_shards[shard_offset + i]->append_wal(keys, values, idxes_by_shard[i], _index_file,
-                                                                      &_page_size));
+                                                                      &_page_size, &_checksum));
             }
         }
     }
@@ -1808,6 +1812,14 @@ bool ShardByLengthMutableIndex::dump(phmap::BinaryOutputArchive& ar_out, std::se
     return true;
 }
 
+static Status checksum_of_file(RandomAccessFile* file, uint64_t offset, uint32_t size, uint32* checksum) {
+    std::string buff;
+    raw::stl_string_resize_uninitialized(&buff, size);
+    RETURN_IF_ERROR(file->read_at_fully(offset, buff.data(), buff.size()));
+    *checksum = crc32c::Value(buff.data(), buff.size());
+    return Status::OK();
+}
+
 Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVersion& version, const CommitType& type) {
     std::shared_ptr<FileSystem> fs;
     ASSIGN_OR_RETURN(fs, FileSystem::CreateSharedFromString(_path));
@@ -1834,6 +1846,7 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _offset = 0;
         _page_size = 0;
+        _checksum = 0;
         break;
     }
     case kSnapshot: {
@@ -1857,6 +1870,9 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         WritableFileOptions wblock_opts;
         wblock_opts.mode = FileSystem::MUST_EXIST;
         ASSIGN_OR_RETURN(_index_file, fs->new_writable_file(wblock_opts, file_name));
+        // open l0 to calc checksum
+        std::unique_ptr<RandomAccessFile> l0_rfile;
+        ASSIGN_OR_RETURN(l0_rfile, fs->new_random_access_file(file_name));
         size_t snapshot_size = _index_file->size();
         meta->clear_wals();
         IndexSnapshotMetaPB* snapshot = meta->mutable_snapshot();
@@ -1866,9 +1882,12 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         data->set_size(snapshot_size);
         snapshot->clear_dumped_shard_idxes();
         snapshot->mutable_dumped_shard_idxes()->Add(dumped_shard_idxes.begin(), dumped_shard_idxes.end());
+        RETURN_IF_ERROR(checksum_of_file(l0_rfile.get(), 0, snapshot_size, &_checksum));
+        snapshot->set_checksum(_checksum);
         meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _offset = snapshot_size;
         _page_size = 0;
+        _checksum = 0;
         break;
     }
     case kAppendWAL: {
@@ -1877,9 +1896,11 @@ Status ShardByLengthMutableIndex::commit(MutableIndexMetaPB* meta, const EditVer
         PagePointerPB* data = wal_pb->mutable_data();
         data->set_offset(_offset);
         data->set_size(_page_size);
+        wal_pb->set_checksum(_checksum);
         meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
         _offset += _page_size;
         _page_size = 0;
+        _checksum = 0;
         break;
     }
     default: {
@@ -1914,15 +1935,31 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
     std::string index_file_name = get_l0_index_file_name(_path, start_version);
     std::shared_ptr<FileSystem> fs;
     ASSIGN_OR_RETURN(fs, FileSystem::CreateSharedFromString(_path));
+    ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(index_file_name));
     phmap::BinaryInputArchive ar(index_file_name.data());
     if (snapshot_size > 0) {
+        // check snapshot's crc32 checksum
+        const uint32_t expected_checksum = snapshot_meta.checksum();
+        // If expected crc32 is 0, which means no crc32 here, skip check.
+        // This may happen when upgrade from old version.
+        if (expected_checksum > 0) {
+            uint32_t current_checksum = 0;
+            RETURN_IF_ERROR(checksum_of_file(read_file.get(), snapshot_off, snapshot_size, &current_checksum));
+            if (current_checksum != expected_checksum) {
+                std::string error_msg = fmt::format(
+                        "persistent index l0 crc checksum fail. filename: {} offset: {} cur_crc: {} expect_crc: {}",
+                        index_file_name, snapshot_off, current_checksum, expected_checksum);
+                LOG(ERROR) << error_msg;
+                return Status::Corruption(error_msg);
+            }
+        }
+        // do load snapshot
         if (!load_snapshot(ar, dumped_shard_idxes)) {
             std::string err_msg = strings::Substitute("failed load snapshot from file $0", index_file_name);
             LOG(WARNING) << err_msg;
             return Status::InternalError(err_msg);
         }
     }
-    ASSIGN_OR_RETURN(auto read_file, fs->new_random_access_file(index_file_name));
     // if mutable index is empty, set _offset as 0, otherwise set _offset as snapshot size
     _offset = snapshot_off + snapshot_size;
     const int n = meta.wals_size();
@@ -1933,6 +1970,19 @@ Status ShardByLengthMutableIndex::load(const MutableIndexMetaPB& meta) {
         const auto end = offset + page_pointer_pb.size();
         std::string buff;
         raw::stl_string_resize_uninitialized(&buff, 4);
+        // check crc32
+        const uint32_t expected_checksum = meta.wals(i).checksum();
+        if (expected_checksum > 0) {
+            uint32_t current_checksum = 0;
+            RETURN_IF_ERROR(checksum_of_file(read_file.get(), offset, page_pointer_pb.size(), &current_checksum));
+            if (current_checksum != expected_checksum) {
+                std::string error_msg = fmt::format(
+                        "persistent index l0 crc checksum fail. filename: {} offset: {} cur_crc: {} expect_crc: {}",
+                        index_file_name, page_pointer_pb.offset(), current_checksum, expected_checksum);
+                LOG(ERROR) << error_msg;
+                return Status::Corruption(error_msg);
+            }
+        }
         while (offset < end) {
             RETURN_IF_ERROR(read_file->read_at_fully(offset, buff.data(), buff.size()));
             const auto key_size = UNALIGNED_LOAD32(buff.data());

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -648,8 +648,7 @@ Status ImmutableIndexWriter::finish() {
             "finish writing immutable index $0 #shard:$1 #kv:$2 #moved:$3($4) kv_bytes:$5 usage:$6"
             "compression_type:$7",
             _idx_file_path_tmp, _nshard, _total, _total_moved, _total_moved * 1000 / std::max(_total, 1UL) / 1000.0,
-            _total_kv_bytes, _total_kv_size * 1000 / std::max(_total_kv_bytes, 1UL) / 1000.0,
-            _meta.compression_type());
+            _total_bytes, _total_kv_size * 1000 / std::max(_total_bytes, 1UL) / 1000.0, _meta.compression_type());
     _version.to_pb(_meta.mutable_version());
     _meta.set_size(_total);
     _meta.set_format_version(PERSISTENT_INDEX_VERSION_4);
@@ -2491,7 +2490,7 @@ StatusOr<std::unique_ptr<ImmutableIndex>> ImmutableIndex::load(std::unique_ptr<R
         dest.uncompressed_size = src.uncompressed_size();
         if (idx->_compression_type == CompressionTypePB::NO_COMPRESSION) {
             DCHECK(dest.uncompressed_size == 0) << "compression type: " << idx->_compression_type
-                                               << " uncompressed_size: " << dest.uncompressed_size;
+                                                << " uncompressed_size: " << dest.uncompressed_size;
         }
         // This is for compatibility, we don't add data_size in shard_info in the rc version
         // And data_size is added to reslove some bug(https://github.com/StarRocks/starrocks/issues/11868)

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -191,7 +191,7 @@ public:
     virtual Status replace(const Slice* keys, const IndexValue* values, const std::vector<size_t>& replace_idxes) = 0;
 
     virtual Status append_wal(const Slice* keys, const IndexValue* values, const std::vector<size_t>& idxes,
-                              std::unique_ptr<WritableFile>& index_file, uint64_t* page_size) = 0;
+                              std::unique_ptr<WritableFile>& index_file, uint64_t* page_size, uint32_t* checksum) = 0;
 
     // load wals
     // |n|: size of key/value array
@@ -370,6 +370,7 @@ private:
     uint32_t _fixed_key_size = -1;
     uint64_t _offset = 0;
     uint64_t _page_size = 0;
+    uint32_t _checksum = 0;
     std::string _path;
     std::unique_ptr<WritableFile> _index_file;
     std::shared_ptr<FileSystem> _fs;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -43,7 +43,8 @@ enum PersistentIndexFileVersion {
     PERSISTENT_INDEX_VERSION_UNKNOWN = 0,
     PERSISTENT_INDEX_VERSION_1,
     PERSISTENT_INDEX_VERSION_2,
-    PERSISTENT_INDEX_VERSION_3
+    PERSISTENT_INDEX_VERSION_3,
+    PERSISTENT_INDEX_VERSION_4
 };
 
 static constexpr uint64_t NullIndexValue = -1;
@@ -504,11 +505,13 @@ private:
         uint32_t value_size;
         uint32_t nbucket;
         uint64_t data_size;
+        uint64_t uncompressed_size;
     };
 
     std::vector<ShardInfo> _shards;
     std::map<size_t, std::pair<size_t, size_t>> _shard_info_by_length;
     std::map<size_t, std::unique_ptr<BloomFilter>> _bf_map;
+    CompressionTypePB _compression_type;
 };
 
 class ImmutableIndexWriter {

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -2304,6 +2304,103 @@ TEST_P(PersistentIndexTest, test_index_keep_delete) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
+TEST_P(PersistentIndexTest, test_l0_append_load_small_data) {
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_l0_append_load_small_data";
+    const std::string kIndexFile = "./PersistentIndexTest_test_l0_append_load_small_data/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    using Key = std::string;
+    PersistentIndexMetaPB index_meta;
+    const int N = 10;
+    const int DEL_N = 6;
+    int64_t cur_version = 0;
+    // insert
+    vector<Key> keys(N);
+    vector<Slice> key_slices;
+    vector<IndexValue> values;
+    key_slices.reserve(N);
+    for (int i = 0; i < N; i++) {
+        keys[i] = "test_varlen_" + std::to_string(i);
+        values.emplace_back(i);
+        key_slices.emplace_back(keys[i]);
+    }
+    // erase
+    vector<Key> erase_keys(DEL_N);
+    vector<Slice> erase_key_slices;
+    erase_key_slices.reserve(DEL_N);
+    for (int i = 0; i < DEL_N; i++) {
+        erase_keys[i] = "test_varlen_" + std::to_string(i);
+        erase_key_slices.emplace_back(erase_keys[i]);
+    }
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    {
+        EditVersion version(cur_version++, 0);
+        index_meta.set_key_size(0);
+        index_meta.set_size(0);
+        version.to_pb(index_meta.mutable_version());
+        MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+        l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+        IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+        version.to_pb(snapshot_meta->mutable_version());
+
+        PersistentIndex index(kPersistentIndexDir);
+
+        // insert
+        ASSERT_OK(index.load(index_meta));
+        ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), N));
+        ASSERT_OK(index.insert(N, key_slices.data(), values.data(), false));
+        ASSERT_OK(index.commit(&index_meta));
+        ASSERT_OK(index.on_commited());
+
+        // delete
+        vector<IndexValue> erase_old_values(erase_keys.size());
+        ASSERT_TRUE(index.prepare(EditVersion(cur_version++, 0), erase_keys.size()).ok());
+        ASSERT_TRUE(index.erase(erase_keys.size(), erase_key_slices.data(), erase_old_values.data()).ok());
+        ASSERT_TRUE(index.commit(&index_meta).ok());
+        ASSERT_TRUE(index.on_commited().ok());
+
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_TRUE(index.get(keys.size(), key_slices.data(), get_values.data()).ok());
+        ASSERT_EQ(keys.size(), get_values.size());
+        for (int i = 0; i < DEL_N; i++) {
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
+        }
+        for (int i = DEL_N; i < values.size(); i++) {
+            ASSERT_EQ(values[i], get_values[i]);
+        }
+    }
+
+    {
+        // rebuild mutableindex according PersistentIndexMetaPB
+        PersistentIndex new_index(kPersistentIndexDir);
+        ASSERT_TRUE(new_index.load(index_meta).ok());
+
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_TRUE(new_index.get(keys.size(), key_slices.data(), get_values.data()).ok());
+        ASSERT_EQ(keys.size(), get_values.size());
+        for (int i = 0; i < DEL_N; i++) {
+            ASSERT_EQ(NullIndexValue, get_values[i].get_value());
+        }
+        for (int i = DEL_N; i < values.size(); i++) {
+            ASSERT_EQ(values[i], get_values[i]);
+        }
+    }
+    {
+        // try to break up checksum
+        index_meta.mutable_l0_meta()->mutable_snapshot()->set_checksum(111);
+        PersistentIndex new_index(kPersistentIndexDir);
+        ASSERT_FALSE(new_index.load(index_meta).ok());
+    }
+    ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
+}
+
 INSTANTIATE_TEST_SUITE_P(PersistentIndexTest, PersistentIndexTest,
                          ::testing::Values(PersistentIndexTestParam{true}, PersistentIndexTestParam{false}));
 

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -2401,7 +2401,6 @@ TEST_P(PersistentIndexTest, test_l0_append_load_small_data) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-INSTANTIATE_TEST_SUITE_P(PersistentIndexTest, PersistentIndexTest,
-                         ::testing::Values(PersistentIndexTestParam{true}, PersistentIndexTestParam{false}));
+INSTANTIATE_TEST_SUITE_P(PersistentIndexTest, PersistentIndexTest, ::testing::Values(PersistentIndexTestParam{false}));
 
 } // namespace starrocks

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -35,7 +35,18 @@
 #include "util/faststring.h"
 
 namespace starrocks {
-PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
+
+struct PersistentIndexTestParam {
+    bool enable_pindex_compression;
+};
+
+class PersistentIndexTest : public testing::TestWithParam<PersistentIndexTestParam> {
+public:
+    virtual ~PersistentIndexTest() {}
+    void SetUp() override { config::enable_pindex_compression = GetParam().enable_pindex_compression; }
+};
+
+TEST_P(PersistentIndexTest, test_fixlen_mutable_index) {
     using Key = uint64_t;
     const int N = 1000;
     vector<Key> keys;
@@ -133,7 +144,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index) {
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index) {
     using Key = std::string;
     const int N = 1000;
     vector<Key> keys(N);
@@ -243,7 +254,7 @@ static std::string gen_random_string_of_random_length(size_t floor, size_t ceil)
     return str;
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
+TEST_P(PersistentIndexTest, test_large_varlen_mutable_index) {
     using Key = std::string;
     const int N = 1000;
     vector<Key> keys(N);
@@ -351,7 +362,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index) {
     ASSERT_EQ(upsert_not_found.size(), expect_not_found);
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
+TEST_P(PersistentIndexTest, test_fixlen_mutable_index_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_fixlen_mutable_index_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_fixlen_mutable_index_wal/index.l0.0.0";
@@ -508,7 +519,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_mutable_index_wal) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
+TEST_P(PersistentIndexTest, test_l0_max_file_size) {
     int64_t l0_max_file_size = config::l0_max_file_size;
     config::l0_max_file_size = 200000;
     config::l0_max_mem_usage = 10240;
@@ -589,7 +600,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_file_size) {
     config::l0_max_file_size = l0_max_file_size;
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l0_max_memory_usage) {
+TEST_P(PersistentIndexTest, test_l0_max_memory_usage) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_l0_max_memory_usage";
     const std::string kIndexFile = "./PersistentIndexTest_test_l0_max_memory_usage/index.l0.0.0";
@@ -649,7 +660,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_max_memory_usage) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l0_min_memory_usage) {
+TEST_P(PersistentIndexTest, test_l0_min_memory_usage) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_l0_min_memory_usage";
     const std::string kIndexFile = "./PersistentIndexTest_test_l0_min_memory_usage/index.l0.0.0";
@@ -718,7 +729,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l0_min_memory_usage) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot";
     const std::string kIndexFile = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot/index.l0.0.0";
@@ -786,7 +797,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_small_varlen_mutable_index_snapshot_wal/index.l0.0.0";
@@ -883,7 +894,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_snapshot_wal)
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
+TEST_P(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_small_varlen_mutable_index_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_small_varlen_mutable_index_wal/index.l0.0.0";
@@ -1010,7 +1021,7 @@ PARALLEL_TEST(PersistentIndexTest, test_small_varlen_mutable_index_wal) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
+TEST_P(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_large_varlen_mutable_index_wal";
     const std::string kIndexFile = "./PersistentIndexTest_test_large_varlen_mutable_index_wal/index.l0.0.0";
@@ -1136,7 +1147,7 @@ PARALLEL_TEST(PersistentIndexTest, test_large_varlen_mutable_index_wal) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
+TEST_P(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     using Key = uint64_t;
     const int N = 200000;
     vector<Key> keys(N);
@@ -1203,7 +1214,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_fixlen_to_immutable) {
     ASSERT_TRUE(fs::remove_all("./index.l1.1.1").ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_flush_varlen_to_immutable) {
+TEST_P(PersistentIndexTest, test_flush_varlen_to_immutable) {
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_flush_varlen_to_immutable";
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString("posix://"));
     bool created;
@@ -1449,7 +1460,7 @@ void build_persistent_index_from_tablet(size_t N) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_build_from_tablet) {
+TEST_P(PersistentIndexTest, test_build_from_tablet) {
     auto manager = StorageEngine::instance()->update_manager();
     config::l0_max_mem_usage = 104857600;
     manager->mem_tracker()->set_limit(-1);
@@ -1466,7 +1477,7 @@ PARALLEL_TEST(PersistentIndexTest, test_build_from_tablet) {
     config::l0_max_mem_usage = 104857600;
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_fixlen_replace) {
+TEST_P(PersistentIndexTest, test_fixlen_replace) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_fixlen_replace";
     const std::string kIndexFile = "./PersistentIndexTest_test_fixlen_replace/index.l0.0.0";
@@ -1540,7 +1551,7 @@ PARALLEL_TEST(PersistentIndexTest, test_fixlen_replace) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_varlen_replace) {
+TEST_P(PersistentIndexTest, test_varlen_replace) {
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_varlen_replace";
     const std::string kIndexFile = "./PersistentIndexTest_test_varlen_replace/index.l0.0.0";
@@ -1614,7 +1625,7 @@ PARALLEL_TEST(PersistentIndexTest, test_varlen_replace) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_get_move_buckets) {
+TEST_P(PersistentIndexTest, test_get_move_buckets) {
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_get_move_buckets";
     PersistentIndex index(kPersistentIndexDir);
     std::vector<uint8_t> bucket_packs_in_page;
@@ -1640,7 +1651,7 @@ PARALLEL_TEST(PersistentIndexTest, test_get_move_buckets) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
+TEST_P(PersistentIndexTest, test_flush_l1_advance) {
     config::l0_max_mem_usage = 10240;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
@@ -1756,7 +1767,7 @@ PARALLEL_TEST(PersistentIndexTest, test_flush_l1_advance) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
+TEST_P(PersistentIndexTest, test_multi_l2_tmp_l1) {
     config::l0_max_mem_usage = 1024;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
@@ -1889,7 +1900,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_tmp_l1) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
+TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
     config::l0_max_mem_usage = 1 * 1024 * 1024; // 1MB
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_not_tmp_l1";
@@ -1990,7 +2001,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
+TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
     config::l0_max_mem_usage = 1 * 1024 * 1024; // 1MB
     FileSystem* fs = FileSystem::Default();
     const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_not_tmp_l1_fixlen";
@@ -2086,7 +2097,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_not_tmp_l1_fixlen) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_multi_l2_delete) {
+TEST_P(PersistentIndexTest, test_multi_l2_delete) {
     config::l0_max_mem_usage = 1024;
     config::max_tmp_l1_num = 10;
     FileSystem* fs = FileSystem::Default();
@@ -2191,7 +2202,7 @@ PARALLEL_TEST(PersistentIndexTest, test_multi_l2_delete) {
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_l2_versions) {
+TEST_P(PersistentIndexTest, test_l2_versions) {
     EditVersionWithMerge m1(INT64_MAX, INT64_MAX, true);
     EditVersionWithMerge m2(INT64_MAX, INT64_MAX, false);
     EditVersionWithMerge m3(10, 0, true);
@@ -2217,7 +2228,7 @@ PARALLEL_TEST(PersistentIndexTest, test_l2_versions) {
     ASSERT_TRUE(m10 < m9);
 }
 
-PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
+TEST_P(PersistentIndexTest, test_index_keep_delete) {
     config::l0_max_mem_usage = 1024;
     config::enable_pindex_minor_compaction = false;
     FileSystem* fs = FileSystem::Default();
@@ -2292,5 +2303,8 @@ PARALLEL_TEST(PersistentIndexTest, test_index_keep_delete) {
     }
     ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
 }
+
+INSTANTIATE_TEST_SUITE_P(PersistentIndexTest, PersistentIndexTest,
+                         ::testing::Values(PersistentIndexTestParam{true}, PersistentIndexTestParam{false}));
 
 } // namespace starrocks

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -45,6 +45,7 @@ message ImmutableIndexShardMetaPB {
     uint64 value_size = 5;
     uint64 nbucket = 6;
     uint64 data_size = 7;
+    uint64 uncompressed_size = 8; // if uncompressed_size is 0, which means no compression
 }
 
 message ShardInfoPB {
@@ -59,6 +60,9 @@ message ImmutableIndexMetaPB {
     uint64 size = 3;
     repeated ImmutableIndexShardMetaPB shards = 4;
     repeated ShardInfoPB shard_info = 5;
+    repeated uint64 shard_bf_off = 6;
+    // because CompressionTypePB defined in proto2, so we use int32 here to be compatible
+    int32 compression_type = 7;
 }
 
 message PersistentIndexMetaPB {

--- a/gensrc/proto/persistent_index.proto
+++ b/gensrc/proto/persistent_index.proto
@@ -22,11 +22,13 @@ message IndexSnapshotMetaPB {
     EditVersionPB version = 1;
     PagePointerPB data = 2;
     repeated uint32 dumped_shard_idxes = 3;
+    uint32 checksum = 4;
 }
 
 message IndexWalMetaPB {
     EditVersionPB version = 1;
     PagePointerPB data = 2;
+    uint32 checksum = 3;
 }
 
 message MutableIndexMetaPB {


### PR DESCRIPTION
Backport #30841 #32112 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
