### PR TITLE
[Enhancement]Reduce HeadObject before read segment file

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -434,7 +434,7 @@ Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
     for (auto& f : _tablet_writer->files()) {
         if (is_segment(f.path)) {
             op_write->mutable_rowset()->add_segments(std::move(f.path));
-            op_write->mutable_rowset()->add_segment_size(std::move(f.size.value()));
+            op_write->mutable_rowset()->add_segment_size(f.size.value());
         } else if (is_del(f.path)) {
             op_write->add_dels(std::move(f.path));
         } else {

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -430,9 +430,11 @@ Status DeltaWriterImpl::finish(DeltaWriter::FinishMode mode) {
     txn_log->set_tablet_id(_tablet_id);
     txn_log->set_txn_id(_txn_id);
     auto op_write = txn_log->mutable_op_write();
+
     for (auto& f : _tablet_writer->files()) {
         if (is_segment(f.path)) {
             op_write->mutable_rowset()->add_segments(std::move(f.path));
+            op_write->mutable_rowset()->add_segment_size(std::move(f.size.value()));
         } else if (is_del(f.path)) {
             op_write->add_dels(std::move(f.path));
         } else {

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "common/statusor.h"
+#include "fs/fs.h"
 #include "gutil/macros.h"
 
 namespace starrocks {

--- a/be/src/storage/lake/delta_writer.h
+++ b/be/src/storage/lake/delta_writer.h
@@ -18,7 +18,6 @@
 #include <vector>
 
 #include "common/statusor.h"
-#include "fs/fs.h"
 #include "gutil/macros.h"
 
 namespace starrocks {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -93,6 +93,7 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
         std::string segment_name = std::string(basename(segment_path));
         _files.emplace_back(FileInfo{segment_name, segment_size});
         _data_size += segment_size;
+        set_segment_size(_seg_writer->segment_path(), segment_size);
         if (segment) {
             segment->set_data_size(segment_size);
             segment->set_index_size(index_size);
@@ -208,6 +209,7 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
         std::string segment_name = std::string(basename(segment_path));
         _files.emplace_back(FileInfo{segment_name, segment_size});
         _data_size += segment_size;
+        set_segment_size(segment_writer->segment_path(), segment_size);
         segment_writer.reset();
     }
     _segment_writers.clear();

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -93,7 +93,6 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
         std::string segment_name = std::string(basename(segment_path));
         _files.emplace_back(FileInfo{segment_name, segment_size});
         _data_size += segment_size;
-        set_segment_size(_seg_writer->segment_path(), segment_size);
         if (segment) {
             segment->set_data_size(segment_size);
             segment->set_index_size(index_size);
@@ -209,7 +208,6 @@ Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
         std::string segment_name = std::string(basename(segment_path));
         _files.emplace_back(FileInfo{segment_name, segment_size});
         _data_size += segment_size;
-        set_segment_size(segment_writer->segment_path(), segment_size);
         segment_writer.reset();
     }
     _segment_writers.clear();

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -99,9 +99,12 @@ Status HorizontalCompactionTask::execute(Progress* progress, CancelFunc cancel_f
     for (auto& rowset : _input_rowsets) {
         op_compaction->add_input_rowsets(rowset->id());
     }
+
     for (auto& file : writer->files()) {
         op_compaction->mutable_output_rowset()->add_segments(file.path);
+        op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
     }
+
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -332,23 +332,23 @@ bool is_primary_key(const TabletMetadata& metadata) {
 
 void rowset_rssid_to_path(const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
                           std::unordered_map<uint32_t, FileInfo>& rssid_to_file_info) {
-    auto get_file_info_from_rowset = [&](const RowsetMetadataPB& meta) -> void {
+    auto get_file_info_from_rowset = [&](const RowsetMetadataPB& meta, const uint32_t rowset_id) -> void {
         bool has_segment_size = (meta.segments_size() == meta.segment_size_size());
         for (int i = 0; i < meta.segments_size(); i++) {
             FileInfo segment_info{.path = meta.segments(i)};
             if (LIKELY(has_segment_size)) {
                 segment_info.size = meta.segment_size(i);
             }
-            rssid_to_file_info[meta.id() + i] = segment_info;
+            rssid_to_file_info[rowset_id + i] = segment_info;
         }
     };
 
     for (auto& rs : metadata.rowsets()) {
-        get_file_info_from_rowset(rs);
+        get_file_info_from_rowset(rs, rs.id());
     }
     const uint32_t rowset_id = metadata.next_rowset_id();
     for (int i = 0; i < op_write.rowset().segments_size(); i++) {
-        get_file_info_from_rowset(op_write.rowset());
+        get_file_info_from_rowset(op_write.rowset(), rowset_id);
     }
 }
 

--- a/be/src/storage/lake/meta_file.cpp
+++ b/be/src/storage/lake/meta_file.cpp
@@ -331,15 +331,24 @@ bool is_primary_key(const TabletMetadata& metadata) {
 }
 
 void rowset_rssid_to_path(const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
-                          std::unordered_map<uint32_t, std::string>& rssid_to_path) {
-    for (auto& rs : metadata.rowsets()) {
-        for (int i = 0; i < rs.segments_size(); i++) {
-            rssid_to_path[rs.id() + i] = rs.segments(i);
+                          std::unordered_map<uint32_t, FileInfo>& rssid_to_file_info) {
+    auto get_file_info_from_rowset = [&](const RowsetMetadataPB& meta) -> void {
+        bool has_segment_size = (meta.segments_size() == meta.segment_size_size());
+        for (int i = 0; i < meta.segments_size(); i++) {
+            FileInfo segment_info{.path = meta.segments(i)};
+            if (LIKELY(has_segment_size)) {
+                segment_info.size = meta.segment_size(i);
+            }
+            rssid_to_file_info[meta.id() + i] = segment_info;
         }
+    };
+
+    for (auto& rs : metadata.rowsets()) {
+        get_file_info_from_rowset(rs);
     }
     const uint32_t rowset_id = metadata.next_rowset_id();
     for (int i = 0; i < op_write.rowset().segments_size(); i++) {
-        rssid_to_path[rowset_id + i] = op_write.rowset().segments(i);
+        get_file_info_from_rowset(op_write.rowset());
     }
 }
 

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -40,9 +40,8 @@ public:
     // append delvec to builder's buffer
     void append_delvec(const DelVectorPtr& delvec, uint32_t segment_id);
     // handle txn log
-    void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, std::string>& replace_segments,
-                       const std::vector<std::string>& orphan_files,
-                       std::map<std::string, uint64_t>& replace_segments_file_size);
+    void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, FileInfo>& replace_segments,
+                       const std::vector<std::string>& orphan_files);
     void apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
     // finalize will generate and sync final meta state to storage.
     // |txn_id| the maximum applied transaction ID, used to construct the delvec file name, and

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -41,7 +41,8 @@ public:
     void append_delvec(const DelVectorPtr& delvec, uint32_t segment_id);
     // handle txn log
     void apply_opwrite(const TxnLogPB_OpWrite& op_write, const std::map<int, std::string>& replace_segments,
-                       const std::vector<std::string>& orphan_files);
+                       const std::vector<std::string>& orphan_files,
+                       std::map<std::string, uint64_t>& replace_segments_file_size);
     void apply_opcompaction(const TxnLogPB_OpCompaction& op_compaction);
     // finalize will generate and sync final meta state to storage.
     // |txn_id| the maximum applied transaction ID, used to construct the delvec file name, and

--- a/be/src/storage/lake/meta_file.h
+++ b/be/src/storage/lake/meta_file.h
@@ -95,7 +95,7 @@ bool is_primary_key(const TabletMetadata& metadata);
 
 // TODO(yixin): cache rowset_rssid_to_path
 void rowset_rssid_to_path(const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
-                          std::unordered_map<uint32_t, std::string>& rssid_to_path);
+                          std::unordered_map<uint32_t, FileInfo>& rssid_to_path);
 
 } // namespace lake
 } // namespace starrocks

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -60,6 +60,7 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
         std::string segment_name = std::string(basename(segment_path));
         _files.emplace_back(FileInfo{segment_name, segment_size});
         _data_size += segment_size;
+        set_segment_size(_seg_writer->segment_path(), segment_size);
         if (segment) {
             segment->set_data_size(segment_size);
             segment->set_index_size(index_size);

--- a/be/src/storage/lake/pk_tablet_writer.cpp
+++ b/be/src/storage/lake/pk_tablet_writer.cpp
@@ -60,7 +60,6 @@ Status HorizontalPkTabletWriter::flush_segment_writer(SegmentPB* segment) {
         std::string segment_name = std::string(basename(segment_path));
         _files.emplace_back(FileInfo{segment_name, segment_size});
         _data_size += segment_size;
-        set_segment_size(_seg_writer->segment_path(), segment_size);
         if (segment) {
             segment->set_data_size(segment_size);
             segment->set_index_size(index_size);

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -235,11 +235,14 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_data_c
     bool ignore_lost_segment = config::experimental_lake_ignore_lost_segment;
 
     // RowsetMetaData upgrade from old version may not have the field of segment_size
-    bool has_segment_size = metadata().segment_size_size() != 0;
-    if (has_segment_size) {
-        DCHECK(metadata().segments_size() == metadata().segment_size_size());
-    }
-    auto files_to_size = metadata().segment_size();
+    auto segment_size_size = metadata().segment_size_size();
+    auto segment_file_size = metadata().segments_size();
+    bool has_segment_size = segment_size_size == segment_file_size;
+    LOG_IF(ERROR, segment_size_size > 0 && segment_size_size != segment_file_size)
+            << "segment_size size != segment file size, tablet: " << _tablet_id << ", rowset: " << metadata().id()
+            << ", segment file size: " << segment_file_size << ", segment_size size: " << segment_size_size;
+
+    const auto& files_to_size = metadata().segment_size();
     int index = 0;
 
     for (const auto& seg_name : metadata().segments()) {
@@ -250,7 +253,8 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_data_c
         index++;
 
         auto segment_path = _tablet_mgr->segment_location(tablet_id(), seg_name);
-        auto segment_or = _tablet_mgr->load_segment(segment_path, seg_id++, &footer_size_hint, fill_data_cache,
+        auto segment_info = FileInfo{segment_path};
+        auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, fill_data_cache,
                                                     fill_metadata_cache, _tablet_schema, segment_size);
         if (segment_or.ok()) {
             segments->emplace_back(std::move(segment_or.value()));

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -506,9 +506,9 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
             const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(i);
             FileInfo file_info{tablet->segment_location(dest_path)};
             // if rewrite fail, let segment gc to clean dest segment file
-            RETURN_IF_ERROR(SegmentRewriter::rewrite(
-                    tablet->segment_location(src_path), file_info, tablet_schema,
-                    read_column_ids, _partial_update_states[i].write_columns, i, partial_rowset_footer));
+            RETURN_IF_ERROR(SegmentRewriter::rewrite(tablet->segment_location(src_path), file_info, tablet_schema,
+                                                     read_column_ids, _partial_update_states[i].write_columns, i,
+                                                     partial_rowset_footer));
             file_info.path = dest_path;
             (*replace_segments)[i] = file_info;
         } else {

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -496,7 +496,7 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
             !_auto_increment_partial_update_states[i].skip_rewrite) {
             FileInfo file_info{.path = tablet->segment_location(dest_path)};
             RETURN_IF_ERROR(SegmentRewriter::rewrite(
-                    tablet->segment_location(src_path), file_info, tablet_schema,
+                    tablet->segment_location(src_path), &file_info, tablet_schema,
                     _auto_increment_partial_update_states[i], read_column_ids,
                     _partial_update_states.size() != 0 ? &_partial_update_states[i].write_columns : nullptr, op_write,
                     tablet));
@@ -506,7 +506,7 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
             const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(i);
             FileInfo file_info{.path = tablet->segment_location(dest_path)};
             // if rewrite fail, let segment gc to clean dest segment file
-            RETURN_IF_ERROR(SegmentRewriter::rewrite(tablet->segment_location(src_path), file_info, tablet_schema,
+            RETURN_IF_ERROR(SegmentRewriter::rewrite(tablet->segment_location(src_path), &file_info, tablet_schema,
                                                      read_column_ids, _partial_update_states[i].write_columns, i,
                                                      partial_rowset_footer));
             file_info.path = dest_path;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -494,7 +494,7 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
         int64_t t_rewrite_start = MonotonicMillis();
         if (op_write.txn_meta().has_auto_increment_partial_update_column_id() &&
             !_auto_increment_partial_update_states[i].skip_rewrite) {
-            FileInfo file_info{tablet->segment_location(dest_path)};
+            FileInfo file_info{.path = tablet->segment_location(dest_path)};
             RETURN_IF_ERROR(SegmentRewriter::rewrite(
                     tablet->segment_location(src_path), file_info, tablet_schema,
                     _auto_increment_partial_update_states[i], read_column_ids,
@@ -504,7 +504,7 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
             (*replace_segments)[i] = file_info;
         } else if (_partial_update_states.size() != 0) {
             const FooterPointerPB& partial_rowset_footer = txn_meta.partial_rowset_footers(i);
-            FileInfo file_info{tablet->segment_location(dest_path)};
+            FileInfo file_info{.path = tablet->segment_location(dest_path)};
             // if rewrite fail, let segment gc to clean dest segment file
             RETURN_IF_ERROR(SegmentRewriter::rewrite(tablet->segment_location(src_path), file_info, tablet_schema,
                                                      read_column_ids, _partial_update_states[i].write_columns, i,

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -62,7 +62,8 @@ public:
                 const MetaFileBuilder* builder, bool need_check_conflict, bool need_lock);
 
     Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
-                           std::map<int, std::string>* replace_segments, std::vector<std::string>* orphan_files);
+                           std::map<int, std::string>* replace_segments, std::vector<std::string>* orphan_files,
+                           std::map<std::string, uint64_t>* segments_size);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
     const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -62,8 +62,7 @@ public:
                 const MetaFileBuilder* builder, bool need_check_conflict, bool need_lock);
 
     Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
-                           std::map<int, std::string>* replace_segments, std::vector<std::string>* orphan_files,
-                           std::map<std::string, uint64_t>* segments_size);
+                           std::map<int, FileInfo>* replace_segments, std::vector<std::string>* orphan_files);
 
     const std::vector<ColumnUniquePtr>& upserts() const { return _upserts; }
     const std::vector<ColumnUniquePtr>& deletes() const { return _deletes; }

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -203,7 +203,9 @@ Status DirectSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
     // update new rowset meta
     for (auto& f : writer->files()) {
         new_rowset_metadata->add_segments(std::move(f.path));
+        new_rowset_metadata->add_segment_size(std::move(f.size.value()));
     }
+
     new_rowset_metadata->set_id(_next_rowset_id);
     new_rowset_metadata->set_num_rows(writer->num_rows());
     new_rowset_metadata->set_data_size(writer->data_size());
@@ -283,10 +285,11 @@ Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
 
     RETURN_IF_ERROR(writer->finish(DeltaWriter::kDontWriteTxnLog));
 
-    // update new rowset meta
     for (auto& f : writer->files()) {
         new_rowset_metadata->add_segments(std::move(f.path));
+        new_rowset_metadata->add_segment_size(std::move(f.size.value()));
     }
+
     new_rowset_metadata->set_id(_next_rowset_id);
     new_rowset_metadata->set_num_rows(writer->num_rows());
     new_rowset_metadata->set_data_size(writer->data_size());

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -203,7 +203,7 @@ Status DirectSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
     // update new rowset meta
     for (auto& f : writer->files()) {
         new_rowset_metadata->add_segments(std::move(f.path));
-        new_rowset_metadata->add_segment_size(std::move(f.size.value()));
+        new_rowset_metadata->add_segment_size(f.size.value());
     }
 
     new_rowset_metadata->set_id(_next_rowset_id);
@@ -287,7 +287,7 @@ Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_
 
     for (auto& f : writer->files()) {
         new_rowset_metadata->add_segments(std::move(f.path));
-        new_rowset_metadata->add_segment_size(std::move(f.size.value()));
+        new_rowset_metadata->add_segment_size(f.size.value());
     }
 
     new_rowset_metadata->set_id(_next_rowset_id);

--- a/be/src/storage/lake/spark_load.cpp
+++ b/be/src/storage/lake/spark_load.cpp
@@ -114,6 +114,7 @@ Status SparkLoadHandler::_load_convert(Tablet& cur_tablet) {
     for (auto& f : writer->files()) {
         if (is_segment(f.path)) {
             op_write->mutable_rowset()->add_segments(std::move(f.path));
+            op_write->mutable_rowset()->add_segment_size(std::move(f.size.value()));
         } else {
             return Status::InternalError(fmt::format("unknown file {}", f.path));
         }

--- a/be/src/storage/lake/spark_load.cpp
+++ b/be/src/storage/lake/spark_load.cpp
@@ -114,7 +114,7 @@ Status SparkLoadHandler::_load_convert(Tablet& cur_tablet) {
     for (auto& f : writer->files()) {
         if (is_segment(f.path)) {
             op_write->mutable_rowset()->add_segments(std::move(f.path));
-            op_write->mutable_rowset()->add_segment_size(std::move(f.size.value()));
+            op_write->mutable_rowset()->add_segment_size(f.size.value());
         } else {
             return Status::InternalError(fmt::format("unknown file {}", f.path));
         }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -569,19 +569,18 @@ StatusOr<VersionedTablet> TabletManager::get_tablet(int64_t tablet_id, int64_t v
     return VersionedTablet(this, std::move(metadata));
 }
 
-StatusOr<SegmentPtr> TabletManager::load_segment(const std::string& segment_path, int segment_id,
+StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, int segment_id,
                                                  size_t* footer_size_hint, bool fill_data_cache,
                                                  bool fill_metadata_cache, TabletSchemaPtr tablet_schema,
                                                  uint64_t segment_size) {
-    auto segment = metacache()->lookup_segment(segment_path);
+    auto segment = metacache()->lookup_segment(segment_info.path);
     if (segment == nullptr) {
-        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_path));
-        segment = std::make_shared<Segment>(std::move(fs), segment_path, segment_id, std::move(tablet_schema), this,
-                                            segment_size);
+        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_info.path));
+        segment = std::make_shared<Segment>(std::move(fs), segment_info, segment_id, std::move(tablet_schema), this);
         if (fill_metadata_cache) {
             // NOTE: the returned segment may be not the same as the parameter passed in
             // Use the one in cache if the same key already exists
-            if (auto cached_segment = metacache()->cache_segment_if_absent(segment_path, segment);
+            if (auto cached_segment = metacache()->cache_segment_if_absent(segment_info.path, segment);
                 cached_segment != nullptr) {
                 segment = cached_segment;
             }

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -571,11 +571,13 @@ StatusOr<VersionedTablet> TabletManager::get_tablet(int64_t tablet_id, int64_t v
 
 StatusOr<SegmentPtr> TabletManager::load_segment(const std::string& segment_path, int segment_id,
                                                  size_t* footer_size_hint, bool fill_data_cache,
-                                                 bool fill_metadata_cache, TabletSchemaPtr tablet_schema) {
+                                                 bool fill_metadata_cache, TabletSchemaPtr tablet_schema,
+                                                 uint64_t segment_size) {
     auto segment = metacache()->lookup_segment(segment_path);
     if (segment == nullptr) {
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_path));
-        segment = std::make_shared<Segment>(std::move(fs), segment_path, segment_id, std::move(tablet_schema), this);
+        segment = std::make_shared<Segment>(std::move(fs), segment_path, segment_id, std::move(tablet_schema), this,
+                                            segment_size);
         if (fill_metadata_cache) {
             // NOTE: the returned segment may be not the same as the parameter passed in
             // Use the one in cache if the same key already exists

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -571,7 +571,7 @@ StatusOr<VersionedTablet> TabletManager::get_tablet(int64_t tablet_id, int64_t v
 
 StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
                                                  bool fill_data_cache, bool fill_metadata_cache,
-                                                 TabletSchemaPtr tablet_schema, uint64_t segment_size) {
+                                                 TabletSchemaPtr tablet_schema) {
     auto segment = metacache()->lookup_segment(segment_info.path);
     if (segment == nullptr) {
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_info.path));

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -569,10 +569,9 @@ StatusOr<VersionedTablet> TabletManager::get_tablet(int64_t tablet_id, int64_t v
     return VersionedTablet(this, std::move(metadata));
 }
 
-StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, int segment_id,
-                                                 size_t* footer_size_hint, bool fill_data_cache,
-                                                 bool fill_metadata_cache, TabletSchemaPtr tablet_schema,
-                                                 uint64_t segment_size) {
+StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
+                                                 bool fill_data_cache, bool fill_metadata_cache,
+                                                 TabletSchemaPtr tablet_schema, uint64_t segment_size) {
     auto segment = metacache()->lookup_segment(segment_info.path);
     if (segment == nullptr) {
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(segment_info.path));

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -135,22 +135,16 @@ public:
 
     std::string delvec_location(int64_t tablet_id, std::string_view delvec_filename) const;
 
-    const LocationProvider* location_provider() const {
-        return _location_provider;
-    }
+    const LocationProvider* location_provider() const { return _location_provider; }
 
     UpdateManager* update_mgr();
 
-    CompactionScheduler* compaction_scheduler() {
-        return _compaction_scheduler.get();
-    }
+    CompactionScheduler* compaction_scheduler() { return _compaction_scheduler.get(); }
 
     void update_metacache_limit(size_t limit);
 
     // The return value will never be null.
-    Metacache* metacache() {
-        return _metacache.get();
-    }
+    Metacache* metacache() { return _metacache.get(); }
 
     StatusOr<int64_t> get_tablet_data_size(int64_t tablet_id, int64_t* version_hint);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -27,6 +27,7 @@
 #include "storage/lake/types_fwd.h"
 
 namespace starrocks {
+struct FileInfo;
 class Segment;
 class TabletSchemaPB;
 class TCreateTabletReq;
@@ -162,7 +163,7 @@ public:
     // updating the cache size where the cached object is not the one as expected.
     void update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint = 0);
 
-    StatusOr<SegmentPtr> load_segment(const std::string& segment_path, int segment_id, size_t* footer_size_hint,
+    StatusOr<SegmentPtr> load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
                                       bool fill_data_cache, bool fill_metadata_cache, TabletSchemaPtr tablet_schema,
                                       uint64_t segment_size = 0);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -135,16 +135,22 @@ public:
 
     std::string delvec_location(int64_t tablet_id, std::string_view delvec_filename) const;
 
-    const LocationProvider* location_provider() const { return _location_provider; }
+    const LocationProvider* location_provider() const {
+        return _location_provider;
+    }
 
     UpdateManager* update_mgr();
 
-    CompactionScheduler* compaction_scheduler() { return _compaction_scheduler.get(); }
+    CompactionScheduler* compaction_scheduler() {
+        return _compaction_scheduler.get();
+    }
 
     void update_metacache_limit(size_t limit);
 
     // The return value will never be null.
-    Metacache* metacache() { return _metacache.get(); }
+    Metacache* metacache() {
+        return _metacache.get();
+    }
 
     StatusOr<int64_t> get_tablet_data_size(int64_t tablet_id, int64_t* version_hint);
 
@@ -164,8 +170,7 @@ public:
     void update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint = 0);
 
     StatusOr<SegmentPtr> load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
-                                      bool fill_data_cache, bool fill_metadata_cache, TabletSchemaPtr tablet_schema,
-                                      uint64_t segment_size = 0);
+                                      bool fill_data_cache, bool fill_metadata_cache, TabletSchemaPtr tablet_schema);
 
 private:
     static std::string global_schema_cache_key(int64_t index_id);

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -163,7 +163,8 @@ public:
     void update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint = 0);
 
     StatusOr<SegmentPtr> load_segment(const std::string& segment_path, int segment_id, size_t* footer_size_hint,
-                                      bool fill_data_cache, bool fill_metadata_cache, TabletSchemaPtr tablet_schema);
+                                      bool fill_data_cache, bool fill_metadata_cache, TabletSchemaPtr tablet_schema,
+                                      uint64_t segment_size = 0);
 
 private:
     static std::string global_schema_cache_key(int64_t index_id);

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -110,6 +110,14 @@ public:
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }
 
 protected:
+    // the pattern of segment_path is like this xxx/table_id/partition_id/data/segment_file_name
+    void set_segment_size(std::string segment_path, uint64_t segment_size) {
+        auto pos = segment_path.find_last_of("/");
+        FileInfo file_info{.path = segment_path.substr(pos + 1), .size = segment_size};
+        _files.emplace_back(file_info);
+    }
+
+protected:
     TabletManager* _tablet_mgr;
     int64_t _tablet_id;
     TabletSchemaCSPtr _schema;

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -110,14 +110,6 @@ public:
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }
 
 protected:
-    // the pattern of segment_path is like this xxx/table_id/partition_id/data/segment_file_name
-    void set_segment_size(std::string segment_path, uint64_t segment_size) {
-        auto pos = segment_path.find_last_of("/");
-        FileInfo file_info{.path = segment_path.substr(pos + 1), .size = segment_size};
-        _files.emplace_back(file_info);
-    }
-
-protected:
     TabletManager* _tablet_mgr;
     int64_t _tablet_id;
     TabletSchemaCSPtr _schema;

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -139,10 +139,8 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     _update_state_cache.update_object_size(state_entry, state.memory_usage());
     // 2. rewrite segment file if it is partial update
     std::vector<std::string> orphan_files;
-    std::map<int, std::string> replace_segments;
-    std::map<std::string, uint64_t> replace_segments_file_size;
-    RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet, &replace_segments, &orphan_files,
-                                          &replace_segments_file_size));
+    std::map<int, FileInfo> replace_segments;
+    RETURN_IF_ERROR(state.rewrite_segment(op_write, metadata, tablet, &replace_segments, &orphan_files));
     PrimaryIndex::DeletesMap new_deletes;
     for (uint32_t i = 0; i < op_write.rowset().segments_size(); i++) {
         new_deletes[rowset_id + i] = {};
@@ -225,7 +223,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     for (auto&& each : new_del_vecs) {
         builder->append_delvec(each.second, each.first);
     }
-    builder->apply_opwrite(op_write, replace_segments, orphan_files, replace_segments_file_size);
+    builder->apply_opwrite(op_write, replace_segments, orphan_files);
     RETURN_IF_ERROR(builder->update_num_del_stat(segment_id_to_add_dels));
 
     TRACE_COUNTER_INCREMENT("rowsetid", rowset_id);
@@ -417,7 +415,7 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
                                          const TabletSchemaCSPtr& tablet_schema,
                                          const std::vector<uint32_t>& rowids) -> Status {
         std::string path = tablet->segment_location(segment_name);
-        auto segment = Segment::open(fs, path, segment_id, tablet_schema);
+        auto segment = Segment::open(fs, FileInfo{path}, segment_id, tablet_schema);
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open rssid: " << segment_id << " path: " << path << " : " << segment.status();
             return segment.status();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -406,7 +406,7 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
     watch.reset();
 
     std::unordered_map<uint32_t, FileInfo> rssid_to_file_info;
-    rowset_rssid_to_segment(metadata, op_write, rssid_to_file_info);
+    rowset_rssid_to_path(metadata, op_write, rssid_to_file_info);
     cost_str << " [catch rssid_to_path] " << watch.elapsed_time();
     watch.reset();
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -420,7 +420,8 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
         }
         auto segment = Segment::open(fs, file_info, segment_id, tablet_schema);
         if (!segment.ok()) {
-            LOG(WARNING) << "Fail to open rssid: " << segment_id << " path: " << path << " : " << segment.status();
+            LOG(WARNING) << "Fail to open rssid: " << segment_id << " path: " << file_info.path << " : "
+                         << segment.status();
             return segment.status();
         }
         if ((*segment)->num_rows() == 0) {
@@ -448,7 +449,7 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
         }
 
         // use 0 segment_id is safe, because we need not get either delvector or dcg here
-        RETURN_IF_ERROR(fetch_values_from_segment(rssid_to_path[rssid], 0, tablet_schema, rowids));
+        RETURN_IF_ERROR(fetch_values_from_segment(rssid_to_file_info[rssid], 0, tablet_schema, rowids));
     }
     if (auto_increment_state != nullptr && with_default) {
         if (fs == nullptr) {
@@ -458,7 +459,7 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
         uint32_t segment_id = auto_increment_state->segment_id;
         const std::vector<uint32_t>& rowids = auto_increment_state->rowids;
 
-        RETURN_IF_ERROR(fetch_values_from_segment(op_write.rowset().segments(segment_id), segment_id,
+        RETURN_IF_ERROR(fetch_values_from_segment(FileInfo{.path = op_write.rowset().segments(segment_id)}, segment_id,
                                                   auto_increment_state->schema, rowids));
     }
     cost_str << " [fetch vals by rowid] " << watch.elapsed_time();

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -414,7 +414,10 @@ Status UpdateManager::get_column_values(Tablet* tablet, const TabletMetadata& me
     auto fetch_values_from_segment = [&](const FileInfo& segment_info, uint32_t segment_id,
                                          const TabletSchemaCSPtr& tablet_schema,
                                          const std::vector<uint32_t>& rowids) -> Status {
-        FileInfo file_info{.path = tablet->segment_location(segment_info.path), .size = segment_info.size};
+        FileInfo file_info{.path = tablet->segment_location(segment_info.path)};
+        if (segment_info.size.has_value()) {
+            file_info.size = segment_info.size;
+        }
         auto segment = Segment::open(fs, file_info, segment_id, tablet_schema);
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open rssid: " << segment_id << " path: " << path << " : " << segment.status();

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -93,7 +93,7 @@ Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_fun
         op_compaction->add_input_rowsets(rowset->id());
     }
     for (auto& file : writer->files()) {
-        op_compaction->mutable_output_rowset()->add_segments(file.path);
+        op_compaction->mutable_output_rowset()->add_segments(std::move(file.path));
         op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
     }
 

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -94,7 +94,9 @@ Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_fun
     }
     for (auto& file : writer->files()) {
         op_compaction->mutable_output_rowset()->add_segments(file.path);
+        op_compaction->mutable_output_rowset()->add_segment_size(file_info.size.value());
     }
+
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());
     op_compaction->mutable_output_rowset()->set_data_size(writer->data_size());
     op_compaction->mutable_output_rowset()->set_overlapped(false);

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -94,7 +94,7 @@ Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_fun
     }
     for (auto& file : writer->files()) {
         op_compaction->mutable_output_rowset()->add_segments(file.path);
-        op_compaction->mutable_output_rowset()->add_segment_size(file_info.size.value());
+        op_compaction->mutable_output_rowset()->add_segment_size(file.size.value());
     }
 
     op_compaction->mutable_output_rowset()->set_num_rows(writer->num_rows());

--- a/be/src/storage/rowset/rowset.cpp
+++ b/be/src/storage/rowset/rowset.cpp
@@ -159,7 +159,8 @@ Status Rowset::do_load() {
     size_t footer_size_hint = 16 * 1024;
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
-        auto res = Segment::open(fs, seg_path, seg_id, _schema, &footer_size_hint,
+        FileInfo seg_info{seg_path};
+        auto res = Segment::open(fs, seg_info, seg_id, _schema, &footer_size_hint,
                                  rowset_meta()->partial_rowset_footer(seg_id));
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
@@ -179,7 +180,8 @@ Status Rowset::reload() {
     size_t footer_size_hint = 16 * 1024;
     for (int seg_id = 0; seg_id < num_segments(); ++seg_id) {
         std::string seg_path = segment_file_path(_rowset_path, rowset_id(), seg_id);
-        auto res = Segment::open(fs, seg_path, seg_id, _schema, &footer_size_hint);
+        FileInfo seg_info{.path = seg_path};
+        auto res = Segment::open(fs, seg_info, seg_id, _schema, &footer_size_hint);
         if (!res.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
             _segments.clear();
@@ -199,7 +201,8 @@ Status Rowset::reload_segment(int32_t segment_id) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_rowset_path));
     size_t footer_size_hint = 16 * 1024;
     std::string seg_path = segment_file_path(_rowset_path, rowset_id(), segment_id);
-    auto res = Segment::open(fs, seg_path, segment_id, _schema, &footer_size_hint);
+    FileInfo seg_info{.path = seg_path};
+    auto res = Segment::open(fs, seg_info, segment_id, _schema, &footer_size_hint);
     if (!res.ok()) {
         LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
         return res.status();
@@ -217,7 +220,8 @@ Status Rowset::reload_segment_with_schema(int32_t segment_id, TabletSchemaCSPtr&
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_rowset_path));
     size_t footer_size_hint = 16 * 1024;
     std::string seg_path = segment_file_path(_rowset_path, rowset_id(), segment_id);
-    auto res = Segment::open(fs, seg_path, segment_id, schema, &footer_size_hint);
+    FileInfo seg_info{.path = seg_path};
+    auto res = Segment::open(fs, seg_info, segment_id, schema, &footer_size_hint);
     if (!res.ok()) {
         LOG(WARNING) << "Fail to open " << seg_path << ": " << res.status();
         return res.status();
@@ -723,7 +727,8 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_update_file_iterators(const 
     for (int64_t i = 0; i < num_update_files(); i++) {
         // open update file
         std::string seg_path = segment_upt_file_path(_rowset_path, rowset_id(), i);
-        ASSIGN_OR_RETURN(auto seg_ptr, Segment::open(seg_options.fs, seg_path, i, _schema));
+        FileInfo seg_info{.path = seg_path};
+        ASSIGN_OR_RETURN(auto seg_ptr, Segment::open(seg_options.fs, seg_info, i, _schema));
         if (seg_ptr->num_rows() == 0) {
             seg_iterators[i] = new_empty_iterator(schema, config::vector_chunk_size);
             continue;
@@ -753,7 +758,8 @@ StatusOr<ChunkIteratorPtr> Rowset::get_update_file_iterator(const Schema& schema
     // open update file
     DCHECK(update_file_id < num_update_files());
     std::string seg_path = segment_upt_file_path(_rowset_path, rowset_id(), update_file_id);
-    ASSIGN_OR_RETURN(auto seg_ptr, Segment::open(seg_options.fs, seg_path, update_file_id, _schema));
+    FileInfo seg_info{.path = seg_path};
+    ASSIGN_OR_RETURN(auto seg_ptr, Segment::open(seg_options.fs, seg_info, update_file_id, _schema));
     if (seg_ptr->num_rows() == 0) {
         return new_empty_iterator(schema, config::vector_chunk_size);
     }

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -664,7 +664,8 @@ Status HorizontalRowsetWriter::_final_merge() {
         }
         std::string tmp_segment_file =
                 Rowset::segment_temp_file_path(_context.rowset_path_prefix, _context.rowset_id, seg_id);
-        auto segment_ptr = Segment::open(_fs, tmp_segment_file, seg_id, _context.tablet_schema);
+        FileInfo tmp_segment_info{.path = tmp_segment_file};
+        auto segment_ptr = Segment::open(_fs, tmp_segment_info, seg_id, _context.tablet_schema);
         if (!segment_ptr.ok()) {
             LOG(WARNING) << "Fail to open " << tmp_segment_file << ": " << segment_ptr.status();
             return segment_ptr.status();

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -425,7 +425,7 @@ HorizontalRowsetWriter::~HorizontalRowsetWriter() {
                 auto st = _fs->delete_file(path);
                 LOG_IF(WARNING, !(st.ok() || st.is_not_found()))
                         << "Fail to delete file=" << path << ", " << st.to_string();
-            }[]
+            }
         }
         // if _already_built is false, we need to release rowset_id to avoid rowset_id leak
         StorageEngine::instance()->release_rowset_id(_context.rowset_id);

--- a/be/src/storage/rowset/rowset_writer.cpp
+++ b/be/src/storage/rowset/rowset_writer.cpp
@@ -425,7 +425,7 @@ HorizontalRowsetWriter::~HorizontalRowsetWriter() {
                 auto st = _fs->delete_file(path);
                 LOG_IF(WARNING, !(st.ok() || st.is_not_found()))
                         << "Fail to delete file=" << path << ", " << st.to_string();
-            }
+            }[]
         }
         // if _already_built is false, we need to release rowset_id to avoid rowset_id leak
         StorageEngine::instance()->release_rowset_id(_context.rowset_id);

--- a/be/src/storage/rowset/segment.cpp
+++ b/be/src/storage/rowset/segment.cpp
@@ -71,25 +71,21 @@ namespace starrocks {
 
 using strings::Substitute;
 
-StatusOr<std::shared_ptr<Segment>> Segment::open(std::shared_ptr<FileSystem> fs, const std::string& path,
+StatusOr<std::shared_ptr<Segment>> Segment::open(std::shared_ptr<FileSystem> fs, FileInfo segment_file_info,
                                                  uint32_t segment_id, std::shared_ptr<const TabletSchema> tablet_schema,
                                                  size_t* footer_length_hint,
                                                  const FooterPointerPB* partial_rowset_footer,
                                                  bool skip_fill_local_cache, lake::TabletManager* tablet_manager) {
-    auto segment = std::make_shared<Segment>(std::move(fs), path, segment_id, std::move(tablet_schema), tablet_manager);
+    auto segment = std::make_shared<Segment>(std::move(fs), std::move(segment_file_info), segment_id,
+                                             std::move(tablet_schema), tablet_manager);
     RETURN_IF_ERROR(segment->open(footer_length_hint, partial_rowset_footer, skip_fill_local_cache));
     return std::move(segment);
 }
 
 Status Segment::parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer, size_t* footer_length_hint,
-                                     const FooterPointerPB* partial_rowset_footer, uint64_t segment_size) {
+                                     const FooterPointerPB* partial_rowset_footer) {
     // Footer := SegmentFooterPB, FooterPBSize(4), FooterPBChecksum(4), MagicNumber(4)
-    uint64_t file_size;
-    if (segment_size != 0) {
-        file_size = segment_size;
-    } else {
-        ASSIGN_OR_RETURN(file_size, read_file->get_size());
-    }
+    ASSIGN_OR_RETURN(auto file_size, read_file->get_size());
 
     if (file_size < 12) {
         return Status::Corruption(
@@ -176,11 +172,10 @@ Status Segment::parse_segment_footer(RandomAccessFile* read_file, SegmentFooterP
     return Status::OK();
 }
 
-Segment::Segment(std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id, TabletSchemaCSPtr tablet_schema,
-                 lake::TabletManager* tablet_manager, uint64_t segment_size)
+Segment::Segment(std::shared_ptr<FileSystem> fs, FileInfo segment_file_info, uint32_t segment_id,
+                 TabletSchemaCSPtr tablet_schema, lake::TabletManager* tablet_manager)
         : _fs(std::move(fs)),
-          _fname(std::move(path)),
-          _segment_size(segment_size),
+          _segment_file_info(std::move(segment_file_info)),
           _tablet_schema(std::move(tablet_schema)),
           _segment_id(segment_id),
           _tablet_manager(tablet_manager) {
@@ -214,15 +209,8 @@ Status Segment::_open(size_t* footer_length_hint, const FooterPointerPB* partial
     SegmentFooterPB footer;
     RandomAccessFileOptions opts{.skip_fill_local_cache = skip_fill_local_cache};
 
-    std::unique_ptr<RandomAccessFile> read_file;
-    if (_segment_size != 0) {
-        FileInfo file_info{.path = _fname, .size = _segment_size};
-        ASSIGN_OR_RETURN(read_file, _fs->new_random_access_file(opts, file_info));
-    } else {
-        ASSIGN_OR_RETURN(read_file, _fs->new_random_access_file(opts, _fname));
-    }
-    RETURN_IF_ERROR(Segment::parse_segment_footer(read_file.get(), &footer, footer_length_hint, partial_rowset_footer,
-                                                  _segment_size));
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(opts, _segment_file_info));
+    RETURN_IF_ERROR(Segment::parse_segment_footer(read_file.get(), &footer, footer_length_hint, partial_rowset_footer));
     RETURN_IF_ERROR(_create_column_readers(&footer));
     _num_rows = footer.num_rows();
     _short_key_index_page = PagePointer(footer.short_key_index_page());
@@ -268,7 +256,8 @@ StatusOr<ChunkIteratorPtr> Segment::_new_iterator(const Schema& schema, const Se
                 if (read_options.is_first_split_of_segment) {
                     read_options.stats->segment_stats_filtered += _column_readers.at(column_unique_id)->num_rows();
                 }
-                return Status::EndOfFile(strings::Substitute("End of file $0, empty iterator", _fname));
+                return Status::EndOfFile(
+                        strings::Substitute("End of file $0, empty iterator", _segment_file_info.path));
             } else {
                 break;
             }
@@ -304,7 +293,7 @@ Status Segment::load_index(bool skip_fill_local_cache) {
 Status Segment::_load_index(bool skip_fill_local_cache) {
     // read and parse short key index page
     RandomAccessFileOptions file_opts{.skip_fill_local_cache = skip_fill_local_cache};
-    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(file_opts, _fname));
+    ASSIGN_OR_RETURN(auto read_file, _fs->new_random_access_file(file_opts, _segment_file_info));
 
     PageReadOptions opts;
     opts.use_page_cache = !config::disable_storage_page_cache;
@@ -381,7 +370,7 @@ StatusOr<std::unique_ptr<ColumnIterator>> Segment::new_column_iterator(ColumnUID
     if (iter != _column_readers.end()) {
         return iter->second->new_iterator(path);
     } else {
-        return Status::NotFound(fmt::format("{} does not contain column of id {}", _fname, id));
+        return Status::NotFound(fmt::format("{} does not contain column of id {}", _segment_file_info.path, id));
     }
 }
 
@@ -395,13 +384,14 @@ Status Segment::new_bitmap_index_iterator(ColumnUID id, const IndexReadOptions& 
 
 StatusOr<std::shared_ptr<Segment>> Segment::new_dcg_segment(const DeltaColumnGroup& dcg, uint32_t idx,
                                                             const TabletSchemaCSPtr& read_tablet_schema) {
+    std::shared_ptr<TabletSchema> tablet_schema;
     if (read_tablet_schema != nullptr) {
-        return Segment::open(_fs, dcg.column_files(parent_name(_fname))[idx], 0,
-                             TabletSchema::create_with_uid(read_tablet_schema, dcg.column_ids()[idx]), nullptr);
+        tablet_schema = TabletSchema::create_with_uid(read_tablet_schema, dcg.column_ids()[idx]);
     } else {
-        return Segment::open(_fs, dcg.column_files(parent_name(_fname))[idx], 0,
-                             TabletSchema::create_with_uid(_tablet_schema.schema(), dcg.column_ids()[idx]), nullptr);
+        tablet_schema = TabletSchema::create_with_uid(_tablet_schema.schema(), dcg.column_ids()[idx]);
     }
+    FileInfo info{.path = dcg.column_files(parent_name(_segment_file_info.path))[idx]};
+    return Segment::open(_fs, info, 0, tablet_schema, nullptr);
 }
 
 Status Segment::get_short_key_index(std::vector<std::string>* sk_index_values) {

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -82,7 +82,7 @@ using ChunkIteratorPtr = std::shared_ptr<ChunkIterator>;
 class Segment : public std::enable_shared_from_this<Segment> {
 public:
     // Like above but share the ownership of |unsafe_tablet_schema_ref|.
-    static StatusOr<std::shared_ptr<Segment>> open(std::shared_ptr<FileSystem> fs, const std::string& path,
+    static StatusOr<std::shared_ptr<Segment>> open(std::shared_ptr<FileSystem> fs, FileInfo segment_file_info,
                                                    uint32_t segment_id, TabletSchemaCSPtr tablet_schema,
                                                    size_t* footer_length_hint = nullptr,
                                                    const FooterPointerPB* partial_rowset_footer = nullptr,
@@ -91,11 +91,10 @@ public:
 
     [[nodiscard]] static Status parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer,
                                                      size_t* footer_length_hint,
-                                                     const FooterPointerPB* partial_rowset_footer,
-                                                     uint64_t segment_size = 0);
+                                                     const FooterPointerPB* partial_rowset_footer);
 
-    Segment(std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id, TabletSchemaCSPtr tablet_schema,
-            lake::TabletManager* tablet_manager, uint64_t segment_size = 0);
+    Segment(std::shared_ptr<FileSystem> fs, FileInfo segment_file_info, uint32_t segment_id,
+            TabletSchemaCSPtr tablet_schema, lake::TabletManager* tablet_manager);
 
     ~Segment();
 
@@ -181,7 +180,7 @@ public:
 
     const TabletSchemaCSPtr tablet_schema_share_ptr() { return _tablet_schema.schema(); }
 
-    const std::string& file_name() const { return _fname; }
+    const std::string& file_name() const { return _segment_file_info.path; }
 
     uint32_t num_rows() const { return _num_rows; }
 
@@ -194,12 +193,11 @@ public:
 
     size_t mem_usage() const;
 
-    int64_t get_data_size() {
-        auto res = _fs->get_file_size(_fname);
-        if (res.ok()) {
-            return res.value();
+    int64_t get_data_size() const {
+        if (_segment_file_info.size.has_value()) {
+            return _segment_file_info.size.value();
         }
-        return 0;
+        return _fs->get_file_size(_segment_file_info.path).value_or(0);
     }
 
     // read short_key_index, for data check, just used in unit test now
@@ -244,7 +242,7 @@ private:
 
     void _reset();
 
-    size_t _basic_info_mem_usage() const { return sizeof(Segment) + _fname.size(); }
+    size_t _basic_info_mem_usage() const { return sizeof(Segment) + _segment_file_info.path.size(); }
 
     size_t _short_key_index_mem_usage() const {
         size_t size = _sk_index_handle.mem_usage();
@@ -267,9 +265,7 @@ private:
     friend class SegmentIterator;
 
     std::shared_ptr<FileSystem> _fs;
-    std::string _fname;
-    // 0 indicates tablet meta data do not contain the info of segment size
-    uint64_t _segment_size;
+    FileInfo _segment_file_info;
     TabletSchemaWrapper _tablet_schema;
     uint32_t _segment_id = 0;
     uint32_t _num_rows = 0;

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -91,10 +91,11 @@ public:
 
     [[nodiscard]] static Status parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer,
                                                      size_t* footer_length_hint,
-                                                     const FooterPointerPB* partial_rowset_footer);
+                                                     const FooterPointerPB* partial_rowset_footer,
+                                                     uint64_t segment_size = 0);
 
     Segment(std::shared_ptr<FileSystem> fs, std::string path, uint32_t segment_id, TabletSchemaCSPtr tablet_schema,
-            lake::TabletManager* tablet_manager);
+            lake::TabletManager* tablet_manager, uint64_t segment_size = 0);
 
     ~Segment();
 
@@ -267,6 +268,8 @@ private:
 
     std::shared_ptr<FileSystem> _fs;
     std::string _fname;
+    // 0 indicates tablet meta data do not contain the info of segment size
+    uint64_t _segment_size;
     TabletSchemaWrapper _tablet_schema;
     uint32_t _segment_id = 0;
     uint32_t _num_rows = 0;

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -26,7 +26,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo* dest_path
                                 const FooterPointerPB& partial_rowset_footer) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path->path));
     WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path.path));
+    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path->path));
     ASSIGN_OR_RETURN(auto rfile, fs->new_random_access_file(src_path));
 
     SegmentFooterPB footer;
@@ -217,7 +217,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo* dest_path
     itr->close();
 
     WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path.path));
+    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path->path));
 
     std::vector<uint32_t> full_column_ids(tschema->num_columns());
     std::iota(full_column_ids.begin(), full_column_ids.end(), 0);

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -194,7 +194,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path
     auto fill_cache = false;
     auto tablet_mgr = tablet->tablet_mgr();
     auto segment_path = tablet->segment_location(op_write.rowset().segments(segment_id));
-    auto segment_info = FileInfo{segment_path};
+    auto segment_info = FileInfo{.path = segment_path};
     ASSIGN_OR_RETURN(auto segment, tablet_mgr->load_segment(segment_info, segment_id, &footer_sine_hint, fill_cache,
                                                             fill_cache, tschema));
     uint32_t num_rows = segment->num_rows();

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -20,13 +20,13 @@ namespace starrocks {
 
 SegmentRewriter::SegmentRewriter() = default;
 
-Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& dest_path,
+Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path,
                                 const std::shared_ptr<const TabletSchema>& tschema, std::vector<uint32_t>& column_ids,
                                 std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
-                                const FooterPointerPB& partial_rowset_footer, uint64_t* file_size) {
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path));
+                                const FooterPointerPB& partial_rowset_footer) {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path.path));
     WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path));
+    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path.path));
     ASSIGN_OR_RETURN(auto rfile, fs->new_random_access_file(src_path));
 
     SegmentFooterPB footer;
@@ -64,9 +64,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
     RETURN_IF_ERROR(writer.finalize_columns(&index_size));
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
-    if (file_size != nullptr) {
-        *file_size = segment_file_size;
-    }
+    dest_path.size = segment_file_size;
 
     return Status::OK();
 }
@@ -163,17 +161,16 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
 // This function is used when the auto-increment column is not specified in partial update.
 // In this function, we use the segment iterator to read the old data, replace the old auto
 // increment column, and rewrite the full segment file through SegmentWriter.
-Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& dest_path,
+Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path,
                                 const TabletSchemaCSPtr& tschema,
                                 starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                                 std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
-                                const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet,
-                                uint64_t* file_size) {
+                                const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet) {
     if (column_ids.size() == 0) {
         DCHECK_EQ(columns, nullptr);
     }
 
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path));
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path.path));
 
     uint32_t auto_increment_column_id = 0;
     for (const auto& col : tschema->columns()) {
@@ -198,7 +195,8 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
     auto fill_cache = false;
     auto tablet_mgr = tablet->tablet_mgr();
     auto segment_path = tablet->segment_location(op_write.rowset().segments(segment_id));
-    ASSIGN_OR_RETURN(auto segment, tablet_mgr->load_segment(segment_path, segment_id, &footer_sine_hint, fill_cache,
+    auto segment_info = FileInfo{segment_path};
+    ASSIGN_OR_RETURN(auto segment, tablet_mgr->load_segment(segment_info, segment_id, &footer_sine_hint, fill_cache,
                                                             fill_cache, tschema));
     uint32_t num_rows = segment->num_rows();
 
@@ -221,7 +219,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
     itr->close();
 
     WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
-    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path));
+    ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path.path));
 
     std::vector<uint32_t> full_column_ids(tschema->num_columns());
     std::iota(full_column_ids.begin(), full_column_ids.end(), 0);
