### PR TITLE
[BugFix] Fix refresh materaizlied view failed when parition column is  date_trunc(str2_date(dt)) 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1338,7 +1338,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      *
      * @return : partitioned materialized view's all need updated partition names.
      */
-    private boolean getPartitionedMVRefreshPartitions(Set<String> toRefreshedPartitioins,
+    private boolean getPartitionedMVRefreshPartitions(Set<String> toRefreshPartitions,
                                                       boolean isQueryRewrite) {
         Preconditions.checkState(partitionInfo instanceof ExpressionRangePartitionInfo);
         // If non-partition-by table has changed, should refresh all mv partitions
@@ -1361,7 +1361,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             if (!baseTable.isNativeTableOrMaterializedView()) {
                 if (tableProperty.getForceExternalTableQueryRewrite() ==
                         TableProperty.QueryRewriteConsistencyMode.DISABLE) {
-                    toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                    toRefreshPartitions.addAll(getVisiblePartitionNames());
                     return false;
                 }
             }
@@ -1372,7 +1372,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             Set<String> partitionNames =
                     getUpdatedPartitionNamesOfTable(baseTable, true, isQueryRewrite, partitionExpr);
             if (CollectionUtils.isNotEmpty(partitionNames)) {
-                toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                toRefreshPartitions.addAll(getVisiblePartitionNames());
                 return true;
             }
         }
@@ -1391,7 +1391,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                         PartitionUtil.getPartitionKeyRange(table, entry.getValue(), partitionExpr));
             } catch (UserException e) {
                 LOG.warn("Materialized view compute partition difference with base table failed.", e);
-                toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                toRefreshPartitions.addAll(getVisiblePartitionNames());
                 return false;
             }
 
@@ -1399,7 +1399,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             Set<String> baseChangedPartition =
                     getUpdatedPartitionNamesOfTable(table, true, isQueryRewrite, partitionExpr);
             if (baseChangedPartition == null) {
-                toRefreshedPartitioins.addAll(getVisiblePartitionNames());
+                toRefreshPartitions.addAll(getVisiblePartitionNames());
                 return true;
             } else {
                 baseChangedPartitionNames.put(table, baseChangedPartition);
@@ -1437,7 +1437,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
             SyncPartitionUtils.calcPotentialRefreshPartition(needRefreshMvPartitionNames, baseChangedPartitionNames,
                     baseToMvNameRef, mvToBaseNameRef);
         }
-        toRefreshedPartitioins.addAll(needRefreshMvPartitionNames);
+        toRefreshPartitions.addAll(needRefreshMvPartitionNames);
         return true;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -292,12 +292,16 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
         return type == TableType.MATERIALIZED_VIEW;
     }
 
