### PR TITLE
[BugFix] fix jni scanner handle decimal type

### DIFF
--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -448,9 +448,8 @@ public class ColumnType {
             String[] ps = type.substring(s + 1, e).split(",");
             precision = Integer.parseInt(ps[0].trim());
             scale = Integer.parseInt(ps[1].trim());
-            if (precision <= MAX_DECIMAL32_PRECISION) {
-                type = "decimal32";
-            } else if (precision <= MAX_DECIMAL64_PRECISION) {
+            // this logic is the same as FE's ScalarType.createUnifiedDecimalType
+            if (precision <= MAX_DECIMAL64_PRECISION) {
                 type = "decimal64";
             } else {
                 type = "decimal128";


### PR DESCRIPTION
Why I'm doing:
jni read decimal like decimal(5,2) 's result is wrong.This is because jni's logic when handle decimal is different than FE, so decimal(5,2) will be treated as decimal64 in FE and BE, but jni reader will treat it as decimal32, which only return 4 Bytes.This is a common problem for hive，hudi，paimon， because in ColumnTypeConverter，they all use ScalarType.createUnifiedDecimalType to convert decimal to SR's decimal type

What I'm doing:
correct jni'reader's logic when handle decimal

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
