### PR TITLE
[Enhancement] [UT] Add PlannerDebugOptions to support debug options for query tests

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/FeConstants.java
@@ -75,8 +75,6 @@ public class FeConstants {
     public static boolean showScanNodeLocalShuffleColumnsInExplain = true;
     // set to true when replay from query dump
     public static boolean isReplayFromQueryDump = false;
-    // Whether to canonize predicate after mv rewrite which make uts more stable
-    public static boolean isCanonizePredicateAfterMVRewrite = false;
     // set false to resolve ut
     public static boolean enablePruneEmptyOutputScan = true;
     public static boolean showJoinLocalShuffleInExplain = true;

--- a/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/profile/Tracers.java
@@ -110,6 +110,16 @@ public class Tracers {
         }
     }
 
+    public static boolean isSetTraceMode(Mode e) {
+        Tracers tracers = THREAD_LOCAL.get();
+        return (tracers.modeMask & 1 << e.ordinal()) != 0;
+    }
+
+    public static boolean isSetTraceModule(Module m) {
+        Tracers tracers = THREAD_LOCAL.get();
+        return (tracers.moduleMask & 1 << m.ordinal()) != 0;
+    }
+
     public static void close() {
         THREAD_LOCAL.remove();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -46,6 +46,8 @@ import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.CompressionUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.VariableMgr.VarAttr;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TOverflowMode;
@@ -273,6 +275,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String NEW_PLANNER_OPTIMIZER_TIMEOUT = "new_planner_optimize_timeout";
     public static final String ENABLE_GROUPBY_USE_OUTPUT_ALIAS = "enable_groupby_use_output_alias";
     public static final String ENABLE_QUERY_DUMP = "enable_query_dump";
+    public static final String QUERY_DEBUG_OPTIONS = "query_debug_options";
     public static final String OPTIMIZER_MATERIALIZED_VIEW_TIMELIMIT = "optimizer_materialized_view_timelimit";
 
     public static final String CBO_MAX_REORDER_NODE_USE_EXHAUSTIVE = "cbo_max_reorder_node_use_exhaustive";
@@ -994,6 +997,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = NEW_PLANNER_OPTIMIZER_TIMEOUT)
     private long optimizerExecuteTimeout = 3000;
+
+    @VariableMgr.VarAttr(name = QUERY_DEBUG_OPTIONS, flag = VariableMgr.INVISIBLE)
+    private String queryDebugOptions = "";
 
     @VariableMgr.VarAttr(name = OPTIMIZER_MATERIALIZED_VIEW_TIMELIMIT)
     private long optimizerMaterializedViewTimeLimitMillis = 1000;
@@ -2087,6 +2093,25 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setOptimizerExecuteTimeout(long optimizerExecuteTimeout) {
         this.optimizerExecuteTimeout = optimizerExecuteTimeout;
+    }
+
+    public QueryDebugOptions getQueryDebugOptions() {
+        if (Strings.isNullOrEmpty(queryDebugOptions)) {
+            return QueryDebugOptions.getInstance();
+        }
+
+        return QueryDebugOptions.read(queryDebugOptions);
+    }
+
+    public void setQueryDebugOptions(String queryDebugOptions) throws SemanticException {
+        if (!Strings.isNullOrEmpty(queryDebugOptions)) {
+            try {
+                QueryDebugOptions.read(queryDebugOptions);
+            } catch (Exception e) {
+                throw new SemanticException("Invalid planner options: %s", queryDebugOptions);
+            }
+        }
+        this.queryDebugOptions = queryDebugOptions;
     }
 
     public long getOptimizerMaterializedViewTimeLimitMillis() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -206,8 +206,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private RefreshJobStatus doMvRefresh(TaskRunContext context, MaterializedViewMetricsEntity mvEntity)
             throws Exception {
-        InsertStmt insertStmt = null;
-        ExecPlan execPlan = null;
         int retryNum = 0;
         boolean checked = false;
 
@@ -276,11 +274,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             }
         }
 
-        // Unlock current database and acquire lock for all databases referenced by the plan
-        insertStmt = prepareRefreshPlan(refTableRefreshPartitions, mvToRefreshedPartitions, refTablePartitionNames);
-
-        // execute the ExecPlan of insert outside lock
-        refreshMaterializedView(mvContext, mvContext.getExecPlan(), insertStmt);
+        // refresh materialized view
+        doRefreshMaterializedView(mvToRefreshedPartitions, refTablePartitionNames);
 
         // insert execute successfully, update the meta of materialized view according to ExecPlan
         updateMeta(mvToRefreshedPartitions, mvContext.getExecPlan(), refTableRefreshPartitions);