@@ -252,9 +250,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
     RETURN_IF_ERROR(writer.finalize_columns(&index_size));
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
-    if (file_size != nullptr) {
-        *file_size = segment_file_size;
-    }
+    dest_path.size = segment_file_size;
 
     return Status::OK();
 }

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -20,11 +20,11 @@ namespace starrocks {
 
 SegmentRewriter::SegmentRewriter() = default;
 
-Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path,
+Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo* dest_path,
                                 const std::shared_ptr<const TabletSchema>& tschema, std::vector<uint32_t>& column_ids,
                                 std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
                                 const FooterPointerPB& partial_rowset_footer) {
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path.path));
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path->path));
     WritableFileOptions wopts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(wopts, dest_path.path));
     ASSIGN_OR_RETURN(auto rfile, fs->new_random_access_file(src_path));
@@ -64,8 +64,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path
     RETURN_IF_ERROR(writer.finalize_columns(&index_size));
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
-    dest_path.size = segment_file_size;
-
+    dest_path->size = segment_file_size;
     return Status::OK();
 }
 
@@ -161,7 +160,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
 // This function is used when the auto-increment column is not specified in partial update.
 // In this function, we use the segment iterator to read the old data, replace the old auto
 // increment column, and rewrite the full segment file through SegmentWriter.
-Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path, const TabletSchemaCSPtr& tschema,
+Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo* dest_path, const TabletSchemaCSPtr& tschema,
                                 starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                                 std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
                                 const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet) {
@@ -169,7 +168,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path
         DCHECK_EQ(columns, nullptr);
     }
 
-    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path.path));
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dest_path->path));
 
     uint32_t auto_increment_column_id = 0;
     for (const auto& col : tschema->columns()) {
@@ -249,8 +248,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path
     RETURN_IF_ERROR(writer.finalize_columns(&index_size));
     RETURN_IF_ERROR(writer.finalize_footer(&segment_file_size));
 
-    dest_path.size = segment_file_size;
-
+    dest_path->size = segment_file_size;
     return Status::OK();
 }
 

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -161,8 +161,7 @@ Status SegmentRewriter::rewrite(const std::string& src_path, const std::string& 
 // This function is used when the auto-increment column is not specified in partial update.
 // In this function, we use the segment iterator to read the old data, replace the old auto
 // increment column, and rewrite the full segment file through SegmentWriter.
-Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path,
-                                const TabletSchemaCSPtr& tschema,
+Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo& dest_path, const TabletSchemaCSPtr& tschema,
                                 starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                                 std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
                                 const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet) {

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -26,7 +26,7 @@ public:
     // read from src, write to dest
     // this function will read data from src_file and write to dest file first
     // then append write_column to dest file
-    static Status rewrite(const std::string& src, FileInfo& dest, const std::shared_ptr<const TabletSchema>& tschema,
+    static Status rewrite(const std::string& src, FileInfo* dest, const std::shared_ptr<const TabletSchema>& tschema,
                           std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>& columns,
                           uint32_t segment_id, const FooterPointerPB& partial_rowseet_footer);
     // this funciton will append write_column to src_file and rebuild segment footer
@@ -36,7 +36,7 @@ public:
     static Status rewrite(const std::string& src_path, const std::string& dest_path, const TabletSchemaCSPtr& tschema,
                           AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                           std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns);
-    static Status rewrite(const std::string& src_path, FileInfo& dest_path, const TabletSchemaCSPtr& tschema,
+    static Status rewrite(const std::string& src_path, FileInfo* dest_path, const TabletSchemaCSPtr& tschema,
                           starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                           std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
                           const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet);

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -26,10 +26,9 @@ public:
     // read from src, write to dest
     // this function will read data from src_file and write to dest file first
     // then append write_column to dest file
-    static Status rewrite(const std::string& src, FileInfo& dest,
-                          const std::shared_ptr<const TabletSchema>& tschema, std::vector<uint32_t>& column_ids,
-                          std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
-                          const FooterPointerPB& partial_rowseet_footer);
+    static Status rewrite(const std::string& src, FileInfo& dest, const std::shared_ptr<const TabletSchema>& tschema,
+                          std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>& columns,
+                          uint32_t segment_id, const FooterPointerPB& partial_rowseet_footer);
     // this funciton will append write_column to src_file and rebuild segment footer
     static Status rewrite(const std::string& src, const TabletSchemaCSPtr& tschema, std::vector<uint32_t>& column_ids,
                           std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -29,7 +29,7 @@ public:
     static Status rewrite(const std::string& src, const std::string& dest,
                           const std::shared_ptr<const TabletSchema>& tschema, std::vector<uint32_t>& column_ids,
                           std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
-                          const FooterPointerPB& partial_rowseet_footer);
+                          const FooterPointerPB& partial_rowseet_footer, uint64_t* file_size = nullptr);
     // this funciton will append write_column to src_file and rebuild segment footer
     static Status rewrite(const std::string& src, const TabletSchemaCSPtr& tschema, std::vector<uint32_t>& column_ids,
                           std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
@@ -40,7 +40,8 @@ public:
     static Status rewrite(const std::string& src_path, const std::string& dest_path, const TabletSchemaCSPtr& tschema,
                           starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                           std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
-                          const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet);
+                          const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet,
+                          uint64_t* file_size = nullptr);
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment_rewriter.h
+++ b/be/src/storage/rowset/segment_rewriter.h
@@ -26,10 +26,10 @@ public:
     // read from src, write to dest
     // this function will read data from src_file and write to dest file first
     // then append write_column to dest file
-    static Status rewrite(const std::string& src, const std::string& dest,
+    static Status rewrite(const std::string& src, FileInfo& dest,
                           const std::shared_ptr<const TabletSchema>& tschema, std::vector<uint32_t>& column_ids,
                           std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
-                          const FooterPointerPB& partial_rowseet_footer, uint64_t* file_size = nullptr);
+                          const FooterPointerPB& partial_rowseet_footer);
     // this funciton will append write_column to src_file and rebuild segment footer
     static Status rewrite(const std::string& src, const TabletSchemaCSPtr& tschema, std::vector<uint32_t>& column_ids,
                           std::vector<std::unique_ptr<Column>>& columns, uint32_t segment_id,
@@ -37,11 +37,10 @@ public:
     static Status rewrite(const std::string& src_path, const std::string& dest_path, const TabletSchemaCSPtr& tschema,
                           AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                           std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns);
-    static Status rewrite(const std::string& src_path, const std::string& dest_path, const TabletSchemaCSPtr& tschema,
+    static Status rewrite(const std::string& src_path, FileInfo& dest_path, const TabletSchemaCSPtr& tschema,
                           starrocks::lake::AutoIncrementPartialUpdateState& auto_increment_partial_update_state,
                           std::vector<uint32_t>& column_ids, std::vector<std::unique_ptr<Column>>* columns,
-                          const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet,
-                          uint64_t* file_size = nullptr);
+                          const starrocks::lake::TxnLogPB_OpWrite& op_write, starrocks::lake::Tablet* tablet);
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -299,7 +299,7 @@ static StatusOr<ChunkPtr> read_from_source_segment(Rowset* rowset, const Schema&
                                                    OlapReaderStatistics* stats, int64_t version,
                                                    RowsetSegmentId rowset_seg_id, const std::string& path) {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(rowset->rowset_path()));
-    auto segment = Segment::open(fs, path, rowset_seg_id.segment_id, rowset->schema());
+    auto segment = Segment::open(fs, FileInfo{path}, rowset_seg_id.segment_id, rowset->schema());
     if (!segment.ok()) {
         LOG(WARNING) << "Fail to open " << path << ": " << segment.status();
         return segment.status();

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -772,7 +772,8 @@ Status RowsetUpdateState::apply(Tablet* tablet, const TabletSchemaCSPtr& tablet_
                 _partial_update_states.size() != 0 ? &_partial_update_states[segment_id].write_columns : nullptr));
     } else if (_partial_update_states.size() != 0) {
         FooterPointerPB partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
-        RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, dest_path, _tablet_schema, read_column_ids,
+        FileInfo file_info{dest_path};
+        RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, file_info, _tablet_schema, read_column_ids,
                                                  _partial_update_states[segment_id].write_columns, segment_id,
                                                  partial_rowset_footer));
     }

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -772,7 +772,7 @@ Status RowsetUpdateState::apply(Tablet* tablet, const TabletSchemaCSPtr& tablet_
                 _partial_update_states.size() != 0 ? &_partial_update_states[segment_id].write_columns : nullptr));
     } else if (_partial_update_states.size() != 0) {
         FooterPointerPB partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
-        FileInfo file_info{dest_path};
+        FileInfo file_info{.path = dest_path};
         RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, file_info, _tablet_schema, read_column_ids,
                                                  _partial_update_states[segment_id].write_columns, segment_id,
                                                  partial_rowset_footer));

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -773,7 +773,7 @@ Status RowsetUpdateState::apply(Tablet* tablet, const TabletSchemaCSPtr& tablet_
     } else if (_partial_update_states.size() != 0) {
         FooterPointerPB partial_rowset_footer = txn_meta.partial_rowset_footers(segment_id);
         FileInfo file_info{.path = dest_path};
-        RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, file_info, _tablet_schema, read_column_ids,
+        RETURN_IF_ERROR(SegmentRewriter::rewrite(src_path, &file_info, _tablet_schema, read_column_ids,
                                                  _partial_update_states[segment_id].write_columns, segment_id,
                                                  partial_rowset_footer));
     }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -4563,7 +4563,7 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
         }
         std::string seg_path =
                 Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), rssid - iter->first);
