### PR TITLE
[Enhancement] Support async segment writer for lake compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -938,6 +938,7 @@ CONF_mString(lake_vacuum_retry_pattern, "*request rate*");
 CONF_mInt64(lake_vacuum_retry_max_attempts, "5");
 CONF_mInt64(lake_vacuum_retry_min_delay_ms, "10");
 CONF_mBool(enable_primary_key_recover, "false");
+CONF_mBool(lake_enable_compaction_async_write, "false");
 
 CONF_mBool(dependency_librdkafka_debug_enable, "false");
 

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -29,6 +29,8 @@
 #include "service/service_be/lake_service.h"
 #include "storage/lake/compaction_task.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/memtable_flush_executor.h"
+#include "storage/storage_engine.h"
 #include "testutil/sync_point.h"
 #include "util/threadpool.h"
 
@@ -245,7 +247,15 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
                 return context->callback->has_error() || context->callback->timeout_exceeded();
             };
             TEST_SYNC_POINT("CompactionScheduler::do_compaction:before_execute_task");
-            status.update(task_or.value()->execute(&context->progress, std::move(should_cancel)));
+            ThreadPool* flush_pool = nullptr;
+            if (config::lake_enable_compaction_async_write) {
+                // CAUTION: we reuse delta writer's memory table flush pool here
+                flush_pool = StorageEngine::instance()->memtable_flush_executor()->get_thread_pool();
+                if (UNLIKELY(flush_pool == nullptr)) {
+                    return Status::InternalError("Get memory table flush pool failed");
+                }
+            }
+            status.update(task_or.value()->execute(&context->progress, std::move(should_cancel), flush_pool));
         } else {
             status.update(task_or.status());
         }

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -45,7 +45,7 @@ public:
     explicit CompactionTask(int64_t txn_id, VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets);
     virtual ~CompactionTask() = default;
 
-    virtual Status execute(Progress* stats, CancelFunc cancel_func) = 0;
+    virtual Status execute(Progress* stats, CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) = 0;
 
     inline static const CancelFunc kNoCancelFn = []() { return false; };
     inline static const CancelFunc kCancelledFn = []() { return true; };

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -29,7 +29,7 @@
 
 namespace starrocks::lake {
 
-Status HorizontalCompactionTask::execute(Progress* progress, CancelFunc cancel_func) {
+Status HorizontalCompactionTask::execute(Progress* progress, CancelFunc cancel_func, ThreadPool* flush_pool) {
     if (progress == nullptr) {
         return Status::InvalidArgument("progress is null");
     }
@@ -57,7 +57,7 @@ Status HorizontalCompactionTask::execute(Progress* progress, CancelFunc cancel_f
     reader_params.fill_data_cache = false;
     RETURN_IF_ERROR(reader.open(reader_params));
 
-    ASSIGN_OR_RETURN(auto writer, _tablet.new_writer(kHorizontal, _txn_id))
+    ASSIGN_OR_RETURN(auto writer, _tablet.new_writer(kHorizontal, _txn_id, 0, flush_pool))
     RETURN_IF_ERROR(writer->open());
     DeferOp defer([&]() { writer->close(); });
 

--- a/be/src/storage/lake/horizontal_compaction_task.h
+++ b/be/src/storage/lake/horizontal_compaction_task.h
@@ -36,7 +36,7 @@ public:
 
     ~HorizontalCompactionTask() override = default;
 
-    Status execute(Progress* progress, CancelFunc cancel_func) override;
+    Status execute(Progress* progress, CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) override;
 
 private:
     StatusOr<int32_t> calculate_chunk_size();

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -26,8 +26,9 @@
 namespace starrocks::lake {
 
 HorizontalPkTabletWriter::HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
-                                                   std::shared_ptr<const TabletSchema> schema, int64_t txn_id)
-        : HorizontalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id),
+                                                   std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
+                                                   ThreadPool* flush_pool)
+        : HorizontalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, flush_pool),
           _rowset_txn_meta(std::make_unique<RowsetTxnMetaPB>()) {}
 
 HorizontalPkTabletWriter::~HorizontalPkTabletWriter() = default;
@@ -72,8 +73,9 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
 
 VerticalPkTabletWriter::VerticalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                                std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                               uint32_t max_rows_per_segment)
