### PR TITLE
[Enhancement] Add default_mv_partition_refresh_number to set default partition_refresh_num

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1659,6 +1659,13 @@ public class OlapTable extends Table {
         return Status.OK;
     }
 
+    // Whether it's a partitioned table partition by columns, range or list.
+    public boolean isPartitionedTable() {
+        return partitionInfo != null && partitionInfo.isPartitioned();
+    }
+
+    // NOTE: It's different from `isPartitionedTable` which `isPartitioned` means table has many buckets rather than
+    // partitions.
     @Override
     public boolean isPartitioned() {
         int numSegs = 0;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -43,6 +43,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.TableName;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.PropertyAnalyzer;
@@ -70,7 +71,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -126,7 +126,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
 
     // This property only applies to materialized views
     // It represents the maximum number of partitions that will be refreshed by a TaskRun refresh
-    private int partitionRefreshNumber = INVALID;
+    private int partitionRefreshNumber = Config.default_mv_partition_refresh_number;
 
     // This property only applies to materialized views
     // When using the system to automatically refresh, the maximum range of the most recent partitions will be refreshed.
@@ -217,11 +217,17 @@ public class TableProperty implements Writable, GsonPostProcessable {
     private PeriodDuration dataCachePartitionDuration;
 
     public TableProperty() {
-        this.properties = new LinkedHashMap<>();
+        this(Maps.newLinkedHashMap());
     }
 
     public TableProperty(Map<String, String> properties) {
         this.properties = properties;
+        if (FeConstants.runningUnitTest) {
+            // FIXME: remove this later.
+            // Since Config.default_mv_refresh_partition_num is set to 1 by default, if not set to -1 in FE UTs,
+            // task run will only refresh 1 partition and will produce wrong result.
+            partitionRefreshNumber = INVALID;
+        }
     }
 
     public TableProperty copy() {

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2600,6 +2600,12 @@ public class Config extends ConfigBase {
     public static boolean enable_mv_automatic_active_check = true;
 
     /**
+     * The refresh partition number when refreshing materialized view at once by default.
+     */
+    @ConfField(mutable = true)
+    public static int default_mv_partition_refresh_number = 1;
+
+    /**
      * Whether analyze the mv after refresh in async mode.
      */
     @ConfField(mutable = true)

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MvTaskRunContext.java
@@ -57,12 +57,7 @@ public class MvTaskRunContext extends TaskRunContext {
     private int partitionTTLNumber = TableProperty.INVALID;
 
     public MvTaskRunContext(TaskRunContext context) {
-        this.ctx = context.ctx;
-        this.definition = context.definition;
-        this.remoteIp = context.remoteIp;
-        this.properties = context.properties;
-        this.type = context.type;
-        this.status = context.status;
+        super(context);
     }
 
     public Map<Table, Map<String, Set<String>>> getRefBaseTableMVIntersectedPartitions() {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -439,7 +439,17 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     }
 
     @VisibleForTesting
-    public void filterPartitionByRefreshNumber(Set<String> partitionsToRefresh, MaterializedView materializedView) {
+    public void filterPartitionByRefreshNumber(Set<String> partitionsToRefresh,
+                                               MaterializedView materializedView) {
+        // refresh all partition when it's a sync refresh, otherwise updated partitions may be lost.
+        if (mvContext.executeOption != null && mvContext.executeOption.getIsSync()) {
+            return;
+        }
+        // ignore if mv is not partitioned.
+        if (!materializedView.isPartitionedTable()) {
+            return;
+        }
+        // ignore if partition_fresh_limit is not set
         int partitionRefreshNumber = materializedView.getTableProperty().getPartitionRefreshNumber();
         if (partitionRefreshNumber <= 0) {
             return;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -306,7 +306,7 @@ public class TaskManager {
         try {
             taskRun = TaskRunBuilder.newBuilder(task)
                     .properties(option.getTaskRunProperties())
-                    .type(option)
+                    .setExecuteOption(option)
                     .setConnectContext(ConnectContext.get()).build();
             submitResult = taskRunManager.submitTaskRun(taskRun, option);
             if (submitResult.getStatus() != SUBMITTED) {
@@ -328,9 +328,12 @@ public class TaskManager {
     }
 
     public SubmitResult executeTaskAsync(Task task, ExecuteOption option) {
-        return taskRunManager
-                .submitTaskRun(TaskRunBuilder.newBuilder(task).properties(option.getTaskRunProperties()).type(option).
-                        build(), option);
+        TaskRun taskRun = TaskRunBuilder
+                .newBuilder(task)
+                .properties(option.getTaskRunProperties())
+                .setExecuteOption(option)
+                .build();
+        return taskRunManager.submitTaskRun(taskRun, option);
     }
 
     public void dropTasks(List<Long> taskIdList, boolean isReplay) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -66,6 +66,8 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private Constants.TaskType type;
 
+    private ExecuteOption executeOption;
+
     TaskRun() {
         future = new CompletableFuture<>();
     }
@@ -116,6 +118,14 @@ public class TaskRun implements Comparable<TaskRun> {
 
     public Constants.TaskType getType() {
         return this.type;
+    }
+
+    public ExecuteOption getExecuteOption() {
+        return executeOption;
+    }
+
+    public void setExecuteOption(ExecuteOption executeOption) {
+        this.executeOption = executeOption;
     }
 
     public Map<String, String> refreshTaskProperties(ConnectContext ctx) {
@@ -186,6 +196,7 @@ public class TaskRun implements Comparable<TaskRun> {
         taskRunContext.setPriority(status.getPriority());
         taskRunContext.setTaskType(type);
         taskRunContext.setStatus(status);
+        taskRunContext.setExecuteOption(executeOption);
 
         processor.processTaskRun(taskRunContext);
         QueryState queryState = runCtx.getState();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunBuilder.java
@@ -23,8 +23,8 @@ import java.util.Map;
 public class TaskRunBuilder {
     private final Task task;
     private Map<String, String> properties;
-    private Constants.TaskType type;
     private ConnectContext connectContext;
+    private ExecuteOption executeOption = new ExecuteOption();
 
     public static TaskRunBuilder newBuilder(Task task) {
         return new TaskRunBuilder(task);
@@ -46,6 +46,7 @@ public class TaskRunBuilder {
         taskRun.setTaskId(task.getId());
         taskRun.setProperties(mergeProperties());
         taskRun.setTask(task);
+        taskRun.setExecuteOption(executeOption);
         taskRun.setType(getTaskType());
         if (task.getSource().equals(Constants.TaskSource.MV)) {
             taskRun.setProcessor(new PartitionBasedMvRefreshProcessor());
@@ -56,7 +57,11 @@ public class TaskRunBuilder {
     }
 
     private Constants.TaskType getTaskType() {
-        return type != null ? type : task.getType();
+        if (executeOption.isManual()) {
+            return Constants.TaskType.MANUAL;
+        } else {
+            return task.getType();
+        }
     }
 
     private Map<String, String> mergeProperties() {
@@ -77,14 +82,16 @@ public class TaskRunBuilder {
         return this;
     }
 
-    public TaskRunBuilder type(ExecuteOption option) {
-        if (option.isManual()) {
-            this.type = Constants.TaskType.MANUAL;
-        }
-        return this;
-    }
-
     public Long getTaskId() {
         return task.getId();
+    }
+
+    public ExecuteOption getExecuteOption() {
+        return executeOption;
+    }
+
+    public TaskRunBuilder setExecuteOption(ExecuteOption executeOption) {
+        this.executeOption = executeOption;
+        return this;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunContext.java
@@ -28,6 +28,22 @@ public class TaskRunContext {
     Map<String, String> properties;
     Constants.TaskType type;
     TaskRunStatus status;
+    ExecuteOption executeOption;
+
+    public TaskRunContext() {
+    }
+
+    public TaskRunContext(TaskRunContext context) {
+        this.ctx = context.ctx;
+        this.definition = context.definition;
+        this.postRun = context.postRun;
+        this.remoteIp = context.remoteIp;
+        this.priority = context.priority;
+        this.properties = context.properties;
+        this.type = context.type;
+        this.status = context.status;
+        this.executeOption = context.executeOption;
+    }
 
     public ConnectContext getCtx() {
         return ctx;
@@ -91,5 +107,13 @@ public class TaskRunContext {
 
     public void setStatus(TaskRunStatus status) {
         this.status = status;
+    }
+
+    public ExecuteOption getExecuteOption() {
+        return executeOption;
+    }
+
+    public void setExecuteOption(ExecuteOption executeOption) {
+        this.executeOption = executeOption;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/MVTestUtils.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer;
 
 import com.starrocks.alter.AlterJobV2;
+import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
@@ -40,6 +41,11 @@ public class MVTestUtils {
                         "rollup job " + alterJobV2.getJobId() + " is running. state: " + alterJobV2.getJobState());
                 ThreadUtil.sleepAtLeastIgnoreInterrupts(1000L);
             }
+        }
+        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
+            Assert.assertEquals(String.format("AlterJobV2 %s should be ROLLUP state at the end",
+                            GsonUtils.GSON.toJson(alterJobV2)),
+                    AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVRewriteWithSchemaChangeTest.java
@@ -1,0 +1,301 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package com.starrocks.sql.optimizer.rule.transformation.materialization;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.CreateMaterializedViewStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.PlanTestBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
+import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
+
+public class MVRewriteWithSchemaChangeTest extends MvRewriteTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        MvRewriteTestBase.beforeClass();
+        // For mv rewrite with schema change or rollup, need to set it false, otherwise unit tests will be failed.
+        FeConstants.runningUnitTest = false;
+        MvRewriteTestBase.prepareDefaultDatas();
+    }
+
+    @Test
+    public void testSyncMVRewrite_PartitionPrune() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `sync_tbl_t1` (\n" +
+                "                  `dt` date NOT NULL COMMENT \"\",\n" +
+                "                  `a` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "                  `b` bigint(20) NOT NULL COMMENT \"\",\n" +
+                "                  `c` bigint(20) NOT NULL COMMENT \"\"\n" +
+                "                ) \n" +
+                "                DUPLICATE KEY(`dt`)\n" +
+                "                COMMENT \"OLAP\"\n" +
+                "                PARTITION BY RANGE(`dt`)\n" +
+                "                (PARTITION p20220501 VALUES [('2022-05-01'), ('2022-05-02')),\n" +
+                "                 PARTITION p20220502 VALUES [('2022-05-02'), ('2022-05-03')),\n" +
+                "                PARTITION p20220503 VALUES [('2022-05-03'), ('2022-05-04')))\n" +
+                "                DISTRIBUTED BY HASH(`a`) BUCKETS 32\n" +
+                "                PROPERTIES (\n" +
+                "                \"replication_num\" = \"1\"" +
+                "                );");
+        String sql = "CREATE MATERIALIZED VIEW sync_mv1 AS select a, b*10 as col2, c+1 as col3 from sync_tbl_t1;";
+        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
+        GlobalStateMgr.getCurrentState().createMaterializedView((CreateMaterializedViewStmt) statementBase);
+        waitingRollupJobV2Finish();
+        String query = "select a, b*10 as col2, c+1 as col3 from sync_tbl_t1 order by a;";
+        String plan = getFragmentPlan(query);
+        PlanTestBase.assertContains(plan, "sync_mv1");
+    }
+
+
+    @Test
+    public void testMVCacheInvalidAndReValid() throws Exception {
+        starRocksAssert.withTable("\n" +
+                "CREATE TABLE test_base_tbl(\n" +
+                "  `dt` datetime DEFAULT NULL,\n" +
+                "  `col1` bigint(20) DEFAULT NULL,\n" +
+                "  `col2` bigint(20) DEFAULT NULL,\n" +
+                "  `col3` bigint(20) DEFAULT NULL,\n" +
+                "  `error_code` varchar(1048576) DEFAULT NULL\n" +
+                ")\n" +
+                "DUPLICATE KEY (dt)\n" +
+                "PARTITION BY date_trunc('day', dt)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ");");
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW  test_cache_mv1 \n" +
+                "DISTRIBUTED BY HASH(col1, dt) BUCKETS 32\n" +
+                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
+                "partition by date_trunc('day', dt)\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ")\n" +
+                "AS select\n" +
+                "      col1,\n" +
+                "        dt,\n" +
+                "        sum(col2) AS sum_col2,\n" +
+                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                "    FROM\n" +
+                "        test_base_tbl AS f\n" +
+                "    GROUP BY\n" +
+                "        col1,\n" +
+                "        dt;");
+        refreshMaterializedView("test", "test_cache_mv1");
+
+        String sql = "select\n" +
+                "      col1,\n" +
+                "        sum(col2) AS sum_col2,\n" +
+                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
+                "    FROM\n" +
+                "        test_base_tbl AS f\n" +
+                "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
+                "    GROUP BY col1;";
+        String plan = getFragmentPlan(sql);
+        PlanTestBase.assertContains(plan, "test_cache_mv1");
+
+        {
+            // invalid base table
+            String alterSql = "alter table test_base_tbl modify column col1  varchar(30);";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql,
+                    connectContext);
+            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterTableStmt);
+            waitForSchemaChangeAlterJobFinish();
+
+            // check mv invalid
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView mv1 = ((MaterializedView) testDb.getTable("test_cache_mv1"));
+            Assert.assertFalse(mv1.isActive());
+            try {
+                cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
+                Assert.fail("could not active the mv");
+            } catch (Exception e) {
+                Assert.assertTrue(e.getMessage().contains("mv schema changed"));
+            }
+
+            plan = getFragmentPlan(sql);
+            PlanTestBase.assertNotContains(plan, "test_cache_mv1");
+        }
+
+        {
+            // alter the column to original one
+            String alterSql = "alter table test_base_tbl modify column col1 bigint;";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql,
+                    connectContext);
+            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterTableStmt);
+            waitForSchemaChangeAlterJobFinish();
+
+            cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
+            plan = getFragmentPlan(sql);
+            PlanTestBase.assertContains(plan, "test_cache_mv1");
+        }
+    }
+
+    @Test
+    public void testMVAggregateTable() throws Exception {
+        starRocksAssert.withTable("CREATE TABLE `t1_agg` (\n" +
+                "  `c_1_0` datetime NULL COMMENT \"\",\n" +
+                "  `c_1_1` decimal128(24, 8) NOT NULL COMMENT \"\",\n" +
+                "  `c_1_2` double SUM NOT NULL COMMENT \"\"\n" +
+                ") ENGINE=OLAP\n" +
+                "AGGREGATE KEY(`c_1_0`, `c_1_1`)\n" +
+                "DISTRIBUTED BY HASH(`c_1_1`) BUCKETS 3");
+
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv_t1_v0 " +
+                "AS " +
+                "SELECT t1_17.c_1_0, t1_17.c_1_1, SUM(t1_17.c_1_2) " +
+                "FROM t1_agg AS t1_17 " +
+                "GROUP BY t1_17.c_1_0, t1_17.c_1_1 ORDER BY t1_17.c_1_0 DESC, t1_17.c_1_1 ASC");
+
+        {
+            String query = "select * from t1_agg";
+            String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, query);
+            PlanTestBase.assertContains(plan, "table: t1_agg, rollup: mv_t1_v0\n");
+        }
+        {
+
+            String query = "select c_1_0, c_1_1, sum(c_1_2) from t1_agg group by c_1_0, c_1_1";
+            String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, query);
+            PlanTestBase.assertContains(plan, "table: t1_agg, rollup: mv_t1_v0\n");
+        }
+
+        starRocksAssert.dropMaterializedView("mv_t1_v0");
+        starRocksAssert.dropTable("t1_agg");
+    }
+
+    @Test
+    public void testMVWithViewAndSubQuery1() throws Exception {
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " SELECT v1, t1d, t1c from (select t0.v1 as v1, test_all_type.t1d, test_all_type.t1c" +
+                    " from t0 join test_all_type" +
+                    " on t0.v1 = test_all_type.t1d) t" +
+                    " where v1 < 100");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(v1)" +
+                    " as " +
+                    " SELECT * from view1");
+            {
+                String query = "SELECT (test_all_type.t1d + 1) * 2, test_all_type.t1c" +
+                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            {
+                String query = "SELECT (t1d + 1) * 2, t1c from view1 where v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+            starRocksAssert.dropView("view1");
+            dropMv("test", "join_mv_1");
+        }
+
+        // nested views
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " SELECT v1 from t0");
+
+            starRocksAssert.withView("create view view2 as " +
+                    " SELECT t1d, t1c from test_all_type");
+
+            starRocksAssert.withView("create view view3 as " +
+                    " SELECT v1, t1d, t1c from (select view1.v1, view2.t1d, view2.t1c" +
+                    " from view1 join view2" +
+                    " on view1.v1 = view2.t1d) t" +
+                    " where v1 < 100");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(v1)" +
+                    " as " +
+                    " SELECT * from view3");
+            {
+                String query = "SELECT (test_all_type.t1d + 1) * 2, test_all_type.t1c" +
+                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            {
+                String query = "SELECT (t1d + 1) * 2, t1c" +
+                        " from view3 where v1 < 100";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            starRocksAssert.dropView("view1");
+            starRocksAssert.dropView("view2");
+            starRocksAssert.dropView("view3");
+            dropMv("test", "join_mv_1");
+        }
+
+        // duplicate views
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " SELECT v1 from t0");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(v11)" +
+                    " as " +
+                    " SELECT v11, v12 from (select vv1.v1 v11, vv2.v1 v12 from view1 vv1 join view1 vv2 on vv1.v1 = vv2.v1 ) t");
+            {
+                String query = "SELECT vv1.v1, vv2.v1 from view1 vv1 join view1 vv2 on vv1.v1 = vv2.v1";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            starRocksAssert.dropView("view1");
+            dropMv("test", "join_mv_1");
+        }
+
+        {
+            starRocksAssert.withView("create view view1 as " +
+                    " select deptno1, deptno2, empid, name " +
+                    "from " +
+                    "(SELECT emps_par.deptno as deptno1, depts.deptno as deptno2, emps_par.empid, emps_par.name from emps_par " +
+                    "join depts" +
+                    " on emps_par.deptno = depts.deptno) t");
+
+            createAndRefreshMv("test", "join_mv_2", "create materialized view join_mv_2" +
+                    " distributed by hash(deptno2)" +
+                    " partition by deptno1" +
+                    " as " +
+                    " SELECT deptno1, deptno2, empid, name from view1 union SELECT deptno1, deptno2, empid, name from view1");
+
+            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
+                    " distributed by hash(deptno2)" +
+                    " partition by deptno1" +
+                    " as " +
+                    " SELECT deptno1, deptno2, empid, name from view1");
+
+            {
+                String query = "SELECT deptno1, deptno2, empid, name from view1";
+                String plan = getFragmentPlan(query);
+                PlanTestBase.assertContains(plan, "join_mv_1");
+            }
+
+            starRocksAssert.dropView("view1");
+            dropMv("test", "join_mv_1");
+            dropMv("test", "join_mv_2");
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Range;
 import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.Database;
 import com.starrocks.catalog.ForeignKeyConstraint;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
@@ -29,15 +28,10 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.qe.ShowResultSet;
-import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.ast.AlterTableStmt;
-import com.starrocks.sql.ast.CreateMaterializedViewStmt;
-import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.CachingMvPlanContextBuilder;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.plan.PlanTestBase;
-import com.starrocks.utframe.UtFrameUtils;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -46,9 +40,6 @@ import java.sql.SQLException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import static com.starrocks.sql.optimizer.MVTestUtils.waitForSchemaChangeAlterJobFinish;
-import static com.starrocks.sql.optimizer.MVTestUtils.waitingRollupJobV2Finish;
 
 public class MvRewriteTest extends MvRewriteTestBase {
 
@@ -189,124 +180,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
                     " SELECT emps_par.deptno as deptno1, depts.deptno as deptno2, emps_par.empid, emps_par.name" +
                     " from emps_par join depts" +
                     " on emps_par.deptno = depts.deptno");
-
-            createAndRefreshMv("test", "join_mv_2", "create materialized view join_mv_2" +
-                    " distributed by hash(deptno2)" +
-                    " partition by deptno1" +
-                    " as " +
-                    " SELECT deptno1, deptno2, empid, name from view1 union SELECT deptno1, deptno2, empid, name from view1");
-
-            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
-                    " distributed by hash(deptno2)" +
-                    " partition by deptno1" +
-                    " as " +
-                    " SELECT deptno1, deptno2, empid, name from view1");
-
-            {
-                String query = "SELECT deptno1, deptno2, empid, name from view1";
-                String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "join_mv_1");
-            }
-
-            starRocksAssert.dropView("view1");
-            dropMv("test", "join_mv_1");
-            dropMv("test", "join_mv_2");
-        }
-    }
-
-    @Test
-    public void testMVWithViewAndSubQuery1() throws Exception {
-        {
-            starRocksAssert.withView("create view view1 as " +
-                    " SELECT v1, t1d, t1c from (select t0.v1 as v1, test_all_type.t1d, test_all_type.t1c" +
-                    " from t0 join test_all_type" +
-                    " on t0.v1 = test_all_type.t1d) t" +
-                    " where v1 < 100");
-
-            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
-                    " distributed by hash(v1)" +
-                    " as " +
-                    " SELECT * from view1");
-            {
-                String query = "SELECT (test_all_type.t1d + 1) * 2, test_all_type.t1c" +
-                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 < 100";
-                String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "join_mv_1");
-            }
-
-            {
-                String query = "SELECT (t1d + 1) * 2, t1c from view1 where v1 < 100";
-                String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "join_mv_1");
-            }
-            starRocksAssert.dropView("view1");
-            dropMv("test", "join_mv_1");
-        }
-
-        // nested views
-        {
-            starRocksAssert.withView("create view view1 as " +
-                    " SELECT v1 from t0");
-
-            starRocksAssert.withView("create view view2 as " +
-                    " SELECT t1d, t1c from test_all_type");
-
-            starRocksAssert.withView("create view view3 as " +
-                    " SELECT v1, t1d, t1c from (select view1.v1, view2.t1d, view2.t1c" +
-                    " from view1 join view2" +
-                    " on view1.v1 = view2.t1d) t" +
-                    " where v1 < 100");
-
-            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
-                    " distributed by hash(v1)" +
-                    " as " +
-                    " SELECT * from view3");
-            {
-                String query = "SELECT (test_all_type.t1d + 1) * 2, test_all_type.t1c" +
-                        " from t0 join test_all_type on t0.v1 = test_all_type.t1d where t0.v1 < 100";
-                String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "join_mv_1");
-            }
-
-            {
-                String query = "SELECT (t1d + 1) * 2, t1c" +
-                        " from view3 where v1 < 100";
-                String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "join_mv_1");
-            }
-
-            starRocksAssert.dropView("view1");
-            starRocksAssert.dropView("view2");
-            starRocksAssert.dropView("view3");
-            dropMv("test", "join_mv_1");
-        }
-
-        // duplicate views
-        {
-            starRocksAssert.withView("create view view1 as " +
-                    " SELECT v1 from t0");
-
-            createAndRefreshMv("test", "join_mv_1", "create materialized view join_mv_1" +
-                    " distributed by hash(v11)" +
-                    " as " +
-                    " SELECT v11, v12 from (select vv1.v1 v11, vv2.v1 v12 from view1 vv1 join view1 vv2 on vv1.v1 = vv2.v1 ) t");
-            {
-                String query = "SELECT vv1.v1, vv2.v1 from view1 vv1 join view1 vv2 on vv1.v1 = vv2.v1";
-                String plan = getFragmentPlan(query);
-                PlanTestBase.assertContains(plan, "join_mv_1");
-            }
-
-            starRocksAssert.dropView("view1");
-            dropMv("test", "join_mv_1");
-        }
-
-        {
-            starRocksAssert.withView("create view view1 as " +
-                    " select deptno1, deptno2, empid, name " +
-                    "from " +
-                    "(SELECT emps_par.deptno as deptno1, depts.deptno as deptno2, emps_par.empid, emps_par.name from emps_par " +
-                    "join depts" +
-                    " on emps_par.deptno = depts.deptno) t");
 
             createAndRefreshMv("test", "join_mv_2", "create materialized view join_mv_2" +
                     " distributed by hash(deptno2)" +
@@ -988,88 +861,7 @@ public class MvRewriteTest extends MvRewriteTestBase {
         }
     }
 
-    @Test
-    public void testMVCacheInvalidAndReValid() throws Exception {
-        starRocksAssert.withTable("\n" +
-                "CREATE TABLE test_base_tbl(\n" +
-                "  `dt` datetime DEFAULT NULL,\n" +
-                "  `col1` bigint(20) DEFAULT NULL,\n" +
-                "  `col2` bigint(20) DEFAULT NULL,\n" +
-                "  `col3` bigint(20) DEFAULT NULL,\n" +
-                "  `error_code` varchar(1048576) DEFAULT NULL\n" +
-                ")\n" +
-                "DUPLICATE KEY (dt)\n" +
-                "PARTITION BY date_trunc('day', dt)\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");");
-        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW  test_cache_mv1 \n" +
-                "DISTRIBUTED BY HASH(col1, dt) BUCKETS 32\n" +
-                "--DISTRIBUTED BY RANDOM BUCKETS 32\n" +
-                "partition by date_trunc('day', dt)\n" +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ")\n" +
-                "AS select\n" +
-                "      col1,\n" +
-                "        dt,\n" +
-                "        sum(col2) AS sum_col2,\n" +
-                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
-                "    FROM\n" +
-                "        test_base_tbl AS f\n" +
-                "    GROUP BY\n" +
-                "        col1,\n" +
-                "        dt;");
-        refreshMaterializedView("test", "test_cache_mv1");
 
-        String sql = "select\n" +
-                "      col1,\n" +
-                "        sum(col2) AS sum_col2,\n" +
-                "        sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3\n" +
-                "    FROM\n" +
-                "        test_base_tbl AS f\n" +
-                "    WHERE (dt >= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                "        AND (dt <= STR_TO_DATE('2023-08-15 00:00:00', '%Y-%m-%d %H:%i:%s'))\n" +
-                "    GROUP BY col1;";
-        String plan = getFragmentPlan(sql);
-        PlanTestBase.assertContains(plan, "test_cache_mv1");
-
-        {
-            // invalid base table
-            String alterSql = "alter table test_base_tbl modify column col1  varchar(30);";
-            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql,
-                    connectContext);
-            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterTableStmt);
-            waitForSchemaChangeAlterJobFinish();
-
-            // check mv invalid
-            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
-            MaterializedView mv1 = ((MaterializedView) testDb.getTable("test_cache_mv1"));
-            Assert.assertFalse(mv1.isActive());
-            try {
-                cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
-                Assert.fail("could not active the mv");
-            } catch (Exception e) {
-                Assert.assertTrue(e.getMessage().contains("mv schema changed"));
-            }
-
-            plan = getFragmentPlan(sql);
-            PlanTestBase.assertNotContains(plan, "test_cache_mv1");
-        }
-
-        {
-            // alter the column to original one
-            String alterSql = "alter table test_base_tbl modify column col1 bigint;";
-            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterSql,
-                    connectContext);
-            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(alterTableStmt);
-            waitForSchemaChangeAlterJobFinish();
-
-            cluster.runSql("test", "alter materialized view test_cache_mv1 active;");
-            plan = getFragmentPlan(sql);
-            PlanTestBase.assertContains(plan, "test_cache_mv1");
-        }
-    }
 
     @Test
     public void testCardinality() throws Exception {
@@ -1466,35 +1258,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
             PlanTestBase.assertContains(plan, "partitions=4/4\n" +
                     "     rollup: test_partition_tbl_mv1");
         }