-        auto segment = Segment::open(fs, seg_path, rssid - iter->first, rowset->schema());
+        auto segment = Segment::open(fs, FileInfo{seg_path}, rssid - iter->first, rowset->schema());
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();
             return segment.status();
@@ -4623,8 +4623,9 @@ Status TabletUpdates::get_column_values(const std::vector<uint32_t>& column_ids,
         }
 
         std::string seg_path = Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), segment_id);
+        FileInfo seg_info{.path = seg_path};
         ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(seg_path));
-        auto segment = Segment::open(fs, seg_path, segment_id, auto_increment_state->schema);
+        auto segment = Segment::open(fs, seg_info, segment_id, auto_increment_state->schema);
         if (!segment.ok()) {
             LOG(WARNING) << "Fail to open " << seg_path << ": " << segment.status();
             return segment.status();

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -697,7 +697,7 @@ Status SegmentDump::_init() {
 
     // open segment
     size_t footer_length = 16 * 1024 * 1024;
-    auto segment_res = Segment::open(_fs, _path, 0, _tablet_schema, &footer_length, nullptr);
+    auto segment_res = Segment::open(_fs, FileInfo{_path}, 0, _tablet_schema, &footer_length, nullptr);
     if (!segment_res.ok()) {
         std::cout << "open segment failed: " << segment_res.status() << std::endl;
         return Status::InternalError("");

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -213,7 +213,7 @@ protected:
         auto path = _location_provider->segment_location(tablet_id, filename);
         std::cerr << path << '\n';
 
-        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, path, 0, _tablet_schema));
+        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, FileInfo{path}, 0, _tablet_schema));
 
         OlapReaderStatistics statistics;
         SegmentReadOptions opts;

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -206,7 +206,7 @@ protected:
         ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestGroupPath));
         auto path = _location_provider->segment_location(tablet_id, filename);
 
