### PR TITLE
[Enhancement] add `static_query_mem_limit` absolute value for query memory limit

### DIFF
--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -132,7 +132,9 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (query_options.__isset.connector_scan_use_query_mem_ratio) {
         mem_ratio = query_options.connector_scan_use_query_mem_ratio;
     }
-    _mem_limit = runtime_state()->query_ctx()->get_static_query_mem_limit() * mem_ratio;
+    if (runtime_state()->query_ctx() != nullptr) {
+        _mem_limit = runtime_state()->query_ctx()->get_static_query_mem_limit() * mem_ratio;
+    }
     _io_tasks_per_scan_operator = config::connector_io_tasks_per_scan_operator;
     if (query_options.__isset.connector_io_tasks_per_scan_operator) {
         _io_tasks_per_scan_operator = query_options.connector_io_tasks_per_scan_operator;

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -132,7 +132,7 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (query_options.__isset.connector_scan_use_query_mem_ratio) {
         mem_ratio = query_options.connector_scan_use_query_mem_ratio;
     }
-    _mem_limit = runtime_state()->query_mem_tracker_ptr()->limit() * mem_ratio;
+    _mem_limit = runtime_state()->query_ctx()->get_static_query_mem_limit() * mem_ratio;
     _io_tasks_per_scan_operator = config::connector_io_tasks_per_scan_operator;
     if (query_options.__isset.connector_io_tasks_per_scan_operator) {
         _io_tasks_per_scan_operator = query_options.connector_io_tasks_per_scan_operator;
@@ -193,7 +193,6 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
 
     scan_op->set_estimated_mem_usage_per_chunk_source(_estimated_mem_usage_per_chunk_source);
     scan_op->set_scan_mem_limit(_mem_limit);
-
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);
 

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -149,6 +149,7 @@ Status HdfsScanner::_build_scanner_context() {
 Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     SCOPED_RAW_TIMER(&_total_running_time);
     RETURN_IF_CANCELLED(_runtime_state);
+    RETURN_IF_ERROR(_runtime_state->check_mem_limit("get chunk from scanner"));
     Status status = do_get_next(runtime_state, chunk);
     if (status.ok()) {
         if (!_scanner_params.conjunct_ctxs.empty() && _scanner_params.eval_conjunct_ctxs) {

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -138,7 +138,11 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
             _mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY, query_mem_limit, _profile->name(), parent);
         }
 
-        _static_query_mem_limit = parent->limit();
+        MemTracker* p = parent;
+        while (!p->has_limit()) {
+            p = p->parent();
+        }
+        _static_query_mem_limit = p->limit();
         if (query_mem_limit > 0) {
             _static_query_mem_limit = std::min(query_mem_limit, _static_query_mem_limit);
         }

--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -137,6 +137,11 @@ void QueryContext::init_mem_tracker(int64_t query_mem_limit, MemTracker* parent,
         } else {
             _mem_tracker = std::make_shared<MemTracker>(MemTracker::QUERY, query_mem_limit, _profile->name(), parent);
         }
+
+        _static_query_mem_limit = parent->limit();
+        if (query_mem_limit > 0) {
+            _static_query_mem_limit = std::min(query_mem_limit, _static_query_mem_limit);
+        }
     });
 }
 

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -199,6 +199,7 @@ public:
     void mark_prepared() { _is_prepared = true; }
     bool is_prepared() { return _is_prepared; }
 
+    int64_t get_static_query_mem_limit() const { return _static_query_mem_limit; }
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
 
@@ -263,6 +264,8 @@ private:
     std::shared_ptr<StreamEpochManager> _stream_epoch_manager;
 
     std::unique_ptr<spill::QuerySpillManager> _spill_manager;
+
+    int64_t _static_query_mem_limit = 0;
 };
 
 class QueryContextManager {

--- a/be/src/exec/pipeline/query_context.h
+++ b/be/src/exec/pipeline/query_context.h
@@ -200,6 +200,7 @@ public:
     bool is_prepared() { return _is_prepared; }
 
     int64_t get_static_query_mem_limit() const { return _static_query_mem_limit; }
+
 public:
     static constexpr int DEFAULT_EXPIRE_SECONDS = 300;
 

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -16,7 +16,9 @@
 
 #include "common/config.h"
 #include "gutil/strings/fastmem.h"
+#include "runtime/current_thread.h"
 #include "util/runtime_profile.h"
+
 namespace starrocks::io {
 
 SharedBufferedInputStream::SharedBufferedInputStream(std::shared_ptr<SeekableInputStream> stream, std::string filename,
@@ -199,6 +201,7 @@ Status SharedBufferedInputStream::get_bytes(const uint8_t** buffer, size_t offse
     ASSIGN_OR_RETURN(auto ret, find_shared_buffer(offset, nbytes));
     SharedBuffer& sb = *ret;
     if (sb.buffer.capacity() == 0) {
+        RETURN_IF_ERROR(CurrentThread::mem_tracker()->check_mem_limit("read into shared buffer"));
         SCOPED_RAW_TIMER(&_shared_io_timer);
         _shared_io_count += 1;
         _shared_io_bytes += sb.size;


### PR DESCRIPTION
> Why I'm doing:

Because there is value to represent actual memory limit for a query

> What I'm doing:

Add a field `statiic_query_mem_limit` to represent actual memory limit for a query
- if `query_mem_limit` is set, then use `query_mem_limit`
- but sometimes `query_mem_limit` could be very large, it should be capped by parent memory limit.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
