### PR TITLE
[BugFix] Fix sort key unique id lost

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -732,7 +732,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
             int sortKeyIdx = targetIndexSchema.indexOf(oneCol.get());
             sortKeyIdxes.add(sortKeyIdx);
-            if (useSortKeyUniqueId && oneCol.get().getUniqueId() > 0) {
+            if (useSortKeyUniqueId && oneCol.get().getUniqueId() >= 0) {
                 sortKeyUniqueIds.add(oneCol.get().getUniqueId());
             } else {
                 useSortKeyUniqueId = false;

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -33,6 +33,10 @@ insert into tab1 values (500,500,500,500,500);
 insert into tab1 values (600,600,600,600,600);
 -- result:
 -- !result
+select * from tab1 where k1 = 100;
+-- result:
+100	100	100	100	100
+-- !result
 alter table tab1 order by (k2,k1);
 -- result:
 -- !result
@@ -53,7 +57,10 @@ select * from tab1;
 600	600	600	600	600
 700	700	700	700	700
 -- !result
-
+select * from tab1 where k2 = 100;
+-- result:
+100	100	100	100	100
+-- !result
 -- name: test_alter_pk_reorder_column_type
 CREATE TABLE `test_alter_pk_reorder_column_type` (
   `k1` date NOT NULL COMMENT "",

--- a/test/sql/test_ddl/T/test_alter_pk_reorder
+++ b/test/sql/test_ddl/T/test_alter_pk_reorder
@@ -20,10 +20,13 @@ insert into tab1 values (300,300,300,300,300);
 insert into tab1 values (400,400,400,400,400);
 insert into tab1 values (500,500,500,500,500);
 insert into tab1 values (600,600,600,600,600);
+select * from tab1 where k1 = 100;
+
 alter table tab1 order by (k2,k1);
 function: wait_alter_table_finish()
 insert into tab1 values (700,700,700,700,700);
 select * from tab1;
+select * from tab1 where k2 = 100;
 
 
 -- name: test_alter_pk_reorder_column_type


### PR DESCRIPTION
Why I'm doing:

The initial column unique id in FE is -1 but the judgment in reorder for primary key table is >0 which is error.

What I'm doing:

Change the judgment to >= 0.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
