### PR TITLE
[BugFix] Fix actual fields size in csv scanner

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -429,13 +429,13 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
 
         if (fields.size() != _num_fields_in_csv) {
             if (_counter->num_rows_filtered++ < REPORT_ERROR_MAX_NUMBER) {
-                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
-                                                                                    row.columns.size(), _parse_options);
+                std::string error_msg =
+                        make_column_count_not_matched_error_message(_num_fields_in_csv, fields.size(), _parse_options);
                 _report_error(record, error_msg);
             }
             if (_state->enable_log_rejected_record()) {
-                std::string error_msg = make_column_count_not_matched_error_message(_num_fields_in_csv,
-                                                                                    row.columns.size(), _parse_options);
+                std::string error_msg =
+                        make_column_count_not_matched_error_message(_num_fields_in_csv, fields.size(), _parse_options);
                 _report_rejected_record(record, error_msg);
             }
             continue;

--- a/be/src/exec/file_scanner.h
+++ b/be/src/exec/file_scanner.h
@@ -68,6 +68,9 @@ public:
     Status create_sequential_file(const TBrokerRangeDesc& range_desc, const TNetworkAddress& address,
                                   const TBrokerScanRangeParams& params, std::shared_ptr<SequentialFile>* file);
 
+    // only for test
+    RuntimeState* TEST_runtime_state() { return _state; }
+
 protected:
     void fill_columns_from_path(ChunkPtr& chunk, int slot_start, const std::vector<std::string>& columns_from_path,
                                 int size);

--- a/be/test/exec/csv_scanner_test.cpp
+++ b/be/test/exec/csv_scanner_test.cpp
@@ -21,6 +21,7 @@
 #include "column/chunk.h"
 #include "column/datum_tuple.h"
 #include "fs/fs_memory.h"
+#include "fs/fs_util.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "runtime/descriptor_helper.h"
 #include "runtime/descriptors.h"
@@ -62,6 +63,7 @@ protected:
         RuntimeState* state = _obj_pool.add(new RuntimeState(TUniqueId(), TQueryOptions(), TQueryGlobals(), nullptr));
         state->set_desc_tbl(desc_tbl);
         state->init_instance_mem_tracker();
+        state->_query_options.query_type = TQueryType::LOAD;
 
         /// TBrokerScanRangeParams
         TBrokerScanRangeParams* params = _obj_pool.add(new TBrokerScanRangeParams());
@@ -982,6 +984,49 @@ TEST_P(CSVScannerTest, test_empty) {
     run_test(TYPE_INT);
     run_test(TYPE_DATE);
     run_test(TYPE_DATETIME);
+}
+
+TEST_P(CSVScannerTest, test_column_count_inconsistent) {
+    std::vector<TypeDescriptor> types;
+    types.emplace_back(TYPE_INT);
+    types.emplace_back(TYPE_DOUBLE);
+    types.emplace_back(TYPE_VARCHAR);
+    types.emplace_back(TYPE_DATE);
+
+    types[2].len = 10;
+
+    std::vector<TBrokerRangeDesc> ranges;
+    TBrokerRangeDesc range_one;
+    range_one.__set_path("./be/test/exec/test_data/csv_scanner/csv_file1");
+    range_one.__set_start_offset(0);
+    range_one.__set_num_of_columns_from_file(types.size());
+    ranges.push_back(range_one);
+
+    auto scanner = create_csv_scanner(types, ranges);
+    EXPECT_NE(scanner, nullptr);
+
+    auto st = scanner->open();
+    ASSERT_TRUE(st.ok()) << st.to_string();
+
+    scanner->use_v2(_use_v2);
+
+    auto log_file_path = "test_column_count_inconsistent_error_log_file";
+    std::ofstream wfile(log_file_path, std::ofstream::out);
+    scanner->TEST_runtime_state()->_error_log_file = &wfile;
+    auto res = scanner->get_next();
+    ASSERT_TRUE(res.status().is_end_of_file()) << res.status().to_string();
+    wfile.close();
+    scanner->TEST_runtime_state()->_error_log_file = nullptr;
+
+    std::ifstream rfile(log_file_path, std::ifstream::in);
+    std::string line;
+    line.resize(1024);
+    rfile.getline(line.data(), line.size());
+    auto found = line.find("Value count does not match column count: expected = 4, actual = 5");
+    ASSERT_TRUE(found != std::string::npos);
+    rfile.close();
+
+    (void)fs::remove(log_file_path);
 }
 
 INSTANTIATE_TEST_CASE_P(CSVScannerTestParams, CSVScannerTest, Values(true, false));


### PR DESCRIPTION
Why I'm doing:

actual fields size always be 0 when value count does not match column count.

`Error: Value count does not match column count: expected = 3, actual = 0`

What I'm doing:

fix actual fields size.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
