### PR TITLE
[Enhancement] Add IO profiler (#36068)

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -19,6 +19,7 @@
 #include "agent/task_signatures_manager.h"
 #include "boost/lexical_cast.hpp"
 #include "common/status.h"
+#include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "runtime/snapshot_loader.h"
 #include "service/backend_options.h"
@@ -305,6 +306,8 @@ void run_clone_task(const std::shared_ptr<CloneAgentTaskRequest>& agent_task_req
     const TCloneReq& clone_req = agent_task_req->task_req;
     AgentStatus status = STARROCKS_SUCCESS;
 
+    auto scope = IOProfiler::scope(IOProfiler::TAG_CLONE, clone_req.tablet_id);
+
     // Return result to fe
     TStatus task_status;
     TFinishTaskRequest finish_task_request;
@@ -377,6 +380,9 @@ void run_clone_task(const std::shared_ptr<CloneAgentTaskRequest>& agent_task_req
 void run_storage_medium_migrate_task(const std::shared_ptr<StorageMediumMigrateTaskRequest>& agent_task_req,
                                      ExecEnv* exec_env) {
     const TStorageMediumMigrateReq& storage_medium_migrate_req = agent_task_req->task_req;
+
+    auto scope = IOProfiler::scope(IOProfiler::TAG_CLONE, storage_medium_migrate_req.tablet_id);
+
     TStatusCode::type status_code = TStatusCode::OK;
     std::vector<std::string> error_msgs;
     TStatus task_status;

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -20,6 +20,7 @@
 #include "exec/pipeline/scan/scan_operator.h"
 #include "exec/workgroup/work_group.h"
 #include "gutil/map_util.h"
+#include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "runtime/exec_env.h"
@@ -297,6 +298,9 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
     std::vector<uint32_t> reader_columns;
 
     RETURN_IF_ERROR(_get_tablet(_scan_range));
+
+    auto scope = IOProfiler::scope(IOProfiler::TAG_QUERY, _scan_range->tablet_id);
+
     RETURN_IF_ERROR(_init_global_dicts(&_params));
     RETURN_IF_ERROR(_init_unused_output_columns(thrift_olap_scan_node.unused_output_column_name));
     RETURN_IF_ERROR(_init_scanner_columns(scanner_columns));
@@ -332,6 +336,7 @@ Status OlapChunkSource::_init_olap_reader(RuntimeState* runtime_state) {
 Status OlapChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     chunk->reset(ChunkHelper::new_chunk_pooled(_prj_iter->output_schema(), _runtime_state->chunk_size(),
                                                _runtime_state->use_column_pool()));
+    auto scope = IOProfiler::scope(IOProfiler::TAG_QUERY, _tablet->tablet_id());
     return _read_chunk_from_storage(_runtime_state, (*chunk).get());
 }
 

--- a/be/src/fs/fs_posix.cpp
+++ b/be/src/fs/fs_posix.cpp
@@ -29,6 +29,7 @@
 #include "gutil/strings/substitute.h"
 #include "gutil/strings/util.h"
 #include "io/fd_input_stream.h"
+#include "io/io_profiler.h"
 #include "testutil/sync_point.h"
 #include "util/errno.h"
 #include "util/slice.h"
@@ -211,6 +212,7 @@ public:
 #ifdef USE_STAROS
         s_sr_posix_write_iosize.Observe(bytes_written);
 #endif
+        IOProfiler::add_write(bytes_written);
         return Status::OK();
     }
 

--- a/be/src/http/action/pprof_actions.cpp
+++ b/be/src/http/action/pprof_actions.cpp
@@ -51,6 +51,7 @@
 #include "http/http_channel.h"
 #include "http/http_headers.h"
 #include "http/http_request.h"
+#include "io/io_profiler.h"
 #include "util/bfd_parser.h"
 
 namespace starrocks {
@@ -166,6 +167,28 @@ void ProfileAction::handle(HttpRequest* req) {
 
     HttpChannel::send_reply(req, str);
 #endif
+}
+
+static std::mutex kIOPprofActionMutex;
+
+void IOProfileAction::handle(HttpRequest* req) {
+    std::lock_guard<std::mutex> lock(kIOPprofActionMutex);
+    auto scoped_span = trace::Scope(Tracer::Instance().start_trace("http_handle_io_profile"));
+
+    int seconds = 10;
+    const std::string& seconds_str = req->param(SECOND_KEY);
+    if (!seconds_str.empty()) {
+        seconds = std::atoi(seconds_str.c_str());
+    }
+    int topn = 10;
+    const std::string& topn_str = req->param("topn");
+    if (!topn_str.empty()) {
+        topn = std::atoi(topn_str.c_str());
+    }
+    topn = std::max(1, topn);
+
+    auto ret = IOProfiler::profile_and_get_topn_stats_str(req->param("mode"), seconds, topn);
+    HttpChannel::send_reply(req, ret);
 }
 
 void CmdlineAction::handle(HttpRequest* req) {

--- a/be/src/http/action/pprof_actions.h
+++ b/be/src/http/action/pprof_actions.h
@@ -64,6 +64,14 @@ public:
     void handle(HttpRequest* req) override;
 };
 
+class IOProfileAction : public HttpHandler {
+public:
+    IOProfileAction() = default;
+    ~IOProfileAction() override = default;
+
+    void handle(HttpRequest* req) override;
+};
+
 class PmuProfileAction : public HttpHandler {
 public:
     PmuProfileAction() = default;

--- a/be/src/io/CMakeLists.txt
+++ b/be/src/io/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(IO STATIC
         compressed_input_stream.cpp
         fd_output_stream.cpp
         fd_input_stream.cpp
+        io_profiler.cpp
         seekable_input_stream.cpp
         readable.cpp
         s3_input_stream.cpp

--- a/be/src/io/fd_input_stream.cpp
+++ b/be/src/io/fd_input_stream.cpp
@@ -21,6 +21,7 @@
 #include "common/logging.h"
 #include "gutil/macros.h"
 #include "io/io_error.h"
+#include "io_profiler.h"
 
 #ifdef USE_STAROS
 #include "fslib/metric_key.h"
@@ -81,6 +82,7 @@ StatusOr<int64_t> FdInputStream::read(void* data, int64_t count) {
     s_posixread_iosize.Observe(res);
 #endif
     _offset += res;
+    IOProfiler::add_read(res);
     return res;
 }
 

--- a/be/src/io/fd_output_stream.cpp
+++ b/be/src/io/fd_output_stream.cpp
@@ -21,6 +21,7 @@
 #include "common/logging.h"
 #include "gutil/macros.h"
 #include "io/io_error.h"
+#include "io/io_profiler.h"
 
 namespace starrocks::io {
 
@@ -68,6 +69,7 @@ Status FdOutputStream::write(const void* data, int64_t count) {
             }
         }
     }
+    IOProfiler::add_write(bytes_written);
     return Status::OK();
 }
 

--- a/be/src/io/io_profiler.cpp
+++ b/be/src/io/io_profiler.cpp
@@ -1,0 +1,266 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io_profiler.h"
+
+#include <mutex>
+#include <thread>
+#include <unordered_set>
+
+#include "fmt/format.h"
+
+namespace starrocks {
+
+std::atomic<uint32_t> IOProfiler::_mode(0);
+
+Status IOProfiler::start(IOProfiler::IOMode op) {
+    if (op == IOMode::IOMODE_NONE) {
+        return Status::InternalError("invalid io profiler mode");
+    }
+    uint32_t old_mode = _mode.load();
+    if (old_mode != IOMode::IOMODE_NONE) {
+        return Status::InternalError("io profiler is already started");
+    }
+    if (_mode.compare_exchange_strong(old_mode, (uint32_t)op)) {
+        LOG(INFO) << "io profiler started, mode=" << op;
+        return Status::OK();
+    } else {
+        LOG(WARNING) << "io profiler already started, mode=" << old_mode;
+        return Status::InternalError("io profiler is already started");
+    }
+}
+
+void IOProfiler::stop() {
+    uint32_t old_mode = _mode.load();
+    if (old_mode == IOMode::IOMODE_NONE) {
+        LOG(INFO) << "io profiler is not started";
+        return;
+    }
+    if (_mode.compare_exchange_strong(old_mode, IOMode::IOMODE_NONE)) {
+        LOG(INFO) << "io profiler stopped";
+    } else {
+        LOG(WARNING) << "io profiler already stopped";
+    }
+    // simple solution to sleep some time to prevent race condition
+    ::usleep(50000);
+}
+
+struct IOStatEntry {
+    uint64_t id{0};
+    std::atomic<uint64_t> read_bytes{0};
+    std::atomic<uint64_t> write_bytes{0};
+    std::atomic<uint32_t> read_ops{0};
+    std::atomic<uint32_t> write_ops{0};
+
+    IOStatEntry(uint64_t id) : id(id) {}
+
+    bool operator==(const IOStatEntry& other) const { return id == other.id; }
+
+    void add_read(uint64_t bytes) {
+        this->read_bytes.fetch_add(bytes);
+        this->read_ops.fetch_add(1);
+    }
+
+    void add_write(uint64_t bytes) {
+        this->write_bytes.fetch_add(bytes);
+        this->write_ops.fetch_add(1);
+    }
+
+    void clear() {
+        this->read_bytes = 0;
+        this->read_ops = 0;
+        this->write_bytes = 0;
+        this->write_ops = 0;
+    }
+
+    static std::string header_string() {
+        return fmt::format("{:>10} {:>10} {:>16} {:>8} {:>16} {:>8} {:>16} {:>8}", "Tablet", "TAG", "read_bytes", "ops",
+                           "write_bytes", "ops", "total_bytes", "ops");
+    }
+
+    std::string to_string() const {
+        uint32_t tag = id >> 48UL;
+        uint64_t tablet_id = id & 0x0000FFFFFFFFFFFFUL;
+        return fmt::format("{:>10} {:>10} {:>16} {:>8} {:>16} {:>8} {:>16} {:>8}", tablet_id,
+                           IOProfiler::tag_to_string(tag), read_bytes.load(), read_ops.load(), write_bytes.load(),
+                           write_ops.load(), read_bytes + write_bytes, read_ops + write_ops);
+    }
+};
+
+class IOStatEntryHash {
+public:
+    size_t operator()(const IOStatEntry& entry) const { return std::hash<uint64_t>()(entry.id); }
+};
+
+static std::mutex _io_stats_mutex;
+static std::unordered_set<IOStatEntry, IOStatEntryHash> _io_stats;
+
+void IOProfiler::reset() {
+    uint32_t old_mode = _mode.load();
+    if (old_mode != IOMode::IOMODE_NONE) {
+        LOG(WARNING) << "stop io profiler before reset";
+        return;
+    }
+    {
+        std::lock_guard<std::mutex> l(_io_stats_mutex);
+        _io_stats.clear();
+    }
+    LOG(INFO) << "io profiler reset";
+}
+
+thread_local IOStatEntry* current_io_stat = nullptr;
+
+void IOProfiler::set_context(uint32_t tag, uint64_t tablet_id) {
+    if (tablet_id == 0) {
+        return;
+    }
+    uint64_t key = ((uint64_t)tag << 48UL) | tablet_id;
+    std::lock_guard<std::mutex> l(_io_stats_mutex);
+    auto it = _io_stats.find(IOStatEntry{key});
+    if (it == _io_stats.end()) {
+        it = _io_stats.emplace(key).first;
+    }
+    current_io_stat = const_cast<IOStatEntry*>(&(*it));
+}
+
+IOStatEntry* IOProfiler::get_context() {
+    return current_io_stat;
+}
+
+void IOProfiler::set_context(IOStatEntry* entry) {
+    current_io_stat = entry;
+}
+
+void IOProfiler::clear_context() {
+    current_io_stat = nullptr;
+}
+
+void IOProfiler::_add_read(int64_t bytes) {
+    if (current_io_stat != nullptr) {
+        current_io_stat->add_read(bytes);
+    }
+}
+
+void IOProfiler::_add_write(int64_t bytes) {
+    if (current_io_stat != nullptr) {
+        current_io_stat->add_write(bytes);
+    }
+}
+
+const char* IOProfiler::tag_to_string(uint32_t tag) {
+    switch (tag) {
+    case TAG_NONE:
+        return "NONE";
+    case TAG_QUERY:
+        return "QUERY";
+    case TAG_LOAD:
+        return "LOAD";
+    case TAG_PKINDEX:
+        return "PKINDEX";
+    case TAG_COMPACTION:
+        return "COMPACTION";
+    case TAG_CLONE:
+        return "CLONE";
+    case TAG_ALTER:
+        return "ALTER";
+    case TAG_MIGRATE:
+        return "MIGRATE";
+    case TAG_SIZE:
+        return "SIZE";
+    default:
+        return "UNKNOWN";
+    }
+};
+
+StatusOr<std::vector<std::string>> IOProfiler::get_topn_stats(size_t n,
+                                                              const std::function<int64_t(const IOStatEntry&)>& func) {
+    std::vector<std::pair<uint64_t, const IOStatEntry*>> stats;
+    std::lock_guard<std::mutex> l(_io_stats_mutex);
+    if (_mode.load() != IOMode::IOMODE_NONE) {
+        return Status::InternalError("io profiler still running");
+    }
+    stats.reserve(_io_stats.size());
+    for (auto& it : _io_stats) {
+        auto v = func(it);
+        if (v > 0) {
+            stats.emplace_back(v, &it);
+        }
+    }
+    std::sort(stats.begin(), stats.end(), [](const auto& a, const auto& b) { return a.first > b.first; });
+    std::vector<std::string> result;
+    n = std::min(n, stats.size());
+    result.reserve(n + 1);
+    result.emplace_back(IOStatEntry::header_string());
+    for (size_t i = 0; i < n; ++i) {
+        result.emplace_back(stats[i].second->to_string());
+    }
+    return result;
+}
+
+StatusOr<std::vector<std::string>> IOProfiler::get_topn_read_stats(size_t n) {
+    return IOProfiler::get_topn_stats(n, [](const IOStatEntry& e) { return e.read_bytes.load(); });
+}
+
+StatusOr<std::vector<std::string>> IOProfiler::get_topn_write_stats(size_t n) {
+    return IOProfiler::get_topn_stats(n, [](const IOStatEntry& e) { return e.write_bytes.load(); });
+}
+
+StatusOr<std::vector<std::string>> IOProfiler::get_topn_total_stats(size_t n) {
+    return IOProfiler::get_topn_stats(n,
+                                      [](const IOStatEntry& e) { return e.read_bytes.load() + e.write_bytes.load(); });
+}
+
+std::string IOProfiler::profile_and_get_topn_stats_str(const std::string& mode, int seconds, size_t topn) {
+    StatusOr<std::vector<std::string>> ret;
+    if (mode == "read") {
+        auto st = IOProfiler::start(IOProfiler::IOMODE_READ);
+        if (!st.ok()) {
+            ret = st;
+        } else {
+            sleep(seconds);
+            IOProfiler::stop();
+            ret = IOProfiler::get_topn_read_stats(topn);
+        }
+    } else if (mode == "write") {
+        auto st = IOProfiler::start(IOProfiler::IOMODE_WRITE);
+        if (!st.ok()) {
+            ret = st;
+        } else {
+            sleep(seconds);
+            IOProfiler::stop();
+            ret = IOProfiler::get_topn_write_stats(topn);
+        }
+    } else {
+        auto st = IOProfiler::start(IOProfiler::IOMODE_ALL);
+        if (!st.ok()) {
+            ret = st;
+        } else {
+            sleep(seconds);
+            IOProfiler::stop();
+            ret = IOProfiler::get_topn_total_stats(topn);
+        }
+    }
+
+    std::stringstream ss;
+    if (!ret.ok()) {
+        ss << "Unable to get io profile: " << ret.status().to_string() << std::endl;
+    } else {
+        for (const auto& it : ret.value()) {
+            ss << it << "\n";
+        }
+    }
+    return ss.str();
+}
+
+} // namespace starrocks

--- a/be/src/io/io_profiler.h
+++ b/be/src/io/io_profiler.h
@@ -1,0 +1,117 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+
+#include "common/status.h"
+#include "common/statusor.h"
+
+namespace starrocks {
+
+class IOStatEntry;
+
+class IOProfiler {
+public:
+    enum IOMode {
+        IOMODE_NONE = 0,
+        IOMODE_READ = 1,
+        IOMODE_WRITE = 2,
+        IOMODE_ALL = 3,
+    };
+
+    enum TAG {
+        TAG_NONE = 0,
+        TAG_QUERY,
+        TAG_LOAD,
+        TAG_PKINDEX,
+        TAG_COMPACTION,
+        TAG_CLONE,
+        TAG_ALTER,
+        TAG_MIGRATE,
+        TAG_SIZE,
+    };
+    static const char* tag_to_string(uint32_t tag);
+
+    static Status start(IOMode op);
+    static void stop();
+    static void reset();
+
+    static void set_context(uint32_t tag, uint64_t tablet_id);
+    static void set_context(IOStatEntry* entry);
+    static IOStatEntry* get_context();
+    static void clear_context();
+
+    class Scope {
+    public:
+        Scope() = delete;
+        Scope(const Scope&) = delete;
+        Scope(Scope&& other) {
+            _old = other._old;
+            other._old = nullptr;
+        }
+        Scope(uint32_t tag, uint64_t tablet_id) {
+            _old = get_context();
+            set_context(tag, tablet_id);
+        }
+        Scope(IOStatEntry* entry) {
+            _old = get_context();
+            set_context(entry);
+        }
+        ~Scope() { set_context(_old); }
+
+    private:
+        IOStatEntry* _old{nullptr};
+    };
+
+    static Scope scope(uint32_t tag, uint64_t tablet_id) { return Scope(tag, tablet_id); }
+    static Scope scope(IOStatEntry* entry) { return Scope(entry); }
+
+    static inline void add_read(int64_t bytes) {
+        if (_mode & IOMode::IOMODE_READ) {
+            _add_read(bytes);
+        }
+    }
+
+    static inline void add_write(int64_t bytes) {
+        if (_mode & IOMode::IOMODE_WRITE) {
+            _add_write(bytes);
+        }
+    }
+
+    static StatusOr<std::vector<std::string>> get_topn_read_stats(size_t n);
+    static StatusOr<std::vector<std::string>> get_topn_write_stats(size_t n);
+    static StatusOr<std::vector<std::string>> get_topn_total_stats(size_t n);
+
+    /**
+     * profile and get topn stats
+     * @param mode read, write, all
+     * @param seconds profile seconds
+     * @param topn get topn stats
+     * @return stats information as tabular format string
+     */
+    static std::string profile_and_get_topn_stats_str(const std::string& mode, int seconds, size_t topn);
+
+protected:
+    static StatusOr<std::vector<std::string>> get_topn_stats(size_t n,
+                                                             const std::function<int64_t(const IOStatEntry&)>& func);
+
+    static void _add_read(int64_t bytes);
+    static void _add_write(int64_t bytes);
+
+    static std::atomic<uint32_t> _mode;
+};
+
+} // namespace starrocks

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -22,6 +22,7 @@
 #include "gen_cpp/olap_file.pb.h"
 #include "gutil/strings/substitute.h"
 #include "http/action/compaction_action.h"
+#include "io/io_profiler.h"
 #include "runtime/exec_env.h"
 #include "runtime/mem_tracker.h"
 #include "storage/storage_engine.h"
@@ -125,6 +126,10 @@ static int64_t unix_seconds() {
     return UnixSeconds();
 }
 
+static std::string io_profile_and_get_topn_stats(const std::string& mode, int seconds, size_t topn) {
+    return IOProfiler::profile_and_get_topn_stats_str(mode, seconds, topn);
+}
+
 void bind_exec_env(ForeignModule& m) {
     {
         auto& cls = m.klass<MemTracker>("MemTracker");
@@ -150,6 +155,7 @@ void bind_exec_env(ForeignModule& m) {
         cls.funcStaticExt<&get_stack_trace_for_threads>("get_stack_trace_for_threads");
         cls.funcStaticExt<&get_stack_trace_for_all_threads>("get_stack_trace_for_all_threads");
         cls.funcStaticExt<&get_stack_trace_for_function>("get_stack_trace_for_function");
+        cls.funcStaticExt<&io_profile_and_get_topn_stats>("io_profile_and_get_topn_stats");
         cls.funcStaticExt<&grep_log_as_string>("grep_log_as_string");
         cls.funcStaticExt<&get_file_write_history>("get_file_write_history");
         cls.funcStaticExt<&unix_seconds>("unix_seconds");

--- a/be/src/service/service_be/http_service.cpp
+++ b/be/src/service/service_be/http_service.cpp
@@ -172,6 +172,10 @@ Status HttpServiceBE::start() {
     _ev_http_server->register_handler(HttpMethod::POST, "/pprof/symbol", symbol_action);
     _http_handlers.emplace_back(symbol_action);
 
+    auto* ioprofile_action = new IOProfileAction();
+    _ev_http_server->register_handler(HttpMethod::GET, "/ioprofile", ioprofile_action);
+    _http_handlers.emplace_back(ioprofile_action);
+
     // register metrics
     {
         auto action = new MetricsAction(StarRocksMetrics::instance()->metrics());

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -20,6 +20,7 @@
 #include "common/logging.h"
 #include "exec/sorting/sorting.h"
 #include "gutil/strings/substitute.h"
+#include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "runtime/descriptors.h"
 #include "storage/chunk_helper.h"
@@ -275,6 +276,8 @@ Status MemTable::flush(SegmentPB* seg_info) {
         return Status::InternalError(
                 fmt::format("memtable of tablet {} reache the capacity limit, detail msg: {}", _tablet_id, msg));
     }
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _tablet_id);
+
     int64_t duration_ns = 0;
     {
         SCOPED_RAW_TIMER(&duration_ns);

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -23,6 +23,7 @@
 #include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "gen_cpp/internal_service.pb.h"
+#include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "service/brpc.h"
 #include "storage/delta_writer.h"
@@ -41,6 +42,7 @@ Status SegmentFlushToken::submit(brpc::Controller* cntl, const PTabletWriterAddS
         auto& writer = this->_writer;
         auto st = Status::OK();
         if (request->has_segment() && cntl->request_attachment().size() > 0) {
+            auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _writer->tablet()->tablet_id());
             auto& segment_pb = request->segment();
             st = writer->write_segment(segment_pb, cntl->request_attachment());
         } else if (!request->eos()) {

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -29,6 +29,7 @@
 #include "gutil/stl_util.h"
 #include "gutil/strings/join.h"
 #include "gutil/strings/substitute.h"
+#include "io/io_profiler.h"
 #include "rocksdb/write_batch.h"
 #include "rowset_merger.h"
 #include "runtime/current_thread.h"
@@ -1033,6 +1034,7 @@ void TabletUpdates::_apply_column_partial_update_commit(const EditVersionInfo& v
 }
 
 void TabletUpdates::_apply_rowset_commit(const EditVersionInfo& version_info) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _tablet.tablet_id());
     uint32_t rowset_id = version_info.deltas[0];
     RowsetSharedPtr rowset = _get_rowset(rowset_id);
     if (rowset->is_column_mode_partial_update()) {
@@ -1618,6 +1620,7 @@ Status TabletUpdates::_do_update(uint32_t rowset_id, int32_t upsert_idx, int32_t
 }
 
 Status TabletUpdates::_do_compaction(std::unique_ptr<CompactionInfo>* pinfo) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_COMPACTION, _tablet.tablet_id());
     int64_t input_rowsets_size = 0;
     int64_t input_row_num = 0;
     auto info = (*pinfo).get();
@@ -1844,6 +1847,7 @@ Status TabletUpdates::_commit_compaction(std::unique_ptr<CompactionInfo>* pinfo,
 }
 
 void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info) {
+    auto scope = IOProfiler::scope(IOProfiler::TAG_COMPACTION, _tablet.tablet_id());
     DeferOp defer([&]() { _compaction_running = false; });
     auto scoped_span = trace::Scope(Tracer::Instance().start_trace_tablet("apply_compaction", _tablet.tablet_id()));
     // NOTE: after commit, apply must success or fatal crash

--- a/be/src/storage/task/engine_alter_tablet_task.cpp
+++ b/be/src/storage/task/engine_alter_tablet_task.cpp
@@ -34,6 +34,7 @@
 
 #include "storage/task/engine_alter_tablet_task.h"
 
+#include "io/io_profiler.h"
 #include "runtime/current_thread.h"
 #include "storage/lake/schema_change.h"
 #include "storage/schema_change.h"
@@ -55,6 +56,8 @@ Status EngineAlterTabletTask::execute() {
     DeferOp op([&] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     StarRocksMetrics::instance()->create_rollup_requests_total.increment(1);
+
+    auto scope = IOProfiler::scope(IOProfiler::TAG_ALTER, _alter_tablet_req.new_tablet_id);
 
     Status res;
     std::string alter_msg_header = strings::Substitute("[Alter Job:$0, tablet:$1]: ", _alter_tablet_req.job_id,


### PR DESCRIPTION
Add an IO profiler to show top activities causing high IO load, the profiler is turned off by default, and will be enabled when user start profiler by HTTP API or script.

Sample usage:

```
(base) decster@decster-MS-7C94:~/projects/starrocks/localrun$ curl --location-trusted http://localhost:8040/ioprofile?seconds=20
    Tablet        TAG       read_bytes      ops      write_bytes      ops      total_bytes      ops
     16016       LOAD                0        0             8025       90             8025       90
     16016      QUERY             3605       17                0        0             3605       17
     16016     PINDEX              260        4              130        2              390        6

mysql> admin execute on 10004 '
    '> System.print(ExecEnv.io_profile_and_get_topn_stats("all", 10, 2))
    '> ';
+-----------------------------------------------------------------------------------------------------+
| result                                                                                              |
+-----------------------------------------------------------------------------------------------------+
|     Tablet        TAG       read_bytes      ops      write_bytes      ops      total_bytes      ops |
|      16016       LOAD                0        0            16050      180            16050      180 |
|      16016    PKINDEX              520        8              390        6              910       14 |
+-----------------------------------------------------------------------------------------------------+
3 rows in set (10.06 sec)

```

Signed-off-by: Binglin Chang <decstery@gmail.com>
(cherry picked from commit 360410d9c3fd035fb1cbb845189a7ea92833da6c)

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
