### PR TITLE
[Enhancement] Introduced a timeout parameter for lake::PublishVersionRequest

### DIFF
--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -158,7 +158,7 @@ void AgentServer::Impl::init_or_die() {
 // But it seems that there's no limit for the number of tablets of a partition.
 // Since a large queue size brings a little overhead, a big one is chosen here.
 #ifdef BE_TEST
-        BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", 1, 1, DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
+        BUILD_DYNAMIC_TASK_THREAD_POOL("publish_version", 1, 3, DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE,
                                        _thread_pool_publish_version);
 #else
         int max_publish_version_worker_count = config::transaction_publish_version_worker_count;

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -34,6 +34,7 @@
 #include "storage/lake/transactions.h"
 #include "storage/lake/vacuum.h"
 #include "testutil/sync_point.h"
+#include "util/bthreads/semaphore.h"
 #include "util/countdown_latch.h"
 #include "util/defer_op.h"
 #include "util/thread.h"
@@ -117,6 +118,38 @@ bvar::PassiveStatus<int> g_publish_version_active_tasks("lake_publish_version_ac
                                                         get_num_publish_active_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_queued_tasks("lake_vacuum_queued_tasks", get_num_vacuum_queued_tasks, nullptr);
 bvar::PassiveStatus<int> g_vacuum_active_tasks("lake_vacuum_active_tasks", get_num_vacuum_active_tasks, nullptr);
+
+// A class use to limit the number of tasks submitted to the thread pool.
+class ConcurrencyLimitedThreadPoolToken {
+public:
+    explicit ConcurrencyLimitedThreadPoolToken(ThreadPool* pool, int max_concurrency)
+            : _pool(pool), _sem(std::make_shared<bthreads::CountingSemaphore<>>(max_concurrency)) {}
+
+    DISALLOW_COPY_AND_MOVE(ConcurrencyLimitedThreadPoolToken);
+
+    Status submit_func(std::function<void()> task, std::chrono::system_clock::time_point deadline) {
+        if (!_sem->try_acquire_until(deadline)) {
+            return Status::TimedOut("acquire semaphore timed out");
+        }
+        auto task_with_semaphore_release = [sem = _sem, task = std::move(task)]() {
+            task();
+            // The `ConcurrencyLimitedThreadPoolToken` object may have been destroyed
+            // before `release()` the semaphore, so we use `std::shared_ptr` to manage
+            // the semaphore to ensure it's still alive when calling `release()`.
+            sem->release();
+        };
+        auto st = _pool->submit_func(std::move(task_with_semaphore_release));
+        if (!st.ok()) {
+            _sem->release();
+        }
+        return st;
+    }
+
+private:
+    ThreadPool* _pool;
+    std::shared_ptr<bthreads::CountingSemaphore<>> _sem;
+};
+
 } // namespace
 
 using BThreadCountDownLatch = GenericCountDownLatch<bthread::Mutex, bthread::ConditionVariable>;
@@ -149,8 +182,11 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
         return;
     }
 
+    auto timeout_ms = request->has_timeout_ms() ? request->timeout_ms() : kDefaultTimeoutForPublishVersion;
+    auto timeout_deadline = std::chrono::system_clock::now() + std::chrono::milliseconds(timeout_ms);
     auto start_ts = butil::gettimeofday_us();
     auto thread_pool = publish_version_thread_pool(_env);
+    auto thread_pool_token = ConcurrencyLimitedThreadPoolToken(thread_pool, thread_pool->max_threads() * 2);
     auto latch = BThreadCountDownLatch(request->tablet_ids_size());
     bthread::Mutex response_mtx;
     scoped_refptr<Trace> trace_gurad = scoped_refptr<Trace>(new Trace());
@@ -176,7 +212,13 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             g_publish_tablet_version_queuing_latency << (run_ts - start_ts);
 
             TRACE_COUNTER_INCREMENT("tablet_id", tablet_id);
