### PR TITLE
[BugFix] Fix DataStreamRecvr profile use-after-free

### DIFF
--- a/be/src/exec/exchange_node.cpp
+++ b/be/src/exec/exchange_node.cpp
@@ -87,7 +87,7 @@ Status ExchangeNode::prepare(RuntimeState* state) {
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _input_row_desc, state->fragment_instance_id(), _id, _num_senders,
             config::exchg_node_buffer_size_bytes, _is_merging, _sub_plan_query_statistics_recvr, false, 1, false);
-    _stream_recvr->bind_profile(0, _runtime_profile.get());
+    _stream_recvr->bind_profile(0, _runtime_profile);
     if (_is_merging) {
         RETURN_IF_ERROR(_sort_exec_exprs.prepare(state, _row_descriptor, _row_descriptor));
     }

--- a/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_merge_sort_source_operator.cpp
@@ -28,7 +28,7 @@ Status ExchangeMergeSortSourceOperator::prepare(RuntimeState* state) {
     _stream_recvr = state->exec_env()->stream_mgr()->create_recvr(
             state, _row_desc, state->fragment_instance_id(), _plan_node_id, _num_sender,
             config::exchg_node_buffer_size_bytes, true, query_statistic_recv, true, 1, true);
-    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics.get());
+    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics);
     return _stream_recvr->create_merger_for_pipeline(state, _sort_exec_exprs, &_is_asc_order, &_nulls_first);
 }
 

--- a/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_parallel_merge_source_operator.cpp
@@ -25,7 +25,7 @@ Status ExchangeParallelMergeSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
     auto* factory = down_cast<ExchangeParallelMergeSourceOperatorFactory*>(_factory);
     _stream_recvr = factory->get_stream_recvr(state);
-    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics.get());
+    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics);
     _merger = factory->get_merge_path_merger(state);
     _merger->bind_profile(_driver_sequence, _unique_metrics.get());
     return Status::OK();

--- a/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
+++ b/be/src/exec/pipeline/exchange/exchange_source_operator.cpp
@@ -25,7 +25,7 @@ namespace starrocks::pipeline {
 Status ExchangeSourceOperator::prepare(RuntimeState* state) {
     RETURN_IF_ERROR(SourceOperator::prepare(state));
     _stream_recvr = static_cast<ExchangeSourceOperatorFactory*>(_factory)->create_stream_recvr(state);
-    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics.get());
+    _stream_recvr->bind_profile(_driver_sequence, _unique_metrics);
     return Status::OK();
 }
 

--- a/be/src/runtime/data_stream_recvr.cpp
+++ b/be/src/runtime/data_stream_recvr.cpp
@@ -195,12 +195,13 @@ DataStreamRecvr::DataStreamRecvr(DataStreamMgr* stream_mgr, RuntimeState* runtim
     }
 }
 
-void DataStreamRecvr::bind_profile(int32_t driver_sequence, RuntimeProfile* profile) {
+void DataStreamRecvr::bind_profile(int32_t driver_sequence, const std::shared_ptr<RuntimeProfile>& profile) {
     DCHECK(profile != nullptr);
     DCHECK_GE(driver_sequence, 0);
     DCHECK_LT(driver_sequence, _metrics.size());
     auto& statistics = _metrics[driver_sequence];
 
+    statistics.runtime_profile = profile;
     statistics.bytes_received_counter = ADD_COUNTER(profile, "BytesReceived", TUnit::BYTES);
     statistics.bytes_pass_through_counter = ADD_COUNTER(profile, "BytesPassThrough", TUnit::BYTES);
     statistics.request_received_counter = ADD_COUNTER(profile, "RequestReceived", TUnit::UNIT);

--- a/be/src/runtime/data_stream_recvr.h
+++ b/be/src/runtime/data_stream_recvr.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <memory>
+
 #include "column/vectorized_fwd.h"
 #include "common/object_pool.h"
 #include "common/status.h"
@@ -87,7 +89,7 @@ class SortExecExprs;
 class DataStreamRecvr {
 public:
     ~DataStreamRecvr();
-    void bind_profile(int32_t driver_sequence, RuntimeProfile* profile);
+    void bind_profile(int32_t driver_sequence, const std::shared_ptr<RuntimeProfile>& profile);
 
     Status get_chunk(std::unique_ptr<Chunk>* chunk);
     Status get_chunk_for_pipeline(std::unique_ptr<Chunk>* chunk, const int32_t driver_sequence);
@@ -201,6 +203,7 @@ private:
     std::shared_ptr<MemTracker> _instance_mem_tracker;
 
     struct Metrics {
+        std::shared_ptr<RuntimeProfile> runtime_profile;
         // Number of bytes received
         RuntimeProfile::Counter* bytes_received_counter = nullptr;
         RuntimeProfile::Counter* bytes_pass_through_counter = nullptr;


### PR DESCRIPTION
Why I'm doing:

Suppose a query is a short-circuited query, and the query execution is ready to finish on Fragment A of some BE, when some rpc from another BE arrives. If Fragment A destructs. At this point SenderQueue access to the profile object will result in use-after-free. our DataStreamRecvr needs to satisfy closure.

What I'm doing:

hold reference in DataStreamRecvr

Fixes  https://github.com/StarRocks/StarRocksTest/issues/4868
![image](https://github.com/StarRocks/starrocks/assets/34912776/e128b141-a2f5-456c-822e-3bceb285539d)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
