### PR TITLE
[Enhancement] Fix CTAS failure caused by HMS getAllTable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -112,6 +112,12 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tblName) {
+        ConnectorMetadata metadata = metadataOfDb(dbName);
+        return metadata.tableExists(dbName, tblName);
+    }
+
+    @Override
     public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String dbName, String tblName) {
         return normal.getMaterializedViewIndex(dbName, tblName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -113,7 +113,7 @@ public interface ConnectorMetadata {
     }
 
     default boolean tableExists(String dbName, String tblName) {
-        return getTable(dbName, tblName) != null;
+        return listTableNames(dbName).contains(tblName);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -112,6 +112,10 @@ public interface ConnectorMetadata {
         return null;
     }
 
+    default boolean tableExists(String dbName, String tblName) {
+        return getTable(dbName, tblName) != null;
+    }
+
     /**
      * Get Table descriptor and materialized index for the materialized view index specific by `dbName`.`tblName`
      *

--- a/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/delta/DeltaLakeMetadata.java
@@ -77,6 +77,11 @@ public class DeltaLakeMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tblName) {
+        return hmsOps.tableExists(dbName, tblName);
+    }
+
+    @Override
     public CloudConfiguration getCloudConfiguration() {
         return hdfsEnvironment.getCloudConfiguration();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/CachingHiveMetastore.java
@@ -292,6 +292,10 @@ public class CachingHiveMetastore implements IHiveMetastore {
         return get(tableCache, HiveTableName.of(dbName, tableName));
     }
 
+    public boolean tableExists(String dbName, String tableName) {
+        return metastore.tableExists(dbName, tableName);
+    }
+
     private Table loadTable(HiveTableName hiveTableName) {
         return metastore.getTable(hiveTableName.getDatabaseName(), hiveTableName.getTableName());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetaClient.java
@@ -259,6 +259,13 @@ public class HiveMetaClient {
         }
     }
 
+    public boolean tableExists(String dbName, String tableName) {
+        try (Timer ignored = Tracers.watchScope(EXTERNAL, "HMS.tableExists")) {
+            return callRPC("tableExists", String.format("Failed to get table exists [%s.%s]", dbName, tableName),
+                    dbName, tableName);
+        }
+    }
+
     public Partition getPartition(String dbName, String tableName, List<String> partitionValues) {
         try (Timer ignored = Tracers.watchScope(EXTERNAL, "HMS.getPartition")) {
             return callRPC("getPartition", String.format("Failed to get partition on %s.%s", dbName, tableName),

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -178,6 +178,11 @@ public class HiveMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tblName) {
+        return hmsOps.tableExists(dbName, tblName);
+    }
+
+    @Override
     public List<String> listPartitionNames(String dbName, String tblName) {
         return hmsOps.getPartitionKeys(dbName, tblName);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -126,6 +126,11 @@ public class HiveMetastore implements IHiveMetastore {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tableName) {
+        return client.tableExists(dbName, tableName);
+    }
+
+    @Override
     public List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues) {
         if (partitionValues.isEmpty()) {
             return client.getPartitionKeys(dbName, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -205,6 +205,10 @@ public class HiveMetastoreOperations {
         return metastore.getTable(dbName, tableName);
     }
 
+    public boolean tableExists(String dbName, String tableName) {
+        return metastore.tableExists(dbName, tableName);
+    }
+
     public List<String> getPartitionKeys(String dbName, String tableName) {
         return metastore.getPartitionKeysByValue(dbName, tableName, HivePartitionValue.ALL_PARTITION_VALUES);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/IHiveMetastore.java
@@ -42,6 +42,8 @@ public interface IHiveMetastore {
 
     Table getTable(String dbName, String tableName);
 
+    boolean tableExists(String dbName, String tableName);
+
     List<String> getPartitionKeysByValue(String dbName, String tableName, List<Optional<String>> partitionValues);
 
     default Map<HivePartitionName, Partition> getCachedPartitions(List<HivePartitionName> hivePartitionNames) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hudi/HudiMetadata.java
@@ -123,6 +123,11 @@ public class HudiMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tblName) {
+        return hmsOps.tableExists(dbName, tblName);
+    }
+
+    @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
                                                    long snapshotId, ScalarOperator predicate,
                                                    List<String> fieldNames, long limit) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/CachingIcebergCatalog.java
@@ -99,6 +99,11 @@ public class CachingIcebergCatalog implements IcebergCatalog {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+        return delegate.tableExists(dbName, tableName);
+    }
+
+    @Override
     public boolean createTable(String dbName,
                                String tableName,
                                Schema schema,

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergCatalog.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,15 @@ public interface IcebergCatalog {
     }
 
     Table getTable(String dbName, String tableName) throws StarRocksConnectorException;
+
+    default boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+        try {
+            getTable(dbName, tableName);
+            return true;
+        } catch (NoSuchTableException e) {
+            return false;
+        }
+    }
 
     default List<String> listPartitionNames(String dbName, String tableName, ExecutorService executorService) {
         org.apache.iceberg.Table icebergTable = getTable(dbName, tableName);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -236,6 +236,11 @@ public class IcebergMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tblName) {
+        return icebergCatalog.tableExists(dbName, tblName);
+    }
+
+    @Override
     public List<String> listPartitionNames(String dbName, String tblName) {
         IcebergCatalogType nativeType = icebergCatalog.getIcebergCatalogType();
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/glue/IcebergGlueCatalog.java
@@ -78,6 +78,11 @@ public class IcebergGlueCatalog implements IcebergCatalog {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+        return delegate.tableExists(TableIdentifier.of(dbName, tableName));
+    }
+
+    @Override
     public List<String> listAllDatabases() {
         return delegate.listNamespaces().stream()
                 .map(ns -> ns.level(0))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hadoop/IcebergHadoopCatalog.java
@@ -93,6 +93,11 @@ public class IcebergHadoopCatalog implements IcebergCatalog {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+        return delegate.tableExists(TableIdentifier.of(dbName, tableName));
+    }
+
+    @Override
     public List<String> listAllDatabases() {
         return delegate.listNamespaces().stream()
                 .map(ns -> ns.level(0))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -99,6 +99,11 @@ public class IcebergHiveCatalog implements IcebergCatalog {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+        return delegate.tableExists(TableIdentifier.of(dbName, tableName));
+    }
+
+    @Override
     public List<String> listAllDatabases() {
         return delegate.listNamespaces().stream()
                 .map(ns -> ns.level(0))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/rest/IcebergRESTCatalog.java
@@ -98,6 +98,11 @@ public class IcebergRESTCatalog implements IcebergCatalog {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tableName) throws StarRocksConnectorException {
+        return delegate.tableExists(TableIdentifier.of(dbName, tableName));
+    }
+
+    @Override
     public List<String> listAllDatabases() {
         return delegate.listNamespaces().stream()
                 .map(ns -> ns.level(0))

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -175,6 +175,11 @@ public class PaimonMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tableName) {
+        return paimonNativeCatalog.tableExists(Identifier.create(dbName, tableName));
+    }
+
+    @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys,
                                                    long snapshotId, ScalarOperator predicate,
                                                    List<String> fieldNames, long limit) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/unified/UnifiedMetadata.java
@@ -136,6 +136,12 @@ public class UnifiedMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public boolean tableExists(String dbName, String tblName) {
+        ConnectorMetadata metadata = metadataOfTable(dbName, tblName);
+        return metadata.tableExists(dbName, tblName);
+    }
+
+    @Override
     public List<RemoteFileInfo> getRemoteFileInfos(Table table, List<PartitionKey> partitionKeys, long snapshotId,
                                                    ScalarOperator predicate, List<String> fieldNames, long limit) {
         ConnectorMetadata metadata = metadataOfTable(table);

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -244,7 +244,7 @@ public class MetadataMgr {
                     ErrorReport.reportDdlException(ErrorCode.ERR_BAD_DB_ERROR, dbName);
                 }
 
-                if (listTableNames(catalogName, dbName).contains(tableName)) {
+                if (tableExists(catalogName, dbName, tableName)) {
                     if (stmt.isSetIfNotExists()) {
                         LOG.info("create table[{}] which already exists", tableName);
                         return false;
@@ -294,6 +294,11 @@ public class MetadataMgr {
             connectorTblMetaInfoMgr.setTableInfoForConnectorTable(catalogName, dbName, connectorTable);
         }
         return connectorTable;
+    }
+
+    public boolean tableExists(String catalogName, String dbName, String tblName) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        return connectorMetadata.map(metadata -> metadata.tableExists(dbName, tblName)).orElse(false);
     }
 
     public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String catalogName, String dbName, String tblName) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -20,12 +20,14 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.information.InfoSchemaDb;
 import com.starrocks.common.UserException;
 import com.starrocks.connector.informationschema.InformationSchemaMetadata;
+import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.sql.ast.CreateMaterializedViewStatement;
 import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import mockit.Expectations;
 import mockit.Mocked;
 import org.junit.jupiter.api.Test;
 
+import java.util.HashMap;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -122,6 +124,12 @@ public class CatalogConnectorMetadataTest {
 
         assertTrue(catalogConnectorMetadata.dbExists("test_db"));
         assertTrue(catalogConnectorMetadata.dbExists(InfoSchemaDb.DATABASE_NAME));
+    }
+
+    @Test
+    void testTableExists() {
+        MockedJDBCMetadata mockedJDBCMetadata = new MockedJDBCMetadata(new HashMap<>());
+        assertTrue(mockedJDBCMetadata.tableExists("db1", "tbl1"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -112,6 +112,13 @@ public class CachingHiveMetastoreTest {
     }
 
     @Test
+    public void testTableExists() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        Assert.assertTrue(cachingHiveMetastore.tableExists("db1", "tbl1"));
+    }
+
+    @Test
     public void testRefreshTable() {
         new Expectations(metastore) {
             {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetaClientTest.java
@@ -211,6 +211,20 @@ public class HiveMetaClientTest {
     }
 
     @Test
+    public void testTableExists(@Mocked HiveMetaStoreClient metaStoreClient) throws TException {
+        new Expectations() {
+            {
+                metaStoreClient.tableExists("hive_db", "hive_table");
+                result = true;
+            }
+        };
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set(MetastoreConf.ConfVars.THRIFT_URIS.getHiveName(), "thrift://127.0.0.1:90300");
+        HiveMetaClient client = new HiveMetaClient(hiveConf);
+        Assert.assertTrue(client.tableExists("hive_db", "hive_table"));
+    }
+
+    @Test
     public void testForCoverage(@Mocked HiveMetaStoreClient metaStoreClient) throws TException {
         Partition partition = new Partition();
         String dbName = "hive_db";

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -174,6 +174,12 @@ public class HiveMetadataTest {
     }
 
     @Test
+    public void testTableExists() {
+        boolean exists = hiveMetadata.tableExists("db1", "tbl1");
+        Assert.assertTrue(exists);
+    }
+
+    @Test
     public void testGetHiveRemoteFiles() throws AnalysisException {
         FeConstants.runningUnitTest = true;
         String tableLocation = "hdfs://127.0.0.1:10000/hive.db/hive_tbl";

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreOperationsTest.java
@@ -120,6 +120,11 @@ public class HiveMetastoreOperationsTest {
     }
 
     @Test
+    public void testTableExists() {
+        Assert.assertTrue(hmsOps.tableExists("db1", "tbl1"));
+    }
+
+    @Test
     public void testGetPartitionKeys() {
         Assert.assertEquals(Lists.newArrayList("col1"), hmsOps.getPartitionKeys("db1", "tbl1"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -96,6 +96,13 @@ public class HiveMetastoreTest {
     }
 
     @Test
+    public void testTableExists() {
+        HiveMetaClient client = new MockedHiveMetaClient();
+        HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
+        Assert.assertTrue(metastore.tableExists("db1", "tbl1"));
+    }
+
+    @Test
     public void testGetPartitionKeys() {
         HiveMetaClient client = new MockedHiveMetaClient();
         HiveMetastore metastore = new HiveMetastore(client, "hive_catalog", MetastoreType.HMS);
@@ -294,6 +301,10 @@ public class HiveMetastoreTest {
             }
 
             return msTable1;
+        }
+
+        public boolean tableExists(String dbName, String tblName) {
+            return getTable(dbName, tblName) != null;
         }
 
         public void alterTable(String dbName, String tableName, Table newTable) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hudi/HudiMetadataTest.java
@@ -110,6 +110,12 @@ public class HudiMetadataTest {
     }
 
     @Test
+    public void testTableExists() {
+        boolean exists = hudiMetadata.tableExists("db1", "table1");
+        Assert.assertTrue(exists);
+    }
+
+    @Test
     public void testGetPartitionKeys() {
         Assert.assertEquals(Lists.newArrayList("col1"), hudiMetadata.listPartitionNames("db1", "tbl1"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGlueCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergGlueCatalogTest.java
@@ -22,6 +22,7 @@ import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -47,5 +48,19 @@ public class IcebergGlueCatalogTest {
                 "glue_native_catalog", new Configuration(), icebergProperties);
         List<String> dbs = icebergGlueCatalog.listAllDatabases();
         Assert.assertEquals(Arrays.asList("db1", "db2"), dbs);
+    }
+
+    @Test
+    public void testTableExists(@Mocked GlueCatalog glueCatalog) {
+        new Expectations() {
+            {
+                glueCatalog.tableExists((TableIdentifier) any);
+                result = true;
+            }
+        };
+        Map<String, String> icebergProperties = new HashMap<>();
+        IcebergGlueCatalog icebergGlueCatalog = new IcebergGlueCatalog(
+                "glue_native_catalog", new Configuration(), icebergProperties);
+        Assert.assertTrue(icebergGlueCatalog.tableExists("db1", "tbl1"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHadoopCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergHadoopCatalogTest.java
@@ -22,6 +22,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.junit.jupiter.api.Test;
 
@@ -31,6 +32,7 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IcebergHadoopCatalogTest {
     @Test
@@ -58,5 +60,18 @@ public class IcebergHadoopCatalogTest {
                 "catalog", new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse"));
         List<String> dbs = icebergHadoopCatalog.listAllDatabases();
         assertEquals(Arrays.asList("db1", "db2"), dbs);
+    }
+
+    @Test
+    public void testTableExists(@Mocked HadoopCatalog hadoopCatalog) {
+        new Expectations() {
+            {
+                hadoopCatalog.tableExists((TableIdentifier) any);
+                result = true;
+            }
+        };
+        IcebergHadoopCatalog icebergHadoopCatalog = new IcebergHadoopCatalog(
+                "catalog", new Configuration(), ImmutableMap.of("iceberg.catalog.warehouse", "s3://path/to/warehouse"));
+        assertTrue(icebergHadoopCatalog.tableExists("db1", "tbl1"));
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -191,6 +191,21 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
+    public void testTableExists(@Mocked IcebergHiveCatalog icebergHiveCatalog,
+                                @Mocked HiveTableOperations hiveTableOperations) {
+        new Expectations() {
+            {
+                icebergHiveCatalog.tableExists("db", "tbl");
+                result = true;
+                minTimes = 0;
+            }
+        };
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
+        Assert.assertTrue(metadata.tableExists("db", "tbl"));
+    }
+
+    @Test
     public void testNotExistTable(@Mocked IcebergHiveCatalog icebergHiveCatalog,
                                   @Mocked HiveTableOperations hiveTableOperations) {
         new Expectations() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -191,8 +191,7 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
-    public void testTableExists(@Mocked IcebergHiveCatalog icebergHiveCatalog,
-                                @Mocked HiveTableOperations hiveTableOperations) {
+    public void testIcebergHiveCatalogTableExists(@Mocked IcebergHiveCatalog icebergHiveCatalog) {
         new Expectations() {
             {
                 icebergHiveCatalog.tableExists("db", "tbl");
@@ -203,6 +202,19 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, icebergHiveCatalog,
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
         Assert.assertTrue(metadata.tableExists("db", "tbl"));
+    }
+
+    @Test
+    public void testIcebergCatalogTableExists(@Mocked IcebergCatalog icebergCatalog) {
+        new Expectations() {
+            {
+                icebergCatalog.getTable("db", "tbl");
+                result = null;
+                minTimes = 0;
+            }
+        };
+        MockIcebergCatalog mockIcebergCatalog = new MockIcebergCatalog();
+        Assert.assertTrue(mockIcebergCatalog.tableExists("db", "tbl"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergRESTCatalogTest.java
@@ -21,6 +21,7 @@ import mockit.Expectations;
 import mockit.Mocked;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,5 +47,19 @@ public class IcebergRESTCatalogTest {
                 "rest_native_catalog", new Configuration(), icebergProperties);
         List<String> dbs = icebergRESTCatalog.listAllDatabases();
         Assert.assertEquals(Arrays.asList("db1", "db2"), dbs);
+    }
+
+    @Test
+    public void testTableExists(@Mocked RESTCatalog restCatalog) {
+        new Expectations() {
+            {
+                restCatalog.tableExists((TableIdentifier) any);
+                result = true;
+            }
+        };
+        IcebergRESTCatalog icebergRESTCatalog = new IcebergRESTCatalog(
+                "rest_native_catalog", new Configuration(), new HashMap<>());
+        boolean exists = icebergRESTCatalog.tableExists("db1", "tbl1");
+        Assert.assertTrue(exists);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergCatalog.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergCatalog.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.connector.exception.StarRocksConnectorException;
+import org.apache.iceberg.Table;
+
+import java.util.List;
+
+public class MockIcebergCatalog implements IcebergCatalog {
+    public MockIcebergCatalog() {}
+
+    @Override
+    public IcebergCatalogType getIcebergCatalogType() {
+        return null;
+    }
+
+    @Override
+    public List<String> listAllDatabases() {
+        return null;
+    }
+
+    @Override
+    public Database getDB(String dbName) {
+        return null;
+    }
+
+    @Override
+    public List<String> listTables(String dbName) {
+        return null;
+    }
+
+    @Override
+    public Table getTable(String dbName, String tableName) throws StarRocksConnectorException {
+        return null;
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonMetadataTest.java
@@ -156,6 +156,17 @@ public class PaimonMetadataTest {
     }
 
     @Test
+    public void testTableExists(@Mocked AbstractFileStoreTable paimonNativeTable) {
+        new Expectations() {
+            {
+                paimonNativeCatalog.tableExists((Identifier) any);
+                result = true;
+            }
+        };
+        Assert.assertTrue(metadata.tableExists("db1", "tbl1"));
+    }
+
+    @Test
     public void testListPartitionNames(@Mocked AbstractFileStoreTable paimonNativeTable,
                                        @Mocked ReadBuilder readBuilder) throws Catalog.TableNotExistException {
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/unified/UnifiedMetadataTest.java
@@ -401,4 +401,17 @@ public class UnifiedMetadataTest {
         createTableStmt.setEngineName("deltalake");
         assertTrue(unifiedMetadata.createTable(createTableStmt));
     }
+
+    @Test
+    public void testTableExists(@Mocked HiveTable hiveTable) {
+        new Expectations() {
+            {
+                hiveMetadata.tableExists("test_db", "test_tbl");
+                result = true;
+                minTimes = 1;
+            }
+        };
+        boolean exists = unifiedMetadata.tableExists("test_db", "test_tbl");
+        Assert.assertTrue(exists);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -187,6 +187,18 @@ public class MetadataMgrTest {
     }
 
     @Test
+    public void testTableExists() throws TException {
+        MetadataMgr metadataMgr = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
+        new Expectations(metadataMgr) {
+            {
+                metadataMgr.tableExists("iceberg_catalog", "iceberg_db", "iceberg_tbl");
+                result = true;
+            }
+        };
+        Assert.assertTrue(metadataMgr.tableExists("iceberg_catalog", "iceberg_db", "iceberg_tbl"));
+    }
+
+    @Test
     public void testCreateIcebergTable() throws Exception {
         String createIcebergCatalogStmt = "create external catalog iceberg_catalog properties (\"type\"=\"iceberg\", " +
                 "\"hive.metastore.uris\"=\"thrift://hms:9083\", \"iceberg.catalog.type\"=\"hive\")";

--- a/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/MetadataMgrTest.java
@@ -226,8 +226,8 @@ public class MetadataMgrTest {
                 result = new com.starrocks.catalog.Database();
                 minTimes = 0;
 
-                metadataMgr.listTableNames("iceberg_catalog", "iceberg_db");
-                result = Lists.newArrayList("iceberg_table");
+                metadataMgr.tableExists("iceberg_catalog", "iceberg_db", "iceberg_table");
+                result = true;
                 minTimes = 0;
             }
         };


### PR DESCRIPTION
Why I'm doing:
When CTAS is used to create Hive external tables, if there are a large number of tables in the db, invoking HMS `getAllTables` will time out and fail, and HMS may have bad effects.

What I'm doing:
Avoid `listTableNames` by using `getTable` to determine whether a table exists.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