@@ -299,11 +294,47 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         return RefreshJobStatus.SUCCESS;
     }
 
+    private void doRefreshMaterializedView(Set<String> mvToRefreshedPartitions,
+                                           Map<String, Set<String>> refTablePartitionNames) throws DmlException {
+        // Use current connection variables instead of mvContext's session variables to be better debug.
+        ConnectContext currConnectCtx = ConnectContext.get();
+        int maxRefreshMaterializedViewRetryNum = 1;
+        if (currConnectCtx != null && currConnectCtx.getSessionVariable() != null) {
+            maxRefreshMaterializedViewRetryNum =
+                    currConnectCtx.getSessionVariable().getQueryDebugOptions().getMaxRefreshMaterializedViewRetryNum();
+            if (maxRefreshMaterializedViewRetryNum <= 0) {
+                maxRefreshMaterializedViewRetryNum = 1;
+            }
+        }
+
+        Throwable lastException = null;
+        for (int i = 0; i < maxRefreshMaterializedViewRetryNum; i++) {
+            boolean isRefreshFailed = false;
+            try {
+                // Unlock current database and acquire lock for all databases referenced by the plan
+                InsertStmt insertStmt = prepareRefreshPlan(mvToRefreshedPartitions, refTablePartitionNames);
+                // execute the ExecPlan of insert outside lock
+                refreshMaterializedView(mvContext, mvContext.getExecPlan(), insertStmt);
+            } catch (Throwable e) {
+                isRefreshFailed = true;
+                LOG.warn("Refresh materialized view {} at {}th retry time failed: {}",
+                        this.materializedView.getName(), i + 1, e);
+                lastException = e;
+            }
+            if (!isRefreshFailed) {
+                return;
+            }
+        }
+        if (lastException != null) {
+            throw new DmlException("Refresh materialized view %s failed after retrying %s times", lastException,
+                    this.materializedView.getName(), maxRefreshMaterializedViewRetryNum);
+        }
+    }
+
     /**
      * Prepare the statement and plan for mv refreshing, considering the partitions of ref table
      */
