### PR TITLE
[Enhancement] more accurate chunk source mem estimation

### DIFF
--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -20,7 +20,6 @@
 #include "io/shared_buffered_input_stream.h"
 #include "util/compression/stream_compression.h"
 
-static constexpr int64_t ROW_FORMAT_ESTIMATED_MEMORY_USAGE = 32LL * 1024 * 1024;
 namespace starrocks {
 
 class CountedSeekableInputStream : public io::SeekableInputStreamWrapper {
@@ -275,11 +274,12 @@ void HdfsScanner::do_update_iceberg_v2_counter(RuntimeProfile* parent_profile, c
 }
 
 int64_t HdfsScanner::estimated_mem_usage() const {
-    if (_shared_buffered_input_stream == nullptr) {
-        // don't read data in columnar format(such as CSV format), usually in a fixed size.
-        return ROW_FORMAT_ESTIMATED_MEMORY_USAGE;
+    if (_shared_buffered_input_stream != nullptr) {
+        int64_t value = _shared_buffered_input_stream->estimated_mem_usage();
+        return value;
     }
-    return _shared_buffered_input_stream->estimated_mem_usage();
+    // return 0 if we don't know estimated memory usage with high confidence.
+    return 0;
 }
 
 void HdfsScanner::update_hdfs_counter(HdfsScanProfile* profile) {

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -303,7 +303,7 @@ public:
     int64_t num_rows_read() const { return _app_stats.num_rows_read; }
     int64_t cpu_time_spent() const { return _total_running_time - _app_stats.io_ns; }
     int64_t io_time_spent() const { return _app_stats.io_ns; }
-    int64_t estimated_mem_usage() const;
+    virtual int64_t estimated_mem_usage() const;
     void set_keep_priority(bool v) { _keep_priority = v; }
     bool keep_priority() const { return _keep_priority; }
     void update_counter();

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -446,10 +446,10 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         }
 
         size_t chunk_size = 0;
-        size_t chunk_size_ori = 0;
+        size_t init_chunk_size = 0;
         if (_orc_reader->get_cvb_size() != 0) {
             chunk_size = _orc_reader->get_cvb_size();
-            chunk_size_ori = chunk_size;
+            init_chunk_size = chunk_size;
             {
                 StatusOr<ChunkPtr> ret;
                 SCOPED_RAW_TIMER(&_app_stats.column_convert_ns);
@@ -505,7 +505,7 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
 
         // if has lazy load fields, skip it if chunk_size == 0
         if (chunk_size == 0) {
-            _app_stats.skip_read_rows += chunk_size_ori;
+            _app_stats.skip_read_rows += init_chunk_size;
             continue;
         }
         {

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -496,4 +496,8 @@ Status HdfsTextScanner::_build_hive_column_name_2_index() {
     return Status::OK();
 }
 
+int64_t HdfsTextScanner::estimated_mem_usage() const {
+    return _reader->buff_capacity() * 2;
+}
+
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -32,6 +32,7 @@ public:
     Status do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk) override;
     Status do_init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
     Status parse_csv(int chunk_size, ChunkPtr* chunk);
+    int64_t estimated_mem_usage() const override;
 
 private:
     // create a reader or re init reader

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -56,11 +56,13 @@ struct ConnectorScanOperatorIOTasksMemLimiter {
         running_chunk_source_count += delta;
     }
 
-    void update_estimated_mem_usage_per_chunk_source(int64_t value) {
+    void update_estimated_mem_usage_per_chunk_source(int64_t value, int64_t return_chunk_mem_bytes) {
         if (value == 0) return;
 
+        VLOG_FILE << "[xxx] update value = " << value << ", chunk = " << return_chunk_mem_bytes;
         std::unique_lock<std::shared_mutex> L(lock);
-        double total = estimated_mem_usage_per_chunk_source * estimated_mem_usage_update_count + value;
+        double total = estimated_mem_usage_per_chunk_source * estimated_mem_usage_update_count + value +
+                       return_chunk_mem_bytes;
         estimated_mem_usage_update_count += 1;
         estimated_mem_usage_per_chunk_source = total / estimated_mem_usage_update_count;
     }
@@ -496,8 +498,8 @@ void ConnectorChunkSource::close(RuntimeState* state) {
 
     ConnectorScanOperatorIOTasksMemLimiter* limiter = _get_io_tasks_mem_limiter();
     limiter->update_running_chunk_source_count(-1);
-    limiter->update_estimated_mem_usage_per_chunk_source(_data_source->estimated_mem_usage());
-
+    limiter->update_estimated_mem_usage_per_chunk_source(_data_source->estimated_mem_usage(),
+                                                         avg_chunk_mem_bytes() * state->chunk_size());
     _closed = true;
     _data_source->close(state);
 }
@@ -583,7 +585,8 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
         P.cs_total_running_time += total_time_ns;
         P.cs_total_io_time += delta_io_time_ns;
         P.cs_total_scan_bytes += delta_scan_bytes;
-        _rows_read += (*chunk)->num_rows();
+        _chunk_rows_read += (*chunk)->num_rows();
+        _chunk_mem_bytes += (*chunk)->memory_usage();
         _chunk_buffer.update_limiter(chunk->get());
         return Status::OK();
     }
@@ -595,6 +598,11 @@ const workgroup::WorkGroupScanSchedEntity* ConnectorChunkSource::_scan_sched_ent
         const workgroup::WorkGroup* wg) const {
     DCHECK(wg != nullptr);
     return wg->connector_scan_sched_entity();
+}
+
+uint64_t ConnectorChunkSource::avg_chunk_mem_bytes() const {
+    if (_chunk_rows_read == 0) return 0;
+    return _chunk_mem_bytes / _chunk_rows_read;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -59,7 +59,6 @@ struct ConnectorScanOperatorIOTasksMemLimiter {
     void update_estimated_mem_usage_per_chunk_source(int64_t value, int64_t return_chunk_mem_bytes) {
         if (value == 0) return;
 
-        VLOG_FILE << "[xxx] update value = " << value << ", chunk = " << return_chunk_mem_bytes;
         std::unique_lock<std::shared_mutex> L(lock);
         double total = estimated_mem_usage_per_chunk_source * estimated_mem_usage_update_count + value +
                        return_chunk_mem_bytes;

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -111,8 +111,10 @@ public:
 
     bool reach_limit() override { return _limit != -1 && _reach_limit.load(); }
 
+    uint64_t avg_chunk_mem_bytes() const;
+
 protected:
-    virtual bool _reach_eof() const { return _limit != -1 && _rows_read >= _limit; }
+    virtual bool _reach_eof() const { return _limit != -1 && _chunk_rows_read >= _limit; }
     Status _open_data_source(RuntimeState* state);
 
     connector::DataSourcePtr _data_source;
@@ -137,7 +139,8 @@ private:
     ChunkPipelineAccumulator _ck_acc;
     bool _opened = false;
     bool _closed = false;
-    uint64_t _rows_read = 0;
+    uint64_t _chunk_rows_read = 0;
+    uint64_t _chunk_mem_bytes = 0;
 };
 
 } // namespace pipeline

--- a/be/src/formats/csv/csv_reader.cpp
+++ b/be/src/formats/csv/csv_reader.cpp
@@ -617,4 +617,8 @@ void CSVReader::split_record(const Record& record, Fields* columns) const {
     }
 }
 
+size_t CSVReader::buff_capacity() const {
+    return _buff.capacity();
+}
+
 } // namespace starrocks

--- a/be/src/formats/csv/csv_reader.h
+++ b/be/src/formats/csv/csv_reader.h
@@ -199,6 +199,8 @@ public:
     // For benchmark, we need to separate io from parsing.
     Status init_buff() { return _fill_buffer(); }
 
+    size_t buff_capacity() const;
+
 protected:
     CSVParseOptions _parse_options;
     size_t _row_delimiter_length;

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -66,8 +66,6 @@ static Status create_hdfs_fs_handle(const std::string& namenode, const std::shar
     const std::map<std::string, std::string> cloud_properties = get_cloud_properties(options);
     if (!cloud_properties.empty()) {
         for (const auto& cloud_property : cloud_properties) {
-            VLOG_FILE << "[xxx] cloud property: key = " << cloud_property.first.data()
-                      << ", value = " << cloud_property.second.data();
             hdfsBuilderConfSetStr(hdfs_builder, cloud_property.first.data(), cloud_property.second.data());
         }
     }

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -263,10 +263,7 @@ void SharedBufferedInputStream::_update_estimated_mem_usage() {
     for (const auto& [_, sb] : _map) {
         mem_usage += sb.size;
     }
-    // in most cases, those data are compressed.
-    // to read it, we need to decompress it, and let's say to add 50% overhead.
-    mem_usage += mem_usage / 2;
-    _estimated_mem_usage = std::max(mem_usage, _estimated_mem_usage);
+    _estimated_mem_usage = std::max(_estimated_mem_usage, mem_usage * 2);
 }
 
 } // namespace starrocks::io

--- a/build.sh
+++ b/build.sh
@@ -470,19 +470,19 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_HOME}/be/output/lib/libmockjvm.so ${STARROCKS_OUTPUT}/be/lib/libjvm.so
     cp -r -p ${STARROCKS_THIRDPARTY}/installed/jemalloc/bin/jeprof ${STARROCKS_OUTPUT}/be/bin
     # format $BUILD_TYPE to lower case
-    ibuildtype=`echo ${BUILD_TYPE} | tr 'A-Z' 'a-z'`
-    if [ "${ibuildtype}" == "release" ] ; then
-        pushd ${STARROCKS_OUTPUT}/be/lib/ &>/dev/null
-        BE_BIN=starrocks_be
-        BE_BIN_DEBUGINFO=starrocks_be.debuginfo
-        echo "Split $BE_BIN debug symbol to $BE_BIN_DEBUGINFO ..."
-        # strip be binary
-        # if eu-strip is available, can replace following three lines into `eu-strip -g -f starrocks_be.debuginfo starrocks_be`
-        objcopy --only-keep-debug $BE_BIN $BE_BIN_DEBUGINFO
-        strip --strip-debug $BE_BIN
-        objcopy --add-gnu-debuglink=$BE_BIN_DEBUGINFO $BE_BIN
-        popd &>/dev/null
-    fi
+    # ibuildtype=`echo ${BUILD_TYPE} | tr 'A-Z' 'a-z'`
+    # if [ "${ibuildtype}" == "release" ] ; then
+    #     pushd ${STARROCKS_OUTPUT}/be/lib/ &>/dev/null
+    #     BE_BIN=starrocks_be
+    #     BE_BIN_DEBUGINFO=starrocks_be.debuginfo
+    #     echo "Split $BE_BIN debug symbol to $BE_BIN_DEBUGINFO ..."
+    #     # strip be binary
+    #     # if eu-strip is available, can replace following three lines into `eu-strip -g -f starrocks_be.debuginfo starrocks_be`
+    #     objcopy --only-keep-debug $BE_BIN $BE_BIN_DEBUGINFO
+    #     strip --strip-debug $BE_BIN
+    #     objcopy --add-gnu-debuglink=$BE_BIN_DEBUGINFO $BE_BIN
+    #     popd &>/dev/null
+    # fi
     cp -r -p ${STARROCKS_HOME}/be/output/www/* ${STARROCKS_OUTPUT}/be/www/
     cp -r -p ${STARROCKS_HOME}/java-extensions/jdbc-bridge/target/starrocks-jdbc-bridge-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/be/lib/jni-packages
     cp -r -p ${STARROCKS_HOME}/java-extensions/udf-extensions/target/udf-extensions-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/be/lib/jni-packages

--- a/build.sh
+++ b/build.sh
@@ -470,19 +470,19 @@ if [ ${BUILD_BE} -eq 1 ]; then
     cp -r -p ${STARROCKS_HOME}/be/output/lib/libmockjvm.so ${STARROCKS_OUTPUT}/be/lib/libjvm.so
     cp -r -p ${STARROCKS_THIRDPARTY}/installed/jemalloc/bin/jeprof ${STARROCKS_OUTPUT}/be/bin
     # format $BUILD_TYPE to lower case
-    # ibuildtype=`echo ${BUILD_TYPE} | tr 'A-Z' 'a-z'`
-    # if [ "${ibuildtype}" == "release" ] ; then
-    #     pushd ${STARROCKS_OUTPUT}/be/lib/ &>/dev/null
-    #     BE_BIN=starrocks_be
-    #     BE_BIN_DEBUGINFO=starrocks_be.debuginfo
-    #     echo "Split $BE_BIN debug symbol to $BE_BIN_DEBUGINFO ..."
-    #     # strip be binary
-    #     # if eu-strip is available, can replace following three lines into `eu-strip -g -f starrocks_be.debuginfo starrocks_be`
-    #     objcopy --only-keep-debug $BE_BIN $BE_BIN_DEBUGINFO
-    #     strip --strip-debug $BE_BIN
-    #     objcopy --add-gnu-debuglink=$BE_BIN_DEBUGINFO $BE_BIN
-    #     popd &>/dev/null
-    # fi
+    ibuildtype=`echo ${BUILD_TYPE} | tr 'A-Z' 'a-z'`
+    if [ "${ibuildtype}" == "release" ] ; then
+        pushd ${STARROCKS_OUTPUT}/be/lib/ &>/dev/null
+        BE_BIN=starrocks_be
+        BE_BIN_DEBUGINFO=starrocks_be.debuginfo
+        echo "Split $BE_BIN debug symbol to $BE_BIN_DEBUGINFO ..."
+        # strip be binary
+        # if eu-strip is available, can replace following three lines into `eu-strip -g -f starrocks_be.debuginfo starrocks_be`
+        objcopy --only-keep-debug $BE_BIN $BE_BIN_DEBUGINFO
+        strip --strip-debug $BE_BIN
+        objcopy --add-gnu-debuglink=$BE_BIN_DEBUGINFO $BE_BIN
+        popd &>/dev/null
+    fi
     cp -r -p ${STARROCKS_HOME}/be/output/www/* ${STARROCKS_OUTPUT}/be/www/
     cp -r -p ${STARROCKS_HOME}/java-extensions/jdbc-bridge/target/starrocks-jdbc-bridge-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/be/lib/jni-packages
     cp -r -p ${STARROCKS_HOME}/java-extensions/udf-extensions/target/udf-extensions-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/be/lib/jni-packages


### PR DESCRIPTION
> Why I'm doing:

Chunk source mem estimation could be more accurate

> What I'm doing:

strategies are:
1. if hdfs scanner has a shared buffer stream, we use `estimated_mem_usage` of that.
2. for csv scanner, we use csv buffer capacity as memory usage
3. for other scanners, if we are not sure, we'd better to use default estimation.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
