### PR TITLE
[Enhancement] add config for lazy delta column compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -293,6 +293,9 @@ CONF_Int32(cumulative_compaction_num_threads_per_disk, "1");
 // when candidate num reach this value, the condidate with lowest score will be dropped.
 CONF_mInt64(max_compaction_candidate_num, "40960");
 
+// If true, SR will try no to merge delta column back to main segment
+CONF_mBool(enable_lazy_delta_column_compaction, "true");
+
 CONF_mInt32(update_compaction_check_interval_seconds, "10");
 CONF_mInt32(update_compaction_num_threads_per_disk, "1");
 CONF_Int32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2464,9 +2464,10 @@ Status TabletUpdates::compaction(MemTracker* mem_tracker) {
         if (info->inputs.size() > 0 && new_bytes > config::update_compaction_result_bytes * 2) {
             break;
         }
-        // Partial update generate empty rowset, compact them first.
-        // Or partial update by column will trigger too many useless compaction cost.
-        if (info->inputs.size() > 1 && has_partial_update_by_column) {
+        // When we enable lazy delta column compaction, which means that we don't want to merge
+        // delta column back to main segment file too soon, for save compaction IO cost.
+        // Separate delta column won't affect query performance.
+        if (info->inputs.size() > 1 && has_partial_update_by_column && config::enable_lazy_delta_column_compaction) {
             break;
         }
         info->inputs.push_back(e.rowsetid);


### PR DESCRIPTION
Why I'm doing:
Lazy delta column compaction is designed for save compaction IO cost. We don't need to merge delta column back to segment too soon, because it doesn't affect query performance. But in some case, we don't want to keep too many delta column files so user can choose to close it. 

What I'm doing:
add config `enable_lazy_delta_column_compaction` for lazy delta column compaction

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