-        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, path, 0, _tablet_schema));
+        ASSIGN_OR_ABORT(auto seg, Segment::open(fs, FileInfo{path}, 0, _tablet_schema));
 
         OlapReaderStatistics statistics;
         SegmentReadOptions opts;

--- a/be/test/storage/lake/async_delta_writer_test.cpp
+++ b/be/test/storage/lake/async_delta_writer_test.cpp
@@ -234,7 +234,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
     auto path0 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, FileInfo{path0}, 0, _tablet_schema));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -336,7 +336,7 @@ TEST_F(LakeAsyncDeltaWriterTest, test_write_concurrently) {
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
     auto path0 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, FileInfo{path0}, 0, _tablet_schema));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;

--- a/be/test/storage/lake/delta_writer_test.cpp
+++ b/be/test/storage/lake/delta_writer_test.cpp
@@ -240,8 +240,8 @@ TEST_F(LakeDeltaWriterTest, test_write) {
     auto path0 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(0));
     auto path1 = _tablet_mgr->segment_location(tablet_id, txnlog->op_write().rowset().segments(1));
 
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, path0, 0, _tablet_schema));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, path1, 1, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, FileInfo{path0}, 0, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, FileInfo{path1}, 1, _tablet_schema));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -283,7 +283,7 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent) {
     std::string segment_path("test_cache_segment_if_absent.dat");
 
     EXPECT_EQ(nullptr, metacache->lookup_segment(segment_path));
-    auto seg1 = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+    auto seg1 = std::make_shared<Segment>(fs, FileInfo{segment_path}, segment_id, schema, _tablet_mgr.get());
 
     {
         // cache seg1, since there is no segment cached before, cache_segment_if_absent will cache the seg1 and return it.
@@ -293,7 +293,7 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent) {
         EXPECT_EQ(seg1, metacache->lookup_segment(segment_path));
     }
 
-    auto seg2 = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+    auto seg2 = std::make_shared<Segment>(fs, FileInfo{segment_path}, segment_id, schema, _tablet_mgr.get());
     {
         auto seg = metacache->cache_segment_if_absent(segment_path, seg2);
         EXPECT_TRUE(seg != nullptr);
@@ -342,7 +342,7 @@ TEST_F(LakeMetacacheTest, test_cache_segment_if_absent_concurrency) {
     for (int i = 0; i < kConcurrency; ++i) {
         TestCacheSegmentConcurrency ctx;
         ctx.pending_count = &pending_count;
-        ctx.segment = std::make_shared<Segment>(fs, segment_path, segment_id, schema, _tablet_mgr.get());
+        ctx.segment = std::make_shared<Segment>(fs, FileInfo{segment_path}, segment_id, schema, _tablet_mgr.get());
         ctx.mutex = &m;
         ctx.cv = &cv;
         ctx.cache = metacache;

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -190,12 +190,14 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
         // clean the cache
         cache->prune();
         //create the dummy segment and put it into metacache
-        auto dummy_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto dummy_segment =
+                std::make_shared<Segment>(fs, FileInfo{path}, sample_segment->id(), schema, _tablet_mgr.get());
         cache->cache_segment(path, dummy_segment);
         EXPECT_EQ(dummy_segment, cache->lookup_segment(path));
         auto sz1 = cache->memory_usage();
 
-        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto mirror_segment =
+                std::make_shared<Segment>(fs, FileInfo{path}, sample_segment->id(), schema, _tablet_mgr.get());
         auto st = mirror_segment->open(nullptr, nullptr, true);
         EXPECT_TRUE(st.ok());
         auto sz2 = cache->memory_usage();
@@ -208,7 +210,8 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
         // clean the cache
         cache->prune();
         //create the dummy segment and put it into metacache
-        auto mirror_segment = std::make_shared<Segment>(fs, path, sample_segment->id(), schema, _tablet_mgr.get());
+        auto mirror_segment =
+                std::make_shared<Segment>(fs, FileInfo{path}, sample_segment->id(), schema, _tablet_mgr.get());
         cache->cache_segment(path, mirror_segment);
         auto sz1 = cache->memory_usage();
         auto ssz1 = mirror_segment->mem_usage();

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -134,8 +134,10 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_success) {
         rowset->set_overlapped(true);
         rowset->set_id(1);
         auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
         for (auto& file : writer->files()) {
             segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
         }
 
         writer->close();
@@ -273,8 +275,10 @@ TEST_F(LakeAggregateTabletReaderTest, test_read_success) {
         rowset->set_overlapped(true);
         rowset->set_id(1);
         auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
         for (auto& file : writer->files()) {
             segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
         }
 
         writer->close();
@@ -300,8 +304,10 @@ TEST_F(LakeAggregateTabletReaderTest, test_read_success) {
         rowset->set_overlapped(false);
         rowset->set_id(2);
         auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
         for (auto& file : writer->files()) {
             segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
         }
 
         writer->close();
@@ -435,8 +441,10 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteTest, test_read_success) {
         rowset->set_overlapped(true);
         rowset->set_id(1);
         auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
         for (auto& file : writer->files()) {
             segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
         }
 
         writer->close();
@@ -582,8 +590,10 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteNotInOneValueTest, test_read_success) 
         rowset->set_overlapped(true);
         rowset->set_id(1);
         auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
         for (auto& file : writer->files()) {
             segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
         }
 
         writer->close();

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -137,10 +137,12 @@ TEST_P(LakeTabletWriterTest, test_write_success) {
     writer->close();
 
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[0].path),
-                                             0, _tablet_schema));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[1].path),
-                                             1, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0,
+                    Segment::open(fs, FileInfo{_tablet_mgr->segment_location(_tablet_metadata->id(), files[0].path)}, 0,
+                                  _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg1,
+                    Segment::open(fs, FileInfo{_tablet_mgr->segment_location(_tablet_metadata->id(), files[1].path)}, 1,
+                                  _tablet_schema));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;
@@ -226,10 +228,12 @@ TEST_P(LakeTabletWriterTest, test_vertical_write_success) {
     writer->close();
 
     ASSIGN_OR_ABORT(auto fs, FileSystem::CreateSharedFromString(kTestDirectory));
-    ASSIGN_OR_ABORT(auto seg0, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[0].path),
-                                             0, _tablet_schema));
-    ASSIGN_OR_ABORT(auto seg1, Segment::open(fs, _tablet_mgr->segment_location(_tablet_metadata->id(), files[1].path),
-                                             1, _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg0,
+                    Segment::open(fs, FileInfo{_tablet_mgr->segment_location(_tablet_metadata->id(), files[0].path)}, 0,
+                                  _tablet_schema));
+    ASSIGN_OR_ABORT(auto seg1,
+                    Segment::open(fs, FileInfo{_tablet_mgr->segment_location(_tablet_metadata->id(), files[1].path)}, 1,
+                                  _tablet_schema));
 
     OlapReaderStatistics statistics;
     SegmentReadOptions opts;

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -128,8 +128,14 @@ TEST_P(LakeTabletWriterTest, test_write_success) {
     auto files = writer->files();
     ASSERT_EQ(2, files.size());
     ASSERT_NE(files[0].path, files[1].path);
+<<<<<<< HEAD
+=======
+    ASSERT_GT(files[0].size.value(), 0);
+    ASSERT_GT(files[1].size.value(), 0);
+>>>>>>> 9e7e247b40 (reduce head object)
     ASSERT_EQ(2 * segment_rows, writer->num_rows());
     ASSERT_GT(writer->data_size(), 0);
+    ASSERT_EQ(files[1].size.value() + files[1].size.value(), writer->data_size());
 
     writer->close();
 
@@ -214,6 +220,9 @@ TEST_P(LakeTabletWriterTest, test_vertical_write_success) {
     auto files = writer->files();
     ASSERT_EQ(2, files.size());
     ASSERT_NE(files[0].path, files[1].path);
+    ASSERT_GT(files[0].size.value(), 0);
+    ASSERT_GT(files[1].size.value(), 0);
+    ASSERT_EQ(files[1].size.value() + files[1].size.value(), writer->data_size());
     ASSERT_EQ(2 * segment_rows, writer->num_rows());
     ASSERT_GT(writer->data_size(), 0);
 

--- a/be/test/storage/lake/tablet_writer_test.cpp
+++ b/be/test/storage/lake/tablet_writer_test.cpp
@@ -128,11 +128,8 @@ TEST_P(LakeTabletWriterTest, test_write_success) {
     auto files = writer->files();
     ASSERT_EQ(2, files.size());
     ASSERT_NE(files[0].path, files[1].path);
-<<<<<<< HEAD
-=======
     ASSERT_GT(files[0].size.value(), 0);
     ASSERT_GT(files[1].size.value(), 0);
->>>>>>> 9e7e247b40 (reduce head object)
     ASSERT_EQ(2 * segment_rows, writer->num_rows());
     ASSERT_GT(writer->data_size(), 0);
     ASSERT_EQ(files[1].size.value() + files[1].size.value(), writer->data_size());

--- a/be/test/storage/meta_reader_test.cpp
+++ b/be/test/storage/meta_reader_test.cpp
@@ -45,7 +45,7 @@ public:
         uint64_t file_size, index_size, footer_pos;
         EXPECT_OK(writer.finalize(&file_size, &index_size, &footer_pos));
 
-        ASSIGN_OR_ABORT(_segment, Segment::open(fs, segment_name, 0, _tablet_schema));
+        ASSIGN_OR_ABORT(_segment, Segment::open(fs, FileInfo{segment_name}, 0, _tablet_schema));
     }
 
 protected:

--- a/be/test/storage/rowset/column_reader_writer_test.cpp
+++ b/be/test/storage/rowset/column_reader_writer_test.cpp
@@ -99,7 +99,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
     }
 
     template <LogicalType type, EncodingTypePB encoding, uint32_t version>

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -48,7 +48,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
     }
 
     void test_int_map() {

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -333,7 +333,7 @@ void RowsetTest::test_final_merge(bool has_merge_condition = false) {
             seg_options.stats = &_stats;
             std::string segment_file =
                     Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, seg_id);
-            auto segment = *Segment::open(seg_options.fs, segment_file, 0, tablet->tablet_schema());
+            auto segment = *Segment::open(seg_options.fs, FileInfo{segment_file}, 0, tablet->tablet_schema());
             ASSERT_NE(segment->num_rows(), 0);
             auto res = segment->new_iterator(schema, seg_options);
             ASSERT_FALSE(res.status().is_end_of_file() || !res.ok() || res.value() == nullptr);
@@ -493,7 +493,7 @@ TEST_F(RowsetTest, FinalMergeVerticalTest) {
 
             std::string segment_file =
                     Rowset::segment_file_path(writer_context.rowset_path_prefix, writer_context.rowset_id, seg_id);
-            auto segment = *Segment::open(seg_options.fs, segment_file, 0, tablet->tablet_schema());
+            auto segment = *Segment::open(seg_options.fs, FileInfo{segment_file}, 0, tablet->tablet_schema());
 
             ASSERT_NE(segment->num_rows(), 0);
             auto res = segment->new_iterator(schema, seg_options);
@@ -853,7 +853,7 @@ TEST_F(RowsetTest, SegmentWriteTest) {
 
         butil::IOBuf data;
         auto buf = new uint8[seg_info->data_size()];
-        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[](uint8*) buf; });
+        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[] (uint8*)buf; });
 
         ASSERT_TRUE(rfile->read_fully(buf, seg_info->data_size()).ok());
         auto st = segment_rowset_writer->flush_segment(*seg_info, data);
@@ -937,7 +937,7 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
     std::shared_ptr<FileSystem> fs = FileSystem::CreateSharedFromString(rowset->rowset_path()).value();
     std::string file_name = Rowset::segment_file_path(rowset->rowset_path(), rowset->rowset_id(), 0);
 
-    auto partial_segment = *Segment::open(fs, file_name, 0, partial_tablet_schema);
+    auto partial_segment = *Segment::open(fs, FileInfo{file_name}, 0, partial_tablet_schema);
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
     std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
@@ -964,7 +964,7 @@ TEST_F(RowsetTest, SegmentRewriterAutoIncrementTest) {
     ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, tablet_schema, auto_increment_partial_update_state,
                                        column_ids, &write_columns));
 
