### PR TITLE
[BugFix] fix mv task definition bug after mv rename

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterMVJobExecutor.java
@@ -367,8 +367,7 @@ public class AlterMVJobExecutor extends AlterJobExecutor {
         Task currentTask = GlobalStateMgr.getCurrentState().getTaskManager().getTask(
                 TaskBuilder.getMvTaskName(materializedView.getId()));
         if (currentTask != null) {
-            currentTask.setDefinition("insert overwrite " + materializedView.getName() + " " +
-                    materializedView.getViewDefineSql());
+            currentTask.setDefinition(materializedView.getTaskDefinition());
             currentTask.setPostRun(TaskBuilder.getAnalyzeMVStmt(materializedView.getName()));
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -523,6 +523,10 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         this.simpleDefineSql = simple;
     }
 
+    public String getTaskDefinition() {
+        return String.format("insert overwrite `%s` %s", getName(), getViewDefineSql());
+    }
+
     public List<BaseTableInfo> getBaseTableInfos() {
         return baseTableInfos;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -118,8 +118,7 @@ public class TaskBuilder {
         taskProperties.putAll(materializedView.getProperties());
 
         task.setProperties(taskProperties);
-        task.setDefinition(
-                "insert overwrite `" + materializedView.getName() + "` " + materializedView.getViewDefineSql());
+        task.setDefinition(materializedView.getTaskDefinition());
         task.setPostRun(getAnalyzeMVStmt(materializedView.getName()));
         task.setExpireTime(0L);
         return task;

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -400,7 +400,7 @@ public class AlterTest {
                 getDb("test").getTable("mv2");
         TaskManager taskManager = GlobalStateMgr.getCurrentState().getTaskManager();
         Task task = taskManager.getTask(TaskBuilder.getMvTaskName(materializedView.getId()));
-        Assert.assertEquals("insert overwrite mv2 SELECT `test`.`testTable1`.`k1`, `test`.`testTable1`.`k2`\n" +
+        Assert.assertEquals("insert overwrite `mv2` SELECT `test`.`testTable1`.`k1`, `test`.`testTable1`.`k2`\n" +
                 "FROM `test`.`testTable1`", task.getDefinition());
         ConnectContext.get().setCurrentUserIdentity(UserIdentity.ROOT);
         ConnectContext.get().setCurrentRoleIds(UserIdentity.ROOT);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskBuilderTest.java
@@ -15,27 +15,18 @@
 package com.starrocks.scheduler;
 
 import com.starrocks.catalog.MaterializedView;
-import mockit.Expectations;
-import mockit.Mocked;
+import com.starrocks.catalog.TableProperty;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class TaskBuilderTest {
 
     @Test
-    public void testTaskBuilderForMv(@Mocked MaterializedView mv) {
-        new Expectations() {
-            {
-                mv.getViewDefineSql();
-                result = "select * from table1";
-
-                mv.getName();
-                result = "aa.bb.cc";
-
-                mv.getId();
-                result = 1;
-            }
-        };
+    public void testTaskBuilderForMv() {
+        MaterializedView mv = new MaterializedView();
+        mv.setName("aa.bb.cc");
+        mv.setViewDefineSql("select * from table1");
+        mv.setTableProperty(new TableProperty());
         Task task = TaskBuilder.buildMvTask(mv, "test");
         Assert.assertEquals("insert overwrite `aa.bb.cc` select * from table1", task.getDefinition());
     }


### PR DESCRIPTION
Why I'm doing:
The definition of mv after rename is incorrect.
What I'm doing:
Fix the definition of mv after rename. Add `` to the name of mv in DEFINITION of task_runs.

Fixes #36376 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
