### PR TITLE
[BugFix] make convert_tz microsecond-aware

### DIFF
--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -841,11 +841,11 @@ void TimestampValue::from_unixtime(int64_t second, int64_t microsecond, const cc
     return;
 }
 
-void TimestampValue::from_unix_second(int64_t second) {
+void TimestampValue::from_unix_second(int64_t second, int64_t microsecond) {
     second += timestamp::UNIX_EPOCH_SECONDS;
     JulianDate day = second / SECS_PER_DAY;
     Timestamp s = second % SECS_PER_DAY;
-    _timestamp = timestamp::from_julian_and_time(day, s * USECS_PER_SEC);
+    _timestamp = timestamp::from_julian_and_time(day, s * USECS_PER_SEC + microsecond);
 }
 
 bool TimestampValue::is_valid() const {

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -120,7 +120,7 @@ public:
     void from_unixtime(int64_t second, const cctz::time_zone& ctz);
     void from_unixtime(int64_t second, int64_t microsecond, const cctz::time_zone& ctz);
 
-    void from_unix_second(int64_t second);
+    void from_unix_second(int64_t second, int64_t microsecond = 0);
 
     template <TimeUnit UNIT>
     TimestampValue add(int count) const {

--- a/test/sql/test_time_fn/R/test_convert_tz
+++ b/test/sql/test_time_fn/R/test_convert_tz
@@ -1,0 +1,40 @@
+-- name: test_convert_tz
+create table dt_test(
+    c1 datetime,
+    c2 varchar(100),
+    c3 varchar(100)
+) duplicate key(c1)
+PROPERTIES("replication_num" = "1");
+-- result:
+-- !result
+insert into dt_test values ('2020-01-01 00:00:00', 'Asia/Shanghai', 'America/Los_Angeles'),
+('2020-01-01 00:00:00.01', 'Asia/Shanghai', 'America/Los_Angeles'),
+('2020-01-01 00:00:00.01', '+08:00', 'America/Los_Angeles'),
+('2020-01-01 00:00:00.01', '+08:00', '+09:00'),
+('2020-01-01 00:00:00.01', 'Asia/Shanghai', 'America/Lima');
+-- result:
+-- !result
+select c1, c2, c3, convert_tz(c1, c2, c3) from dt_test order by c1, c2, c3;
+-- result:
+2020-01-01 00:00:00	Asia/Shanghai	America/Los_Angeles	2019-12-31 08:00:00
+2020-01-01 00:00:00.010000	+08:00	+09:00	2020-01-01 01:00:00.010000
+2020-01-01 00:00:00.010000	+08:00	America/Los_Angeles	2019-12-31 08:00:00.010000
+2020-01-01 00:00:00.010000	Asia/Shanghai	America/Lima	2019-12-31 11:00:00.010000
+2020-01-01 00:00:00.010000	Asia/Shanghai	America/Los_Angeles	2019-12-31 08:00:00.010000
+-- !result
+select c1, convert_tz(c1, 'Asia/Shanghai', '+09:00') from dt_test  order by c1;
+-- result:
+2020-01-01 00:00:00	2020-01-01 01:00:00
+2020-01-01 00:00:00.010000	2020-01-01 01:00:00.010000
+2020-01-01 00:00:00.010000	2020-01-01 01:00:00.010000
+2020-01-01 00:00:00.010000	2020-01-01 01:00:00.010000
+2020-01-01 00:00:00.010000	2020-01-01 01:00:00.010000
+-- !result
+select convert_tz('2019-08-01 13:21:03', 'Asia/Shanghai', 'America/Los_Angeles');
+-- result:
+2019-07-31 22:21:03
+-- !result
+select convert_tz('2019-08-01 13:21:03.001', 'Asia/Shanghai', 'America/Los_Angeles');
+-- result:
+2019-07-31 22:21:03.001000
+-- !result

--- a/test/sql/test_time_fn/T/test_convert_tz
+++ b/test/sql/test_time_fn/T/test_convert_tz
@@ -1,0 +1,16 @@
+-- name: test_convert_tz
+create table dt_test(
+    c1 datetime,
+    c2 varchar(100),
+    c3 varchar(100)
+) duplicate key(c1)
+PROPERTIES("replication_num" = "1");
+insert into dt_test values ('2020-01-01 00:00:00', 'Asia/Shanghai', 'America/Los_Angeles'),
+('2020-01-01 00:00:00.01', 'Asia/Shanghai', 'America/Los_Angeles'),
+('2020-01-01 00:00:00.01', '+08:00', 'America/Los_Angeles'),
+('2020-01-01 00:00:00.01', '+08:00', '+09:00'),
+('2020-01-01 00:00:00.01', 'Asia/Shanghai', 'America/Lima');
+select c1, c2, c3, convert_tz(c1, c2, c3) from dt_test order by c1, c2, c3;
+select c1, convert_tz(c1, 'Asia/Shanghai', '+09:00') from dt_test  order by c1;
+select convert_tz('2019-08-01 13:21:03', 'Asia/Shanghai', 'America/Los_Angeles');
+select convert_tz('2019-08-01 13:21:03.001', 'Asia/Shanghai', 'America/Los_Angeles');


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
