### PR TITLE
[Tool] Remove concurrency control of inspection pipeline

### DIFF
--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -21,10 +21,6 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: 'INSPECTION-MAIN'
-  cancel-in-progress: false
-
 permissions:
   checks: write
   actions: write
@@ -228,7 +224,7 @@ jobs:
             echo "PR_NUMBER=${{ needs.build.outputs.pr_number }}" >> $GITHUB_OUTPUT
             echo "BRANCH=main" >> $GITHUB_OUTPUT
             echo "BASE_VERSION=${{ needs.build.outputs.base_version }}" >> $GITHUB_OUTPUT
-          else:
+          else
             echo "PR_NUMBER=${{ inputs.COMMIT_ID }}" >> $GITHUB_OUTPUT
             echo "BRANCH=${{ inputs.BRANCH }}" >> $GITHUB_OUTPUT
             echo "TAR_PATH=${{ inputs.TAR_PATH }}" >> $GITHUB_OUTPUT
@@ -259,7 +255,7 @@ jobs:
             bucket_prefix=`echo ${repo%/*} | tr '[:upper:]' '[:lower:]'`
             tar_path="oss://${bucket_prefix}-ci-release/$BRANCH/Release/pr/${{needs.build.outputs.build_output_tar}}"
             with_cov="--with-coverage"
-          else:
+          else
             tar_path=${TAR_PATH}
           fi
           


### PR DESCRIPTION
Why I'm doing:
Daily inspection may be triggered by different branches, remove the concurrency control to avoid the pending status. 

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
