### PR TITLE
[Enhancement] Fix compile error in gcc-13

### DIFF
--- a/be/src/block_cache/cache_options.h
+++ b/be/src/block_cache/cache_options.h
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace starrocks {
 

--- a/be/src/gutil/cpu.cc
+++ b/be/src/gutil/cpu.cc
@@ -5,6 +5,7 @@
 #include "gutil/cpu.h"
 
 #include <algorithm>
+#include <cstdint>
 #include <cstring>
 #include <fstream>
 #include <sstream>

--- a/be/src/util/cidr.h
+++ b/be/src/util/cidr.h
@@ -34,6 +34,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace starrocks {


### PR DESCRIPTION
Why I'm doing:
We can't compile in gcc-13

What I'm doing:
just fix it.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
