### PR TITLE
[Enhancement] refresh row count info immediately after load (backport #36472)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -1310,6 +1310,10 @@ public class OlapTable extends Table {
         return false;
     }
 
+    public boolean isTempPartition(long partitionId) {
+        return tempPartitions.getPartition(partitionId) != null;
+    }
+
     @Override
     public TTableDescriptor toThrift(List<ReferencedPartitionInfo> partitions) {
         TOlapTable tOlapTable = new TOlapTable(getName());

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/AnalyzeMgr.java
@@ -226,6 +226,11 @@ public class AnalyzeMgr implements Writable {
         return basicStatsMetaMap;
     }
 
+    public long getExistUpdateRows(Long tableId) {
+        BasicStatsMeta existInfo =  basicStatsMetaMap.get(tableId);
+        return existInfo == null ? 0 : existInfo.getUpdateRows();
+    }
+
     public void addHistogramStatsMeta(HistogramStatsMeta histogramStatsMeta) {
         histogramStatsMetaMap.put(
                 new Pair<>(histogramStatsMeta.getTableId(), histogramStatsMeta.getColumn()), histogramStatsMeta);
@@ -471,50 +476,32 @@ public class AnalyzeMgr implements Writable {
         }
         TxnCommitAttachment attachment = transactionState.getTxnCommitAttachment();
         if (attachment instanceof RLTaskTxnCommitAttachment) {
-            BasicStatsMeta basicStatsMeta = null;
             if (!transactionState.getTableIdList().isEmpty()) {
-                basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap()
-                        .get(transactionState.getTableIdList().get(0));
-            }
-            if (basicStatsMeta != null) {
-                basicStatsMeta.increaseUpdateRows(((RLTaskTxnCommitAttachment) attachment).getLoadedRows());
+                long tableId = transactionState.getTableIdList().get(0);
+                long loadedRows = ((RLTaskTxnCommitAttachment) attachment).getLoadedRows();
+                updateBasicStatsMeta(db.getId(), tableId, loadedRows);
             }
         } else if (attachment instanceof ManualLoadTxnCommitAttachment) {
-            BasicStatsMeta basicStatsMeta = null;
             if (!transactionState.getTableIdList().isEmpty()) {
-                basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap()
-                        .get(transactionState.getTableIdList().get(0));
-            }
-            if (basicStatsMeta != null) {
-                basicStatsMeta.increaseUpdateRows(((ManualLoadTxnCommitAttachment) attachment).getLoadedRows());
+                long tableId = transactionState.getTableIdList().get(0);
+                long loadedRows = ((ManualLoadTxnCommitAttachment) attachment).getLoadedRows();
+                updateBasicStatsMeta(db.getId(), tableId, loadedRows);
             }
         } else if (attachment instanceof LoadJobFinalOperation) {
             LoadJobFinalOperation loadJobFinalOperation = (LoadJobFinalOperation) attachment;
             loadJobFinalOperation.getLoadingStatus().travelTableCounters(
-                    kv -> {
-                        BasicStatsMeta basicStatsMeta =
-                                GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().get(kv.getKey());
-                        if (basicStatsMeta != null) {
-                            basicStatsMeta.increaseUpdateRows(kv.getValue().get(TableMetricsEntity.TABLE_LOAD_ROWS));
-                        }
-                    }
+                    kv -> updateBasicStatsMeta(db.getId(), kv.getKey(), kv.getValue().get(TableMetricsEntity.TABLE_LOAD_ROWS))
             );
         } else if (attachment instanceof InsertTxnCommitAttachment) {
             BasicStatsMeta basicStatsMeta = null;
             if (!transactionState.getTableIdList().isEmpty()) {
-                basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap()
-                        .get(transactionState.getTableIdList().get(0));
-            }
-            if (basicStatsMeta != null) {
+                long tableId = transactionState.getTableIdList().get(0);
                 long loadRows = ((InsertTxnCommitAttachment) attachment).getLoadedRows();
                 if (loadRows == 0) {
-                    OlapTable table = (OlapTable) db.getTable(basicStatsMeta.getTableId());
-                    if (table != null) {
-                        basicStatsMeta.increaseUpdateRows(table.getRowCount());
-                    }
-                } else {
-                    basicStatsMeta.increaseUpdateRows(((InsertTxnCommitAttachment) attachment).getLoadedRows());
+                    OlapTable table = (OlapTable) db.getTable(tableId);
+                    loadRows = table != null ? table.getRowCount() : 0;
                 }
+                updateBasicStatsMeta(db.getId(), tableId, loadRows);
             }
         }
     }
@@ -640,6 +627,18 @@ public class AnalyzeMgr implements Writable {
         for (int i = 0; i < histogramStatsMetaSize; ++i) {
             HistogramStatsMeta histogramStatsMeta = reader.readJson(HistogramStatsMeta.class);
             replayAddHistogramStatsMeta(histogramStatsMeta);
+        }
+    }
+
+    private void updateBasicStatsMeta(long dbId, long tableId, long loadedRows) {
+        BasicStatsMeta basicStatsMeta = GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().get(tableId);
+        if (basicStatsMeta == null) {
+            // first load without analyze op, we need fill a meta with loaded rows for cardinality estimation
+            BasicStatsMeta meta = new BasicStatsMeta(dbId, tableId, Lists.newArrayList(),
+                    StatsConstants.AnalyzeType.SAMPLE, LocalDateTime.now(), Maps.newHashMap(), loadedRows);
+            GlobalStateMgr.getCurrentAnalyzeMgr().getBasicStatsMetaMap().put(tableId, meta);
+        } else {
+            basicStatsMeta.increaseUpdateRows(loadedRows);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/BasicStatsMeta.java
@@ -18,11 +18,11 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
-import com.starrocks.common.Config;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.statistics.TableStatistic;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -51,6 +51,9 @@ public class BasicStatsMeta implements Writable {
     @SerializedName("properties")
     private Map<String, String> properties;
 
+    // The old semantics indicated the increment of ingestion tasks after last statistical collect job.
+    // Since manually collecting sampled job would reset it to zero, affecting the incremental information,
+    // it is now changed to record the total number of rows in the table.
     @SerializedName("updateRows")
     private long updateRows;
 
@@ -58,13 +61,21 @@ public class BasicStatsMeta implements Writable {
                           StatsConstants.AnalyzeType type,
                           LocalDateTime updateTime,
                           Map<String, String> properties) {
+        this(dbId, tableId, columns, type, updateTime, properties, 0);
+    }
+
+    public BasicStatsMeta(long dbId, long tableId, List<String> columns,
+                          StatsConstants.AnalyzeType type,
+                          LocalDateTime updateTime,
+                          Map<String, String> properties,
+                          long updateRows) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.columns = columns;
         this.type = type;
         this.updateTime = updateTime;
         this.properties = properties;
-        this.updateRows = 0;
+        this.updateRows = updateRows;
     }
 
     @Override
@@ -111,29 +122,24 @@ public class BasicStatsMeta implements Writable {
         Database database = GlobalStateMgr.getCurrentState().getDb(dbId);
         OlapTable table = (OlapTable) database.getTable(tableId);
         long totalPartitionCount = table.getPartitions().size();
-        long updatePartitionRowCount = 0;
-        long updatePartitionCount = 0;
+
+        long tableRowCount = 1L;
+        long cachedTableRowCount = 1L;
+        long updatePartitionRowCount = 0L;
+        long updatePartitionCount = 0L;
         for (Partition partition : table.getPartitions()) {
-            if (!partition.hasData()) {
-                // skip init empty partition
-                continue;
+            tableRowCount += partition.getRowCount();
+            TableStatistic tableStatistic = GlobalStateMgr.getCurrentStatisticStorage()
+                    .getTableStatistic(table.getId(), partition.getId());
+            if (tableStatistic != null) {
+                cachedTableRowCount += tableStatistic.getRowCount();
             }
-
             LocalDateTime loadTimes = StatisticUtils.getPartitionLastUpdateTime(partition);
-            if (updateTime.isAfter(loadTimes)) {
-                continue;
+            if (partition.hasData() && updateTime.isBefore(loadTimes)) {
+                updatePartitionCount++;
             }
-
-            updatePartitionCount++;
-            updatePartitionRowCount += partition.getRowCount();
         }
-
-        // promise new partitions row count
-        LocalDateTime updateRowCountTimes = GlobalStateMgr.getCurrentTabletStatMgr().getLastWorkTimestamp();
-        if (StatisticUtils.getTableLastUpdateTime(table).plusSeconds(Config.tablet_stat_update_interval_second)
-                .isAfter(updateRowCountTimes)) {
-            updatePartitionRowCount += updateRows;
-        }
+        updatePartitionRowCount = Math.max(1, Math.max(tableRowCount, updateRows) - cachedTableRowCount);
 
         double updateRatio;
         // 1. If none updated partitions, health is 1
@@ -153,6 +159,10 @@ public class BasicStatsMeta implements Writable {
 
     public long getUpdateRows() {
         return updateRows;
+    }
+
+    public void setUpdateRows(Long updateRows) {
+        this.updateRows = updateRows;
     }
 
     public void increaseUpdateRows(Long delta) {

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -289,8 +289,10 @@ public class StatisticExecutor {
                         Lists.newArrayList(histogramStatsMeta.getColumn()), refreshAsync);
             }
         } else {
+            long existUpdateRows = GlobalStateMgr.getCurrentAnalyzeMgr().getExistUpdateRows(table.getId());
             BasicStatsMeta basicStatsMeta = new BasicStatsMeta(db.getId(), table.getId(),
-                    statsJob.getColumns(), statsJob.getType(), analyzeStatus.getEndTime(), statsJob.getProperties());
+                    statsJob.getColumns(), statsJob.getType(), analyzeStatus.getEndTime(),
+                    statsJob.getProperties(), existUpdateRows);
             GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(basicStatsMeta);
             GlobalStateMgr.getCurrentAnalyzeMgr().refreshBasicStatisticsCache(
                     basicStatsMeta.getDbId(), basicStatsMeta.getTableId(), basicStatsMeta.getColumns(), refreshAsync);

--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticsMetaManager.java
@@ -268,7 +268,8 @@ public class StatisticsMetaManager extends FrontendDaemon {
             BasicStatsMeta basicStatsMeta = entry.getValue();
             GlobalStateMgr.getCurrentAnalyzeMgr().addBasicStatsMeta(new BasicStatsMeta(
                     basicStatsMeta.getDbId(), basicStatsMeta.getTableId(), basicStatsMeta.getColumns(),
-                    basicStatsMeta.getType(), LocalDateTime.MIN, basicStatsMeta.getProperties()));
+                    basicStatsMeta.getType(), LocalDateTime.MIN, basicStatsMeta.getProperties(),
+                    basicStatsMeta.getUpdateRows()));
         }
 
         for (AnalyzeJob analyzeJob : GlobalStateMgr.getCurrentAnalyzeMgr().getAllAnalyzeJobList()) {


### PR DESCRIPTION
Why I'm doing:
cannot obatin a correct row count immediately after load which may lead a bad plan.

What I'm doing:
use loaded rows from load task to help us estimate a more accurate row count .

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
