### PR TITLE
[Feature] Support configure aws sts endpoint and region

### DIFF
--- a/be/src/fs/credential/cloud_configuration.h
+++ b/be/src/fs/credential/cloud_configuration.h
@@ -30,6 +30,8 @@ public:
     std::string secret_key;
     std::string session_token;
     std::string iam_role_arn;
+    std::string sts_region;
+    std::string sts_endpoint;
     std::string external_id;
     std::string region;
     std::string endpoint;
@@ -38,7 +40,8 @@ public:
         return use_aws_sdk_default_behavior == rhs.use_aws_sdk_default_behavior &&
                use_instance_profile == rhs.use_instance_profile && access_key == rhs.access_key &&
                secret_key == rhs.secret_key && session_token == rhs.session_token && iam_role_arn == rhs.iam_role_arn &&
-               external_id == rhs.external_id && region == rhs.region && endpoint == rhs.endpoint;
+               sts_region == rhs.sts_region && sts_endpoint == rhs.sts_endpoint && external_id == rhs.external_id &&
+               region == rhs.region && endpoint == rhs.endpoint;
     }
 };
 

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -31,6 +31,8 @@ static const std::string AWS_S3_ACCESS_KEY = "aws.s3.access_key";
 static const std::string AWS_S3_SECRET_KEY = "aws.s3.secret_key";
 static const std::string AWS_S3_SESSION_TOKEN = "aws.s3.session_token";
 static const std::string AWS_S3_IAM_ROLE_ARN = "aws.s3.iam_role_arn";
+static const std::string AWS_S3_STS_REGION = "aws.s3.sts.region";
+static const std::string AWS_S3_STS_ENDPOINT = "aws.s3.sts.endpoint";
 static const std::string AWS_S3_EXTERNAL_ID = "aws.s3.external_id";
 static const std::string AWS_S3_REGION = "aws.s3.region";
 static const std::string AWS_S3_ENDPOINT = "aws.s3.endpoint";
@@ -78,6 +80,8 @@ public:
         aws_cloud_credential.secret_key = get_or_default(properties, AWS_S3_SECRET_KEY, std::string());
         aws_cloud_credential.session_token = get_or_default(properties, AWS_S3_SESSION_TOKEN, std::string());
         aws_cloud_credential.iam_role_arn = get_or_default(properties, AWS_S3_IAM_ROLE_ARN, std::string());
+        aws_cloud_credential.sts_region = get_or_default(properties, AWS_S3_STS_REGION, std::string());
+        aws_cloud_credential.sts_endpoint = get_or_default(properties, AWS_S3_ENDPOINT, std::string());
         aws_cloud_credential.external_id = get_or_default(properties, AWS_S3_EXTERNAL_ID, std::string());
         aws_cloud_credential.region = get_or_default(properties, AWS_S3_REGION, std::string());
         aws_cloud_credential.endpoint = get_or_default(properties, AWS_S3_ENDPOINT, std::string());

--- a/be/src/fs/credential/cloud_configuration_factory.h
+++ b/be/src/fs/credential/cloud_configuration_factory.h
@@ -81,7 +81,7 @@ public:
         aws_cloud_credential.session_token = get_or_default(properties, AWS_S3_SESSION_TOKEN, std::string());
         aws_cloud_credential.iam_role_arn = get_or_default(properties, AWS_S3_IAM_ROLE_ARN, std::string());
         aws_cloud_credential.sts_region = get_or_default(properties, AWS_S3_STS_REGION, std::string());
-        aws_cloud_credential.sts_endpoint = get_or_default(properties, AWS_S3_ENDPOINT, std::string());
+        aws_cloud_credential.sts_endpoint = get_or_default(properties, AWS_S3_STS_ENDPOINT, std::string());
         aws_cloud_credential.external_id = get_or_default(properties, AWS_S3_EXTERNAL_ID, std::string());
         aws_cloud_credential.region = get_or_default(properties, AWS_S3_REGION, std::string());
         aws_cloud_credential.endpoint = get_or_default(properties, AWS_S3_ENDPOINT, std::string());

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -17,14 +17,11 @@
 #include <aws/core/Aws.h>
 #include <aws/core/auth/AWSCredentialsProvider.h>
 #include <aws/core/auth/AWSCredentialsProviderChain.h>