-    auto segment = *Segment::open(fs, dst_file_name, 0, tablet_schema);
+    auto segment = *Segment::open(fs, FileInfo{dst_file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 }
 
@@ -1018,11 +1018,11 @@ TEST_F(RowsetTest, SegmentDeleteWriteTest) {
     butil::IOBuf data;
     auto buf = new uint8[seg_info->data_size()];
     ASSERT_TRUE(rfile->read_fully(buf, seg_info->data_size()).ok());
-    data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[](uint8*) buf; });
+    data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[] (uint8*)buf; });
 
     auto del_buf = new uint8[seg_info->delete_data_size()];
     ASSERT_TRUE(dfile->read_fully(del_buf, seg_info->delete_data_size()).ok());
-    data.append_user_data(del_buf, seg_info->delete_data_size(), [](void* buf) { delete[](uint8*) buf; });
+    data.append_user_data(del_buf, seg_info->delete_data_size(), [](void* buf) { delete[] (uint8*)buf; });
 
     auto st = segment_rowset_writer->flush_segment(*seg_info, data);
     LOG(INFO) << st;

--- a/be/test/storage/rowset/rowset_test.cpp
+++ b/be/test/storage/rowset/rowset_test.cpp
@@ -853,7 +853,7 @@ TEST_F(RowsetTest, SegmentWriteTest) {
 
         butil::IOBuf data;
         auto buf = new uint8[seg_info->data_size()];
-        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[] (uint8*)buf; });
+        data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[](uint8*) buf; });
 
         ASSERT_TRUE(rfile->read_fully(buf, seg_info->data_size()).ok());
         auto st = segment_rowset_writer->flush_segment(*seg_info, data);
