### PR TITLE
Fix spark connector push down

### DIFF
--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -695,6 +695,9 @@ Status DescriptorTbl::create(RuntimeState* state, ObjectPool* pool, const TDescr
     for (const auto& tdesc : thrift_tbl.slotDescriptors) {
         SlotDescriptor* slot_d = pool->add(new SlotDescriptor(tdesc));
         (*tbl)->_slot_desc_map[tdesc.id] = slot_d;
+        if (!slot_d->col_name().empty()) {
+            (*tbl)->_slot_with_column_name_map[tdesc.id] = slot_d;
+        }
 
         // link to parent
         auto entry = (*tbl)->_tuple_desc_map.find(tdesc.parent);
@@ -732,6 +735,17 @@ SlotDescriptor* DescriptorTbl::get_slot_descriptor(SlotId id) const {
     auto i = _slot_desc_map.find(id);
 
     if (i == _slot_desc_map.end()) {
+        return nullptr;
+    } else {
+        return i->second;
+    }
+}
+
+SlotDescriptor* DescriptorTbl::get_slot_descriptor_with_column(SlotId id) const {
+    // TODO: is there some boost function to do exactly this?
+    auto i = _slot_with_column_name_map.find(id);
+
+    if (i == _slot_with_column_name_map.end()) {
         return nullptr;
     } else {
         return i->second;

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -430,6 +430,7 @@ public:
     TableDescriptor* get_table_descriptor(TableId id) const;
     TupleDescriptor* get_tuple_descriptor(TupleId id) const;
     SlotDescriptor* get_slot_descriptor(SlotId id) const;
+    SlotDescriptor* get_slot_descriptor_with_column(SlotId id) const;
 
     // return all registered tuple descriptors
     void get_tuple_descs(std::vector<TupleDescriptor*>* descs) const;
@@ -444,6 +445,7 @@ private:
     TableDescriptorMap _tbl_desc_map;
     TupleDescriptorMap _tuple_desc_map;
     SlotDescriptorMap _slot_desc_map;
+    SlotDescriptorMap _slot_with_column_name_map;
 
     DescriptorTbl() = default;
 };

--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -422,8 +422,7 @@ Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params) {
 }
 
 Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, const FinishCallback& cb) {
-    return exec_plan_fragment(
-            params, [](auto&& PH1) { return empty_function(std::forward<decltype(PH1)>(PH1)); }, cb);
+    return exec_plan_fragment(params, [](auto&& PH1) { return empty_function(std::forward<decltype(PH1)>(PH1)); }, cb);
 }
 
 Status FragmentMgr::exec_plan_fragment(const TExecPlanFragmentParams& params, const StartSuccCallback& start_cb,
@@ -858,7 +857,7 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
             LOG(WARNING) << "tuple descriptor is null. id: " << slot_ref.tuple_id;
             return Status::InvalidArgument("tuple descriptor is null");
         }
-        auto* slot_desc = desc_tbl->get_slot_descriptor(slot_ref.slot_id);
+        auto* slot_desc = desc_tbl->get_slot_descriptor_with_column(slot_ref.slot_id);
         if (slot_desc == nullptr) {
             LOG(WARNING) << "slot descriptor is null. id: " << slot_ref.slot_id;
             return Status::InvalidArgument("slot descriptor is null");


### PR DESCRIPTION
Why I'm doing:

when spark execute sql like that columns in selectClause but not in whereClause, slotDesc will contain null columnName, 
```
select  k1, k2 from tb1 where v1 > 3 

```
but spark-sr-connector use it to pushdown filter .so it will cause error

What I'm doing:

Fixes #issue

## What type of PR is this:

- [* ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