-        : VerticalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, max_rows_per_segment) {}
+                                               uint32_t max_rows_per_segment, ThreadPool* flush_pool)
+        : VerticalGeneralTabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id, max_rows_per_segment,
+                                      flush_pool) {}
 
 VerticalPkTabletWriter::~VerticalPkTabletWriter() = default;
 

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -30,7 +30,8 @@ namespace starrocks::lake {
 class HorizontalPkTabletWriter : public HorizontalGeneralTabletWriter {
 public:
     explicit HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
-                                      std::shared_ptr<const TabletSchema> schema, int64_t txn_id);
+                                      std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
+                                      ThreadPool* flush_pool = nullptr);
 
     ~HorizontalPkTabletWriter() override;
 
@@ -59,7 +60,7 @@ class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {
 public:
     explicit VerticalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                     std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                    uint32_t max_rows_per_segment);
+                                    uint32_t max_rows_per_segment, ThreadPool* flush_pool = nullptr);
 
     ~VerticalPkTabletWriter() override;
 

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -27,7 +27,8 @@
 
 namespace starrocks {
 class TabletSchema;
-}
+class ThreadPool;
+} // namespace starrocks
 
 namespace starrocks {
 class Schema;
@@ -85,7 +86,8 @@ public:
     // `segment_max_rows` is used in vertical writer
     // NOTE: This method may update the version hint
     StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id,
-                                                       uint32_t max_rows_per_segment = 0);
+                                                       uint32_t max_rows_per_segment = 0,
+                                                       ThreadPool* flush_pool = nullptr);
 
     // NOTE: This method may update the version hint
     StatusOr<std::shared_ptr<const TabletSchema>> get_schema();

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -27,6 +27,7 @@ namespace starrocks {
 class Chunk;
 class Column;
 class TabletSchema;
+class ThreadPool;
 
 namespace lake {
 
@@ -38,8 +39,12 @@ enum WriterType : int { kHorizontal = 0, kVertical = 1 };
 class TabletWriter {
 public:
     explicit TabletWriter(TabletManager* tablet_mgr, int64_t tablet_id, std::shared_ptr<const TabletSchema> schema,
-                          int64_t txn_id)
-            : _tablet_mgr(tablet_mgr), _tablet_id(tablet_id), _schema(std::move(schema)), _txn_id(txn_id) {}
+                          int64_t txn_id, ThreadPool* flush_pool = nullptr)
+            : _tablet_mgr(tablet_mgr),
+              _tablet_id(tablet_id),
+              _schema(std::move(schema)),
+              _txn_id(txn_id),
+              _flush_pool(flush_pool) {}
 
     virtual ~TabletWriter() = default;
 
@@ -114,6 +119,7 @@ protected:
     int64_t _tablet_id;
     TabletSchemaCSPtr _schema;
     int64_t _txn_id;
+    ThreadPool* _flush_pool;
     std::vector<FileInfo> _files;
     int64_t _num_rows = 0;
     int64_t _data_size = 0;

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -36,23 +36,25 @@ int64_t VersionedTablet::version() const {
 }
 
 StatusOr<std::unique_ptr<TabletWriter>> VersionedTablet::new_writer(WriterType type, int64_t txn_id,
-                                                                    uint32_t max_rows_per_segment) {
+                                                                    uint32_t max_rows_per_segment,
+                                                                    ThreadPool* flush_pool) {
     auto tablet_schema = get_schema();
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id);
+            return std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id, flush_pool);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                            max_rows_per_segment);
+                                                            max_rows_per_segment, flush_pool);
         }
     } else {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id);
