### PR TITLE
[BugFix] Fix iceberg mv refresh NPE when snapshot is expired

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -459,9 +459,9 @@ public abstract class ConnectorPartitionTraits {
                 }
 
                 long basePartitionVersion = basePartitionInfo.getVersion();
-                if (basePartitionVersion < currentVersion) {
+                if (basePartitionVersion != currentVersion) {
                     result.addAll(IcebergPartitionUtils.getChangedPartitionNames(baseTable.getNativeTable(),
-                            basePartitionVersion));
+                            basePartitionVersion, snapshot));
                 }
             }
             return result;

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -66,25 +66,32 @@ public class IcebergPartitionUtils {
         }
     }
 
-    public static Set<String> getChangedPartitionNames(Table table, long fromTimestampMillis) {
-        Set<IcebergPartition> changedPartition = getChangedPartition(table, fromTimestampMillis);
+    public static Set<String> getChangedPartitionNames(Table table, long fromTimestampMillis,
+                                                       Snapshot toSnapshot) {
+        Set<IcebergPartition> changedPartition = getChangedPartition(table, fromTimestampMillis,
+                toSnapshot);
         return changedPartition.stream().map(partition -> PartitionUtil.
                 convertIcebergPartitionToPartitionName(table.spec(), partition.data)).collect(Collectors.toSet());
     }
 
-    public static Set<IcebergPartition> getChangedPartition(Table table, long fromTimestampMillis) {
+    public static Set<IcebergPartition> getChangedPartition(Table table, long fromExclusiveTimestampMillis,
+                                                            Snapshot toSnapshot) {
         ImmutableSet.Builder<IcebergPartition> builder = ImmutableSet.builder();
-        Snapshot snapShot = table.currentSnapshot();
-        if (snapShot.timestampMillis() >= fromTimestampMillis) {
+        Snapshot snapShot = toSnapshot;
+        if (toSnapshot.timestampMillis() >= fromExclusiveTimestampMillis) {
+            // find the first snapshot which it's timestampMillis is less than or equals fromExclusiveTimestampMillis
             while (snapShot.parentId() != null) {
                 snapShot = table.snapshot(snapShot.parentId());
-                if (snapShot.timestampMillis() <= fromTimestampMillis) {
+                // snapshot is null when it's expired
+                if (snapShot == null || snapShot.timestampMillis() <= fromExclusiveTimestampMillis) {
                     break;
                 }
             }
-            if (snapShot.timestampMillis() <= fromTimestampMillis) {
+            // get incremental changelog scan when find the first snapshot
+            // which it's timestampMillis is less than fromExclusiveTimestampMillis
+            if (snapShot != null && snapShot.timestampMillis() <= fromExclusiveTimestampMillis) {
                 IncrementalChangelogScan incrementalChangelogScan = table.newIncrementalChangelogScan().
-                        fromSnapshotExclusive(snapShot.snapshotId());
+                        fromSnapshotExclusive(snapShot.snapshotId()).toSnapshot(toSnapshot.snapshotId());
                 try (CloseableIterable<ChangelogScanTask> tasks = incrementalChangelogScan.planFiles()) {
                     for (ChangelogScanTask task : tasks) {
                         ChangelogOperation operation = task.operation();
@@ -102,18 +109,25 @@ public class IcebergPartitionUtils {
                     }
                 } catch (Exception e) {
                     LOG.warn("get incrementalChangelogScan failed", e);
+                    return getAllPartition(table);
                 }
-            } else {
-                try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
-                    for (FileScanTask task : tasks) {
-                        PartitionSpec spec = task.spec();
-                        StructLike data = task.partition();
-                        builder.add(new IcebergPartition(spec, data, ChangelogOperation.INSERT));
-                    }
-                } catch (Exception e) {
-                    LOG.warn("get all iceberg partition failed", e);
-                }
+                return builder.build();
             }
+        }
+
+        return getAllPartition(table);
+    }
+
+    public static Set<IcebergPartition> getAllPartition(Table table) {
+        ImmutableSet.Builder<IcebergPartition> builder = ImmutableSet.builder();
+        try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+            for (FileScanTask task : tasks) {
+                PartitionSpec spec = task.spec();
+                StructLike data = task.partition();
+                builder.add(new IcebergPartition(spec, data, ChangelogOperation.INSERT));
+            }
+        } catch (Exception e) {
+            LOG.warn("get all iceberg partition failed", e);
         }
         return builder.build();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsCollectJobFactory.java
@@ -300,7 +300,8 @@ public class StatisticsCollectJobFactory {
             IcebergTable icebergTable = (IcebergTable) table;
             if (statisticsUpdateTime != LocalDateTime.MIN && !icebergTable.isUnPartitioned()) {
                 updatedPartitions.addAll(IcebergPartitionUtils.getChangedPartitionNames(icebergTable.getNativeTable(),
-                                statisticsUpdateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()));
+                        statisticsUpdateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli(),
+                        icebergTable.getNativeTable().currentSnapshot()));
             }
         }
         LOG.info("create external full statistics job for table: {}, partitions: {}",

--- a/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/statistic/StatisticsCollectJobTest.java
@@ -39,6 +39,7 @@ import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.iceberg.Snapshot;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -741,7 +742,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
 
         new MockUp<IcebergPartitionUtils>() {
             @Mock
-            public Set<String> getChangedPartitionNames(org.apache.iceberg.Table table, long fromTimestampMillis) {
+            public Set<String> getChangedPartitionNames(org.apache.iceberg.Table table, long fromTimestampMillis,
+                                                               Snapshot toSnapshot) {
                 return new HashSet<>();
             }
         };
@@ -770,7 +772,8 @@ public class StatisticsCollectJobTest extends PlanTestNoneDBBase {
         };
         new MockUp<IcebergPartitionUtils>() {
             @Mock
-            public Set<String> getChangedPartitionNames(org.apache.iceberg.Table table, long fromTimestampMillis) {
+            public Set<String> getChangedPartitionNames(org.apache.iceberg.Table table, long fromTimestampMillis,
+                                                        Snapshot toSnapshot) {
                 return Sets.newHashSet("date=2020-01-01", "date=2020-01-02", "date=2020-01-03");
             }
         };


### PR DESCRIPTION
Why I'm doing:
iceberg mv refresh NPE when snapshot is expired
What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
