### PR TITLE
[BugFix] Fix full sort circular reference leak

### DIFF
--- a/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
+++ b/be/src/exec/pipeline/sort/spillable_partition_sort_sink_operator.cpp
@@ -69,7 +69,7 @@ Status SpillablePartitionSortSinkOperator::set_finishing(RuntimeState* state) {
     // if has spill task. we should wait all spill task finished then to call finished
     // TODO: test cancel case
     auto io_executor = _chunks_sorter->spill_channel()->io_executor();
-    auto chunk_sorter = _chunks_sorter;
+    auto chunk_sorter = _chunks_sorter.get();
     _sort_context->ref();
     auto set_call_back_function = [this, chunk_sorter](RuntimeState* state, auto io_executor) {
         return _chunks_sorter->spiller()->set_flush_all_call_back(


### PR DESCRIPTION
Why I'm doing:

introduced by https://github.com/StarRocks/starrocks/pull/36223
shared_ptr circular reference leak in 
ChunksSorter->Spiller->CallBackLambda->ChunksSorter->...

What I'm doing:
just keep chunk_sorter raw ptr will be OK. chunk_sorter will be hold in _sort_context

Fixes https://github.com/StarRocks/StarRocksTest/issues/5023

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
