### PR TITLE
[BugFix] Fix load fail when load multi partition and enable lake_enable_batch_publish_version

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStateBatch.java
@@ -46,8 +46,10 @@ public class TransactionStateBatch implements Writable {
     }
 
     public void setCompactionScore(long tableId, long partitionId, Quantiles quantiles) {
-        transactionStates.stream().forEach(transactionState -> transactionState.getTableCommitInfo(tableId).
-                getPartitionCommitInfo(partitionId).setCompactionScore(quantiles));
+        this.transactionStates.stream()
+                .map(transactionState -> transactionState.getTableCommitInfo(tableId))
+                .filter(commitInfo -> commitInfo.getPartitionCommitInfo(partitionId) != null)
+                .forEach(commitInfo -> commitInfo.getPartitionCommitInfo(partitionId).setCompactionScore(quantiles));
     }
 
     public void setTransactionVisibleInfo() {


### PR DESCRIPTION
## Why I'm doing:

when enable lake_enable_batch_publish_version, each transaction state may has different load partition

## What I'm doing:
check partition before set compaction score

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