-    }
-
-    @Test
-    public void testPartitionPrune_SyncMV1() throws Exception {
-        starRocksAssert.withTable("CREATE TABLE `sync_tbl_t1` (\n" +
-                "                  `dt` date NOT NULL COMMENT \"\",\n" +
-                "                  `a` bigint(20) NOT NULL COMMENT \"\",\n" +
-                "                  `b` bigint(20) NOT NULL COMMENT \"\",\n" +
-                "                  `c` bigint(20) NOT NULL COMMENT \"\"\n" +
-                "                ) \n" +
-                "                DUPLICATE KEY(`dt`)\n" +
-                "                COMMENT \"OLAP\"\n" +
-                "                PARTITION BY RANGE(`dt`)\n" +
-                "                (PARTITION p20220501 VALUES [('2022-05-01'), ('2022-05-02')),\n" +
-                "                 PARTITION p20220502 VALUES [('2022-05-02'), ('2022-05-03')),\n" +
-                "                PARTITION p20220503 VALUES [('2022-05-03'), ('2022-05-04')))\n" +
-                "                DISTRIBUTED BY HASH(`a`) BUCKETS 32\n" +
-                "                PROPERTIES (\n" +
-                "                \"in_memory\" = \"false\",\n" +
-                "                \"storage_format\" = \"DEFAULT\",\n" +
-                "                \"enable_persistent_index\" = \"false\"\n" +
-                "                );");
-        String sql = "CREATE MATERIALIZED VIEW sync_mv1 AS select a, b*10 as col2, c+1 as col3 from sync_tbl_t1;";
-        StatementBase statementBase = UtFrameUtils.parseStmtWithNewParser(sql, connectContext);
-        GlobalStateMgr.getCurrentState().createMaterializedView((CreateMaterializedViewStmt) statementBase);
-        waitingRollupJobV2Finish();
-        String query = "select a, b*10 as col2, c+1 as col3 from sync_tbl_t1 order by a;";
-        String plan = getFragmentPlan(query);
-        PlanTestBase.assertContains(plan, "sync_mv1");
     }
 
     @Test
