### PR TITLE
[BugFix] Fix actual fields size in csv scanner (#36478)

### DIFF
--- a/be/src/exec/csv_scanner.cpp
+++ b/be/src/exec/csv_scanner.cpp
@@ -417,7 +417,7 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
             if (_counter->num_rows_filtered++ < 50) {
                 std::stringstream error_msg;
                 error_msg << "Value count does not match column count. "
-                          << "Expect " << _num_fields_in_csv << ", but got " << row.columns.size() << "."
+                          << "Expect " << _num_fields_in_csv << ", but got " << fields.size() << "."
                           << "Column delimiter: " << string_2_asc(_parse_options.column_delimiter) << ","
                           << "Row delimiter: " << string_2_asc(_parse_options.row_delimiter) << ".";
                 _report_error(record.to_string(), error_msg.str());
@@ -425,7 +425,7 @@ Status CSVScanner::_parse_csv(Chunk* chunk) {
             if (_state->enable_log_rejected_record()) {
                 std::stringstream error_msg;
                 error_msg << "Value count does not match column count. "
-                          << "Expect " << _num_fields_in_csv << ", but got " << row.columns.size() << "."
+                          << "Expect " << _num_fields_in_csv << ", but got " << fields.size() << "."
                           << "Column delimiter: " << string_2_asc(_parse_options.column_delimiter) << ","
                           << "Row delimiter: " << string_2_asc(_parse_options.row_delimiter) << ".";
                 _state->append_rejected_record_to_file(record.to_string(), error_msg.str(), _curr_reader->filename());

--- a/be/src/exec/file_scanner.h
+++ b/be/src/exec/file_scanner.h
@@ -68,6 +68,9 @@ public:
     Status create_sequential_file(const TBrokerRangeDesc& range_desc, const TNetworkAddress& address,
                                   const TBrokerScanRangeParams& params, std::shared_ptr<SequentialFile>* file);
 
+    // only for test
+    RuntimeState* TEST_runtime_state() { return _state; }
+
 protected:
     void fill_columns_from_path(ChunkPtr& chunk, int slot_start, const std::vector<std::string>& columns_from_path,
                                 int size);


### PR DESCRIPTION
#36478

Why I'm doing:

actual fields size always be 0 when value count does not match column count.

Error: Value count does not match column count: expected = 3, actual = 0

What I'm doing:

fix actual fields size.

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
