### PR TITLE
[BugFix] fix update replica version by mistake in txn log applier (backport #36292)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -101,7 +101,28 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                         long lastFailedVersion = replica.getLastFailedVersion();
                         long newVersion = version;
                         long lastSucessVersion = replica.getLastSuccessVersion();
-                        if (!errorReplicaIds.contains(replica.getId())) {
+                        if (!txnState.tabletCommitInfosContainsReplica(tablet.getId(), replica.getBackendId())
+                                || errorReplicaIds.contains(replica.getId())) {
+                            // There are 2 cases that we can't update version to visible version and need to 
+                            // set lastFailedVersion.
+                            // 1. this replica doesn't have version publish yet. This maybe happen when clone concurrent 
+                            //    with data loading.
+                            // 2. this replica has data loading failure.
+                            //
+                            // for example, A,B,C 3 replicas, B,C failed during publish version (Or never publish),
+                            // then B C will be set abnormal and all loadings will be failed, B,C will have to recover
+                            // by clone, it is very inefficient and may lose data.
+                            // Using this method, B,C will publish failed, and fe will publish again,
+                            // not update their last failed version.
+                            // if B is published successfully in next turn, then B is normal and C will be set
+                            // abnormal so that quorum is maintained and loading will go on.
+                            LOG.warn("skip update replica[{}.{}] to visible version", tablet.getId(), replica.getBackendId());
+                            newVersion = replica.getVersion();
+                            if (version > lastFailedVersion) {
+                                lastFailedVersion = version;
+                                hasFailedVersion = true;
+                            }
+                        } else {
                             if (replica.getLastFailedVersion() > 0) {
                                 // if the replica is a failed replica, then not changing version
                                 newVersion = replica.getVersion();
@@ -118,19 +139,6 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
 
                             // success version always move forward
                             lastSucessVersion = version;
-                        } else {
-                            // for example, A,B,C 3 replicas, B,C failed during publish version,
-                            // then B C will be set abnormal and all loadings will be failed, B,C will have to recover
-                            // by clone, it is very inefficient and may lose data.
-                            // Using this method, B,C will publish failed, and fe will publish again,
-                            // not update their last failed version.
-                            // if B is published successfully in next turn, then B is normal and C will be set
-                            // abnormal so that quorum is maintained and loading will go on.
-                            newVersion = replica.getVersion();
-                            if (version > lastFailedVersion) {
-                                lastFailedVersion = version;
-                                hasFailedVersion = true;
-                            }
                         }
                         replica.updateVersionInfo(newVersion, lastFailedVersion, lastSucessVersion);
                     } // end for replicas

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTestUtil.java
@@ -83,6 +83,7 @@ public class GlobalStateMgrTestUtil {
     public static String testTxnLable3 = "testTxnLable3";
     public static String testTxnLable4 = "testTxnLable4";
     public static String testTxnLable5 = "testTxnLable5";
+    public static String testTxnLable9 = "testTxnLable9";
     public static String testEsTable1 = "partitionedEsTable1";
     public static long testEsTableId1 = 14;
 


### PR DESCRIPTION
Why I'm doing:
In previous PR #26788 , we store tablet commit info in transaction state, and when finish transaction, if this replica no exist in tablet commit info, we skip update its version to visible version. So we can fix issue like this:
```
ERROR 1064 (HY000): capture_consistent_versions error: version not found. tablet_id: 12032, version: 6 tablet_max_version:2 backend [id=10145] [host=172.26.80.102]
```
But in `OlapTableTxnLogApplier`, there is still can update replica's version to visible version, which will cause issue happen again.

What I'm doing:
Add tablet commit info check to `OlapTableTxnLogApplier`.

backport #36292

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [x] 3.0
  - [x] 2.5
