### PR TITLE
[BugFix] ensure viewCache fingerprint unique

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/View.java
@@ -240,7 +240,7 @@ public class View extends Table {
                 } else if (table.get().isNativeTableOrMaterializedView()) {
                     OlapTable olapTable = (OlapTable) table.get();
                     joiner.add(olapTable.getId() + "-" + olapTable.lastSchemaUpdateTime.get() + "-"
-                            + olapTable.lastVersionUpdateEndTime);
+                            + olapTable.lastVersionUpdateEndTime + "-" + System.identityHashCode(olapTable));
                 } else {
                     // external table set a cache ttl of 180s
                     long now = System.currentTimeMillis();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -416,6 +416,7 @@ public class UtFrameUtils {
         connectContext.setQueryId(UUIDUtil.genUUID());
         connectContext.setExecutionId(UUIDUtil.toTUniqueId(connectContext.getQueryId()));
         connectContext.setDumpInfo(new QueryDumpInfo(connectContext));
+        connectContext.setThreadLocalInfo();
         originStmt = LogUtil.removeLineSeparator(originStmt);
 
         List<StatementBase> statements;


### PR DESCRIPTION
Why I'm doing:
Casue in plan retry phase, the copied olapTable would also ref the `lastSchemaUpdateTime` of the original olapTable which make the viewCache fingerprint not unique. This will lead the cache refresh strategy not work.

What I'm doing:
Add object's identityHashCode in the fingerprint to make it unique.
Set threadLocal in UtFrameUtils.buildPlan() to ensure the `ConnectContext.get()` return a right result.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
