### PR TITLE
[BugFix] Optimize partition compensate strategy for performance(Part1)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2705,6 +2705,12 @@ public class Config extends ConfigBase {
     public static long mv_plan_cache_max_size = 1000;
 
     /**
+     * Max cache key size during query lifecycle to avoid repeating computes.
+     */
+    @ConfField(mutable = true)
+    public static long mv_query_context_cache_max_size = 1000;
+
+    /**
      * Checking the connectivity of port opened by FE,
      * mainly used for checking edit log port currently.
      */

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2704,10 +2704,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long mv_plan_cache_max_size = 1000;
 
-    /**
-     * Max cache key size during query lifecycle to avoid repeating computes.
-     */
-    @ConfField(mutable = true)
+    @ConfField(mutable = true, comment = "Max materialized view rewrite cache size during one query's lifecycle " +
+            "so can avoid repeating compute to reduce optimizer time in materialized view rewrite, " +
+            "but may occupy some extra FE's memory. It's well-done when there are many relative " +
+            "materialized views(>10) or query is complex(multi table joins).")
     public static long mv_query_context_cache_max_size = 1000;
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -435,6 +435,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String NESTED_MV_REWRITE_MAX_LEVEL = "nested_mv_rewrite_max_level";
     public static final String ENABLE_MATERIALIZED_VIEW_REWRITE = "enable_materialized_view_rewrite";
     public static final String ENABLE_MATERIALIZED_VIEW_UNION_REWRITE = "enable_materialized_view_union_rewrite";
+    public static final String ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE =
+            "enable_materialized_view_rewrite_partition_compensate";
 
     public static final String LARGE_DECIMAL_UNDERLYING_TYPE = "large_decimal_underlying_type";
 
@@ -1394,6 +1396,15 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_MATERIALIZED_VIEW_UNION_REWRITE)
     private boolean enableMaterializedViewUnionRewrite = true;
+
+    /**
+     * Whether to compensate partition predicates in mv rewrite, see
+     * <code>Materialization#isCompensatePartitionPredicate</code> for more details.
+     * NOTE: if set it false, it will be rewritten by the mv defined sql with user's query and will add
+     * extra compensated predicates which can rewrite more cases but may lose consistency check.
+     */
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE)
+    private boolean enableMaterializedViewRewritePartitionCompensate = true;
 
     @VarAttr(name = ENABLE_RULE_BASED_MATERIALIZED_VIEW_REWRITE)
     private boolean enableRuleBasedMaterializedViewRewrite = true;
@@ -2739,6 +2750,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setEnableRuleBasedMaterializedViewRewrite(boolean enableRuleBasedMaterializedViewRewrite) {
         this.enableRuleBasedMaterializedViewRewrite = enableRuleBasedMaterializedViewRewrite;
+    }
+
+    public boolean isEnableMaterializedViewRewritePartitionCompensate() {
+        return enableMaterializedViewRewritePartitionCompensate;
+    }
+
+    public void setEnableMaterializedViewRewritePartitionCompensate(boolean enableMaterializedViewRewritePartitionCompensate) {
+        this.enableMaterializedViewRewritePartitionCompensate = enableMaterializedViewRewritePartitionCompensate;
     }
 
     public boolean isEnableMaterializedViewViewDeltaRewrite() {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1400,10 +1400,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     /**
      * Whether to compensate partition predicates in mv rewrite, see
      * <code>Materialization#isCompensatePartitionPredicate</code> for more details.
-     * NOTE: if set it false, it will be rewritten by the mv defined sql with user's query and will add
+     * NOTE: if set it false, it will be rewritten by the mv defined sql with user's query and will not add
      * extra compensated predicates which can rewrite more cases but may lose consistency check.
      */
-    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE)
+    @VarAttr(name = ENABLE_MATERIALIZED_VIEW_REWRITE_PARTITION_COMPENSATE, flag = VariableMgr.INVISIBLE)
     private boolean enableMaterializedViewRewritePartitionCompensate = true;
 
     @VarAttr(name = ENABLE_RULE_BASED_MATERIALIZED_VIEW_REWRITE)

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -103,6 +103,7 @@ import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.common.DmlException;
 import com.starrocks.sql.common.ListPartitionDiff;
 import com.starrocks.sql.common.PartitionDiffer;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.common.RangePartitionDiff;
 import com.starrocks.sql.common.SyncPartitionUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -403,17 +404,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             StatementPlanner.unLock(locker, dbs);
         }
 
-        // add trace info if needed
-        Tracers.log(Tracers.Module.MV,
-                args -> "[TRACE QUERY] MV: " + materializedView.getName() +
-                        "\nMV PartitionsToRefresh: " + String.join(",", (Set<String>) args[0]) +
-                        "\nBase PartitionsToScan:" + refTablePartitionNames +
-                        "\nInsert Plan:\n" +
-                        ((ExecPlan) args[1]).getExplainString(StatementBase.ExplainLevel.VERBOSE),
-                mvToRefreshedPartitions, execPlan);
+        QueryDebugOptions debugOptions = ctx.getSessionVariable().getQueryDebugOptions();
         // log the final mv refresh plan for each refresh for better trace and debug
