### PR TITLE
[Enhancement] add QueryScanBytes to profile header

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -297,6 +297,10 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
                 "QueryCumulativeCpuTime", TUnit::TIME_NS,
                 RuntimeProfile::Counter::create_strategy(TUnit::TIME_NS, TCounterMergeType::SKIP_FIRST_MERGE));
         query_cumulative_cpu->set(query_ctx->cpu_cost());
+        auto* query_scan_bytes = profile->add_counter(
+                "QueryScanBytes", TUnit::BYTES,
+                RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));
+        query_scan_bytes->set(query_ctx->get_scan_bytes());
         auto* query_spill_bytes = profile->add_counter(
                 "QuerySpillBytes", TUnit::BYTES,
                 RuntimeProfile::Counter::create_strategy(TUnit::BYTES, TCounterMergeType::SKIP_FIRST_MERGE));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -324,6 +324,7 @@ public class QueryRuntimeProfile {
         long maxQueryCumulativeCpuTime = 0;
         long maxQueryPeakMemoryUsage = 0;
         long maxQueryExecutionWallTime = 0;
+        long maxQueryScanBytes = 0;
         long maxQuerySpillBytes = 0;
 
         List<RuntimeProfile> newFragmentProfiles = Lists.newArrayList();
@@ -370,6 +371,12 @@ public class QueryRuntimeProfile {
                     maxQueryExecutionWallTime = Math.max(maxQueryExecutionWallTime, toBeRemove.getValue());
                 }
                 instanceProfile.removeCounter("QueryExecutionWallTime");
+
+                toBeRemove = instanceProfile.getCounter("QueryScanBytes");
+                if (toBeRemove != null) {
+                    maxQueryScanBytes = Math.max(maxQueryScanBytes, toBeRemove.getValue());
+                }
+                instanceProfile.removeCounter("QueryScanBytes");
 
                 toBeRemove = instanceProfile.getCounter("QuerySpillBytes");
                 if (toBeRemove != null) {
@@ -500,6 +507,8 @@ public class QueryRuntimeProfile {
         queryCumulativeCpuTime.setValue(maxQueryCumulativeCpuTime);
         Counter queryPeakMemoryUsage = newQueryProfile.addCounter("QueryPeakMemoryUsage", TUnit.BYTES, null);
         queryPeakMemoryUsage.setValue(maxQueryPeakMemoryUsage);
+        Counter queryScanBytes = newQueryProfile.addCounter("QueryScanBytes", TUnit.BYTES, null);
+        queryScanBytes.setValue(maxQueryScanBytes);
         Counter queryExecutionWallTime = newQueryProfile.addCounter("QueryExecutionWallTime", TUnit.TIME_NS, null);
         queryExecutionWallTime.setValue(maxQueryExecutionWallTime);
         Counter querySpillBytes = newQueryProfile.addCounter("QuerySpillBytes", TUnit.BYTES, null);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ExplainAnalyzer.java
@@ -316,7 +316,7 @@ public class ExplainAnalyzer {
     private void appendSummaryInfo() {
         appendSummaryLine("Summary");
 
-        // 1. Brief information
+        // Brief information
         pushIndent(GraphElement.LEAF_METRIC_INDENT);
         if (plan.getFragments().stream()
                 .anyMatch(fragment -> fragment.getSink().instanceOf(OlapTableSink.class))) {
@@ -336,7 +336,7 @@ public class ExplainAnalyzer {
                     " for running; ", NodeState.FINISHED.symbol, " for finished");
         }
 
-        // 2. Time Usage
+        // Time Usage
         appendSummaryLine("TotalTime: ", summaryProfile.containsInfoString(ProfileManager.TOTAL_TIME) ?
                 summaryProfile.getInfoString(ProfileManager.TOTAL_TIME) :
                 summaryProfile.getCounter(ProfileManager.TOTAL_TIME));
@@ -370,17 +370,20 @@ public class ExplainAnalyzer {
         appendSummaryLine("FrontendProfileMergeTime: ", executionProfile.getCounter("FrontendProfileMergeTime"));
         popIndent(); // metric indent
 
-        // 3. Memory Usage
+        // Memory Usage
         appendSummaryLine("QueryPeakMemoryUsage: ", executionProfile.getCounter("QueryPeakMemoryUsage"),
                 ", QueryAllocatedMemoryUsage: ", executionProfile.getCounter("QueryAllocatedMemoryUsage"));
 
-        // 4. Top Cpu Nodes
+        // Query Scan Bytes
+        appendSummaryLine("QueryScanBytes: ", executionProfile.getCounter("QueryScanBytes"));
+
+        // Top Cpu Nodes
         appendCpuTopNodes();
 
-        // 5. Top Memory Nodes
+        // Top Memory Nodes
         appendMemoryNodes();
 
-        // 6. Runtime Progress
+        // Runtime Progress
         if (isRuntimeProfile) {
             long finishedCount = allNodeInfos.values().stream()
                     .filter(nodeInfo -> nodeInfo.state.isFinished())
@@ -391,7 +394,7 @@ public class ExplainAnalyzer {
             }
         }
 
-        // 7. Non default Variables
+        // Non default Variables
         String sessionVariables = summaryProfile.getInfoString("NonDefaultSessionVariables");
         Map<String, SessionVariable.NonDefaultValue> variables = Maps.newTreeMap();
         variables.putAll(SessionVariable.NonDefaultValue.parseFrom(sessionVariables));


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

add QueryScanBytes to profile header

Now the profile 'Execution' section looks like:
```
Execution:
     - Topology: {"rootId":6,"nodes":[{"id":6,"name":"MERGE_EXCHANGE","properties":{"sinkIds":[],"displayMem":true},"children":[5]},{"id":5,"name":"SORT","properties":{"sinkIds":[6],"displayMem":true},"children":[4]},{"id":4,"name":"AGGREGATION","properties":{"displayMem":true},"children":[3]},{"id":3,"name":"EXCHANGE","properties":{"displayMem":true},"children":[2]},{"id":2,"name":"AGGREGATION","properties":{"sinkIds":[3],"displayMem":true},"children":[1]},{"id":1,"name":"PROJECT","properties":{"displayMem":false},"children":[0]},{"id":0,"name":"HDFS_SCAN","properties":{"displayMem":true},"children":[]}]}
     - FrontendProfileMergeTime: 8.977ms
     - QueryAllocatedMemoryUsage: 1.625 GB
     - QueryCumulativeCpuTime: 1s46ms
     - QueryCumulativeNetworkTime: 712.950us
     - QueryCumulativeOperatorTime: 379.269ms
     - QueryCumulativeScanTime: 167.797ms
     - QueryDeallocatedMemoryUsage: 1.624 GB
     - QueryExecutionWallTime: 184.880ms
     - QueryPeakMemoryUsage: 65.510 MB
     - QueryPeakScheduleTime: 8.980ms
     - QueryScanBytes: 65.392 MB
     - QuerySpillBytes: 0.000 B
     - ResultDeliverTime: 0ns
``` 

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
 - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5