### PR TITLE
[Enhancement] limit persistent index compaction by disk

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1036,8 +1036,10 @@ CONF_Bool(enable_pindex_minor_compaction, "true");
 // if l2 num is larger than this, stop doing async compaction,
 // add this config to prevent l2 grow too large.
 CONF_mInt64(max_allow_pindex_l2_num, "5");
-// control the background compaction threads
-CONF_mInt64(pindex_major_compaction_num_threads, "0");
+// Number of max major compaction threads
+CONF_mInt32(pindex_major_compaction_num_threads, "0");
+// Limit of major compaction per disk.
+CONF_mInt32(pindex_major_compaction_limit_per_disk, "2");
 // control the persistent index schedule compaction interval
 CONF_mInt64(pindex_major_compaction_schedule_interval_seconds, "15");
 // control the local persistent index in shared_data gc/evict interval

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -117,7 +117,8 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             PersistentIndexCompactionManager* mgr =
                     StorageEngine::instance()->update_manager()->get_pindex_compaction_mgr();
             if (mgr != nullptr) {
-                (void)mgr->update_max_threads(config::pindex_major_compaction_num_threads);
+                const int max_pk_index_compaction_thread_cnt = std::max(1, config::pindex_major_compaction_num_threads);
+                (void)mgr->update_max_threads(max_pk_index_compaction_thread_cnt);
             }
         });
         _config_callback.emplace("update_memory_limit_percent", [&]() {

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -397,9 +397,11 @@ void* StorageEngine::_pk_index_major_compaction_thread_callback(void* arg) {
     ProfilerRegisterThread();
 #endif
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
-        SLEEP_IN_BG_WORKER(config::pindex_major_compaction_schedule_interval_seconds);
+        SLEEP_IN_BG_WORKER(1);
         // schedule persistent index compaction
-        _update_manager->get_pindex_compaction_mgr()->schedule();
+        _update_manager->get_pindex_compaction_mgr()->schedule([&]() {
+            return StorageEngine::instance()->tablet_manager()->pick_tablets_to_do_pk_index_major_compaction();
+        });
     }
 
     return nullptr;

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -4842,8 +4842,8 @@ StatusOr<EditVersion> PersistentIndex::_major_compaction_impl(
     return new_l2_version;
 }
 
-static void modify_l2_versions(const std::vector<EditVersion>& input_l2_versions, const EditVersion& output_l2_version,
-                               PersistentIndexMetaPB& index_meta) {
+void PersistentIndex::modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
+                                         const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta) {
     // delete input l2 versions, and add output l2 version
     std::vector<EditVersion> new_l2_versions;
     std::vector<bool> new_l2_version_merged;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -751,6 +751,9 @@ public:
 
     void reset_cancel_major_compaction();
 
+    static void modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
+                                   const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta);
+
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,
                                       const EditVersionWithMerge& min_l2_version);

--- a/be/src/storage/persistent_index_compaction_manager.cpp
+++ b/be/src/storage/persistent_index_compaction_manager.cpp
@@ -29,7 +29,7 @@ PersistentIndexCompactionManager::~PersistentIndexCompactionManager() {
 }
 
 Status PersistentIndexCompactionManager::init() {
-    int max_pk_index_compaction_thread_cnt =
+    const int max_pk_index_compaction_thread_cnt =
             config::pindex_major_compaction_num_threads > 0
                     ? config::pindex_major_compaction_num_threads
                     : std::max((size_t)1, StorageEngine::instance()->get_store_num() * 2);
@@ -50,7 +50,7 @@ public:
 
     void run() override {
         WARN_IF_ERROR(_tablet->updates()->pk_index_major_compaction(), "Failed to run PkIndexMajorCompactionTask");
-        _mgr->unmark_running(_tablet->tablet_id());
+        _mgr->unmark_running(_tablet.get());
     }
 
 private:
@@ -58,48 +58,63 @@ private:
     PersistentIndexCompactionManager* _mgr;
 };
 
-void PersistentIndexCompactionManager::schedule() {
-    if (_too_many_tasks()) {
-        // too many running tasks, stop schedule
-        LOG(WARNING) << "PersistentIndex compaction schedule failed, too many running tasks";
-        return;
-    }
-    std::vector<TabletAndScore> pick_tablets =
-            StorageEngine::instance()->tablet_manager()->pick_tablets_to_do_pk_index_major_compaction();
-    for (auto& tablet_score : pick_tablets) {
-        const int64_t tablet_id = tablet_score.first->tablet_id();
-        if (_need_skip(tablet_id)) {
+void PersistentIndexCompactionManager::schedule(const std::function<std::vector<TabletAndScore>()>& pick_algo) {
+    update_ready_tablet_queue(pick_algo);
+    for (auto it = _ready_tablets_queue.begin(); it != _ready_tablets_queue.end();) {
+        auto& tablet_score = *it;
+        if (is_running(tablet_score.first.get())) {
+            // remove this tablet because it is already running
+            it = _ready_tablets_queue.erase(it);
             continue;
         }
-        mark_running(tablet_id);
+        if (disk_limit(tablet_score.first.get())) {
+            // skip it, may re-run it next round.
+            ++it;
+            continue;
+        }
+        mark_running(tablet_score.first.get());
         std::shared_ptr<Runnable> r = std::make_shared<PkIndexMajorCompactionTask>(tablet_score.first, this);
         auto st = _worker_thread_pool->submit(std::move(r));
         if (!st.ok()) {
-            unmark_running(tablet_id);
+            // Resource busy, break and quit
+            unmark_running(tablet_score.first.get());
             LOG(ERROR) << strings::Substitute("submit pk index compaction task failed: $0", st.to_string());
             break;
         }
+        it = _ready_tablets_queue.erase(it);
     }
 }
 
-void PersistentIndexCompactionManager::mark_running(int64_t tablet_id) {
-    std::lock_guard<std::mutex> guard(_mutex);
-    _running_tablets.insert(tablet_id);
+void PersistentIndexCompactionManager::update_ready_tablet_queue(
+        const std::function<std::vector<TabletAndScore>()>& pick_algo) {
+    size_t current_time = time(nullptr);
+    if (current_time - _last_schedule_time > config::pindex_major_compaction_schedule_interval_seconds) {
+        // need re-schedule
+        _ready_tablets_queue = pick_algo();
+        _last_schedule_time = current_time;
+    }
 }
 
-void PersistentIndexCompactionManager::unmark_running(int64_t tablet_id) {
+void PersistentIndexCompactionManager::mark_running(Tablet* tablet) {
     std::lock_guard<std::mutex> guard(_mutex);
-    _running_tablets.erase(tablet_id);
+    _running_tablets.insert(tablet->tablet_id());
+    _data_dir_to_task_num_map[tablet->data_dir()]++;
 }
 
-bool PersistentIndexCompactionManager::_too_many_tasks() {
+void PersistentIndexCompactionManager::unmark_running(Tablet* tablet) {
     std::lock_guard<std::mutex> guard(_mutex);
-    return _running_tablets.size() > MAX_RUNNING_TABLETS;
+    _running_tablets.erase(tablet->tablet_id());
+    _data_dir_to_task_num_map[tablet->data_dir()]--;
 }
 
-bool PersistentIndexCompactionManager::_need_skip(int64_t tablet_id) {
+bool PersistentIndexCompactionManager::is_running(Tablet* tablet) {
     std::lock_guard<std::mutex> guard(_mutex);
-    return _running_tablets.count(tablet_id) > 0;
+    return _running_tablets.count(tablet->tablet_id()) > 0;
+}
+
+bool PersistentIndexCompactionManager::disk_limit(Tablet* tablet) {
+    std::lock_guard<std::mutex> guard(_mutex);
+    return _data_dir_to_task_num_map[tablet->data_dir()] >= std::max(1, config::pindex_major_compaction_limit_per_disk);
 }
 
 Status PersistentIndexCompactionManager::update_max_threads(int max_threads) {

--- a/be/src/storage/persistent_index_compaction_manager.h
+++ b/be/src/storage/persistent_index_compaction_manager.h
@@ -21,6 +21,7 @@
 
 #include "storage/olap_common.h"
 #include "storage/tablet.h"
+#include "storage/tablet_manager.h"
 
 namespace starrocks {
 
@@ -31,19 +32,28 @@ public:
     PersistentIndexCompactionManager() {}
     ~PersistentIndexCompactionManager();
     Status init();
-    void schedule();
-    void mark_running(int64_t tablet_id);
-    void unmark_running(int64_t tablet_id);
+    void schedule(const std::function<std::vector<TabletAndScore>()>& pick_algo);
+    // Mark tablet is running and increase disk concurrency
+    void mark_running(Tablet* tablet);
+    // Mark tablet is no running and decrease disk concurrency
+    void unmark_running(Tablet* tablet);
+    // change the thread pool thread count
     Status update_max_threads(int max_threads);
+    // Call pick algo function, and refresh ready tablet queue
+    void update_ready_tablet_queue(const std::function<std::vector<TabletAndScore>()>& pick_algo);
+    // Is tablet in running state
+    bool is_running(Tablet* tablet);
+    // Is tablet's disk out of concurrency limit
+    bool disk_limit(Tablet* tablet);
 
 private:
-    bool _too_many_tasks();
-    bool _need_skip(int64_t tablet_id);
-    static const uint32_t MAX_RUNNING_TABLETS = 1000;
-
     std::mutex _mutex;
+    // Sorted by prority
+    std::vector<TabletAndScore> _ready_tablets_queue;
     std::unordered_set<int64_t> _running_tablets;
     std::unique_ptr<ThreadPool> _worker_thread_pool;
+    std::unordered_map<DataDir*, uint64_t> _data_dir_to_task_num_map;
+    size_t _last_schedule_time = 0;
 };
 
 } // namespace starrocks

--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -21,6 +21,7 @@
 #include "fs/fs_memory.h"
 #include "fs/fs_util.h"
 #include "storage/chunk_helper.h"
+#include "storage/persistent_index_compaction_manager.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
 #include "storage/rowset/rowset_writer.h"
@@ -2806,6 +2807,224 @@ TEST_P(PersistentIndexTest, test_snapshot_with_minor_compact) {
         }
     }
     config::l0_max_mem_usage = old_config;
+}
+
+TEST_P(PersistentIndexTest, pindex_compaction_disk_limit) {
+    TabletSharedPtr tablet = create_tablet(rand(), rand());
+    TabletSharedPtr tablet2 = create_tablet(rand(), rand());
+    TabletSharedPtr tablet3 = create_tablet(rand(), rand());
+    config::pindex_major_compaction_limit_per_disk = 1;
+    PersistentIndexCompactionManager mgr;
+    ASSERT_FALSE(mgr.disk_limit(tablet.get()));
+    mgr.mark_running(tablet.get());
+    ASSERT_TRUE(mgr.is_running(tablet.get()));
+    ASSERT_FALSE(mgr.is_running(tablet2.get()));
+    ASSERT_FALSE(mgr.is_running(tablet3.get()));
+    ASSERT_TRUE(mgr.disk_limit(tablet.get()));
+    ASSERT_TRUE(mgr.disk_limit(tablet2.get()));
+    ASSERT_TRUE(mgr.disk_limit(tablet3.get()));
+    config::pindex_major_compaction_limit_per_disk = 2;
+    ASSERT_FALSE(mgr.disk_limit(tablet2.get()));
+    mgr.mark_running(tablet2.get());
+    ASSERT_TRUE(mgr.is_running(tablet.get()));
+    ASSERT_TRUE(mgr.is_running(tablet2.get()));
+    ASSERT_FALSE(mgr.is_running(tablet3.get()));
+    ASSERT_TRUE(mgr.disk_limit(tablet3.get()));
+
+    mgr.unmark_running(tablet.get());
+    ASSERT_FALSE(mgr.is_running(tablet.get()));
+    ASSERT_TRUE(mgr.is_running(tablet2.get()));
+    ASSERT_FALSE(mgr.is_running(tablet3.get()));
+    ASSERT_FALSE(mgr.disk_limit(tablet3.get()));
+}
+
+TEST_P(PersistentIndexTest, pindex_compaction_schedule) {
+    TabletSharedPtr tablet = create_tablet(rand(), rand());
+    ASSERT_OK(tablet->init());
+    TabletSharedPtr tablet2 = create_tablet(rand(), rand());
+    ASSERT_OK(tablet2->init());
+    TabletSharedPtr tablet3 = create_tablet(rand(), rand());
+    ASSERT_OK(tablet3->init());
+    PersistentIndexCompactionManager mgr;
+    ASSERT_OK(mgr.init());
+    mgr.schedule([&]() {
+        std::vector<TabletAndScore> ret;
+        ret.emplace_back(tablet, 1.0);
+        ret.emplace_back(tablet2, 2.0);
+        ret.emplace_back(tablet3, 3.0);
+        return ret;
+    });
+}
+
+TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_update) {
+    int64_t old_config = config::max_allow_pindex_l2_num;
+    config::max_allow_pindex_l2_num = 100;
+    config::l0_max_mem_usage = 100 * 1024; // 100KB
+    FileSystem* fs = FileSystem::Default();
+    const std::string kPersistentIndexDir = "./PersistentIndexTest_test_multi_l2_not_tmp_l1_update";
+    const std::string kIndexFile = "./PersistentIndexTest_test_multi_l2_not_tmp_l1_update/index.l0.0.0";
+    bool created;
+    ASSERT_OK(fs->create_dir_if_missing(kPersistentIndexDir, &created));
+
+    using Key = std::string;
+    PersistentIndexMetaPB index_meta;
+    // total size
+    const int N = 100000;
+    // upsert size
+    const int M = 1000;
+    // K means each step size
+    const int K = N / M;
+    int64_t cur_version = 0;
+
+    {
+        ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+        ASSERT_OK(wfile->close());
+    }
+
+    // build index
+    EditVersion version(cur_version++, 0);
+    index_meta.set_key_size(0);
+    index_meta.set_size(0);
+    version.to_pb(index_meta.mutable_version());
+    MutableIndexMetaPB* l0_meta = index_meta.mutable_l0_meta();
+    l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_3);
+    IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+    version.to_pb(snapshot_meta->mutable_version());
+
+    PersistentIndex index(kPersistentIndexDir);
+
+    {
+        // continue upsert key from 0 to N
+        vector<Key> keys(M);
+        vector<Slice> key_slices(M);
+        vector<IndexValue> values(M);
+
+        auto incre_key = [&](int step) {
+            for (int i = 0; i < M; i++) {
+                keys[i] = "test_varlen_" + std::to_string(i + step * M);
+                values[i] = i + step * M;
+                key_slices[i] = keys[i];
+            }
+        };
+
+        auto update_key = [&](int step) {
+            for (int i = 0; i < M; i++) {
+                keys[i] = "test_varlen_" + std::to_string(i + step * M);
+                values[i] = i + step * M + (i % 2 == 0) ? 111 : 222;
+                key_slices[i] = keys[i];
+            }
+        };
+
+        // 1. upsert
+        for (int i = 0; i < K; i++) {
+            incre_key(i);
+            std::vector<IndexValue> old_values(M);
+            ASSERT_OK(index.load(index_meta));
+            ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
+            ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));
+            ASSERT_OK(index.commit(&index_meta));
+            ASSERT_OK(index.on_commited());
+        }
+
+        // 2. update half key
+        for (int i = 0; i < K - 2; i++) {
+            update_key(i);
+            std::vector<IndexValue> old_values(M);
+            ASSERT_OK(index.load(index_meta));
+            ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
+            ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));
+            ASSERT_OK(index.commit(&index_meta));
+            ASSERT_OK(index.on_commited());
+        }
+    }
+
+    auto verify_fn = [&](PersistentIndex& cur_index) {
+        vector<Key> keys(N);
+        vector<Slice> key_slices;
+        vector<IndexValue> values;
+        key_slices.reserve(N);
+        for (int i = 0; i < N; i++) {
+            keys[i] = "test_varlen_" + std::to_string(i);
+            if (i < N - M * 2) {
+                values.emplace_back(i + (i % 2 == 0) ? 111 : 222);
+            } else {
+                values.emplace_back(i);
+            }
+            key_slices.emplace_back(keys[i]);
+        }
+
+        std::vector<IndexValue> get_values(keys.size());
+        ASSERT_TRUE(cur_index.get(keys.size(), key_slices.data(), get_values.data()).ok());
+        ASSERT_EQ(keys.size(), get_values.size());
+        for (int i = 0; i < values.size(); i++) {
+            ASSERT_EQ(values[i], get_values[i]);
+        }
+    };
+
+    {
+        // 2. verify
+        verify_fn(index);
+    }
+
+    {
+        // 3. verify after l2 compaction
+        ASSERT_OK(index.TEST_major_compaction(index_meta));
+        verify_fn(index);
+    }
+
+    {
+        // rebuild mutableindex according to PersistentIndexMetaPB
+        PersistentIndex index2(kPersistentIndexDir);
+        ASSERT_TRUE(index2.load(index_meta).ok());
+        verify_fn(index2);
+    }
+
+    ASSERT_TRUE(fs::remove_all(kPersistentIndexDir).ok());
+    config::max_allow_pindex_l2_num = old_config;
+}
+
+TEST_P(PersistentIndexTest, pindex_major_compact_meta) {
+    // (1.0), (1.1), (3.0), (4.1), (5.0)
+    // merge (1.0), (1.1), (3.0) into (3.0)
+    std::vector<EditVersion> current_l2_versions;
+    std::vector<bool> current_l2_version_merged;
+    current_l2_versions.emplace_back(1, 0);
+    current_l2_versions.emplace_back(1, 1);
+    current_l2_versions.emplace_back(3, 0);
+    current_l2_versions.emplace_back(4, 1);
+    current_l2_versions.emplace_back(5, 0);
+    current_l2_version_merged.emplace_back(false);
+    current_l2_version_merged.emplace_back(false);
+    current_l2_version_merged.emplace_back(false);
+    current_l2_version_merged.emplace_back(false);
+    current_l2_version_merged.emplace_back(false);
+
+    PersistentIndexMetaPB index_meta;
+    for (const auto& ver : current_l2_versions) {
+        ver.to_pb(index_meta.add_l2_versions());
+    }
+    for (const bool merge : current_l2_version_merged) {
+        index_meta.add_l2_version_merged(merge);
+    }
+
+    std::vector<EditVersion> input_l2_versions;
+    input_l2_versions.emplace_back(1, 0);
+    input_l2_versions.emplace_back(1, 1);
+    input_l2_versions.emplace_back(3, 0);
+    PersistentIndex::modify_l2_versions(input_l2_versions, input_l2_versions.back(), index_meta);
+
+    // check result
+    ASSERT_EQ(index_meta.l2_versions_size(), index_meta.l2_version_merged_size());
+    ASSERT_EQ(index_meta.l2_versions_size(), 3);
+    for (int i = 0; i < index_meta.l2_versions_size(); i++) {
+        EditVersion a(index_meta.l2_versions(i));
+        ASSERT_TRUE(a == current_l2_versions[i + 2]);
+        if (i == 0) {
+            ASSERT_TRUE(index_meta.l2_version_merged(i));
+        } else {
+            ASSERT_FALSE(index_meta.l2_version_merged(i));
+        }
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(PersistentIndexTest, PersistentIndexTest,


### PR DESCRIPTION
Why I'm doing:
In current implementation, we doesn't control the compaction concurrency on one disk, which will cause compaction unbalanced between disks, and some disk's  IO cost will be too high.

What I'm doing:
1. Limit the disk compaction concurrency by config `pindex_major_compaction_limit_per_disk `. 
2. Refactor persistent index compaction scheduler code.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
