### PR TITLE
[BugFix] Fix export task split in cloud native table export job

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/ExportJob.java
@@ -52,11 +52,15 @@ import com.starrocks.analysis.TableRef;
 import com.starrocks.analysis.TupleDescriptor;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MysqlTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
@@ -312,46 +316,67 @@ public class ExportJob implements Writable, GsonPostProcessable {
             scanNodes.add(scanNode);
             fragments.add(fragment);
         } else {
-            for (TScanRangeLocations tablet : tabletLocations) {
-                List<TScanRangeLocation> locations = tablet.getLocations();
-                Collections.shuffle(locations);
-                tablet.setLocations(locations.subList(0, 1));
-            }
-
-            long maxBytesPerBe = Config.export_max_bytes_per_be_per_task;
-            TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
-            List<TScanRangeLocations> copyTabletLocations = Lists.newArrayList(tabletLocations);
-            int taskIdx = 0;
-            while (!copyTabletLocations.isEmpty()) {
-                Map<Long, Long> bytesPerBe = Maps.newHashMap();
-                List<TScanRangeLocations> taskTabletLocations = Lists.newArrayList();
-                Iterator<TScanRangeLocations> iter = copyTabletLocations.iterator();
-                while (iter.hasNext()) {
-                    TScanRangeLocations scanRangeLocations = iter.next();
-                    long tabletId = scanRangeLocations.getScan_range().getInternal_scan_range().getTablet_id();
-                    long backendId = scanRangeLocations.getLocations().get(0).getBackend_id();
-                    Replica replica = invertedIndex.getReplica(tabletId, backendId);
-                    long dataSize = replica != null ? replica.getDataSize() : 0L;
-
-                    Long assignedBytes = bytesPerBe.get(backendId);
-                    if (assignedBytes == null || assignedBytes < maxBytesPerBe) {
-                        taskTabletLocations.add(scanRangeLocations);
-                        bytesPerBe.put(backendId, assignedBytes != null ? assignedBytes + dataSize : dataSize);
-                        iter.remove();
-                    }
-                }
-
-                OlapScanNode taskScanNode = genOlapScanNodeByLocation(taskTabletLocations);
-                scanNodes.add(taskScanNode);
-                PlanFragment fragment = genPlanFragment(exportTable.getType(), taskScanNode, taskIdx++);
-                fragments.add(fragment);
-            }
-
-            LOG.info("total {} tablets of export job {}, and assign them to {} coordinators",
-                    tabletLocations.size(), id, fragments.size());
+            genTaskFragments(fragments, scanNodes);
         }
 
         genCoordinators(stmt, fragments, scanNodes);
+    }
+
+    private void genTaskFragments(List<PlanFragment> fragments, List<ScanNode> scanNodes) throws UserException {
+        Preconditions.checkNotNull(tabletLocations);
+
+        for (TScanRangeLocations tablet : tabletLocations) {
+            List<TScanRangeLocation> locations = tablet.getLocations();
+            Collections.shuffle(locations);
+            tablet.setLocations(locations.subList(0, 1));
+        }
+
+        long maxBytesPerBe = Config.export_max_bytes_per_be_per_task;
+        TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
+        List<TScanRangeLocations> copyTabletLocations = Lists.newArrayList(tabletLocations);
+        int taskIdx = 0;
+        while (!copyTabletLocations.isEmpty()) {
+            Map<Long, Long> bytesPerBe = Maps.newHashMap();
+            List<TScanRangeLocations> taskTabletLocations = Lists.newArrayList();
+            Iterator<TScanRangeLocations> iter = copyTabletLocations.iterator();
+            while (iter.hasNext()) {
+                TScanRangeLocations scanRangeLocations = iter.next();
+                long backendId = scanRangeLocations.getLocations().get(0).getBackend_id();
+                long tabletId = scanRangeLocations.getScan_range().getInternal_scan_range().getTablet_id();
+                TabletMeta tabletMeta = invertedIndex.getTabletMeta(tabletId);
+                long dataSize = 0L;
+                if (tabletMeta.isLakeTablet()) {
+                    Partition partition = exportTable.getPartition(tabletMeta.getPartitionId());
+                    if (partition != null) {
+                        MaterializedIndex index = partition.getIndex(tabletMeta.getIndexId());
+                        if (index != null) {
+                            Tablet tablet = index.getTablet(tabletId);
+                            if (tablet != null) {
+                                dataSize = tablet.getDataSize(true);
+                            }
+                        }
+                    }
+                } else {
+                    Replica replica = invertedIndex.getReplica(tabletId, backendId);
+                    dataSize = replica != null ? replica.getDataSize() : 0L;
+                }
+
+                Long assignedBytes = bytesPerBe.get(backendId);
+                if (assignedBytes == null || assignedBytes < maxBytesPerBe) {
+                    taskTabletLocations.add(scanRangeLocations);
+                    bytesPerBe.put(backendId, assignedBytes != null ? assignedBytes + dataSize : dataSize);
+                    iter.remove();
+                }
+            }
+
+            OlapScanNode taskScanNode = genOlapScanNodeByLocation(taskTabletLocations);
+            scanNodes.add(taskScanNode);
+            PlanFragment fragment = genPlanFragment(exportTable.getType(), taskScanNode, taskIdx++);
+            fragments.add(fragment);
+        }
+
+        LOG.info("total {} tablets of export job {}, and assign them to {} coordinators",
+                tabletLocations.size(), id, fragments.size());
     }
 
     private ScanNode genScanNode() throws UserException {
@@ -453,7 +478,7 @@ public class ExportJob implements Writable, GsonPostProcessable {
             LOG.info("split export job to tasks. job id: {}, job query id: {}, task idx: {}, task query id: {}",
                     id, DebugUtil.printId(this.queryId), i, DebugUtil.printId(queryId));
         }
-        LOG.info("create {} coordintors for export job: {}", coordList.size(), id);
+        LOG.info("create {} coordinators for export job: {}", coordList.size(), id);
     }
 
     // For olap table, it may have multiple replica, 