@@ -1018,11 +1018,11 @@ TEST_F(RowsetTest, SegmentDeleteWriteTest) {
     butil::IOBuf data;
     auto buf = new uint8[seg_info->data_size()];
     ASSERT_TRUE(rfile->read_fully(buf, seg_info->data_size()).ok());
-    data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[] (uint8*)buf; });
+    data.append_user_data(buf, seg_info->data_size(), [](void* buf) { delete[](uint8*) buf; });
 
     auto del_buf = new uint8[seg_info->delete_data_size()];
     ASSERT_TRUE(dfile->read_fully(del_buf, seg_info->delete_data_size()).ok());
-    data.append_user_data(del_buf, seg_info->delete_data_size(), [](void* buf) { delete[] (uint8*)buf; });
+    data.append_user_data(del_buf, seg_info->delete_data_size(), [](void* buf) { delete[](uint8*) buf; });
 
     auto st = segment_rowset_writer->flush_segment(*seg_info, data);
     LOG(INFO) << st;

--- a/be/test/storage/rowset/segment_iterator_test.cpp
+++ b/be/test/storage/rowset/segment_iterator_test.cpp
@@ -189,7 +189,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSetWithUnusedColumn) {
     ASSERT_OK(segment_data_builder.finalize_footer());
 
     //
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
@@ -291,7 +291,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDictWithUnusedColumn) {
     ASSERT_OK(segment_data_builder.append(1, slice_provider));
     ASSERT_OK(segment_data_builder.finalize_footer());
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
@@ -385,7 +385,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNotSuperSet) {
     ASSERT_OK(segment_data_builder.append(1, slice_provider));
     ASSERT_OK(segment_data_builder.finalize_footer());
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
@@ -479,7 +479,7 @@ TEST_F(SegmentIteratorTest, TestGlobalDictNoLocalDict) {
     ASSERT_OK(segment_data_builder.append(1, slice_provider));
     ASSERT_OK(segment_data_builder.finalize_footer());
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -118,7 +118,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
         }
     }
 