-    public boolean isView() {
+    public boolean isOlapView() {
         return type == TableType.VIEW;
     }
 
     public boolean isHiveView() {
         return type == TableType.HIVE_VIEW;
+    }
+
+    public boolean isView() {
+        return isOlapView() || isHiveView();
     }
 
     public boolean isOlapTableOrMaterializedView() {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/GrantsTo.java
@@ -466,7 +466,7 @@ public class GrantsTo {
                 }
 
                 if (objectType.equals(ObjectType.VIEW)) {
-                    if (table.isView()) {
+                    if (table.isOlapView()) {
                         objects.add(Lists.newArrayList(catalogName, dbName, table.getName()));
                     }
                 } else if (objectType.equals(ObjectType.MATERIALIZED_VIEW)) {
@@ -474,7 +474,7 @@ public class GrantsTo {
                         objects.add(Lists.newArrayList(catalogName, dbName, table.getName()));
                     }
                 } else {
-                    if (!table.isView() && !table.isMaterializedView()) {
+                    if (!table.isOlapView() && !table.isMaterializedView()) {
                         objects.add(Lists.newArrayList(catalogName, dbName, table.getName()));
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
@@ -123,7 +123,7 @@ public class TablePEntryObject implements PEntryObject {
                     throw new PrivObjNotFoundException("cannot find table " +
                             tokens.get(1) + " in db " + tokens.get(0) + ", msg: " + e.getMessage());
                 }
-                if (table == null || table.isView() || table.isMaterializedView()) {
+                if (table == null || table.isOlapView() || table.isMaterializedView()) {
                     throw new PrivObjNotFoundException("cannot find table " +
                             tokens.get(1) + " in db " + tokens.get(0));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ViewPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ViewPEntryObject.java
@@ -51,7 +51,7 @@ public class ViewPEntryObject extends TablePEntryObject {
                 tblUUID = PrivilegeBuiltinConstants.ALL_TABLES_UUID;
             } else {
                 Table table = database.getTable(tokens.get(1));
-                if (table == null || !table.isView()) {
+                if (table == null || !table.isOlapView()) {
                     throw new PrivObjNotFoundException("cannot find view " + tokens.get(1) + " in db " + tokens.get(0));
                 }
                 tblUUID = table.getUUID();

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/starrocks/RangerStarRocksAccessController.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/ranger/starrocks/RangerStarRocksAccessController.java
@@ -240,7 +240,7 @@ public class RangerStarRocksAccessController extends RangerAccessController {
             throws AccessDeniedException {
         Database database = GlobalStateMgr.getCurrentState().getDb(db);
         for (Table table : database.getTables()) {
-            if (table.isView()) {
+            if (table.isOlapView()) {
                 checkViewAction(userIdentity, roleIds, new TableName(database.getFullName(), table.getName()), privilegeType);
             } else if (table.isMaterializedView()) {
                 checkMaterializedViewAction(userIdentity, roleIds,

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -902,7 +902,7 @@ public class ShowExecutor {
                     }
 
                     try {
-                        if (tbl.isView()) {
+                        if (tbl.isOlapView()) {
                             Authorizer.checkAnyActionOnView(
                                     connectContext.getCurrentUserIdentity(), connectContext.getCurrentRoleIds(),
                                     new TableName(db.getFullName(), tbl.getName()));

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1522,7 +1522,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
             try {
-                if (table.isOlapTable()) {
+                if (table.isView()) {
+                    // skip to collect snapshots for views
+                } else if (table.isOlapTable()) {
                     Table copied = DeepCopy.copyWithGson(table, OlapTable.class);
                     if (copied == null) {
                         throw new DmlException("Failed to copy olap table: %s", table.getName());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -157,7 +157,7 @@ public class MaterializedViewAnalyzer {
                 }
             }
 
-            if (table.isOlapView()) {
+            if (table.isView()) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -157,7 +157,7 @@ public class MaterializedViewAnalyzer {
                 }
             }
 
-            if (table.isView()) {
+            if (table.isOlapView()) {
                 continue;
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -1764,13 +1764,13 @@ public class MaterializedViewRewriter {
             ColumnRefSet originalRefSet,
             boolean isEqual,
             boolean isUnion,
-            List<ScalarOperator> rewrittenFailedPredciates) {
+            List<ScalarOperator> rewrittenFailedPredicates) {
         final EquationRewriter equationRewriter = isEqual ?
                 buildEquationRewriter(exprMap, rewriteContext, false, false) :
                 buildEquationRewriter(exprMap, rewriteContext, true, false);
         final List<ScalarOperator> conjuncts = Utils.extractConjuncts(predicate);
         final List<ScalarOperator> rewrittens =
-                rewriteScalarOpToTarget(conjuncts, equationRewriter, null, originalRefSet, isUnion, rewrittenFailedPredciates);
+                rewriteScalarOpToTarget(conjuncts, equationRewriter, null, originalRefSet, isUnion, rewrittenFailedPredicates);
         if (rewrittens == null || rewrittens.isEmpty()) {
             logMVRewrite(mvRewriteContext, "rewrite scalar operator failed. isEqual:{}, isUnion:{}, predicate:{},",
                     isEqual, isUnion, predicate);
@@ -2302,7 +2302,7 @@ public class MaterializedViewRewriter {
             EquationRewriter equationRewriter,
             Map<ColumnRefOperator, ColumnRefOperator> outputMapping,
             ColumnRefSet originalColumnSet, boolean isUnion,
-            List<ScalarOperator> rewrittenFailedPredciates) {
+            List<ScalarOperator> rewrittenFailedPredicates) {
         List<ScalarOperator> rewrittenExprs = Lists.newArrayList();
         equationRewriter.setOutputMapping(outputMapping);
         for (ScalarOperator expr : exprsToRewrites) {
@@ -2310,7 +2310,7 @@ public class MaterializedViewRewriter {
             if (expr.isVariable() && expr == rewritten) {
                 // it means it can not be rewritten  by target
                 if (isUnion) {
-                    rewrittenFailedPredciates.add(expr);
+                    rewrittenFailedPredicates.add(expr);
                     continue;
                 } else {
                     logMVRewrite(mvRewriteContext, "Rewrite scalar operator failed: {} cannot be rewritten",
@@ -2320,7 +2320,7 @@ public class MaterializedViewRewriter {
             }
             if (originalColumnSet != null && !isAllExprReplaced(rewritten, originalColumnSet)) {
                 if (isUnion) {
-                    rewrittenFailedPredciates.add(expr);
+                    rewrittenFailedPredicates.add(expr);
                     continue;
                 } else {
                     // it means there is some column that can not be rewritten by outputs of mv

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRefreshAndRewriteIcebergTest.java
@@ -22,11 +22,14 @@ import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@TestMethodOrder(MethodOrderer.MethodName.class)
 public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
     @BeforeClass
     public static void beforeClass() throws Exception {
@@ -46,6 +49,37 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                 "as select a, b, d, bitmap_union(to_bitmap(t1.c))" +
                 " from iceberg0.partitioned_db.part_tbl1 as t1 " +
                 " group by a, b, d;");
+
+        testSingleTableWithMVRewrite(mvName);
+
+        starRocksAssert.dropMaterializedView(mvName);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
+    }
+
+
+    @Test
+    public void testStr2DateMVRefreshRewriteSingleTableWithView() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withView("CREATE VIEW view1 as select a, b, d, bitmap_union(to_bitmap(t1.c))\n" +
+                " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                " group by a, b, d;");
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by str2date(d,'%Y-%m-%d') " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select * from view1");
+
+        testSingleTableWithMVRewrite(mvName);
+
+        starRocksAssert.dropMaterializedView(mvName);
+        starRocksAssert.dropView("view1");
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
+    }
+
+    private void testSingleTableWithMVRewrite(String mvName) throws Exception {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
 
@@ -152,8 +186,6 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     "     TABLE: part_tbl1\n" +
                     "     PREDICATES: 13: d != '2023-08-01', 13: d != '2023-08-02'");
         }
-        starRocksAssert.dropMaterializedView(mvName);
-        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
     }
 
     @Test
@@ -186,7 +218,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
                     " inner join iceberg0.partitioned_db.part_tbl2 t2 on t1.d=t2.d " +
                     " inner join iceberg0.partitioned_db.part_tbl3 t3 on t1.d=t3.d " +
                     " where t1.d='2023-08-01';";
-            String plan = getFragmentPlan(query, "MV");
+            String plan = getFragmentPlan(query);
             PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
                     "     TABLE: test_mv1\n" +
                     "     PREAGGREGATION: ON\n" +
@@ -1732,6 +1764,7 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         starRocksAssert.dropMaterializedView(mvName);
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
     }
+
     @Test
     public void testStr2DateMVRefreshRewriteWithBitmapHash_InnerJoin() throws Exception {
         String mvName = "test_mv1";
@@ -1837,5 +1870,123 @@ public class MvRefreshAndRewriteIcebergTest extends MvRewriteTestBase {
         }
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewriteSingleTableWithDateTruc_Day() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withView("CREATE VIEW view1 as select " +
+                " a, b, " +
+                " date_trunc('day', str2date(d,'%Y-%m-%d')) as dt, " +
+                " bitmap_union(to_bitmap(t1.c))\n" +
+                " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                " group by a, b, dt;");
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by dt " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select * from view1");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p20230801_20230802"), partitions);
+
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        {
+            String query = "select a, b, date_trunc('day', str2date(d,'%Y-%m-%d')) as dt, " +
+                    " count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " where d='2023-08-01'" +
+                    " group by a, b, dt;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     partitions=1/1");
+        }
+
+        // TODO: Support date_trunc('day', str2date(t1.d, ''%Y-%m-%d'')) to str2date(d, '%Y-%m-%d')
+        {
+            String query = "select a, b, count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " where date_trunc('day', str2date(t1.d, '%Y-%m-%d'))  >= '2023-08-01' \n" +
+                    " group by a, b;";
+            String plan = getFragmentPlan(query, "MV");
+            PlanTestBase.assertNotContains(plan, mvName);
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+        starRocksAssert.dropView("view1");
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
+    }
+
+    @Test
+    public void testStr2DateMVRefreshRewriteSingleTableWithDateTruc_Month() throws Exception {
+        String mvName = "test_mv1";
+        starRocksAssert.withView("CREATE VIEW view1 as select a, b, " +
+                " date_trunc('month', str2date(d,'%Y-%m-%d')) as dt, " +
+                " bitmap_union(to_bitmap(t1.c))\n" +
+                " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                " group by a, b, d;");
+        starRocksAssert.withMaterializedView("create materialized view " + mvName + " " +
+                "partition by dt " +
+                "distributed by hash(a) " +
+                "REFRESH DEFERRED MANUAL " +
+                "PROPERTIES (\n" +
+                "'replication_num' = '1'" +
+                ") " +
+                "as select * from view1");
+        Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+        MaterializedView materializedView = ((MaterializedView) testDb.getTable(mvName));
+
+        // initial create
+        starRocksAssert.getCtx().executeSql("refresh materialized view " + mvName + " partition start('2023-08-01') " +
+                "end ('2023-08-02') force with sync mode");
+        List<String> partitions =
+                materializedView.getPartitions().stream().map(Partition::getName).sorted()
+                        .collect(Collectors.toList());
+        Assert.assertEquals(Arrays.asList("p202308_202309"), partitions);
+
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
+        {
+            String query = "select " +
+                    " a, b, date_trunc('month', str2date(d,'%Y-%m-%d')) as dt, " +
+                    " count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " where date_trunc('month', str2date(d,'%Y-%m-%d')) ='2023-08-01'" +
+                    " group by a, b, dt;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, "UNION");
+            PlanTestBase.assertContains(plan, "0:OlapScanNode\n" +
+                    "     TABLE: test_mv1\n" +
+                    "     PREAGGREGATION: ON\n" +
+                    "     PREDICATES: 9: dt = '2023-08-01'\n" +
+                    "     partitions=1/1\n" +
+                    "     rollup: test_mv1");
+        }
+
+        // TODO: Support date_trunc('day', str2date(t1.d, ''%Y-%m-%d'')) to str2date(d, '%Y-%m-%d')
+        {
+            String query = "select a, b, d, count(distinct t1.c)\n" +
+                    " from iceberg0.partitioned_db.part_tbl1 as t1 \n" +
+                    " where t1.d >= '2023-08-01' \n" +
+                    " group by a, b, d;";
+            String plan = getFragmentPlan(query);
+            PlanTestBase.assertNotContains(plan, mvName);
+        }
+
+        starRocksAssert.dropMaterializedView(mvName);
+        starRocksAssert.dropView("view1");
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -342,8 +342,8 @@ public class MvRewriteTestBase {
     public String getFragmentPlan(String sql, String traceModule) throws Exception {
         Pair<String, Pair<ExecPlan, String>> result =
                 UtFrameUtils.getFragmentPlanWithTrace(connectContext, sql, traceModule);
-        String traceLog = result.first;
         Pair<ExecPlan, String> execPlanWithQuery = result.second;
+        String traceLog = execPlanWithQuery.second;
         if (!Strings.isNullOrEmpty(traceLog)) {
             System.out.println(traceLog);
         }


### PR DESCRIPTION
Why I'm doing:

After PR(https://github.com/StarRocks/starrocks/pull/34000), refresh mv with partition column (eg: date_trunc(str2date(dt)) will fail because `transferRange` can only handle date literal.

```
        // assume expr partition must be DateLiteral and only one partition
        LiteralExpr lowerExpr = baseRange.lowerEndpoint().getKeys().get(0);
        LiteralExpr upperExpr = baseRange.upperEndpoint().getKeys().get(0);
        Preconditions.checkArgument(lowerExpr instanceof DateLiteral);
```

After PR(https://github.com/StarRocks/starrocks/pull/36525), we will first collect BaseTable snapshot info to be used after refresh success. But it should not collect views snapshot info instead.


What I'm doing:
- call `convertToDatePartitionRange ` before `transferRange` to convert string literal to date literal;
- change `isView` method to `isOlapView` which only means it's an OLAP type view
- add `isView` method to represent it's a olap view or hive view.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5123 https://github.com/StarRocks/StarRocksTest/issues/5057

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