-        if (LOG.isDebugEnabled()) {
-            LOG.debug("MV Refresh Final Plan" +
+        if (LOG.isDebugEnabled() || debugOptions.isEnableQueryTraceLog()) {
+            LOG.info("MV Refresh Final Plan" +
                             "\nMV: {}" +
                             "\nMV PartitionsToRefresh: {}" +
                             "\nBase PartitionsToScan: {}" +

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
@@ -31,6 +31,9 @@ public class QueryDebugOptions {
     @SerializedName(value = "enableMVEagerUnionAllRewrite")
     private boolean enableMVEagerUnionAllRewrite = false;
 
+    @SerializedName(value = "enableQueryTraceLog")
+    private boolean enableQueryTraceLog = false;
+
     public QueryDebugOptions() {
         // To make unit test more stable, add retry times for refreshing materialized views.
         if (FeConstants.runningUnitTest) {
@@ -60,6 +63,14 @@ public class QueryDebugOptions {
 
     public void setEnableMVEagerUnionAllRewrite(boolean enableMVEagerUnionAllRewrite) {
         this.enableMVEagerUnionAllRewrite = enableMVEagerUnionAllRewrite;
+    }
+
+    public boolean isEnableQueryTraceLog() {
+        return enableQueryTraceLog;
+    }
+
+    public void setEnableQueryTraceLog(boolean enableQueryTraceLog) {
+        this.enableQueryTraceLog = enableQueryTraceLog;
     }
 
     public static QueryDebugOptions getInstance() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -424,18 +424,18 @@ public class MaterializationContext {
      *  means MV's partitions can cover all needed partitions from Query.
      * </p>
      */
-    public boolean isCompensatePartitionPredicate(OptExpression queryExpression) {
+    public boolean getOrInitCompensatePartitionPredicate(OptExpression queryExpression) {
         if (!isCompensatePartitionPredicateOpt.isPresent()) {
             SessionVariable sessionVariable = optimizerContext.getSessionVariable();
             // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
             isCompensatePartitionPredicateOpt = sessionVariable.isEnableMaterializedViewRewritePartitionCompensate() ?
                     MvUtils.isNeedCompensatePartitionPredicate(queryExpression, this) : Optional.of(false);
         }
-        return isCompensatePartitionPredicateOpt.isPresent() ? isCompensatePartitionPredicateOpt.get() : true;
+        return isCompensatePartitionPredicateOpt.orElse(true);
     }
 
     public boolean isCompensatePartitionPredicate() {
-        return isCompensatePartitionPredicateOpt.isPresent() ? isCompensatePartitionPredicateOpt.get() : true;
+        return isCompensatePartitionPredicateOpt.orElse(true);
     }
 
     public ScalarOperator getMVPrunedPartitionPredicate() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MaterializationContext.java
@@ -15,15 +15,20 @@
 package com.starrocks.sql.optimizer;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
+import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
@@ -35,6 +40,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -79,6 +85,18 @@ public class MaterializationContext {
     // in Optimizer Transformation phase but not be really used.
     private long mvUsedCount = 0;
 
+    //// Caches for the mv rewrite lifecycle
+
+    // Cache whether to need to compensate partition predicates or not, and it's not changed
+    // during one query, so it's safe to cache it and be used for each optimizer rule.
+    // But it is different for each materialized view, compensate partition predicate from the plan's
+    // `selectedPartitionIds`, and check `isNeedCompensatePartitionPredicate` to get more information.
+    private Optional<Boolean> isCompensatePartitionPredicateOpt = Optional.empty();
+    // Cache a mv's pruned partition predicates in the rewrite because it's not changed through the context.
+    private Optional<ScalarOperator> mvPrunedPartitionPredicateOpt = Optional.empty();
+    // Cache partition compensates predicates for each ScanNode and isCompensate pair.
+    private Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
+
     public MaterializationContext(OptimizerContext optimizerContext,
                                   MaterializedView mv,
                                   OptExpression mvExpression,
@@ -102,6 +120,7 @@ public class MaterializationContext {
         this.matchedGroups = Lists.newArrayList();
         this.mvPartialPartitionPredicate = mvPartialPartitionPredicate;
         this.refTableUpdatePartitionNames = refTableUpdatePartitionNames;
+        this.scanOpToPartitionCompensatePredicates = Maps.newHashMap();
     }
 
     public MaterializedView getMv() {
@@ -371,4 +390,67 @@ public class MaterializationContext {
         }
     }
 
+    /**
+     * What's the meaning of partition compensate in mv rewriting?
+     * <p>
+     * Because `PartitionPruner` will prune predicates associated with partition columns before mv rewrite,
+     * so we cannot use both current query/mv plan's predicates for rewrite, otherwise it may generate
+     * wrong rewrite results because of loss of pruned predicates.
+     * </p>
+     *
+     * <p>
+     *There are two choices to recover partition predicates from the current pruned plan:
+     *Method 1:
+     *  Because `PartitionPruner` keeps partitions to scan in `selectedPartitionIds` after complex pruning rules,
+     *  so use `selectedPartitionIds` to compensate complete partition ranges with lower and upper bound directly.
+     *
+     * Method 2:
+     *  `PartitionPruner` also will keep original predicates before partition pruning, so we can use original
+     *  pruned partition predicates as the compensated partition predicates directly.
+     *</p>
+     *
+     * <p>
+     * Method1(default) takes advantage of `PartitionPruner`'s prune abilities and deduces a new normalized partition
+     * predicate, but it may generate some redundant or noisy partition predicates to disturb rewriting.
+     *
+     * Method2(preferred) doesn't use the advantage of `PartitionPruner`'s prune abilities and treats query and mv's original
+     * queries to compare/rewrite, and it will simplify the rewrite routine.
+     * And also, MV rewrite's abilities should cover `PartitionPruner` and no use Method1 either.
+     * </p>
+     *
+     * <p>
+     * What's the current strategy to handle this?
+     *  Method1 is used by default to avoid breaking compatibility, but optimize it when MV is no need to compensate which
+     *  means MV's partitions can cover all needed partitions from Query.
+     * </p>
+     */
+    public boolean isCompensatePartitionPredicate(OptExpression queryExpression) {
+        if (!isCompensatePartitionPredicateOpt.isPresent()) {
+            SessionVariable sessionVariable = optimizerContext.getSessionVariable();
+            // only set this when `queryExpression` contains ref table, otherwise the cached value maybe dirty.
+            isCompensatePartitionPredicateOpt = sessionVariable.isEnableMaterializedViewRewritePartitionCompensate() ?
+                    MvUtils.isNeedCompensatePartitionPredicate(queryExpression, this) : Optional.of(false);
+        }
+        return isCompensatePartitionPredicateOpt.isPresent() ? isCompensatePartitionPredicateOpt.get() : true;
+    }
+
+    public boolean isCompensatePartitionPredicate() {
+        return isCompensatePartitionPredicateOpt.isPresent() ? isCompensatePartitionPredicateOpt.get() : true;
+    }
+
+    public ScalarOperator getMVPrunedPartitionPredicate() {
+        if (!mvPrunedPartitionPredicateOpt.isPresent()) {
+            List<ScalarOperator> mvPrunedPartitionPredicates = MvUtils.getMVPrunedPartitionPredicates(mv, mvExpression);
+            if (mvPrunedPartitionPredicates == null || mvPrunedPartitionPredicates.isEmpty()) {
+                mvPrunedPartitionPredicateOpt = Optional.of(ConstantOperator.TRUE);
+            } else {
+                mvPrunedPartitionPredicateOpt = Optional.of(Utils.compoundAnd(mvPrunedPartitionPredicates));
+            }
+        }
+        return mvPrunedPartitionPredicateOpt.get();
+    }
+
+    public Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> getScanOpToPartitionCompensatePredicates() {
+        return scanOpToPartitionCompensatePredicates;
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewriteContext.java
@@ -47,9 +47,6 @@ public class MvRewriteContext {
 
     private List<JoinDeriveContext> joinDeriveContexts;
 
-    // Whether to compensate partition predicate from the plan's `selectedPartitionIds`,
-    // check `isNeedCompensatePartitionPredicate` to get more information.
-    private final boolean isCompensatePartitionPredicate;
 
     public MvRewriteContext(
             MaterializationContext materializationContext,
@@ -58,8 +55,7 @@ public class MvRewriteContext {
             ReplaceColumnRefRewriter queryColumnRefRewriter,
             PredicateSplit queryPredicateSplit,
             List<ScalarOperator> onPredicates,
-            Rule rule,
-            boolean isCompensatePartitionPredicate) {
+            Rule rule) {
         this.materializationContext = materializationContext;
         this.queryTables = queryTables;
         this.queryExpression = queryExpression;
@@ -68,7 +64,6 @@ public class MvRewriteContext {
         this.onPredicates = onPredicates;
         this.rule = rule;
         this.joinDeriveContexts = Lists.newArrayList();
-        this.isCompensatePartitionPredicate = isCompensatePartitionPredicate;
     }
 
     public MaterializationContext getMaterializationContext() {
@@ -121,9 +116,5 @@ public class MvRewriteContext {
 
     public void setEnforcedNonExistedColumns(List<ColumnRefOperator> enforcedNonExistedColumns) {
         this.enforcedNonExistedColumns = enforcedNonExistedColumns;
-    }
-
-    public boolean isCompensatePartitionPredicate() {
-        return this.isCompensatePartitionPredicate;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerContext.java
@@ -68,6 +68,11 @@ public class OptimizerContext {
     // collect LogicalViewScanOperators
     private List<LogicalViewScanOperator> viewScans;
 
+    // QueryMaterializationContext is different from MaterializationContext that it keeps the context during the query
+    // lifecycle instead of per materialized view.
+    // TODO: refactor materialized view's variables/contexts into this.
+    private QueryMaterializationContext queryMaterializationContext;
+
     @VisibleForTesting
     public OptimizerContext(Memo memo, ColumnRefFactory columnRefFactory) {
         this.memo = memo;
@@ -252,5 +257,19 @@ public class OptimizerContext {
 
     public List<LogicalViewScanOperator> getViewScans() {
         return viewScans;
+    }
+
+    public void setQueryMaterializationContext(QueryMaterializationContext queryMaterializationContext) {
+        this.queryMaterializationContext = queryMaterializationContext;
+    }
+
+    public QueryMaterializationContext getQueryMaterializationContext() {
+        return queryMaterializationContext;
+    }
+
+    public void clear() {
+        if (this.queryMaterializationContext != null) {
+            this.queryMaterializationContext.clear();
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/QueryMaterializationContext.java
@@ -1,0 +1,104 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.sql.optimizer;
+
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.starrocks.common.Config;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ReplaceColumnRefRewriter;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
+import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Set;
+
+/**
+ * Store materialized view context during the query lifecycle which is seperated from per materialized view's context.
+ */
+public class QueryMaterializationContext {
+    protected static final Logger LOG = LogManager.getLogger(QueryMaterializationContext.class);
+
+    // Because PredicateSplit's construct is expensive, cache query predicates to its final predicate split per query.
+    // Cache query predicate to its canonized predicate to avoid one predicate's repeat canonized.
+    private final Cache<Object, Object> mvQueryContextCache = Caffeine.newBuilder()
+            .maximumSize(Config.mv_query_context_cache_max_size)
+            .recordStats()
+            .build();
+
+    public QueryMaterializationContext() {
+    }
+
+    public Cache<Object, Object> getMvQueryContextCache() {
+        return mvQueryContextCache;
+    }
+
+    public PredicateSplit getPredicateSplit(Set<ScalarOperator> predicates,
+                                            ReplaceColumnRefRewriter columnRefRewriter) {
+        // Cache predicate split for predicates because it's time costing if there are too many materialized views.
+        Object cached = mvQueryContextCache.getIfPresent(predicates);
+        if (cached != null) {
+            return (PredicateSplit) cached;
+        }
+        ScalarOperator queryPredicate = rewriteOptExprCompoundPredicate(predicates, columnRefRewriter);
+        PredicateSplit predicateSplit = PredicateSplit.splitPredicate(queryPredicate);
+        if (predicateSplit != null) {
+            mvQueryContextCache.put(predicates, predicateSplit);
+        }
+        return predicateSplit;
+    }
+
+    private ScalarOperator rewriteOptExprCompoundPredicate(Set<ScalarOperator> conjuncts,
+                                                           ReplaceColumnRefRewriter columnRefRewriter) {
+        if (conjuncts == null || conjuncts.isEmpty()) {
+            return null;
+        }
+        ScalarOperator compoundPredicate = Utils.compoundAnd(conjuncts);
+        compoundPredicate = columnRefRewriter.rewrite(compoundPredicate.clone());
+        return getCanonizedPredicate(compoundPredicate);
+    }
+
+    public ScalarOperator getCanonizedPredicate(ScalarOperator predicate) {
+        try {
+            return (ScalarOperator) mvQueryContextCache.get(predicate, x -> {
+                ScalarOperator rewritten = new ScalarOperatorRewriter()
+                        .rewrite(predicate.clone(), ScalarOperatorRewriter.MV_SCALAR_REWRITE_RULES);
+                return rewritten;
+            });
+        } catch (NullPointerException e) {
+            return null;
+        } catch (Exception e) {
+            LOG.warn("Canonize predicate for rewrite failed: ", e);
+            return null;
+        }
+    }
+
+    // Invalidate all caches by hand to avoid memory allocation after query optimization.
+    public void clear() {
+        if (ConnectContext.get() != null) {
+            QueryDebugOptions debugOptions = ConnectContext.get().getSessionVariable().getQueryDebugOptions();
+            if (debugOptions.isEnableQueryTraceLog()) {
+                LOG.info("MVQueryContextCache Stats:{}, estimatedSize:{}",
+                        mvQueryContextCache.stats(), mvQueryContextCache.estimatedSize());
+            }
+        }
+        this.mvQueryContextCache.invalidateAll();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Utils.java
@@ -95,7 +95,16 @@ public class Utils {
         return list;
     }
 
-    private static void extractConjunctsImpl(ScalarOperator root, List<ScalarOperator> result) {
+    public static Set<ScalarOperator> extractConjunctSet(ScalarOperator root) {
+        Set<ScalarOperator> list = Sets.newHashSet();
+        if (null == root) {
+            return list;
+        }
+        extractConjunctsImpl(root, list);
+        return list;
+    }
+
+    private static void extractConjunctsImpl(ScalarOperator root, Collection<ScalarOperator> result) {
         if (!OperatorType.COMPOUND.equals(root.getOpType())) {
             result.add(root);
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -54,6 +54,7 @@ import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
 import com.starrocks.sql.optimizer.OptimizerTraceUtil;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -106,6 +107,7 @@ public class MaterializedViewRewriter {
     protected static final Logger LOG = LogManager.getLogger(MaterializedViewRewriter.class);
     protected final MvRewriteContext mvRewriteContext;
     protected final MaterializationContext materializationContext;
+    protected final QueryMaterializationContext queryMaterializationContext;
     protected final OptimizerContext optimizerContext;
     // Mark whether query's plan is rewritten by materialized view.
     public static final String REWRITE_SUCCESS = "Rewrite Succeed";
@@ -136,6 +138,7 @@ public class MaterializedViewRewriter {
         this.mvRewriteContext = mvRewriteContext;
         this.materializationContext = mvRewriteContext.getMaterializationContext();
         this.optimizerContext = materializationContext.getOptimizerContext();
+        this.queryMaterializationContext = optimizerContext.getQueryMaterializationContext();
     }
 
     /**
@@ -208,8 +211,10 @@ public class MaterializedViewRewriter {
         // of a materialized view (MV).
         final ScalarOperator mvJoinOnPredicate = mvJoinOp.getOnPredicate();
         final ScalarOperator queryJoinOnPredicate = queryJoinOp.getOnPredicate();
-        final ScalarOperator normQueryJoinOnPredicate = MvUtils.canonizePredicateForRewrite(queryJoinOnPredicate);
-        final ScalarOperator normMVJoinOnPredicate = MvUtils.canonizePredicateForRewrite(mvJoinOnPredicate);
+        final ScalarOperator normQueryJoinOnPredicate = MvUtils.canonizePredicateForRewrite(queryMaterializationContext,
+                queryJoinOnPredicate);
+        final ScalarOperator normMVJoinOnPredicate = MvUtils.canonizePredicateForRewrite(queryMaterializationContext,
+                mvJoinOnPredicate);
         final Set<ScalarOperator> queryJoinOnPredicates = Sets.newHashSet(Utils.extractConjuncts(normQueryJoinOnPredicate));
         final Set<ScalarOperator> diffPredicates = Sets.newHashSet(Utils.extractConjuncts(normMVJoinOnPredicate));
         if (!checkJoinOnPredicateFromOnPredicates(queryJoinOnPredicates, diffPredicates)) {
@@ -402,14 +407,12 @@ public class MaterializedViewRewriter {
 
     private boolean checkJoinChildPredicate(OptExpression queryExpr, OptExpression mvExpr, int index) {
         // extract the ith child's all conjuncts in query
-        ScalarOperator normalizedQueryPredicate =
-                MvUtils.canonizePredicateForRewrite(Utils.compoundAnd(MvUtils.getAllValidPredicates(queryExpr.inputAt(index))));
-        Set<ScalarOperator> queryPredicates = Sets.newHashSet(Utils.extractConjuncts(normalizedQueryPredicate));
+        Collection<ScalarOperator> queryPredicates = MvUtils.canonizePredicatesForRewrite(queryMaterializationContext,
+                MvUtils.getAllValidPredicates(queryExpr.inputAt(index)));
 
         // extract the ith child's all conjuncts in mv
-        ScalarOperator normalizedMvPredicate =
-                MvUtils.canonizePredicateForRewrite(Utils.compoundAnd(MvUtils.getAllValidPredicates(mvExpr.inputAt(index))));
-        Set<ScalarOperator> mvPredicates = Sets.newHashSet(Utils.extractConjuncts(normalizedMvPredicate));
+        Collection<ScalarOperator> mvPredicates = MvUtils.canonizePredicatesForRewrite(queryMaterializationContext,
+                MvUtils.getAllValidPredicates(mvExpr.inputAt(index)));
 
         if (queryPredicates.isEmpty() && mvPredicates.isEmpty()) {
             return true;
@@ -566,15 +569,15 @@ public class MaterializedViewRewriter {
         final ReplaceColumnRefRewriter mvColumnRefRewriter =
                 MvUtils.getReplaceColumnRefWriter(mvExpression, mvColumnRefFactory);
 
-        final List<ScalarOperator> mvConjuncts = MvUtils.getAllValidPredicates(mvExpression);
+        final Set<ScalarOperator> mvConjuncts = MvUtils.getAllValidPredicates(mvExpression);
         ScalarOperator mvPartitionCompensate = compensateMVPartitionPredicate(mvConjuncts, mvColumnRefRewriter);
         if (mvPartitionCompensate != ConstantOperator.TRUE) {
             mvConjuncts.addAll(MvUtils.getAllValidPredicates(mvPartitionCompensate));
         }
-        ScalarOperator mvPredicate = MvUtils.rewriteOptExprCompoundPredicate(mvConjuncts, mvColumnRefRewriter);
-        final PredicateSplit mvPredicateSplit = PredicateSplit.splitPredicate(mvPredicate);
+        final PredicateSplit mvPredicateSplit =
+                queryMaterializationContext.getPredicateSplit(mvConjuncts, mvColumnRefRewriter);
 
-        logMVRewrite(mvRewriteContext, "\nTry to rewrite query with mv:{}, match mode:{}",
+        logMVRewrite(mvRewriteContext, "Try to rewrite query with mv:{}, match mode:{}",
                 materializationContext.getMv().getName(), matchMode);
         if (matchMode == MatchMode.VIEW_DELTA) {
             return rewriteViewDelta(queryTables, mvTables, mvPredicateSplit, mvColumnRefRewriter,
@@ -591,7 +594,7 @@ public class MaterializedViewRewriter {
      * into materialized view's predicate split. so it can be used for predicate compensate or union all
      * rewrite.
      */
-    private ScalarOperator compensateMVPartitionPredicate(List<ScalarOperator> mvPredicates,
+    private ScalarOperator compensateMVPartitionPredicate(Set<ScalarOperator> mvPredicates,
                                                           ReplaceColumnRefRewriter mvColumnRefRewriter) {
         ScalarOperator mvPrunedPartitionPredicate = getMVCompensatePartitionPredicate();
         if (mvPrunedPartitionPredicate != null) {
@@ -608,11 +611,9 @@ public class MaterializedViewRewriter {
     }
 
     private ScalarOperator getMVCompensatePartitionPredicate() {
-        if (mvRewriteContext.isCompensatePartitionPredicate()) {
-            return materializationContext.getMvPartialPartitionPredicate();
-        } else {
-            return null;
-        }
+        return  materializationContext.isCompensatePartitionPredicate() ?
+                materializationContext.getMvPartialPartitionPredicate() :
+                materializationContext.getMVPrunedPartitionPredicate();
     }
 
     private OptExpression rewriteViewDelta(List<Table> queryTables,
@@ -1130,7 +1131,7 @@ public class MaterializedViewRewriter {
 
     private ScalarOperator collectMvPrunePredicate(MaterializationContext mvContext) {
         final OptExpression mvExpression = mvContext.getMvExpression();
-        final List<ScalarOperator> conjuncts = MvUtils.getAllValidPredicates(mvExpression);
+        final Set<ScalarOperator> conjuncts = MvUtils.getAllValidPredicates(mvExpression);
         final ColumnRefSet mvOutputColumnRefSet = mvExpression.getOutputColumns();
         // conjuncts related to partition and distribution
         final List<ScalarOperator> mvPrunePredicates = Lists.newArrayList();
@@ -1238,7 +1239,7 @@ public class MaterializedViewRewriter {
                 ScalarOperator normalizedPredicate = normalizePredicate(finalCompensationPredicate);
                 // Canonize predicates to make uts more stable.
                 if (optimizerContext.getSessionVariable().getQueryDebugOptions().isEnableNormalizePredicateAfterMVRewrite()) {
-                    normalizedPredicate = MvUtils.canonizePredicateForRewrite(normalizedPredicate);
+                    normalizedPredicate = MvUtils.canonizePredicateForRewrite(queryMaterializationContext, normalizedPredicate);
                 }
                 newScanOpBuilder.setPredicate(normalizedPredicate);
 
@@ -1570,6 +1571,7 @@ public class MaterializedViewRewriter {
             return null;
         }
 
+        logMVRewrite(mvRewriteContext, "Try to pull up query's predicates to make possible for union rewrite");
         // try to pull up query's predicates to make possible for rewrite from mv to query.
         PredicateSplit mvPredicateSplit = rewriteContext.getMvPredicateSplit();
         PredicateSplit queryPredicateSplit = rewriteContext.getQueryPredicateSplit();
@@ -1582,7 +1584,7 @@ public class MaterializedViewRewriter {
         queryPredicates.addAll(Utils.extractConjuncts(queryPredicateSplit.getRangePredicates()));
         queryPredicates.addAll(Utils.extractConjuncts(queryPredicateSplit.getResidualPredicates()));
 
-        List<ScalarOperator> queryOnPredicates = MvUtils.getJoinOnPredicates(rewriteContext.getQueryExpression());
+        Set<ScalarOperator> queryOnPredicates = MvUtils.getJoinOnPredicates(rewriteContext.getQueryExpression());
         ColumnRefSet queryOnPredicateUsedColRefs = Optional.ofNullable(Utils.compoundAnd(queryOnPredicates))
                 .map(x -> x.getUsedColumns())
                 .orElse(new ColumnRefSet());
@@ -1697,6 +1699,8 @@ public class MaterializedViewRewriter {
                         " from view to query, rewrittenFailedPredicates:{}", rewrittenFailedPredicates);
                 return null;
             }
+            logMVRewrite(mvRewriteContext, "Success to rewrite union with extra failed compensate predicates:{}",
+                    rewrittenPair.first);
             mvCompensationPredicates = Utils.compoundAnd(mvCompensationPredicates, rewrittenPair.first);
             queryExpression = rewrittenPair.second;
         }
@@ -1715,6 +1719,8 @@ public class MaterializedViewRewriter {
             logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite MV based on query");
             return null;
         }
+        logMVRewrite(mvRewriteContext, "Success to rewrite union with compensate predicates:{}",
+                mvCompensationPredicates);
 
         // viewBasedRewrite will return the tree of "select a, b from t where a < 10" based on mv expression
         final OptExpression viewInput = viewBasedRewrite(rewriteContext, mvOptExpr);
@@ -1722,7 +1728,6 @@ public class MaterializedViewRewriter {
             logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite query based on MV");
             return null;
         }
-
 
         // Avoid UNION_ALL rule's dead loop, set a bit mask for the new query operator:
         //                 UNION                         UNION
@@ -1889,8 +1894,9 @@ public class MaterializedViewRewriter {
                 Operator.Builder builder = OperatorBuilderFactory.build(optExpression.getOp());
                 builder.withOperator(optExpression.getOp());
                 // builder.setPredicate(Utils.compoundAnd(predicate, optExpression.getOp().getPredicate()));
-                builder.setPredicate(MvUtils.canonizePredicateForRewrite(
-                        Utils.compoundAnd(predicate, optExpression.getOp().getPredicate())));
+                ScalarOperator canonizePredicates = MvUtils.canonizePredicateForRewrite(
+                        queryMaterializationContext, Utils.compoundAnd(predicate, optExpression.getOp().getPredicate()));
+                builder.setPredicate(canonizePredicates);
                 Operator newQueryOp = builder.build();
                 return OptExpression.create(newQueryOp, optExpression.getInputs());
             } else {
@@ -1915,7 +1921,7 @@ public class MaterializedViewRewriter {
         return joinPredicatePushdown.pushdown(predicate);
     }
 
-    private List<ScalarOperator> getPartitionRelatedPredicates(List<ScalarOperator> conjuncts, MaterializedView mv) {
+    private List<ScalarOperator> getPartitionRelatedPredicates(Set<ScalarOperator> conjuncts, MaterializedView mv) {
         PartitionInfo partitionInfo = mv.getPartitionInfo();
         if (!(partitionInfo instanceof ExpressionRangePartitionInfo)) {
             return Lists.newArrayList();
@@ -1942,11 +1948,11 @@ public class MaterializedViewRewriter {
         List<Column> partitionColumns = expressionRangePartitionInfo.getPartitionColumns();
         Preconditions.checkState(partitionColumns.size() == 1);
         ScalarOperator queryPredicate = rewriteContext.getQueryPredicateSplit().toScalarOperator();
-        List<ScalarOperator> queryPredicates = Utils.extractConjuncts(queryPredicate);
+        Set<ScalarOperator> queryPredicates = Utils.extractConjunctSet(queryPredicate);
         List<ScalarOperator> queryPartitionRelatedScalars = getPartitionRelatedPredicates(queryPredicates, mv);
 
         ScalarOperator mvPredicate = rewriteContext.getMvPredicateSplit().toScalarOperator();
-        List<ScalarOperator> mvPredicates = Utils.extractConjuncts(mvPredicate);
+        Set<ScalarOperator> mvPredicates = Utils.extractConjunctSet(mvPredicate);
         List<ScalarOperator> mvPartitionRelatedScalars = getPartitionRelatedPredicates(mvPredicates, mv);
         if (queryPartitionRelatedScalars.isEmpty() && !mvPartitionRelatedScalars.isEmpty()) {
             // when query has no partition related predicates and mv has,
@@ -2175,13 +2181,13 @@ public class MaterializedViewRewriter {
         if (equalPredicates == null) {
             return ec;
         }
-        equalPredicates = MvUtils.canonizePredicateForRewrite(equalPredicates);
+        equalPredicates = MvUtils.canonizePredicateForRewrite(queryMaterializationContext, equalPredicates);
 
         List<ScalarOperator> outerJoinOnPredicate = MvUtils.collectOuterAntiJoinOnPredicate(expression);
         final PredicateSplit outerJoinPredicateSplit = PredicateSplit.splitPredicate(Utils.compoundAnd(outerJoinOnPredicate));
         // should use ReplaceColumnRefRewriter to rewrite outerJoinPredicateSplit to base tables
         ScalarOperator outerJoinEqualPredicates = refRewriter.rewrite(outerJoinPredicateSplit.getEqualPredicates());
-        outerJoinEqualPredicates = MvUtils.canonizePredicateForRewrite(outerJoinEqualPredicates);
+        outerJoinEqualPredicates = MvUtils.canonizePredicateForRewrite(queryMaterializationContext, outerJoinEqualPredicates);
         List<ScalarOperator> outerJoinConjuncts = Utils.extractConjuncts(outerJoinEqualPredicates);
 
         for (ScalarOperator equalPredicate : Utils.extractConjuncts(equalPredicates)) {
@@ -2661,8 +2667,10 @@ public class MaterializedViewRewriter {
         } else {
             Pair<ScalarOperator, ScalarOperator> rewrittenSrcTarget =
                     columnRewriter.rewriteSrcTargetWithEc(srcPu.clone(), targetPu.clone(), isQueryToMV);
-            ScalarOperator canonizedSrcPu = MvUtils.canonizePredicateForRewrite(rewrittenSrcTarget.first);
-            ScalarOperator canonizedTargetPu = MvUtils.canonizePredicateForRewrite(rewrittenSrcTarget.second);
+            ScalarOperator canonizedSrcPu = MvUtils.canonizePredicateForRewrite(
+                    queryMaterializationContext, rewrittenSrcTarget.first);
+            ScalarOperator canonizedTargetPu = MvUtils.canonizePredicateForRewrite(
+                    queryMaterializationContext, rewrittenSrcTarget.second);
 
             if (isRangePredicate) {
                 compensationPu = getCompensationRangePredicate(canonizedSrcPu, canonizedTargetPu);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -1014,9 +1014,8 @@ public class MvUtils {
         }
 
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
-        boolean isCompensatePartition = mvContext.isCompensatePartitionPredicate(queryExpression);
+        boolean isCompensatePartition = mvContext.getOrInitCompensatePartitionPredicate(queryExpression);
         // Compensate partition predicates and add them into query predicate.
-        boolean isPartitionCompensate = mvContext.isCompensatePartitionPredicate();
         Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOperatorScalarOperatorMap =
                 mvContext.getScanOpToPartitionCompensatePredicates();
         for (LogicalScanOperator scanOperator : scanOperators) {
@@ -1024,7 +1023,7 @@ public class MvUtils {
                 continue;
             }
             List<ScalarOperator> partitionPredicate = scanOperatorScalarOperatorMap
-                    .computeIfAbsent(Pair.create(scanOperator, isPartitionCompensate), x -> {
+                    .computeIfAbsent(Pair.create(scanOperator, isCompensatePartition), x -> {
                         return isCompensatePartition ? getCompensatePartitionPredicates(columnRefFactory, scanOperator) :
                                 getScanOpPrunedPartitionPredicates(scanOperator);
                     });

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -69,6 +69,7 @@ import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.Optimizer;
 import com.starrocks.sql.optimizer.OptimizerConfig;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
@@ -76,6 +77,7 @@ import com.starrocks.sql.optimizer.base.PhysicalPropertySet;
 import com.starrocks.sql.optimizer.operator.AggType;
 import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
+import com.starrocks.sql.optimizer.operator.OperatorType;
 import com.starrocks.sql.optimizer.operator.ScanOperatorPredicates;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
@@ -103,7 +105,7 @@ import com.starrocks.sql.optimizer.transformer.RelationTransformer;
 import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.sql.optimizer.transformer.TransformerContext;
 import com.starrocks.sql.parser.ParsingException;
-import org.apache.commons.collections4.ListUtils;
+import org.apache.commons.collections4.SetUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -463,32 +465,25 @@ public class MvUtils {
     }
 
     // get all predicates within and below root
-    public static List<ScalarOperator> getAllValidPredicates(OptExpression root) {
-        List<ScalarOperator> predicates = Lists.newArrayList();
+    public static Set<ScalarOperator> getAllValidPredicates(OptExpression root) {
+        Set<ScalarOperator> predicates = Sets.newHashSet();
         getAllValidPredicates(root, predicates);
         return predicates;
     }
 
-    public static List<ScalarOperator> getAllValidPredicates(ScalarOperator conjunct) {
+    public static Set<ScalarOperator> getAllValidPredicates(ScalarOperator conjunct) {
         if (conjunct == null) {
-            return Lists.newArrayList();
+            return Sets.newHashSet();
         }
         return Utils.extractConjuncts(conjunct).stream().filter(MvUtils::isValidPredicate)
-                .collect(Collectors.toList());
+                .collect(Collectors.toSet());
     }
 
     public static List<ColumnRefOperator> getPredicateColumns(OptExpression root) {
         List<ColumnRefOperator> res = Lists.newArrayList();
-        List<ScalarOperator> predicates = getAllValidPredicates(root);
-        ListUtils.emptyIfNull(predicates).forEach(x -> x.getColumnRefs(res));
+        Set<ScalarOperator> predicates = getAllValidPredicates(root);
+        SetUtils.emptyIfNull(predicates).forEach(x -> x.getColumnRefs(res));
         return res;
-    }
-
-    // get all predicates within and below root
-    public static List<ScalarOperator> getAllPredicates(OptExpression root) {
-        List<ScalarOperator> predicates = Lists.newArrayList();
-        getAllPredicates(root, x -> true, predicates);
-        return predicates;
     }
 
     // If join is not cross/inner join, MV Rewrite must rewrite, otherwise may cause bad results.
@@ -503,13 +498,13 @@ public class MvUtils {
     //select count(1)
     //          from customer left outer join orders on c_custkey = o_custkey
     //          where o_comment not like '%special%requests%';
-    public static List<ScalarOperator> getJoinOnPredicates(OptExpression root) {
-        List<ScalarOperator> predicates = Lists.newArrayList();
+    public static Set<ScalarOperator> getJoinOnPredicates(OptExpression root) {
+        Set<ScalarOperator> predicates = Sets.newHashSet();
         getJoinOnPredicates(root, predicates);
         return predicates;
     }
 
-    private static void getJoinOnPredicates(OptExpression root, List<ScalarOperator> predicates) {
+    private static void getJoinOnPredicates(OptExpression root, Set<ScalarOperator> predicates) {
         Operator operator = root.getOp();
 
         if (operator instanceof LogicalJoinOperator) {
@@ -529,17 +524,6 @@ public class MvUtils {
         }
     }
 
-    public static ScalarOperator rewriteOptExprCompoundPredicate(List<ScalarOperator> conjuncts,
-                                                                 ReplaceColumnRefRewriter columnRefRewriter) {
-        ScalarOperator compoundPredicate = null;
-        if (!conjuncts.isEmpty()) {
-            compoundPredicate = Utils.compoundAnd(conjuncts);
-            compoundPredicate = columnRefRewriter.rewrite(compoundPredicate.clone());
-        }
-        compoundPredicate = MvUtils.canonizePredicateForRewrite(compoundPredicate);
-        return compoundPredicate;
-    }
-
     public static ReplaceColumnRefRewriter getReplaceColumnRefWriter(OptExpression root,
                                                                      ColumnRefFactory columnRefFactory) {
         Map<ColumnRefOperator, ScalarOperator> mvLineage = LineageFactory.getLineage(root, columnRefFactory);
@@ -548,14 +532,14 @@ public class MvUtils {
 
     private static void collectPredicates(List<ScalarOperator> conjuncts,
                                           Function<ScalarOperator, Boolean> supplier,
-                                          List<ScalarOperator> predicates) {
+                                          Set<ScalarOperator> predicates) {
         conjuncts.stream().filter(p -> supplier.apply(p)).forEach(predicates::add);
     }
 
     // push-down predicates are excluded when calculating compensate predicates,
     // because they are derived from equivalence class, the original predicates have be considered
     private static void collectValidPredicates(List<ScalarOperator> conjuncts,
-                                               List<ScalarOperator> predicates) {
+                                               Set<ScalarOperator> predicates) {
         collectPredicates(conjuncts, MvUtils::isValidPredicate, predicates);
     }
 
@@ -572,7 +556,7 @@ public class MvUtils {
      */
     private static void getAllPredicates(OptExpression root,
                                          Function<ScalarOperator, Boolean> supplier,
-                                         List<ScalarOperator> predicates) {
+                                         Set<ScalarOperator> predicates) {
         Operator operator = root.getOp();
 
         // Ignore aggregation predicates, because aggregation predicates should be rewritten after
@@ -597,7 +581,7 @@ public class MvUtils {
      * Get all valid predicates from input opt expression. `valid` predicate means this predicate is not
      * a pushed-down predicate or redundant predicate among others.
      */
-    private static void getAllValidPredicates(OptExpression root, List<ScalarOperator> predicates) {
+    private static void getAllValidPredicates(OptExpression root, Set<ScalarOperator> predicates) {
         getAllPredicates(root, MvUtils::isValidPredicate, predicates);
     }
 
@@ -621,14 +605,25 @@ public class MvUtils {
      * 2. if you need to rewrite src predicate to target predicate, should use `canonizePredicateForRewrite`
      *  both rather than one use `canonizePredicate` or `canonizePredicateForRewrite`.
      */
-    public static ScalarOperator canonizePredicateForRewrite(ScalarOperator predicate) {
+    public static ScalarOperator canonizePredicateForRewrite(QueryMaterializationContext queryMaterializationContext,
+                                                             ScalarOperator predicate) {
         if (predicate == null) {
             return null;
         }
-        // do not change original predicate, clone it here
-        ScalarOperator cloned = predicate.clone();
-        ScalarOperatorRewriter rewrite = new ScalarOperatorRewriter();
-        return rewrite.rewrite(cloned, ScalarOperatorRewriter.MV_SCALAR_REWRITE_RULES);
+        return queryMaterializationContext == null ?
+                new ScalarOperatorRewriter().rewrite(predicate.clone(), ScalarOperatorRewriter.MV_SCALAR_REWRITE_RULES)
+                : queryMaterializationContext.getCanonizedPredicate(predicate);
+    }
+
+    public static Collection<ScalarOperator> canonizePredicatesForRewrite(
+            QueryMaterializationContext queryMaterializationContext,
+            Collection<ScalarOperator> predicates) {
+        if (predicates == null || predicates.isEmpty()) {
+            return predicates;
+        }
+        return predicates.stream()
+                .map(x -> canonizePredicateForRewrite(queryMaterializationContext, x))
+                .collect(Collectors.toSet());
     }
 
     public static ScalarOperator getCompensationPredicateForDisjunctive(ScalarOperator src, ScalarOperator target) {
@@ -942,13 +937,8 @@ public class MvUtils {
         return true;
     }
 
-    public static List<ScalarOperator> compensatePartitionPredicateForHiveScan(LogicalHiveScanOperator scanOperator,
-                                                                               boolean isCompensate) {
+    public static List<ScalarOperator> compensatePartitionPredicateForHiveScan(LogicalHiveScanOperator scanOperator) {
         ScanOperatorPredicates scanOperatorPredicates = scanOperator.getScanOperatorPredicates();
-        if (!isCompensate) {
-            return scanOperatorPredicates.getPrunedPartitionConjuncts();
-        }
-
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
 
         Preconditions.checkState(scanOperator.getTable().isHiveTable());
@@ -985,6 +975,11 @@ public class MvUtils {
         return partitionPredicates;
     }
 
+    public static final ImmutableList<OperatorType> SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES =
+            ImmutableList.<OperatorType>builder()
+            .add(OperatorType.LOGICAL_OLAP_SCAN)
+            .add(OperatorType.LOGICAL_HIVE_SCAN)
+            .build();
     /**
      * - if `isCompensate` is true, use `selectedPartitionIds` to compensate complete partition ranges
      *  with lower and upper bound.
@@ -1010,26 +1005,29 @@ public class MvUtils {
      *      `partitionPredicate` : k1>='2020-02-11'
      *      however for mv  we need: k1>='2020-02-11' and k1 < "2020-03-01"
      */
-    public static ScalarOperator compensatePartitionPredicate(OptExpression plan,
+    public static ScalarOperator compensatePartitionPredicate(MaterializationContext mvContext,
                                                               ColumnRefFactory columnRefFactory,
-                                                              boolean isCompensate) {
-        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(plan);
+                                                              OptExpression queryExpression) {
+        List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(queryExpression);
         if (scanOperators.isEmpty()) {
             return ConstantOperator.createBoolean(true);
         }
 
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
+        boolean isCompensatePartition = mvContext.isCompensatePartitionPredicate(queryExpression);
+        // Compensate partition predicates and add them into query predicate.
+        boolean isPartitionCompensate = mvContext.isCompensatePartitionPredicate();
+        Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOperatorScalarOperatorMap =
+                mvContext.getScanOpToPartitionCompensatePredicates();
         for (LogicalScanOperator scanOperator : scanOperators) {
-            List<ScalarOperator> partitionPredicate = null;
-            if (scanOperator instanceof LogicalOlapScanOperator) {
-                partitionPredicate = compensatePartitionPredicateForOlapScan((LogicalOlapScanOperator) scanOperator,
-                        columnRefFactory, isCompensate);
-            } else if (scanOperator instanceof LogicalHiveScanOperator) {
-                partitionPredicate = compensatePartitionPredicateForHiveScan((LogicalHiveScanOperator) scanOperator,
-                        isCompensate);
-            } else {
+            if (!SUPPORTED_PARTITION_COMPENSATE_SCAN_TYPES.contains(scanOperator.getOpType())) {
                 continue;
             }
+            List<ScalarOperator> partitionPredicate = scanOperatorScalarOperatorMap
+                    .computeIfAbsent(Pair.create(scanOperator, isPartitionCompensate), x -> {
+                        return isCompensatePartition ? getCompensatePartitionPredicates(columnRefFactory, scanOperator) :
+                                getScanOpPrunedPartitionPredicates(scanOperator);
+                    });
             if (partitionPredicate == null) {
                 return null;
             }
@@ -1037,6 +1035,20 @@ public class MvUtils {
         }
         return partitionPredicates.isEmpty() ? ConstantOperator.createBoolean(true) :
                 Utils.compoundAnd(partitionPredicates);
+    }
+
+    private static List<ScalarOperator> getCompensatePartitionPredicates(ColumnRefFactory columnRefFactory,
+                                                                         LogicalScanOperator scanOperator) {
+        List<ScalarOperator> partitionPredicate = null;
+        if (scanOperator instanceof LogicalOlapScanOperator) {
+            partitionPredicate = compensatePartitionPredicateForOlapScan((LogicalOlapScanOperator) scanOperator,
+                    columnRefFactory);
+        } else if (scanOperator instanceof LogicalHiveScanOperator) {
+            partitionPredicate = compensatePartitionPredicateForHiveScan((LogicalHiveScanOperator) scanOperator);
+        } else {
+            return null;
+        }
+        return partitionPredicate;
     }
 
     /**
@@ -1049,12 +1061,12 @@ public class MvUtils {
      * @param mvContext : materialized view context
      * @return
      */
-    public static boolean isNeedCompensatePartitionPredicate(OptExpression plan,
-                                                             MaterializationContext mvContext) {
+    public static Optional<Boolean> isNeedCompensatePartitionPredicate(OptExpression plan,
+                                                                       MaterializationContext mvContext) {
         Set<String> mvPartitionNameToRefresh = mvContext.getMvPartitionNamesToRefresh();
         // If mv contains no partitions to refresh, no need compensate
         if (Objects.isNull(mvPartitionNameToRefresh) || mvPartitionNameToRefresh.isEmpty()) {
-            return false;
+            return Optional.of(false);
         }
 
         // If ref table contains no partitions to refresh, no need compensate.
@@ -1062,29 +1074,31 @@ public class MvUtils {
         // it can not be a candidate.
         Set<String> refTablePartitionNameToRefresh = mvContext.getRefTableUpdatePartitionNames();
         if (Objects.isNull(refTablePartitionNameToRefresh) || refTablePartitionNameToRefresh.isEmpty()) {
-            return false;
+            // NOTE: This should not happen: `mvPartitionNameToRefresh` is not empty, so `refTablePartitionNameToRefresh`
+            // should not empty. Return true in the situation to avoid bad cases.
+            return Optional.of(true);
         }
 
         List<LogicalScanOperator> scanOperators = MvUtils.getScanOperator(plan);
         // If no scan operator, no need compensate
         if (scanOperators.isEmpty()) {
-            return false;
+            return Optional.of(false);
         }
         if (scanOperators.stream().anyMatch(scan -> scan instanceof LogicalViewScanOperator)) {
-            return true;
+            return Optional.of(true);
         }
 
         // If no partition table and columns, no need compensate
         MaterializedView mv = mvContext.getMv();
         Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
         if (partitionTableAndColumns == null) {
-            return false;
+            return Optional.of(false);
         }
         Table refBaseTable = partitionTableAndColumns.first;
         Optional<LogicalScanOperator> optRefScanOperator =
                 scanOperators.stream().filter(x -> isRefBaseTable(x, refBaseTable)).findFirst();
         if (!optRefScanOperator.isPresent()) {
-            return false;
+            return Optional.empty();
         }
 
         LogicalScanOperator scanOperator = optRefScanOperator.get();
@@ -1093,45 +1107,45 @@ public class MvUtils {
             OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
             // If table's not partitioned, no need compensate
             if (olapTable.getPartitionInfo() instanceof SinglePartitionInfo) {
-                return false;
+                return Optional.of(false);
             }
 
             List<Long> selectPartitionIds = olapScanOperator.getSelectedPartitionId();
             if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-                return false;
+                return Optional.of(false);
             }
 
             // determine whether query's partitions can be satisfied by materialized view.
             for (Long selectPartitionId : selectPartitionIds) {
                 Partition partition = olapTable.getPartition(selectPartitionId);
                 if (partition != null && refTablePartitionNameToRefresh.contains(partition.getName())) {
-                    return true;
+                    return Optional.of(true);
                 }
             }
-            return false;
+            return Optional.of(false);
         } else if (scanOperator instanceof LogicalHiveScanOperator) {
             HiveTable hiveTable = (HiveTable) scanOperator.getTable();
             // If table's not partitioned, no need compensate
             if (hiveTable.isUnPartitioned()) {
-                return false;
+                return Optional.of(false);
             }
             LogicalHiveScanOperator hiveScanOperator = (LogicalHiveScanOperator)  scanOperator;
             ScanOperatorPredicates scanOperatorPredicates = hiveScanOperator.getScanOperatorPredicates();
             Collection<Long> selectPartitionIds = scanOperatorPredicates.getSelectedPartitionIds();
             if (Objects.isNull(selectPartitionIds) || selectPartitionIds.size() == 0) {
-                return false;
+                return Optional.of(false);
             }
             // determine whether query's partitions can be satisfied by materialized view.
             List<PartitionKey> selectPartitionKeys = scanOperatorPredicates.getSelectedPartitionKeys();
             for (PartitionKey partitionKey : selectPartitionKeys) {
                 String mvPartitionName = PartitionUtil.generateMVPartitionName(partitionKey);
                 if (refTablePartitionNameToRefresh.contains(mvPartitionName)) {
-                    return true;
+                    return Optional.of(true);
                 }
             }
-            return false;
+            return Optional.of(false);
         } else {
-            return true;
+            return Optional.of(true);
         }
     }
 
@@ -1143,11 +1157,7 @@ public class MvUtils {
      * @return
      */
     private static List<ScalarOperator> compensatePartitionPredicateForOlapScan(LogicalOlapScanOperator olapScanOperator,
-                                                                                ColumnRefFactory columnRefFactory,
-                                                                                boolean isCompensate) {
-        if (!isCompensate) {
-            return olapScanOperator.getPrunedPartitionPredicates();
-        }
+                                                                                ColumnRefFactory columnRefFactory) {
         List<ScalarOperator> partitionPredicates = Lists.newArrayList();
         Preconditions.checkState(olapScanOperator.getTable().isNativeTableOrMaterializedView());
         OlapTable olapTable = (OlapTable) olapScanOperator.getTable();
@@ -1167,6 +1177,7 @@ public class MvUtils {
         if (olapScanOperator.getSelectedPartitionId().isEmpty()) {
             return olapScanOperator.getPrunedPartitionPredicates();
         }
+
         if (olapTable.getPartitionInfo() instanceof ExpressionRangePartitionInfo) {
             ExpressionRangePartitionInfo partitionInfo =
                     (ExpressionRangePartitionInfo) olapTable.getPartitionInfo();
@@ -1271,6 +1282,48 @@ public class MvUtils {
             return convertPartitionKeysToPredicate(columnRefOption.get(), latestBaseTableRanges);
         }
         return null;
+    }
+
+    public static List<ScalarOperator> getMVPrunedPartitionPredicates(MaterializedView mv,
+                                                                      OptExpression mvPlan) {
+        Pair<Table, Column> partitionTableAndColumns = mv.getDirectTableAndPartitionColumn();
+        if (partitionTableAndColumns == null) {
+            return null;
+        }
+
+        Table refBaseTable = partitionTableAndColumns.first;
+        List<OptExpression> scanExprs = MvUtils.collectScanExprs(mvPlan);
+        for (OptExpression scanExpr : scanExprs) {
+            LogicalScanOperator scanOperator = (LogicalScanOperator) scanExpr.getOp();
+            if (!isRefBaseTable(scanOperator, refBaseTable)) {
+                continue;
+            }
+
+            List<ScalarOperator> prunedPredicates = getScanOpPrunedPartitionPredicates(scanOperator);
+            if (prunedPredicates == null || prunedPredicates.isEmpty()) {
+                return List.of(ConstantOperator.TRUE);
+            } else {
+                return prunedPredicates;
+            }
+        }
+        return null;
+    }
+
+    private static List<ScalarOperator> getScanOpPrunedPartitionPredicates(LogicalScanOperator scanOperator) {
+        if (scanOperator == null) {
+            return null;
+        }
+
+        if (scanOperator instanceof LogicalOlapScanOperator) {
+            return ((LogicalOlapScanOperator) scanOperator).getPrunedPartitionPredicates();
+        } else if (scanOperator instanceof LogicalHiveScanOperator) {
+            ScanOperatorPredicates scanOperatorPredicates =
+                    ((LogicalHiveScanOperator) scanOperator).getScanOperatorPredicates();
+            return scanOperatorPredicates.getPrunedPartitionConjuncts();
+        } else {
+            // Cannot decide whether it has been pruned or not, return null for now.
+            return null;
+        }
     }
 
     private static boolean isRefBaseTable(LogicalScanOperator scanOperator, Table refBaseTable) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization.rule;
 
+import com.github.benmanes.caffeine.cache.Cache;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
@@ -25,6 +26,7 @@ import com.starrocks.sql.optimizer.MaterializationContext;
 import com.starrocks.sql.optimizer.MvRewriteContext;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.QueryMaterializationContext;
 import com.starrocks.sql.optimizer.base.ColumnRefFactory;
 import com.starrocks.sql.optimizer.operator.logical.LogicalOlapScanOperator;
 import com.starrocks.sql.optimizer.operator.pattern.Pattern;
@@ -38,9 +40,11 @@ import com.starrocks.sql.optimizer.rule.transformation.materialization.MVPartiti
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MaterializedViewRewriter;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils;
 import com.starrocks.sql.optimizer.rule.transformation.materialization.PredicateSplit;
+import org.apache.arrow.util.Preconditions;
 import org.apache.commons.collections4.CollectionUtils;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static com.starrocks.metric.MaterializedViewMetricsEntity.isUpdateMaterializedViewMetrics;
@@ -118,24 +122,20 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
                 MvUtils.getReplaceColumnRefWriter(queryExpression, queryColumnRefFactory);
 
         List<ScalarOperator> onPredicates = MvUtils.collectOnPredicate(queryExpression);
-        onPredicates = onPredicates.stream().map(MvUtils::canonizePredicateForRewrite).collect(Collectors.toList());
+        QueryMaterializationContext queryMaterializationContext = context.getQueryMaterializationContext();
+        onPredicates = onPredicates.stream()
+                .map(p -> MvUtils.canonizePredicateForRewrite(queryMaterializationContext, p))
+                .collect(Collectors.toList());
         List<Table> queryTables = MvUtils.getAllTables(queryExpression);
         ConnectContext connectContext = ConnectContext.get();
         for (MaterializationContext mvContext : mvCandidateContexts) {
-            // 1. check whether to need compensate or not
-            // 2. `queryPredicateSplit` is different for each materialized view, so we can not cache it anymore.
-            boolean isCompensatePartitionPredicate =
-                    MvUtils.isNeedCompensatePartitionPredicate(queryExpression, mvContext);
-            PredicateSplit queryPredicateSplit =
-                    getQuerySplitPredicate(mvContext, queryExpression, queryColumnRefFactory,
-                            queryColumnRefRewriter, isCompensatePartitionPredicate);
+            PredicateSplit queryPredicateSplit = getQuerySplitPredicate(context, mvContext, queryExpression,
+                    queryColumnRefFactory, queryColumnRefRewriter);
             if (queryPredicateSplit == null) {
                 continue;
             }
-            MvRewriteContext mvRewriteContext =
-                    new MvRewriteContext(mvContext, queryTables, queryExpression,
-                            queryColumnRefRewriter, queryPredicateSplit, onPredicates, this,
-                            isCompensatePartitionPredicate);
+            MvRewriteContext mvRewriteContext = new MvRewriteContext(mvContext, queryTables, queryExpression,
+                        queryColumnRefRewriter, queryPredicateSplit, onPredicates, this);
 
             // rewrite query
             MaterializedViewRewriter mvRewriter = getMaterializedViewRewrite(mvRewriteContext);
@@ -181,30 +181,33 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
      * eg: for sync mv without partition columns, we always no need compensate partition predicates because
      * mv and the base table are always synced.
      */
-    private PredicateSplit getQuerySplitPredicate(MaterializationContext mvContext,
+    private PredicateSplit getQuerySplitPredicate(OptimizerContext optimizerContext,
+                                                  MaterializationContext mvContext,
                                                   OptExpression queryExpression,
                                                   ColumnRefFactory queryColumnRefFactory,
-                                                  ReplaceColumnRefRewriter queryColumnRefRewriter,
-                                                  boolean isCompensate) {
-        // sync mv always has the same partition with
-        // Compensate partition predicates and add them into query predicate.
-        final ScalarOperator queryPartitionPredicate = MvUtils.compensatePartitionPredicate(
-                queryExpression, queryColumnRefFactory, isCompensate);
+                                                  ReplaceColumnRefRewriter queryColumnRefRewriter) {
+        // Cache partition predicate predicates because it's expensive time costing if there are too many materialized views or
+        // query expressions are too complex.
+        final ScalarOperator queryPartitionPredicate = MvUtils.compensatePartitionPredicate(mvContext,
+                queryColumnRefFactory, queryExpression);
         if (queryPartitionPredicate == null) {
-            logMVRewrite(mvContext.getOptimizerContext(), this, "Compensate query expression's partition predicates " +
-                    "from pruned partitions failed.");
+            logMVRewrite(mvContext.getOptimizerContext(), this, "Compensate query expression's partition " +
+                    "predicates from pruned partitions failed.");
             return null;
         }
         // only add valid predicates into query split predicate
-        List<ScalarOperator> queryConjuncts = MvUtils.getAllValidPredicates(queryExpression);
+        Set<ScalarOperator> queryConjuncts = MvUtils.getAllValidPredicates(queryExpression);
         if (!ConstantOperator.TRUE.equals(queryPartitionPredicate)) {
             logMVRewrite(mvContext.getOptimizerContext(), this, "Query compensate partition predicate:{}",
                     queryPartitionPredicate);
             queryConjuncts.addAll(MvUtils.getAllValidPredicates(queryPartitionPredicate));
         }
-        ScalarOperator queryPredicate =
-                MvUtils.rewriteOptExprCompoundPredicate(queryConjuncts, queryColumnRefRewriter);
-        return PredicateSplit.splitPredicate(queryPredicate);
+
+        QueryMaterializationContext queryMaterializationContext = optimizerContext.getQueryMaterializationContext();
+        Cache<Object, Object> predicateSplitCache = queryMaterializationContext.getMvQueryContextCache();
+        Preconditions.checkArgument(predicateSplitCache != null);
+        // Cache predicate split for predicates because it's time costing if there are too many materialized views.
+        return queryMaterializationContext.getPredicateSplit(queryConjuncts, queryColumnRefRewriter);
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewHiveTPCHTest.java
@@ -29,7 +29,6 @@ public class MaterializedViewHiveTPCHTest extends MaterializedViewTestBase {
         executeSqlFile("sql/materialized-view/tpch-hive/ddl_tpch_mv1.sql");
     }
 
-
     @Test
     public void testQuery1() {
         runFileUnitTest("materialized-view/tpch-hive/q1");
@@ -62,7 +61,7 @@ public class MaterializedViewHiveTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery7() {
-        runFileUnitTestWithNormalizedResult("materialized-view/tpch-hive/q7");
+        runFileUnitTest("materialized-view/tpch-hive/q7");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
@@ -17,7 +17,6 @@ package com.starrocks.planner;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.common.FeConstants;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.plan.MockTpchStatisticStorage;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
@@ -51,27 +50,17 @@ public class MaterializedViewLowCardTPCHTest extends MaterializedViewTestBase {
 
     @Test
     public void testQuery7() throws Exception {
-        QueryDebugOptions debugOptions = new QueryDebugOptions();
-        debugOptions.setEnableNormalizePredicateAfterMVRewrite(true);
-        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
-
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         String plan = getVerboseExplain(TpchSQL.Q07);
         assertContainsIgnoreColRefs(plan, "group by: [425: n_name, INT, true], " +
                 "[426: n_name, INT, true], " +
                 "[49: year, SMALLINT, false]");
-        connectContext.getSessionVariable().setQueryDebugOptions("");
     }
 
     @Test
     public void testQuery12() throws Exception {
-        QueryDebugOptions debugOptions = new QueryDebugOptions();
-        debugOptions.setEnableNormalizePredicateAfterMVRewrite(true);
-        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
-
         FeConstants.USE_MOCK_DICT_MANAGER = true;
         String plan = getVerboseExplain(TpchSQL.Q12);
         assertCContains(plan, "group by: [90: l_shipmode, INT, true]");
-        connectContext.getSessionVariable().setQueryDebugOptions("");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -294,7 +294,7 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
             String query = "select sum(t1f) as total, t1a, t1b from test.test_all_type group by t1a, t1b;";
             {
                 sql(query, true).match("mv0")
-                        .containsIgnoreColRefs("1:t1a := 12:t1a\n" +
+                        .contains("1:t1a := 12:t1a\n" +
                                 "            2:t1b := 14:t1b\n" +
                                 "            11:sum := 13:total");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -1232,8 +1232,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
-    @Ignore
-    // TODO: union all support
     public void testJoinAggregateMaterializationNoAggregateFuncs7() {
         testRewriteOK("select depts.deptno, dependents.empid\n"
                         + "from depts\n"
@@ -1270,8 +1268,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
-    @Ignore
-    // TODO: union all support
     public void testJoinAggregateMaterializationNoAggregateFuncs9() {
         testRewriteOK("select depts.deptno, dependents.empid\n"
                         + "from depts\n"
@@ -1317,7 +1313,6 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
     }
 
     @Test
-    @Ignore
     public void testJoinAggregateMaterializationAggregateFuncs2() {
         testRewriteOK("select empid, emps.deptno, count(*) as c, sum(empid) as s\n"
                         + "from emps join depts using (deptno)\n"
@@ -3851,33 +3846,31 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
 
     @Test
     public void testNestedAggregateBelowJoin2() throws Exception {
-        {
-            String mv1 = "create materialized view mv1 \n" +
-                    "distributed by random \n" +
-                    "refresh async\n" +
-                    "as select empid, deptno, locationid, \n" +
-                    " sum(salary) as total, count(salary)  as cnt\n" +
-                    " from emps group by empid, deptno, locationid ";
-            String mv2 = "create materialized view mv2 \n" +
-                    "distributed by random \n" +
-                    "refresh async\n" +
-                    "as select sum(total) as sum, t2.locationid, t2.empid, t2.deptno  from \n" +
-                    "(select empid, deptno, t.locationid, total, cnt from mv1 t join locations \n" +
-                    "on t.locationid = locations.locationid) t2\n" +
-                    "group by t2.locationid, t2.empid, t2.deptno";
-            starRocksAssert.withMaterializedView(mv1);
-            starRocksAssert.withMaterializedView(mv2);
+        String mv1 = "create materialized view mv1 \n" +
+                "distributed by random \n" +
+                "refresh async\n" +
+                "as select empid, deptno, locationid, \n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid, deptno, locationid ";
+        String mv2 = "create materialized view mv2 \n" +
+                "distributed by random \n" +
+                "refresh async\n" +
+                "as select sum(total) as sum, t2.locationid, t2.empid, t2.deptno  from \n" +
+                "(select empid, deptno, t.locationid, total, cnt from mv1 t join locations \n" +
+                "on t.locationid = locations.locationid) t2\n" +
+                "group by t2.locationid, t2.empid, t2.deptno";
+        starRocksAssert.withMaterializedView(mv1);
+        starRocksAssert.withMaterializedView(mv2);
 
-            sql("select sum(total) as sum, t.locationid  from \n" +
-                    "(select locationid, \n" +
-                    " sum(salary) as total, count(salary)  as cnt\n" +
-                    " from emps where empid = 2 and deptno = 10 group by locationid) t join locations \n" +
-                    "on t.locationid = locations.locationid\n" +
-                    "group by t.locationid")
-                    .match("mv2");
-            starRocksAssert.dropMaterializedView("mv1");
-            starRocksAssert.dropMaterializedView("mv2");
-        }
+        sql("select sum(total) as sum, t.locationid  from \n" +
+                "(select locationid, \n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps where empid = 2 and deptno = 10 group by locationid) t join locations \n" +
+                "on t.locationid = locations.locationid\n" +
+                "group by t.locationid")
+                .match("mv2");
+        starRocksAssert.dropMaterializedView("mv1");
+        starRocksAssert.dropMaterializedView("mv2");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
+++ b/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
@@ -276,6 +276,9 @@ public class MSchema {
             )
     ).withValues("('2020-01-01', '{'a': 1, 'gender': 'man'}')");
 
+    public static final MTable TABLE_WITH_DAY_PARTITION1 = TABLE_WITH_DAY_PARTITION.copyWithName("table_with_day_partition1");
+    public static final MTable TABLE_WITH_DAY_PARTITION2 = TABLE_WITH_DAY_PARTITION.copyWithName("table_with_day_partition2");
+
     public static final List<MTable>  TABLE_MARKETING = List.of(
             EMPS,
             EMPS_NULL,
@@ -290,6 +293,8 @@ public class MSchema {
             T0,
             TABLE_WITH_PARTITION,
             TABLE_WITH_DAY_PARTITION,
+            TABLE_WITH_DAY_PARTITION1,
+            TABLE_WITH_DAY_PARTITION2,
             TABLE_WITH_DATETIME_PARTITION,
             TEST_BASE_PART,
             T1,

--- a/fe/fe-core/src/test/java/com/starrocks/schema/MTable.java
+++ b/fe/fe-core/src/test/java/com/starrocks/schema/MTable.java
@@ -58,6 +58,24 @@ public class MTable {
         this.partKeys = partKeys;
     }
 
+    public MTable copyWithName(String newTableName) {
+        MTable mTable = new MTable(newTableName, this.distCol, Lists.newArrayList(this.columns));
+        mTable.partCol = this.partCol;
+        mTable.duplicateKeys = this.duplicateKeys;
+        if (this.partKeys != null) {
+            mTable.partKeys = Lists.newArrayList(this.partKeys);
+        }
+        mTable.bucketNum = this.bucketNum;
+        mTable.replicateNum = this.replicateNum;
+        if (this.values != null) {
+            mTable.values = Lists.newArrayList(this.values);
+        }
+        if (this.properties != null) {
+            mTable.properties = Lists.newArrayList(this.properties);
+        }
+        return mTable;
+    }
+
     public String getTableName() {
         return tableName;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionCompensateOptBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVPartitionCompensateOptBench.java
@@ -1,0 +1,189 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.google.common.collect.ImmutableList;
+import com.starrocks.common.Pair;
+import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+
+import java.util.List;
+
+@Ignore
+public class MVPartitionCompensateOptBench extends MvRewriteTestBase {
+
+    private static final int MV_NUMS = 100;
+    private static final int BENCHMARK_RUNS = 10;
+
+    @Rule
+    public TestRule mvPartitionCompensateBench = new BenchmarkRule();
+
+    @BeforeClass
+    public static void setup() throws Exception {
+        MvRewriteTestBase.beforeClass();
+        starRocksAssert.withTable(cluster, "table_with_day_partition");
+        starRocksAssert.withTable(cluster, "table_with_day_partition1");
+        starRocksAssert.withTable(cluster, "table_with_day_partition2");
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteCandidateLimit(1000);
+        connectContext.getSessionVariable().setCboMaterializedViewRewriteRuleOutputLimit(1000);
+
+        List<String> mvPartitionExprs = ImmutableList.of("id_date", "date_trunc('day', id_date)");
+        List<Pair<String, String>> refreshPartitions = ImmutableList.of(
+                Pair.create("1991-03-30", "1991-03-31"),
+                Pair.create("1991-03-30", "1991-04-01"),
+                Pair.create("1991-03-30", "1991-04-02"),
+                Pair.create("1991-04-01", "1991-04-30")
+        );
+
+        starRocksAssert.getCtx().setDumpInfo(null);
+        QueryDebugOptions debugOptions = new QueryDebugOptions();
+        debugOptions.setEnableQueryTraceLog(true);
+        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
+
+        int i = 0;
+        while (i < MV_NUMS) {
+            for (String mvPartitionExpr : mvPartitionExprs) {
+                String mvName = "mv_partition_compensate_" + i;
+                System.out.println(mvName);
+                String mvSQL = String.format("CREATE MATERIALIZED VIEW if not exists %s \n" +
+                        "PARTITION BY %s \n" +
+                        "REFRESH DEFERRED MANUAL " +
+                        "AS " +
+                        "select a.t1a, a.id_date, sum(a.t1b), sum(b.t1b) " +
+                        "from table_with_day_partition a" +
+                        " left join table_with_day_partition1 b on a.id_date=b.id_date " +
+                        " left join table_with_day_partition2 c on a.id_date=c.id_date " +
+                        "group by a.t1a,a.id_date;", mvName, mvPartitionExpr);
+                starRocksAssert.withMaterializedView(mvSQL);
+
+                Pair<String, String> refreshParts = refreshPartitions.get(i % refreshPartitions.size());
+                cluster.runSql("test", String.format("refresh materialized view %s partition " +
+                        "start('%s') end('%s') with sync mode;", mvName, refreshParts.first, refreshParts.second));
+                i++;
+            }
+        }
+    }
+
+    private void testMVPartitionCompensatePerf(int i) {
+        List<Pair<String, Boolean>> expects = ImmutableList.of(
+                // no partition expressions
+                Pair.create("a.id_date='1991-03-30'", true),
+                Pair.create("a.id_date>='1991-03-30'", false),
+                Pair.create("a.id_date!='1991-03-30'", false),
+                // with partition expressions && partition expressions can be pruned
+                Pair.create("date_format(a.id_date, '%Y%m%d')='19910330'", true),
+                Pair.create("date_format(a.id_date, '%Y-%m-%d')='1991-03-30'", true),
+                Pair.create("date_trunc('day', a.id_date)='1991-03-30'", true),
+                Pair.create("date_trunc('day', a.id_date)>='1991-03-30'", false),
+                Pair.create("subdate(a.id_date, interval 1 day)='1991-03-29'", true),
+                Pair.create("adddate(a.id_date, interval 1 day)='1991-03-31'", true),
+                // with partition expressions && partition expressions can be pruned
+                Pair.create("cast(a.id_date as string)='1991-03-30'", false),
+                Pair.create("cast(a.id_date as string) >='1991-03-30'", false)
+        );
+        Pair<String, Boolean> expect = expects.get(i);
+        String query = String.format("select a.t1a, a.id_date, sum(a.t1b), sum(b.t1b) \n" +
+                "from table_with_day_partition a\n" +
+                " left join table_with_day_partition1 b on a.id_date=b.id_date \n" +
+                " left join table_with_day_partition2 c on a.id_date=c.id_date \n" +
+                " where %s " +
+                " group by a.t1a,a.id_date;", expect.first);
+        try {
+            String plan = getFragmentPlan(query);
+            if (expect.second) {
+                PlanTestBase.assertContains(plan, "mv_partition_compensate_");
+            } else {
+                PlanTestBase.assertNotContains(plan, "mv_partition_compensate_");
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf0() {
+        testMVPartitionCompensatePerf(0);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf1() {
+        testMVPartitionCompensatePerf(1);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf2() {
+        testMVPartitionCompensatePerf(2);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf3() {
+        testMVPartitionCompensatePerf(3);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf4() {
+        testMVPartitionCompensatePerf(4);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf5() {
+        testMVPartitionCompensatePerf(5);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf6() {
+        testMVPartitionCompensatePerf(6);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf7() {
+        testMVPartitionCompensatePerf(7);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf8() {
+        testMVPartitionCompensatePerf(8);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf9() {
+        testMVPartitionCompensatePerf(9);
+    }
+
+    @Test
+    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = BENCHMARK_RUNS)
+    public void testMVPartitionCompensatePerf10() {
+        testMVPartitionCompensatePerf(10);
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -1078,7 +1078,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
                     " where t1.d in ('2023-08-01', '2023-08-02') " +
                     " group by t1.d, t2.b, t3.c;";
-            String plan = getFragmentPlan(query);
+            String plan = getFragmentPlan(query, "MV");
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "test_mv1");
         }
@@ -1204,6 +1204,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                 materializedView.getPartitions().stream().map(Partition::getName).sorted()
                         .collect(Collectors.toList());
         Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
 
         {
             String query = "select t1.a, t2.b, t1.d, count(t1.c)\n" +
@@ -1274,7 +1275,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d \n" +
                     " where t1.d >= '2023-08-01' \n" +
                     " group by t1.a, t2.b, t1.d;";
-            String plan = getFragmentPlan(query);
+            String plan = getFragmentPlan(query, "MV");
             PlanTestBase.assertContains(plan, "UNION");
             PlanTestBase.assertContains(plan, "14:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -117,8 +117,10 @@ public class MvRewriteTestBase {
         cluster = PseudoCluster.getInstance();
 
         connectContext = UtFrameUtils.createDefaultCtx();
-        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000);
-        connectContext.getSessionVariable().setOptimizerMaterializedViewTimeLimitMillis(3000);
+        // 300s: 5min
+        connectContext.getSessionVariable().setOptimizerExecuteTimeout(3000 * 100);
+        // 300s: 5min
+        connectContext.getSessionVariable().setOptimizerMaterializedViewTimeLimitMillis(3000 * 100);
         connectContext.getSessionVariable().setEnableShortCircuit(false);
 
         starRocksAssert = new StarRocksAssert(connectContext);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -458,7 +458,7 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                 "  |  predicates: 1: k1 > 1, 2: k2 LIKE 'a%'";
         String p =
                 "7:SELECT\n" +
-                "  |   predicates: 2: k2 LIKE 'a%', 1: k1 > 1";
+                "  |  predicates: 2: k2 LIKE 'a%', 1: k1 > 1";
         PlanTestBase.assertContainsIgnoreColRefs(p1, p);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtilsTest.java
@@ -43,7 +43,7 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.util.List;
+import java.util.Set;
 
 public class MvUtilsTest {
     private static ConnectContext connectContext;
@@ -112,7 +112,7 @@ public class MvUtilsTest {
         OptExpression scanExpr2 = OptExpression.create(scanOperator2);
         LogicalJoinOperator joinOperator = new LogicalJoinOperator(JoinOperator.INNER_JOIN, binaryPredicate);
         OptExpression joinExpr = OptExpression.create(joinOperator, scanExpr, scanExpr2);
-        List<ScalarOperator> predicates = MvUtils.getAllValidPredicates(joinExpr);
+        Set<ScalarOperator> predicates = MvUtils.getAllValidPredicates(joinExpr);
         Assert.assertEquals(3, predicates.size());
         Assert.assertTrue(MvUtils.isAllEqualInnerOrCrossJoin(joinExpr));
         LogicalJoinOperator joinOperator2 = new LogicalJoinOperator(JoinOperator.LEFT_OUTER_JOIN, binaryPredicate);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/NormalizePredicateBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/NormalizePredicateBench.java
@@ -155,7 +155,7 @@ public class NormalizePredicateBench {
 
     @Benchmark
     public void bench_NormalizePredicate_Random() {
-        ScalarOperator res = MvUtils.canonizePredicateForRewrite(randomPredicate);
+        ScalarOperator res = MvUtils.canonizePredicateForRewrite(null, randomPredicate);
     }
 
     @Benchmark
@@ -172,7 +172,8 @@ public class NormalizePredicateBench {
      */
     @Benchmark
     public void bench_NormalizePredicate_Disjunctive() {
-        ScalarOperator res = MvUtils.canonizePredicateForRewrite(disjunctive);
+        ScalarOperator res =
+                MvUtils.canonizePredicateForRewrite(null, disjunctive);
     }
 
     @Benchmark

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -34,7 +34,6 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.StatementBase;
-import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.LogicalPlanPrinter;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.thrift.TExplainLevel;
@@ -109,28 +108,71 @@ public class PlanTestNoneDBBase {
         }
     }
 
-    private static String ignoreColRefs(String s) {
-        // ignore colRef id
-        // eg:
-        //  |  predicates: 2: k2 LIKE 'a%'
-        // to
-        //  |  predicates: $: k2 LIKE 'a%'
-        String str = s.replaceAll("\\d+: ", "\\$ ");
-        // ignore predicate order
-        // |  predicates: 2: k2 LIKE 'a%' or 1: k1 > 1
-        // TODO: only reorder predicates rather than the whole line.
-        return Arrays.stream(StringUtils.split(str, " ,;")).sorted().collect(Collectors.joining(" "));
+    private static final String NORMAL_PLAN_PREDICATE_PREFIX = "PREDICATES:";
+    private static final String LOWER_NORMAL_PLAN_PREDICATE_PREFIX = "predicates:";
+    private static final String LOGICAL_PLAN_SCAN_PREFIX = "SCAN ";
+    private static final String LOGICAL_PLAN_PREDICATE_PREFIX = " predicate";
+
+    private static String normalizeLogicalPlanPredicate(String predicate) {
+        if (predicate.startsWith(LOGICAL_PLAN_SCAN_PREFIX) && predicate.contains(LOGICAL_PLAN_PREDICATE_PREFIX)) {
+            String[] splitArray = predicate.split(LOGICAL_PLAN_PREDICATE_PREFIX);
+            Preconditions.checkArgument(splitArray.length == 2);
+            String first = splitArray[0];
+            String second = splitArray[1];
+            String predicates = second.substring(1, second.length() - 2);
+            StringBuilder sb = new StringBuilder();
+            sb.append(first);
+            sb.append(LOGICAL_PLAN_PREDICATE_PREFIX + "[");
+            String sorted = Arrays.stream(predicates.split(" AND ")).sorted().collect(Collectors.joining(" AND "));
+            sorted = Arrays.stream(sorted.split(" OR ")).sorted().collect(Collectors.joining(" OR "));
+            sb.append(sorted);
+            sb.append("])");
+            return sb.toString();
+        } else {
+            return predicate;
+        }
+    }
+
+    private static String normalizeLogicalPlan(String plan) {
+        return Stream.of(plan.split("\n"))
+                .filter(s -> !s.contains("tabletList"))
+                .map(str -> str.replaceAll("\\d+: ", "col\\$: ").trim())
+                .map(str -> str.replaceAll("\\d+, ", "col\\$, ").trim())
+                .map(str -> str.replaceAll("\\d+]", "col\\$]").trim())
+                .map(str -> normalizeLogicalPlanPredicate(str))
+                .collect(Collectors.joining("\n"));
+    }
+
+    private static String normalizeNormalPlanSeparator(String predicate, String sep) {
+        String[] predicates = predicate.split(sep);
+        Preconditions.checkArgument(predicates.length == 2);
+        return predicates[0] + sep + Arrays.stream(predicates[1].split(",")).sorted().collect(Collectors.joining(","));
+    }
+
+    public static String normalizeNormalPlanPredicate(String predicate) {
+        if (predicate.contains(NORMAL_PLAN_PREDICATE_PREFIX)) {
+            return normalizeNormalPlanSeparator(predicate, NORMAL_PLAN_PREDICATE_PREFIX);
+        } else if (predicate.contains(LOWER_NORMAL_PLAN_PREDICATE_PREFIX)) {
+            return normalizeNormalPlanSeparator(predicate, LOWER_NORMAL_PLAN_PREDICATE_PREFIX);
+        } else {
+            return predicate;
+        }
+    }
+
+    public static String normalizeNormalPlan(String plan) {
+        return Stream.of(plan.split("\n")).filter(s -> !s.contains("tabletList"))
+                .map(str -> str.replaceAll("\\d+: ", "col\\$: ").trim())
+                .map(str -> normalizeNormalPlanPredicate(str))
+                .collect(Collectors.joining("\n"));
     }
 
     public static void assertContainsIgnoreColRefs(String text, String... pattern) {
-        String normT = Stream.of(text.split("\n"))
-                .map(str -> ignoreColRefs(str))
-                .collect(Collectors.joining("\n"));
+        String normT = normalizeNormalPlan(text);
         for (String s : pattern) {
             // If pattern contains multi lines, only check line by line.
-            for (String line : s.split("\n")) {
-                String normS = ignoreColRefs(line).trim();
-                Assert.assertTrue(text, normT.contains(normS));
+            String normS = normalizeNormalPlan(s);
+            for (String line : normS.split("\n")) {
+                Assert.assertTrue(text, normT.contains(line));
             }
         }
     }
@@ -641,44 +683,19 @@ public class PlanTestNoneDBBase {
     }
 
     private void checkWithIgnoreTabletList(String expect, String actual) {
-        expect = Stream.of(expect.split("\n")).
-                filter(s -> !s.contains("tabletList")).collect(Collectors.joining("\n"));
         if (isIgnoreExplicitColRefIds()) {
-            checkWithIgnoreTabletListAndColRefIds(expect, actual);
+            String ignoreExpect = normalizeLogicalPlan(expect);
+            String ignoreActual = normalizeLogicalPlan(actual);
+            Assert.assertEquals(actual, ignoreExpect, ignoreActual);
         } else {
+            expect = Stream.of(expect.split("\n")).
+                    filter(s -> !s.contains("tabletList")).collect(Collectors.joining("\n"));
             expect = Stream.of(expect.split("\n")).filter(s -> !s.contains("tabletList"))
                     .collect(Collectors.joining("\n"));
             actual = Stream.of(actual.split("\n")).filter(s -> !s.contains("tabletList"))
                     .collect(Collectors.joining("\n"));
             Assert.assertEquals(expect, actual);
         }
-    }
-
-    private void checkWithIgnoreTabletListAndColRefIds(String expect, String actual) {
-        QueryDebugOptions queryDebugOptions =
-                connectContext.getSessionVariable().getQueryDebugOptions();
-        boolean isNormalizePredicate =
-                queryDebugOptions.enableNormalizePredicateAfterMVRewrite;
-
-        String ignoreExpect = Stream.of(expect.split("\n"))
-                .filter(s -> !s.contains("tabletList"))
-                .map(str -> str.replaceAll("\\d+", "").trim())
-                .map(str -> {
-                    return isNormalizePredicate ?
-                            Arrays.stream(str.split("")).sorted().collect(Collectors.joining())
-                            : str;
-                })
-                .collect(Collectors.joining("\n"));
-        String ignoreActual = Stream.of(actual.split("\n"))
-                .filter(s -> !s.contains("tabletList"))
-                .map(str -> str.replaceAll("\\d+", "").trim())
-                .map(str -> {
-                    return isNormalizePredicate ?
-                            Arrays.stream(str.split("")).sorted().collect(Collectors.joining())
-                            : str;
-                })
-                .collect(Collectors.joining("\n"));
-        Assert.assertEquals(actual, ignoreExpect, ignoreActual);
     }
 
     protected void assertPlanContains(String sql, String... explain) throws Exception {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -137,8 +137,9 @@ public class PlanTestNoneDBBase {
         return Stream.of(plan.split("\n"))
                 .filter(s -> !s.contains("tabletList"))
                 .map(str -> str.replaceAll("\\d+: ", "col\\$: ").trim())
-                .map(str -> str.replaceAll("\\d+, ", "col\\$, ").trim())
-                .map(str -> str.replaceAll("\\d+]", "col\\$]").trim())
+                .map(str -> str.replaceAll("\\[\\d+]", "[col\\$]").trim())
+                .map(str -> str.replaceAll("\\[\\d+, \\d+]", "[col\\$, col\\$]").trim())
+                .map(str -> str.replaceAll("\\[\\d+, \\d+, \\d+]", "[col\\$, col\\$, col\\$]").trim())
                 .map(str -> normalizeLogicalPlanPredicate(str))
                 .collect(Collectors.joining("\n"));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -416,6 +416,7 @@ public class UtFrameUtils {
                                    GetPlanHook<R> returnedSupplier) throws Exception {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
+        // connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
         connectContext.setThreadLocalInfo();
         if (connectContext.getSessionVariable().getEnableQueryDump()) {
             connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
@@ -426,6 +427,9 @@ public class UtFrameUtils {
         List<StatementBase> statements;
         try (Timer ignored = Tracers.watchScope("Parser")) {
             statements = SqlParser.parse(originStmt, connectContext.getSessionVariable());
+        }
+        if (connectContext.getDumpInfo() != null) {
+            connectContext.getDumpInfo().setOriginStmt(originStmt);
         }
         SessionVariable oldSessionVariable = connectContext.getSessionVariable();
         StatementBase statementBase = statements.get(0);

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q11.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch-hive/q11.sql
@@ -30,15 +30,15 @@ order by
 TOP-N (order by [[18: sum DESC NULLS LAST]])
     TOP-N (order by [[18: sum DESC NULLS LAST]])
         INNER JOIN (join-predicate [cast(18: sum as double) > cast(37: expr as double)] post-join-predicate [null])
-            AGGREGATE ([GLOBAL] aggregate [{: sum=sum(: sum)}] group by [[: ps_partkey]] having [null]
-                EXCHANGE SHUFFLE[]
-                    AGGREGATE ([LOCAL] aggregate [{: sum=sum(: expr)}] group by [[: ps_partkey]] having [null]
-                        SCAN (mv[partsupp_mv] columns[: n_name, : ps_partkey, : ps_partvalue] predicate[: n_name = PERU])
+            AGGREGATE ([GLOBAL] aggregate [{18: sum=sum(18: sum)}] group by [[1: ps_partkey]] having [null]
+                EXCHANGE SHUFFLE[1]
+                    AGGREGATE ([LOCAL] aggregate [{18: sum=sum(17: expr)}] group by [[1: ps_partkey]] having [null]
+                        SCAN (mv[partsupp_mv] columns[39: n_name, 43: ps_partkey, 53: ps_partvalue] predicate[39: n_name = PERU])
             EXCHANGE BROADCAST
                 ASSERT LE 1
                     AGGREGATE ([GLOBAL] aggregate [{36: sum=sum(36: sum)}] group by [[]] having [null]
                         EXCHANGE GATHER
                             AGGREGATE ([LOCAL] aggregate [{36: sum=sum(35: expr)}] group by [[]] having [null]
-                                SCAN (mv[partsupp_mv] columns[114: n_name, 128: ps_partvalue] predicate[114: n_name = PERU])
+                                SCAN (mv[partsupp_mv] columns[110: n_name, 124: ps_partvalue] predicate[110: n_name = PERU])
 [end]
 

--- a/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5.sql
+++ b/fe/fe-core/src/test/resources/sql/materialized-view/tpch/q5.sql
@@ -4,6 +4,6 @@ TOP-N (order by [[49: sum DESC NULLS LAST]])
         AGGREGATE ([GLOBAL] aggregate [{49: sum=sum(49: sum)}] group by [[42: n_name]] having [null]
             EXCHANGE SHUFFLE[42]
                 AGGREGATE ([LOCAL] aggregate [{49: sum=sum(48: expr)}] group by [[42: n_name]] having [null]
-                    SCAN (mv[lineitem_mv] columns[81: c_nationkey, 96: o_orderdate, 107: s_nationkey, 109: l_saleprice, 115: n_name2, 118: r_name2] predicate[107: s_nationkey = 81: c_nationkey AND 96: o_orderdate >= 1995-01-01 AND 96: o_orderdate < 1996-01-01 AND 118: r_name2 = AFRICA])
+                    SCAN (mv[lineitem_mv] columns[78: c_nationkey, 104: s_nationkey, 106: l_saleprice, 112: n_name2, 115: r_name2] predicate[115: r_name2 = AFRICA AND 78: c_nationkey = 104: s_nationkey])
 [end]
 


### PR DESCRIPTION
Why I'm doing:
When there are many materialized views, the mv rewrite optimizer time may cost too much. The main reason is that mv rewrite computes partition prune and cannonize predicates too much and there are a lot of repeat with them.


What I'm doing:

For the repeat compute, we can add some caches during the query's lifecycle. Add caches below:
- Add caches for per materialized view used for partition predicates mainly:
```
    // Cache whether to need to compensate partition predicates or not, and it's not changed
    // during one query, so it's safe to cache it and be used for each optimizer rule.
    // But it is different for each materialized view, compensate partition predicate from the plan's
    // `selectedPartitionIds`, and check `isNeedCompensatePartitionPredicate` to get more information.
    private Optional<Boolean> isCompensatePartitionPredicateOpt = Optional.empty();
    // Cache a mv's pruned partition predicates in the rewrite because it's not changed through the context.
    private Optional<ScalarOperator> mvPrunedPartitionPredicateOpt = Optional.empty();
    // Cache partition compensates predicates for each ScanNode and isCompensate pair.
    private Map<Pair<LogicalScanOperator, Boolean>, List<ScalarOperator>> scanOpToPartitionCompensatePredicates;
```
- Add caches for the query level no matter which materialized view: 

```
    // `mvQueryContextCache` is designed for a common cache which is used during the query's rewrite lifecycle, so can be
    // managed in a more unified mode. In the current situation, it's used in two ways:
    // 1. cache query predicates to its final predicate split per query because PredicateSplit's construct is expensive.
    // 2. cache query predicate to its canonized predicate to avoid one predicate's repeat canonized.
    // It can be be used for more situations later.
    private final Cache<Object, Object> mvQueryContextCache = Caffeine.newBuilder()
            .maximumSize(Config.mv_query_context_cache_max_size)
            .recordStats()
            .build();
```


I had two tests in my apple mac as below:
```
➜  ~ sysctl -a|grep cpu
kern.sched_rt_avoid_cpu0: 0
kern.cpu_checkin_interval: 4000
hw.ncpu: 8
hw.activecpu: 8
hw.perflevel0.physicalcpu: 6
hw.perflevel0.physicalcpu_max: 6
hw.perflevel0.logicalcpu: 6
hw.perflevel0.logicalcpu_max: 6
hw.perflevel0.cpusperl2: 3
hw.perflevel1.physicalcpu: 2
hw.perflevel1.physicalcpu_max: 2
hw.perflevel1.logicalcpu: 2
hw.perflevel1.logicalcpu_max: 2
hw.perflevel1.cpusperl2: 2
hw.physicalcpu: 8
hw.physicalcpu_max: 8
hw.logicalcpu: 8
hw.logicalcpu_max: 8
hw.cputype: 16777228
hw.cpusubtype: 2
hw.cpu64bit_capable: 1
hw.cpufamily: 458787763
hw.cpusubfamily: 4
machdep.cpu.cores_per_package: 8
machdep.cpu.core_count: 8
machdep.cpu.logical_per_package: 8
machdep.cpu.thread_count: 8
machdep.cpu.brand_string: Apple M1 Pro
```
### Test1

Run `testMVPartitionCompensatePerf1` 100 times with 10 materialized views:
```
    @Test
    @BenchmarkOptions(warmupRounds = 3, benchmarkRounds = 100)
    public void testMVPartitionCompensatePerf1() {
        testMVPartitionCompensatePerf(1);
    }
```

Before:
![image](https://github.com/StarRocks/starrocks/assets/5104975/001d4e1b-a9ca-492b-be12-ab965e4972f1)

After:
![image](https://github.com/StarRocks/starrocks/assets/5104975/c7759361-6724-49ff-ad95-78ee2a7840fe)

### Test2
Run `MVPartitionCompensateOptBench` all tests with 100 mv and benchmarkRounds=10:


Before | After(without mv limit 1000) | Default(with limit mvs)
-- | -- | --
3.16 | 1.27 | 1.13
7.49 | 1.81 | 1.23
4.13 | 1.44 | 1.03
2.68 | 1.06 | 0.95
2.64 | 1.05 | 0.95
2.71 | 1.05 | 0.9
4.89 | 1.44 | 1.02
2.45 | 1 | 0.86
2.48 | 0.95 | 0.89
2.26 | 0.95 | 0.88
2.13 | 0.92 | 0.83
```
   connectContext.getSessionVariable().setCboMaterializedViewRewriteCandidateLimit(1000);
   connectContext.getSessionVariable().setCboMaterializedViewRewriteRuleOutputLimit(1000);
```
Final Cache Stats:
Query2, one round:
```
PredicateSplitCache  Stats:CacheStats{hitCount=7863, missCount=16, loadSuccessCount=16, loadFailureCount=0, totalLoadTime=2402417, evictionCount=0, evictionWeight=0}, estimatedSize:16
, PredicateCanonizedCache Stats:CacheStats{hitCount=5273, missCount=50, loadSuccessCount=50, loadFailureCount=0, totalLoadTime=2449207, evictionCount=0, evictionWeight=0}, estimatedSize:50
```
Fixes https://github.com/StarRocks/StarRocksTest/issues/5178

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
