### PR TITLE
[BugFix] no throw exception when loading plugin fail

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/plugin/PluginMgr.java
@@ -241,7 +241,7 @@ public class PluginMgr implements Writable {
             pluginLoader.setStatus(PluginStatus.INSTALLED);
         } catch (IOException | UserException e) {
             pluginLoader.setStatus(PluginStatus.ERROR, e.getMessage());
-            throw e;
+            LOG.warn("fail to load plugin", e);
         } finally {
             // this is a replay process, so whether it is successful or not, add it's name.
             addDynamicPluginNameIfAbsent(info.getName());

--- a/fe/fe-core/src/test/java/com/starrocks/plugin/PluginMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/plugin/PluginMgrTest.java
@@ -35,11 +35,16 @@
 package com.starrocks.plugin;
 
 import com.starrocks.common.Config;
+import com.starrocks.common.UserException;
 import com.starrocks.common.io.DataOutputBuffer;
+import com.starrocks.common.util.DigitalVersion;
+import com.starrocks.plugin.PluginInfo.PluginType;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.utframe.UtFrameUtils;
 import org.apache.commons.io.FileUtils;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
@@ -67,89 +72,28 @@ public class PluginMgrTest {
         Config.plugin_dir = PluginTestUtil.getTestPathString("target");
     }
 
-    //    @Test
-    //    public void testInstallPluginZip() {
-    //        try {
-    //            // path "target/audit_plugin_demo" is where we are going to install the plugin
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo")));
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo/auditdemo.jar")));
-    //
-    //            InstallPluginStmt stmt =
-    //                    new InstallPluginStmt(PluginTestUtil.getTestPathString("auditdemo.zip"), Maps.newHashMap());
-    //            GlobalStateMgr.getCurrentState().installPlugin(stmt);
-    //
-    //            PluginMgr pluginMgr = GlobalStateMgr.getCurrentPluginMgr();
-    //
-    //            assertEquals(2, pluginMgr.getActivePluginList(PluginInfo.PluginType.AUDIT).size());
-    //
-    //            Plugin p = pluginMgr.getActivePlugin("audit_plugin_demo", PluginInfo.PluginType.AUDIT);
-    //
-    //            assertNotNull(p);
-    //            assertTrue(p instanceof AuditPlugin);
-    //            assertTrue(((AuditPlugin) p).eventFilter(AuditEvent.EventType.AFTER_QUERY));
-    //            assertFalse(((AuditPlugin) p).eventFilter(AuditEvent.EventType.BEFORE_QUERY));
-    //
-    //            assertTrue(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo")));
-    //            assertTrue(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo/auditdemo.jar")));
-    //
-    //            assertEquals(1, pluginMgr.getAllDynamicPluginInfo().size());
-    //            PluginInfo info = pluginMgr.getAllDynamicPluginInfo().get(0);
-    //
-    //            assertEquals("audit_plugin_demo", info.getName());
-    //            assertEquals(PluginInfo.PluginType.AUDIT, info.getType());
-    //            assertEquals("just for test", info.getDescription());
-    //            assertEquals("plugin.AuditPluginDemo", info.getClassName());
-    //
-    //            pluginMgr.uninstallPlugin("audit_plugin_demo");
-    //
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo")));
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_demo/auditdemo.jar")));
-    //
-    //        } catch (IOException | UserException e) {
-    //            e.printStackTrace();
-    //            assert false;
-    //        }
-    //    }
+    @Test
+    public void testLoadPluginFail() {
+        try {
 
-    //    @Test
-    //    public void testInstallPluginLocal() {
-    //        try {
-    //            // path "target/audit_plugin_demo" is where we are going to install the plugin
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_local_demo")));
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_local_demo/auditdemo.jar")));
-    //
-    //            InstallPluginStmt stmt =
-    //                    new InstallPluginStmt(PluginTestUtil.getTestPathString("test_local_plugin"), Maps.newHashMap());
-    //            GlobalStateMgr.getCurrentState().installPlugin(stmt);
-    //
-    //            PluginMgr pluginMgr = GlobalStateMgr.getCurrentPluginMgr();
-    //
-    //            assertTrue(Files.exists(PluginTestUtil.getTestPath("test_local_plugin")));
-    //            assertTrue(Files.exists(PluginTestUtil.getTestPath("test_local_plugin/auditdemo.jar")));
-    //
-    //            Plugin p = pluginMgr.getActivePlugin("audit_plugin_local_demo", PluginInfo.PluginType.AUDIT);
-    //
-    //            assertEquals(2, pluginMgr.getActivePluginList(PluginInfo.PluginType.AUDIT).size());
-    //
-    //            assertNotNull(p);
-    //            assertTrue(p instanceof AuditPlugin);
-    //            assertTrue(((AuditPlugin) p).eventFilter(AuditEvent.EventType.AFTER_QUERY));
-    //            assertFalse(((AuditPlugin) p).eventFilter(AuditEvent.EventType.BEFORE_QUERY));
-    //
-    //            assertTrue(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_local_demo")));
-    //            assertTrue(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_local_demo/auditdemo.jar")));
-    //
-    //            testSerializeBuiltinPlugin(pluginMgr);
-    //            pluginMgr.uninstallPlugin("audit_plugin_local_demo");
-    //
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_local_demo")));
-    //            assertFalse(Files.exists(PluginTestUtil.getTestPath("target/audit_plugin_local_demo/auditdemo.jar")));
-    //
-    //        } catch (IOException | UserException e) {
-    //            e.printStackTrace();
-    //            assert false;
-    //        }
-    //    }
+            PluginMgr pluginMgr = GlobalStateMgr.getCurrentPluginMgr();
+            PluginInfo info = new PluginInfo();
+            info.name = "plugin-name";
+            info.type = PluginType.AUDIT;
+            info.description = "plugin description";
+            info.version = DigitalVersion.CURRENT_STARROCKS_VERSION;
+            info.javaVersion = DigitalVersion.JDK_1_8_0;
+            info.className = "hello.jar";
+            info.soName = "hello.so";
+            info.source = "test";
+            info.properties.put("md5sum", "cf0c536b8f2a0a0690b44d783d019e90");
+            pluginMgr.replayLoadDynamicPlugin(info);
+
+        } catch (IOException | UserException e) {
+            e.printStackTrace();
+            assert false;
+        }
+    }
 
     private void testSerializeBuiltinPlugin(PluginMgr mgr) {
         try {


### PR DESCRIPTION
Why I'm doing:
Now FE start and load plugin fail will throw exception and cause FE  can't start. Load plugin fail shouldn't cause FE start fail.

What I'm doing:
No throw exception when loading plugin fail. It will only show plugin with error status:
```
MySQL [(none)]> show plugins\G;
*************************** 1. row ***************************
       Name: xxx
       Type: AUDIT
Description: xxx
    Version: 0.12.0
JavaVersion: 1.8.31
  ClassName: xxx
     SoName: xxx
    Sources: xxx
     Status: ERROR
 Properties: {}
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