-    FileInfo file_info{dst_file_name};
+    FileInfo file_info{.path = dst_file_name};
     ASSERT_OK(SegmentRewriter::rewrite(file_name, file_info, tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -99,7 +99,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     partial_rowset_footer.set_position(footer_position);
     partial_rowset_footer.set_size(file_size - footer_position);
 
-    auto partial_segment = *Segment::open(_fs, file_name, 0, partial_tablet_schema);
+    auto partial_segment = *Segment::open(_fs, FileInfo{file_name}, 0, partial_tablet_schema);
     ASSERT_EQ(partial_segment->num_rows(), num_rows);
 
     std::shared_ptr<TabletSchema> tablet_schema = TabletSchemaHelper::create_tablet_schema(
@@ -118,10 +118,11 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
         }
     }
 
-    ASSERT_OK(SegmentRewriter::rewrite(file_name, dst_file_name, tablet_schema, read_column_ids, write_columns,
+    FileInfo file_info{dst_file_name};
+    ASSERT_OK(SegmentRewriter::rewrite(file_name, file_info, tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 
-    auto segment = *Segment::open(_fs, dst_file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{dst_file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
@@ -172,7 +173,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     }
     ASSERT_OK(SegmentRewriter::rewrite(file_name, tablet_schema, read_column_ids, new_write_columns,
                                        partial_segment->id(), partial_rowset_footer));
-    auto rewrite_segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto rewrite_segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
 
     ASSERT_EQ(rewrite_segment->num_rows(), num_rows);
     res = rewrite_segment->new_iterator(schema, seg_options);

--- a/be/test/storage/rowset/segment_rewriter_test.cpp
+++ b/be/test/storage/rowset/segment_rewriter_test.cpp
@@ -119,7 +119,7 @@ TEST_F(SegmentRewriterTest, rewrite_test) {
     }
 
     FileInfo file_info{.path = dst_file_name};
-    ASSERT_OK(SegmentRewriter::rewrite(file_name, file_info, tablet_schema, read_column_ids, write_columns,
+    ASSERT_OK(SegmentRewriter::rewrite(file_name, &file_info, tablet_schema, read_column_ids, write_columns,
                                        partial_segment->id(), partial_rowset_footer));
 
     auto segment = *Segment::open(_fs, FileInfo{dst_file_name}, 0, tablet_schema);

--- a/be/test/storage/rowset/segment_test.cpp
+++ b/be/test/storage/rowset/segment_test.cpp
@@ -106,7 +106,7 @@ protected:
         uint64_t file_size, index_size, footer_position;
         ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-        *res = *Segment::open(_fs, filename, 0, query_schema);
+        *res = *Segment::open(_fs, FileInfo{filename}, 0, query_schema);
         ASSERT_EQ(nrows, (*res)->num_rows());
     }
 
@@ -215,7 +215,7 @@ TEST_F(SegmentReaderWriterTest, TestHorizontalWrite) {
     uint64_t footer_position;
     ASSERT_OK(writer.finalize(&file_size, &index_size, &footer_position));
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
@@ -343,7 +343,7 @@ TEST_F(SegmentReaderWriterTest, TestVerticalWrite) {
 
     ASSERT_OK(writer.finalize_footer(&file_size));
 
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;
@@ -442,7 +442,7 @@ TEST_F(SegmentReaderWriterTest, TestReadMultipleTypesColumn) {
     }
 
     ASSERT_OK(writer.finalize_footer(&file_size));
-    auto segment = *Segment::open(_fs, file_name, 0, tablet_schema);
+    auto segment = *Segment::open(_fs, FileInfo{file_name}, 0, tablet_schema);
     ASSERT_EQ(segment->num_rows(), num_rows);
 
     SegmentReadOptions seg_options;

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -50,7 +50,7 @@ protected:
     void TearDown() override {}
 
     std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
-        return std::make_shared<Segment>(fs, fname, 1, _dummy_segment_schema, nullptr);
+        return std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
     }
 
     void test_int_struct() {

--- a/be/test/storage/segment_flush_executor_test.cpp
+++ b/be/test/storage/segment_flush_executor_test.cpp
@@ -198,7 +198,7 @@ public:
         OlapReaderStatistics stats;
         seg_options.stats = &stats;
         std::string segment_file = Rowset::segment_file_path(_tablet->schema_hash_path(), rowset->rowset_id(), 0);
-        auto segment = *Segment::open(seg_options.fs, segment_file, 0, _tablet->tablet_schema());
+        auto segment = *Segment::open(seg_options.fs, FileInfo{segment_file}, 0, _tablet->tablet_schema());
         ASSERT_EQ(segment->num_rows(), num_rows);
         auto schema = ChunkHelper::convert_schema(_tablet->tablet_schema());
         auto res = segment->new_iterator(schema, seg_options);

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -56,6 +56,7 @@ message RowsetMetadataPB {
     optional DeletePredicatePB delete_predicate = 6;
     // approximate, BE upgrade from old version can't get exact number of dels
     optional int64 num_dels = 7;
+    repeated uint64 segment_size = 8 [packed=true];
 }
 
 


### PR DESCRIPTION
Why I'm doing:
We must get file size though a HeadObject  http request if cache missing before read segment file in shard_data.
What I'm doing:
Reduce the HeadObject by recording the file size in tablet metadata
Fixes #issue
For tpc-ds 100G, 
|Original HeadObject request number| Optimized HeadObejct request numver|
|------|-------|
|551655|46|
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
