### PR TITLE
[BugFix] [Refactor] Add TableSnapshotInfo to avoid changes of the base table during mv's refresh period

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -91,9 +91,6 @@ public class IcebergTable extends Table {
 
     private org.apache.iceberg.Table nativeTable; // actual iceberg table
     private List<Column> partitionColumns;
-    // used for recording the last snapshot time when refresh mv based on mv.
-    @SerializedName(value = "refreshSnapshotTime")
-    private AtomicLong refreshSnapshotTime = new AtomicLong(-1);
 
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
 
@@ -248,14 +245,6 @@ public class IcebergTable extends Table {
             nativeTable = resourceMappingTable.getNativeTable();
         }
         return nativeTable;
-    }
-
-    public long getRefreshSnapshotTime() {
-        return refreshSnapshotTime.get();
-    }
-
-    public void setRefreshSnapshotTime(long refreshSnapshotTime) {
-        this.refreshSnapshotTime.set(refreshSnapshotTime);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -92,7 +92,8 @@ public class IcebergTable extends Table {
     private org.apache.iceberg.Table nativeTable; // actual iceberg table
     private List<Column> partitionColumns;
     // used for recording the last snapshot time when refresh mv based on mv.
-    private long refreshSnapshotTime = -1L;
+    @SerializedName(value = "refreshSnapshotTime")
+    private AtomicLong refreshSnapshotTime = new AtomicLong(-1);
 
     private final AtomicLong partitionIdGen = new AtomicLong(0L);
 
@@ -250,11 +251,11 @@ public class IcebergTable extends Table {
     }
 
     public long getRefreshSnapshotTime() {
-        return refreshSnapshotTime;
+        return refreshSnapshotTime.get();
     }
 
     public void setRefreshSnapshotTime(long refreshSnapshotTime) {
-        this.refreshSnapshotTime = refreshSnapshotTime;
+        this.refreshSnapshotTime.set(refreshSnapshotTime);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -427,7 +427,7 @@ public abstract class ConnectorPartitionTraits {
         @Override
         public Optional<Long> maxPartitionRefreshTs() {
             IcebergTable icebergTable = (IcebergTable) table;
-            return Optional.of(icebergTable.getRefreshSnapshotTime());
+            return icebergTable.getSnapshot().map(Snapshot::timestampMillis);
         }
 
         @Override

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -449,7 +449,6 @@ public abstract class ConnectorPartitionTraits {
                 MaterializedView.BasePartitionInfo basePartitionInfo =
                         baseTableInfoVisibleVersionMap.get(ICEBERG_ALL_PARTITION);
                 if (basePartitionInfo == null) {
-                    baseTable.setRefreshSnapshotTime(currentVersion);
                     return new HashSet<>(partitionNames);
                 }
                 // check if there are new partitions which are not in baseTableInfoVisibleVersionMap
@@ -459,13 +458,8 @@ public abstract class ConnectorPartitionTraits {
                     }
                 }
 
-                if (!result.isEmpty()) {
-                    baseTable.setRefreshSnapshotTime(currentVersion);
-                }
-
                 long basePartitionVersion = basePartitionInfo.getVersion();
                 if (basePartitionVersion < currentVersion) {
-                    baseTable.setRefreshSnapshotTime(currentVersion);
                     result.addAll(IcebergPartitionUtils.getChangedPartitionNames(baseTable.getNativeTable(),
                             basePartitionVersion));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -686,8 +686,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
             Table baseTable = snapshotInfo.getBaseTable();
             if (baseTable.isIcebergTable()) {
-                IcebergTable icebergTable = (IcebergTable) baseTable;
-                icebergTable.setRefreshSnapshotTime(snapshotInfo.getRefreshSnapshotTime());
                 // iceberg table use ALL as partition name, so we don't need to remove partition info
                 currentTablePartitionInfo.keySet().removeIf(partitionName ->
                         (!partitionNames.contains(partitionName) && !partitionName.equals(ICEBERG_ALL_PARTITION)));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -110,6 +110,7 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.sql.plan.ExecPlan;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.iceberg.Snapshot;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -153,8 +154,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     private Database db;
     private MaterializedView materializedView;
     private MvTaskRunContext mvContext;
-    // table id -> <base table info, snapshot table>
-    private Map<Long, Pair<BaseTableInfo, Table>> snapshotBaseTables;
+
+    // Collect all bases tables of the materialized view to be updated meta after mv refresh success.
+    // format :     table id -> <base table info, snapshot table>
+    private Map<Long, TableSnapshotInfo> snapshotBaseTables;
 
     private long oldTransactionVisibleWaitTimeout;
 
@@ -209,9 +212,13 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         int retryNum = 0;
         boolean checked = false;
 
-        Map<Table, Set<String>> refTableRefreshPartitions = null;
+        // to refresh partition names of materialized view
         Set<String> mvToRefreshedPartitions = null;
+        // ref table of materialized view : refreshed partition names
+        Map<TableSnapshotInfo, Set<String>> refTableRefreshPartitions = null;
+        // ref table of materialized view : refreshed partition names
         Map<String, Set<String>> refTablePartitionNames = null;
+
         long startRefreshTs = System.currentTimeMillis();
         while (!checked) {
             // sync partitions between materialized view and base tables out of lock
@@ -256,10 +263,15 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 refTableRefreshPartitions = getRefTableRefreshPartitions(mvToRefreshedPartitions);
 
                 refTablePartitionNames = refTableRefreshPartitions.entrySet().stream()
-                                .collect(Collectors.toMap(x -> x.getKey().getName(), Map.Entry::getValue));
-                LOG.debug("materialized view:{} source partitions :{}",
-                        materializedView.getName(), refTableRefreshPartitions);
+                        .collect(Collectors.toMap(x -> x.getKey().getBaseTable().getName(), Map.Entry::getValue));
 
+                updateBaseTablePartitionSnapshotInfos(mvToRefreshedPartitions, refTableRefreshPartitions);
+
+                // add debug info
+                if (LOG.isDebugEnabled()) {
+                    LOG.debug("materialized view:{} source partitions :{}",
+                            materializedView.getName(), refTableRefreshPartitions);
+                }
                 // add message into information_schema
                 if (this.getMVTaskRunExtraMessage() != null) {
                     MVTaskRunExtraMessage extraMessage = getMVTaskRunExtraMessage();
@@ -500,9 +512,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     private void refreshExternalTable(TaskRunContext context) {
-        for (Pair<BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
-            BaseTableInfo baseTableInfo = tablePair.first;
-            Table table = tablePair.second;
+        for (TableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
+            Table table = snapshotInfo.getBaseTable();
             if (!table.isNativeTableOrMaterializedView() && !table.isHiveView()) {
                 context.getCtx().getGlobalStateMgr().getMetadataMgr().refreshTable(baseTableInfo.getCatalogName(),
                         baseTableInfo.getDbName(), table, Lists.newArrayList(), true);
@@ -517,7 +529,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      */
     private void updateMeta(Set<String> mvRefreshedPartitions,
                             ExecPlan execPlan,
-                            Map<Table, Set<String>> refTableAndPartitionNames) {
+                            Map<TableSnapshotInfo, Set<String>> refTableAndPartitionNames) {
         Locker locker = new Locker();
         // update the meta if succeed
         if (!locker.lockAndCheckExist(db, LockType.WRITE)) {
@@ -536,37 +548,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 return;
             }
 
-            // NOTE: For each task run, ref-base table's incremental partition and all non-ref base tables' partitions
-            // are refreshed, so we need record it into materialized view.
-            // NOTE: We don't use the pruned partition infos from ExecPlan because the optimized partition infos are not
-            // exact to describe which partitions are refreshed.
-            Map<Table, Set<String>> baseTableAndPartitionNames = Maps.newHashMap();
-            for (Map.Entry<Table, Set<String>> e : refTableAndPartitionNames.entrySet()) {
-                Set<String> realPartitionNames =
-                        e.getValue().stream()
-                                .flatMap(name -> convertMVPartitionNameToRealPartitionName(e.getKey(), name).stream())
-                                .collect(Collectors.toSet());
-                baseTableAndPartitionNames.put(e.getKey(), realPartitionNames);
-            }
-            Map<Table, Set<String>> nonRefTableAndPartitionNames = getNonRefTableRefreshPartitions();
-            if (!nonRefTableAndPartitionNames.isEmpty()) {
-                baseTableAndPartitionNames.putAll(nonRefTableAndPartitionNames);
-            }
-
             MaterializedView.MvRefreshScheme mvRefreshScheme = materializedView.getRefreshScheme();
             MaterializedView.AsyncRefreshContext refreshContext = mvRefreshScheme.getAsyncRefreshContext();
 
-            // update materialized view partition to ref base table partition names meta
-            updateAssociatedPartitionMeta(refreshContext, mvRefreshedPartitions, refTableAndPartitionNames);
-
-            Map<Long, Map<String, MaterializedView.BasePartitionInfo>> changedOlapTablePartitionInfos =
-                    getSelectedPartitionInfosOfOlapTable(baseTableAndPartitionNames);
-            Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> changedExternalTablePartitionInfos
-                    = getSelectedPartitionInfosOfExternalTable(baseTableAndPartitionNames);
-            Preconditions.checkState(changedOlapTablePartitionInfos.size() + changedExternalTablePartitionInfos.size()
-                    <= baseTableAndPartitionNames.size());
-            updateMetaForOlapTable(refreshContext, changedOlapTablePartitionInfos);
-            updateMetaForExternalTable(refreshContext, changedExternalTablePartitionInfos);
+            // NOTE: update all base tables meta to be used in mv rewrite.
+            // FIXME(lism): only record the referred base table later to avoid recording too much metas.
+            Map<Boolean, List<TableSnapshotInfo>> snapshotInfoSplits = snapshotBaseTables.values()
+                    .stream()
+                    .collect(Collectors.partitioningBy(s -> s.getBaseTable().isNativeTableOrMaterializedView()));
+            if (snapshotInfoSplits.get(true) != null) {
+                updateMetaForOlapTable(refreshContext, snapshotInfoSplits.get(true));
+            }
+            if (snapshotInfoSplits.get(false) != null) {
+                updateMetaForExternalTable(refreshContext, snapshotInfoSplits.get(false));
+            }
 
             // add message into information_schema
             if (this.getMVTaskRunExtraMessage() != null) {
@@ -590,7 +585,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private void updateAssociatedPartitionMeta(MaterializedView.AsyncRefreshContext refreshContext,
                                                Set<String> mvRefreshedPartitions,
-                                               Map<Table, Set<String>> refTableAndPartitionNames) {
+                                               Map<TableSnapshotInfo, Set<String>> refTableAndPartitionNames) {
         Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
         if (!Objects.isNull(mvToBaseNameRefs) && !Objects.isNull(refTableAndPartitionNames) &&
                 !refTableAndPartitionNames.isEmpty()) {
@@ -599,8 +594,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         refreshContext.getMvPartitionNameRefBaseTablePartitionMap();
                 for (String mvRefreshedPartition : mvRefreshedPartitions) {
                     Map<Table, Set<String>> mvToBaseNameRef = mvToBaseNameRefs.get(mvRefreshedPartition);
-                    for (Map.Entry<Table, Set<String>> entry : refTableAndPartitionNames.entrySet()) {
-                        Table refBaseTable = entry.getKey();
+                    for (TableSnapshotInfo snapshotInfo : refTableAndPartitionNames.keySet()) {
+                        Table refBaseTable = snapshotInfo.getBaseTable();
                         if (!mvToBaseNameRef.containsKey(refBaseTable)) {
                             continue;
                         }
@@ -614,7 +609,6 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                                 .put(mvRefreshedPartition, realBaseTableAssociatedPartitions);
                     }
                 }
-
             } catch (Exception e) {
                 LOG.warn("Update materialized view {} with the associated ref base table partitions failed: ",
                         materializedView.getName(), e);
@@ -623,7 +617,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     private void updateMetaForOlapTable(MaterializedView.AsyncRefreshContext refreshContext,
-                                        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> changedTablePartitionInfos) {
+                                        List<TableSnapshotInfo> changedTablePartitionInfos) {
         Map<Long, Map<String, MaterializedView.BasePartitionInfo>> currentVersionMap =
                 refreshContext.getBaseTableVisibleVersionMap();
         Table partitionTable = null;
@@ -632,20 +626,19 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             partitionTable = partitionTableAndColumn.first;
         }
         // update version map of materialized view
-        for (Map.Entry<Long, Map<String, MaterializedView.BasePartitionInfo>> tableEntry
-                : changedTablePartitionInfos.entrySet()) {
-            Long tableId = tableEntry.getKey();
+        for (TableSnapshotInfo snapshotInfo : changedTablePartitionInfos) {
+            Table snapshotTable = snapshotInfo.getBaseTable();
+            Long tableId = snapshotTable.getId();
             if (partitionTable != null && tableId != partitionTable.getId()) {
                 continue;
             }
             currentVersionMap.computeIfAbsent(tableId, (v) -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
                     currentVersionMap.get(tableId);
-            Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = tableEntry.getValue();
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = snapshotInfo.getRefreshedPartitionInfos();
             currentTablePartitionInfo.putAll(partitionInfoMap);
 
             // remove partition info of not-exist partition for snapshot table from version map
-            Table snapshotTable = snapshotBaseTables.get(tableId).second;
             if (snapshotTable.isOlapOrCloudNativeTable()) {
                 OlapTable snapshotOlapTable = (OlapTable) snapshotTable;
                 currentTablePartitionInfo.keySet().removeIf(partitionName ->
@@ -655,48 +648,62 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         if (!changedTablePartitionInfos.isEmpty()) {
             ChangeMaterializedViewRefreshSchemeLog changeRefreshSchemeLog =
                     new ChangeMaterializedViewRefreshSchemeLog(materializedView);
+            Collection<Map<String, MaterializedView.BasePartitionInfo>> allChangedPartitionInfos =
+                    changedTablePartitionInfos
+                            .stream()
+                            .map(snapshot -> snapshot.getRefreshedPartitionInfos())
+                            .collect(Collectors.toList());
             long maxChangedTableRefreshTime =
-                    MvUtils.getMaxTablePartitionInfoRefreshTime(changedTablePartitionInfos.values());
+                    MvUtils.getMaxTablePartitionInfoRefreshTime(allChangedPartitionInfos);
             materializedView.getRefreshScheme().setLastRefreshTime(maxChangedTableRefreshTime);
             GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(changeRefreshSchemeLog);
         }
     }
 
-    private void updateMetaForExternalTable(
-            MaterializedView.AsyncRefreshContext refreshContext,
-            Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> changedTablePartitionInfos) {
+    private void updateMetaForExternalTable(MaterializedView.AsyncRefreshContext refreshContext,
+                                            List<TableSnapshotInfo> changedTablePartitionInfos) {
         Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> currentVersionMap =
                 refreshContext.getBaseTableInfoVisibleVersionMap();
         BaseTableInfo partitionTableInfo = null;
         if (mvContext.hasNextBatchPartition()) {
             Pair<Table, Column> partitionTableAndColumn = getRefBaseTableAndPartitionColumn(snapshotBaseTables);
-            partitionTableInfo = snapshotBaseTables.get(partitionTableAndColumn.first.getId()).first;
+            partitionTableInfo = snapshotBaseTables.get(partitionTableAndColumn.first.getId()).getBaseTableInfo();
         }
         // update version map of materialized view
-        for (Map.Entry<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> tableEntry
-                : changedTablePartitionInfos.entrySet()) {
-            BaseTableInfo baseTableInfo = tableEntry.getKey();
+        for (TableSnapshotInfo snapshotInfo : changedTablePartitionInfos) {
+            BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
             if (partitionTableInfo != null && !partitionTableInfo.equals(baseTableInfo)) {
                 continue;
             }
             currentVersionMap.computeIfAbsent(baseTableInfo, (v) -> Maps.newConcurrentMap());
             Map<String, MaterializedView.BasePartitionInfo> currentTablePartitionInfo =
                     currentVersionMap.get(baseTableInfo);
-            Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = tableEntry.getValue();
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = snapshotInfo.getRefreshedPartitionInfos();
             currentTablePartitionInfo.putAll(partitionInfoMap);
 
             // remove partition info of not-exist partition for snapshot table from version map
             Set<String> partitionNames = Sets.newHashSet(PartitionUtil.getPartitionNames(baseTableInfo.getTable()));
-            // iceberg table use ALL as partition name, so we don't need to remove partition info
-            currentTablePartitionInfo.keySet().removeIf(partitionName ->
-                    (!partitionNames.contains(partitionName) && !partitionName.equals(ICEBERG_ALL_PARTITION)));
 
+            Table baseTable = snapshotInfo.getBaseTable();
+            if (baseTable.isIcebergTable()) {
+                IcebergTable icebergTable = (IcebergTable) baseTable;
+                icebergTable.setRefreshSnapshotTime(snapshotInfo.getRefreshSnapshotTime());
+                // iceberg table use ALL as partition name, so we don't need to remove partition info
+                currentTablePartitionInfo.keySet().removeIf(partitionName ->
+                        (!partitionNames.contains(partitionName) && !partitionName.equals(ICEBERG_ALL_PARTITION)));
+            } else {
+                currentTablePartitionInfo.keySet().removeIf(partitionName -> !partitionNames.contains(partitionName));
+            }
         }
         if (!changedTablePartitionInfos.isEmpty()) {
             ChangeMaterializedViewRefreshSchemeLog changeRefreshSchemeLog =
                     new ChangeMaterializedViewRefreshSchemeLog(materializedView);
-            long maxChangedTableRefreshTime =
-                    MvUtils.getMaxTablePartitionInfoRefreshTime(changedTablePartitionInfos.values());
+            Collection<Map<String, MaterializedView.BasePartitionInfo>> allChangedPartitionInfos =
+                    changedTablePartitionInfos
+                            .stream()
+                            .map(snapshot -> snapshot.getRefreshedPartitionInfos())
+                            .collect(Collectors.toList());
+            long maxChangedTableRefreshTime = MvUtils.getMaxTablePartitionInfoRefreshTime(allChangedPartitionInfos);
             materializedView.getRefreshScheme().setLastRefreshTime(maxChangedTableRefreshTime);
             GlobalStateMgr.getCurrentState().getEditLog().logMvChangeRefreshScheme(changeRefreshSchemeLog);
         }
@@ -743,7 +750,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      * Sync base table's partition infos to be used later.
      */
     private void syncPartitions(TaskRunContext context) {
-        snapshotBaseTables = collectBaseTables(materializedView);
+        snapshotBaseTables = collectBaseTableSnapshotInfos(materializedView);
+
         PartitionInfo partitionInfo = materializedView.getPartitionInfo();
         if (!(partitionInfo instanceof SinglePartitionInfo)) {
             Pair<Table, Column> partitionTableAndColumn = getRefBaseTableAndPartitionColumn(snapshotBaseTables);
@@ -761,16 +769,14 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     /**
-     * @param tables : base tables of the materialized view
-     * @return       : return the ref base table and column that materialized view's partition column
-     * derives from if it exists, otherwise return null.
+     * return the ref base table and column that materialized view's partition column
+     *  derives from if it exists, otherwise return null.
      */
-    private Pair<Table, Column> getRefBaseTableAndPartitionColumn(
-            Map<Long, Pair<BaseTableInfo, Table>> tables) {
+    private Pair<Table, Column> getRefBaseTableAndPartitionColumn(Map<Long, TableSnapshotInfo> tableSnapshotInfos) {
         SlotRef slotRef = MaterializedView.getRefBaseTablePartitionSlotRef(materializedView);
-        for (Pair<BaseTableInfo, Table> tableInfo : tables.values()) {
-            BaseTableInfo baseTableInfo = tableInfo.first;
-            Table table = tableInfo.second;
+        for (TableSnapshotInfo snapshotInfo : tableSnapshotInfos.values()) {
+            BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
+            Table table = snapshotInfo.getBaseTable();
             if (slotRef.getTblNameWithoutAnalyzed().getTbl().equals(baseTableInfo.getTableName())) {
                 return Pair.create(table, table.getColumn(slotRef.getColumnName()));
             }
@@ -926,8 +932,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      * - its base table has updated.
      */
     private boolean isNonPartitionedMVNeedToRefresh() {
-        for (Pair<BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
-            Table snapshotTable = tablePair.second;
+        for (TableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            Table snapshotTable = snapshotInfo.getBaseTable();
             if (unSupportRefreshByPartition(snapshotTable)) {
                 return true;
             }
@@ -944,8 +950,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      */
     private boolean isPartitionedMVNeedToRefreshBaseOnNonRefTables(Table partitionTable) {
         Map<Table, Column> tableColumnMap = materializedView.getRelatedPartitionTableAndColumn();
-        for (Pair<BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
-            Table snapshotTable = tablePair.second;
+        for (TableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            Table snapshotTable = snapshotInfo.getBaseTable();
             if (snapshotTable.getId() == partitionTable.getId()) {
                 continue;
             }
@@ -1390,9 +1396,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
 
     private boolean checkBaseTablePartitionChange() {
         // check snapshotBaseTables and current tables in catalog
-        for (Pair<BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
-            BaseTableInfo baseTableInfo = tablePair.first;
-            Table snapshotTable = tablePair.second;
+        for (TableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
+            Table snapshotTable = snapshotInfo.getBaseTable();
 
             Database db = baseTableInfo.getDb();
             if (db == null) {
@@ -1498,8 +1504,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     @VisibleForTesting
-    public Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
-        Map<Long, Pair<BaseTableInfo, Table>> tables = Maps.newHashMap();
+    public Map<Long, TableSnapshotInfo> collectBaseTableSnapshotInfos(MaterializedView materializedView) {
+        Map<Long, TableSnapshotInfo> tables = Maps.newHashMap();
         List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
 
         for (BaseTableInfo baseTableInfo : baseTableInfos) {
@@ -1525,15 +1531,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     if (copied == null) {
                         throw new DmlException("Failed to copy olap table: %s", table.getName());
                     }
-                    tables.put(table.getId(), Pair.create(baseTableInfo, copied));
+                    tables.put(table.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
                 } else if (table.isCloudNativeTable()) {
                     LakeTable copied = DeepCopy.copyWithGson(table, LakeTable.class);
                     if (copied == null) {
                         throw new DmlException("Failed to copy lake table: %s", table.getName());
                     }
-                    tables.put(table.getId(), Pair.create(baseTableInfo, copied));
+                    tables.put(table.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
+                } else if (table.isIcebergTable()) {
+                    IcebergTable icebergTable = (IcebergTable) table;
+                    Snapshot snapshot = icebergTable.getNativeTable().currentSnapshot();
+                    long currentVersion = snapshot != null ? snapshot.timestampMillis() : -1;
+                    tables.put(table.getId(), new TableSnapshotInfo(baseTableInfo, table, currentVersion));
                 } else {
-                    tables.put(table.getId(), Pair.create(baseTableInfo, table));
+                    tables.put(table.getId(), new TableSnapshotInfo(baseTableInfo, table, -1));
                 }
             } finally {
                 locker.unLockDatabase(db, LockType.READ);
@@ -1541,6 +1552,42 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
         }
 
         return tables;
+    }
+
+    @VisibleForTesting
+    public void updateBaseTablePartitionSnapshotInfos(
+            Set<String> mvRefreshedPartitions,
+            Map<TableSnapshotInfo, Set<String>> refTableAndPartitionNames) throws AnalysisException {
+        // NOTE: For each task run, ref-base table's incremental partition and all non-ref base tables' partitions
+        // are refreshed, so we need record it into materialized view.
+        // NOTE: We don't use the pruned partition infos from ExecPlan because the optimized partition infos are not
+        // exact to describe which partitions are refreshed.
+        Map<TableSnapshotInfo, Set<String>> baseTableAndPartitionNames = Maps.newHashMap();
+        for (Map.Entry<TableSnapshotInfo, Set<String>> e : refTableAndPartitionNames.entrySet()) {
+            TableSnapshotInfo snapshotInfo = e.getKey();
+            Table baseTable = snapshotInfo.getBaseTable();
+            Set<String> realPartitionNames = e.getValue().stream()
+                    .flatMap(name -> convertMVPartitionNameToRealPartitionName(baseTable, name).stream())
+                    .collect(Collectors.toSet());
+            baseTableAndPartitionNames.put(snapshotInfo, realPartitionNames);
+        }
+        Map<TableSnapshotInfo, Set<String>> nonRefTableAndPartitionNames = getNonRefTableRefreshPartitions();
+        if (!nonRefTableAndPartitionNames.isEmpty()) {
+            baseTableAndPartitionNames.putAll(nonRefTableAndPartitionNames);
+        }
+
+        // update materialized view partition to ref base table partition names meta
+        MaterializedView.MvRefreshScheme mvRefreshScheme = materializedView.getRefreshScheme();
+        MaterializedView.AsyncRefreshContext refreshContext = mvRefreshScheme.getAsyncRefreshContext();
+        updateAssociatedPartitionMeta(refreshContext, mvRefreshedPartitions, refTableAndPartitionNames);
+
+        for (Map.Entry<TableSnapshotInfo, Set<String>> e : baseTableAndPartitionNames.entrySet()) {
+            TableSnapshotInfo snapshotInfo = e.getKey();
+            Set<String> refreshedPartitionNames = e.getValue();
+            Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos =
+                    getRefreshedPartitionInfos(snapshotInfo, refreshedPartitionNames);
+            snapshotInfo.setRefreshedPartitionInfos(refreshedPartitionInfos);
+        }
     }
 
     private Map<String, String> getPartitionProperties(MaterializedView materializedView) {
@@ -1692,32 +1739,34 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      * @return : return to-refreshed base table's table name and partition names mapping
      */
     @VisibleForTesting
-    public Map<Table, Set<String>> getRefTableRefreshPartitions(Set<String> mvToRefreshedPartitions) {
-        Map<Table, Set<String>> refTableAndPartitionNames = Maps.newHashMap();
+    public Map<TableSnapshotInfo, Set<String>> getRefTableRefreshPartitions(Set<String> mvToRefreshedPartitions) {
+        Map<TableSnapshotInfo, Set<String>> refTableAndPartitionNames = Maps.newHashMap();
         Map<String, Map<Table, Set<String>>> mvToBaseNameRefs = mvContext.getMvRefBaseTableIntersectedPartitions();
         if (mvToBaseNameRefs == null) {
             return refTableAndPartitionNames;
         }
-        for (Pair<BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
-            Table table = tablePair.second;
+        for (TableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            Table snapshotTable = snapshotInfo.getBaseTable();
             Set<String> needRefreshTablePartitionNames = null;
             for (String mvPartitionName : mvToRefreshedPartitions) {
                 if (!mvToBaseNameRefs.containsKey(mvPartitionName)) {
                     continue;
                 }
                 Map<Table, Set<String>> mvToBaseNameRef = mvToBaseNameRefs.get(mvPartitionName);
-                if (mvToBaseNameRef.containsKey(table)) {
+                if (mvToBaseNameRef.containsKey(snapshotTable)) {
                     if (needRefreshTablePartitionNames == null) {
                         needRefreshTablePartitionNames = Sets.newHashSet();
                     }
                     // The table in this map has related partition with mv
                     // It's ok to add empty set for a table, means no partition corresponding to this mv partition
-                    needRefreshTablePartitionNames.addAll(mvToBaseNameRef.get(table));
+                    needRefreshTablePartitionNames.addAll(mvToBaseNameRef.get(snapshotTable));
+                } else {
+                    LOG.warn("MV {}'s refTable {} is not found in `mvRefBaseTableIntersectedPartitions`",
+                            materializedView.getName(), snapshotTable.getName());
                 }
             }
-            //TODO: (choury) why not add all partitions of table?
             if (needRefreshTablePartitionNames != null) {
-                refTableAndPartitionNames.put(table, needRefreshTablePartitionNames);
+                refTableAndPartitionNames.put(snapshotInfo, needRefreshTablePartitionNames);
             }
         }
         return refTableAndPartitionNames;
@@ -1726,20 +1775,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     /**
      * Return all non-ref base table and refreshed partitions.
      */
-    private Map<Table, Set<String>> getNonRefTableRefreshPartitions() {
-        Map<Table, Set<String>> tableNamePartitionNames = Maps.newHashMap();
+    private Map<TableSnapshotInfo, Set<String>> getNonRefTableRefreshPartitions() {
+        Map<TableSnapshotInfo, Set<String>> tableNamePartitionNames = Maps.newHashMap();
         Map<Table, Map<String, Set<String>>> baseTableToMvNameRefs = mvContext.getRefBaseTableMVIntersectedPartitions();
-        for (Pair<BaseTableInfo, Table> tablePair : snapshotBaseTables.values()) {
-            Table table = tablePair.second;
+        for (TableSnapshotInfo snapshotInfo : snapshotBaseTables.values()) {
+            Table table = snapshotInfo.getBaseTable();
             if (baseTableToMvNameRefs != null && baseTableToMvNameRefs.containsKey(table)) {
                 // do nothing
             } else {
                 if (table.isNativeTableOrMaterializedView()) {
-                    tableNamePartitionNames.put(table, ((OlapTable) table).getVisiblePartitionNames());
+                    tableNamePartitionNames.put(snapshotInfo, ((OlapTable) table).getVisiblePartitionNames());
                 } else if (table.isView()) {
                     // do nothing
                 } else {
-                    tableNamePartitionNames.put(table, Sets.newHashSet(PartitionUtil.getPartitionNames(table)));
+                    tableNamePartitionNames.put(snapshotInfo, Sets.newHashSet(PartitionUtil.getPartitionNames(table)));
                 }
             }
         }
@@ -1747,90 +1796,55 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     /**
-     * Collect base olap tables and its partition infos based on refreshed table infos.
-     *
-     * @param baseTableAndPartitionNames : refreshed base table and its partition names mapping.
-     * @return
+     * Collect base table and its refreshed partition infos based on refreshed table infos.
      */
-    private Map<Long, Map<String, MaterializedView.BasePartitionInfo>> getSelectedPartitionInfosOfOlapTable(
-            Map<Table, Set<String>> baseTableAndPartitionNames) {
-        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> changedOlapTablePartitionInfos = Maps.newHashMap();
-        for (Map.Entry<Table, Set<String>> entry : baseTableAndPartitionNames.entrySet()) {
-            if (entry.getKey().isNativeTableOrMaterializedView()) {
-                Map<String, MaterializedView.BasePartitionInfo> partitionInfos = Maps.newHashMap();
-                OlapTable olapTable = (OlapTable) entry.getKey();
-                for (String partitionName : entry.getValue()) {
-                    Partition partition = olapTable.getPartition(partitionName);
-                    MaterializedView.BasePartitionInfo basePartitionInfo = new MaterializedView.BasePartitionInfo(
-                            partition.getId(), partition.getVisibleVersion(), partition.getVisibleVersionTime());
-                    partitionInfos.put(partition.getName(), basePartitionInfo);
-                }
-                changedOlapTablePartitionInfos.put(olapTable.getId(), partitionInfos);
+    private Map<String, MaterializedView.BasePartitionInfo> getRefreshedPartitionInfos(
+            TableSnapshotInfo snapshotInfo, Set<String> refreshedPartitionNames) {
+        Table baseTable = snapshotInfo.getBaseTable();
+        BaseTableInfo baseTableInfo = snapshotInfo.getBaseTableInfo();
+        if (baseTable.isNativeTableOrMaterializedView()) {
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfos = Maps.newHashMap();
+            OlapTable olapTable = (OlapTable) baseTable;
+            for (String partitionName : refreshedPartitionNames) {
+                Partition partition = olapTable.getPartition(partitionName);
+                MaterializedView.BasePartitionInfo basePartitionInfo = new MaterializedView.BasePartitionInfo(
+                        partition.getId(), partition.getVisibleVersion(), partition.getVisibleVersionTime());
+                partitionInfos.put(partition.getName(), basePartitionInfo);
             }
+            return partitionInfos;
+        } else if (baseTable.isHiveTable()) {
+            HiveTable hiveTable = (HiveTable) baseTable;
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfos =
+                    getSelectedPartitionInfos(hiveTable, Lists.newArrayList(refreshedPartitionNames),
+                            baseTableInfo);
+            return partitionInfos;
+        } else if (baseTable.isJDBCTable()) {
+            JDBCTable jdbcTable = (JDBCTable) baseTable;
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfos =
+                    getSelectedPartitionInfos(jdbcTable, Lists.newArrayList(refreshedPartitionNames),
+                            baseTableInfo);
+            return partitionInfos;
+        } else if (baseTable.isIcebergTable()) {
+            // first record the changed partition infos, it needs to use this these partition infos to check if
+            // the partition has been deal with. the task has PARTITION_START/PARTITION_END properties, could
+            // refresh partial partitions.
+            long refreshSnapshotTime = snapshotInfo.getRefreshSnapshotTime();
+            Map<String, MaterializedView.BasePartitionInfo> partitionInfos = refreshedPartitionNames
+                    .stream().
+                    collect(Collectors.toMap(partitionName ->
+                                    partitionName, partitionName ->
+                            new MaterializedView.BasePartitionInfo(-1, refreshSnapshotTime, refreshSnapshotTime)));
+            // add ALL partition info, use this partition info to check if any partition has been updated.
+            partitionInfos.put(ICEBERG_ALL_PARTITION, new MaterializedView.BasePartitionInfo(-1,
+                    refreshSnapshotTime, refreshSnapshotTime));
+            return partitionInfos;
+        } else {
+            // FIXME: base table does not support partition-level refresh and does not update the meta
+            //  in materialized view.
+            LOG.warn("Refresh materialized view {} with non-supported-partition-level refresh base table {}",
+                    materializedView.getName(), baseTable.getName());
+            return Maps.newHashMap();
         }
-        return changedOlapTablePartitionInfos;
-    }
-
-    /**
-     * Collect base hive tables and its partition infos based on refreshed table infos.
-     *
-     * @param baseTableAndPartitionNames : refreshed base table and its partition names mapping.
-     * @return
-     */
-    private Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> getSelectedPartitionInfosOfExternalTable(
-            Map<Table, Set<String>> baseTableAndPartitionNames) {
-        Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> changedOlapTablePartitionInfos =
-                Maps.newHashMap();
-        for (Map.Entry<Table, Set<String>> entry : baseTableAndPartitionNames.entrySet()) {
-            if (entry.getKey().isHiveTable()) {
-                HiveTable hiveTable = (HiveTable) entry.getKey();
-                Optional<BaseTableInfo> baseTableInfoOptional = materializedView.getBaseTableInfos().stream().filter(
-                                baseTableInfo -> baseTableInfo.getTableIdentifier().equals(hiveTable.getTableIdentifier())).
-                        findAny();
-                if (!baseTableInfoOptional.isPresent()) {
-                    continue;
-                }
-                BaseTableInfo baseTableInfo = baseTableInfoOptional.get();
-                Map<String, MaterializedView.BasePartitionInfo> partitionInfos =
-                        getSelectedPartitionInfos(hiveTable, Lists.newArrayList(entry.getValue()),
-                                baseTableInfo);
-                changedOlapTablePartitionInfos.put(baseTableInfo, partitionInfos);
-            } else if (entry.getKey().isJDBCTable()) {
-                JDBCTable jdbcTable = (JDBCTable) entry.getKey();
-                Optional<BaseTableInfo> baseTableInfoOptional = materializedView.getBaseTableInfos().stream().filter(
-                                baseTableInfo -> baseTableInfo.getTableIdentifier().equals(jdbcTable.getTableIdentifier())).
-                        findAny();
-                if (!baseTableInfoOptional.isPresent()) {
-                    continue;
-                }
-                BaseTableInfo baseTableInfo = baseTableInfoOptional.get();
-                Map<String, MaterializedView.BasePartitionInfo> partitionInfos =
-                        getSelectedPartitionInfos(jdbcTable, Lists.newArrayList(entry.getValue()),
-                                baseTableInfo);
-                changedOlapTablePartitionInfos.put(baseTableInfo, partitionInfos);
-            } else if (entry.getKey().isIcebergTable()) {
-                IcebergTable icebergTable = (IcebergTable) entry.getKey();
-                Optional<BaseTableInfo> baseTableInfoOptional = materializedView.getBaseTableInfos().stream().filter(
-                                baseTableInfo -> baseTableInfo.getTableIdentifier().equals(icebergTable.getTableIdentifier())).
-                        findAny();
-                if (!baseTableInfoOptional.isPresent()) {
-                    continue;
-                }
-                BaseTableInfo baseTableInfo = baseTableInfoOptional.get();
-                // first record the changed partition infos, it needs to use this these partition infos to check if
-                // the partition has been deal with. the task has PARTITION_START/PARTITION_END properties, could
-                // refresh partial partitions.
-                Map<String, MaterializedView.BasePartitionInfo> partitionInfos = entry.getValue().stream().collect(
-                        Collectors.toMap(partitionName -> partitionName,
-                                partitionName -> new MaterializedView.BasePartitionInfo(-1,
-                                        icebergTable.getRefreshSnapshotTime(), icebergTable.getRefreshSnapshotTime())));
-                // add ALL partition info, use this partition info to check if the partition has been updated.
-                partitionInfos.put(ICEBERG_ALL_PARTITION, new MaterializedView.BasePartitionInfo(-1,
-                        icebergTable.getRefreshSnapshotTime(), icebergTable.getRefreshSnapshotTime()));
-                changedOlapTablePartitionInfos.put(baseTableInfo, partitionInfos);
-            }
-        }
-        return changedOlapTablePartitionInfos;
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.scheduler;
+
+import com.google.common.collect.Maps;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.Table;
+
+import java.util.Map;
+
+/**
+ * `TableSnapshotInfo` represents a snapshot of the base table of materialized view.
+ *  To avoid changes of the base table during mv's refresh period, collect base tables' snapshot info before refresh
+ *  and use those to update refreshed meta of base tables after refresh finished.
+ */
+public class TableSnapshotInfo {
+    private final BaseTableInfo baseTableInfo;
+    private final Table baseTable;
+
+    // used for iceberg table
+    private final long refreshSnapshotTime;
+
+    // partition's base info to be used in `updateMeta`
+    Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos = Maps.newHashMap();
+
+    public TableSnapshotInfo(BaseTableInfo baseTableInfo, Table baseTable, long refreshSnapshotTime) {
+        this.baseTableInfo = baseTableInfo;
+        this.baseTable = baseTable;
+        this.refreshSnapshotTime = refreshSnapshotTime;
+    }
+
+    public BaseTableInfo getBaseTableInfo() {
+        return baseTableInfo;
+    }
+
+    public Table getBaseTable() {
+        return baseTable;
+    }
+
+    public long getRefreshSnapshotTime() {
+        return refreshSnapshotTime;
+    }
+
+    public Map<String, MaterializedView.BasePartitionInfo> getRefreshedPartitionInfos() {
+        return refreshedPartitionInfos;
+    }
+
+    public void setRefreshedPartitionInfos(Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos) {
+        this.refreshedPartitionInfos = refreshedPartitionInfos;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -115,7 +115,7 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
             // 1. check whether to need compensate or not
             // 2. `queryPredicateSplit` is different for each materialized view, so we can not cache it anymore.
             boolean isCompensatePartitionPredicate = MvUtils.isNeedCompensatePartitionPredicate(queryExpression, mvContext);
-            PredicateSplit queryPredicateSplit = getQuerySplitPredicate(context, queryExpression, queryColumnRefFactory,
+            PredicateSplit queryPredicateSplit = getQuerySplitPredicate(mvContext, queryExpression, queryColumnRefFactory,
                     queryColumnRefRewriter, isCompensatePartitionPredicate);
             if (queryPredicateSplit == null) {
                 continue;
@@ -158,17 +158,17 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
      * eg: for sync mv without partition columns, we always no need compensate partition predicates because
      * mv and the base table are always synced.
      */
-    private PredicateSplit getQuerySplitPredicate(OptimizerContext context,
+    private PredicateSplit getQuerySplitPredicate(MaterializationContext mvContext,
                                                   OptExpression queryExpression,
                                                   ColumnRefFactory queryColumnRefFactory,
                                                   ReplaceColumnRefRewriter queryColumnRefRewriter,
                                                   boolean isCompensate) {
         // sync mv always has the same partition with
         // Compensate partition predicates and add them into query predicate.
-        final ScalarOperator queryPartitionPredicate =
-                MvUtils.compensatePartitionPredicate(queryExpression, queryColumnRefFactory, isCompensate);
+        final ScalarOperator queryPartitionPredicate = MvUtils.compensatePartitionPredicate(
+                queryExpression, queryColumnRefFactory, isCompensate);
         if (queryPartitionPredicate == null) {
-            logMVRewrite(context, this, "Compensate query expression's partition predicates " +
+            logMVRewrite(mvContext.getOptimizerContext(), this, "Compensate query expression's partition predicates " +
                     "from pruned partitions failed.");
             return null;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/MVRefreshTestBase.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -109,4 +110,8 @@ public class MVRefreshTestBase {
     public static void tearDown() throws Exception {
     }
 
+    public void executeInsertSql(ConnectContext connectContext, String sql) throws Exception {
+        connectContext.setQueryId(UUIDUtil.genUUID());
+        new StmtExecutor(connectContext, sql).execute();
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -28,7 +28,6 @@ import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
-import com.starrocks.common.Pair;
 import com.starrocks.common.io.DeepCopy;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.UUIDUtil;
@@ -63,6 +62,8 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -79,6 +80,7 @@ import static com.starrocks.scheduler.TaskRun.PARTITION_END;
 import static com.starrocks.scheduler.TaskRun.PARTITION_START;
 import static com.starrocks.sql.plan.PlanTestBase.cleanupEphemeralMVs;
 
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
     @BeforeClass
@@ -375,11 +377,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
     private static void initAndExecuteTaskRun(TaskRun taskRun) throws Exception {
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
-    }
-
-    private static void executeInsertSql(ConnectContext ctx, String insertSql) throws Exception {
-        ctx.setQueryId(UUIDUtil.genUUID());
-        new StmtExecutor(ctx, insertSql).execute();
     }
 
     @Test
@@ -1699,8 +1696,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         // mv need refresh with base table partition p1, p1 renamed with p10 after collect and before insert overwrite
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
-            private Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
-                Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
+            private Map<Long, TableSnapshotInfo> collectBaseTableSnapshotInfos(MaterializedView materializedView) {
+                Map<Long, TableSnapshotInfo> olapTables = Maps.newHashMap();
                 List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
 
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {
@@ -1721,7 +1718,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), Pair.create(baseTableInfo, copied));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
                 }
 
                 String renamePartitionSql = "ALTER TABLE test.tbl1 RENAME PARTITION p1 p1_1";
@@ -1751,8 +1748,9 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
-            public Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
-                Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
+            public Map<Long, TableSnapshotInfo> collectBaseTableSnapshotInfos(
+                    MaterializedView materializedView) {
+                Map<Long, TableSnapshotInfo> olapTables = Maps.newHashMap();
                 List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {
                     if (!baseTableInfo.getTable().isOlapTable()) {
@@ -1772,7 +1770,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), Pair.create(baseTableInfo, olapTable));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, olapTable, -1));
                 }
 
                 try {
@@ -1811,8 +1809,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
-            public Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
-                Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
+            public Map<Long, TableSnapshotInfo> collectBaseTableSnapshotInfos(MaterializedView materializedView) {
+                Map<Long, TableSnapshotInfo> olapTables = Maps.newHashMap();
                 List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {
                     if (!baseTableInfo.getTable().isOlapTable()) {
@@ -1832,7 +1830,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), Pair.create(baseTableInfo, copied));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
                 }
 
                 String addPartitionSql =
@@ -1910,8 +1908,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         OlapTable tbl1 = ((OlapTable) testDb.getTable("tbl1"));
         new MockUp<PartitionBasedMvRefreshProcessor>() {
             @Mock
-            private Map<Long, Pair<BaseTableInfo, Table>> collectBaseTables(MaterializedView materializedView) {
-                Map<Long, Pair<BaseTableInfo, Table>> olapTables = Maps.newHashMap();
+            private Map<Long, TableSnapshotInfo> collectBaseTableSnapshotInfos(MaterializedView materializedView) {
+                Map<Long, TableSnapshotInfo> olapTables = Maps.newHashMap();
                 List<BaseTableInfo> baseTableInfos = materializedView.getBaseTableInfos();
                 for (BaseTableInfo baseTableInfo : baseTableInfos) {
                     if (!baseTableInfo.getTable().isOlapTable()) {
@@ -1931,7 +1929,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), Pair.create(baseTableInfo, copied));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
                 }
 
                 String dropPartitionSql = "ALTER TABLE test.tbl1 DROP PARTITION p4";
@@ -2890,19 +2888,26 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         starRocksAssert.dropMaterializedView(mvName);
     }
 
+    private Map<Table, Set<String>> getRefTableRefreshedPartitions(PartitionBasedMvRefreshProcessor processor) {
+        Map<TableSnapshotInfo, Set<String>> baseTables = processor
+                .getRefTableRefreshPartitions(Sets.newHashSet("p20220101"));
+        Assert.assertEquals(2, baseTables.size());
+        return baseTables.entrySet().stream().collect(Collectors.toMap(x -> x.getKey().getBaseTable(), x -> x.getValue()));
+    }
+
     @Test
-    public void testFilterPartitionByJoinPredicate() throws Exception {
+    public void testFilterPartitionByJoinPredicate1() throws Exception {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         //normal case, join predicate is partition column
         // a.k1 = date_trunc(month, b.k1)
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by k1 \n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '10000')" +
-                "refresh manual\n" +
-                "as select a.k1, b.k2 from test.tbl15 as a join test.tbl16 as b " +
-                "on a.k1 = date_trunc('month', b.k1);");
+                        "partition by k1 \n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '10000')" +
+                        "refresh manual\n" +
+                        "as select a.k1, b.k2 from test.tbl15 as a join test.tbl16 as b " +
+                        "on a.k1 = date_trunc('month', b.k1);");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(2, materializedView.getPartitionExprMaps().size());
 
@@ -2911,7 +2916,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
-        Map<Table, Set<String>> baseTables = processor.getRefTableRefreshPartitions(Sets.newHashSet("p20220101"));
+        Map<Table, Set<String>> baseTables = getRefTableRefreshedPartitions(processor);
         Assert.assertEquals(2, baseTables.size());
         Assert.assertEquals(Sets.newHashSet("p20220101"), baseTables.get(testDb.getTable("tbl15")));
         Assert.assertEquals(Sets.newHashSet("p20220101", "p20220102", "p20220103"), baseTables.get(testDb.getTable("tbl16")));
@@ -2924,176 +2929,227 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Assert.assertEquals("{tbl15=[p20220201], tbl16=[p20220202, p20220201]}",
                 processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
 
+    @Test
+    public void testFilterPartitionByJoinPredicate3() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         // join predicate has no equal condition
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by k1 \n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '10000')" +
-                "refresh manual\n" +
-                "as select tbl1.k1, tbl2.k2 from tbl1  join tbl2 on tbl1.k1 = tbl2.k1 or tbl1.k2 = tbl2.k2;");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+                        "partition by k1 \n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '10000')" +
+                        "refresh manual\n" +
+                        "as select tbl1.k1, tbl2.k2 from tbl1  join tbl2 on tbl1.k1 = tbl2.k1 or tbl1.k2 = tbl2.k2;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
-        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-        taskRun = TaskRunBuilder.newBuilder(task).build();
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
 
-        new StmtExecutor(connectContext, "insert into tbl1 partition(p2) values('2022-02-02', 3, 10);").execute();
-        taskRun.executeTaskRun();
-        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
-        Assert.assertEquals(Sets.newHashSet("p2"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-        Assert.assertEquals("{tbl1=[p2]}",
-                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        {
+            executeInsertSql(connectContext, "insert into tbl1 partition(p2) values('2022-02-02', 3, 10);");
+            taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+            taskRun.executeTaskRun();
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+            Assert.assertEquals(Sets.newHashSet("p2"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+            ExecPlan execPlan = processor.getMvContext().getExecPlan();
+            Assert.assertTrue(execPlan != null);
+            Assert.assertEquals("{tbl1=[p2]}",
+                    processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        }
 
-        new StmtExecutor(connectContext, "insert into tbl2 partition(p2) values('2022-02-02', 3, 10);").execute();
-        taskRun.executeTaskRun();
-        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
-        ExecPlan execPlan = processor.getMvContext().getExecPlan();
-        assertPlanContains(execPlan, "partitions=5/5\n     rollup: tbl1", "partitions=2/2\n     rollup: tbl2");
-        starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+        {
+            executeInsertSql(connectContext, "insert into tbl2 partition(p2) values('2022-02-02', 3, 10);");
+            taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
+            taskRun.executeTaskRun();
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+            ExecPlan execPlan = processor.getMvContext().getExecPlan();
+            Assert.assertTrue(execPlan != null);
+            assertPlanContains(execPlan, "partitions=5/5\n     rollup: tbl1", "partitions=2/2\n     rollup: tbl2");
+            starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+        }
+    }
 
+    @Test
+    public void testFilterPartitionByJoinPredicate31() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         // join predicate is not mv partition expr
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by date_trunc('month',k1) \n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '100')" +
-                "refresh manual\n" +
-                "as select tbl1.k1, tbl2.k2 from tbl1  join tbl2 using(k1);");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+                        "partition by date_trunc('month',k1) \n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '100')" +
+                        "refresh manual\n" +
+                        "as select tbl1.k1, tbl2.k2 from tbl1  join tbl2 using(k1);");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
 
-
+    @Test
+    public void testFilterPartitionByJoinPredicate4() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         // nest table alias join
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by date_trunc('month', k1) \n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "refresh manual\n" +
-                "as select a.k1, b.k2 from test.tbl15 as a join test.tbl16 as b " +
-                "on date_trunc('month', a.k1) = b.k1;");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+                        "partition by date_trunc('month', k1) \n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "refresh manual\n" +
+                        "as select a.k1, b.k2 from test.tbl15 as a join test.tbl16 as b " +
+                        "on date_trunc('month', a.k1) = b.k1;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(2, materializedView.getPartitionExprMaps().size());
-        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-        taskRun = TaskRunBuilder.newBuilder(task).build();
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
 
         new StmtExecutor(connectContext, "insert into tbl15 partition(p20220202) values('2022-02-02', 3, 10);").execute();
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         Assert.assertEquals(Sets.newHashSet("p202202_202203"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
         Assert.assertEquals("{tbl15=[p20220202, p20220201], tbl16=[p20220202, p20220201]}",
                 processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
 
+    @Test
+    public void testFilterPartitionByJoinPredicate5() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         // nest table alias join
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by k1\n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '100')" +
-                "refresh manual\n" +
-                "as select a.ds as k1, a.k2 from" +
-                "(select date_trunc('DAY', k1) as ds, k1, k2 from (select k1, k2 from (select * from tbl1)t1 )t2 ) a left join " +
-                "(select date_trunc('DAY', k1) as ds, k2 from (select * from tbl2)t ) b " +
-                "on date_trunc('DAY', a.k1) = b.ds and a.k2 = b.k2 left join " +
-                "(select date_trunc('DAY', k1) as ds, k2 from tbl15) c " +
-                "on a.k2 = c.k2 and a.ds = c.ds;");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+                        "partition by k1\n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '100')" +
+                        "refresh manual\n" +
+                        "as select a.ds as k1, a.k2 from" +
+                        "(select date_trunc('DAY', k1) as ds, k1, k2 from (select k1, k2 from " +
+                        "(select * from tbl1)t1 )t2 ) a left join " +
+                        "(select date_trunc('DAY', k1) as ds, k2 from (select * from tbl2)t ) b " +
+                        "on date_trunc('DAY', a.k1) = b.ds and a.k2 = b.k2 left join " +
+                        "(select date_trunc('DAY', k1) as ds, k2 from tbl15) c " +
+                        "on a.k2 = c.k2 and a.ds = c.ds;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(3, materializedView.getPartitionExprMaps().size());
-        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-        taskRun = TaskRunBuilder.newBuilder(task).build();
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
 
-        new StmtExecutor(connectContext, "insert into tbl2 partition(p1) values('2022-01-02', 3, 10);").execute();
+        executeInsertSql(connectContext, "insert into tbl2 partition(p1) values('2022-01-02', 3, 10);");
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
         Assert.assertEquals(Sets.newHashSet("p20211201_20220101", "p20220101_20220201"),
                 processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-        Assert.assertEquals("{tbl2=[p1], tbl15=[p20220103, p20220102, p20220101], tbl1=[p0, p1]}",
-                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
+        Map<String, Set<String>> refBasePartitionsToRefreshMap =
+                processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap();
+        Map<String, String> expect = ImmutableMap.of(
+                "tbl1", "[p0, p1_1]",
+                "tbl2", "[p1]",
+                "tbl15", "[p20220101, p20220102, p20220103]"
+        );
+        for (Map.Entry<String, Set<String>> e : refBasePartitionsToRefreshMap.entrySet()) {
+            String k = e.getKey();
+            Set<String> v = Sets.newTreeSet(e.getValue());
+            Assert.assertEquals(expect.get(k), v.toString());
+        }
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
 
+    @Test
+    public void testFilterPartitionByJoinPredicate6() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         // nest function in join predicate
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by k1\n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '100')" +
-                "refresh manual\n" +
-                "as select a.ds as k1, a.k2 from" +
-                "(select date_trunc('day', k1) as ds, k2 from tbl1) a " +
-                "left join " +
-                "(select k1 as ds, k2 from tbl2) b " +
-                "on date_trunc('day', a.ds) = b.ds and a.k2 = b.k2 ;");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+                        "partition by k1\n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '100')" +
+                        "refresh manual\n" +
+                        "as select a.ds as k1, a.k2 from" +
+                        "(select date_trunc('day', k1) as ds, k2 from tbl1) a " +
+                        "left join " +
+                        "(select k1 as ds, k2 from tbl2) b " +
+                        "on date_trunc('day', a.ds) = b.ds and a.k2 = b.k2 ;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
 
+    @Test
+    public void testFilterPartitionByJoinPredicate7() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         // duplicate table join
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by k1\n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '100')" +
-                "refresh manual\n" +
-                "as select a.ds as k1, a.k2 from" +
-                "(select k1 as ds, k2 from tbl1) a left join " +
-                "(select k1 as ds, k2 from tbl2) b " +
-                "on a.ds = b.ds and a.k2 = b.k2 left join " +
-                "(select k1 as ds, k2 from tbl2) c " +
-                "on a.ds = c.ds and a.k2 = c.k2;");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+                        "partition by k1\n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '100')" +
+                        "refresh manual\n" +
+                        "as select a.ds as k1, a.k2 from" +
+                        "(select k1 as ds, k2 from tbl1) a left join " +
+                        "(select k1 as ds, k2 from tbl2) b " +
+                        "on a.ds = b.ds and a.k2 = b.k2 left join " +
+                        "(select k1 as ds, k2 from tbl2) c " +
+                        "on a.ds = c.ds and a.k2 = c.k2;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
 
+    @Test
+    public void testFilterPartitionByJoinPredicate8() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by k1\n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '100')" +
-                "refresh manual\n" +
-                "as select a.ds as k1, a.k2 from" +
-                "(select date_trunc('day', k1) as ds, k2 from tbl1) a " +
-                "left join " +
-                "(select date_trunc('day', k1) as ds, k2 from tbl1) b " +
-                "on a.ds = b.ds and a.k2 = b.k2 " +
-                "left join " +
-                "(select date_trunc('day', k1) as ds, k2 from tbl1) c " +
-                "on a.ds = c.ds;");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+                        "partition by k1\n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '100')" +
+                        "refresh manual\n" +
+                        "as select a.ds as k1, a.k2 from" +
+                        "(select date_trunc('day', k1) as ds, k2 from tbl1) a " +
+                        "left join " +
+                        "(select date_trunc('day', k1) as ds, k2 from tbl1) b " +
+                        "on a.ds = b.ds and a.k2 = b.k2 " +
+                        "left join " +
+                        "(select date_trunc('day', k1) as ds, k2 from tbl1) c " +
+                        "on a.ds = c.ds;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
         Assert.assertEquals(1, materializedView.getPartitionExprMaps().size());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
+    }
 
+    @Test
+    public void testFilterPartitionByJoinPredicate9() throws Exception {
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         // unsupported function in join predicate
         starRocksAssert.useDatabase("test").withMaterializedView(
                 "create materialized view test.mv_join_predicate\n" +
-                "partition by k1\n" +
-                "distributed by hash(k2) buckets 10\n" +
-                "PROPERTIES('partition_refresh_number' = '100')" +
-                "refresh manual\n" +
-                "as select a.ds as k1, a.k2 from" +
-                "(select k1 as ds, k2 from tbl1) a left join " +
-                "(select k1 as ds, k2 from tbl2) b " +
-                "on a.ds = b.ds and a.k2 = b.k2 left join " +
-                "(select date_add(k1, INTERVAL 1 DAY) as ds, k2 from tbl15) c " +
-                "on a.ds = c.ds and a.k2 = c.k2;");
-        materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
-        task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
-        taskRun = TaskRunBuilder.newBuilder(task).build();
+                        "partition by k1\n" +
+                        "distributed by hash(k2) buckets 10\n" +
+                        "PROPERTIES('partition_refresh_number' = '100')" +
+                        "refresh manual\n" +
+                        "as select a.ds as k1, a.k2 from" +
+                        "(select k1 as ds, k2 from tbl1) a left join " +
+                        "(select k1 as ds, k2 from tbl2) b " +
+                        "on a.ds = b.ds and a.k2 = b.k2 left join " +
+                        "(select date_add(k1, INTERVAL 1 DAY) as ds, k2 from tbl15) c " +
+                        "on a.ds = c.ds and a.k2 = c.k2;");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable("mv_join_predicate"));
+        Task task = TaskBuilder.buildMvTask(materializedView, testDb.getFullName());
+        TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
 
-        new StmtExecutor(connectContext, "insert into tbl2 partition(p1) values('2022-01-02', 3, 10);").execute();
+        executeInsertSql(connectContext, "insert into tbl2 partition(p1) values('2022-01-02', 3, 10);");
         taskRun.executeTaskRun();
-        processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
-        Assert.assertEquals(Sets.newHashSet("p0", "p1"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
-        Assert.assertEquals("{tbl2=[p1], tbl1=[p0, p1]}",
+        PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+        Assert.assertEquals(Sets.newHashSet("p0", "p1_1"), processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());
+        Assert.assertEquals("{tbl2=[p1], tbl1=[p0, p1_1]}",
                 processor.getMVTaskRunExtraMessage().getRefBasePartitionsToRefreshMap().toString());
         starRocksAssert.useDatabase("test").dropMaterializedView("mv_join_predicate");
     }
@@ -3119,7 +3175,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
         taskRun.executeTaskRun();
         PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
-        Map<Table, Set<String>> baseTables = processor.getRefTableRefreshPartitions(Sets.newHashSet("p20220101"));
+        Map<Table, Set<String>> baseTables = getRefTableRefreshedPartitions(processor);
         Assert.assertEquals(2, baseTables.size());
         Assert.assertEquals(Sets.newHashSet("p20220101"), baseTables.get(testDb.getTable("tbl15")));
         Assert.assertEquals(Sets.newHashSet("p20220101"), baseTables.get(testDb.getTable("tbl16")));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -82,7 +82,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     partitions=1/1");
         }
 
-        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select a, b, d, count(distinct t1.c)\n" +
                     " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
@@ -154,6 +153,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
         }
         starRocksAssert.dropMaterializedView(mvName);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
     }
 
     @Test
@@ -186,7 +186,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
                     " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
                     " where t1.d='2023-08-01';";
-            String plan = getFragmentPlan(query);
+            String plan = getFragmentPlan(query, "MV");
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
                     "     PREAGGREGATION: ON\n" +
@@ -804,7 +804,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     PREAGGREGATION: ON\n" +
                     "     partitions=1/1");
         }
-        connectContext.getSessionVariable().setFollowerQueryForwardMode("force");
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
                     " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
@@ -853,6 +853,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     rollup: test_mv1");
         }
         starRocksAssert.dropMaterializedView(mvName);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
     }
 
     @Test
@@ -1075,6 +1076,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                         .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
                     " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
@@ -1089,7 +1091,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     PREAGGREGATION: ON\n" +
                     "     partitions=1/1");
         }
-        connectContext.getSessionVariable().setFollowerQueryForwardMode("force");
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
         {
             String query = "select  t1.d, t2.b, t3.c, count(t1.a) " +
                     " from  iceberg0.partitioned_db.part_tbl1 as t1 " +
@@ -1098,7 +1100,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " where t1.d>='2023-08-01' " +
                     " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
@@ -1114,7 +1115,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " where t1.d>='2023-08-01' and t2.b != '' and t2.b is not null " +
                     " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
@@ -1132,7 +1132,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " and t3.c in ('xxx') " +
                     " group by t1.d, t2.b, t3.c;";
             String plan = getFragmentPlan(query);
-            System.out.println(plan);
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "13:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
@@ -1140,6 +1139,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     partitions=1/1\n" +
                     "     rollup: test_mv1");
         }
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView(mvName);
     }
 
@@ -1479,6 +1479,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                         .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         {
             String query = "select t1.a, t2.b, t1.d, count(distinct t1.c)\n" +
                     " from  iceberg0.partitioned_db.part_tbl1 as t1 \n" +
@@ -1650,6 +1651,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                         .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
 
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         {
             String query = "select  t1.d, t2.b, t3.c, bitmap_union(bitmap_hash(t1.a)) " +
                     " from  iceberg0.partitioned_db.part_tbl1 as t1 " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -29,6 +29,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
+import com.starrocks.common.Pair;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -58,6 +59,7 @@ import mockit.Mock;
 import mockit.MockUp;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -335,6 +337,17 @@ public class MvRewriteTestBase {
         String s = UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
                 getExplainString(TExplainLevel.NORMAL);
         return s;
+    }
+
+    public String getFragmentPlan(String sql, String traceModule) throws Exception {
+        Pair<String, Pair<ExecPlan, String>> result =
+                UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);
+        String traceLog = result.first;
+        Pair<ExecPlan, String> execPlanWithQuery = result.second;
+        if (!Strings.isNullOrEmpty(traceLog)) {
+            System.out.println(traceLog);
+        }
+        return execPlanWithQuery.first.getExplainString(TExplainLevel.NORMAL);
     }
 
     public static Table getTable(String dbName, String mvName) {

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -984,7 +984,7 @@ class StarrocksSQLApiLib(object):
         time.sleep(1)
         sql = "explain %s" % (query)
         res = self.execute_sql(sql, True)
-        tools.assert_false(str(res["result"]).find(mv_name) > 0, "assert mv %s is not found" % (mv_name))
+        tools.assert_false(str(res["result"]).find(mv_name) > 0, "assert mv %s is found" % (mv_name))
 
     def wait_alter_table_finish(self, alter_type="COLUMN", off=9):
         """

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
@@ -1,0 +1,117 @@
+-- name: test_mv_iceberg_rewrite
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database db_${uuid0};
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION START ("2023-12-01") END ("2023-12-03") WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt;
+-- result:
+2023-12-02	4000
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt;
+-- result:
+2023-12-03	4002
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+-- result:
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} GROUP BY dt order by dt;
+-- result:
+2023-12-01	4000
+2023-12-02	4000
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+-- result:
+None
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+-- result:
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} GROUP BY dt order by dt;
+-- result:
+2023-12-01	4000
+2023-12-02	4000
+2023-12-03	4002
+2023-12-04	4002
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
@@ -1,0 +1,56 @@
+-- name: test_mv_iceberg_rewrite
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+
+set catalog default_catalog;
+create database db_${uuid0};
+use db_${uuid0};
+
+CREATE MATERIALIZED VIEW test_mv1 PARTITION BY dt 
+REFRESH DEFERRED MANUAL AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+
+-- partial refresh
+REFRESH MATERIALIZED VIEW test_mv1 PARTITION START ("2023-12-01") END ("2023-12-03") WITH SYNC MODE;
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt", "test_mv1")
+function: check_no_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt;
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt;
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} GROUP BY dt order by dt;
+
+-- total refresh
+REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-01' GROUP BY dt", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-02' GROUP BY dt", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt", "test_mv1")
+function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt='2023-12-03' GROUP BY dt", "test_mv1")
+
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
+SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} GROUP BY dt order by dt;


### PR DESCRIPTION
Why I'm doing:

After PR(https://github.com/StarRocks/starrocks/pull/34000), MVs based iceberg table cannot be rewritten. This is because the iceberg table to update meta after refresh success is not the same as the snapshot table.

What I'm doing:
- Don't update IcebergTable's `refreshSnapshotTime ` in query time.
- To avoid changes of the base table during mv's refresh period, collect base tables' snapshot info before refresh and use those to update refreshed meta of base tables after refresh finished.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5056 https://github.com/StarRocks/StarRocksTest/issues/5057


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
