### PR TITLE
[Enhancement] Skip read pindex when we pick all rowsets to do compaction for primary key table

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -295,7 +295,7 @@ CONF_mInt64(max_compaction_candidate_num, "40960");
 
 CONF_mInt32(update_compaction_check_interval_seconds, "60");
 CONF_mInt32(update_compaction_num_threads_per_disk, "1");
-CONF_Int32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
+CONF_mInt32(update_compaction_per_tablet_min_interval_seconds, "120"); // 2min
 CONF_mInt64(max_update_compaction_num_singleton_deltas, "1000");
 CONF_mInt64(update_compaction_size_threshold, "268435456");
 CONF_mInt64(update_compaction_result_bytes, "1073741824");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1053,6 +1053,9 @@ CONF_mBool(enable_pindex_compression, "true");
 // filter bytes is less or equal than 10% of pindex bytes, we will use bloom filter to filter some records
 CONF_mInt32(max_bf_read_bytes_percent, "10");
 
+// If primary compaction pick all rowsets, we could rebuild pindex directly and skip read from index.
+CONF_mBool(enable_pindex_rebuild_in_compaction, "true");
+
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -745,6 +745,10 @@ public:
         return res;
     }
 
+    Status reset();
+
+    void reset_cancel_major_compaction();
+
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,
                                       const EditVersionWithMerge& min_l2_version);
@@ -849,6 +853,8 @@ protected:
     std::vector<EditVersionWithMerge> _l2_versions;
     // all l2
     std::vector<std::unique_ptr<ImmutableIndex>> _l2_vec;
+    
+    bool _cancel_major_compaction = false;
 
 private:
     bool _need_bloom_filter = false;

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -361,6 +361,8 @@ public:
 
     void clear();
 
+    Status create_index_file(std::string& path);
+
     static StatusOr<std::unique_ptr<ShardByLengthMutableIndex>> create(size_t key_size, const std::string& path);
 
 private:
@@ -745,7 +747,7 @@ public:
         return res;
     }
 
-    Status reset();
+    Status reset(Tablet* tablet, EditVersion version);
 
     void reset_cancel_major_compaction();
 
@@ -853,7 +855,7 @@ protected:
     std::vector<EditVersionWithMerge> _l2_versions;
     // all l2
     std::vector<std::unique_ptr<ImmutableIndex>> _l2_vec;
-    
+
     bool _cancel_major_compaction = false;
 
 private:

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -747,7 +747,7 @@ public:
         return res;
     }
 
-    Status reset(Tablet* tablet, EditVersion version);
+    Status reset(Tablet* tablet, EditVersion version, PersistentIndexMetaPB* index_meta);
 
     void reset_cancel_major_compaction();
 

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1415,7 +1415,7 @@ Status PrimaryIndex::major_compaction(Tablet* tablet) {
     }
 }
 
