### PR TITLE
[Feature] support named arguments for table functions

### DIFF
--- a/docs/en/sql-reference/sql-functions/table-functions/generate_series.md
+++ b/docs/en/sql-reference/sql-functions/table-functions/generate_series.md
@@ -27,6 +27,7 @@ generate_series(start, end [,step])
 - `step`: the value to increment or decrement, optional.  Supported data types are INT, BIGINT, and LARGEINT. If not specified, the default step is 1. `step` can be either negative or positive, but cannot be zero.
 
 The three parameters must have the same data type, for example, `generate_series(INT start, INT end [, INT step])`.
+It supports named arguments from v3.3, where all parameters are input with names, like `name=>expr`, for example, `generate_series(start=>3, end=>7, step=>2)`.
 
 ## Return value
 
@@ -138,6 +139,17 @@ SELECT * FROM t_numbers, generate_series(t_numbers.start, t_numbers.end, -1);
 |     9 |    6 |               7 |
 |     9 |    6 |               6 |
 +-------+------+-----------------+
+```
+Example 6: Generate a sequence of values within the range [2,5] in ascending order with the specified step `2`, using named arguments.
+
+```SQL
+MySQL > select * from TABLE(generate_series(start=>2, end=>5, step=>2));
++-----------------+
+| generate_series |
++-----------------+
+|               2 |
+|               4 |
++-----------------+
 ```
 
 The input row `(NULL, 10)` has a NULL value and zero rows are returned for this row.

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1234,10 +1234,10 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
     }
 
     public static Function getBuiltinFunction(String name, Type[] argTypes, String[] argNames, Function.CompareMode mode) {
-        FunctionName fnName = new FunctionName(name);
         if (argNames == null) {
             return getBuiltinFunction(name, argTypes, mode);
         }
+        FunctionName fnName = new FunctionName(name);
         Function searchDesc = new Function(fnName, argTypes, argNames, Type.INVALID, false);
         return GlobalStateMgr.getCurrentState().getFunction(searchDesc, mode);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1235,6 +1235,9 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
 
     public static Function getBuiltinFunction(String name, Type[] argTypes, String[] argNames, Function.CompareMode mode) {
         FunctionName fnName = new FunctionName(name);
+        if (argNames == null) {
+            return getBuiltinFunction(name, argTypes, mode);
+        }
         Function searchDesc = new Function(fnName, argTypes, argNames, Type.INVALID, false);
         return GlobalStateMgr.getCurrentState().getFunction(searchDesc, mode);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Expr.java
@@ -1233,6 +1233,12 @@ public abstract class Expr extends TreeNode<Expr> implements ParseNode, Cloneabl
         return GlobalStateMgr.getCurrentState().getFunction(searchDesc, mode);
     }
 
+    public static Function getBuiltinFunction(String name, Type[] argTypes, String[] argNames, Function.CompareMode mode) {
+        FunctionName fnName = new FunctionName(name);
+        Function searchDesc = new Function(fnName, argTypes, argNames, Type.INVALID, false);
+        return GlobalStateMgr.getCurrentState().getFunction(searchDesc, mode);
+    }
+
     /**
      * Pushes negation to the individual operands of a predicate
      * tree rooted at 'root'.

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
@@ -53,14 +53,23 @@ import java.util.stream.Collectors;
 public class FunctionParams implements Writable {
     private boolean isStar;
     private List<Expr> exprs;
+
+    private List<String> exprsNames;
     private boolean isDistinct;
 
     private List<OrderByElement> orderByElements;
     // c'tor for non-star params
     public FunctionParams(boolean isDistinct, List<Expr> exprs) {
+        if (exprs.stream().anyMatch(e -> e instanceof NamedArgument)) {
+            this.exprs = exprs.stream().map(e -> (e instanceof NamedArgument ? ((NamedArgument) e).getExpr()
+                    : e)).collect(Collectors.toList());
+            this.exprsNames = exprs.stream().map(e -> (e instanceof NamedArgument ? ((NamedArgument) e).getName()
+                    : "")).collect(Collectors.toList());
+        } else {
+            this.exprs = exprs;
+        }
         isStar = false;
         this.isDistinct = isDistinct;
-        this.exprs = exprs;
         this.orderByElements = null;
     }
 
@@ -87,6 +96,10 @@ public class FunctionParams implements Writable {
         isStar = true;
         isDistinct = false;
         orderByElements = null;
+    }
+
+    public List<String> getExprsNames() {
+        return exprsNames;
     }
 
     public static FunctionParams createStarParam() {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
@@ -42,6 +42,7 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -146,6 +147,26 @@ public class FunctionParams implements Writable {
 
     public List<Expr> exprs() {
         return exprs;
+    }
+
+    public void reorderNamedArg(String[] names) {
+        String[] newNames = new String[exprsNames.size()];
+        Expr[] newExprs = new Expr[exprs.size()];
+        for (int i = 0; i < exprsNames.size(); i++) {
+            if (exprsNames.get(i).equals("")) {
+                newNames[i] = exprsNames.get(i);
+                newExprs[i] = exprs.get(i);
+            } else {
+                for (int j = 0; j < names.length; j++) {
+                    if (exprsNames.get(i).equals(names[j])) {
+                        newNames[j] = exprsNames.get(i);
+                        newExprs[j] = exprs.get(i);
+                    }
+                }
+            }
+        }
+        exprs = Arrays.asList(newExprs);
+        exprsNames = Arrays.asList(newNames);
     }
 
     public void setIsDistinct(boolean v) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionParams.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.analysis;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.common.io.Writable;
@@ -150,23 +151,31 @@ public class FunctionParams implements Writable {
     }
 
     public void reorderNamedArg(String[] names) {
+        Preconditions.checkState(names.length == exprsNames.size());
         String[] newNames = new String[exprsNames.size()];
-        Expr[] newExprs = new Expr[exprs.size()];
+        Expr[] newExprs = new Expr[exprsNames.size()];
         for (int i = 0; i < exprsNames.size(); i++) {
-            if (exprsNames.get(i).equals("")) {
-                newNames[i] = exprsNames.get(i);
-                newExprs[i] = exprs.get(i);
-            } else {
-                for (int j = 0; j < names.length; j++) {
-                    if (exprsNames.get(i).equals(names[j])) {
-                        newNames[j] = exprsNames.get(i);
-                        newExprs[j] = exprs.get(i);
-                    }
+            for (int j = 0; j < names.length; j++) {
+                if (exprsNames.get(i).equals(names[j])) {
+                    newNames[j] = exprsNames.get(i);
+                    newExprs[j] = exprs.get(i);
                 }
             }
         }
         exprs = Arrays.asList(newExprs);
         exprsNames = Arrays.asList(newNames);
+    }
+
+    public String getNamedArgStr() {
+        Preconditions.checkState(exprs.size() == exprsNames.size());
+        String result = "";
+        for (int i = 0; i < exprs.size(); i++) {
+            if (i != 0) {
+                result = result.concat(",");
+            }
+            result = result.concat(exprsNames.get(i) + "=>" + exprs.get(i).toSql());
+        }
+        return result;
     }
 
     public void setIsDistinct(boolean v) {

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/NamedArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/NamedArgument.java
@@ -60,6 +60,6 @@ public class NamedArgument extends Expr {
 
     @Override
     public String toString() {
-        return toSqlImpl();
+        return name + "=>" + expr.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/NamedArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/NamedArgument.java
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.analysis;
+
+import com.starrocks.sql.ast.AstVisitor;
+
+public class NamedArgument extends Expr {
+    private final String name;
+
+    private Expr expr;
+
+    public NamedArgument(String name, Expr expr) {
+        this.name = name;
+        this.expr = expr;
+    }
+
+    public NamedArgument(NamedArgument other) {
+        this.name = other.name;
+        this.expr = other.expr;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public Expr getExpr() {
+        return expr;
+    }
+
+    public void setExpr(Expr expr) {
+        this.expr = expr;
+    }
+
+    @Override
+    public Expr clone() {
+        return new NamedArgument(name, expr);
+    }
+
+    @Override
+    public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
+        return visitor.visitNamedArgument(this, context);
+    }
+
+    @Override
+    protected String toSqlImpl() {
+        return name + "=>" + expr.toSql();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/analysis/NamedArgument.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/NamedArgument.java
@@ -57,4 +57,9 @@ public class NamedArgument extends Expr {
     protected String toSqlImpl() {
         return name + "=>" + expr.toSql();
     }
+
+    @Override
+    public String toString() {
+        return toSqlImpl();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Function.java
@@ -106,7 +106,7 @@ public class Function implements Writable {
     private Type[] argTypes;
 
     @SerializedName(value = "argNames")
-    private String[] argNames;
+    protected String[] argNames;
 
     // If true, this function has variable arguments.
     // TODO: we don't currently support varargs with no fixed types. i.e. fn(...)
@@ -472,14 +472,19 @@ public class Function implements Writable {
             return false;
         }
         if (o.hasNamedArg()) {
+            if (!this.hasNamedArg()) {
+                return false;
+            }
+            Boolean[] mask = new Boolean[o.argTypes.length];
             for (int i = 0; i < this.argTypes.length; ++i) {
                 boolean found = false;
                 for (int j = 0; j < o.getNumArgs(); j++) {
-                    if (this.argNames[i] == o.argNames[j]) {
+                    if (!mask[j] && this.argNames[i] == o.argNames[j]) {
                         if (!o.argTypes[j].matchesType(this.argTypes[i])) {
                             return false;
                         }
                         found = true;
+                        mask[j] = true;
                     }
                 }
                 if (!found) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -838,7 +838,7 @@ public class FunctionSet {
     public Function getFunction(Function desc, Function.CompareMode mode) {
         List<Function> fns = vectorizedFunctions.get(desc.functionName());
         if (desc.hasNamedArg() && fns != null && !fns.isEmpty()) {
-            fns = fns.stream().filter(f -> f.hasNamedArg()).collect(Collectors.toList());
+            fns = fns.stream().filter(Function::hasNamedArg).collect(Collectors.toList());
         }
         if (fns == null || fns.isEmpty()) {
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -837,6 +837,9 @@ public class FunctionSet {
 
     public Function getFunction(Function desc, Function.CompareMode mode) {
         List<Function> fns = vectorizedFunctions.get(desc.functionName());
+        if (desc.hasNamedArg() && fns != null && !fns.isEmpty()) {
+            fns = fns.stream().filter(f -> f.hasNamedArg()).collect(Collectors.toList());
+        }
         if (fns == null || fns.isEmpty()) {
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -47,13 +47,31 @@ public class TableFunction extends Function {
     @SerializedName(value = "symbolName")
     private String symbolName = "";
 
+    @SerializedName(value = "argumentNames")
+    private List<String> argNames;
+
     // only used for serialization
     protected TableFunction() {
     }
 
+    public TableFunction(FunctionName fnName, List<String> argNames, List<String> defaultColumnNames, List<Type> argTypes,
+                         List<Type> tableFnReturnTypes) {
+        this(fnName, argNames, defaultColumnNames, argTypes, tableFnReturnTypes, false);
+    }
+
     public TableFunction(FunctionName fnName, List<String> defaultColumnNames, List<Type> argTypes,
                          List<Type> tableFnReturnTypes) {
-        this(fnName, defaultColumnNames, argTypes, tableFnReturnTypes, false);
+        this(fnName, Lists.newArrayList(""), defaultColumnNames, argTypes, tableFnReturnTypes, false);
+    }
+
+    public TableFunction(FunctionName fnName, List<String> argNames, List<String> defaultColumnNames, List<Type> argTypes,
+                         List<Type> tableFnReturnTypes, boolean varArgs) {
+        super(fnName, argTypes, Type.INVALID, varArgs);
+        this.tableFnReturnTypes = tableFnReturnTypes;
+        this.defaultColumnNames = defaultColumnNames;
+        this.argNames = argNames;
+
+        setBinaryType(TFunctionBinaryType.BUILTIN);
     }
 
     public TableFunction(FunctionName fnName, List<String> defaultColumnNames, List<Type> argTypes,
@@ -70,6 +88,7 @@ public class TableFunction extends Function {
         defaultColumnNames = other.defaultColumnNames;
         tableFnReturnTypes = other.tableFnReturnTypes;
         symbolName = other.symbolName;
+        argNames = other.argNames;
     }
 
     public static void initBuiltins(FunctionSet functionSet) {
@@ -90,6 +109,7 @@ public class TableFunction extends Function {
         for (Type type : Lists.newArrayList(Type.TINYINT, Type.SMALLINT, Type.INT, Type.BIGINT, Type.LARGEINT)) {
             // generate_series with default step size: 1
             TableFunction func = new TableFunction(new FunctionName("generate_series"),
+                    Lists.newArrayList("start", "end"),
                     Lists.newArrayList("generate_series"),
                     Lists.newArrayList(type, type),
                     Lists.newArrayList(type));
@@ -97,6 +117,7 @@ public class TableFunction extends Function {
 
             // generate_series with explicit step size
             func = new TableFunction(new FunctionName("generate_series"),
+                    Lists.newArrayList("start", "end", "step"),
                     Lists.newArrayList("generate_series"),
                     Lists.newArrayList(type, type, type),
                     Lists.newArrayList(type));
@@ -138,6 +159,7 @@ public class TableFunction extends Function {
         this.symbolName = tableFunction.symbolName;
         this.tableFnReturnTypes = tableFunction.getTableFnReturnTypes();
         this.defaultColumnNames = tableFunction.getDefaultColumnNames();
+        this.argNames = tableFunction.argNames;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -46,10 +46,6 @@ public class TableFunction extends Function {
     private List<Type> tableFnReturnTypes;
     @SerializedName(value = "symbolName")
     private String symbolName = "";
-
-    @SerializedName(value = "argumentNames")
-    private List<String> argNames;
-
     // only used for serialization
     protected TableFunction() {
     }
@@ -61,16 +57,15 @@ public class TableFunction extends Function {
 
     public TableFunction(FunctionName fnName, List<String> defaultColumnNames, List<Type> argTypes,
                          List<Type> tableFnReturnTypes) {
-        this(fnName, Lists.newArrayList(""), defaultColumnNames, argTypes, tableFnReturnTypes, false);
+        this(fnName, null, defaultColumnNames, argTypes, tableFnReturnTypes, false);
     }
 
-    public TableFunction(FunctionName fnName, List<String> argNames, List<String> defaultColumnNames, List<Type> argTypes,
-                         List<Type> tableFnReturnTypes, boolean varArgs) {
+    public TableFunction(FunctionName fnName, List<String> argNames, List<String> defaultColumnNames,
+                         List<Type> argTypes, List<Type> tableFnReturnTypes, boolean varArgs) {
         super(fnName, argTypes, Type.INVALID, varArgs);
         this.tableFnReturnTypes = tableFnReturnTypes;
         this.defaultColumnNames = defaultColumnNames;
-        this.argNames = argNames;
-
+        setArgNames(argNames);
         setBinaryType(TFunctionBinaryType.BUILTIN);
     }
 
@@ -79,7 +74,6 @@ public class TableFunction extends Function {
         super(fnName, argTypes, Type.INVALID, varArgs);
         this.tableFnReturnTypes = tableFnReturnTypes;
         this.defaultColumnNames = defaultColumnNames;
-
         setBinaryType(TFunctionBinaryType.BUILTIN);
     }
 
@@ -88,7 +82,6 @@ public class TableFunction extends Function {
         defaultColumnNames = other.defaultColumnNames;
         tableFnReturnTypes = other.tableFnReturnTypes;
         symbolName = other.symbolName;
-        argNames = other.argNames;
     }
 
     public static void initBuiltins(FunctionSet functionSet) {
@@ -159,7 +152,6 @@ public class TableFunction extends Function {
         this.symbolName = tableFunction.symbolName;
         this.tableFnReturnTypes = tableFunction.getTableFnReturnTypes();
         this.defaultColumnNames = tableFunction.getDefaultColumnNames();
-        this.argNames = tableFunction.argNames;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -47,6 +47,7 @@ import com.starrocks.analysis.LargeIntLiteral;
 import com.starrocks.analysis.LikePredicate;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.MultiInPredicate;
+import com.starrocks.analysis.NamedArgument;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.Parameter;
@@ -1948,6 +1949,11 @@ public class ExpressionAnalyzer {
             }
             StructType returnType = new StructType(structFields);
             node.setType(returnType);
+            return null;
+        }
+
+        @Override
+        public Void visitNamedArgument(NamedArgument node, Scope context) {
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -875,9 +875,14 @@ public class QueryAnalyzer {
             }
 
             if (fn == null) {
-                throw new SemanticException("Unknown table function '%s(%s)' '%s'", node.getFunctionName().getFunction(),
-                        Arrays.stream(argTypes).map(Object::toString).collect(Collectors.joining(",")),
-                        namesArray == null ? "" : ", or it doesn't support named arguments");
+                if (namesArray == null) {
+                    throw new SemanticException("Unknown table function '%s(%s)'", node.getFunctionName().getFunction(),
+                            Arrays.stream(argTypes).map(Object::toString).collect(Collectors.joining(",")));
+                } else {
+                    throw new SemanticException("Unknown table function '%s(%s)', the function doesn't support named " +
+                            "arguments or has invalid arguments",
+                            node.getFunctionName().getFunction(), node.getFunctionParams().getNamedArgStr());
+                }
             }
             if (namesArray != null) {
                 Preconditions.checkState(fn.hasNamedArg());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -862,8 +862,12 @@ public class QueryAnalyzer {
                 AnalyzerUtils.verifyNoWindowFunctions(args.get(i), "Table Function");
                 AnalyzerUtils.verifyNoGroupingFunctions(args.get(i), "Table Function");
             }
-
-            Function fn = Expr.getBuiltinFunction(node.getFunctionName().getFunction(), argTypes,
+            List<String> names = node.getFunctionParams().getExprsNames();
+            String[] namesArray = null;
+            if (!names.isEmpty()) {
+                namesArray = names.toArray(String[]::new);
+            }
+            Function fn = Expr.getBuiltinFunction(node.getFunctionName().getFunction(), argTypes, namesArray,
                     Function.CompareMode.IS_NONSTRICT_SUPERTYPE_OF);
 
             if (fn == null) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -864,7 +864,7 @@ public class QueryAnalyzer {
             }
             List<String> names = node.getFunctionParams().getExprsNames();
             String[] namesArray = null;
-            if (!names.isEmpty()) {
+            if (names != null && !names.isEmpty()) {
                 namesArray = names.toArray(String[]::new);
             }
             Function fn = Expr.getBuiltinFunction(node.getFunctionName().getFunction(), argTypes, namesArray,
@@ -875,8 +875,13 @@ public class QueryAnalyzer {
             }
 
             if (fn == null) {
-                throw new SemanticException("Unknown table function '%s(%s)'", node.getFunctionName().getFunction(),
-                        Arrays.stream(argTypes).map(Object::toString).collect(Collectors.joining(",")));
+                throw new SemanticException("Unknown table function '%s(%s)' '%s'", node.getFunctionName().getFunction(),
+                        Arrays.stream(argTypes).map(Object::toString).collect(Collectors.joining(",")),
+                        namesArray == null ? "" : ", or it doesn't support named arguments");
+            }
+            if (namesArray != null) {
+                Preconditions.checkState(fn.hasNamedArg());
+                node.getFunctionParams().reorderNamedArg(fn.getArgNames());
             }
 
             if (!(fn instanceof TableFunction)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -38,6 +38,7 @@ import com.starrocks.analysis.LikePredicate;
 import com.starrocks.analysis.LimitElement;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.MultiInPredicate;
+import com.starrocks.analysis.NamedArgument;
 import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.Parameter;
 import com.starrocks.analysis.ParseNode;
@@ -1248,6 +1249,10 @@ public abstract class AstVisitor<R, C> {
     }
 
     public R visitDictionaryExpr(DictionaryExpr node, C context) {
+        return visitExpression(node, context);
+    }
+
+    public R visitNamedArgument(NamedArgument node, C context) {
         return visitExpression(node, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4581,7 +4581,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitNamedArguments(StarRocksParser.NamedArgumentsContext context) {
         String name = ((Identifier) visit(context.identifier())).getValue();
-        if (name.isEmpty() || name.equals(" ")) {
+        if (name == null || name.isEmpty() || name.equals(" ")) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
         }
         Expr node = (Expr) visit(context.expression());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4580,7 +4580,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
 
     @Override
     public ParseNode visitNamedArgument(StarRocksParser.NamedArgumentContext context) {
-        String name = ((StringLiteral) visitString(context.string())).getStringValue();
+        String name = ((Identifier) visit(context.identifier())).getValue();
         if (name.isEmpty() || name.equals(" ")) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4579,7 +4579,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     }
 
     @Override
-    public ParseNode visitNamedArgument(StarRocksParser.NamedArgumentContext context) {
+    public ParseNode visitNamedArguments(StarRocksParser.NamedArgumentsContext context) {
         String name = ((Identifier) visit(context.identifier())).getValue();
         if (name.isEmpty() || name.equals(" ")) {
             throw new ParsingException(PARSER_ERROR_MSG.unsupportedExpr(" The left of => shouldn't be empty"));
@@ -4610,7 +4610,12 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitNormalizedTableFunction(StarRocksParser.NormalizedTableFunctionContext context) {
         QualifiedName functionName = getQualifiedName(context.qualifiedName());
-        List<Expr> parameters = visit(context.expressionList().expression(), Expr.class);
+        List<Expr> parameters = null;
+        if (context.argumentList().expressionList() != null) {
+            parameters = visit(context.argumentList().expressionList().expression(), Expr.class);
+        } else {
+            parameters = visit(context.argumentList().namedArgumentList().namedArgument(), Expr.class);
+        }
         int namedArgNum = parameters.stream().filter(f -> f instanceof NamedArgument).collect(toList()).size();
         if (namedArgNum > 0 && namedArgNum < parameters.size()) {
             throw new SemanticException("All arguments must be passed by name or all must be passed positionally");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2066,11 +2066,24 @@ relationPrimary
     | subquery (AS? alias=identifier columnAliases?)?                                   #subqueryWithAlias
     | qualifiedName '(' expressionList ')'
         (AS? alias=identifier columnAliases?)?                                          #tableFunction
-    | TABLE '(' qualifiedName '(' expressionList ')' ')'
+    | TABLE '(' qualifiedName '(' argumentList ')' ')'
         (AS? alias=identifier columnAliases?)?                                          #normalizedTableFunction
     | FILES propertyList
         (AS? alias=identifier columnAliases?)?                                          #fileTableFunction
     | '(' relations ')'                                                                 #parenthesizedRelation
+    ;
+
+argumentList
+    : expressionList
+    | namedArgumentList
+    ;
+
+namedArgumentList
+    : namedArgument (',' namedArgument)*
+    ;
+
+namedArgument
+    : identifier '=>' expression                                                        #namedArguments
     ;
 
 joinRelation
@@ -2197,7 +2210,6 @@ expression
     | NOT expression                                                                      #logicalNot
     | left=expression operator=(AND|LOGICAL_AND) right=expression                         #logicalBinary
     | left=expression operator=(OR|LOGICAL_OR) right=expression                           #logicalBinary
-    | identifier '=>' expression                                                          #namedArgument
     ;
 
 expressionList

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2197,6 +2197,7 @@ expression
     | NOT expression                                                                      #logicalNot
     | left=expression operator=(AND|LOGICAL_AND) right=expression                         #logicalBinary
     | left=expression operator=(OR|LOGICAL_OR) right=expression                           #logicalBinary
+    | string '=>' expression                                                              #namedArgument
     ;
 
 expressionList

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -2197,7 +2197,7 @@ expression
     | NOT expression                                                                      #logicalNot
     | left=expression operator=(AND|LOGICAL_AND) right=expression                         #logicalBinary
     | left=expression operator=(OR|LOGICAL_OR) right=expression                           #logicalBinary
-    | string '=>' expression                                                              #namedArgument
+    | identifier '=>' expression                                                          #namedArgument
     ;
 
 expressionList

--- a/test/sql/test_function/R/test_named_argments
+++ b/test/sql/test_function/R/test_named_argments
@@ -6,6 +6,23 @@ select * from TABLE(generate_series(start=>2, end=>5));
 4
 5
 -- !result
+select * from TABLE(generate_series(end=>5, start=>2));
+-- result:
+2
+3
+4
+5
+-- !result
+select * from TABLE(generate_series(start=>2, end=>5, step=>2));
+-- result:
+2
+4
+-- !result
+select * from TABLE(generate_series(step=>2, start=>2, end=>5));
+-- result:
+2
+4
+-- !result
 select * from TABLE(generate_series(start=>2, stop=>5));
 -- result:
 E: (1064, "Getting analyzing error. Detail message: Unknown table function 'generate_series(start=>2,stop=>5)', the function doesn't support named arguments or has invalid arguments.")

--- a/test/sql/test_function/R/test_named_argments
+++ b/test/sql/test_function/R/test_named_argments
@@ -1,0 +1,44 @@
+-- name: test named arguments for table functions
+select * from TABLE(generate_series(start=>2, end=>5));
+-- result:
+2
+3
+4
+5
+-- !result
+select * from TABLE(generate_series(start=>2, stop=>5));
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table function 'generate_series(start=>2,stop=>5)', the function doesn't support named arguments or has invalid arguments.")
+-- !result
+select * from TABLE(generate_series(end=>5,start=>2, step = 2));
+-- result:
+E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: All arguments must be passed by name or all must be passed positionally.')
+-- !result
+select * from TABLE(generate_series(start=>2, =>5));
+-- result:
+E: (1064, "Getting syntax error at line 1, column 46. Detail message: Unexpected input '=>', the most similar input is {a legal identifier}.")
+-- !result
+select * from TABLE(generate_series(start=>2, 5));
+-- result:
+E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: All arguments must be passed by name or all must be passed positionally.')
+-- !result
+select * from TABLE(generate_series(start=>2, stop=>null));
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table function 'generate_series(start=>2,stop=>NULL)', the function doesn't support named arguments or has invalid arguments.")
+-- !result
+select * from TABLE(generate_series(start=>2, end=>null));
+-- result:
+E: (1064, 'table function not support null parameter')
+-- !result
+select * from TABLE(generate_series(start=>2, end=>4,step->3));
+-- result:
+E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: All arguments must be passed by name or all must be passed positionally.')
+-- !result
+select * from TABLE(generate_series(start=>2, step=>2, end=>4,start=>3));
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table function 'generate_series(start=>2,step=>2,end=>4,start=>3)', the function doesn't support named arguments or has invalid arguments.")
+-- !result
+select * from TABLE(generate_series(start=>2, step=>2, end=>4,end=>6));
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table function 'generate_series(start=>2,step=>2,end=>4,end=>6)', the function doesn't support named arguments or has invalid arguments.")
+-- !result

--- a/test/sql/test_function/R/test_named_argments
+++ b/test/sql/test_function/R/test_named_argments
@@ -29,7 +29,7 @@ E: (1064, "Getting analyzing error. Detail message: Unknown table function 'gene
 -- !result
 select * from TABLE(generate_series(end=>5,start=>2, step = 2));
 -- result:
-E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: All arguments must be passed by name or all must be passed positionally.')
+E: (1064, 'Getting syntax error at line 1, column 58. Detail message: Unexpected input '=', the most similar input is {'=>'}.')
 -- !result
 select * from TABLE(generate_series(start=>2, =>5));
 -- result:

--- a/test/sql/test_function/R/test_named_argments
+++ b/test/sql/test_function/R/test_named_argments
@@ -29,7 +29,7 @@ E: (1064, "Getting analyzing error. Detail message: Unknown table function 'gene
 -- !result
 select * from TABLE(generate_series(end=>5,start=>2, step = 2));
 -- result:
-E: (1064, 'Getting syntax error at line 1, column 58. Detail message: Unexpected input '=', the most similar input is {'=>'}.')
+E: (1064, "Getting syntax error at line 1, column 58. Detail message: Unexpected input '=', the most similar input is {'=>'}.")
 -- !result
 select * from TABLE(generate_series(start=>2, =>5));
 -- result:

--- a/test/sql/test_function/R/test_named_argments
+++ b/test/sql/test_function/R/test_named_argments
@@ -37,7 +37,7 @@ E: (1064, "Getting syntax error at line 1, column 46. Detail message: Unexpected
 -- !result
 select * from TABLE(generate_series(start=>2, 5));
 -- result:
-E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: All arguments must be passed by name or all must be passed positionally.')
+E: (1064, "Getting syntax error at line 1, column 46. Detail message: Unexpected input '5', the most similar input is {a legal identifier}.")
 -- !result
 select * from TABLE(generate_series(start=>2, stop=>null));
 -- result:
@@ -49,7 +49,7 @@ E: (1064, 'table function not support null parameter')
 -- !result
 select * from TABLE(generate_series(start=>2, end=>4,step->3));
 -- result:
-E: (1064, 'Unexpected exception: Getting analyzing error. Detail message: All arguments must be passed by name or all must be passed positionally.')
+E: (1064, "Getting syntax error at line 1, column 57. Detail message: Unexpected input '->', the most similar input is {'=>'}.")
 -- !result
 select * from TABLE(generate_series(start=>2, step=>2, end=>4,start=>3));
 -- result:

--- a/test/sql/test_function/T/test_named_argments
+++ b/test/sql/test_function/T/test_named_argments
@@ -1,0 +1,12 @@
+-- name: test named arguments for table functions
+
+select * from TABLE(generate_series(start=>2, end=>5));
+select * from TABLE(generate_series(start=>2, stop=>5));
+select * from TABLE(generate_series(end=>5,start=>2, step = 2));
+select * from TABLE(generate_series(start=>2, =>5));
+select * from TABLE(generate_series(start=>2, 5));
+select * from TABLE(generate_series(start=>2, stop=>null));
+select * from TABLE(generate_series(start=>2, end=>null));
+select * from TABLE(generate_series(start=>2, end=>4,step->3));
+select * from TABLE(generate_series(start=>2, step=>2, end=>4,start=>3));
+select * from TABLE(generate_series(start=>2, step=>2, end=>4,end=>6));

--- a/test/sql/test_function/T/test_named_argments
+++ b/test/sql/test_function/T/test_named_argments
@@ -1,6 +1,9 @@
 -- name: test named arguments for table functions
 
 select * from TABLE(generate_series(start=>2, end=>5));
+select * from TABLE(generate_series(end=>5, start=>2));
+select * from TABLE(generate_series(start=>2, end=>5, step=>2));
+select * from TABLE(generate_series(step=>2, start=>2, end=>5));
 select * from TABLE(generate_series(start=>2, stop=>5));
 select * from TABLE(generate_series(end=>5,start=>2, step = 2));
 select * from TABLE(generate_series(start=>2, =>5));

--- a/test/sql/test_join/R/test_join_array
+++ b/test/sql/test_join/R/test_join_array
@@ -1104,7 +1104,7 @@ None	[1,2,3,4,10]
 -- !result
 select s.s_1, t.i_1 from array_test s full join array_test t on s.s_1 => t.i_1 order by 1, 2;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 70. Detail message: Unexpected input '=', the most similar input is {<EOF>, ';'}.")
+E: (1064, "Getting syntax error at line 1, column 70. Detail message: Unexpected input '=>', the most similar input is {<EOF>, ';'}.")
 -- !result
 select s.aas_1, t.aas_1 from array_test s full join array_test t on s.aas_1 <= t.aas_1 order by 1, 2;
 -- result:

--- a/test/sql/test_join/R/test_join_map
+++ b/test/sql/test_join/R/test_join_map
@@ -295,7 +295,7 @@ E: (1064, 'Getting analyzing error from line 1, column 62 to line 1, column 75. 
 -- !result
 select t.map3, s.map5 from map_test t left join map_test s on s.map3 => t.map5 order by t.pk;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 69. Detail message: Unexpected input '=', the most similar input is {<EOF>, ';'}.")
+E: (1064, "Getting syntax error at line 1, column 69. Detail message: Unexpected input '=>', the most similar input is {<EOF>, ';'}.")
 -- !result
 select t.map5, s.map5 from map_test t left join map_test s on s.map5 = t.map5 order by t.pk;
 -- result:
@@ -325,7 +325,7 @@ E: (1064, 'Getting analyzing error from line 1, column 63 to line 1, column 76. 
 -- !result
 select t.map3, s.map5 from map_test t right join map_test s on s.map3 => t.map5 order by t.pk;
 -- result:
-E: (1064, "Getting syntax error at line 1, column 70. Detail message: Unexpected input '=', the most similar input is {<EOF>, ';'}.")
+E: (1064, "Getting syntax error at line 1, column 70. Detail message: Unexpected input '=>', the most similar input is {<EOF>, ';'}.")
 -- !result
 select t.map5, s.map5 from map_test t right join map_test s on s.map5 = t.map5 order by t.pk;
 -- result:


### PR DESCRIPTION
support named arguments for table functions, keep the same behavior with Trino:
1. all parameters should be named arguments, without mixing positional arguments;
2. can mix default parameters
3. can reorder named arguments

```
MySQL > select * from TABLE(generate_series(start=>2, end=>5, step=>2));
+-----------------+
| generate_series |
+-----------------+
|               2 |
|               4 |
+-----------------+
```


## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

[doc ](https://starrocks.feishu.cn/docx/MHJMdopaworwxIxued7c9ya9njg?from=from_copylink)