### PR TITLE
[BugFix] Fix secondary tablet writer does not abort properly

### DIFF
--- a/be/src/runtime/local_tablets_channel.cpp
+++ b/be/src/runtime/local_tablets_channel.cpp
@@ -692,6 +692,7 @@ void LocalTabletsChannel::abort(const std::vector<int64_t>& tablet_ids, const st
     for (auto tablet_id : tablet_ids) {
         auto it = _delta_writers.find(tablet_id);
         if (it != _delta_writers.end()) {
+            it->second->cancel(Status::Cancelled(reason));
             it->second->abort(abort_with_exception);
         }
     }

--- a/be/src/storage/async_delta_writer.cpp
+++ b/be/src/storage/async_delta_writer.cpp
@@ -107,12 +107,6 @@ Status AsyncDeltaWriter::_init() {
     if (int r = bthread::execution_queue_start(&_queue_id, &opts, _execute, _writer.get()); r != 0) {
         return Status::InternalError(fmt::format("fail to create bthread execution queue: {}", r));
     }
-    if (replica_state() == Secondary) {
-        _segment_flush_executor = StorageEngine::instance()->segment_flush_executor()->create_flush_token(_writer);
-        if (_segment_flush_executor == nullptr) {
-            return Status::InternalError("SegmentFlushExecutor init failed");
-        }
-    }
     return Status::OK();
 }
 
@@ -145,7 +139,7 @@ void AsyncDeltaWriter::flush() {
 }
 
 void AsyncDeltaWriter::write_segment(const AsyncDeltaWriterSegmentRequest& req) {
-    auto st = _segment_flush_executor->submit(req.cntl, req.request, req.response, req.done);
+    auto st = _writer->segment_flush_token()->submit(_writer.get(), req.cntl, req.request, req.response, req.done);
     if (!st.ok()) {
         LOG(WARNING) << "Failed to submit write segment, err=" << st;
     }
@@ -180,10 +174,6 @@ void AsyncDeltaWriter::abort(bool with_log) {
     int r = bthread::execution_queue_execute(_queue_id, task, &options);
     LOG_IF(WARNING, r != 0) << "Fail to execution_queue_execute: " << r;
 
-    if (_segment_flush_executor != nullptr) {
-        _segment_flush_executor->cancel();
-    }
-
     // Wait until all background tasks finished
     // https://github.com/StarRocks/starrocks/issues/8906
     _close();
@@ -199,10 +189,6 @@ void AsyncDeltaWriter::_close() {
         LOG_IF(WARNING, r != 0) << "Fail to stop execution queue: " << r;
         r = bthread::execution_queue_join(_queue_id);
         LOG_IF(WARNING, r != 0) << "Fail to join execution queue: " << r;
-    }
-    // wait is thread-safe
-    if (_segment_flush_executor != nullptr) {
-        _segment_flush_executor->wait();
     }
 }
 

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -128,7 +128,6 @@ private:
     std::shared_ptr<DeltaWriter> _writer;
     bthread::ExecutionQueueId<Task> _queue_id;
     std::atomic<bool> _closed;
-    std::unique_ptr<starrocks::SegmentFlushToken> _segment_flush_executor = nullptr;
 };
 
 class CommittedRowsetInfo {

--- a/be/src/storage/async_delta_writer.h
+++ b/be/src/storage/async_delta_writer.h
@@ -103,6 +103,9 @@ public:
 
     int64_t write_buffer_size() const { return _writer->write_buffer_size(); }
 
+    // Just for testing
+    DeltaWriter* writer() { return _writer.get(); }
+
 private:
     struct private_type {
         explicit private_type(int) {}

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -54,6 +54,7 @@ DeltaWriter::DeltaWriter(DeltaWriterOptions opt, MemTracker* mem_tracker, Storag
           _tablet_schema(new TabletSchema),
           _flush_token(nullptr),
           _replicate_token(nullptr),
+          _segment_flush_token(nullptr),
           _with_rollback_log(true) {}
 
 DeltaWriter::~DeltaWriter() {
@@ -63,6 +64,9 @@ DeltaWriter::~DeltaWriter() {
     }
     if (_replicate_token != nullptr) {
         _replicate_token->shutdown();
+    }
+    if (_segment_flush_token != nullptr) {
+        _segment_flush_token->shutdown();
     }
     switch (get_state()) {
     case kUninitialized:
@@ -307,6 +311,9 @@ Status DeltaWriter::_init() {
     _flush_token = _storage_engine->memtable_flush_executor()->create_flush_token();
     if (_replica_state == Primary && _opt.replicas.size() > 1) {
         _replicate_token = _storage_engine->segment_replicate_executor()->create_replicate_token(&_opt);
+    }
+    if (replica_state() == Secondary) {
+        _segment_flush_token = StorageEngine::instance()->segment_flush_executor()->create_flush_token();
     }
     _set_state(kWriting, Status::OK());
 
@@ -671,6 +678,9 @@ void DeltaWriter::cancel(const Status& st) {
     if (_replicate_token != nullptr) {
         _replicate_token->cancel(st);
     }
+    if (_segment_flush_token != nullptr) {
+        _segment_flush_token->cancel(st);
+    }
 }
 
 void DeltaWriter::abort(bool with_log) {
@@ -683,6 +693,9 @@ void DeltaWriter::abort(bool with_log) {
     }
     if (_replicate_token != nullptr) {
         _replicate_token->shutdown();
+    }
+    if (_segment_flush_token != nullptr) {
+        _segment_flush_token->shutdown();
     }
 
     VLOG(1) << "Aborted delta writer. tablet_id: " << _tablet->tablet_id() << " txn_id: " << _opt.txn_id

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -137,6 +137,8 @@ public:
 
     const ReplicateToken* replicate_token() const { return _replicate_token.get(); }
 
+    SegmentFlushToken* segment_flush_token() const { return _segment_flush_token.get(); }
+
     // REQUIRE: has successfully `commit()`ed
     const DictColumnsValidMap& global_dict_columns_valid_info() const {
         CHECK_EQ(kCommitted, _state);
@@ -200,6 +202,7 @@ private:
 
     std::unique_ptr<FlushToken> _flush_token;
     std::unique_ptr<ReplicateToken> _replicate_token;
+    std::unique_ptr<SegmentFlushToken> _segment_flush_token;
     bool _with_rollback_log;
     // initial value is max value
     size_t _memtable_buffer_row = std::numeric_limits<size_t>::max();

--- a/be/src/storage/delta_writer.h
+++ b/be/src/storage/delta_writer.h
@@ -119,6 +119,8 @@ public:
 
     const PUniqueId& load_id() const { return _opt.load_id; }
 
+    int64_t index_id() const { return _opt.index_id; }
+
     int64_t partition_id() const;
 
     int64_t node_id() const { return _opt.node_id; }

--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -16,6 +16,7 @@
 
 #include <fmt/format.h>
 
+#include <atomic>
 #include <memory>
 #include <utility>
 
@@ -30,70 +31,153 @@
 
 namespace starrocks {
 
-SegmentFlushToken::SegmentFlushToken(std::unique_ptr<ThreadPoolToken> flush_pool_token,
-                                     std::shared_ptr<starrocks::DeltaWriter> delta_writer)
-        : _flush_token(std::move(flush_pool_token)), _writer(std::move(delta_writer)) {}
+// A task responsible for flushing the segment received the primary tablet. It will also
+// respond to the brpc BackendInternalServiceImpl<T>::tablet_writer_add_segment if release()
+// is not called.
+class SegmentFlushTask final : public Runnable {
+public:
+    SegmentFlushTask(SegmentFlushToken* flush_token, DeltaWriter* writer, brpc::Controller* cntl,
+                     const PTabletWriterAddSegmentRequest* request, PTabletWriterAddSegmentResult* response,
+                     google::protobuf::Closure* done)
+            : _flush_token(flush_token),
+              _writer(writer),
+              _cntl(cntl),
+              _request(request),
+              _response(response),
+              _done(done) {}
 
-Status SegmentFlushToken::submit(brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,
-                                 PTabletWriterAddSegmentResult* response, google::protobuf::Closure* done) {
-    ClosureGuard closure_guard(done);
-
-    auto submit_st = _flush_token->submit_func([this, cntl, request, response, done] {
-        auto& writer = this->_writer;
-        auto st = Status::OK();
-        if (request->has_segment() && cntl->request_attachment().size() > 0) {
-            auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _writer->tablet()->tablet_id());
-            auto& segment_pb = request->segment();
-            st = writer->write_segment(segment_pb, cntl->request_attachment());
-        } else if (!request->eos()) {
-            st = Status::InternalError(fmt::format("request {} has no segment", request->DebugString()));
+    // Destructor which will respond to the brpc if run() or release() is not called.
+    ~SegmentFlushTask() override {
+        if (_run_or_released.load()) {
+            return;
         }
-        if (st.ok()) {
-            if (request->eos()) {
-                st = writer->close();
-                if (st.ok()) {
-                    st = writer->commit();
-                }
-                if (st.ok()) {
-                    auto* tablet_info = response->add_tablet_vec();
-                    tablet_info->set_tablet_id(writer->tablet()->tablet_id());
-                    tablet_info->set_schema_hash(writer->tablet()->schema_hash());
-                    tablet_info->set_node_id(writer->node_id());
-                    const auto& rowset_global_dict_columns_valid_info =
-                            writer->committed_rowset_writer()->global_dict_columns_valid_info();
-                    const auto* rowset_global_dicts = writer->committed_rowset_writer()->rowset_global_dicts();
-                    for (const auto& item : rowset_global_dict_columns_valid_info) {
-                        if (item.second && rowset_global_dicts != nullptr &&
-                            rowset_global_dicts->find(item.first) != rowset_global_dicts->end()) {
-                            tablet_info->add_valid_dict_cache_columns(item.first);
-                            tablet_info->add_valid_dict_collected_version(rowset_global_dicts->at(item.first).version);
-                        } else {
-                            tablet_info->add_invalid_dict_cache_columns(item.first);
-                        }
-                    }
+        Status status =
+                Status::Cancelled(fmt::format("Segment flush task does not run, and it may be cancelled,"
+                                              " txn_id: {}, tablet id: {}",
+                                              _request->txn_id(), _request->tablet_id()));
+        _send_fail_response(status);
+    }
+
+    // Run the task if release() is not called which will flush the segment, and respond the brpc
+    // BackendInternalServiceImpl<T>::tablet_writer_add_segment.
+    void run() override {
+        bool expect = false;
+        if (!_run_or_released.compare_exchange_strong(expect, true)) {
+            return;
+        }
+
+        // if token status is not ok, respond with failure
+        auto token_st = _flush_token->status();
+        if (!token_st.ok()) {
+            _send_fail_response(token_st);
+            return;
+        }
+
+        auto st = Status::OK();
+        if (_request->has_segment() && _cntl->request_attachment().size() > 0) {
+            auto scope = IOProfiler::scope(IOProfiler::TAG_LOAD, _writer->tablet()->tablet_id());
+            auto& segment_pb = _request->segment();
+            st = _writer->write_segment(segment_pb, _cntl->request_attachment());
+        } else if (!_request->eos()) {
+            st = Status::InternalError(fmt::format("request {} has no segment", _request->DebugString()));
+        }
+
+        bool eos = _request->eos();
+        if (st.ok() && eos) {
+            st = _writer->close();
+            if (st.ok()) {
+                st = _writer->commit();
+            }
+        }
+
+        if (!st.ok()) {
+            _writer->abort(true);
+            _send_fail_response(st);
+        } else {
+            _send_success_response(eos, st);
+        }
+    }
+
+    // Release the task which means it should not be run and respond to the brpc.
+    void release() {
+        bool expect = false;
+        _run_or_released.compare_exchange_strong(expect, true);
+    }
+
+private:
+    void _send_success_response(bool eos, Status& st) {
+        if (eos) {
+            auto* tablet_info = _response->add_tablet_vec();
+            tablet_info->set_tablet_id(_writer->tablet()->tablet_id());
+            tablet_info->set_schema_hash(_writer->tablet()->schema_hash());
+            tablet_info->set_node_id(_writer->node_id());
+            const auto& rowset_global_dict_columns_valid_info =
+                    _writer->committed_rowset_writer()->global_dict_columns_valid_info();
+            const auto* rowset_global_dicts = _writer->committed_rowset_writer()->rowset_global_dicts();
+            for (const auto& item : rowset_global_dict_columns_valid_info) {
+                if (item.second && rowset_global_dicts != nullptr &&
+                    rowset_global_dicts->find(item.first) != rowset_global_dicts->end()) {
+                    tablet_info->add_valid_dict_cache_columns(item.first);
+                    tablet_info->add_valid_dict_collected_version(rowset_global_dicts->at(item.first).version);
+                } else {
+                    tablet_info->add_invalid_dict_cache_columns(item.first);
                 }
             }
         }
-        if (!st.ok()) {
-            writer->abort(true);
-            auto* tablet_info = response->add_failed_tablet_vec();
-            tablet_info->set_tablet_id(writer->tablet()->tablet_id());
-            tablet_info->set_node_id(writer->node_id());
-            tablet_info->set_schema_hash(0);
-        }
+
+        st.to_protobuf(_response->mutable_status());
+        _done->Run();
+    }
+
+    void _send_fail_response(Status& st) {
+        auto* tablet_info = _response->add_failed_tablet_vec();
+        tablet_info->set_tablet_id(_writer->tablet()->tablet_id());
+        tablet_info->set_node_id(_writer->node_id());
+        tablet_info->set_schema_hash(0);
+        st.to_protobuf(_response->mutable_status());
+        _done->Run();
+    }
+
+    SegmentFlushToken* _flush_token;
+    DeltaWriter* _writer;
+    brpc::Controller* _cntl;
+    const PTabletWriterAddSegmentRequest* _request;
+    PTabletWriterAddSegmentResult* _response;
+    google::protobuf::Closure* _done;
+    // whether run() or release() has been called
+    std::atomic<bool> _run_or_released = false;
+};
+
+SegmentFlushToken::SegmentFlushToken(std::unique_ptr<ThreadPoolToken> flush_pool_token)
+        : _flush_token(std::move(flush_pool_token)) {}
+
+Status SegmentFlushToken::submit(DeltaWriter* writer, brpc::Controller* cntl,
+                                 const PTabletWriterAddSegmentRequest* request, PTabletWriterAddSegmentResult* response,
+                                 google::protobuf::Closure* done) {
+    ClosureGuard closure_guard(done);
+    Status st = status();
+    if (!st.ok()) {
         st.to_protobuf(response->mutable_status());
-        done->Run();
-    });
+        return st;
+    }
+
+    auto task = std::make_shared<SegmentFlushTask>(this, writer, cntl, request, response, done);
+    auto submit_st = _flush_token->submit(std::move(task));
     if (submit_st.ok()) {
         closure_guard.release();
     } else {
+        task->release();
         submit_st.to_protobuf(response->mutable_status());
     }
 
     return submit_st;
 }
 
-void SegmentFlushToken::cancel() {
+void SegmentFlushToken::cancel(const Status& st) {
+    set_status(st);
+}
+
+void SegmentFlushToken::shutdown() {
     _flush_token->shutdown();
 }
 
@@ -119,9 +203,8 @@ Status SegmentFlushExecutor::update_max_threads(int max_threads) {
     }
 }
 
-std::unique_ptr<SegmentFlushToken> SegmentFlushExecutor::create_flush_token(
-        const std::shared_ptr<starrocks::DeltaWriter>& delta_writer, ThreadPool::ExecutionMode execution_mode) {
-    return std::make_unique<SegmentFlushToken>(_flush_pool->new_token(execution_mode), delta_writer);
+std::unique_ptr<SegmentFlushToken> SegmentFlushExecutor::create_flush_token(ThreadPool::ExecutionMode execution_mode) {
+    return std::make_unique<SegmentFlushToken>(_flush_pool->new_token(execution_mode));
 }
 
 } // namespace starrocks

--- a/be/src/storage/segment_flush_executor.h
+++ b/be/src/storage/segment_flush_executor.h
@@ -20,6 +20,7 @@
 
 #include "common/status.h"
 #include "storage/olap_define.h"
+#include "util/spinlock.h"
 #include "util/threadpool.h"
 
 namespace brpc {
@@ -42,19 +43,34 @@ class DeltaWriter;
 
 class SegmentFlushToken {
 public:
-    SegmentFlushToken(std::unique_ptr<ThreadPoolToken> flush_pool_token,
-                      std::shared_ptr<starrocks::DeltaWriter> delta_writer);
+    SegmentFlushToken(std::unique_ptr<ThreadPoolToken> flush_pool_token);
 
-    Status submit(brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,
+    Status submit(DeltaWriter* writer, brpc::Controller* cntl, const PTabletWriterAddSegmentRequest* request,
                   PTabletWriterAddSegmentResult* response, google::protobuf::Closure* done);
 
-    void cancel();
+    Status status() const {
+        std::lock_guard l(_status_lock);
+        return _status;
+    }
+
+    void set_status(const Status& status) {
+        if (status.ok()) return;
+        std::lock_guard l(_status_lock);
+        if (_status.ok()) _status = status;
+    }
+
+    void cancel(const Status& st);
+
+    void shutdown();
 
     void wait();
 
 private:
     std::unique_ptr<ThreadPoolToken> _flush_token;
-    std::shared_ptr<DeltaWriter> _writer;
+
+    mutable SpinLock _status_lock;
+    // Records the current flush status of the tablet.
+    Status _status;
 };
 
 class SegmentFlushExecutor {
@@ -69,7 +85,6 @@ public:
     Status update_max_threads(int max_threads);
 
     std::unique_ptr<SegmentFlushToken> create_flush_token(
-            const std::shared_ptr<starrocks::DeltaWriter>& delta_writer,
             ThreadPool::ExecutionMode execution_mode = ThreadPool::ExecutionMode::CONCURRENT);
 
     ThreadPool* get_thread_pool() { return _flush_pool.get(); }

--- a/be/src/storage/segment_flush_executor.h
+++ b/be/src/storage/segment_flush_executor.h
@@ -63,7 +63,7 @@ public:
 
     void shutdown();
 
-    void wait();
+    Status wait();
 
 private:
     std::unique_ptr<ThreadPoolToken> _flush_token;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -284,6 +284,7 @@ set(EXEC_FILES
         ./storage/rowset_merger_test.cpp
         ./storage/schema_change_test.cpp
         ./storage/row_store_encoder_test.cpp
+        ./storage/segment_flush_executor_test.cpp
         ./storage/storage_engine_test.cpp
         ./storage/binlog_test_base.cpp
         ./storage/binlog_file_test.cpp

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -1,0 +1,318 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/segment_flush_executor.h"
+
+#include <brpc/controller.h>
+#include <gtest/gtest.h>
+
+#include <utility>
+
+#include "column/datum_tuple.h"
+#include "fs/fs_util.h"
+#include "runtime/descriptor_helper.h"
+#include "runtime/runtime_state.h"
+#include "storage/async_delta_writer.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset/segment_options.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet.h"
+#include "storage/tablet_manager.h"
+#include "storage/txn_manager.h"
+#include "testutil/assert.h"
+
+namespace starrocks {
+
+class SegmentFlushExecutorTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        srand(GetCurrentTimeMicros());
+        _partition_id = 1;
+        _index_id = 1;
+        _tablet = create_tablet(rand(), rand());
+        _mem_tracker = std::make_unique<MemTracker>(-1);
+    }
+
+    void TearDown() override {
+        if (_tablet) {
+            auto st = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet->tablet_id());
+            CHECK(st.ok()) << st.to_string();
+            _tablet.reset();
+        }
+
+        if (!_primary_tablet_segment_dir.empty()) {
+            fs::remove_all(_primary_tablet_segment_dir);
+        }
+    }
+
+    Status prepare_primary_tablet_segment_dir(std::string path) {
+        _primary_tablet_segment_dir = std::move(path);
+        RETURN_IF_ERROR(fs::remove_all(_primary_tablet_segment_dir));
+        return fs::create_directories(_primary_tablet_segment_dir);
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int32_t schema_hash) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = TKeysType::DUP_KEYS;
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        TColumn c0;
+        c0.column_name = "c0";
+        c0.__set_is_key(true);
+        c0.__set_is_allow_null(false);
+        c0.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(c0);
+
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    TupleDescriptor* _create_tuple_desc() {
+        TTupleDescriptorBuilder tuple_builder;
+        for (int i = 0; i < _tablet->tablet_schema()->num_columns(); i++) {
+            auto& column = _tablet->tablet_schema()->column(i);
+            TSlotDescriptorBuilder builder;
+            std::string column_name{column.name()};
+            TSlotDescriptor slot_desc = builder.type(column.type())
+                                                .column_name(column_name)
+                                                .column_pos(i)
+                                                .nullable(column.is_nullable())
+                                                .build();
+            tuple_builder.add_slot(slot_desc);
+        }
+        TDescriptorTableBuilder table_builder;
+        tuple_builder.build(&table_builder);
+        std::vector<TTupleId> row_tuples = std::vector<TTupleId>{0};
+        std::vector<bool> nullable_tuples = std::vector<bool>{false};
+        DescriptorTbl* tbl = nullptr;
+        DescriptorTbl::create(&_runtime_state, &_pool, table_builder.desc_tbl(), &tbl, config::vector_chunk_size);
+        auto* row_desc = _pool.add(new RowDescriptor(*tbl, row_tuples, nullable_tuples));
+        auto* tuple_desc = row_desc->tuple_descriptors()[0];
+
+        return tuple_desc;
+    }
+
+    std::unique_ptr<AsyncDeltaWriter> create_delta_writer(int64_t tablet_id, int32_t schema_hash,
+                                                          MemTracker* mem_tracker) {
+        DeltaWriterOptions options;
+        options.tablet_id = tablet_id;
+        options.schema_hash = schema_hash;
+        options.txn_id = rand();
+        options.partition_id = _partition_id;
+        options.load_id.set_lo(rand());
+        options.load_id.set_hi(rand());
+        options.index_id = _index_id;
+        options.node_id = 0;
+        options.timeout_ms = 3600000;
+        options.write_quorum = WriteQuorumTypePB::MAJORITY;
+        options.replica_state = ReplicaState::Secondary;
+        TupleDescriptor* tuple_desc = _create_tuple_desc();
+        options.slots = &tuple_desc->slots();
+
+        auto status_or = AsyncDeltaWriter::open(options, mem_tracker);
+        CHECK(status_or.ok()) << status_or.status().to_string();
+        return std::move(status_or.value());
+    }
+
+    void create_single_seg_rowset(Tablet* tablet, int num_rows, std::string& path, RowsetSharedPtr& rowset,
+                                  SegmentPB* segment_pb) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id;
+        rowset_id.init(10000);
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = tablet->partition_id();
+        writer_context.rowset_path_prefix = _tablet->schema_hash_path();
+        writer_context.rowset_state = VISIBLE;
+        writer_context.tablet_schema = tablet->tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+
+        std::unique_ptr<RowsetWriter> rowset_writer;
+        ASSERT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &rowset_writer).ok());
+        std::vector<uint32_t> column_indexes{0};
+        auto schema = ChunkHelper::convert_schema(tablet->tablet_schema(), column_indexes);
+        auto chunk = ChunkHelper::new_chunk(schema, num_rows);
+        for (auto i = 0; i < num_rows; ++i) {
+            chunk->columns()[0]->append_datum(Datum(static_cast<int32_t>(i)));
+        }
+        ASSERT_OK(rowset_writer->flush_chunk(*chunk, segment_pb));
+        rowset = rowset_writer->build().value();
+    }
+
+    void attach_segment_data(SegmentPB& segment_pb, brpc::Controller* controller) {
+        std::shared_ptr<FileSystem> fs;
+        ASSIGN_OR_ABORT(fs, FileSystem::CreateSharedFromString(segment_pb.path()));
+        auto res = fs->new_random_access_file(segment_pb.path());
+        ASSERT_TRUE(res.ok());
+        auto rfile = std::move(res.value());
+        auto buf = new uint8[segment_pb.data_size()];
+        butil::IOBuf data;
+        data.append_user_data(buf, segment_pb.data_size(), [](void* buf) { delete[](uint8*) buf; });
+        auto st = rfile->read_fully(buf, segment_pb.data_size());
+        ASSERT_OK(st);
+        controller->request_attachment().append(data);
+    }
+
+    Status get_prepared_rowset(int64_t tablet_id, int64_t txn_id, int64_t partition_id, RowsetSharedPtr* rowset) {
+        std::map<TabletInfo, RowsetSharedPtr> tablet_infos;
+        StorageEngine::instance()->txn_manager()->get_txn_related_tablets(txn_id, partition_id, &tablet_infos);
+        for (auto& [tablet_info, rs] : tablet_infos) {
+            if (tablet_info.tablet_id == tablet_id) {
+                (*rowset) = rs;
+                return Status::OK();
+            }
+        }
+        return Status::NotFound(fmt::format("Rowset not found. tablet_id: {}, txn_id: {}, partition_id: {}", tablet_id,
+                                            txn_id, partition_id));
+    }
+
+    void check_single_segment_rowset_result(RowsetSharedPtr& rowset, int num_rows) {
+        ASSERT_EQ(1, rowset->rowset_meta()->num_segments());
+        SegmentReadOptions seg_options;
+        ASSIGN_OR_ABORT(seg_options.fs, FileSystem::CreateSharedFromString("posix://"));
+        OlapReaderStatistics stats;
+        seg_options.stats = &stats;
+        std::string segment_file = Rowset::segment_file_path(_tablet->schema_hash_path(), rowset->rowset_id(), 0);
+        auto segment = *Segment::open(seg_options.fs, segment_file, 0, _tablet->tablet_schema());
+        ASSERT_EQ(segment->num_rows(), num_rows);
+        auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
+        auto res = segment->new_iterator(schema, seg_options);
+        ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
+
+        auto seg_iterator = res.value();
+        ASSERT_TRUE(seg_iterator->init_encoded_schema(EMPTY_GLOBAL_DICTMAPS).ok());
+        auto chunk = ChunkHelper::new_chunk(seg_iterator->schema(), 100);
+        int count = 0;
+        while (true) {
+            auto st = seg_iterator->get_next(chunk.get());
+            if (st.is_end_of_file()) {
+                break;
+            }
+            ASSERT_FALSE(!st.ok());
+            for (auto i = 0; i < chunk->num_rows(); i++) {
+                EXPECT_EQ(count, chunk->get(i)[0].get_int32());
+                count += 1;
+            }
+            chunk->reset();
+        }
+        ASSERT_EQ(num_rows, count);
+    }
+
+protected:
+    int64_t _partition_id;
+    int64_t _index_id;
+    TabletSharedPtr _tablet;
+    std::unique_ptr<MemTracker> _mem_tracker;
+    std::string _primary_tablet_segment_dir;
+    RuntimeState _runtime_state;
+    ObjectPool _pool;
+};
+
+class MockClosure : public ::google::protobuf::Closure {
+public:
+    MockClosure() = default;
+    ~MockClosure() override = default;
+
+    void Run() override { _run.store(true); }
+
+    bool has_run() { return _run.load(); }
+
+private:
+    std::atomic_bool _run = false;
+};
+
+TEST_F(SegmentFlushExecutorTest, test_write_and_commit_segment) {
+    ASSERT_OK(prepare_primary_tablet_segment_dir("./ut_dir/SegmentFlushExecutorTest_test_write_segment"));
+    // the rowset on the primary tablet
+    RowsetSharedPtr primary_rowset;
+    std::unique_ptr<SegmentPB> segment_pb = std::make_unique<SegmentPB>();
+    create_single_seg_rowset(_tablet.get(), 10, _primary_tablet_segment_dir, primary_rowset, segment_pb.get());
+
+    std::shared_ptr<AsyncDeltaWriter> async_delta_writer =
+            create_delta_writer(_tablet->tablet_id(), _tablet->schema_hash(), _mem_tracker.get());
+    DeltaWriter* delta_writer = async_delta_writer->writer();
+    PTabletWriterAddSegmentRequest request;
+    std::unique_ptr<starrocks::PUniqueId> id = std::make_unique<starrocks::PUniqueId>();
+    id->set_lo(delta_writer->load_id().lo());
+    id->set_hi(delta_writer->load_id().hi());
+    request.set_allocated_id(id.release());
+    request.set_txn_id(delta_writer->txn_id());
+    request.set_index_id(delta_writer->index_id());
+    request.set_tablet_id(delta_writer->tablet()->tablet_id());
+    request.set_eos(true);
+
+    brpc::Controller controller;
+    attach_segment_data(*segment_pb.get(), &controller);
+    request.set_allocated_segment(segment_pb.release());
+
+    PTabletWriterAddSegmentResult response;
+    MockClosure closure;
+    AsyncDeltaWriterSegmentRequest async_request{
+            .cntl = &controller, .request = &request, .response = &response, .done = &closure};
+    async_delta_writer->write_segment(async_request);
+    ASSERT_OK(delta_writer->segment_flush_token()->wait());
+    ASSERT_TRUE(closure.has_run());
+    RowsetSharedPtr prepared_rowset;
+    ASSERT_OK(get_prepared_rowset(_tablet->tablet_id(), delta_writer->txn_id(), _partition_id, &prepared_rowset));
+    check_single_segment_rowset_result(prepared_rowset, 10);
+    ASSERT_OK(StorageEngine::instance()->txn_manager()->delete_txn(_partition_id, _tablet, delta_writer->txn_id()));
+}
+
+TEST_F(SegmentFlushExecutorTest, test_submit_after_cancel) {
+    ASSERT_OK(prepare_primary_tablet_segment_dir("./ut_dir/SegmentFlushExecutorTest_test_submit_after_cancel"));
+    std::shared_ptr<AsyncDeltaWriter> async_delta_writer =
+            create_delta_writer(_tablet->tablet_id(), _tablet->schema_hash(), _mem_tracker.get());
+    DeltaWriter* delta_writer = async_delta_writer->writer();
+    PTabletWriterAddSegmentRequest request;
+    std::unique_ptr<starrocks::PUniqueId> id = std::make_unique<starrocks::PUniqueId>();
+    id->set_lo(delta_writer->load_id().lo());
+    id->set_hi(delta_writer->load_id().hi());
+    request.set_allocated_id(id.release());
+    request.set_txn_id(delta_writer->txn_id());
+    request.set_index_id(delta_writer->index_id());
+    request.set_tablet_id(delta_writer->tablet()->tablet_id());
+    request.set_eos(true);
+
+    brpc::Controller controller;
+    PTabletWriterAddSegmentResult response;
+    MockClosure closure;
+    // submit should fail after the writer is canceled, and the closure should be run to respond the brpc
+    async_delta_writer->cancel(Status::Cancelled("Artificial cancel"));
+    Status st = delta_writer->segment_flush_token()->submit(delta_writer, &controller, &request, &response, &closure);
+    ASSERT_FALSE(st.ok());
+    ASSERT_TRUE(closure.has_run());
+}
+
+TEST_F(SegmentFlushExecutorTest, test_abort) {
+    ASSERT_OK(prepare_primary_tablet_segment_dir("./ut_dir/SegmentFlushExecutorTest_test_abort"));
+    std::shared_ptr<AsyncDeltaWriter> async_delta_writer =
+            create_delta_writer(_tablet->tablet_id(), _tablet->schema_hash(), _mem_tracker.get());
+    async_delta_writer->abort();
+    ASSERT_EQ(kAborted, async_delta_writer->writer()->get_state());
+}
+} // namespace starrocks


### PR DESCRIPTION
Why I'm doing:
In replicated storage, there are two problems when aborting secondary tablet writer
1. The segment flush task submitted by `SegmentFlushToken` should always response to the brpc request `tablet_writer_add_segment`, but if the token is shutdown before the task runs, the task will be discarded, and not respond to the brpc request. As a result the client will wait until timeout which will block the `SegmentReplicateExecutor` on the client side, and affect other loads
2. `AsyncDeltaWriter::abort` calls `SegmentFlushExecutor::cancel` in the bthread used for brpc, but `SegmentFlushExecutor::cancel` calls `ThreadPoolToken::shutdown` which can wait for the running segment flush task to finish, so it can block bthread which will affect other brpcs

What I'm doing:
1. Define a class `SegmentFlushTask` which will response to the brpc request in the destructor if has not responded. This will ensure there will always be a response no matter the task is discarded or runs
2. `AsyncDeltaWriter::abort` should shutdown `SegmentFlushToken` in an async way like memtable flush token and segment replicate token to avoid block bthread. To fail the running tasks as soon as possible, `LocalTabletsChannel#abort` should call `AsyncDeltaWriter::cancel` before abort. It will just set an error status in `SegmentFlushToken`, and the tasks will check the status to fail ASAP

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
