### PR TITLE
[Enhancement] more timely memory release about cloud native pk table compaction

### DIFF
--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -108,7 +108,7 @@ void CompactionState::release_segments(uint32_t segment_id) {
     _memory_usage -= pk_cols[segment_id]->memory_usage();
     _update_manager->compaction_state_mem_tracker()->release(pk_cols[segment_id]->memory_usage());
     // reset ptr to release memory immediately
-    pk_cols[segment_id].reset(nullptr);
+    pk_cols[segment_id].reset();
 }
 
 std::string CompactionState::to_string() const {

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -107,7 +107,8 @@ void CompactionState::release_segments(uint32_t segment_id) {
     }
     _memory_usage -= pk_cols[segment_id]->memory_usage();
     _update_manager->compaction_state_mem_tracker()->release(pk_cols[segment_id]->memory_usage());
-    pk_cols[segment_id]->reset_column();
+    // reset ptr to release memory immediately
+    pk_cols[segment_id].reset(nullptr);
 }
 
 std::string CompactionState::to_string() const {


### PR DESCRIPTION
Why I'm doing:
In current implementation, we use `reset_column` to release column memory. But in fact `reset_column` will call `std::vector().clear()` which won't release memory immediately.

What I'm doing:
Use `reset(nullptr);` instead of `reset_column`, so I can release memory immediately.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