+            return std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
+                                                                   flush_pool);
         } else {
             DCHECK(type == kVertical);
             return std::make_unique<VerticalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
-                                                                 max_rows_per_segment);
+                                                                 max_rows_per_segment, flush_pool);
         }
     }
 }

--- a/be/src/storage/lake/versioned_tablet.h
+++ b/be/src/storage/lake/versioned_tablet.h
@@ -22,6 +22,7 @@
 namespace starrocks {
 class TabletSchema;
 class Schema;
+class ThreadPool;
 } // namespace starrocks
 
 namespace starrocks::lake {
@@ -67,7 +68,8 @@ public:
 
     // `segment_max_rows` is used in vertical writer
     StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id,
-                                                       uint32_t max_rows_per_segment = 0);
+                                                       uint32_t max_rows_per_segment = 0,
+                                                       ThreadPool* flush_pool = nullptr);
 
     StatusOr<std::unique_ptr<TabletReader>> new_reader(Schema schema);
 

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -31,7 +31,7 @@
 
 namespace starrocks::lake {
 
-Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_func) {
+Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_func, ThreadPool* flush_pool) {
     if (progress == nullptr) {
         return Status::InvalidArgument("progress is null");
     }
@@ -52,7 +52,7 @@ Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_fun
 
     uint32_t max_rows_per_segment =
             CompactionUtils::get_segment_max_rows(config::max_segment_file_size, _total_num_rows, _total_data_size);
-    ASSIGN_OR_RETURN(auto writer, _tablet.new_writer(kVertical, _txn_id, max_rows_per_segment));
+    ASSIGN_OR_RETURN(auto writer, _tablet.new_writer(kVertical, _txn_id, max_rows_per_segment, flush_pool));
     RETURN_IF_ERROR(writer->open());
     DeferOp defer([&]() { writer->close(); });
 

--- a/be/src/storage/lake/vertical_compaction_task.h
+++ b/be/src/storage/lake/vertical_compaction_task.h
@@ -39,7 +39,7 @@ public:
 
     ~VerticalCompactionTask() override = default;
 
-    Status execute(Progress* progress, CancelFunc cancel_func) override;
+    Status execute(Progress* progress, CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) override;
 
 private:
     StatusOr<int32_t> calculate_chunk_size_for_column_group(const std::vector<uint32_t>& column_group);

--- a/be/src/util/threadpool.h
+++ b/be/src/util/threadpool.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <fmt/format.h>
+
 #include <atomic>
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/list_hook.hpp>
@@ -48,6 +50,9 @@
 
 #include "common/status.h"
 #include "gutil/ref_counted.h"
+#include "util/bthreads/semaphore.h"
+// resolve `barrier` macro conflicts with boost/thread.hpp header file
+#undef barrier
 #include "util/monotime.h"
 #include "util/priority_queue.h"
 
@@ -479,6 +484,38 @@ private:
 
     ThreadPoolToken(const ThreadPoolToken&) = delete;
     const ThreadPoolToken& operator=(const ThreadPoolToken&) = delete;
+};
+
+// A class use to limit the number of tasks submitted to the thread pool.
+class ConcurrencyLimitedThreadPoolToken {
+public:
+    explicit ConcurrencyLimitedThreadPoolToken(ThreadPool* pool, int max_concurrency)
+            : _pool(pool), _sem(std::make_shared<bthreads::CountingSemaphore<>>(max_concurrency)) {}
+
+    DISALLOW_COPY_AND_MOVE(ConcurrencyLimitedThreadPoolToken);
+
+    Status submit_func(std::function<void()> task, std::chrono::system_clock::time_point deadline) {
+        if (!_sem->try_acquire_until(deadline)) {
+            auto t = MilliSecondsSinceEpochFromTimePoint(deadline);
+            return Status::TimedOut(fmt::format("acquire semaphore reached deadline={}", t));
+        }
+        auto task_with_semaphore_release = [sem = _sem, task = std::move(task)]() {
+            task();
+            // The `ConcurrencyLimitedThreadPoolToken` object may have been destroyed
+            // before `release()` the semaphore, so we use `std::shared_ptr` to manage
+            // the semaphore to ensure it's still alive when calling `release()`.
+            sem->release();
+        };
+        auto st = _pool->submit_func(std::move(task_with_semaphore_release));
+        if (!st.ok()) {
+            _sem->release();
+        }
+        return st;
+    }
+
+private:
+    ThreadPool* _pool;
+    std::shared_ptr<bthreads::CountingSemaphore<>> _sem;
 };
 
 } // namespace starrocks


