### PR TITLE
[Enhancement] Deduplicate the partitionValues in the createPartition RPC to avoid unnecessary overhead for the FE

### DIFF
--- a/be/src/exec/tablet_info.cpp
+++ b/be/src/exec/tablet_info.cpp
@@ -27,6 +27,22 @@ namespace starrocks {
 
 static const std::string LOAD_OP_COLUMN = "__op";
 
+struct VectorCompare {
+    bool operator()(const std::vector<std::string>& a, const std::vector<std::string>& b) const {
+        if (a.size() != b.size()) {
+            return a.size() < b.size();
+        }
+
+        for (size_t i = 0; i < a.size(); ++i) {
+            if (a[i] != b[i]) {
+                return a[i] < b[i];
+            }
+        }
+
+        return false;
+    }
+};
+
 std::string ChunkRow::debug_string() {
     std::stringstream os;
     os << "index " << index << " [";
@@ -486,6 +502,7 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
 
     _compute_hashes(chunk, indexes);
 
+    std::set<std::vector<std::string>, VectorCompare> partition_columns_set;
     if (!_partition_columns.empty()) {
         Columns partition_columns(_partition_slot_descs.size());
         if (!_partitions_expr_ctxs.empty()) {
@@ -523,7 +540,10 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
                                         << row.debug_string();
                                 partition_value_items->emplace_back(column->raw_item_value(i));
                             }
-                            (*partition_not_exist_row_values).emplace_back(*partition_value_items);
+                            auto r = partition_columns_set.insert(*partition_value_items);
+                            if (r.second) {
+                                (*partition_not_exist_row_values).emplace_back(*partition_value_items);
+                            }
                         } else {
                             VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
                                     << row.debug_string();
@@ -554,6 +574,9 @@ Status OlapTablePartitionParam::find_tablets(Chunk* chunk, std::vector<OlapTable
                                 VLOG(3) << "partition not exist chunk row:" << chunk->debug_row(i) << " partition row "
                                         << row.debug_string();
                                 partition_value_items->emplace_back(column->raw_item_value(i));
+                            }
+                            auto r = partition_columns_set.insert(*partition_value_items);
+                            if (r.second) {
                                 (*partition_not_exist_row_values).emplace_back(*partition_value_items);
                             }
                         } else {

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -374,8 +374,8 @@ Status OlapTableSink::_automatic_create_partition() {
     request.__set_table_id(_vectorized_partition->table_id());
     request.__set_partition_values(_partition_not_exist_row_values);
 
-    VLOG(1) << "load_id=" << print_id(_load_id) << ", txn_id: " << std::to_string(_txn_id)
-            << "automatic partition rpc begin request " << request;
+    LOG(INFO) << "load_id=" << print_id(_load_id) << ", txn_id: " << std::to_string(_txn_id)
+              << "automatic partition rpc begin request " << request;
     TNetworkAddress master_addr = get_master_address();
     auto timeout_ms = _runtime_state->query_options().query_timeout * 1000 / 2;
     int retry_times = 0;
@@ -394,8 +394,8 @@ Status OlapTableSink::_automatic_create_partition() {
     } while (result.status.status_code == TStatusCode::SERVICE_UNAVAILABLE &&
              butil::gettimeofday_s() - start_ts < timeout_ms / 1000);
 
-    VLOG(1) << "load_id=" << print_id(_load_id) << ", txn_id: " << std::to_string(_txn_id)
-            << "automatic partition rpc end response " << result;
+    LOG(INFO) << "load_id=" << print_id(_load_id) << ", txn_id: " << std::to_string(_txn_id)
+              << "automatic partition rpc end response " << result;
     if (result.status.status_code == TStatusCode::OK) {
         // add new created partitions
         RETURN_IF_ERROR(_vectorized_partition->add_partitions(result.partitions));


### PR DESCRIPTION
## Why I'm doing:
* partitionValues in createPartition RPC may have duplicate record, it will cost unnecessary overhead on FE.

## What I'm doing:
* Deduplicate partitionValues
* use INFO replace VLOG after we deduplicate the log

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
