### PR TITLE
[BugFix] Fast schema evolution task lost default expr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -736,7 +736,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
             int sortKeyIdx = targetIndexSchema.indexOf(oneCol.get());
             sortKeyIdxes.add(sortKeyIdx);
-            if (useSortKeyUniqueId && oneCol.get().getUniqueId() > 0) {
+            if (useSortKeyUniqueId && oneCol.get().getUniqueId() >= 0) {
                 sortKeyUniqueIds.add(oneCol.get().getUniqueId());
             } else {
                 useSortKeyUniqueId = false;

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -180,7 +180,6 @@ public class SchemaChangeHandler extends AlterHandler {
     private boolean processAddColumn(AddColumnClause alterClause, OlapTable olapTable,
                                      Map<Long, LinkedList<Column>> indexSchemaMap,
                                      IntSupplier colUniqueIdSupplier) throws DdlException {
-        LOG.info("process add column");
         Column column = alterClause.getColumn();
         ColumnPosition columnPos = alterClause.getColPos();
         String targetIndexName = alterClause.getRollupName();
@@ -217,7 +216,6 @@ public class SchemaChangeHandler extends AlterHandler {
     private boolean processAddColumns(AddColumnsClause alterClause, OlapTable olapTable,
                                       Map<Long, LinkedList<Column>> indexSchemaMap,
                                       IntSupplier colUniqueIdSupplier) throws DdlException {
-        LOG.info("process add columns");
         List<Column> columns = alterClause.getColumns();
         String targetIndexName = alterClause.getRollupName();
         checkIndexExists(olapTable, targetIndexName);
@@ -271,8 +269,6 @@ public class SchemaChangeHandler extends AlterHandler {
      */
     private boolean processDropColumn(DropColumnClause alterClause, OlapTable olapTable,
                                       Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes) throws DdlException {
-
-        LOG.info("process drop column");
         boolean fastSchemaEvolution = 
                 (olapTable.getUseFastSchemaEvolution() == null) ? false : olapTable.getUseFastSchemaEvolution();
         String dropColName = alterClause.getColName();

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -180,6 +180,7 @@ public class SchemaChangeHandler extends AlterHandler {
     private boolean processAddColumn(AddColumnClause alterClause, OlapTable olapTable,
                                      Map<Long, LinkedList<Column>> indexSchemaMap,
                                      IntSupplier colUniqueIdSupplier) throws DdlException {
+        LOG.info("process add column");
         Column column = alterClause.getColumn();
         ColumnPosition columnPos = alterClause.getColPos();
         String targetIndexName = alterClause.getRollupName();
@@ -216,6 +217,7 @@ public class SchemaChangeHandler extends AlterHandler {
     private boolean processAddColumns(AddColumnsClause alterClause, OlapTable olapTable,
                                       Map<Long, LinkedList<Column>> indexSchemaMap,
                                       IntSupplier colUniqueIdSupplier) throws DdlException {
+        LOG.info("process add columns");
         List<Column> columns = alterClause.getColumns();
         String targetIndexName = alterClause.getRollupName();
         checkIndexExists(olapTable, targetIndexName);
@@ -241,10 +243,10 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
 
-        boolean ligthSchemaChange = true;
+        boolean ligthSchemaChange = olapTable.getUseFastSchemaEvolution();
         if (alterClause.getGeneratedColumnPos() == null) {
             for (Column column : columns) {
-                ligthSchemaChange = addColumnInternal(olapTable, column, null, targetIndexId, baseIndexId, indexSchemaMap,
+                ligthSchemaChange &= addColumnInternal(olapTable, column, null, targetIndexId, baseIndexId, indexSchemaMap,
                         newColNameSet);
             }
         } else {
@@ -270,7 +272,9 @@ public class SchemaChangeHandler extends AlterHandler {
     private boolean processDropColumn(DropColumnClause alterClause, OlapTable olapTable,
                                       Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes) throws DdlException {
 
-        boolean fastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
+        LOG.info("process drop column");
+        boolean fastSchemaEvolution = 
+                (olapTable.getUseFastSchemaEvolution() == null) ? false : olapTable.getUseFastSchemaEvolution();
         String dropColName = alterClause.getColName();
         String targetIndexName = alterClause.getRollupName();
         checkIndexExists(olapTable, targetIndexName);
@@ -767,9 +771,14 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException("unsupported default expr:" + newColumn.getDefaultExpr().getExpr());
         }
 
-        boolean fastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
+        boolean fastSchemaEvolution = 
+                (olapTable.getUseFastSchemaEvolution() == null) ? false : olapTable.getUseFastSchemaEvolution();
         // if column is generated column, need to rewrite table data, so we can not use light schema change
         if (newColumn.isAutoIncrement() || newColumn.isGeneratedColumn()) {
+            fastSchemaEvolution = false;
+        }
+
+        if (newColumn.getDefaultValue() != null && newColumn.getDefaultExpr() != null) {
             fastSchemaEvolution = false;
         }
 
@@ -1425,7 +1434,11 @@ public class SchemaChangeHandler extends AlterHandler {
     @Nullable
     public AlterJobV2 analyzeAndCreateJob(List<AlterClause> alterClauses, Database db, OlapTable olapTable) throws UserException {
         //alterClauses can or cannot light schema change
-        boolean fastSchemaEvolution = true;
+        if (olapTable == null) {
+            throw new DdlException("olapTable is null");
+        }
+        boolean fastSchemaEvolution = 
+                (olapTable.getUseFastSchemaEvolution() == null) ? false : olapTable.getUseFastSchemaEvolution();
         //for multi add colmuns clauses
         IntSupplier colUniqueIdSupplier = new IntSupplier() {
             private int pendingMaxColUniqueId = olapTable.getMaxColUniqueId();
@@ -1444,6 +1457,7 @@ public class SchemaChangeHandler extends AlterHandler {
         }
         List<Index> newIndexes = olapTable.getCopiedIndexes();
         Map<String, String> propertyMap = new HashMap<>();
+        Set<String> addColumnsName = Sets.newHashSet();
         for (AlterClause alterClause : alterClauses) {
             Map<String, String> properties = alterClause.getProperties();
             if (properties != null) {
@@ -1527,16 +1541,21 @@ public class SchemaChangeHandler extends AlterHandler {
 
             if (alterClause instanceof AddColumnClause) {
                 // add column
-                fastSchemaEvolution =
+                addColumnsName.add(((AddColumnClause) alterClause).getColumn().getName());
+                fastSchemaEvolution &=
                         processAddColumn((AddColumnClause) alterClause, olapTable, indexSchemaMap,
                                 colUniqueIdSupplier);
             } else if (alterClause instanceof AddColumnsClause) {
                 // add columns
-                fastSchemaEvolution =
+                List<Column> columns = ((AddColumnsClause) alterClause).getColumns();
+                for (Column column : columns) {
+                    addColumnsName.add(column.getName());
+                }
+                fastSchemaEvolution &=
                         processAddColumns((AddColumnsClause) alterClause, olapTable, indexSchemaMap, colUniqueIdSupplier);
             } else if (alterClause instanceof DropColumnClause) {
                 // drop column and drop indexes on this column
-                fastSchemaEvolution =
+                fastSchemaEvolution &=
                         processDropColumn((DropColumnClause) alterClause, olapTable, indexSchemaMap,
                                 newIndexes);
             } else if (alterClause instanceof ModifyColumnClause) {
@@ -1579,8 +1598,10 @@ public class SchemaChangeHandler extends AlterHandler {
         if (fastSchemaEvolution) {
             long jobId = GlobalStateMgr.getCurrentState().getNextId();
             long txnId = GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+            long startTime = ConnectContext.get().getStartTime();
             //for schema change add/drop value column optimize, direct modify table meta.
-            modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, newIndexes, jobId, txnId, false);
+            modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, newIndexes, jobId, txnId, startTime,
+                                        addColumnsName, false);
             return null;
         } else {
             return createJob(db.getId(), olapTable, indexSchemaMap, propertyMap, newIndexes);
@@ -2264,7 +2285,8 @@ public class SchemaChangeHandler extends AlterHandler {
     // the invoker should keep write lock
     public void modifyTableAddOrDropColumns(Database db, OlapTable olapTable,
                                             Map<Long, LinkedList<Column>> indexSchemaMap,
-                                            List<Index> indexes, long jobId, long txnId, boolean isReplay)
+                                            List<Index> indexes, long jobId, long txnId, long startTime,
+                                            Set<String> addColumnsName, boolean isReplay)
             throws DdlException, NotImplementedException {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.WRITE);
@@ -2372,12 +2394,13 @@ public class SchemaChangeHandler extends AlterHandler {
             List<Long> indexIds = new ArrayList<Long>();
             indexIds.add(baseIndexId);
             indexIds.addAll(olapTable.getIndexIdListExceptBaseIndex());
-            Set<String> modifiedColumns = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+            Set<String> modifiedColumns = Sets.newHashSet();
             Boolean hasMv = !olapTable.getRelatedMaterializedViews().isEmpty();
             for (long idx : indexIds) {
                 List<Column> indexSchema = indexSchemaMap.get(idx);
                 MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(idx);
                 List<Column> originSchema = currentIndexMeta.getSchema();
+                
                 if (hasMv && indexSchema.size() < originSchema.size()) {
                     // drop column
                     List<Column> differences = originSchema.stream().filter(element ->
@@ -2386,6 +2409,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     Integer dropIdx = new Integer(originSchema.indexOf(differences.get(0)));
                     modifiedColumns.add(originSchema.get(dropIdx).getName());
                 }
+
                 List<Integer> sortKeyUniqueIds = currentIndexMeta.getSortKeyUniqueIds();
                 List<Integer> newSortKeyIdxes = new ArrayList<Integer>();
                 if (sortKeyUniqueIds != null) {
@@ -2398,6 +2422,24 @@ public class SchemaChangeHandler extends AlterHandler {
                         newSortKeyIdxes.add(sortKeyIdx);
                     }
                 }
+
+                // upgrade from old version and replay task, addColumnsName maybe null
+                if (addColumnsName != null) {
+                    for (String columnName : addColumnsName) {
+                        Optional<Column> col = indexSchema.stream().filter(c -> c.getName() == columnName).findFirst();
+                        if (!col.isPresent()) {
+                            continue;
+                        }
+                        Column column = col.get();
+                        if (column.getDefaultExpr() != null) {
+                            Column.DefaultValueType defaultValueType = column.getDefaultValueType();
+                            if (defaultValueType == Column.DefaultValueType.CONST) {
+                                column.setDefaultValue(column.calculatedDefaultValueWithTime(startTime));
+                            }
+                        }
+                    }
+                }
+
                 currentIndexMeta.setSchema(indexSchema);
                 if (!newSortKeyIdxes.isEmpty()) {
                     currentIndexMeta.setSortKeyIdxes(newSortKeyIdxes);
@@ -2422,18 +2464,6 @@ public class SchemaChangeHandler extends AlterHandler {
             }
             olapTable.setMaxColUniqueId(maxColUniqueId);
 
-            if (!isReplay) {
-                TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),
-                        indexSchemaMap, indexes, jobId, txnId);
-                LOG.debug("logModifyTableAddOrDropColumns info:{}", info);
-                GlobalStateMgr.getCurrentState().getEditLog().logModifyTableAddOrDropColumns(info);
-            }
-
-            schemaChangeJob.setWatershedTxnId(txnId);
-            schemaChangeJob.setJobState(AlterJobV2.JobState.FINISHED);
-            schemaChangeJob.setFinishedTimeMs(System.currentTimeMillis());
-            this.addAlterJobV2(schemaChangeJob);
-
             // inactive related mv
             if (!modifiedColumns.isEmpty()) {
                 for (MvId mvId : olapTable.getRelatedMaterializedViews()) {
@@ -2454,6 +2484,18 @@ public class SchemaChangeHandler extends AlterHandler {
                     }
                 }
             }
+
+            if (!isReplay) {
+                TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),
+                        indexSchemaMap, indexes, jobId, txnId, startTime, addColumnsName);
+                LOG.debug("logModifyTableAddOrDropColumns info:{}", info);
+                GlobalStateMgr.getCurrentState().getEditLog().logModifyTableAddOrDropColumns(info);
+            }
+
+            schemaChangeJob.setWatershedTxnId(txnId);
+            schemaChangeJob.setJobState(AlterJobV2.JobState.FINISHED);
+            schemaChangeJob.setFinishedTimeMs(System.currentTimeMillis());
+            this.addAlterJobV2(schemaChangeJob);
 
             olapTable.lastSchemaUpdateTime.set(System.currentTimeMillis());
             LOG.info("finished modify table's add or drop columns. table: {}, is replay: {}", olapTable.getName(),
@@ -2480,7 +2522,8 @@ public class SchemaChangeHandler extends AlterHandler {
         Locker locker = new Locker();
         try {
             locker.lockDatabase(db, LockType.WRITE);
-            modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, indexes, jobId, info.getTxnId(), true);
+            modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, indexes, jobId, info.getTxnId(), 
+                                        info.getStartTime(), info.getAddColumnsName(), true);
         } catch (DdlException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop columns", e);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -575,14 +575,14 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     }
 
     public DefaultValueType getDefaultValueType() {
-        if (defaultValue != null) {
-            return DefaultValueType.CONST;
-        } else if (defaultExpr != null) {
+        if (defaultExpr != null) {
             if ("now()".equalsIgnoreCase(defaultExpr.getExpr())) {
                 return DefaultValueType.CONST;
             } else {
                 return DefaultValueType.VARY;
             }
+        } else if (defaultValue != null) {
+            return DefaultValueType.CONST;
         }
         return DefaultValueType.NULL;
     }
@@ -593,20 +593,24 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // This function is only used to a const default value like "-1" or now().
     // If the default value is uuid(), this function is not suitable.
     public String calculatedDefaultValue() {
+        if (defaultExpr != null) {
+            if ("now()".equalsIgnoreCase(defaultExpr.getExpr())) {
+                // current transaction time
+                if (ConnectContext.get() != null) {
+                    LocalDateTime localDateTime = Instant.ofEpochMilli(ConnectContext.get().getStartTime())
+                            .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
+                    return localDateTime.format(DATE_TIME_FORMATTER);
+                } else {
+                    // should not run up here
+                    return LocalDateTime.now().format(DATE_TIME_FORMATTER);
+                }
+            }
+        }
+        
         if (defaultValue != null) {
             return defaultValue;
         }
-        if ("now()".equalsIgnoreCase(defaultExpr.getExpr())) {
-            // current transaction time
-            if (ConnectContext.get() != null) {
-                LocalDateTime localDateTime = Instant.ofEpochMilli(ConnectContext.get().getStartTime())
-                        .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
-                return localDateTime.format(DATE_TIME_FORMATTER);
-            } else {
-                // should not run up here
-                return LocalDateTime.now().format(DATE_TIME_FORMATTER);
-            }
-        }
+
         return null;
     }
 
@@ -617,14 +621,18 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
     // This function is only used to a const default value like "-1" or now().
     // If the default value is uuid(), this function is not suitable.
     public String calculatedDefaultValueWithTime(long currentTimestamp) {
+        if (defaultExpr != null) {
+            if ("now()".equalsIgnoreCase(defaultExpr.getExpr())) {
+                LocalDateTime localDateTime = Instant.ofEpochMilli(currentTimestamp)
+                        .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
+                return localDateTime.format(DATE_TIME_FORMATTER);
+            }
+        }
+
         if (defaultValue != null) {
             return defaultValue;
         }
-        if ("now()".equalsIgnoreCase(defaultExpr.getExpr())) {
-            LocalDateTime localDateTime = Instant.ofEpochMilli(currentTimestamp)
-                    .atZone(TimeUtils.getTimeZone().toZoneId()).toLocalDateTime();
-            return localDateTime.format(DATE_TIME_FORMATTER);
-        }
+
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/TableAddOrDropColumnsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/TableAddOrDropColumnsInfo.java
@@ -49,6 +49,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * PersistInfo for Table properties
@@ -67,16 +68,22 @@ public class TableAddOrDropColumnsInfo implements Writable {
     private long jobId;
     @SerializedName(value = "txnId")
     private long txnId;
+    @SerializedName(value = "startTime")
+    private long startTime;
+    @SerializedName(value = "addColumnsName")
+    private Set<String> addColumnsName;
 
     public TableAddOrDropColumnsInfo(long dbId, long tableId,
             Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes, long jobId,
-            long txnId) {
+            long txnId, long startTime, Set<String> addColumnsName) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.indexSchemaMap = indexSchemaMap;
         this.indexes = indexes;
         this.jobId = jobId;
         this.txnId = txnId;
+        this.startTime = startTime;
+        this.addColumnsName = addColumnsName;
     }
 
     public long getDbId() {
@@ -101,6 +108,14 @@ public class TableAddOrDropColumnsInfo implements Writable {
 
     public long getTxnId() {
         return txnId;
+    }
+
+    public long getStartTime() {
+        return startTime;
+    }
+
+    public Set<String> getAddColumnsName() {
+        return addColumnsName;
     }
 
     @Override
@@ -143,6 +158,8 @@ public class TableAddOrDropColumnsInfo implements Writable {
         sb.append(" indexes: ").append(indexes);
         sb.append(" jobId: ").append(jobId);
         sb.append(" txnId: ").append(txnId);
+        sb.append(" startTime: ").append(startTime);
+        sb.append(" addColumnsName: ").append(addColumnsName);
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.alter;
 
+import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
@@ -51,6 +52,7 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -378,13 +380,15 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         Assertions.assertDoesNotThrow(
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 100, 100, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 100, 100, 100,
+                                                     Collections.emptySet(), false));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         Assertions.assertDoesNotThrow(
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 101, 101, true));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 101, 101, 101,
+                                                     Collections.emptySet(), true));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
@@ -392,7 +396,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         tbl.setState(OlapTableState.ROLLUP);
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 102, 102, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 102, 102, 102,
+                                                     Collections.emptySet(), false));
         tbl.setState(beforeState);
 
         Map<Long, LinkedList<Column>> indexSchemaMapInvalid2 = new HashMap<>(indexSchemaMap);
@@ -402,7 +407,8 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid2, newIndexes, 103, 103, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid2, newIndexes, 103, 103, 103,
+                                                     Sets.newHashSet("kk"), false));
 
         Map<Long, LinkedList<Column>> indexSchemaMapInvalid3 = new HashMap<>(indexSchemaMap);
 
@@ -410,13 +416,15 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         indexSchemaMapInvalid3.get(tbl.getBaseIndexId()).removeIf(Column::isKey);
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid3, newIndexes, 104, 104, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid3, newIndexes, 104, 104, 104,
+                                                     Collections.emptySet(), false));
 
         Map<Long, LinkedList<Column>> emptyIndexMap = new HashMap<>();
 
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, emptyIndexMap, newIndexes, 105, 105, false));
+                        .modifyTableAddOrDropColumns(db, tbl, emptyIndexMap, newIndexes, 105, 105, 105, 
+                                                     Collections.emptySet(), false));
 
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeJobV2Test.java
@@ -238,6 +238,7 @@ public class SchemaChangeJobV2Test extends DDLTestBase {
         alterClauses.add(new ModifyTablePropertiesClause(properties));
         Database db = CatalogMocker.mockDb();
         OlapTable olapTable = (OlapTable) db.getTable(CatalogMocker.TEST_TBL2_ID);
+        olapTable.setUseFastSchemaEvolution(false);
         schemaChangeHandler.process(alterClauses, db, olapTable);
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().isExist());
         Assert.assertTrue(olapTable.getTableProperty().getDynamicPartitionProperty().getEnable());

--- a/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
@@ -23,16 +23,21 @@ public class TableAddOrDropColumnsInfoTest {
     @Test
     public void test() {
         TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(1, 1,
-                Collections.emptyMap(), Collections.emptyList(), 0, 1);
+                Collections.emptyMap(), Collections.emptyList(), 0, 1, 0,
+                Collections.emptySet());
 
         Assert.assertEquals(1, info.getDbId());
         Assert.assertEquals(1, info.getTableId());
         Assert.assertEquals(0, info.getIndexes().size());
         Assert.assertEquals(0, info.getIndexSchemaMap().size());
         Assert.assertEquals(0, info.getJobId());
+        Assert.assertEquals(1, info.getTxnId());
+        Assert.assertEquals(0, info.getStartTime());
+        Assert.assertEquals(0, info.getAddColumnsName().size());
 
         TableAddOrDropColumnsInfo info2 = new TableAddOrDropColumnsInfo(1, 1,
-                Collections.emptyMap(), Collections.emptyList(), 0, 1);
+                Collections.emptyMap(), Collections.emptyList(), 0, 1, 0,
+                Collections.emptySet());
 
         Assert.assertEquals(info.hashCode(), info2.hashCode());
         Assert.assertEquals(info, info2);

--- a/test/sql/test_ddl/R/test_alter_pk_reorder
+++ b/test/sql/test_ddl/R/test_alter_pk_reorder
@@ -33,6 +33,10 @@ insert into tab1 values (500,500,500,500,500);
 insert into tab1 values (600,600,600,600,600);
 -- result:
 -- !result
+select * from tab1 where k1 = 100;
+-- result:
+100	100	100	100	100
+-- !result
 alter table tab1 order by (k2,k1);
 -- result:
 -- !result
@@ -53,7 +57,10 @@ select * from tab1;
 600	600	600	600	600
 700	700	700	700	700
 -- !result
-
+select * from tab1 where k2 = 100;
+-- result:
+100	100	100	100	100
+-- !result
 -- name: test_alter_pk_reorder_column_type
 CREATE TABLE `test_alter_pk_reorder_column_type` (
   `k1` date NOT NULL COMMENT "",

--- a/test/sql/test_ddl/T/test_alter_pk_reorder
+++ b/test/sql/test_ddl/T/test_alter_pk_reorder
@@ -20,10 +20,13 @@ insert into tab1 values (300,300,300,300,300);
 insert into tab1 values (400,400,400,400,400);
 insert into tab1 values (500,500,500,500,500);
 insert into tab1 values (600,600,600,600,600);
+select * from tab1 where k1 = 100;
+
 alter table tab1 order by (k2,k1);
 function: wait_alter_table_finish()
 insert into tab1 values (700,700,700,700,700);
 select * from tab1;
+select * from tab1 where k2 = 100;
 
 
 -- name: test_alter_pk_reorder_column_type

--- a/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/R/test_fast_schema_evolution
@@ -54,8 +54,8 @@ insert into t1 values(2, 2, 3);
 select * from t1 order by k;
 -- result:
 1	None	None
-2	3	5
 2	2	3
+2	3	5
 -- !result
 alter table t1 add column k2 int key;
 -- result:
@@ -67,8 +67,8 @@ None
 select * from t1 order by k;
 -- result:
 1	None	None	None
-2	None	3	5
 2	None	2	3
+2	None	3	5
 -- !result
 insert into t1 values(3, 2, 3, 4);
 -- result:
@@ -76,8 +76,8 @@ insert into t1 values(3, 2, 3, 4);
 select * from t1 order by k;
 -- result:
 1	None	None	None
-2	None	3	5
 2	None	2	3
+2	None	3	5
 3	2	3	4
 -- !result
 delete from t1 where v3>4;
@@ -629,5 +629,96 @@ drop table tab1;
 -- result:
 -- !result
 drop database test_fast_schema_evolution_and_mv;
+-- result:
+-- !result
+-- name: test_fast_schema_evolution_add_column_with_expr
+create database test_fast_schema_evolution_add_column_with_expr;
+-- result:
+-- !result
+use test_fast_schema_evolution_add_column_with_expr;
+-- result:
+-- !result
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+-- result:
+-- !result
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+-- result:
+-- !result
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+-- result:
+-- !result
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+-- result:
+-- !result
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+-- result:
+-- !result
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+-- result:
+-- !result
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+-- result:
+-- !result
+select * from tab1;
+-- result:
+100	k2_100	100	100	100	v4_100	v5_100
+200	k2_200	200	200	200	v4_200	v5_200
+300	k2_300	300	300	300	v4_300	v5_300
+400	k2_400	400	400	400	v4_400	v5_400
+500	k2_500	500	500	500	v4_500	v5_500
+600	k2_600	600	600	600	v4_600	v5_600
+-- !result
+alter table tab1 add column c1 datetime default current_timestamp;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(*) from tab1 where c1 is NULL;
+-- result:
+0
+-- !result
+alter table tab1 add column c2 datetime not null default current_timestamp;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(*) from tab1 where c2 is NULL;
+-- result:
+0
+-- !result
+alter table tab1 add column c3 datetime;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+select count(*) from tab1 where c3 is NULL;
+-- result:
+6
+-- !result
+drop table tab1;
+-- result:
+-- !result
+drop database test_fast_schema_evolution_add_column_with_expr;
 -- result:
 -- !result

--- a/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
+++ b/test/sql/test_fast_schema_evolution/T/test_fast_schema_evolution
@@ -271,3 +271,51 @@ select * from tab1;
 
 drop table tab1;
 drop database test_fast_schema_evolution_and_mv;
+
+-- name: test_fast_schema_evolution_add_column_with_expr
+create database test_fast_schema_evolution_add_column_with_expr;
+use test_fast_schema_evolution_add_column_with_expr;
+
+CREATE table tab1 (
+      k1 INTEGER,
+      k2 VARCHAR(50),
+      v1 INTEGER,
+      v2 INTEGER,
+      v3 INTEGER,
+      v4 varchar(50),
+      v5 varchar(50)
+)
+ENGINE=OLAP
+DUPLICATE KEY(`k1`,`k2`)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 1
+PROPERTIES (
+    "replication_num" = "1",
+    "fast_schema_evolution" = "true"
+);
+insert into tab1 values (100, "k2_100", 100, 100, 100, "v4_100", "v5_100");
+insert into tab1 values (200, "k2_200", 200, 200, 200, "v4_200", "v5_200");
+insert into tab1 values (300, "k2_300", 300, 300, 300, "v4_300", "v5_300");
+insert into tab1 values (400, "k2_400", 400, 400, 400, "v4_400", "v5_400");
+insert into tab1 values (500, "k2_500", 500, 500, 500, "v4_500", "v5_500");
+insert into tab1 values (600, "k2_600", 600, 600, 600, "v4_600", "v5_600");
+select * from tab1;
+
+alter table tab1 add column c1 datetime default current_timestamp;
+function: wait_alter_table_finish()
+
+select count(*) from tab1 where c1 is NULL;
+
+
+alter table tab1 add column c2 datetime not null default current_timestamp;
+function: wait_alter_table_finish()
+
+select count(*) from tab1 where c2 is NULL;
+
+
+alter table tab1 add column c3 datetime;
+function: wait_alter_table_finish()
+
+select count(*) from tab1 where c3 is NULL;
+
+drop table tab1;
+drop database test_fast_schema_evolution_add_column_with_expr;


### PR DESCRIPTION
Why I'm doing:

When we add a new column with a default expr like now(), if we enable fast schema evolution, the default expr is lost. The reason is when we add a new column with a default expr, FE will calculate a const default value and assign to BE tablet column but the FE column default value is NULL. If we enable fast schema evolution, we don't send the default value to BE and we will generate the new tablet schema according to FE columns. That's why the default value is lost.

What I'm doing:

Calculate a const default value and assign to FE column.

Fixes #issue

```
CREATE TABLE `tab1` (
  `k1` int(11) NULL COMMENT "",
  `v1` int(11) NULL COMMENT ""
) ENGINE=OLAP
DUPLICATE KEY(`k1`)
DISTRIBUTED BY HASH(`k1`) BUCKETS 1
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"fast_schema_evolution" = "true",
"compression" = "LZ4"
); 

insert into tab1 values (1, 1);
alter table tab1 add column c1 datetime default current_timestamp;
```
create table and add a new column with default expr.

Before this pr, the result is:
```
MySQL [zq_test]> select * from tab1;
+------+------+---------------------+
| k1   | v1   | c1                  |
+------+------+---------------------+
|    1 |    1 | NULL                |
+------+------+---------------------+
```

After this pr, the result is:
```
MySQL [zq_test]> select * from tab1;
+------+------+---------------------+
| k1   | v1   | c1                  |
+------+------+---------------------+
|    1 |    1 | 2023-12-07 00:34:15 |
+------+------+---------------------+
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