@@ -1981,38 +1744,6 @@ public class MvRewriteTest extends MvRewriteTestBase {
                 starRocksAssert.dropMaterializedView(mvName);
             }
         }
-    }
-
-    @Test
-    public void testMVAggregateTable() throws Exception {
-        starRocksAssert.withTable("CREATE TABLE `t1_agg` (\n" +
-                "  `c_1_0` datetime NULL COMMENT \"\",\n" +
-                "  `c_1_1` decimal128(24, 8) NOT NULL COMMENT \"\",\n" +
-                "  `c_1_2` double SUM NOT NULL COMMENT \"\"\n" +
-                ") ENGINE=OLAP\n" +
-                "AGGREGATE KEY(`c_1_0`, `c_1_1`)\n" +
-                "DISTRIBUTED BY HASH(`c_1_1`) BUCKETS 3");
-
-        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW mv_t1_v0 " +
-                "AS " +
-                "SELECT t1_17.c_1_0, t1_17.c_1_1, SUM(t1_17.c_1_2) " +
-                "FROM t1_agg AS t1_17 " +
-                "GROUP BY t1_17.c_1_0, t1_17.c_1_1 ORDER BY t1_17.c_1_0 DESC, t1_17.c_1_1 ASC");
-
-        {
-            String query = "select * from t1_agg";
-            String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, query);
-            PlanTestBase.assertContains(plan, "table: t1_agg, rollup: mv_t1_v0\n");
-        }
-        {
-
-            String query = "select c_1_0, c_1_1, sum(c_1_2) from t1_agg group by c_1_0, c_1_1";
-            String plan = UtFrameUtils.getVerboseFragmentPlan(connectContext, query);
-            PlanTestBase.assertContains(plan, "table: t1_agg, rollup: mv_t1_v0\n");
-        }
-
-        starRocksAssert.dropMaterializedView("mv_t1_v0");
-        starRocksAssert.dropTable("t1_agg");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -94,6 +94,7 @@ public class MvRewriteTestBase {
         Config.enable_new_publish_mechanism = true;
         Config.alter_scheduler_interval_millisecond = 100;
         FeConstants.enablePruneEmptyOutputScan = false;
+        FeConstants.runningUnitTest = true;
         startSuiteTime = Instant.now().getEpochSecond();
 
         // build a small cache for test

--- a/test/lib/sr_sql_lib.py
+++ b/test/lib/sr_sql_lib.py
@@ -919,14 +919,15 @@ class StarrocksSQLApiLib(object):
             count += 1
         tools.assert_equal("FINISHED", status, "wait alter table finish error")
 
-    def wait_async_materialized_view_finish(self, mv_name, check_count=60):
+    def wait_async_materialized_view_finish(self, mv_name, min_success_num = 1, check_count=60):
         """
         wait async materialized view job finish and return status
         """
         status = ""
         show_sql = "SHOW MATERIALIZED VIEWS WHERE name='" + mv_name + "'"
         count = 0
-        while count < check_count:
+        success_num = 0
+        while count < check_count and success_num < min_success_num:
             res = self.execute_sql(show_sql, True)
             status = res["result"][-1][12]
             if status != "SUCCESS":
@@ -934,7 +935,7 @@ class StarrocksSQLApiLib(object):
             else:
                 # sleep another 5s to avoid FE's async action.
                 time.sleep(1)
-                break
+                success_num += 1
             count += 1
         tools.assert_equal("SUCCESS", status, "wait aysnc materialized view finish error")
 

--- a/test/sql/test_materialized_view/R/test_create_mv_with_params
+++ b/test/sql/test_materialized_view/R/test_create_mv_with_params
@@ -1,0 +1,135 @@
+-- name: test_create_mv_with_params
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+-- result:
+-- !result
+set catalog mv_iceberg_${uuid0};
+-- result:
+-- !result
+create database mv_ice_db_${uuid0};
+-- result:
+-- !result
+use mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+create database test_create_mv_with_params;
+-- result:
+-- !result
+use test_create_mv_with_params;
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_iceberg_mv0_${uuid0} PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties (
+    "replication_num" = "1",
+    "partition_refresh_number" = "1"
+)
+AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+-- result:
+-- !result
+refresh materialized view test_iceberg_mv0_${uuid0};
+function: wait_async_materialized_view_finish("test_iceberg_mv0_${uuid0}", 2)
+-- result:
+None
+-- !result
+select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv0_${uuid0}%";
+-- result:
+1
+-- !result
+SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
+-- result:
+2023-12-01	4000
+2023-12-02	4000
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+drop materialized view test_iceberg_mv0_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_iceberg_mv1_${uuid0} PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties (
+    "replication_num" = "1"
+)
+AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+-- result:
+-- !result
+refresh materialized view test_iceberg_mv1_${uuid0};
+function: wait_async_materialized_view_finish("test_iceberg_mv1_${uuid0}", 2)
+-- result:
+None
+-- !result
+select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv1_${uuid0}%";
+-- result:
+1
+-- !result
+SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
+-- result:
+2023-12-01	4000
+2023-12-02	4000
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+drop materialized view test_iceberg_mv1_${uuid0};
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW test_iceberg_mv2_${uuid0} PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties (
+    "replication_num" = "1",
+    "partition_refresh_number" = "1"
+)
+AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+-- result:
+-- !result
+refresh materialized view test_iceberg_mv2_${uuid0} with sync mode;
+function: wait_async_materialized_view_finish("test_iceberg_mv2_${uuid0}")
+-- result:
+None
+-- !result
+select count(*) == 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv2_${uuid0}%";
+-- result:
+E: (1064, "Getting syntax error at line 1, column 16. Detail message: Unexpected input '=', the most similar input is {<EOF>, ';'}.")
+-- !result
+SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
+-- result:
+2023-12-01	4000
+2023-12-02	4000
+2023-12-03	4002
+2023-12-04	4002
+-- !result
+drop materialized view test_iceberg_mv2_${uuid0};
+-- result:
+-- !result
+drop database test_create_mv_with_params;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_create_mv_with_params
+++ b/test/sql/test_materialized_view/T/test_create_mv_with_params
@@ -1,0 +1,83 @@
+-- name: test_create_mv_with_params
+
+create external catalog mv_iceberg_${uuid0}
+properties
+(
+    "type" = "iceberg",
+    "iceberg.catalog.type" = "hive",
+    "hive.metastore.uris" = "${iceberg_catalog_hive_metastore_uris}"
+);
+set catalog mv_iceberg_${uuid0};
+create database mv_ice_db_${uuid0};
+use mv_ice_db_${uuid0};
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01'),
+  ('abc', 2000, '2023-12-02'),
+  (NULL, 2000, '2023-12-02'),
+  ('ab1d8cf2a2c0e14fa89d8117792be6eb6f', 2001, '2023-12-03'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2001, '2023-12-03'),
+  ('abc', 2001, '2023-12-04'),
+  (NULL, 2001, '2023-12-04');
+
+set catalog default_catalog;
+
+create database test_create_mv_with_params;
+use test_create_mv_with_params;
+
+-- case 1: with specific param
+CREATE MATERIALIZED VIEW test_iceberg_mv0_${uuid0} PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties (
+    "replication_num" = "1",
+    "partition_refresh_number" = "1"
+)
+AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+
+refresh materialized view test_iceberg_mv0_${uuid0};
+function: wait_async_materialized_view_finish("test_iceberg_mv0_${uuid0}", 2)
+-- result should be > 1, because it refresh partitions one by one
+select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv0_${uuid0}%";
+SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
+drop materialized view test_iceberg_mv0_${uuid0};
+
+-- case 2: with no params
+CREATE MATERIALIZED VIEW test_iceberg_mv1_${uuid0} PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties (
+    "replication_num" = "1"
+)
+AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+
+refresh materialized view test_iceberg_mv1_${uuid0};
+function: wait_async_materialized_view_finish("test_iceberg_mv1_${uuid0}", 2)
+-- result should be > 1, because it refresh partitions one by one
+select count(*) > 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv1_${uuid0}%";
+SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
+drop materialized view test_iceberg_mv1_${uuid0};
+
+-- case3: test sync mode with params
+CREATE MATERIALIZED VIEW test_iceberg_mv2_${uuid0} PARTITION BY dt 
+REFRESH DEFERRED MANUAL 
+properties (
+    "replication_num" = "1",
+    "partition_refresh_number" = "1"
+)
+AS SELECT dt,sum(col_int) 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt;
+
+refresh materialized view test_iceberg_mv2_${uuid0} with sync mode;
+function: wait_async_materialized_view_finish("test_iceberg_mv2_${uuid0}")
+-- result should be 1, because it refresh partitions by sync
+select count(*) = 1 from information_schema.task_runs where `database`='test_create_mv_with_params' and `DEFINITION` like "%test_iceberg_mv2_${uuid0}%";
+SELECT dt,sum(col_int)  FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0}  GROUP BY dt order by dt;
+drop materialized view test_iceberg_mv2_${uuid0};
+
+drop database test_create_mv_with_params;


### PR DESCRIPTION
Why I'm doing:
1. Now `default_mv_refresh_partition_num`=-1, this will refresh all partitions at the same time when refreshing mv which may cause OOM or other failures if base tables have a lot of partitions.
2. SyncMV refresh will only refresh partition updated partitions if users set `refresh_partition_num`,  but this may cause wrong results because users want to refresh all need refresh partitions.

What I'm doing:

- Add default_mv_refresh_partition_num to config default partition refresh num;
- set default partition_refresh_num to 1;
- Fix MV Sync Refresh may 

Fixes #issue

TODO:
- Maybe we can adjust `refresh_partition_num` adaptively according the cluster size/load and mv's defination.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