--- a/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/ExportJobTest.java
@@ -15,8 +15,33 @@
 package com.starrocks.load;
 
 import com.google.common.collect.Lists;
+import com.starrocks.analysis.BrokerDesc;
+import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.analysis.TupleId;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Replica.ReplicaState;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.catalog.TabletInvertedIndex;
+import com.starrocks.catalog.TabletMeta;
+import com.starrocks.common.Config;
 import com.starrocks.common.Pair;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.UUIDUtil;
+import com.starrocks.planner.OlapScanNode;
+import com.starrocks.planner.PlanFragment;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TInternalScanRange;
 import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.thrift.TScanRange;
+import com.starrocks.thrift.TScanRangeLocation;
+import com.starrocks.thrift.TScanRangeLocations;
+import com.starrocks.thrift.TStorageMedium;
+import mockit.Expectations;
+import mockit.Mocked;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -36,5 +61,168 @@ public class ExportJobTest {
 
         Assert.assertEquals(sList, updateInfo.serialize(tList));
         Assert.assertEquals(tList, updateInfo.deserialize(sList));
+    }
+
+    @Test
+    public void testLakeGenTaskFragments(@Mocked GlobalStateMgr globalStateMgr,
+                                         @Mocked TabletInvertedIndex invertedIndex,
+                                         @Mocked Table table,
+                                         @Mocked Partition partition,
+                                         @Mocked MaterializedIndex index,
+                                         @Mocked Tablet tablet,
+                                         @Mocked OlapScanNode scanNode,
+                                         @Mocked PlanFragment fragment,
+                                         @Mocked BrokerDesc brokerDesc) {
+        // tabletId  backendId  dataSize
+        //     1        0           1
+        //     2        0           2
+        //     3        0           3
+        //     4        0           4
+        //     5        0           5
+        TabletMeta tabletMeta = new TabletMeta(0L, 1L, 2L, 3L, 4, TStorageMedium.HDD, true);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentInvertedIndex();
+                result = invertedIndex;
+                invertedIndex.getTabletMeta(anyLong);
+                result = tabletMeta;
+                tablet.getDataSize(true);
+                returns(1L, 2L, 3L, 4L, 5L);
+                brokerDesc.hasBroker();
+                result = true;
+            }
+        };
+
+        List<TScanRangeLocations> locationsList = Lists.newArrayList();
+        for (int i = 1; i < 6; ++i) {
+            TInternalScanRange internalScanRange = new TInternalScanRange();
+            internalScanRange.setTablet_id(i);
+            TScanRange scanRange = new TScanRange();
+            scanRange.setInternal_scan_range(internalScanRange);
+
+            TScanRangeLocation scanRangeLocation = new TScanRangeLocation();
+            scanRangeLocation.setBackend_id(0);
+
+            TScanRangeLocations locations = new TScanRangeLocations();
+            locations.setScan_range(scanRange);
+            locations.setLocations(Lists.newArrayList(scanRangeLocation));
+            locationsList.add(locations);
+        }
+
+
+
+        ExportJob job = new ExportJob(0, UUIDUtil.genUUID());
+        Deencapsulation.setField(job, "tabletLocations", locationsList);
+        Deencapsulation.setField(job, "exportTable", table);
+        Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
+        Deencapsulation.setField(job, "brokerDesc", brokerDesc);
+
+        // 1 task: (1,2,3,4,5)
+        List<PlanFragment> fragments = Lists.newArrayList();
+        List<ScanNode> scanNodes = Lists.newArrayList();
+        Config.export_max_bytes_per_be_per_task = 100L;
+        Deencapsulation.invoke(job, "genTaskFragments", fragments, scanNodes);
+        Assert.assertEquals(1, fragments.size());
+        Assert.assertEquals(1, scanNodes.size());
+
+        // 2 tasks: (1,2,3), (4,5)
+        fragments.clear();
+        scanNodes.clear();
+        Config.export_max_bytes_per_be_per_task = 5L;
+        Deencapsulation.invoke(job, "genTaskFragments", fragments, scanNodes);
+        Assert.assertEquals(5, fragments.size());
+        Assert.assertEquals(5, scanNodes.size());
+
+        // 5 tasks: (1), (2), (3), (4), (5)
+        fragments.clear();
+        scanNodes.clear();
+        Config.export_max_bytes_per_be_per_task = 1L;
+        Deencapsulation.invoke(job, "genTaskFragments", fragments, scanNodes);
+        Assert.assertEquals(5, fragments.size());
+        Assert.assertEquals(5, scanNodes.size());
+    }
+
+    @Test
+    public void testOlapGenTaskFragments(@Mocked GlobalStateMgr globalStateMgr,
+                                         @Mocked TabletInvertedIndex invertedIndex,
+                                         @Mocked Table table,
+                                         @Mocked Partition partition,
+                                         @Mocked MaterializedIndex index,
+                                         @Mocked Tablet tablet,
+                                         @Mocked OlapScanNode scanNode,
+                                         @Mocked PlanFragment fragment,
+                                         @Mocked BrokerDesc brokerDesc) {
+        // tabletId  backendId  dataSize
+        //     1        0           1
+        //     2        0           2
+        //     3        0           3
+        //     4        0           4
+        //     5        0           5
+        TabletMeta tabletMeta = new TabletMeta(0L, 1L, 2L, 3L, 4, TStorageMedium.HDD, false);
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentInvertedIndex();
+                result = invertedIndex;
+                invertedIndex.getTabletMeta(anyLong);
+                result = tabletMeta;
+                invertedIndex.getReplica(anyLong, anyLong);
+                returns(
+                        new Replica(1L, 0L, 1L, 0, 1L, 1L, ReplicaState.NORMAL, -1L, -1L),
+                        new Replica(2L, 0L, 1L, 0, 2L, 2L, ReplicaState.NORMAL, -1L, -1L),
+                        new Replica(3L, 0L, 1L, 0, 3L, 3L, ReplicaState.NORMAL, -1L, -1L),
+                        new Replica(4L, 0L, 1L, 0, 4L, 4L, ReplicaState.NORMAL, -1L, -1L),
+                        new Replica(5L, 0L, 1L, 0, 5L, 5L, ReplicaState.NORMAL, -1L, -1L));
+                brokerDesc.hasBroker();
+                result = true;
+            }
+        };
+
+        List<TScanRangeLocations> locationsList = Lists.newArrayList();
+        for (int i = 1; i < 6; ++i) {
+            TInternalScanRange internalScanRange = new TInternalScanRange();
+            internalScanRange.setTablet_id(i);
+            TScanRange scanRange = new TScanRange();
+            scanRange.setInternal_scan_range(internalScanRange);
+
+            TScanRangeLocation scanRangeLocation = new TScanRangeLocation();
+            scanRangeLocation.setBackend_id(0);
+
+            TScanRangeLocations locations = new TScanRangeLocations();
+            locations.setScan_range(scanRange);
+            locations.setLocations(Lists.newArrayList(scanRangeLocation));
+            locationsList.add(locations);
+        }
+
+
+
+        ExportJob job = new ExportJob(0, UUIDUtil.genUUID());
+        Deencapsulation.setField(job, "tabletLocations", locationsList);
+        Deencapsulation.setField(job, "exportTable", table);
+        Deencapsulation.setField(job, "exportTupleDesc", new TupleDescriptor(new TupleId(0)));
+        Deencapsulation.setField(job, "brokerDesc", brokerDesc);
+
+        // 1 task: (1,2,3,4,5)
+        List<PlanFragment> fragments = Lists.newArrayList();
+        List<ScanNode> scanNodes = Lists.newArrayList();
+        Config.export_max_bytes_per_be_per_task = 100L;
+        Deencapsulation.invoke(job, "genTaskFragments", fragments, scanNodes);
+        Assert.assertEquals(1, fragments.size());
+        Assert.assertEquals(1, scanNodes.size());
+
+        // 2 tasks: (1,2,3), (4,5)
+        fragments.clear();
+        scanNodes.clear();
+        Config.export_max_bytes_per_be_per_task = 5L;
+        Deencapsulation.invoke(job, "genTaskFragments", fragments, scanNodes);
+        Assert.assertEquals(5, fragments.size());
+        Assert.assertEquals(5, scanNodes.size());
+
+        // 5 tasks: (1), (2), (3), (4), (5)
+        fragments.clear();
+        scanNodes.clear();
+        Config.export_max_bytes_per_be_per_task = 1L;
+        Deencapsulation.invoke(job, "genTaskFragments", fragments, scanNodes);
+        Assert.assertEquals(5, fragments.size());
+        Assert.assertEquals(5, scanNodes.size());
     }
 }


### PR DESCRIPTION
Why I'm doing:
there is no replicas in TabletInvertedIndex for cloud native table, so replica is null when splitting export task, and all tablets will be split into one task.

What I'm doing:
get the real tablet size and fix this.

Fixes #36382

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
