### PR TITLE
[Feature] support JSON options for broker load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -300,6 +300,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                         .setFileStatusList(attachment.getFileStatusByTable(aggKey))
                         .setFileNum(attachment.getFileNumByTable(aggKey))
                         .setLoadId(loadId)
+                        .setJSONOptions(jsonOptions)
                         .build();
 
                 task.prepare();

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -171,6 +171,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     @SerializedName("mc")
     protected String mergeCondition;
+    @SerializedName("jo")
+    protected JSONOptions jsonOptions = new JSONOptions();
 
     public int getProgress() {
         return this.progress;
@@ -392,6 +394,18 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
             if (properties.containsKey(LoadStmt.LOG_REJECTED_RECORD_NUM)) {
                 logRejectedRecordNum = Long.parseLong(properties.get(LoadStmt.LOG_REJECTED_RECORD_NUM));
+            }
+
+            if (properties.containsKey(LoadStmt.STRIP_OUTER_ARRAY)) {
+                jsonOptions.stripOuterArray = Boolean.parseBoolean(properties.get(LoadStmt.STRIP_OUTER_ARRAY));
+            }
+
+            if (properties.containsKey(LoadStmt.JSONPATHS)) {
+                jsonOptions.jsonPaths = properties.get(LoadStmt.JSONPATHS);
+            }
+
+            if (properties.containsKey(LoadStmt.JSONROOT)) {
+                jsonOptions.jsonRoot = properties.get(LoadStmt.JSONROOT);
             }
         }
     }
@@ -1157,6 +1171,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             authorizationInfo.write(out);
         }
         Text.writeString(out, timezone);
+        jsonOptions.write(out);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -1250,6 +1265,28 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         public static LoadJobStateUpdateInfo read(DataInput in) throws IOException {
             String json = Text.readString(in);
             return GsonUtils.GSON.fromJson(json, LoadJobStateUpdateInfo.class);
+        }
+    }
+
+    public static class JSONOptions implements Writable {
+        @SerializedName("s")
+        public boolean stripOuterArray;
+
+        @SerializedName("jp")
+        public String jsonPaths;
+
+        @SerializedName("jr")
+        public String jsonRoot;
+
+        @Override
+        public void write(DataOutput out) throws IOException {
+            String json = GsonUtils.GSON.toJson(this);
+            Text.writeString(out, json);
+        }
+
+        public static JSONOptions read(DataInput in) throws IOException {
+            String json = Text.readString(in);
+            return GsonUtils.GSON.fromJson(json, JSONOptions.class);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -1171,7 +1171,6 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
             authorizationInfo.write(out);
         }
         Text.writeString(out, timezone);
-        jsonOptions.write(out);
     }
 
     public void readFields(DataInput in) throws IOException {
@@ -1268,7 +1267,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         }
     }
 
