### PR TITLE
[Enhancement] refresh row count info immediately after load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1476,6 +1476,10 @@ public class OlapTable extends Table {
         return false;
     }
 
+    public boolean isTempPartition(long partitionId) {
+        return tempPartitions.getPartition(partitionId) != null;
+    }
+
     @Override
     public TTableDescriptor toThrift(List<ReferencedPartitionInfo> partitions) {
         TOlapTable tOlapTable = new TOlapTable(getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
@@ -111,7 +111,7 @@ public class StatisticsCalcUtils {
                 // The purpose of this is to make the statistics of the number of rows more accurate.
                 // For example, a large amount of data LOAD may cause the number of rows to change greatly.
                 // This leads to very inaccurate row counts.
-
+                long deltaRows = deltaRows(table, basicStatsMeta.getUpdateRows());
                 for (Partition partition : selectedPartitions) {
                     long partitionRowCount;
                     TableStatistic tableStatistic = GlobalStateMgr.getCurrentStatisticStorage()
@@ -120,12 +120,12 @@ public class StatisticsCalcUtils {
                     if (tableStatistic.equals(TableStatistic.unknown())) {
                         partitionRowCount = partition.getRowCount();
                         if (updateDatetime.isAfter(lastWorkTimestamp)) {
-                            partitionRowCount += deltaRows(table, basicStatsMeta.getUpdateRows());
+                            partitionRowCount += deltaRows;
                         }
                     } else {
                         partitionRowCount = tableStatistic.getRowCount();
                         if (updateDatetime.isAfter(basicStatsMeta.getUpdateTime())) {
-                            partitionRowCount += deltaRows(table, basicStatsMeta.getUpdateRows());
+                            partitionRowCount += deltaRows;
                         }
                     }
                     updateQueryDumpInfo(optimizerContext, table, partition.getName(), partitionRowCount);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/StatisticsCalcUtils.java
@@ -100,7 +100,9 @@ public class StatisticsCalcUtils {
 
             BasicStatsMeta basicStatsMeta =
                     GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().get(table.getId());
-            if (basicStatsMeta != null && basicStatsMeta.getType().equals(StatsConstants.AnalyzeType.FULL)) {
+            StatsConstants.AnalyzeType analyzeType = basicStatsMeta == null ? null : basicStatsMeta.getType();
+            LocalDateTime lastWorkTimestamp = GlobalStateMgr.getCurrentTabletStatMgr().getLastWorkTimestamp();
+            if (StatsConstants.AnalyzeType.FULL == analyzeType) {
 
                 // The basicStatsMeta.getUpdateRows() interface can get the number of
                 // loaded rows in the table since the last statistics update. But this number is at the table level.
@@ -109,42 +111,44 @@ public class StatisticsCalcUtils {
                 // The purpose of this is to make the statistics of the number of rows more accurate.
                 // For example, a large amount of data LOAD may cause the number of rows to change greatly.
                 // This leads to very inaccurate row counts.
-                int partitionCountModifiedAfterLastAnalyze = 0;
-                for (Partition partition : table.getPartitions()) {
-                    LocalDateTime updateDatetime = StatisticUtils.getPartitionLastUpdateTime(partition);
-                    if (updateDatetime.isAfter(basicStatsMeta.getUpdateTime())) {
-                        partitionCountModifiedAfterLastAnalyze++;
-                    }
-                }
 
                 for (Partition partition : selectedPartitions) {
                     long partitionRowCount;
                     TableStatistic tableStatistic = GlobalStateMgr.getCurrentStatisticStorage()
                             .getTableStatistic(table.getId(), partition.getId());
+                    LocalDateTime updateDatetime = StatisticUtils.getPartitionLastUpdateTime(partition);
                     if (tableStatistic.equals(TableStatistic.unknown())) {
                         partitionRowCount = partition.getRowCount();
+                        if (updateDatetime.isAfter(lastWorkTimestamp)) {
+                            partitionRowCount += deltaRows(table, basicStatsMeta.getUpdateRows());
+                        }
                     } else {
                         partitionRowCount = tableStatistic.getRowCount();
-                    }
-                    if (partitionCountModifiedAfterLastAnalyze > 0) {
-                        LocalDateTime updateDatetime = StatisticUtils.getPartitionLastUpdateTime(partition);
                         if (updateDatetime.isAfter(basicStatsMeta.getUpdateTime())) {
-                            partitionRowCount +=
-                                    basicStatsMeta.getUpdateRows() / partitionCountModifiedAfterLastAnalyze;
+                            partitionRowCount += deltaRows(table, basicStatsMeta.getUpdateRows());
                         }
                     }
+                    updateQueryDumpInfo(optimizerContext, table, partition.getName(), partitionRowCount);
                     rowCount += partitionRowCount;
-                    if (optimizerContext != null && optimizerContext.getDumpInfo() != null) {
-                        optimizerContext.getDumpInfo()
-                                .addPartitionRowCount(table, partition.getName(), partitionRowCount);
-                    }
                 }
-            } else {
-                for (Partition partition : selectedPartitions) {
-                    rowCount += partition.getRowCount();
-                    if (optimizerContext != null && optimizerContext.getDumpInfo() != null) {
-                        optimizerContext.getDumpInfo()
-                                .addPartitionRowCount(table, partition.getName(), partition.getRowCount());
+                return Math.max(rowCount, 1);
+            }
+
+            for (Partition partition : selectedPartitions) {
+                rowCount += partition.getRowCount();
+                updateQueryDumpInfo(optimizerContext, table, partition.getName(), partition.getRowCount());
+            }
+
+            // attempt use updateRows from basicStatsMeta to adjust estimated row counts
+            if (StatsConstants.AnalyzeType.SAMPLE == analyzeType
+                    && basicStatsMeta.getUpdateTime().isAfter(lastWorkTimestamp)) {
+                long statsRowCount = Math.max(basicStatsMeta.getUpdateRows() / table.getPartitions().size(), 1)
+                        * selectedPartitions.size();
+                if (statsRowCount > rowCount) {
+                    rowCount = statsRowCount;
+                    for (Partition partition : selectedPartitions) {
+                        updateQueryDumpInfo(optimizerContext, table, partition.getName(),
+                                rowCount / selectedPartitions.size());
                     }
                 }
             }
@@ -154,6 +158,37 @@ public class StatisticsCalcUtils {
         }
 
         return 1;
+    }
+
+    private static void updateQueryDumpInfo(OptimizerContext optimizerContext, Table table,
+                                            String partitionName, long rowCount) {
+        if (optimizerContext != null && optimizerContext.getDumpInfo() != null) {
+            try {
+                optimizerContext.getDumpInfo().addPartitionRowCount(table, partitionName, rowCount);
+            } catch (Exception e) {
+                optimizerContext.getDumpInfo().addException(e.getMessage());
+            }
+        }
+    }
+
+    private static long deltaRows(Table table, long totalRowCount) {
+        long tblRowCount = 0L;
+        for (Partition partition : table.getPartitions()) {
+            long partitionRowCount;
+            TableStatistic tableStatistic = GlobalStateMgr.getCurrentStatisticStorage()
+                    .getTableStatistic(table.getId(), partition.getId());
+            if (tableStatistic.equals(TableStatistic.unknown())) {
+                partitionRowCount = partition.getRowCount();
+            } else {
+                partitionRowCount = tableStatistic.getRowCount();
+            }
+            tblRowCount += partitionRowCount;
+        }
+        if (tblRowCount < totalRowCount) {
+            return Math.max(1, (totalRowCount - tblRowCount) / table.getPartitions().size());
+        } else {
+            return 0;
+        }
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -302,6 +302,11 @@ public class AnalyzeMgr implements Writable {
         return basicStatsMetaMap;
     }
 
+    public long getExistUpdateRows(Long tableId) {
+        BasicStatsMeta existInfo =  basicStatsMetaMap.get(tableId);
+        return existInfo == null ? 0 : existInfo.getUpdateRows();
+    }
+
     public Map<StatsMetaKey, ExternalBasicStatsMeta> getExternalBasicStatsMetaMap() {
         return externalBasicStatsMetaMap;
     }
@@ -551,50 +556,31 @@ public class AnalyzeMgr implements Writable {
         }
         TxnCommitAttachment attachment = transactionState.getTxnCommitAttachment();
         if (attachment instanceof RLTaskTxnCommitAttachment) {
-            BasicStatsMeta basicStatsMeta = null;
             if (!transactionState.getTableIdList().isEmpty()) {
-                basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap()
-                        .get(transactionState.getTableIdList().get(0));
-            }
-            if (basicStatsMeta != null) {
-                basicStatsMeta.increaseUpdateRows(((RLTaskTxnCommitAttachment) attachment).getLoadedRows());
+                long tableId = transactionState.getTableIdList().get(0);
+                long loadedRows = ((RLTaskTxnCommitAttachment) attachment).getLoadedRows();
+                updateBasicStatsMeta(db.getId(), tableId, loadedRows);
             }
         } else if (attachment instanceof ManualLoadTxnCommitAttachment) {
-            BasicStatsMeta basicStatsMeta = null;
             if (!transactionState.getTableIdList().isEmpty()) {
-                basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap()
-                        .get(transactionState.getTableIdList().get(0));
-            }
-            if (basicStatsMeta != null) {
-                basicStatsMeta.increaseUpdateRows(((ManualLoadTxnCommitAttachment) attachment).getLoadedRows());
+                long tableId = transactionState.getTableIdList().get(0);
+                long loadedRows = ((ManualLoadTxnCommitAttachment) attachment).getLoadedRows();
+                updateBasicStatsMeta(db.getId(), tableId, loadedRows);
             }
         } else if (attachment instanceof LoadJobFinalOperation) {
             LoadJobFinalOperation loadJobFinalOperation = (LoadJobFinalOperation) attachment;
             loadJobFinalOperation.getLoadingStatus().travelTableCounters(
-                    kv -> {
-                        BasicStatsMeta basicStatsMeta =
-                                GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().get(kv.getKey());
-                        if (basicStatsMeta != null) {
-                            basicStatsMeta.increaseUpdateRows(kv.getValue().get(TableMetricsEntity.TABLE_LOAD_ROWS));
-                        }
-                    }
+                    kv -> updateBasicStatsMeta(db.getId(), kv.getKey(), kv.getValue().get(TableMetricsEntity.TABLE_LOAD_ROWS))
             );
         } else if (attachment instanceof InsertTxnCommitAttachment) {
-            BasicStatsMeta basicStatsMeta = null;
             if (!transactionState.getTableIdList().isEmpty()) {
-                basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap()
-                        .get(transactionState.getTableIdList().get(0));
-            }
-            if (basicStatsMeta != null) {
+                long tableId = transactionState.getTableIdList().get(0);
                 long loadRows = ((InsertTxnCommitAttachment) attachment).getLoadedRows();
                 if (loadRows == 0) {
-                    OlapTable table = (OlapTable) db.getTable(basicStatsMeta.getTableId());
-                    if (table != null) {
-                        basicStatsMeta.increaseUpdateRows(table.getRowCount());
-                    }
-                } else {
-                    basicStatsMeta.increaseUpdateRows(((InsertTxnCommitAttachment) attachment).getLoadedRows());
+                    OlapTable table = (OlapTable) db.getTable(tableId);
+                    loadRows = table != null ? table.getRowCount() : 0;
                 }
+                updateBasicStatsMeta(db.getId(), tableId, loadRows);
             }
         }
     }
@@ -730,6 +716,18 @@ public class AnalyzeMgr implements Writable {
         for (int i = 0; i < externalBasicStatsMetaSize; ++i) {
             ExternalBasicStatsMeta basicStatsMeta = reader.readJson(ExternalBasicStatsMeta.class);
             replayAddExternalBasicStatsMeta(basicStatsMeta);
+        }
+    }
+
+    private void updateBasicStatsMeta(long dbId, long tableId, long loadedRows) {
+        BasicStatsMeta basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().get(tableId);
+        if (basicStatsMeta == null) {
+            // first load without analyze op, we need fill a meta with loaded rows for cardinality estimation
+            BasicStatsMeta meta = new BasicStatsMeta(dbId, tableId, Lists.newArrayList(),
+                    StatsConstants.AnalyzeType.SAMPLE, LocalDateTime.now(), Maps.newHashMap(), loadedRows);
+            GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().put(tableId, meta);
+        } else {
+            basicStatsMeta.increaseUpdateRows(loadedRows);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -58,13 +58,21 @@ public class BasicStatsMeta implements Writable {
                           StatsConstants.AnalyzeType type,
                           LocalDateTime updateTime,
                           Map<String, String> properties) {
+        this(dbId, tableId, columns, type, updateTime, properties, 0);
+    }
+
+    public BasicStatsMeta(long dbId, long tableId, List<String> columns,
+                          StatsConstants.AnalyzeType type,
+                          LocalDateTime updateTime,
+                          Map<String, String> properties,
+                          long updateRows) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.columns = columns;
         this.type = type;
         this.updateTime = updateTime;
         this.properties = properties;
-        this.updateRows = 0;
+        this.updateRows = updateRows;
     }
 
     @Override
@@ -153,6 +161,10 @@ public class BasicStatsMeta implements Writable {
 
     public long getUpdateRows() {
         return updateRows;
+    }
+
+    public void setUpdateRows(Long updateRows) {
+        this.updateRows = updateRows;
     }
 
     public void increaseUpdateRows(Long delta) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -122,12 +122,12 @@ public class BasicStatsMeta implements Writable {
         long tableRowCount = 1L;
         long cachedTableRowCount = 1L;
         for (Partition partition : table.getPartitions()) {
-           tableRowCount += partition.getRowCount();
-           TableStatistic tableStatistic = GlobalStateMgr.getCurrentStatisticStorage()
-                   .getTableStatistic(table.getId(), partition.getId());
-           if (tableStatistic != null) {
-               cachedTableRowCount += tableStatistic.getRowCount();
-           }
+            tableRowCount += partition.getRowCount();
+            TableStatistic tableStatistic = GlobalStateMgr.getCurrentStatisticStorage()
+                    .getTableStatistic(table.getId(), partition.getId());
+            if (tableStatistic != null) {
+                cachedTableRowCount += tableStatistic.getRowCount();
+            }
         }
 
         tableRowCount = Math.max(tableRowCount, updateRows);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -299,9 +299,10 @@ public class StatisticExecutor {
             }
         } else {
             if (table.isNativeTableOrMaterializedView()) {
+                long existUpdateRows = GlobalStateMgr.getCurrentAnalyzeMgr().getExistUpdateRows(table.getId());
                 BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), table.getId(),
                         statsJob.getColumns(), statsJob.getType(), analyzeStatus.getEndTime(),
-                        statsJob.getProperties());
+                        statsJob.getProperties(), existUpdateRows);
                 GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(basicStatsMeta);
                 GlobalStateMgr.getCurrentAnalyzeMgr().refreshBasicStatisticsCache(
                         basicStatsMeta.getDbId(), basicStatsMeta.getTableId(), basicStatsMeta.getColumns(),

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -272,7 +272,8 @@ public class StatisticsMetaManager extends FrontendDaemon {
             BasicStatsMeta basicStatsMeta = entry.getValue();
             GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(
                     basicStatsMeta.getDbId(), basicStatsMeta.getTableId(), basicStatsMeta.getColumns(),
-                    basicStatsMeta.getType(), LocalDateTime.MIN, basicStatsMeta.getProperties()));
+                    basicStatsMeta.getType(), LocalDateTime.MIN, basicStatsMeta.getProperties(),
+                    basicStatsMeta.getUpdateRows()));
         }
 
         for (AnalyzeJob analyzeJob : GlobalStateMgr.getCurrentAnalyzeMgr().getAllAnalyzeJobList()) {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1382,4 +1382,4 @@ class StarrocksSQLApiLib(object):
         expect = r"cardinality=" + rows
         match = re.search(expect, str(res["result"]))
         print(expect)
-        tools.assert_true(match, "unexpected cardinality. " + str(res["result"]))
+        tools.assert_true(match, "expected cardinality: " + rows + ". but found: " + str(res["result"]))

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -1373,3 +1373,13 @@ class StarrocksSQLApiLib(object):
             res_json = json.loads(res)
             tools.assert_dict_contains_subset({"status": "OK"}, res_json,
                                               f"failed to update be config [response={res}] [url={exec_url}]")
+
+    def assert_table_cardinality(self, sql, rows):
+        """
+        assert table with an expected row counts
+        """
+        res = self.execute_sql(sql, True)
+        expect = r"cardinality=" + rows
+        match = re.search(expect, str(res["result"]))
+        print(expect)
+        tools.assert_true(match, "unexpected cardinality. " + str(res["result"]))

--- a/test/sql/test_refresh_statistics/R/test_refresh_statistics
+++ b/test/sql/test_refresh_statistics/R/test_refresh_statistics
@@ -37,21 +37,21 @@ function: assert_table_cardinality('explain select * from activities', '5')
 -- result:
 None
 -- !result
-insert into activities values (1, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
-(2, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
-(3, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
-(4, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
+insert into activities values (1, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(2, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
+(3, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
+(4, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
+(5, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-03', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-04', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
 -- result:
 -- !result
 [UC]analyze sample table activities with sync mode;
 -- result:
-test_db_caaa5af293e611eeafdd2207f0c2897f.activities	sample	status	OK
+test_db_ccb50316957511eeabcf2207f0c2897f.activities	sample	status	OK
 -- !result
 function: assert_table_cardinality('explain select * from activities', '1\d+')
 -- result:
@@ -60,15 +60,15 @@ None
 insert into test_2 select * from activities;
 -- result:
 -- !result
-function: assert_table_cardinality('explain select * from test_2', '5')
+function: assert_table_cardinality('explain select * from test_2', '1\d+')
 -- result:
 None
 -- !result
 [UC]analyze sample table test_2;
 -- result:
-test_db_caaa5af293e611eeafdd2207f0c2897f.test_2	sample	status	OK
+test_db_ccb50316957511eeabcf2207f0c2897f.test_2	sample	status	OK
 -- !result
-function: assert_table_cardinality('explain select * from test_2', '5')
+function: assert_table_cardinality('explain select * from test_2', '1\d+')
 -- result:
 None
 -- !result
@@ -86,7 +86,7 @@ insert into test_2 values (1, '2021-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a'
 -- !result
 [UC]analyze sample table test_2;
 -- result:
-test_db_caaa5af293e611eeafdd2207f0c2897f.test_2	sample	status	OK
+test_db_ccb50316957511eeabcf2207f0c2897f.test_2	sample	status	OK
 -- !result
 function: assert_table_cardinality('explain select * from test_2', '1\d+')
 -- result:

--- a/test/sql/test_refresh_statistics/R/test_refresh_statistics
+++ b/test/sql/test_refresh_statistics/R/test_refresh_statistics
@@ -1,0 +1,94 @@
+-- name: test_refresh_statistics
+CREATE TABLE `activities` (
+  `LINE` largeint(40) NOT NULL COMMENT "",
+  `EVENTTIME` datetime NULL COMMENT "",
+  `_SORTING` bigint(20) NULL COMMENT "",
+  `ACTIVITY_EN` varchar(65536) NULL COMMENT "",
+  `_CASE_KEY` varchar(65536) NULL COMMENT "",
+  `USER_NAME` varchar(65536) NULL COMMENT "",
+  `USER_TYPE` varchar(65536) NULL COMMENT "",
+  `CHANGED_TABLE` varchar(65536) NULL COMMENT "",
+  `CHANGED_FIELD` varchar(65536) NULL COMMENT "",
+  `CHANGED_FROM` varchar(65536) NULL COMMENT "",
+  `CHANGED_TO` varchar(65536) NULL COMMENT "",
+  `CELONIS__ID__CEL_OMS_PO_LINE_ACTIVITIES` largeint(40) NULL COMMENT ""
+) ENGINE=OLAP
+UNIQUE KEY(`LINE`, `EVENTTIME`, `_SORTING`, `ACTIVITY_EN`)
+partition by (`LINE`)
+DISTRIBUTED BY HASH(`LINE`, `EVENTTIME`, `_SORTING`, `ACTIVITY_EN`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4");
+-- result:
+-- !result
+create table test_2 like activities;
+-- result:
+-- !result
+insert into activities values (1, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(2, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
+(3, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
+(4, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
+-- result:
+-- !result
+function: assert_table_cardinality('explain select * from activities', '5')
+-- result:
+None
+-- !result
+insert into activities values (1, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(2, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
+(3, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
+(4, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
+-- result:
+-- !result
+[UC]analyze sample table activities with sync mode;
+-- result:
+test_db_caaa5af293e611eeafdd2207f0c2897f.activities	sample	status	OK
+-- !result
+function: assert_table_cardinality('explain select * from activities', '1\d+')
+-- result:
+None
+-- !result
+insert into test_2 select * from activities;
+-- result:
+-- !result
+function: assert_table_cardinality('explain select * from test_2', '5')
+-- result:
+None
+-- !result
+[UC]analyze sample table test_2;
+-- result:
+test_db_caaa5af293e611eeafdd2207f0c2897f.test_2	sample	status	OK
+-- !result
+function: assert_table_cardinality('explain select * from test_2', '5')
+-- result:
+None
+-- !result
+insert into test_2 values (1, '2021-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-03', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-04', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-06', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-07', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-08', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-09', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-10', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1);
+-- result:
+-- !result
+[UC]analyze sample table test_2;
+-- result:
+test_db_caaa5af293e611eeafdd2207f0c2897f.test_2	sample	status	OK
+-- !result
+function: assert_table_cardinality('explain select * from test_2', '1\d+')
+-- result:
+None
+-- !result

--- a/test/sql/test_refresh_statistics/R/test_refresh_statistics
+++ b/test/sql/test_refresh_statistics/R/test_refresh_statistics
@@ -51,7 +51,7 @@ insert into activities values (1, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a',
 -- !result
 [UC]analyze sample table activities with sync mode;
 -- result:
-test_db_ccb50316957511eeabcf2207f0c2897f.activities	sample	status	OK
+test_db_f6c267c8957711eea4152207f0c2897f.activities	sample	status	OK
 -- !result
 function: assert_table_cardinality('explain select * from activities', '1\d+')
 -- result:
@@ -66,7 +66,7 @@ None
 -- !result
 [UC]analyze sample table test_2;
 -- result:
-test_db_ccb50316957511eeabcf2207f0c2897f.test_2	sample	status	OK
+test_db_f6c267c8957711eea4152207f0c2897f.test_2	sample	status	OK
 -- !result
 function: assert_table_cardinality('explain select * from test_2', '1\d+')
 -- result:
@@ -86,7 +86,7 @@ insert into test_2 values (1, '2021-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a'
 -- !result
 [UC]analyze sample table test_2;
 -- result:
-test_db_ccb50316957511eeabcf2207f0c2897f.test_2	sample	status	OK
+test_db_f6c267c8957711eea4152207f0c2897f.test_2	sample	status	OK
 -- !result
 function: assert_table_cardinality('explain select * from test_2', '1\d+')
 -- result:

--- a/test/sql/test_refresh_statistics/T/test_refresh_statistics
+++ b/test/sql/test_refresh_statistics/T/test_refresh_statistics
@@ -32,16 +32,16 @@ insert into activities values (1, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a',
 
 function: assert_table_cardinality('explain select * from activities', '5')
 
-insert into activities values (1, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
-(2, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
-(3, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
-(4, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
-(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
+insert into activities values (1, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(2, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
+(3, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
+(4, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
+(5, '2020-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-03', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-04', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
 
 [UC]analyze sample table activities with sync mode;
 
@@ -49,11 +49,11 @@ function: assert_table_cardinality('explain select * from activities', '1\d+')
 
 insert into test_2 select * from activities;
 
-function: assert_table_cardinality('explain select * from test_2', '5')
+function: assert_table_cardinality('explain select * from test_2', '1\d+')
 
 [UC]analyze sample table test_2;
 
-function: assert_table_cardinality('explain select * from test_2', '5')
+function: assert_table_cardinality('explain select * from test_2', '1\d+')
 
 insert into test_2 values (1, '2021-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
 (1, '2021-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),

--- a/test/sql/test_refresh_statistics/T/test_refresh_statistics
+++ b/test/sql/test_refresh_statistics/T/test_refresh_statistics
@@ -1,0 +1,79 @@
+-- name: test_refresh_statistics
+CREATE TABLE `activities` (
+  `LINE` largeint(40) NOT NULL COMMENT "",
+  `EVENTTIME` datetime NULL COMMENT "",
+  `_SORTING` bigint(20) NULL COMMENT "",
+  `ACTIVITY_EN` varchar(65536) NULL COMMENT "",
+  `_CASE_KEY` varchar(65536) NULL COMMENT "",
+  `USER_NAME` varchar(65536) NULL COMMENT "",
+  `USER_TYPE` varchar(65536) NULL COMMENT "",
+  `CHANGED_TABLE` varchar(65536) NULL COMMENT "",
+  `CHANGED_FIELD` varchar(65536) NULL COMMENT "",
+  `CHANGED_FROM` varchar(65536) NULL COMMENT "",
+  `CHANGED_TO` varchar(65536) NULL COMMENT "",
+  `CELONIS__ID__CEL_OMS_PO_LINE_ACTIVITIES` largeint(40) NULL COMMENT ""
+) ENGINE=OLAP
+UNIQUE KEY(`LINE`, `EVENTTIME`, `_SORTING`, `ACTIVITY_EN`)
+partition by (`LINE`)
+DISTRIBUTED BY HASH(`LINE`, `EVENTTIME`, `_SORTING`, `ACTIVITY_EN`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4");
+
+create table test_2 like activities;
+
+insert into activities values (1, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(2, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
+(3, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
+(4, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
+
+function: assert_table_cardinality('explain select * from activities', '5')
+
+insert into activities values (1, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(2, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',2),
+(3, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',3),
+(4, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',4),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5),
+(5, '2020-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',5);
+
+[UC]analyze sample table activities with sync mode;
+
+function: assert_table_cardinality('explain select * from activities', '1\d+')
+
+insert into test_2 select * from activities;
+
+function: assert_table_cardinality('explain select * from test_2', '5')
+
+[UC]analyze sample table test_2;
+
+function: assert_table_cardinality('explain select * from test_2', '5')
+
+insert into test_2 values (1, '2021-01-01', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-02', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-03', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-04', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-05', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-06', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-07', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-08', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-09', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1),
+(1, '2021-01-10', 1, 'a', 'a', 'a', 'a', 'a', 'a', 'a', 'a',1);
+
+[UC]analyze sample table test_2;
+
+function: assert_table_cardinality('explain select * from test_2', '1\d+')
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Why I'm doing:
cannot obatin  a correct row count immediately after load which may lead a bad plan.

What I'm doing:
use loaded rows from load task to help us estimate a more accurate row count .


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
