### PR TITLE
[Enhancement] optimize the optimistic lock for insert-select

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/OptimisticVersion.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/OptimisticVersion.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.starrocks.catalog.OlapTable;
+
+/**
+ * Generate a monotonic version for optimistic lock.
+ * NOTE: currently we use the nano time, which is usually precise enough for the schema-change and version update
+ * operations. Previously we use the millisecond time, which is not safe enough.
+ * TODO: refactor related code to here
+ */
+public class OptimisticVersion {
+
+    /**
+     * Generate a version
+     */
+    public static long generate() {
+        return System.nanoTime();
+    }
+
+    /**
+     * Validate the candidate version
+     */
+    public static boolean validateTableUpdate(OlapTable olapTable, long candidateVersion) {
+        long schemaUpdate = olapTable.lastSchemaUpdateTime.get();
+        long dataUpdateStart = olapTable.lastVersionUpdateStartTime.get();
+        long dataUpdateEnd = olapTable.lastVersionUpdateEndTime.get();
+
+        return (schemaUpdate < candidateVersion) &&
+                (dataUpdateEnd >= dataUpdateStart && dataUpdateEnd < candidateVersion);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -230,7 +230,7 @@ public class StatementPlanner {
         // only collect once to save the original olapTable info
         Set<OlapTable> olapTables = collectOriginalOlapTables(queryStmt, dbs);
         for (int i = 0; i < Config.max_query_retry_time; ++i) {
-            long planStartTime = System.nanoTime();
+            long planStartTime = OptimisticVersion.generate();
             if (!isSchemaValid) {
                 reAnalyzeStmt(queryStmt, dbs, session);
                 colNames = query.getColumnOutputNames();
@@ -271,7 +271,7 @@ public class StatementPlanner {
                  */
                 // For only olap table queries, we need to lock db here.
                 // Because we need to ensure multi partition visible versions are consistent.
-                long buildFragmentStartTime = System.nanoTime();
+                long buildFragmentStartTime = OptimisticVersion.generate();
                 ExecPlan plan = PlanFragmentBuilder.createPhysicalPlan(
                         optimizedPlan, session, logicalPlan.getOutputColumn(), columnRefFactory, colNames,
                         resultSinkType,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -135,7 +135,8 @@ public class StatementPlanner {
             } else if (stmt instanceof InsertStmt) {
                 InsertStmt insertStmt = (InsertStmt) stmt;
                 boolean isSelect = !(insertStmt.getQueryStatement().getQueryRelation() instanceof ValuesRelation);
-                boolean useOptimisticLock = isOnlyOlapTableQueries && isSelect &&
+                boolean isLeader = GlobalStateMgr.getCurrentState().isLeader();
+                boolean useOptimisticLock = isOnlyOlapTableQueries && isSelect && isLeader &&
                         !session.getSessionVariable().isCboUseDBLock();
                 return new InsertPlanner(dbs, useOptimisticLock).plan((InsertStmt) stmt, session);
             } else if (stmt instanceof UpdateStmt) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -48,9 +48,9 @@ import com.starrocks.sql.ast.InsertStmt;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
-import com.starrocks.sql.ast.SelectRelation;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.ast.UpdateStmt;
+import com.starrocks.sql.ast.ValuesRelation;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.common.UnsupportedException;
@@ -134,7 +134,7 @@ public class StatementPlanner {
                 return planQuery(stmt, resultSinkType, session, false);
             } else if (stmt instanceof InsertStmt) {
                 InsertStmt insertStmt = (InsertStmt) stmt;
-                boolean isSelect = insertStmt.getQueryStatement().getQueryRelation() instanceof SelectRelation;
+                boolean isSelect = !(insertStmt.getQueryStatement().getQueryRelation() instanceof ValuesRelation);
                 boolean useOptimisticLock = isOnlyOlapTableQueries && isSelect;
                 if (useOptimisticLock) {
                     unLock(locker, dbs);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -137,10 +137,6 @@ public class StatementPlanner {
                 boolean isSelect = !(insertStmt.getQueryStatement().getQueryRelation() instanceof ValuesRelation);
                 boolean useOptimisticLock = isOnlyOlapTableQueries && isSelect &&
                         !session.getSessionVariable().isCboUseDBLock();
-                if (useOptimisticLock) {
-                    unLock(locker, dbs);
-                    needWholePhaseLock = false;
-                }
                 return new InsertPlanner(dbs, useOptimisticLock).plan((InsertStmt) stmt, session);
             } else if (stmt instanceof UpdateStmt) {
                 return new UpdatePlanner().plan((UpdateStmt) stmt, session);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -620,34 +620,27 @@ public class AnalyzerUtils {
             return null;
         }
 
+        // TODO: support cloud native table and mv
         private Table copyTable(Table originalTable) {
-            if (originalTable.isOlapTable()) {
-                OlapTable table = (OlapTable) originalTable;
-                if (!idMap.containsKey(table.getId())) {
-                    olapTables.add(table);
-                    idMap.put(table.getId(), table);
-                    // Only copy the necessary olap table meta to avoid the lock when plan query
-                    OlapTable copied = new OlapTable();
-                    table.copyOnlyForQuery(copied);
-                    return copied;
-                } else {
-                    return idMap.get(table.getId());
-                }
-            } else if (originalTable.isOlapMaterializedView()) {
-                MaterializedView table = (MaterializedView) originalTable;
-                if (!idMap.containsKey(table.getId())) {
-                    olapTables.add(table);
-                    idMap.put(table.getId(), table);
-                    // Only copy the necessary olap table meta to avoid the lock when plan query
-                    MaterializedView copied = new MaterializedView();
-                    table.copyOnlyForQuery(copied);
-                    return copied;
-                } else {
-                    return idMap.get(table.getId());
-                }
+            OlapTable table = (OlapTable) originalTable;
+            OlapTable existed = idMap.get(table.getId());
+            if (existed != null) {
+                return existed;
             }
-            // TODO: support cloud native table and mv
-            return null;
+
+            OlapTable copied = null;
+            if (originalTable.isOlapTable()) {
+                copied = new OlapTable();
+            } else if (originalTable.isOlapMaterializedView()) {
+                copied = new MaterializedView();
+            } else {
+                return null;
+            }
+
+            olapTables.add(table);
+            idMap.put(table.getId(), table);
+            table.copyOnlyForQuery(copied);
+            return copied;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerUtils.java
@@ -389,6 +389,7 @@ public class AnalyzerUtils {
         protected Map<TableName, Table> tables;
 
         public TableCollector() {
+            this.tables = Maps.newHashMap();
         }
 
         public TableCollector(Map<TableName, Table> dbs) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/OptimisticVersionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/OptimisticVersionTest.java
@@ -1,0 +1,115 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.analyzer.Analyzer;
+import com.starrocks.sql.analyzer.AnalyzerUtils;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.PlanTestBase;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OptimisticVersionTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @AfterAll
+    public static void afterAll() {
+        PlanTestBase.afterClass();
+    }
+
+    @Test
+    public void testOptimisticVersion() {
+        OlapTable table = new OlapTable();
+
+        // initialized
+        assertTrue(OptimisticVersion.validateTableUpdate(table, OptimisticVersion.generate()));
+
+        // schema change
+        table.lastSchemaUpdateTime.set(OptimisticVersion.generate());
+        assertTrue(OptimisticVersion.validateTableUpdate(table, OptimisticVersion.generate()));
+
+        // in update
+        table.lastVersionUpdateStartTime.set(OptimisticVersion.generate());
+        assertFalse(OptimisticVersion.validateTableUpdate(table, OptimisticVersion.generate()));
+
+        table.lastVersionUpdateEndTime.set(OptimisticVersion.generate());
+        assertTrue(OptimisticVersion.validateTableUpdate(table, OptimisticVersion.generate()));
+    }
+
+    @Test
+    public void testInsert() throws Exception {
+        starRocksAssert.withTable("create table test_insert(c1 int, c2 int) " +
+                "distributed by hash(c1) " +
+                "properties('replication_num'='1')");
+        final String sql = "insert into test_insert select * from test_insert";
+
+        List<StatementBase> stmts = SqlParser.parse(sql, new SessionVariable());
+        InsertStmt insertStmt = (InsertStmt) stmts.get(0);
+
+        // analyze
+        Analyzer.analyze(insertStmt, starRocksAssert.getCtx());
+        Map<String, Database> dbs = AnalyzerUtils.collectAllDatabase(starRocksAssert.getCtx(), insertStmt);
+
+        // normal planner
+        new InsertPlanner(dbs, true).plan(insertStmt, starRocksAssert.getCtx());
+
+        // retry but failed
+        new MockUp<OptimisticVersion>() {
+            @Mock
+            public boolean validateTableUpdate(OlapTable olapTable, long candidateVersion) {
+                return false;
+            }
+        };
+        assertThrows(SemanticException.class, () ->
+                new InsertPlanner(dbs, true).plan(insertStmt, starRocksAssert.getCtx()));
+
+        // retry and succeed
+        new MockUp<OptimisticVersion>() {
+            private boolean retried = false;
+
+            @Mock
+            public boolean validateTableUpdate(OlapTable olapTable, long candidateVersion) {
+                if (retried) {
+                    return true;
+                }
+                retried = true;
+                return false;
+            }
+        };
+        new InsertPlanner(dbs, true).plan(insertStmt, starRocksAssert.getCtx());
+
+    }
+
+}


### PR DESCRIPTION
Why I'm doing:
- For complicated `insert-select` statement, the optimizer may takes a long time, which would lead to lock issue if it holds the database lock at the mean time


What I'm doing:
- Apply the optimistic lock optimization to insert-select statement: release all dblocks when planning the `select` statement, the acquire the lock beside that

Behavior change:
- The `insert-select` statement may throw exceptions in the case that failed after retries

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