-    private InsertStmt prepareRefreshPlan(Map<Table, Set<String>> refTableRefreshPartitions,
-                                          Set<String> mvToRefreshedPartitions,
+    private InsertStmt prepareRefreshPlan(Set<String> mvToRefreshedPartitions,
                                           Map<String, Set<String>> refTablePartitionNames) throws AnalysisException {
         // 1. Prepare context
         ConnectContext ctx = mvContext.getCtx();
@@ -328,8 +359,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         try {
             StatementPlanner.lock(locker, dbs);
 
-            insertStmt =
-                    analyzeInsertStmt(insertStmt, mvToRefreshedPartitions, refTablePartitionNames, materializedView);
+            insertStmt = analyzeInsertStmt(insertStmt, refTablePartitionNames, materializedView);
             // Must set execution id before StatementPlanner.plan
             ctx.setExecutionId(UUIDUtil.toTUniqueId(ctx.getQueryId()));
             execPlan = StatementPlanner.plan(insertStmt, ctx);
@@ -1169,7 +1199,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     @VisibleForTesting
     public InsertStmt analyzeInsertStmt(InsertStmt insertStmt,
-                                        Set<String> materializedViewPartitions,
                                         Map<String, Set<String>> refTableRefreshPartitions,
                                         MaterializedView materializedView) throws AnalysisException {
         Analyzer.analyze(insertStmt, ConnectContext.get());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SetStmtAnalyzer.java
@@ -51,6 +51,7 @@ import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.ast.UserVariable;
 import com.starrocks.sql.ast.ValuesRelation;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.system.HeartbeatFlags;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TTabletInternalParallelMode;
@@ -219,6 +220,17 @@ public class SetStmtAnalyzer {
                         EnumUtils.getEnumList(SessionVariable.FollowerQueryForwardMode.class), ",");
                 throw new SemanticException(String.format("Unsupported follower query forward mode: %s, " +
                         "supported list is %s", queryFollowerForwardMode, supportedList));
+            }
+        }
+
+        // query_debug_options
+        if (variable.equalsIgnoreCase(SessionVariable.QUERY_DEBUG_OPTIONS)) {
+            String queryDebugOptions = resolvedExpression.getStringValue();
+            try {
+                QueryDebugOptions.read(queryDebugOptions);
+            } catch (Exception e) {
+                throw new SemanticException(String.format("Unsupported query_debug_options: %s, " +
+                        "it should be the `QueryDebugOptions` class's json deserialized string", queryDebugOptions));
             }
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.common;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.FeConstants;
+import com.starrocks.persist.gson.GsonUtils;
+
+public class QueryDebugOptions {
+    private static QueryDebugOptions INSTANCE = new QueryDebugOptions();
+
+    // Whether to canonize predicate after mv rewrite which make uts more stable
+    @SerializedName(value = "enableNormalizePredicateAfterMVRewrite")
+    public boolean enableNormalizePredicateAfterMVRewrite = false;
+
+    @SerializedName(value = "maxRefreshMaterializedViewRetryNum")
+    private int maxRefreshMaterializedViewRetryNum = 1;
+
+    public QueryDebugOptions() {
+        // To make unit test more stable, add retry times for refreshing materialized views.
+        if (FeConstants.runningUnitTest) {
+            this.maxRefreshMaterializedViewRetryNum = 3;
+        }
+    }
+
+    public boolean isEnableNormalizePredicateAfterMVRewrite() {
+        return enableNormalizePredicateAfterMVRewrite;
+    }
+
+    public void setEnableNormalizePredicateAfterMVRewrite(boolean enableNormalizePredicateAfterMVRewrite) {
+        this.enableNormalizePredicateAfterMVRewrite = enableNormalizePredicateAfterMVRewrite;
+    }
+
+    public int getMaxRefreshMaterializedViewRetryNum() {
+        return maxRefreshMaterializedViewRetryNum;
+    }
+
+    public void setMaxRefreshMaterializedViewRetryNum(int maxRefreshMaterializedViewRetryNum) {
+        this.maxRefreshMaterializedViewRetryNum = maxRefreshMaterializedViewRetryNum;
+    }
+
+    public static QueryDebugOptions getInstance() {
+        return INSTANCE;
+    }
+
+    public static QueryDebugOptions read(String json) {
+        return GsonUtils.GSON.fromJson(json, QueryDebugOptions.class);
+    }
+
+    @Override
+    public String toString() {
+        return GsonUtils.GSON.toJson(this);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -45,6 +45,7 @@ import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Timer;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
@@ -85,15 +86,14 @@ public class MvRewritePreprocessor {
 
     public void prepare(OptExpression optExpression) {
         try (Timer ignored = Tracers.watchScope("preprocessMvs")) {
+            // MV Rewrite will be used when cbo is enabled.
+            if (context.getOptimizerConfig().isRuleBased()) {
+                return;
+            }
+
             Set<Table> queryTables = MvUtils.getAllTables(optExpression).stream().collect(Collectors.toSet());
-            logMVPrepare(connectContext, "Query input tables: {}", queryTables);
-            logMVPrepare(connectContext, "Materialized views params, " +
-                            "enable_experimental_mv:{}, enable_materialized_view_rewrite:{}," +
-                            "isRuleBased:{}",
-                    Config.enable_experimental_mv,
-                    connectContext.getSessionVariable().isEnableMaterializedViewRewrite(),
-                    context.getOptimizerConfig().isRuleBased());
-            logMVPrepare(connectContext, "QueryID:", context.getQueryId());
+            logMVParams(connectContext, queryTables);
+;
             try {
                 Set<MaterializedView> relatedMVs =
                         getRelatedMVs(connectContext, queryTables, context.getOptimizerConfig().isRuleBased());
@@ -107,7 +107,54 @@ public class MvRewritePreprocessor {
             }
         }
     }
+    private void logMVParams(ConnectContext connectContext, Set<Table> queryTables) {
+        if (!Tracers.isSetTraceModule(Tracers.Module.MV)) {
+            return;
+        }
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        logMVPrepare(connectContext, "Query input tables: {}", queryTables);
 
+        // enable or not
+        logMVPrepare(connectContext, "---------------------------------");
+        logMVPrepare(connectContext, "Materialized View Enable/Disable Params: ");
+        logMVPrepare(connectContext, "  enable_experimental_mv: {}", Config.enable_experimental_mv);
+        logMVPrepare(connectContext, "  enable_materialized_view_rewrite: {}",
+                sessionVariable.isEnableMaterializedViewRewrite());
+        logMVPrepare(connectContext, "  enable_materialized_view_union_rewrite: {}",
+                sessionVariable.isEnableMaterializedViewUnionRewrite());
+        logMVPrepare(connectContext, "  enable_materialized_view_view_delta_rewrite: {}",
+                sessionVariable.isEnableMaterializedViewViewDeltaRewrite());
+        logMVPrepare(connectContext, "  enable_materialized_view_single_table_view_delta_rewrite: {}",
+                sessionVariable.isEnableMaterializedViewSingleTableViewDeltaRewrite());
+        logMVPrepare(connectContext, "  enable_materialized_view_plan_cache: {}",
+                sessionVariable.isEnableMaterializedViewPlanCache());
+        logMVPrepare(connectContext, "  mv_auto_analyze_async: {}",
+                Config.mv_auto_analyze_async);
+        logMVPrepare(connectContext, "  enable_mv_automatic_active_check: {}",
+                Config.enable_mv_automatic_active_check);
+        logMVPrepare(connectContext, "  enable_sync_materialized_view_rewrite: {}",
+                sessionVariable.isEnableSyncMaterializedViewRewrite());
+
+        // limit
+        logMVPrepare(connectContext, "---------------------------------");
+        logMVPrepare(connectContext, "Materialized View Limit Params: ");
+        logMVPrepare(connectContext, "  optimizer_materialized_view_timelimit: {}",
+                sessionVariable.getMaterializedViewJoinSameTablePermutationLimit());
+        logMVPrepare(connectContext, "  materialized_view_join_same_table_permutation_limit: {}",
+                sessionVariable.getMaterializedViewJoinSameTablePermutationLimit());
+        logMVPrepare(connectContext, "  skip_whole_phase_lock_mv_limit: {}",
+                Config.skip_whole_phase_lock_mv_limit);
+
+        // config
+        logMVPrepare(connectContext, "---------------------------------");
+        logMVPrepare(connectContext, "Materialized View Config Params: ");
+        logMVPrepare(connectContext, "  analyze_mv: {}", sessionVariable.getAnalyzeForMV());
+        logMVPrepare(connectContext, "  query_excluding_mv_names: {}", sessionVariable.getQueryExcludingMVNames());
+        logMVPrepare(connectContext, "  query_including_mv_names: {}", sessionVariable.getQueryIncludingMVNames());
+        logMVPrepare(connectContext, "  materialized_view_rewrite_mode: {}",
+                sessionVariable.getMaterializedViewRewriteMode());
+        logMVPrepare(connectContext, "---------------------------------");
+    }
     private MaterializedView copyOnlyMaterializedView(MaterializedView mv) {
         // TODO: add read lock?
         // Query will not lock dbs in the optimizer stage, so use a shallow copy of mv to avoid

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -46,8 +46,8 @@ public class OptimizerTraceUtil {
                                     String format, Object... object) {
         Tracers.log(Tracers.Module.MV, input -> {
             String str = MessageFormatter.arrayFormat(format, object).getMessage();
-            Object[] args = new Object[] {ctx.getQueryId(), mv == null ? "GLOBAL" : mv.getName(), str};
-            return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}][{}] {}", args).getMessage();
+            Object[] args = new Object[] {mv == null ? "GLOBAL" : mv.getName(), str};
+            return MessageFormatter.arrayFormat("[MV TRACE] [PREPARE {}] {}", args).getMessage();
         });
     }
 
@@ -67,11 +67,10 @@ public class OptimizerTraceUtil {
                                     String format, Object... object) {
         Tracers.log(Tracers.Module.MV, input -> {
             Object[] args = new Object[] {
-                    optimizerContext.getQueryId(),
                     rule.type().name(),
                     String.format(format, object)
             };
-            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {} {}] {}", args).getMessage();
+            return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {}] {}", args).getMessage();
         });
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -39,7 +39,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.UniqueConstraint;
-import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
 import com.starrocks.common.profile.Tracers;
 import com.starrocks.common.util.StringUtils;
@@ -1279,7 +1278,7 @@ public class MaterializedViewRewriter {
 
                 ScalarOperator normalizedPredicate = normalizePredicate(finalCompensationPredicate);
                 // Canonize predicates to make uts more stable.
-                if (FeConstants.runningUnitTest && FeConstants.isCanonizePredicateAfterMVRewrite) {
+                if (optimizerContext.getSessionVariable().getQueryDebugOptions().isEnableNormalizePredicateAfterMVRewrite()) {
                     normalizedPredicate = MvUtils.canonizePredicateForRewrite(normalizedPredicate);
                 }
                 newScanOpBuilder.setPredicate(normalizedPredicate);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SetStmtTest.java
@@ -50,6 +50,7 @@ import com.starrocks.sql.ast.SetStmt;
 import com.starrocks.sql.ast.SetType;
 import com.starrocks.sql.ast.SystemVariable;
 import com.starrocks.sql.ast.UserVariable;
+import com.starrocks.sql.common.QueryDebugOptions;
 import mockit.Mocked;
 import org.apache.commons.lang3.EnumUtils;
 import org.junit.Assert;
@@ -255,6 +256,65 @@ public class SetStmtTest {
                 Assert.assertEquals("Getting analyzing error. Detail message: " +
                         "Unsupported follower query forward mode: bad_case, " +
                         "supported list is DEFAULT,FOLLOWER,LEADER.", e.getMessage());;
+            }
+        }
+    }
+
+    @Test
+    public void testQueryDebuOptions() throws AnalysisException {
+        // normal
+        {
+            String[] jsons = {
+                    "",
+                    "{'enableNormalizePredicateAfterMVRewrite':'true'}",
+                    "{'maxRefreshMaterializedViewRetryNum':2}",
+                    "{'enableNormalizePredicateAfterMVRewrite':'true', 'maxRefreshMaterializedViewRetryNum':2}",
+            };
+            for (String json : jsons) {
+                try {
+                    SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.QUERY_DEBUG_OPTIONS,
+                            new StringLiteral(json));
+                    SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                } catch (Exception e) {
+                    Assert.fail();;
+                }
+            }
+        }
+        // bad
+        {
+            String[] jsons = {
+                    "abc",
+                    "{abc",
+            };
+            for (String json : jsons) {
+                try {
+                    SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.QUERY_DEBUG_OPTIONS,
+                            new StringLiteral(json));
+                    SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                    Assert.fail();;
+                } catch (Exception e) {
+                    Assert.assertTrue(e.getMessage().contains("Unsupported query_debug_option"));
+                    e.printStackTrace();
+                }
+            }
+        }
+        // non normal
+        {
+            String[] jsons = {
+                    "{'enableNormalizePredicateAfterMVRewrite2':'true'}",
+                    "{'maxRefreshMaterializedViewRetryNum2':'2'}"
+            };
+            for (String json : jsons) {
+                try {
+                    SystemVariable setVar = new SystemVariable(SetType.SESSION, SessionVariable.QUERY_DEBUG_OPTIONS,
+                            new StringLiteral(json));
+                    SetStmtAnalyzer.analyze(new SetStmt(Lists.newArrayList(setVar)), ctx);
+                    QueryDebugOptions debugOptions = QueryDebugOptions.read(json);
+                    Assert.assertEquals(debugOptions.getMaxRefreshMaterializedViewRetryNum(), 1);
+                    Assert.assertEquals(debugOptions.isEnableNormalizePredicateAfterMVRewrite(), false);
+                } catch (Exception e) {
+                    Assert.fail();;
+                }
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.planner;
 
-import com.starrocks.common.FeConstants;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,9 +60,7 @@ public class MaterializedViewHiveTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery7() {
-        FeConstants.isCanonizePredicateAfterMVRewrite = true;
-        runFileUnitTest("materialized-view/tpch-hive/q7");
-        FeConstants.isCanonizePredicateAfterMVRewrite = false;
+        runFileUnitTestWithNormalizedResult("materialized-view/tpch-hive/q7");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTPCHTest.java
@@ -77,9 +77,7 @@ public class MaterializedViewTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery7() {
-        FeConstants.isCanonizePredicateAfterMVRewrite = true;
-        runFileUnitTest("materialized-view/tpch/q7");
-        FeConstants.isCanonizePredicateAfterMVRewrite = false;
+        runFileUnitTestWithNormalizedResult("materialized-view/tpch/q7");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -26,6 +26,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -465,5 +466,13 @@ public class MaterializedViewTestBase extends PlanTestBase {
         String tableName = matcher.group(1);
         starRocksAssert.withMaterializedView(sql);
         refreshMaterializedView(db, tableName);
+    }
+
+    public void runFileUnitTestWithNormalizedResult(String fileName) {
+        QueryDebugOptions debugOptions = new QueryDebugOptions();
+        debugOptions.setEnableNormalizePredicateAfterMVRewrite(true);
+        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
+        runFileUnitTest(fileName);
+        connectContext.getSessionVariable().setQueryDebugOptions("");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -39,12 +39,14 @@ import com.starrocks.connector.jdbc.MockedJDBCMetadata;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.LoadPlanner;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.plan.ExecPlan;
 import com.starrocks.thrift.TExplainLevel;
@@ -3159,6 +3161,14 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Assert.assertEquals("{tbl15=[p20220202, p20220201], tbl16=[p20220202, p20220201]}",
                 processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_union_filter");
+    }
+
+    @Test
+    public void testQueryDebugOptions() {
+        SessionVariable sessionVariable = connectContext.getSessionVariable();
+        QueryDebugOptions debugOptions = sessionVariable.getQueryDebugOptions();
+        Assert.assertEquals(debugOptions.getMaxRefreshMaterializedViewRetryNum(), 3);
+        Assert.assertEquals(debugOptions.isEnableNormalizePredicateAfterMVRewrite(), false);
     }
 }
 


### PR DESCRIPTION
Why I'm doing:

- FE UTs are not stable and be easy to fail.

What I'm doing:
- Add `PlannerDebugOptions ` so can adjust FE UT's strategy(eg. MV refresh retry time) to be more stable.
- Optimize MV Trace logs.

```
mysql> trace logs mv  SELECT dt,sum(num) FROM iceberg_catalog_04a3a26a_9327_11ee_8313_00163e0e489a.test_mv_async_db_04a5e516_9327_11ee_8313_00163e0e489a.t1 GROUP BY dt ORDER BY 1;
+------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                               |
+------------------------------------------------------------------------------------------------------------------------------+
|  8ms|    [MV TRACE] [PREPARE GLOBAL] Query input tables: [Table [id=100000029, name=t1, type=ICEBERG]]                       |
| 10ms|    [MV TRACE] [PREPARE GLOBAL] ---------------------------------                                                       |
| 10ms|    [MV TRACE] [PREPARE GLOBAL] Materialized View Enable/Disable Params:                                                |
| 10ms|    [MV TRACE] [PREPARE GLOBAL]   enable_experimental_mv: true                                                          |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   enable_materialized_view_rewrite: true                                                |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   enable_materialized_view_union_rewrite: true                                          |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   enable_materialized_view_view_delta_rewrite: true                                     |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   enable_materialized_view_single_table_view_delta_rewrite: false                       |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   enable_materialized_view_plan_cache: true                                             |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   mv_auto_analyze_async: true                                                           |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   enable_mv_automatic_active_check: true                                                |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   enable_sync_materialized_view_rewrite: true                                           |
| 11ms|    [MV TRACE] [PREPARE GLOBAL] ---------------------------------                                                       |
| 11ms|    [MV TRACE] [PREPARE GLOBAL] Materialized View Limit Params:                                                         |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   optimizer_materialized_view_timelimit: 5                                              |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   materialized_view_join_same_table_permutation_limit: 5                                |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   skip_whole_phase_lock_mv_limit: 5                                                     |
| 11ms|    [MV TRACE] [PREPARE GLOBAL] ---------------------------------                                                       |
| 11ms|    [MV TRACE] [PREPARE GLOBAL] Materialized View Config Params:                                                        |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   analyze_mv: sample                                                                    |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   query_excluding_mv_names:                                                             |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   query_including_mv_names:                                                             |
| 11ms|    [MV TRACE] [PREPARE GLOBAL]   materialized_view_rewrite_mode: DEFAULT                                               |
| 11ms|    [MV TRACE] [PREPARE GLOBAL] ---------------------------------                                                       |
| 11ms|    [MV TRACE] [PREPARE GLOBAL] Table/MaterializedView t1 has related materialized views: [MvId{dbId=10118, id=312010}] |
| 11ms|    [MV TRACE] [PREPARE GLOBAL] Table/MaterializedView mv1 has no related materialized views, identifier:mv1            |
| 17ms|    [MV TRACE] [PREPARE mv1] Prepare MV mv1 success                                                                     |
| 17ms|    [MV TRACE] [PREPARE GLOBAL] RelatedMVs: [mv1], CandidateMVs: [mv1]                                                  |
| 34ms|    [MV TRACE] [REWRITE TF_MV_AGGREGATE_SCAN_RULE mv1] Construct 1 relation id mappings from query to mv                |
| 41ms|    [MV TRACE] [REWRITE TF_MV_AGGREGATE_SCAN_RULE mv1] Rewrite Succeed                                                  |
| 46ms|    Query has already been successfully rewritten by: mv1.                                                              |
| Tracer Cost: 3111us                                                                                                          |
+------------------------------------------------------------------------------------------------------------------------------+
32 rows in set (0.05 sec)
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