-Status PrimaryIndex::reset(Tablet* tablet, EditVersion version) {
+Status PrimaryIndex::reset(Tablet* tablet, EditVersion version, PersistentIndexMetaPB* index_meta) {
     _table_id = tablet->belonged_table_id();
     _tablet_id = tablet->tablet_id();
     const TabletSchemaCSPtr tablet_schema_ptr = tablet->tablet_schema();
@@ -1433,7 +1433,7 @@ Status PrimaryIndex::reset(Tablet* tablet, EditVersion version) {
             _persistent_index.reset();
         }
         _persistent_index = std::make_unique<PersistentIndex>(tablet->schema_hash_path());
-        RETURN_IF_ERROR(_persistent_index->reset(tablet, version));
+        RETURN_IF_ERROR(_persistent_index->reset(tablet, version, index_meta));
     } else {
         if (_pkey_to_rssid_rowid != nullptr) {
             _pkey_to_rssid_rowid.reset();

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1414,4 +1414,20 @@ Status PrimaryIndex::major_compaction(Tablet* tablet) {
     }
 }
 
+Status PrimaryIndex::reset() {
+    if (_persistent_index != nullptr) {
+        return _persistent_index->reset();
+    } else {
+        _pkey_to_rssid_rowid.reset();
+        _pkey_to_rssid_rowid = create_hash_index(_enc_pk_type, _key_size);
+    }
+    return Status::OK();
+}
+
+void PrimaryIndex::reset_cancel_major_compaction() {
+    if (_persistent_index != nullptr) {
+        _persistent_index->reset_cancel_major_compaction();
+    }
+}
+
 } // namespace starrocks

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1278,9 +1278,10 @@ Status PrimaryIndex::insert(uint32_t rssid, const vector<uint32_t>& rowids, cons
     DCHECK(_status.ok() && (_pkey_to_rssid_rowid || _persistent_index));
     if (_persistent_index != nullptr) {
         auto scope = IOProfiler::scope(IOProfiler::TAG_PKINDEX, _tablet_id);
-        RETURN_IF_ERROR(_insert_into_persistent_index(rssid, rowids, pks));
+        return _insert_into_persistent_index(rssid, rowids, pks);
+    } else {
+        return _pkey_to_rssid_rowid->insert(rssid, rowids, pks, 0, pks.size());
     }
-    return _pkey_to_rssid_rowid->insert(rssid, rowids, pks, 0, pks.size());
 }
 
 Status PrimaryIndex::insert(uint32_t rssid, uint32_t rowid_start, const Column& pks) {
@@ -1414,13 +1415,33 @@ Status PrimaryIndex::major_compaction(Tablet* tablet) {
     }
 }
 
-Status PrimaryIndex::reset() {
-    if (_persistent_index != nullptr) {
-        return _persistent_index->reset();
+Status PrimaryIndex::reset(Tablet* tablet, EditVersion version) {
+    _table_id = tablet->belonged_table_id();
+    _tablet_id = tablet->tablet_id();
+    const TabletSchemaCSPtr tablet_schema_ptr = tablet->tablet_schema();
+    vector<ColumnId> pk_columns(tablet_schema_ptr->num_key_columns());
+    for (auto i = 0; i < tablet_schema_ptr->num_key_columns(); i++) {
+        pk_columns[i] = (ColumnId)i;
+    }
+    auto pkey_schema = ChunkHelper::convert_schema(tablet_schema_ptr, pk_columns);
+    _set_schema(pkey_schema);
+
+    size_t fix_size = PrimaryKeyEncoder::get_encoded_fixed_size(_pk_schema);
+
+    if (tablet->get_enable_persistent_index() && (fix_size <= 128)) {
+        if (_persistent_index != nullptr) {
+            _persistent_index.reset();
+        }
+        _persistent_index = std::make_unique<PersistentIndex>(tablet->schema_hash_path());
+        RETURN_IF_ERROR(_persistent_index->reset(tablet, version));
     } else {
-        _pkey_to_rssid_rowid.reset();
+        if (_pkey_to_rssid_rowid != nullptr) {
+            _pkey_to_rssid_rowid.reset();
+        }
         _pkey_to_rssid_rowid = create_hash_index(_enc_pk_type, _key_size);
     }
+    _loaded = true;
+
     return Status::OK();
 }
 

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -135,6 +135,10 @@ public:
 
     size_t key_size() { return _key_size; }
 
+    Status reset();
+
+    void reset_cancel_major_compaction();
+
 protected:
     void _set_schema(const Schema& pk_schema);
 

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -135,7 +135,7 @@ public:
 
     size_t key_size() { return _key_size; }
 
-    Status reset();
+    Status reset(Tablet* tablet, EditVersion version);
 
     void reset_cancel_major_compaction();
 

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -135,7 +135,7 @@ public:
 
     size_t key_size() { return _key_size; }
 
-    Status reset(Tablet* tablet, EditVersion version);
+    Status reset(Tablet* tablet, EditVersion version, PersistentIndexMetaPB* index_meta);
 
     void reset_cancel_major_compaction();
 

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1941,11 +1941,11 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     bool rebuild_index = (version_info.rowsets.size() == 1 && config::enable_pindex_rebuild_in_compaction);
     // only one output rowset, compaction pick all rowsets, so we can skip pindex read and rebuild index
     if (rebuild_index) {
-        st = index.reset();
+        st = index.reset(&_tablet, version_info.version);
     } else {
         st = index.load(&_tablet);
     }
-    
+
     manager->index_cache().update_object_size(index_entry, index.memory_usage());
     // `enable_persistent_index` of tablet maybe change by alter, we should get `enable_persistent_index` from index to
     // avoid inconsistency between persistent index file and PersistentIndexMeta

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1938,7 +1938,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     index_entry->update_expire_time(MonotonicMillis() + manager->get_index_cache_expire_ms(_tablet));
     auto& index = index_entry->value();
     Status st;
-    bool rebuild_index = (version_info.rowsets.size() == 1);
+    bool rebuild_index = (version_info.rowsets.size() == 1 && config::enable_pindex_rebuild_in_compaction);
     // only one output rowset, compaction pick all rowsets, so we can skip pindex read and rebuild index
     if (rebuild_index) {
         st = index.reset();

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -1937,27 +1937,39 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     auto index_entry = manager->index_cache().get_or_create(tablet_id);
     index_entry->update_expire_time(MonotonicMillis() + manager->get_index_cache_expire_ms(_tablet));
     auto& index = index_entry->value();
+
     Status st;
+    // `enable_persistent_index` of tablet maybe change by alter, we should get `enable_persistent_index` from index to
+    // avoid inconsistency between persistent index file and PersistentIndexMeta
+    bool enable_persistent_index = index.enable_persistent_index();
+    PersistentIndexMetaPB index_meta;
+    if (enable_persistent_index) {
+        st = TabletMetaManager::get_persistent_index_meta(_tablet.data_dir(), tablet_id, &index_meta);
+        if (!st.ok() && !st.is_not_found()) {
+            std::string msg = strings::Substitute("get persistent index meta failed: $0 $1", st.to_string(),
+                                                  _debug_string(false, true));
+            failure_handler(msg);
+            return;
+        }
+    }
+
     bool rebuild_index = (version_info.rowsets.size() == 1 && config::enable_pindex_rebuild_in_compaction);
     // only one output rowset, compaction pick all rowsets, so we can skip pindex read and rebuild index
     if (rebuild_index) {
-        st = index.reset(&_tablet, version_info.version);
+        st = index.reset(&_tablet, version_info.version, &index_meta);
     } else {
         st = index.load(&_tablet);
     }
 
     manager->index_cache().update_object_size(index_entry, index.memory_usage());
-    // `enable_persistent_index` of tablet maybe change by alter, we should get `enable_persistent_index` from index to
-    // avoid inconsistency between persistent index file and PersistentIndexMeta
-    bool enable_persistent_index = index.enable_persistent_index();
     // release or remove index entry when function end
     DeferOp index_defer([&]() {
+        index.reset_cancel_major_compaction();
         if (enable_persistent_index ^ _tablet.get_enable_persistent_index()) {
             manager->index_cache().remove(index_entry);
         } else {
             manager->index_cache().release(index_entry);
         }
-        index.reset_cancel_major_compaction();
     });
     if (!st.ok()) {
         manager->index_cache().remove(index_entry);
@@ -2054,16 +2066,6 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
     _compaction_state.reset();
     int64_t t_index_delvec = MonotonicMillis();
 
-    PersistentIndexMetaPB index_meta;
-    if (enable_persistent_index) {
-        st = TabletMetaManager::get_persistent_index_meta(_tablet.data_dir(), tablet_id, &index_meta);
-        if (!st.ok() && !st.is_not_found()) {
-            std::string msg = strings::Substitute("get persistent index meta failed: $0 $1", st.to_string(),
-                                                  _debug_string(false, true));
-            failure_handler(msg);
-            return;
-        }
-    }
     st = index.commit(&index_meta);
     if (!st.ok()) {
         std::string msg =


### PR DESCRIPTION
Why I'm doing:

At the last step of primary key table, we need to update pindex and we will read the pindex first and update pindex. If we pick all rowsets to compaction, read pindex is not necessary and we could rebuild pindex directly, it could reduce the disk read IO.

What I'm doing:

Skip pindex read and rebuild pindex directly if compaction pick all rowsets.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
