### PR TITLE
[Enhancement] Improve JNI reader for date type and timestamp type

### DIFF
--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -183,57 +183,6 @@ Status JniScanner::_append_string_data(const FillColumnArgs& args) {
     return Status::OK();
 }
 
-Status JniScanner::_append_date_data(const FillColumnArgs& args) {
-    int* offset_ptr = static_cast<int*>(next_chunk_meta_as_ptr());
-    char* column_ptr = static_cast<char*>(next_chunk_meta_as_ptr());
-
-    using ColumnType = typename starrocks::RunTimeColumnType<TYPE_DATE>;
-    auto* runtime_column = down_cast<ColumnType*>(args.column);
-    runtime_column->resize_uninitialized(args.num_rows);
-    DateValue* runtime_data = runtime_column->get_data().data();
-
-    for (int i = 0; i < args.num_rows; i++) {
-        if (args.nulls && args.nulls[i]) {
-            // NULL
-        } else {
-            std::string date_str(column_ptr + offset_ptr[i], column_ptr + offset_ptr[i + 1]);
-            DateValue dv;
-            if (!dv.from_string(date_str.c_str(), date_str.size())) {
-                return Status::DataQualityError(fmt::format("Invalid date value occurs on column[{}], value is [{}]",
-                                                            args.slot_name, date_str));
-            }
-            runtime_data[i] = dv;
-        }
-    }
-    return Status::OK();
-}
-
-Status JniScanner::_append_datetime_data(const FillColumnArgs& args) {
-    int* offset_ptr = static_cast<int*>(next_chunk_meta_as_ptr());
-    char* column_ptr = static_cast<char*>(next_chunk_meta_as_ptr());
-
-    using ColumnType = typename starrocks::RunTimeColumnType<TYPE_DATETIME>;
-    auto* runtime_column = down_cast<ColumnType*>(args.column);
-    runtime_column->resize_uninitialized(args.num_rows);
-    TimestampValue* runtime_data = runtime_column->get_data().data();
-
-    for (int i = 0; i < args.num_rows; i++) {
-        if (args.nulls && args.nulls[i]) {
-            // NULL
-        } else {
-            std::string origin_str(column_ptr + offset_ptr[i], column_ptr + offset_ptr[i + 1]);
-            std::string datetime_str = origin_str.substr(0, origin_str.find('.'));
-            TimestampValue tsv;
-            if (!tsv.from_datetime_format_str(datetime_str.c_str(), datetime_str.size(), "%Y-%m-%d %H:%i:%s")) {
-                return Status::DataQualityError(fmt::format(
-                        "Invalid datetime value occurs on column[{}], value is [{}]", args.slot_name, origin_str));
-            }
-            runtime_data[i] = tsv;
-        }
-    }
-    return Status::OK();
-}
-
 Status JniScanner::_append_array_data(const FillColumnArgs& args) {
     DCHECK(args.slot_type.is_array_type());
 

--- a/be/src/exec/jni_scanner.cpp
+++ b/be/src/exec/jni_scanner.cpp
@@ -375,9 +375,9 @@ Status JniScanner::_fill_column(FillColumnArgs* pargs) {
     } else if (column_type == LogicalType::TYPE_VARBINARY) {
         RETURN_IF_ERROR((_append_string_data<TYPE_VARBINARY>(args)));
     } else if (column_type == LogicalType::TYPE_DATE) {
-        RETURN_IF_ERROR((_append_date_data(args)));
+        RETURN_IF_ERROR((_append_primitive_data<TYPE_DATE>(args)));
     } else if (column_type == LogicalType::TYPE_DATETIME) {
-        RETURN_IF_ERROR((_append_datetime_data(args)));
+        RETURN_IF_ERROR((_append_primitive_data<TYPE_DATETIME>(args)));
     } else if (column_type == LogicalType::TYPE_DECIMAL32) {
         RETURN_IF_ERROR((_append_primitive_data<TYPE_DECIMAL32>(args)));
     } else if (column_type == LogicalType::TYPE_DECIMAL64) {

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
@@ -17,32 +17,32 @@ package com.starrocks.hive.reader;
 import com.starrocks.jni.connector.ColumnType;
 import com.starrocks.jni.connector.ColumnValue;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
-import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
 public class HiveColumnValue implements ColumnValue {
-    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private final Object fieldData;
     private final ObjectInspector fieldInspector;
+    private String timeZone;
 
-    HiveColumnValue(ObjectInspector fieldInspector, Object fieldData) {
+    HiveColumnValue(ObjectInspector fieldInspector, Object fieldData, String timeZone) {
         this.fieldInspector = fieldInspector;
         this.fieldData = fieldData;
+        this.timeZone = timeZone;
     }
 
     private Object inspectObject() {
@@ -96,23 +96,6 @@ public class HiveColumnValue implements ColumnValue {
     }
 
     @Override
-    public String getTimestamp(ColumnType.TypeValue type) {
-        // for rcfile with LazyBinaryColumnarSerDe, it will store timestamp type as UTC
-        // So we need adjust timestamp type's value according to current time zone
-        if (fieldData instanceof TimestampWritableV2) {
-            TimestampWritableV2 localTimestampWritable = (TimestampWritableV2) fieldData;
-            LocalDateTime localDateTime = LocalDateTime.ofInstant(
-                    Instant.ofEpochSecond(localTimestampWritable.getSeconds(), localTimestampWritable.getNanos()),
-                    ZoneId.systemDefault());
-            return localDateTime.format(DATETIME_FORMATTER);
-        } else if (fieldData instanceof Timestamp) {
-            return fieldData.toString();
-        } else {
-            return inspectObject().toString();
-        }
-    }
-
-    @Override
     public byte[] getBytes() {
         return (byte[]) inspectObject();
     }
@@ -125,7 +108,7 @@ public class HiveColumnValue implements ColumnValue {
         for (Object item : items) {
             HiveColumnValue cv = null;
             if (item != null) {
-                cv = new HiveColumnValue(itemInspector, item);
+                cv = new HiveColumnValue(itemInspector, item, timeZone);
             }
             values.add(cv);
         }
@@ -140,10 +123,10 @@ public class HiveColumnValue implements ColumnValue {
             HiveColumnValue cv0 = null;
             HiveColumnValue cv1 = null;
             if (kv.getKey() != null) {
-                cv0 = new HiveColumnValue(keyObjectInspector, kv.getKey());
+                cv0 = new HiveColumnValue(keyObjectInspector, kv.getKey(), timeZone);
             }
             if (kv.getValue() != null) {
-                cv1 = new HiveColumnValue(valueObjectInspector, kv.getValue());
+                cv1 = new HiveColumnValue(valueObjectInspector, kv.getValue(), timeZone);
             }
             keys.add(cv0);
             values.add(cv1);
@@ -161,7 +144,7 @@ public class HiveColumnValue implements ColumnValue {
                 StructField sf = fields.get(idx);
                 Object o = inspector.getStructFieldData(fieldData, sf);
                 if (o != null) {
-                    cv = new HiveColumnValue(sf.getFieldObjectInspector(), o);
+                    cv = new HiveColumnValue(sf.getFieldObjectInspector(), o, timeZone);
                 }
             }
             values.add(cv);
@@ -185,21 +168,13 @@ public class HiveColumnValue implements ColumnValue {
 
     @Override
     public LocalDate getDate() {
-        return LocalDate.ofEpochDay((int) fieldData);
+        return LocalDate.ofEpochDay((((DateObjectInspector) fieldInspector).getPrimitiveJavaObject(fieldData))
+                .toEpochDay());
     }
 
     @Override
     public LocalDateTime getDateTime(ColumnType.TypeValue type) {
-        // for rcfile with LazyBinaryColumnarSerDe, it will store timestamp type as UTC
-        // So we need adjust timestamp type's value according to current time zone
-        if (fieldData instanceof TimestampWritableV2) {
-            TimestampWritableV2 localTimestampWritable = (TimestampWritableV2) fieldData;
-            LocalDateTime localDateTime = LocalDateTime.ofInstant(
-                    Instant.ofEpochSecond(localTimestampWritable.getSeconds(), localTimestampWritable.getNanos()),
-                    ZoneId.systemDefault());
-            return localDateTime;
-        } else {
-            return LocalDateTime.parse(inspectObject().toString(), DATETIME_FORMATTER);
-        }
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond((((TimestampObjectInspector) fieldInspector)
+                .getPrimitiveJavaObject(fieldData)).toEpochSecond()), ZoneId.of(timeZone));
     }
 }

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiColumnValue.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiColumnValue.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static com.starrocks.hudi.reader.HudiScannerUtils.DATETIME_FORMATTER;
+import static com.starrocks.hudi.reader.HudiScannerUtils.DATE_FORMATTER;
 import static com.starrocks.hudi.reader.HudiScannerUtils.TIMESTAMP_UNIT_MAPPING;
 
 public class HudiColumnValue implements ColumnValue {
@@ -81,19 +82,6 @@ public class HudiColumnValue implements ColumnValue {
     @Override
     public String getString(ColumnType.TypeValue type) {
         return inspectObject().toString();
-    }
-
-    @Override
-    public String getTimestamp(ColumnType.TypeValue type) {
-        // INT64 timestamp type
-        if (HudiScannerUtils.isMaybeInt64Timestamp(type) && (fieldData instanceof LongWritable)) {
-            long datetime = ((LongWritable) fieldData).get();
-            TimeUnit timeUnit = TIMESTAMP_UNIT_MAPPING.get(type);
-            LocalDateTime localDateTime = HudiScannerUtils.getTimestamp(datetime, timeUnit, true);
-            return HudiScannerUtils.formatDateTime(localDateTime);
-        } else {
-            return inspectObject().toString();
-        }
     }
 
     @Override
@@ -164,7 +152,7 @@ public class HudiColumnValue implements ColumnValue {
 
     @Override
     public LocalDate getDate() {
-        return LocalDate.ofEpochDay((int) fieldData);
+        return LocalDate.parse(inspectObject().toString(), DATE_FORMATTER);
     }
 
     @Override

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 
 public class HudiScannerUtils {
     public static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     public static final Map<String, String> HIVE_TYPE_MAPPING = new HashMap<>();
     public static Map<ColumnType.TypeValue, TimeUnit> TIMESTAMP_UNIT_MAPPING = new HashMap<>();
 

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class HudiScannerUtils {
-    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    public static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     public static final Map<String, String> HIVE_TYPE_MAPPING = new HashMap<>();
     public static Map<ColumnType.TypeValue, TimeUnit> TIMESTAMP_UNIT_MAPPING = new HashMap<>();
 

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
@@ -20,15 +20,12 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class HudiScannerUtils {
-    public static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
-    public static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     public static final Map<String, String> HIVE_TYPE_MAPPING = new HashMap<>();
     public static Map<ColumnType.TypeValue, TimeUnit> TIMESTAMP_UNIT_MAPPING = new HashMap<>();
 
@@ -79,10 +76,6 @@ public class HudiScannerUtils {
                 break;
         }
         return LocalDateTime.ofInstant(Instant.ofEpochSecond(seconds, nanoseconds), zone);
-    }
-
-    public static String formatDateTime(LocalDateTime dateTime) {
-        return dateTime.format(DATETIME_FORMATTER);
     }
 
     public static boolean isMaybeInt64Timestamp(ColumnType.TypeValue type) {

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -238,8 +238,6 @@ public class ColumnType {
                     typeValue = parseDecimal(t);
                 } else if (t.startsWith("timestamp")) {
                     typeValue = TypeValue.DATETIME;
-                } else if (t.equalsIgnoreCase("date")) {
-                    typeValue = TypeValue.DATE;
                 } else {
                     typeValue = PRIMITIVE_TYPE_VALUE_MAPPING.getOrDefault(t, null);
                 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -238,7 +238,7 @@ public class ColumnType {
                     typeValue = parseDecimal(t);
                 } else if (t.startsWith("timestamp")) {
                     typeValue = TypeValue.DATETIME;
-                } else if (t.startsWith("date")) {
+                } else if (t.equalsIgnoreCase("date")) {
                     typeValue = TypeValue.DATE;
                 } else {
                     typeValue = PRIMITIVE_TYPE_VALUE_MAPPING.getOrDefault(t, null);

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -114,6 +114,8 @@ public class ColumnType {
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DECIMAL32, 4);
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DECIMAL64, 8);
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DECIMAL128, 16);
+        PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DATE, 16);
+        PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DATETIME, 16);
     }
 
     @Override
@@ -234,6 +236,10 @@ public class ColumnType {
             default: {
                 if (t.startsWith("decimal")) {
                     typeValue = parseDecimal(t);
+                } else if (t.startsWith("timestamp")) {
+                    typeValue = TypeValue.DATETIME;
+                } else if (t.startsWith("date")) {
+                    typeValue = TypeValue.DATE;
                 } else {
                     typeValue = PRIMITIVE_TYPE_VALUE_MAPPING.getOrDefault(t, null);
                 }
@@ -261,9 +267,7 @@ public class ColumnType {
     }
 
     public boolean isByteStorageType() {
-        return typeValue == TypeValue.STRING || typeValue == TypeValue.DATE
-                || typeValue == TypeValue.BINARY || typeValue == TypeValue.DATETIME
-                || typeValue == TypeValue.DATETIME_MICROS || typeValue == TypeValue.DATETIME_MILLIS;
+        return typeValue == TypeValue.STRING || typeValue == TypeValue.BINARY;
     }
 
     public boolean isArray() {

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -236,8 +236,6 @@ public class ColumnType {
             default: {
                 if (t.startsWith("decimal")) {
                     typeValue = parseDecimal(t);
-                } else if (t.startsWith("timestamp")) {
-                    typeValue = TypeValue.DATETIME;
                 } else {
                     typeValue = PRIMITIVE_TYPE_VALUE_MAPPING.getOrDefault(t, null);
                 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
@@ -33,7 +33,6 @@ public interface ColumnValue {
     double getDouble();
 
     String getString(ColumnType.TypeValue type);
-    String getTimestamp(ColumnType.TypeValue type);
     byte[] getBytes();
 
     void unpackArray(List<ColumnValue> values);

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
@@ -15,6 +15,8 @@
 package com.starrocks.jni.connector;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ColumnValue {
@@ -43,4 +45,8 @@ public interface ColumnValue {
     byte getByte();
 
     BigDecimal getDecimal();
+
+    LocalDate getDate();
+
+    LocalDateTime getDateTime(ColumnType.TypeValue type);
 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -444,25 +444,15 @@ public class OffHeapColumnVector {
 
     public int appendDate(LocalDate v) {
         reserve(elementsAppended + 1);
-        putDate(elementsAppended, v);
-        return elementsAppended++;
-    }
-
-    private void putDate(int rowId, LocalDate v) {
         int date = convertToDate(v.getYear(), v.getMonthValue(), v.getDayOfMonth());
-        Platform.putInt(null, data + rowId * 4L, date);
+        return appendInt(date);
     }
 
     public int appendDateTime(LocalDateTime v) {
         reserve(elementsAppended + 1);
-        putDateTime(elementsAppended, v);
-        return elementsAppended++;
-    }
-
-    private void putDateTime(int rowId, LocalDateTime v) {
-        long time = convertToDateTime(v.getYear(), v.getMonthValue(), v.getDayOfMonth(), v.getHour(),
+        long datetime = convertToDateTime(v.getYear(), v.getMonthValue(), v.getDayOfMonth(), v.getHour(),
                 v.getMinute(), v.getSecond(), v.getNano() / 1000);
-        Platform.putLong(null, data + rowId * 8L, time);
+        return appendLong(datetime);
     }
 
     public void updateMeta(OffHeapColumnVector meta) {
@@ -724,6 +714,9 @@ public class OffHeapColumnVector {
         return bytes;
     }
 
+    /**
+     * logical components in be: time_types.cpp, date::from_date
+     */
     public static int convertToDate(int year, int month, int day) {
         int century;
         int julianDate;
@@ -743,6 +736,9 @@ public class OffHeapColumnVector {
         return julianDate;
     }
 
+    /**
+     * logical components in be: time_types.h, timestamp::from_datetime
+     */
     public static long convertToDateTime(int year, int month, int day, int hour, int minute, int second, int microsecond) {
         int secsPerMinute = 60;
         int minsPerHour = 60;

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -717,7 +717,7 @@ public class OffHeapColumnVector {
     /**
      * logical components in be: time_types.cpp, date::from_date
      */
-    public static int convertToDate(int year, int month, int day) {
+    private int convertToDate(int year, int month, int day) {
         int century;
         int julianDate;
 
@@ -739,7 +739,7 @@ public class OffHeapColumnVector {
     /**
      * logical components in be: time_types.h, timestamp::from_datetime
      */
-    public static long convertToDateTime(int year, int month, int day, int hour, int minute, int second, int microsecond) {
+    private long convertToDateTime(int year, int month, int day, int hour, int minute, int second, int microsecond) {
         int secsPerMinute = 60;
         int minsPerHour = 60;
         long usecsPerSec = 1000000;

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -449,8 +449,8 @@ public class OffHeapColumnVector {
     }
 
     private void putDate(int rowId, LocalDate v) {
-        long date = convertToDate(v.getYear(), v.getMonthValue(), v.getDayOfMonth());
-        Platform.putLong(null, data + rowId * 16L, date);
+        int date = convertToDate(v.getYear(), v.getMonthValue(), v.getDayOfMonth());
+        Platform.putInt(null, data + rowId * 4L, date);
     }
 
     public int appendDateTime(LocalDateTime v) {
@@ -462,7 +462,7 @@ public class OffHeapColumnVector {
     private void putDateTime(int rowId, LocalDateTime v) {
         long time = convertToDateTime(v.getYear(), v.getMonthValue(), v.getDayOfMonth(), v.getHour(),
                 v.getMinute(), v.getSecond(), v.getNano() / 1000);
-        Platform.putLong(null, data + rowId * 16L, time);
+        Platform.putLong(null, data + rowId * 8L, time);
     }
 
     public void updateMeta(OffHeapColumnVector meta) {
@@ -724,9 +724,9 @@ public class OffHeapColumnVector {
         return bytes;
     }
 
-    public static long convertToDate(int year, int month, int day) {
-        long century;
-        long julianDate;
+    public static int convertToDate(int year, int month, int day) {
+        int century;
+        int julianDate;
 
         if (month > 2) {
             month += 1;
@@ -746,10 +746,11 @@ public class OffHeapColumnVector {
     public static long convertToDateTime(int year, int month, int day, int hour, int minute, int second, int microsecond) {
         int secsPerMinute = 60;
         int minsPerHour = 60;
-        int usecsPerSec = 1000000;
+        long usecsPerSec = 1000000;
         int timeStampBits = 40;
         long julianDate = convertToDate(year, month, day);
-        long timestamp = (((((hour * minsPerHour) + minute) * secsPerMinute) + second) * usecsPerSec) + microsecond;
+        long timestamp = (((((hour * minsPerHour) + minute) * secsPerMinute) + second) * usecsPerSec)
+                + microsecond;
         return julianDate << timeStampBits | timestamp;
     }
 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -20,6 +20,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -440,6 +442,29 @@ public class OffHeapColumnVector {
         return elementsAppended++;
     }
 
+    public int appendDate(LocalDate v) {
+        reserve(elementsAppended + 1);
+        putDate(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putDate(int rowId, LocalDate v) {
+        long date = convertToDate(v.getYear(), v.getMonthValue(), v.getDayOfMonth());
+        Platform.putLong(null, data + rowId * 16L, date);
+    }
+
+    public int appendDateTime(LocalDateTime v) {
+        reserve(elementsAppended + 1);
+        putDateTime(elementsAppended, v);
+        return elementsAppended++;
+    }
+
+    private void putDateTime(int rowId, LocalDateTime v) {
+        long time = convertToDateTime(v.getYear(), v.getMonthValue(), v.getDayOfMonth(), v.getHour(),
+                v.getMinute(), v.getSecond(), v.getNano() / 1000);
+        Platform.putLong(null, data + rowId * 16L, time);
+    }
+
     public void updateMeta(OffHeapColumnVector meta) {
         if (type.isUnknown()) {
             meta.appendLong(0);
@@ -501,8 +526,10 @@ public class OffHeapColumnVector {
                 appendBinary(o.getBytes());
                 break;
             case STRING:
-            case DATE:
                 appendString(o.getString(typeValue));
+                break;
+            case DATE:
+                appendDate(o.getDate());
                 break;
             case DECIMALV2:
             case DECIMAL32:
@@ -513,7 +540,7 @@ public class OffHeapColumnVector {
             case DATETIME:
             case DATETIME_MICROS:
             case DATETIME_MILLIS:
-                appendString(o.getTimestamp(typeValue));
+                appendDateTime(o.getDateTime(typeValue));
                 break;
             case ARRAY: {
                 List<ColumnValue> values = new ArrayList<>();
@@ -695,5 +722,34 @@ public class OffHeapColumnVector {
             bytes[length - 1 - i] = temp;
         }
         return bytes;
+    }
+
+    public static long convertToDate(int year, int month, int day) {
+        long century;
+        long julianDate;
+
+        if (month > 2) {
+            month += 1;
+            year += 4800;
+        } else {
+            month += 13;
+            year += 4799;
+        }
+        century = year / 100;
+        julianDate = year * 365 - 32167;
+        julianDate += year / 4 - century + century / 4;
+        julianDate += 7834 * month / 256 + day;
+
+        return julianDate;
+    }
+
+    public static long convertToDateTime(int year, int month, int day, int hour, int minute, int second, int microsecond) {
+        int secsPerMinute = 60;
+        int minsPerHour = 60;
+        int usecsPerSec = 1000000;
+        int timeStampBits = 40;
+        long julianDate = convertToDate(year, month, day);
+        long timestamp = (((((hour * minsPerHour) + minute) * secsPerMinute) + second) * usecsPerSec) + microsecond;
+        return julianDate << timeStampBits | timestamp;
     }
 }

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
@@ -78,11 +78,6 @@ public class PaimonColumnValue implements ColumnValue {
     }
 
     @Override
-    public String getTimestamp(ColumnType.TypeValue type) {
-        return fieldData.toString();
-    }
-
-    @Override
     public byte[] getBytes() {
         return (byte[]) fieldData;
     }

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
@@ -29,8 +29,10 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 
 public class PaimonColumnValue implements ColumnValue {
@@ -72,24 +74,12 @@ public class PaimonColumnValue implements ColumnValue {
 
     @Override
     public String getString(ColumnType.TypeValue type) {
-        if (type == ColumnType.TypeValue.DATE) {
-            int epoch = (int) fieldData;
-            LocalDate date = LocalDate.ofEpochDay(epoch);
-            return PaimonScannerUtils.formatDate(date);
-        } else {
-            return fieldData.toString();
-        }
+        return fieldData.toString();
     }
 
     @Override
     public String getTimestamp(ColumnType.TypeValue type) {
-        if (type == ColumnType.TypeValue.DATETIME_MILLIS) {
-            Timestamp ts = (Timestamp) fieldData;
-            LocalDateTime dateTime = ts.toLocalDateTime();
-            return PaimonScannerUtils.formatDateTime(dateTime);
-        } else {
-            return fieldData.toString();
-        }
+        return fieldData.toString();
     }
 
     @Override
@@ -158,5 +148,16 @@ public class PaimonColumnValue implements ColumnValue {
             }
             values.add(cv);
         }
+    }
+
+    @Override
+    public LocalDate getDate() {
+        return LocalDate.ofEpochDay((int) fieldData);
+    }
+
+    @Override
+    public LocalDateTime getDateTime(ColumnType.TypeValue type) {
+        return Instant.ofEpochMilli(((Timestamp) fieldData)
+                .getMillisecond()).atZone(ZoneOffset.ofHours(0)).toLocalDateTime();
     }
 }

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
@@ -29,10 +29,8 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.utils.InternalRowUtils;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import java.util.List;
 
 public class PaimonColumnValue implements ColumnValue {
@@ -152,7 +150,6 @@ public class PaimonColumnValue implements ColumnValue {
 
     @Override
     public LocalDateTime getDateTime(ColumnType.TypeValue type) {
-        return Instant.ofEpochMilli(((Timestamp) fieldData)
-                .getMillisecond()).atZone(ZoneOffset.ofHours(0)).toLocalDateTime();
+        return ((Timestamp) fieldData).toLocalDateTime();
     }
 }


### PR DESCRIPTION
Why I'm doing:
Now jni reader use format string to convert date and timestamp type.
This cost too much time

What I'm doing:
In jni reader, we convert date and timestamp type to starrocks date and datetime, then we can use memcpy in be to reduce
the [**format string** ] overhead

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5