### PR TITLE
[Enhancement] Mask the secret key/access key in CREATE CATALOG statement

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PrintableMap.java
@@ -44,6 +44,8 @@ public class PrintableMap<K, V> {
         SENSITIVE_KEY.add("fs.s3a.secret.key");
         SENSITIVE_KEY.add("aws.s3.access_key");
         SENSITIVE_KEY.add("aws.s3.secret_key");
+        SENSITIVE_KEY.add("aws.glue.access_key");
+        SENSITIVE_KEY.add("aws.glue.secret_key");
         SENSITIVE_KEY.add("fs.oss.accessKeyId");
         SENSITIVE_KEY.add("fs.oss.accessKeySecret");
         SENSITIVE_KEY.add("fs.cosn.userinfo.secretId");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -1266,7 +1266,6 @@ public class AstToStringBuilder {
 
         @Override
         public String visitCreateCatalogStatement(CreateCatalogStmt stmt, Void context) {
-
             StringBuilder sb = new StringBuilder();
             sb.append("CREATE EXTERNAL CATALOG '");
             sb.append(stmt.getCatalogName()).append("' ");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -61,6 +61,7 @@ import com.starrocks.sql.ast.BaseCreateAlterUserStmt;
 import com.starrocks.sql.ast.BaseGrantRevokePrivilegeStmt;
 import com.starrocks.sql.ast.BaseGrantRevokeRoleStmt;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.CreateResourceStmt;
 import com.starrocks.sql.ast.CreateRoutineLoadStmt;
 import com.starrocks.sql.ast.CreateStorageVolumeStmt;
@@ -1260,6 +1261,19 @@ public class AstToStringBuilder {
                         append(new PrintableMap<>(properties, "=", true, false))
                         .append(")");
             }
+            return sb.toString();
+        }
+
+        @Override
+        public String visitCreateCatalogStatement(CreateCatalogStmt stmt, Void context) {
+
+            StringBuilder sb = new StringBuilder();
+            sb.append("CREATE EXTERNAL CATALOG '");
+            sb.append(stmt.getCatalogName()).append("' ");
+            if (stmt.getComment() != null) {
+                sb.append("COMMENT \"").append(stmt.getComment()).append("\" ");
+            }
+            sb.append("PROPERTIES(").append(new PrintableMap<>(stmt.getProperties(), " = ", true, false, true)).append(")");
             return sb.toString();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/CreateCatalogStmt.java
@@ -74,4 +74,9 @@ public class CreateCatalogStmt extends DdlStmt {
         sb.append("PROPERTIES(").append(new PrintableMap<>(properties, " = ", true, false)).append(")");
         return sb.toString();
     }
+
+    @Override
+    public boolean needAuditEncryption() {
+        return true;
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CatalogStmtTest.java
@@ -22,6 +22,7 @@ import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.MetadataMgr;
 import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.analyzer.AstToStringBuilder;
 import com.starrocks.sql.ast.CreateCatalogStmt;
 import com.starrocks.sql.ast.DropCatalogStmt;
 import com.starrocks.sql.ast.StatementBase;
@@ -154,5 +155,26 @@ public class CatalogStmtTest {
         DDLStmtExecutor.execute(dropCatalogStmt_2, connectCtx);
         Assert.assertFalse(catalogMgr.catalogExists("hive_catalog"));
         Assert.assertFalse(connectorMgr.connectorExists("hive_catalog"));
+    }
+
+    @Test
+    public void testToString() {
+        String sql = "CREATE EXTERNAL CATALOG " +
+                "`aauato_test_delta_lake_access_key_catalog` COMMENT 'auto test delta lake access key catalog!@#' " +
+                "PROPERTIES(\"type\" = \"deltalake\",\"aws.s3.region\" = \"us-west-2\"," +
+                "\"hive.metastore.type\" = \"glue\",\"aws.glue.region\" = \"us-west-2\"," +
+                "\"aws.glue.use_instance_profile\" = \"false\",\"aws.glue.access_key\" = \"some_key1\"," +
+                "\"aws.glue.secret_key\" = \"some_key2\",\"aws.s3.use_instance_profile\" = \"false\"" +
+                ",\"aws.s3.access_key\" = \"some_key3\",\"aws.s3.secret_key\" = \"some_key4\");\n";
+        ConnectContext ctx = starRocksAssert.getCtx();
+        CreateCatalogStmt
+                stmt = (CreateCatalogStmt) com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
+        Assert.assertEquals("CREATE EXTERNAL CATALOG 'aauato_test_delta_lake_access_key_catalog' " +
+                "COMMENT \"auto test delta lake access key catalog!@#\" PROPERTIES(\"aws.s3.access_key\"  =  \"***\", " +
+                "\"hive.metastore.type\"  =  \"glue\", \"aws.s3.secret_key\"  =  \"***\", " +
+                "\"aws.glue.secret_key\"  =  \"***\", \"aws.s3.region\"  =  \"us-west-2\", " +
+                "\"aws.glue.use_instance_profile\"  =  \"false\", \"aws.s3.use_instance_profile\"  =  \"false\", " +
+                "\"aws.glue.region\"  =  \"us-west-2\", \"type\"  =  \"deltalake\", " +
+                "\"aws.glue.access_key\"  =  \"***\")", AstToStringBuilder.toString(stmt));
     }
 }


### PR DESCRIPTION
Why I'm doing:
The access key/ secret key of CREATE CATALOG statement is printed in the audit log.
![image](https://github.com/StarRocks/starrocks/assets/16649269/6baa1423-db51-4b70-b5b5-234d025ec4fe)

What I'm doing:
This PR masks the secret key/access key as `***` in the audit log.
```
CREATE EXTERNAL CATALOG 'aauato_test_delta_lake_access_key_catalog' COMMENT "auto test delta lake access key catalog!@#" PROPERTIES("aws.s3.access_key"  =  "***", "hive.metastore.type"  =  "glue", "aws.s3.secret_key"  =  "***", "aws.glue.secret_key"  =  "***", "aws.s3.region"  =  "us-west-2", "aws.glue.use_instance_profile"  =  "false", "aws.s3.use_instance_profile"  =  "false", "aws.glue.region"  =  "us-west-2", "type"  =  "deltalake", "aws.glue.access_key"  =  "***"
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
