### PR TITLE
[BugFix] Fix create/alter table with zero bucket size

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -367,7 +367,7 @@ public class PropertyAnalyzer {
             } catch (NumberFormatException e) {
                 throw new AnalysisException("Bucket size: " + e.getMessage());
             }
-            if (bucketSize <= 0) {
+            if (bucketSize < 0) {
                 throw new AnalysisException("Illegal bucket size: " + bucketSize);
             }
             return bucketSize;

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -355,7 +355,7 @@ public class OlapTableFactory implements AbstractTableFactory {
             try {
                 long bucketSize = PropertyAnalyzer.analyzeLongProp(properties,
                         PropertyAnalyzer.PROPERTIES_BUCKET_SIZE, Config.default_automatic_bucket_size);
-                if (bucketSize > 0) {
+                if (bucketSize >= 0) {
                     table.setAutomaticBucketSize(bucketSize);
                 } else {
                     throw new DdlException("Illegal bucket size: " + bucketSize);

--- a/test/sql/test_automatic_bucket/R/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/R/test_automatic_partition
@@ -40,9 +40,8 @@ PROPERTIES (
 );
 -- !result
 -- name: test_invalid_bucket_size
-create table t(k int) properties('bucket_size'='0');
+create table t0(k int) properties('bucket_size'='0');
 -- result:
-E: (1064, 'Unexpected exception: Illegal bucket size: 0')
 -- !result
 create table t(k int) properties('bucket_size'='-1');
 -- result:
@@ -53,7 +52,6 @@ create table t(k int) properties('bucket_size'='1024');
 -- !result
 alter table t set('bucket_size'='0');
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Illegal bucket size: 0.')
 -- !result
 alter table t set('bucket_size'='-1');
 -- result:

--- a/test/sql/test_automatic_bucket/T/test_automatic_partition
+++ b/test/sql/test_automatic_bucket/T/test_automatic_partition
@@ -5,7 +5,7 @@ alter table t set('bucket_size'='1024');
 show create table t;
 
 -- name: test_invalid_bucket_size
-create table t(k int) properties('bucket_size'='0');
+create table t0(k int) properties('bucket_size'='0');
 create table t(k int) properties('bucket_size'='-1');
 create table t(k int) properties('bucket_size'='1024');
 alter table t set('bucket_size'='0');


### PR DESCRIPTION
## Why I'm doing:
create/alter table with zero bucket size fail

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