-    public static class JSONOptions implements Writable {
+    public static class JSONOptions {
         @SerializedName("s")
         public boolean stripOuterArray;
 
@@ -1277,16 +1276,5 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
         @SerializedName("jr")
         public String jsonRoot;
-
-        @Override
-        public void write(DataOutput out) throws IOException {
-            String json = GsonUtils.GSON.toJson(this);
-            Text.writeString(out, json);
-        }
-
-        public static JSONOptions read(DataInput in) throws IOException {
-            String json = Text.readString(in);
-            return GsonUtils.GSON.fromJson(json, JSONOptions.class);
-        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -103,6 +103,8 @@ public class LoadLoadingTask extends LoadTask {
     private final List<List<TBrokerFileStatus>> fileStatusList;
     private final int fileNum;
 
+    private final LoadJob.JSONOptions jsonOptions;
+
     private LoadLoadingTask(Builder builder) {
         super(builder.callback, TaskType.LOADING, builder.priority);
         this.db = builder.db;
@@ -128,6 +130,7 @@ public class LoadLoadingTask extends LoadTask {
         this.loadId = builder.loadId;
         this.fileStatusList = builder.fileStatusList;
         this.fileNum = builder.fileNum;
+        this.jsonOptions = builder.jsonOptions;
     }
 
     public void prepare() throws UserException {
@@ -136,6 +139,7 @@ public class LoadLoadingTask extends LoadTask {
                 brokerDesc, fileGroups, fileStatusList, fileNum);
         loadPlanner.setPartialUpdateMode(partialUpdateMode);
         loadPlanner.setMergeConditionStr(mergeConditionStr);
+        loadPlanner.setJsonOptions(jsonOptions);
         loadPlanner.plan();
     }
 
@@ -303,6 +307,8 @@ public class LoadLoadingTask extends LoadTask {
         private LoadTaskCallback callback;
         private int priority;
 
+        private LoadJob.JSONOptions jsonOptions = new LoadJob.JSONOptions();
+
         public Builder setCallback(LoadTaskCallback callback) {
             this.callback = callback;
             return this;
@@ -415,6 +421,11 @@ public class LoadLoadingTask extends LoadTask {
 
         public Builder setFileNum(int fileNum) {
             this.fileNum = fileNum;
+            return this;
+        }
+
+        public Builder setJSONOptions(LoadJob.JSONOptions options) {
+            this.jsonOptions = options;
             return this;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FileScanNode.java
@@ -44,6 +44,7 @@ import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.catalog.TableFunctionTable;
+import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.sql.ast.ImportColumnDesc;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.NullLiteral;
@@ -158,6 +159,8 @@ public class FileScanNode extends LoadScanNode {
     // 3. use vectorized engine
     private boolean useVectorizedLoad;
 
+    private LoadJob.JSONOptions jsonOptions = new LoadJob.JSONOptions();
+
     private boolean nullExprInAutoIncrement;
     private static class ParamCreateContext {
         public BrokerFileGroup fileGroup;
@@ -256,6 +259,10 @@ public class FileScanNode extends LoadScanNode {
 
     public void setUseVectorizedLoad(boolean useVectorizedLoad) {
         this.useVectorizedLoad = useVectorizedLoad;
+    }
+
+    public void setJSONOptions(LoadJob.JSONOptions options) {
+        this.jsonOptions = options;
     }
 
     public boolean nullExprInAutoIncrement() {
@@ -608,6 +615,11 @@ public class FileScanNode extends LoadScanNode {
             TBrokerRangeDesc rangeDesc =
                     createBrokerRangeDesc(curFileOffset, fileStatus, formatType, rangeBytes, columnsFromPath,
                             numberOfColumnsFromFile);
+
+            rangeDesc.setStrip_outer_array(jsonOptions.stripOuterArray);
+            rangeDesc.setJsonpaths(jsonOptions.jsonPaths);
+            rangeDesc.setJson_root(jsonOptions.jsonRoot);
+
             brokerScanRange(smallestLocations.first).addToRanges(rangeDesc);
             smallestLocations.second += rangeBytes;
             locationsHeap.add(smallestLocations);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/LoadPlanner.java
@@ -42,6 +42,7 @@ import com.starrocks.common.util.DebugUtil;
 import com.starrocks.load.BrokerFileGroup;
 import com.starrocks.load.EtlJobType;
 import com.starrocks.load.Load;
+import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.streamload.StreamLoadInfo;
 import com.starrocks.planner.DataPartition;
 import com.starrocks.planner.DataSink;
@@ -130,6 +131,8 @@ public class LoadPlanner {
     // Routine load related structs
     TRoutineLoadTask routineLoadTask;
     private TPartialUpdateMode partialUpdateMode = TPartialUpdateMode.ROW_MODE;
+
+    private LoadJob.JSONOptions jsonOptions = new LoadJob.JSONOptions();
 
     private Boolean missAutoIncrementColumn = Boolean.FALSE;
 
@@ -230,6 +233,10 @@ public class LoadPlanner {
 
     public void setMergeConditionStr(String mergeConditionStr) {
         this.mergeConditionStr = mergeConditionStr;
+    }
+
+    public void setJsonOptions(LoadJob.JSONOptions options) {
+        this.jsonOptions = options;
     }
 
     public void plan() throws UserException {
@@ -378,6 +385,7 @@ public class LoadPlanner {
             fileScanNode.setLoadInfo(loadJobId, txnId, destTable, brokerDesc, fileGroups, strictMode,
                     parallelInstanceNum);
             fileScanNode.setUseVectorizedLoad(true);
+            fileScanNode.setJSONOptions(jsonOptions);
             fileScanNode.init(analyzer);
             fileScanNode.finalizeStats(analyzer);
             scanNode = fileScanNode;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/LoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/LoadStmt.java
@@ -109,6 +109,10 @@ public class LoadStmt extends DdlStmt {
     public static final String BOS_ACCESSKEY = "bos_accesskey";
     public static final String BOS_SECRET_ACCESSKEY = "bos_secret_accesskey";
 
+    public static final String STRIP_OUTER_ARRAY = "strip_outer_array";
+    public static final String JSONPATHS = "jsonpaths";
+    public static final String JSONROOT = "json_root";
+
     // mini load params
     public static final String KEY_IN_PARAM_COLUMNS = "columns";
     public static final String KEY_IN_PARAM_SET = "set";
@@ -145,6 +149,9 @@ public class LoadStmt extends DdlStmt {
             .add(PARTIAL_UPDATE_MODE)
             .add(SPARK_LOAD_SUBMIT_TIMEOUT)
             .add(MERGE_CONDITION)
+            .add(STRIP_OUTER_ARRAY)
+            .add(JSONPATHS)
+            .add(JSONROOT)
             .build();
 
     public LoadStmt(LabelName label, List<DataDescription> dataDescriptions, BrokerDesc brokerDesc,

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/BrokerLoadJobTest.java
@@ -71,6 +71,7 @@ import mockit.Injectable;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
+import org.apache.spark.sql.AnalysisException;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -597,5 +598,25 @@ public class BrokerLoadJobTest {
         Assert.assertEquals("0", loadingStatus.getCounters().get(BrokerLoadJob.DPP_ABNORMAL_ALL));
         int progress = Deencapsulation.getField(brokerLoadJob, "progress");
         Assert.assertEquals(99, progress);
+    }
+
+    @Test
+    public void testSetProperties(@Injectable BrokerPendingTaskAttachment attachment1,
+                                                       @Injectable LoadTask loadTask1,
+                                                       @Mocked GlobalStateMgr globalStateMgr,
+                                  @Injectable Database database) throws AnalysisException, DdlException {
+
+        BrokerLoadJob brokerLoadJob = new BrokerLoadJob();
+        Map<String, String> properties = Maps.newHashMap();
+        properties.put(LoadStmt.JSONPATHS, "[\"$.key2\"");
+        properties.put(LoadStmt.STRIP_OUTER_ARRAY, "true");
+        properties.put(LoadStmt.JSONROOT, "$.key1");
+        brokerLoadJob.setJobProperties(properties);
+
+        LoadJob.JSONOptions options = Deencapsulation.getField(brokerLoadJob, "jsonOptions");
+
+        Assert.assertEquals("[\"$.key2\"", options.jsonPaths);
+        Assert.assertTrue(options.stripOuterArray);
+        Assert.assertEquals("$.key1", options.jsonRoot);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/loadv2/LoadLoadingTaskTest.java
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.load.loadv2;
+
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.server.GlobalStateMgr;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class LoadLoadingTaskTest {
+    @Test
+    public void testBuilder(
+            @Mocked GlobalStateMgr globalStateMgr) {
+
+        new Expectations() {
+            {
+                GlobalStateMgr.getCurrentState().getNextId();
+                result = 1;
+                times = 1;
+            }};
+
+        // json options
+        LoadJob.JSONOptions jsonOptions = new LoadJob.JSONOptions();
+        jsonOptions.jsonRoot = "\"$.data\"";
+        jsonOptions.jsonPaths = "[\"$.key1\"]";
+        jsonOptions.stripOuterArray = true;
+
+        LoadLoadingTask task = new LoadLoadingTask.Builder()
+                .setJSONOptions(jsonOptions)
+                .build();
+
+
+        LoadJob.JSONOptions realJSONOptions =  Deencapsulation.getField(task, "jsonOptions");
+        Assert.assertEquals(jsonOptions, realJSONOptions);
+    }
+}


### PR DESCRIPTION
Why I'm doing:
In stream load/routine load, we support JSON options including `strip_outer_array`, `jsonpaths` and `json_root`.
What I'm doing:
This PR adds the JSON options support for broker load.

Fixes https://github.com/StarRocks/starrocks/issues/36519

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