-            auto res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns, commit_time);
+
+            StatusOr<lake::TabletMetadataPtr> res;
+            if (std::chrono::system_clock::now() < timeout_deadline) {
+                res = lake::publish_version(_tablet_mgr, tablet_id, base_version, new_version, txns, commit_time);
+            } else {
+                res = Status::TimedOut("timeout exceeded");
+            }
             if (res.ok()) {
                 auto metadata = std::move(res).value();
                 auto score = compaction_score(metadata);
@@ -193,7 +235,7 @@ void LakeServiceImpl::publish_version(::google::protobuf::RpcController* control
             g_publish_tablet_version_latency << (butil::gettimeofday_us() - run_ts);
         };
 
-        auto st = thread_pool->submit_func(task);
+        auto st = thread_pool_token.submit_func(std::move(task), timeout_deadline);
         if (!st.ok()) {
             g_publish_version_failed_tasks << 1;
             LOG(WARNING) << "Fail to submit publish version task: " << st << ". tablet_id=" << tablet_id

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -103,7 +103,7 @@ private:
                                           ::starrocks::lake::PublishLogVersionResponse* response);
 
 private:
-    static constexpr int64_t kDefaultTimeoutForGetTabletStat = 5 * 60 * 1000L; // 5 minutes
+    static constexpr int64_t kDefaultTimeoutForGetTabletStat = 5 * 60 * 1000L;  // 5 minutes
     static constexpr int64_t kDefaultTimeoutForPublishVersion = 1 * 60 * 1000L; // 1 minute
 
     ExecEnv* _env;

--- a/be/src/service/service_be/lake_service.h
+++ b/be/src/service/service_be/lake_service.h
@@ -104,6 +104,7 @@ private:
 
 private:
     static constexpr int64_t kDefaultTimeoutForGetTabletStat = 5 * 60 * 1000L; // 5 minutes
+    static constexpr int64_t kDefaultTimeoutForPublishVersion = 1 * 60 * 1000L; // 1 minute
 
     ExecEnv* _env;
     lake::TabletManager* _tablet_mgr;

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -36,6 +36,13 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
     VLOG(1) << "publish version tablet_id: " << tablet_id << ", txns: " << JoinInts(txn_ids, ",")
             << ", base_version: " << base_version << ", new_version: " << new_version;
 
+    auto new_metadata_path = tablet_mgr->tablet_metadata_location(tablet_id, new_version);
+    auto cached_new_metadata = tablet_mgr->metacache()->lookup_tablet_metadata(new_metadata_path);
+    if (cached_new_metadata != nullptr) {
+        LOG(INFO) << "Found cached tablet metadata for version " << new_version << " of tablet " << tablet_id;
+        return std::move(cached_new_metadata);
+    }
+
     auto new_version_metadata_or_error = [=](Status error) -> StatusOr<TabletMetadataPtr> {
         auto res = tablet_mgr->get_tablet_metadata(tablet_id, new_version);
         if (res.ok()) return res;

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -39,7 +39,7 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
     auto new_metadata_path = tablet_mgr->tablet_metadata_location(tablet_id, new_version);
     auto cached_new_metadata = tablet_mgr->metacache()->lookup_tablet_metadata(new_metadata_path);
     if (cached_new_metadata != nullptr) {
-        LOG(INFO) << "Skipped publish version because target metadata found in cache. tablet_id=" tablet_id
+        LOG(INFO) << "Skipped publish version because target metadata found in cache. tablet_id=" << tablet_id
                   << " base_version=" << base_version << " new_version=" << new_version
                   << " txn_ids=" << JoinInts(txn_ids, ",");
         return std::move(cached_new_metadata);

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -39,7 +39,9 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
     auto new_metadata_path = tablet_mgr->tablet_metadata_location(tablet_id, new_version);
     auto cached_new_metadata = tablet_mgr->metacache()->lookup_tablet_metadata(new_metadata_path);
     if (cached_new_metadata != nullptr) {
-        LOG(INFO) << "Found cached tablet metadata for version " << new_version << " of tablet " << tablet_id;
+        LOG(INFO) << "Skipped publish version because target metadata found in cache. tablet_id=" tablet_id
+                  << " base_version=" << base_version << " new_version=" << new_version
+                  << " txn_ids=" << JoinInts(txn_ids, ",");
         return std::move(cached_new_metadata);
     }
 

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -408,7 +408,8 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     int inactive_threads = _num_threads + _num_threads_pending_start - _active_threads;
     int additional_threads = static_cast<int>(_queue.size()) + threads_from_this_submit - inactive_threads;
     bool need_a_thread = false;
-    if (additional_threads > 0 && _num_threads + _num_threads_pending_start < _max_threads.load(std::memory_order_acquire)) {
+    if (additional_threads > 0 &&
+        _num_threads + _num_threads_pending_start < _max_threads.load(std::memory_order_acquire)) {
         need_a_thread = true;
         _num_threads_pending_start++;
     }

--- a/be/src/util/threadpool.cpp
+++ b/be/src/util/threadpool.cpp
@@ -372,7 +372,7 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
 
     // Size limit check.
     int64_t capacity_remaining = 0;
-    const int cur_max_threads = _max_threads.load();
+    const int cur_max_threads = _max_threads.load(std::memory_order_acquire);
     if (cur_max_threads >= _active_threads) {
         capacity_remaining = static_cast<int64_t>(cur_max_threads) - _active_threads +
                              static_cast<int64_t>(_max_queue_size) - _total_queued_tasks;
@@ -384,7 +384,8 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     if (capacity_remaining < 1) {
         return Status::ServiceUnavailable(strings::Substitute(
                 "Thread pool is at capacity ($0/$1 tasks running, $2/$3 tasks queued)",
-                _num_threads + _num_threads_pending_start, _max_threads.load(), _total_queued_tasks, _max_queue_size));
+                _num_threads + _num_threads_pending_start, _max_threads.load(std::memory_order_acquire),
+                _total_queued_tasks, _max_queue_size));
     }
 
     // Should we create another thread?
@@ -407,7 +408,7 @@ Status ThreadPool::do_submit(std::shared_ptr<Runnable> r, ThreadPoolToken* token
     int inactive_threads = _num_threads + _num_threads_pending_start - _active_threads;
     int additional_threads = static_cast<int>(_queue.size()) + threads_from_this_submit - inactive_threads;
     bool need_a_thread = false;
-    if (additional_threads > 0 && _num_threads + _num_threads_pending_start < _max_threads.load()) {
+    if (additional_threads > 0 && _num_threads + _num_threads_pending_start < _max_threads.load(std::memory_order_acquire)) {
         need_a_thread = true;
         _num_threads_pending_start++;
     }
@@ -480,8 +481,8 @@ Status ThreadPool::update_max_threads(int max_threads) {
         LOG(WARNING) << err_msg;
         return Status::InvalidArgument(err_msg);
     } else {
-        _max_threads.store(max_threads);
-        LOG(INFO) << "ThreadPool " << _name << " update max threads : " << _max_threads.load();
+        _max_threads.store(max_threads, std::memory_order_release);
+        LOG(INFO) << "ThreadPool " << _name << " update max threads : " << _max_threads.load(std::memory_order_acquire);
     }
     return Status::OK();
 }

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -241,6 +241,8 @@ public:
         return _active_threads;
     }
 
+    int max_threads() const { return _max_threads.load(std::memory_order_acquire); }
+
 private:
     friend class ThreadPoolBuilder;
     friend class ThreadPoolToken;

--- a/be/src/util/time.h
+++ b/be/src/util/time.h
@@ -160,4 +160,12 @@ inline ::timespec TimespecFromTimePoint(const std::chrono::time_point<std::chron
     return spec;
 }
 
+inline uint64_t SecondsSinceEpochFromTimePoint(const std::chrono::system_clock::time_point& tp) {
+    return std::chrono::duration_cast<std::chrono::seconds>(tp.time_since_epoch()).count();
+}
+
+inline uint64_t MilliSecondsSinceEpochFromTimePoint(const std::chrono::system_clock::time_point& tp) {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(tp.time_since_epoch()).count();
+}
+
 } // namespace starrocks

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -60,6 +60,7 @@ import java.sql.SQLSyntaxErrorException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -267,6 +268,10 @@ public class PseudoCluster {
             return null;
         }
         return backends.get(host);
+    }
+
+    public Collection<PseudoBackend> getBackends() {
+        return backends.values();
     }
 
     public PseudoBackend getBackendByHost(String host) {

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/LakePublishBatchTest.java
@@ -33,6 +33,7 @@ import com.starrocks.common.Config;
 import com.starrocks.lake.LakeTablet;
 import com.starrocks.lake.StarOSAgent;
 import com.starrocks.lake.Utils;
+import com.starrocks.pseudocluster.PseudoBackend;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
@@ -40,6 +41,7 @@ import com.starrocks.server.RunMode;
 import com.starrocks.server.SharedDataStorageVolumeMgr;
 import com.starrocks.server.SharedNothingStorageVolumeMgr;
 import com.starrocks.storagevolume.StorageVolume;
+import com.starrocks.system.ComputeNode;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Mock;
@@ -59,7 +61,6 @@ public class LakePublishBatchTest {
 
     private static final String DB = "db_for_test";
     private static final String TABLE = "table_for_test";
-
     private TransactionState.TxnCoordinator transactionSource =
             new TransactionState.TxnCoordinator(TransactionState.TxnSourceType.FE, "localfe");
 
@@ -329,8 +330,9 @@ public class LakePublishBatchTest {
     public void testPublishLogVersion() throws Exception {
         new MockUp<Utils>() {
             @Mock
-            public Long chooseBackend(LakeTablet tablet) {
-                return 10001L;
+            public ComputeNode chooseNode(LakeTablet tablet) {
+                PseudoBackend pseudoBackend = cluster.getBackends().stream().findAny().get();
+                return new ComputeNode(pseudoBackend.getId(), pseudoBackend.getHost(), 9055);
             }
         };
 

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -33,6 +33,7 @@ message PublishVersionRequest {
     // If the size of txn_ids is greater than 1, commit_time should be the commit time of the last transaction.
     // Meansured as the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC)
     optional int64 commit_time = 5;
+    optional int64 timeout_ms = 6;
 }
 
 message PublishVersionResponse {


### PR DESCRIPTION
This PR contains the following optimizations:
- Introduced a timeout parameter for the PublishVersionRequest to handle potential long execution time.
- Implemented cache lookup for 'publish_version' function to enhance performance.
- Avoid submitting a large number of tasks to the thread pool at once, causing the thread pool to become saturated and the task to fail.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
