### PR TITLE
[UT] Fixup table creation sql in test_query_cache_use_fresh_global_dict

### DIFF
--- a/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/R/test_query_cache_use_fresh_global_dict
@@ -26,7 +26,6 @@ PROPERTIES (
 "in_memory" = "false",
 "enable_persistent_index" = "false",
 "replicated_storage" = "true",
-"light_schema_change" = "true",
 "compression" = "LZ4"
 );
 -- result:

--- a/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
+++ b/test/sql/test_query_cache_use_fresh_global_dict/T/test_query_cache_use_fresh_global_dict
@@ -24,7 +24,6 @@ PROPERTIES (
 "in_memory" = "false",
 "enable_persistent_index" = "false",
 "replicated_storage" = "true",
-"light_schema_change" = "true",
 "compression" = "LZ4"
 );
 insert into t0 values('2023-01-01', 'foo_0001', 'bar_0010', 1);


### PR DESCRIPTION
Why I'm doing:

In 3.1, the property "light_schema_change" in table creation sql is not supported, so report errors as follows:
```
E: (1064, 'Unexpected exception: Unknown properties: {light_schema_change=true}')
```

What I'm doing:
Remove this the property  "light_schema_change".