### PR DESCRIPTION
## Why I'm doing:
With cloud-native table, compaction process was slow and it's easy for the compaction score to continue to rise.

## What I'm doing:
Increase vertical compaction speed by writing segment files in parallel and asynchronous manner.

The enhancements have been tested against the TPC-DS 100GB dataset and demonstrated a significant reduction in compaction time. Here is the test environment setup:

* TPC-DS 100GB dataset, catalog_sales table was chosen as the target table, it has 34 columns which means vertical compaction policy will be chosen by default
* The catalog_sales table was initialized as a duplicated table with 1 partition and 1 bucket
* The catalog_sales table was created with data cache enabled by default
* Data was continuously imported in 5 consecutive broker load jobs

In Case 1, we set `lake_enable_compaction_async_write` to true, which means segments finalization will execute in a parallel mode.

```sql
MySQL [sr_tpcds_bin_partitioned_orc_100]> show proc '/compactions';
+--------------------------------------------------------------------------+-------+---------------------+---------------------+---------------------+-------+
| Partition                                                                | TxnID | StartTime           | CommitTime          | FinishTime          | Error |
+--------------------------------------------------------------------------+-------+---------------------+---------------------+---------------------+-------+
| sr_tpcds_bin_partitioned_orc_100.catalog_sales_cache.catalog_sales_cache | 13    | 2023-12-25 16:08:35 | 2023-12-25 16:11:27 | 2023-12-25 16:11:28 | NULL  |
| sr_tpcds_bin_partitioned_orc_100.catalog_sales_cache.catalog_sales_cache | 15    | 2023-12-25 16:11:28 | 2023-12-25 16:30:12 | 2023-12-25 16:30:12 | NULL  |
| sr_tpcds_bin_partitioned_orc_100.catalog_sales_cache.catalog_sales_cache | 17    | 2023-12-25 16:30:12 | 2023-12-25 16:45:42 | 2023-12-25 16:45:42 | NULL  |
```

In Case 2, we set `lake_enable_async_segment_writer` to false, which was the de-facto manner of the previous serialize mode.

```sql
MySQL [sr_tpcds_bin_partitioned_orc_100]> show proc '/compactions';
+--------------------------------------------------------------------------+-------+---------------------+---------------------+---------------------+-------+
| Partition                                                                | TxnID | StartTime           | CommitTime          | FinishTime          | Error |
+--------------------------------------------------------------------------+-------+---------------------+---------------------+---------------------+-------+
| sr_tpcds_bin_partitioned_orc_100.catalog_sales_cache.catalog_sales_cache | 25    | 2023-12-25 16:54:56 | 2023-12-25 17:02:34 | 2023-12-25 17:02:34 | NULL  |
| sr_tpcds_bin_partitioned_orc_100.catalog_sales_cache.catalog_sales_cache | 27    | 2023-12-25 17:02:34 | 2023-12-25 17:37:03 | 2023-12-25 17:37:03 | NULL  |
| sr_tpcds_bin_partitioned_orc_100.catalog_sales_cache.catalog_sales_cache | 29    | 2023-12-25 17:37:03 | 2023-12-25 18:11:53 | 2023-12-25 18:11:53 | NULL  |
+--------------------------------------------------------------------------+-------+---------------------+---------------------+---------------------+-------+
```

The results showed that after parallel optimization of segment finalizing, total time cost of vertical compaction reduced from **76min55s** to **37min7s**.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