+#include <aws/core/client/ClientConfiguration.h>
 #include <aws/identity-management/auth/STSAssumeRoleCredentialsProvider.h>
 #include <aws/s3/model/CopyObjectRequest.h>
-#include <aws/s3/model/CreateBucketRequest.h>
-#include <aws/s3/model/DeleteBucketRequest.h>
 #include <aws/s3/model/DeleteObjectRequest.h>
 #include <aws/s3/model/DeleteObjectsRequest.h>
-#include <aws/s3/model/GetObjectRequest.h>
-#include <aws/s3/model/HeadObjectRequest.h>
 #include <aws/s3/model/ListObjectsV2Request.h>
 #include <aws/s3/model/ListObjectsV2Result.h>
 #include <aws/s3/model/PutObjectRequest.h>
@@ -148,7 +145,14 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3ClientFactory::_get_aws_cre
 
     if (!aws_cloud_credential.iam_role_arn.empty()) {
         // Do assume role
-        auto sts = std::make_shared<Aws::STS::STSClient>(credential_provider);
+        Aws::Client::ClientConfiguration clientConfiguration{};
+        if (!aws_cloud_credential.sts_region.empty()) {
+            clientConfiguration.region = aws_cloud_credential.sts_region;
+        }
+        if (!aws_cloud_credential.sts_endpoint.empty()) {
+            clientConfiguration.endpointOverride = aws_cloud_credential.sts_endpoint;
+        }
+        auto sts = std::make_shared<Aws::STS::STSClient>(credential_provider, clientConfiguration);
         credential_provider = std::make_shared<Aws::Auth::STSAssumeRoleCredentialsProvider>(
                 aws_cloud_credential.iam_role_arn, Aws::String(), aws_cloud_credential.external_id,
                 Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts);

--- a/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/CloudConfigurationConstants.java
@@ -25,6 +25,8 @@ public class CloudConfigurationConstants {
     public static final String AWS_S3_SECRET_KEY = "aws.s3.secret_key";
     public static final String AWS_S3_SESSION_TOKEN = "aws.s3.session_token";
     public static final String AWS_S3_IAM_ROLE_ARN = "aws.s3.iam_role_arn";
+    public static final String AWS_S3_STS_REGION = "aws.s3.sts.region";
+    public static final String AWS_S3_STS_ENDPOINT = "aws.s3.sts.endpoint";
     public static final String AWS_S3_EXTERNAL_ID = "aws.s3.external_id";
     public static final String AWS_S3_REGION = "aws.s3.region";
     public static final String AWS_S3_ENDPOINT = "aws.s3.endpoint";
@@ -51,6 +53,8 @@ public class CloudConfigurationConstants {
     public static final String AWS_GLUE_SECRET_KEY = "aws.glue.secret_key";
     public static final String AWS_GLUE_SESSION_TOKEN = "aws.glue.session_token";
     public static final String AWS_GLUE_IAM_ROLE_ARN = "aws.glue.iam_role_arn";
+    public static final String AWS_GLUE_STS_REGION = "aws.glue.sts.region";
+    public static final String AWS_GLUE_STS_ENDPOINT = "aws.glue.sts.endpoint";
     public static final String AWS_GLUE_EXTERNAL_ID = "aws.glue.external_id";
     public static final String AWS_GLUE_REGION = "aws.glue.region";
     public static final String AWS_GLUE_ENDPOINT = "aws.glue.endpoint";

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfigurationProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudConfigurationProvider.java
@@ -28,6 +28,8 @@ import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_IAM_
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_REGION;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_SECRET_KEY;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_SESSION_TOKEN;
+import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_STS_ENDPOINT;
+import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_STS_REGION;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_USE_AWS_SDK_DEFAULT_BEHAVIOR;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_GLUE_USE_INSTANCE_PROFILE;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_ACCESS_KEY;
@@ -39,6 +41,8 @@ import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_IAM_RO
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_REGION;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_SECRET_KEY;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_SESSION_TOKEN;
+import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_STS_ENDPOINT;
+import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_STS_REGION;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_AWS_SDK_DEFAULT_BEHAVIOR;
 import static com.starrocks.credential.CloudConfigurationConstants.AWS_S3_USE_INSTANCE_PROFILE;
 public class AWSCloudConfigurationProvider implements CloudConfigurationProvider {
@@ -59,6 +63,8 @@ public class AWSCloudConfigurationProvider implements CloudConfigurationProvider
                 hiveConf.get(AWS_GLUE_SECRET_KEY, ""),
                 hiveConf.get(AWS_GLUE_SESSION_TOKEN, ""),
                 hiveConf.get(AWS_GLUE_IAM_ROLE_ARN, ""),
+                hiveConf.get(AWS_GLUE_STS_REGION, ""),
+                hiveConf.get(AWS_GLUE_STS_ENDPOINT, ""),
                 hiveConf.get(AWS_GLUE_EXTERNAL_ID, ""),
                 hiveConf.get(AWS_GLUE_REGION, DEFAULT_AWS_REGION),
                 hiveConf.get(AWS_GLUE_ENDPOINT, "")
@@ -79,6 +85,8 @@ public class AWSCloudConfigurationProvider implements CloudConfigurationProvider
                 properties.getOrDefault(AWS_S3_SECRET_KEY, ""),
                 properties.getOrDefault(AWS_S3_SESSION_TOKEN, ""),
                 properties.getOrDefault(AWS_S3_IAM_ROLE_ARN, ""),
+                properties.getOrDefault(AWS_S3_STS_REGION, ""),
+                properties.getOrDefault(AWS_S3_STS_ENDPOINT, ""),
                 properties.getOrDefault(AWS_S3_EXTERNAL_ID, ""),
                 properties.getOrDefault(AWS_S3_REGION, DEFAULT_AWS_REGION),
                 properties.getOrDefault(AWS_S3_ENDPOINT, "")

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
@@ -147,6 +147,8 @@ public class AWSCloudCredential implements CloudCredential {
                 stsBuilder.setRegion(stsRegion);
             }
             if (!stsEndpoint.isEmpty()) {
+                // Glue is using aws sdk v1. If the user provides the sts endpoint, the sts region must also be specified.
+                // But in aws sdk v2, user only need to provide one of the two
                 Preconditions.checkArgument(!stsRegion.isEmpty(),
                         String.format("STS endpoint is set to %s but no signing region was provided", stsEndpoint));
                 stsBuilder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(stsEndpoint, stsRegion));
@@ -188,6 +190,8 @@ public class AWSCloudCredential implements CloudCredential {
             configuration.set("fs.s3a.assumed.role.sts.endpoint.region", stsRegion);
         }
         if (!stsEndpoint.isEmpty()) {
+            // Hadoop is using aws sdk v1. If the user provides the sts endpoint, the sts region must also be specified.
+            // But in aws sdk v2, user only need to provide one of the two
             Preconditions.checkArgument(!stsRegion.isEmpty(),
                     String.format("STS endpoint is set to %s but no signing region was provided", stsEndpoint));
             configuration.set("fs.s3a.assumed.role.sts.endpoint", stsEndpoint);

--- a/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
+++ b/fe/fe-core/src/main/java/com/starrocks/credential/aws/AWSCloudCredential.java
@@ -22,6 +22,7 @@ import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenService;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
 import com.google.common.base.Preconditions;
@@ -80,6 +81,10 @@ public class AWSCloudCredential implements CloudCredential {
 
     private final String iamRoleArn;
 
+    private final String stsRegion;
+
+    private final String stsEndpoint;
+
     private final String externalId;
 
     private final String region;
@@ -87,7 +92,8 @@ public class AWSCloudCredential implements CloudCredential {
     private final String endpoint;
 
     protected AWSCloudCredential(boolean useAWSSDKDefaultBehavior, boolean useInstanceProfile, String accessKey,
-                                 String secretKey, String sessionToken, String iamRoleArn, String externalId, String region,
+                                 String secretKey, String sessionToken, String iamRoleArn, String stsRegion,
+                                 String stsEndpoint, String externalId, String region,
                                  String endpoint) {
         Preconditions.checkNotNull(accessKey);
         Preconditions.checkNotNull(secretKey);
@@ -102,6 +108,8 @@ public class AWSCloudCredential implements CloudCredential {
         this.secretKey = secretKey;
         this.sessionToken = sessionToken;
         this.iamRoleArn = iamRoleArn;
+        this.stsRegion = stsRegion;
+        this.stsEndpoint = stsEndpoint;
         this.externalId = externalId;
         this.region = region;
         this.endpoint = endpoint;
@@ -135,8 +143,13 @@ public class AWSCloudCredential implements CloudCredential {
             }
             AWSSecurityTokenServiceClientBuilder stsBuilder = AWSSecurityTokenServiceClientBuilder.standard()
                     .withCredentials(awsCredentialsProvider);
-            if (!region.isEmpty()) {
-                stsBuilder.setRegion(region);
+            if (!stsRegion.isEmpty()) {
+                stsBuilder.setRegion(stsRegion);
+            }
+            if (!stsEndpoint.isEmpty()) {
+                Preconditions.checkArgument(!stsRegion.isEmpty(),
+                        String.format("STS endpoint is set to %s but no signing region was provided", stsEndpoint));
+                stsBuilder.setEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(stsEndpoint, stsRegion));
             }
             AWSSecurityTokenService token = stsBuilder.build();
             builder.withStsClient(token);
@@ -171,6 +184,14 @@ public class AWSCloudCredential implements CloudCredential {
         configuration.set("fs.s3a.aws.credentials.provider",
                 "com.starrocks.credential.provider.AssumedRoleCredentialProvider");
         configuration.set("fs.s3a.assumed.role.arn", iamRoleArn);
+        if (!stsRegion.isEmpty()) {
+            configuration.set("fs.s3a.assumed.role.sts.endpoint.region", stsRegion);
+        }
+        if (!stsEndpoint.isEmpty()) {
+            Preconditions.checkArgument(!stsRegion.isEmpty(),
+                    String.format("STS endpoint is set to %s but no signing region was provided", stsEndpoint));
+            configuration.set("fs.s3a.assumed.role.sts.endpoint", stsEndpoint);
+        }
         configuration.set(AssumedRoleCredentialProvider.CUSTOM_CONSTANT_HADOOP_EXTERNAL_ID, externalId);
         // TODO(SmithCruise) Not support assume role in none-ec2 machine
         // if (!region.isEmpty()) {
@@ -246,6 +267,8 @@ public class AWSCloudCredential implements CloudCredential {
         properties.put(CloudConfigurationConstants.AWS_S3_SECRET_KEY, secretKey);
         properties.put(CloudConfigurationConstants.AWS_S3_SESSION_TOKEN, sessionToken);
         properties.put(CloudConfigurationConstants.AWS_S3_IAM_ROLE_ARN, iamRoleArn);
+        properties.put(CloudConfigurationConstants.AWS_S3_STS_REGION, stsRegion);
+        properties.put(CloudConfigurationConstants.AWS_S3_STS_ENDPOINT, stsEndpoint);
         properties.put(CloudConfigurationConstants.AWS_S3_EXTERNAL_ID, externalId);
         properties.put(CloudConfigurationConstants.AWS_S3_REGION, region);
         properties.put(CloudConfigurationConstants.AWS_S3_ENDPOINT, endpoint);
@@ -260,6 +283,8 @@ public class AWSCloudCredential implements CloudCredential {
                 ", secretKey='" + secretKey + '\'' +
                 ", sessionToken='" + sessionToken + '\'' +
                 ", iamRoleArn='" + iamRoleArn + '\'' +
+                ", stsRegion='" + stsRegion + '\'' +
+                ", stsEndpoint='" + stsEndpoint + '\'' +
                 ", externalId='" + externalId + '\'' +
                 ", region='" + region + '\'' +
                 ", endpoint='" + endpoint + '\'' +
@@ -278,6 +303,7 @@ public class AWSCloudCredential implements CloudCredential {
             awsCredentialInfo.setDefaultCredential(defaultCredentialInfo.build());
         } else if (useInstanceProfile) {
             if (!iamRoleArn.isEmpty()) {
+                // TODO: Support assumeRole with custom sts region and sts endpoint
                 AwsAssumeIamRoleCredentialInfo.Builder assumeIamRowCredentialInfo
                         = AwsAssumeIamRoleCredentialInfo.newBuilder();
                 assumeIamRowCredentialInfo.setIamRoleArn(iamRoleArn);

--- a/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/AWSCloudConfigurationTest.java
@@ -63,9 +63,10 @@ public class AWSCloudConfigurationTest {
         hiveConf.set("aws.glue.region", "us-west-1");
         AWSCloudCredential awsCloudCredential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
         Assert.assertNotNull(awsCloudCredential);
-        Assert.assertEquals("AWSCloudCredential{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
-                "accessKey='ak', secretKey='sk', sessionToken='', iamRoleArn='', externalId='', " +
-                "region='us-west-1', endpoint=''}", awsCloudCredential.toCredString());
+        Assert.assertEquals("AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
+                "useInstanceProfile=false, accessKey='ak', secretKey='sk', sessionToken='', iamRoleArn='', " +
+                "stsRegion='', stsEndpoint='', externalId='', region='us-west-1', endpoint=''}",
+                awsCloudCredential.toCredString());
 
         hiveConf = new HiveConf();
         awsCloudCredential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
@@ -83,5 +84,53 @@ public class AWSCloudConfigurationTest {
         Configuration configuration = new Configuration();
         cloudConfiguration.applyToConfiguration(configuration);
         Assert.assertEquals("us-east-1", configuration.get("fs.s3a.endpoint.region"));
+    }
+
+    @Test
+    public void testS3AssumeRoleRegionEndpoint() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("aws.s3.access_key", "ak");
+        properties.put("aws.s3.secret_key", "sk");
+        properties.put("aws.s3.iam_role_arn", "arn");
+        properties.put("aws.s3.sts.endpoint", "endpoint");
+        {
+            CloudConfiguration cloudConfiguration =
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+            Assert.assertNotNull(cloudConfiguration);
+            Configuration configuration = new Configuration();
+            Assert.assertThrows(IllegalArgumentException.class,
+                    () -> cloudConfiguration.applyToConfiguration(configuration));
+        }
+
+        properties.put("aws.s3.sts.region", "region");
+        {
+            CloudConfiguration cloudConfiguration =
+                    CloudConfigurationFactory.buildCloudConfigurationForStorage(properties);
+            Assert.assertNotNull(cloudConfiguration);
+            Configuration configuration = new Configuration();
+            cloudConfiguration.applyToConfiguration(configuration);
+            Assert.assertEquals("region", configuration.get("fs.s3a.assumed.role.sts.endpoint.region"));
+            Assert.assertEquals("endpoint", configuration.get("fs.s3a.assumed.role.sts.endpoint"));
+        }
+    }
+
+    @Test
+    public void testGlueAssumeRoleRegionEndpoint() {
+        HiveConf hiveConf = new HiveConf();
+        hiveConf.set("aws.glue.access_key", "ak");
+        hiveConf.set("aws.glue.secret_key", "sk");
+        hiveConf.set("aws.glue.iam_role_arn", "arn");
+        hiveConf.set("aws.glue.sts.endpoint", "endpoint");
+        {
+            AWSCloudCredential credential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
+            Assert.assertNotNull(credential);
+            Assert.assertThrows(IllegalArgumentException.class, credential::generateAWSCredentialsProvider);
+        }
+
+        hiveConf.set("aws.glue.sts.region", "region");
+        {
+            AWSCloudCredential credential = CloudConfigurationFactory.buildGlueCloudCredential(hiveConf);
+            Assert.assertNotNull(credential);
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/credential/CloudConfigurationFactoryTest.java
@@ -39,11 +39,12 @@ public class CloudConfigurationFactoryTest {
         Assert.assertNotNull(cloudConfiguration);
         Assert.assertEquals(CloudType.AWS, cloudConfiguration.getCloudType());
         Assert.assertEquals(
-                "AWSCloudConfiguration{resources='', jars='', hdpuser='', cred=AWSCloudCredential{" +
-                        "useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
-                        "accessKey='ak', secretKey='sk', sessionToken='token', iamRoleArn='', " +
-                        "externalId='', region='region', endpoint=''}, enablePathStyleAccess=false, " +
-                        "enableSSL=true}", cloudConfiguration.toConfString());
+                "AWSCloudConfiguration{resources='', jars='', hdpuser='', " +
+                        "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
+                        "useInstanceProfile=false, accessKey='ak', secretKey='sk', " +
+                        "sessionToken='token', iamRoleArn='', stsRegion='', stsEndpoint='', externalId='', " +
+                        "region='region', endpoint=''}, enablePathStyleAccess=false, enableSSL=true}",
+                cloudConfiguration.toConfString());
     }
 
     @Test
@@ -67,9 +68,10 @@ public class CloudConfigurationFactoryTest {
         cc.toFileStoreInfo();
         Assert.assertEquals(cc.toConfString(),
                 "AWSCloudConfiguration{resources='', jars='', hdpuser='', " +
-                        "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, " +
-                        "useInstanceProfile=false, accessKey='XX', secretKey='YY', sessionToken='', iamRoleArn='', " +
-                        "externalId='', region='ZZ', endpoint=''}, enablePathStyleAccess=false, enableSSL=true}");
+                        "cred=AWSCloudCredential{useAWSSDKDefaultBehavior=false, useInstanceProfile=false, " +
+                        "accessKey='XX', secretKey='YY', sessionToken='', iamRoleArn='', stsRegion='', " +
+                        "stsEndpoint='', externalId='', region='ZZ', endpoint=''}, " +
+                        "enablePathStyleAccess=false, enableSSL=true}");
     }
 
     @Test
@@ -261,8 +263,9 @@ public class CloudConfigurationFactoryTest {
         HiveConf conf = new HiveConf();
         conf.set(CloudConfigurationConstants.AWS_GLUE_USE_AWS_SDK_DEFAULT_BEHAVIOR, "true");
         AWSCloudCredential cred = CloudConfigurationFactory.buildGlueCloudCredential(conf);
-        Assert.assertEquals(cred.toCredString(),
-                "AWSCloudCredential{useAWSSDKDefaultBehavior=true, useInstanceProfile=false, accessKey='', secretKey='', " +
-                        "sessionToken='', iamRoleArn='', externalId='', region='us-east-1', endpoint=''}");
+        Assert.assertNotNull(cred);
+        Assert.assertEquals("AWSCloudCredential{useAWSSDKDefaultBehavior=true, useInstanceProfile=false, " +
+                        "accessKey='', secretKey='', sessionToken='', iamRoleArn='', stsRegion='', " +
+                        "stsEndpoint='', externalId='', region='us-east-1', endpoint=''}", cred.toCredString());
     }
 }

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_deltalake
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_deltalake
@@ -1,0 +1,57 @@
+-- name: test_aws_glue_s3_deltalake
+CREATE EXTERNAL CATALOG test_aws_glue_s3_deltalake
+PROPERTIES
+(
+"type"="deltalake",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+-- result:
+-- !result
+select * from test_aws_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+-- result:
+3	2003-01-01	Reform to further facilitate maturity of capital market
+2	2002-01-01	Mathematical Description of Systems
+4	2004-01-01	KMT official from Taiwan to visit mainland
+1	2001-01-01	youth is a wonderful thing
+5	2005-01-01	China leading engine for global economy
+-- !result
+drop catalog test_aws_glue_s3_deltalake;
+-- result:
+-- !result
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_deltalake
+PROPERTIES
+(
+"type"="deltalake",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+-- result:
+-- !result
+select * from test_aws_assume_role_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+-- result:
+4	2004-01-01	KMT official from Taiwan to visit mainland
+1	2001-01-01	youth is a wonderful thing
+5	2005-01-01	China leading engine for global economy
+2	2002-01-01	Mathematical Description of Systems
+3	2003-01-01	Reform to further facilitate maturity of capital market
+-- !result
+drop catalog test_aws_assume_role_glue_s3_deltalake;
+-- result:
+-- !result

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_hive
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_hive
@@ -1,0 +1,57 @@
+-- name: test_aws_glue_s3_hive
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hive
+PROPERTIES
+(
+"type"="hive",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+-- result:
+-- !result
+select * from test_aws_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+-- result:
+2	2002-01-01	Mathematical Description of Systems
+4	2004-01-01	KMT official from Taiwan to visit mainland
+1	2001-01-01	youth is a wonderful thing
+3	2003-01-01	Reform to further facilitate maturity of capital market
+5	2005-01-01	China leading engine for global economy
+-- !result
+drop catalog test_aws_glue_s3_hive;
+-- result:
+-- !result
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hive
+PROPERTIES
+(
+"type"="hive",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+-- result:
+-- !result
+select * from test_aws_assume_role_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+-- result:
+2	2002-01-01	Mathematical Description of Systems
+3	2003-01-01	Reform to further facilitate maturity of capital market
+4	2004-01-01	KMT official from Taiwan to visit mainland
+5	2005-01-01	China leading engine for global economy
+1	2001-01-01	youth is a wonderful thing
+-- !result
+drop catalog test_aws_assume_role_glue_s3_hive;
+-- result:
+-- !result

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_hudi
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_hudi
@@ -1,0 +1,57 @@
+-- name: test_aws_glue_s3_hudi
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hudi
+PROPERTIES
+(
+"type"="hudi",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+-- result:
+-- !result
+select * from test_aws_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+-- result:
+20231214112322440	20231214112322440_0_0	20231214112322440_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	1	1	2001-01-01	youth is a wonderful thing
+20231214112358551	20231214112358551_0_1	20231214112358551_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	2	2	2002-01-01	Mathematical Description of Systems
+20231214112415730	20231214112415730_0_2	20231214112415730_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	3	3	2003-01-01	Reform to further facilitate maturity of capital market
+20231214112430418	20231214112430418_0_3	20231214112430418_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	4	4	2004-01-01	KMT official from Taiwan to visit mainland
+20231214112445066	20231214112445066_0_4	20231214112445066_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	5	5	2005-01-01	China leading engine for global economy
+-- !result
+drop catalog test_aws_glue_s3_hudi;
+-- result:
+-- !result
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hudi
+PROPERTIES
+(
+"type"="hudi",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+-- result:
+-- !result
+select * from test_aws_assume_role_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+-- result:
+20231214112322440	20231214112322440_0_0	20231214112322440_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	1	1	2001-01-01	youth is a wonderful thing
+20231214112358551	20231214112358551_0_1	20231214112358551_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	2	2	2002-01-01	Mathematical Description of Systems
+20231214112415730	20231214112415730_0_2	20231214112415730_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	3	3	2003-01-01	Reform to further facilitate maturity of capital market
+20231214112430418	20231214112430418_0_3	20231214112430418_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	4	4	2004-01-01	KMT official from Taiwan to visit mainland
+20231214112445066	20231214112445066_0_4	20231214112445066_0_0		35e09593-cb35-498d-bcc8-931babe056e9-0_0-73-72_20231214112445066.parquet	5	5	2005-01-01	China leading engine for global economy
+-- !result
+drop catalog test_aws_assume_role_glue_s3_hudi;
+-- result:
+-- !result

--- a/test/sql/test_aws_authentication/R/test_aws_glue_s3_iceberg
+++ b/test/sql/test_aws_authentication/R/test_aws_glue_s3_iceberg
@@ -1,0 +1,57 @@
+-- name: test_aws_glue_s3_iceberg
+CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg
+PROPERTIES
+(
+"type"="iceberg",
+"iceberg.catalog.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+-- result:
+-- !result
+select * from test_aws_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+-- result:
+4	2004-01-01	KMT official from Taiwan to visit mainland
+5	2005-01-01	China leading engine for global economy
+1	2001-01-01	youth is a wonderful thing
+3	2003-01-01	Reform to further facilitate maturity of capital market
+2	2002-01-01	Mathematical Description of Systems
+-- !result
+drop catalog test_aws_glue_s3_iceberg;
+-- result:
+-- !result
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_iceberg
+PROPERTIES
+(
+"type"="iceberg",
+"iceberg.catalog.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+-- result:
+-- !result
+select * from test_aws_assume_role_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+-- result:
+1	2001-01-01	youth is a wonderful thing
+4	2004-01-01	KMT official from Taiwan to visit mainland
+2	2002-01-01	Mathematical Description of Systems
+5	2005-01-01	China leading engine for global economy
+3	2003-01-01	Reform to further facilitate maturity of capital market
+-- !result
+drop catalog test_aws_assume_role_glue_s3_iceberg;
+-- result:
+-- !result

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_deltalake
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_deltalake
@@ -1,0 +1,41 @@
+-- name: test_aws_glue_s3_deltalake
+CREATE EXTERNAL CATALOG test_aws_glue_s3_deltalake
+PROPERTIES
+(
+"type"="deltalake",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+
+select * from test_aws_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+
+drop catalog test_aws_glue_s3_deltalake;
+
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_deltalake
+PROPERTIES
+(
+"type"="deltalake",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+
+select * from test_aws_assume_role_glue_s3_deltalake.sql_test_db.deltalake_glue_s3;
+
+drop catalog test_aws_assume_role_glue_s3_deltalake;
+

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_hive
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_hive
@@ -1,0 +1,41 @@
+-- name: test_aws_glue_s3_hive
+
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hive
+PROPERTIES
+(
+"type"="hive",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+
+select * from test_aws_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+
+drop catalog test_aws_glue_s3_hive;
+
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hive
+PROPERTIES
+(
+"type"="hive",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+
+select * from test_aws_assume_role_glue_s3_hive.sql_test_db.hive_glue_s3_parquet;
+
+drop catalog test_aws_assume_role_glue_s3_hive;

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_hudi
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_hudi
@@ -1,0 +1,40 @@
+-- name: test_aws_glue_s3_hudi
+CREATE EXTERNAL CATALOG test_aws_glue_s3_hudi
+PROPERTIES
+(
+"type"="hudi",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+
+select * from test_aws_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+
+drop catalog test_aws_glue_s3_hudi;
+
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hudi
+PROPERTIES
+(
+"type"="hudi",
+"hive.metastore.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+
+select * from test_aws_assume_role_glue_s3_hudi.sql_test_db.hudi_glue_s3_parquet;
+
+drop catalog test_aws_assume_role_glue_s3_hudi;

--- a/test/sql/test_aws_authentication/T/test_aws_glue_s3_iceberg
+++ b/test/sql/test_aws_authentication/T/test_aws_glue_s3_iceberg
@@ -1,0 +1,40 @@
+-- name: test_aws_glue_s3_iceberg
+CREATE EXTERNAL CATALOG test_aws_glue_s3_iceberg
+PROPERTIES
+(
+"type"="iceberg",
+"iceberg.catalog.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}"
+);
+
+select * from test_aws_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+
+drop catalog test_aws_glue_s3_iceberg;
+
+CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_iceberg
+PROPERTIES
+(
+"type"="iceberg",
+"iceberg.catalog.type"="glue",
+"aws.glue.access_key"="${aws_ak}",
+"aws.glue.secret_key"="${aws_sk}",
+"aws.glue.region"="${aws_region}",
+"aws.glue.assume_role"="${aws_assume_role}",
+"aws.glue.sts.region"="${aws_sts_region}",
+"aws.glue.sts.endpoint"="${aws_sts_endpoint}",
+"aws.s3.access_key"="${aws_ak}",
+"aws.s3.secret_key"="${aws_sk}",
+"aws.s3.region"="${aws_region}",
+"aws.s3.assume_role"="${aws_assume_role}",
+"aws.s3.sts.region"="${aws_sts_region}",
+"aws.s3.sts.endpoint"="${aws_sts_endpoint}"
+);
+
+select * from test_aws_assume_role_glue_s3_iceberg.sql_test_db.iceberg_glue_s3_orc;
+
+drop catalog test_aws_assume_role_glue_s3_iceberg;


### PR DESCRIPTION
Why I'm doing:
Sometimes users need to use a custom sts endpoint to assume role, so we need to support it.

What I'm doing:

Add below four new parameters:
`aws.s3.sts.endpoint` / `aws.s3.sts.region` to custom s3 sts's endpoint and region for assume role.
`aws.glue.sts.endpoint` / `aws.glue.sts.endpoint` to custom glue sts's endpoint and region for assume role.

**Notice:**  In aws SDK v1, If the user provides the sts endpoint, the sts region must also be specified. But in aws SDK v2, the user only needs to provide one of the two. SR's glue and Hadoop are using aws SDK v1, but Iceberg is using aws SDK v2.

**So we recommend the user only specific sts region.**

Add also add sql-test to cover aws authentication case.

```sql
CREATE EXTERNAL CATALOG test_aws_assume_role_glue_s3_hive_1
PROPERTIES
(
"type"="hive",
"hive.metastore.type"="glue",
"aws.glue.access_key"="ak",
"aws.glue.secret_key"="sk",
"aws.glue.region"="ap-southeast-1",
"aws.glue.assume_role" = "arn:aws:iam::123:role/starrocks-sql-test",
"aws.glue.sts.endpoint" = "sts.ap-southeast-1.amazonaws.com",
"aws.s3.access_key"="ak",
"aws.s3.secret_key"="sk",
"aws.s3.region"="ap-southeast-1",
"aws.s3.assume_role" = "arn:aws:iam::123:role/starrocks-sql-test",
"aws.s3.sts.endpoint" = "sts.ap-southeast-1.amazonaws.com"
);
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
