### PR TITLE
[Refactor] Get tablet schema from metadata when doing schema changes in shared data mode

### DIFF
--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -47,8 +47,7 @@ Status HorizontalCompactionTask::execute(Progress* progress, CancelFunc cancel_f
     VLOG(3) << "Start horizontal compaction. tablet: " << _tablet.id() << ", reader chunk size: " << chunk_size;
 
     Schema schema = ChunkHelper::convert_schema(tablet_schema);
-    Tablet tablet(_tablet.tablet_manager(), _tablet.id());
-    TabletReader reader(tablet, _tablet.version(), schema, _input_rowsets);
+    TabletReader reader(_tablet.tablet_manager(), _tablet.metadata(), schema, _input_rowsets);
     RETURN_IF_ERROR(reader.prepare());
     TabletReaderParams reader_params;
     reader_params.reader_type = READER_CUMULATIVE_COMPACTION;

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -23,11 +23,23 @@
 #include "storage/lake/rowset.h"
 #include "storage/lake/tablet_reader.h"
 #include "storage/lake/tablet_writer.h"
+#include "storage/lake/versioned_tablet.h"
 #include "storage/schema_change_utils.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_reader_params.h"
 
 namespace starrocks::lake {
+
+struct SchemaChangeParams {
+    VersionedTablet base_tablet;
+    VersionedTablet new_tablet;
+    int64_t txn_id;
+    MaterializedViewParamMap materialized_params_map;
+    std::unique_ptr<TExpr> where_expr;
+    bool sc_sorting = false;
+    bool sc_directly = false;
+    std::unique_ptr<ChunkChanger> chunk_changer = nullptr;
+};
 
 class SchemaChange {
 public:
@@ -57,15 +69,12 @@ public:
 
 class ConvertedSchemaChange : public SchemaChange {
 public:
-    explicit ConvertedSchemaChange(TabletManager* tablet_manager, int64_t txn_id, Tablet* base_tablet,
-                                   Tablet* new_tablet, int64_t version, ChunkChanger* chunk_changer)
+    explicit ConvertedSchemaChange(TabletManager* tablet_manager, int64_t txn_id, VersionedTablet base_tablet,
+                                   VersionedTablet new_tablet, ChunkChanger* chunk_changer)
             : SchemaChange(tablet_manager, txn_id),
-              _base_tablet(base_tablet),
-              _new_tablet(new_tablet),
-              _version(version),
+              _base_tablet(std::move(base_tablet)),
+              _new_tablet(std::move(new_tablet)),
               _chunk_changer(chunk_changer) {
-        CHECK(_base_tablet != nullptr);
-        CHECK(_new_tablet != nullptr);
         CHECK(_chunk_changer != nullptr);
     }
 
@@ -74,9 +83,8 @@ public:
     Status init() override;
 
 protected:
-    Tablet* _base_tablet = nullptr;
-    Tablet* _new_tablet = nullptr;
-    int64_t _version = 0;
+    VersionedTablet _base_tablet;
+    VersionedTablet _new_tablet;
     ChunkChanger* _chunk_changer = nullptr;
 
     TabletReaderParams _read_params;
@@ -92,9 +100,10 @@ protected:
 
 class DirectSchemaChange final : public ConvertedSchemaChange {
 public:
-    explicit DirectSchemaChange(TabletManager* tablet_manager, int64_t txn_id, Tablet* base_tablet, Tablet* new_tablet,
-                                int64_t version, ChunkChanger* chunk_changer)
-            : ConvertedSchemaChange(tablet_manager, txn_id, base_tablet, new_tablet, version, chunk_changer) {}
+    explicit DirectSchemaChange(TabletManager* tablet_manager, int64_t txn_id, VersionedTablet base_tablet,
+                                VersionedTablet new_tablet, ChunkChanger* chunk_changer)
+            : ConvertedSchemaChange(tablet_manager, txn_id, std::move(base_tablet), std::move(new_tablet),
+                                    chunk_changer) {}
 
     ~DirectSchemaChange() override = default;
 
@@ -105,9 +114,10 @@ public:
 
 class SortedSchemaChange final : public ConvertedSchemaChange {
 public:
-    explicit SortedSchemaChange(TabletManager* tablet_manager, int64_t txn_id, Tablet* base_tablet, Tablet* new_tablet,
-                                int64_t version, ChunkChanger* chunk_changer, size_t memory_limitation)
-            : ConvertedSchemaChange(tablet_manager, txn_id, base_tablet, new_tablet, version, chunk_changer),
+    explicit SortedSchemaChange(TabletManager* tablet_manager, int64_t txn_id, VersionedTablet base_tablet,
+                                VersionedTablet new_tablet, ChunkChanger* chunk_changer, size_t memory_limitation)
+            : ConvertedSchemaChange(tablet_manager, txn_id, std::move(base_tablet), std::move(new_tablet),
+                                    chunk_changer),
               _memory_limitation(memory_limitation) {}
 
     ~SortedSchemaChange() override = default;
@@ -136,9 +146,9 @@ Status ConvertedSchemaChange::init() {
     _read_params.fill_data_cache = false;
     _read_params.sorted_by_keys_per_tablet = true;
 
-    ASSIGN_OR_RETURN(auto base_tablet_schema, _base_tablet->get_schema());
+    auto base_tablet_schema = _base_tablet.get_schema();
     _base_schema = ChunkHelper::convert_schema(base_tablet_schema, _chunk_changer->get_selected_column_indexes());
-    ASSIGN_OR_RETURN(_new_tablet_schema, _new_tablet->get_schema());
+    _new_tablet_schema = _new_tablet.get_schema();
     _new_schema = ChunkHelper::convert_schema(_new_tablet_schema);
 
     _base_chunk = ChunkHelper::new_chunk(_base_schema, config::vector_chunk_size);
@@ -151,12 +161,13 @@ Status ConvertedSchemaChange::init() {
 
 Status DirectSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_metadata) {
     // create reader
-    auto reader = std::make_unique<TabletReader>(*_base_tablet, _version, _base_schema, std::vector<RowsetPtr>{rowset});
+    auto reader = std::make_unique<TabletReader>(_base_tablet.tablet_manager(), _base_tablet.metadata(), _base_schema,
+                                                 std::vector<RowsetPtr>{rowset});
     RETURN_IF_ERROR(reader->prepare());
     RETURN_IF_ERROR(reader->open(_read_params));
 
     // create writer
-    ASSIGN_OR_RETURN(auto writer, _new_tablet->new_writer(kHorizontal, _txn_id));
+    ASSIGN_OR_RETURN(auto writer, _new_tablet.new_writer(kHorizontal, _txn_id));
     RETURN_IF_ERROR(writer->open());
     DeferOp defer([&]() { writer->close(); });
 
@@ -219,14 +230,15 @@ Status SortedSchemaChange::init() {
 
 Status SortedSchemaChange::process(RowsetPtr rowset, RowsetMetadata* new_rowset_metadata) {
     // create reader
-    auto reader = std::make_unique<TabletReader>(*_base_tablet, _version, _base_schema, std::vector<RowsetPtr>{rowset});
+    auto reader = std::make_unique<TabletReader>(_base_tablet.tablet_manager(), _base_tablet.metadata(), _base_schema,
+                                                 std::vector<RowsetPtr>{rowset});
     RETURN_IF_ERROR(reader->prepare());
     RETURN_IF_ERROR(reader->open(_read_params));
 
     // create writer
     ASSIGN_OR_RETURN(auto writer, DeltaWriterBuilder()
                                           .set_tablet_manager(_tablet_manager)
-                                          .set_tablet_id(_new_tablet->id())
+                                          .set_tablet_id(_new_tablet.id())
                                           .set_txn_id(_txn_id)
                                           .set_max_buffer_size(_max_buffer_size)
                                           .set_mem_tracker(CurrentThread::mem_tracker())
@@ -299,24 +311,24 @@ Status SchemaChangeHandler::process_alter_tablet(const TAlterTabletReqV2& reques
 
 Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& request) {
     // get base tablet and new tablet
-    auto alter_version = request.alter_version;
-    ASSIGN_OR_RETURN(auto base_tablet, _tablet_manager->get_tablet(request.base_tablet_id));
-    ASSIGN_OR_RETURN(auto new_tablet, _tablet_manager->get_tablet(request.new_tablet_id));
-    ASSIGN_OR_RETURN(auto base_schema, base_tablet.get_schema());
-    ASSIGN_OR_RETURN(auto new_schema, new_tablet.get_schema());
-    ASSIGN_OR_RETURN(auto has_delete_predicates, base_tablet.has_delete_predicates(alter_version));
+    const auto alter_version = request.alter_version;
+    ASSIGN_OR_RETURN(auto base_tablet, _tablet_manager->get_tablet(request.base_tablet_id, alter_version));
+    ASSIGN_OR_RETURN(auto new_tablet, _tablet_manager->get_tablet(request.new_tablet_id, 1));
+    auto base_schema = base_tablet.get_schema();
+    auto new_schema = new_tablet.get_schema();
+    auto has_delete_predicates = base_tablet.has_delete_predicates();
 
     std::vector<std::string> base_table_columns;
-    for (auto& column : base_schema->columns()) {
-        base_table_columns.emplace_back(std::string{column.name()});
+    base_table_columns.reserve(base_schema->columns().size());
+    for (const auto& column : base_schema->columns()) {
+        base_table_columns.emplace_back(column.name());
     }
     // parse request and create schema change params
     SchemaChangeParams sc_params;
-    sc_params.base_tablet = &base_tablet;
-    sc_params.new_tablet = &new_tablet;
+    sc_params.base_tablet = base_tablet;
+    sc_params.new_tablet = new_tablet;
     sc_params.chunk_changer =
             std::make_unique<ChunkChanger>(base_schema, new_schema, base_table_columns, request.alter_job_type);
-    sc_params.version = alter_version;
     sc_params.txn_id = request.txn_id;
 
     SchemaChangeUtils::init_materialized_params(request, &sc_params.materialized_params_map, sc_params.where_expr);
@@ -335,7 +347,7 @@ Status SchemaChangeHandler::do_process_alter_tablet(const TAlterTabletReqV2& req
     RETURN_IF_ERROR(convert_historical_rowsets(sc_params, op_schema_change));
 
     // write txn log
-    RETURN_IF_ERROR(new_tablet.put_txn_log(std::move(txn_log)));
+    RETURN_IF_ERROR(new_tablet.tablet_manager()->put_txn_log(std::move(txn_log)));
     return Status::OK();
 }
 
@@ -386,49 +398,47 @@ Status SchemaChangeHandler::do_process_update_tablet_meta(const TTabletMetaInfo&
 
 Status SchemaChangeHandler::convert_historical_rowsets(const SchemaChangeParams& sc_params,
                                                        TxnLogPB_OpSchemaChange* op_schema_change) {
-    auto base_tablet = sc_params.base_tablet;
-    auto new_tablet = sc_params.new_tablet;
-    auto alter_version = sc_params.version;
+    const auto& base_tablet = sc_params.base_tablet;
+    const auto& new_tablet = sc_params.new_tablet;
     LOG(INFO) << "begin to convert historical rowsets from base tablet to new tablet. "
-              << "base tablet: " << base_tablet->id() << ", new tablet: " << new_tablet->id()
-              << ", version: " << alter_version;
+              << "base tablet: " << base_tablet.id() << ", new tablet: " << new_tablet.id()
+              << ", version: " << base_tablet.version();
 
     // create schema change procedure
     std::unique_ptr<SchemaChange> sc_procedure;
     auto chunk_changer = sc_params.chunk_changer.get();
     if (sc_params.sc_sorting) {
-        LOG(INFO) << "doing sorted schema change for base tablet: " << base_tablet->id();
+        LOG(INFO) << "doing sorted schema change for base tablet: " << base_tablet.id();
         size_t memory_limitation =
                 static_cast<size_t>(config::memory_limitation_per_thread_for_schema_change) * 1024 * 1024 * 1024;
         sc_procedure = std::make_unique<SortedSchemaChange>(_tablet_manager, sc_params.txn_id, base_tablet, new_tablet,
-                                                            alter_version, chunk_changer, memory_limitation);
+                                                            chunk_changer, memory_limitation);
         op_schema_change->set_linked_segment(false);
     } else {
         // Note: In current implementation, linked schema change may refer to the segments deleted by gc,
         // so disable linked schema change and will support it in the later version.
-        LOG(INFO) << "doing direct schema change for base tablet: " << base_tablet->id()
+        LOG(INFO) << "doing direct schema change for base tablet: " << base_tablet.id()
                   << ", params directly: " << sc_params.sc_directly;
         sc_procedure = std::make_unique<DirectSchemaChange>(_tablet_manager, sc_params.txn_id, base_tablet, new_tablet,
-                                                            alter_version, chunk_changer);
+                                                            chunk_changer);
         op_schema_change->set_linked_segment(false);
     }
     RETURN_IF_ERROR(sc_procedure->init());
 
-    ASSIGN_OR_RETURN(auto base_metadata, base_tablet->get_metadata(alter_version));
-
     // convert rowsets
-    ASSIGN_OR_RETURN(auto rowsets, base_tablet->get_rowsets(*base_metadata));
+    auto rowsets = base_tablet.get_rowsets();
     for (const auto& rowset : rowsets) {
         auto st = sc_procedure->process(rowset, op_schema_change->add_rowsets());
         if (!st.ok()) {
             std::string err_msg =
                     fmt::format("failed to convert rowset. base tablet: {}, new tablet: {}, index: {}, status: {}",
-                                base_tablet->id(), new_tablet->id(), rowset->index(), st.to_string());
+                                base_tablet.id(), new_tablet.id(), rowset->index(), st.to_string());
             LOG(WARNING) << err_msg;
             return st;
         }
     }
 
+    auto base_metadata = base_tablet.metadata();
     // no need to copy delete vector file any more
     // new tablet meta can refer existing delete vector file directly
     if (op_schema_change->linked_segment() && base_metadata->has_delvec_meta()) {
@@ -436,8 +446,8 @@ Status SchemaChangeHandler::convert_historical_rowsets(const SchemaChangeParams&
     }
 
     LOG(INFO) << "finish convert historical rowsets from base tablet to new tablet. "
-              << "base tablet: " << base_tablet->id() << ", new tablet: " << new_tablet->id()
-              << ", version: " << alter_version;
+              << "base tablet: " << base_tablet.id() << ", new tablet: " << new_tablet.id()
+              << ", version: " << base_tablet.version();
     return Status::OK();
 }
 

--- a/be/src/storage/lake/schema_change.h
+++ b/be/src/storage/lake/schema_change.h
@@ -17,12 +17,14 @@
 #include "common/statusor.h"
 #include "gen_cpp/AgentService_types.h"
 #include "gen_cpp/olap_file.pb.h"
-#include "storage/lake/tablet.h"
 #include "storage/schema_change_utils.h"
 
 namespace starrocks::lake {
 
 class TabletManager;
+class VersionedTablet;
+class TxnLogPB_OpSchemaChange;
+struct SchemaChangeParams;
 
 class SchemaChangeHandler {
 public:
@@ -36,18 +38,6 @@ public:
     DISALLOW_COPY_AND_MOVE(SchemaChangeHandler);
 
 private:
-    struct SchemaChangeParams {
-        Tablet* base_tablet;
-        Tablet* new_tablet;
-        int64_t version;
-        int64_t txn_id;
-        MaterializedViewParamMap materialized_params_map;
-        std::unique_ptr<TExpr> where_expr;
-        bool sc_sorting = false;
-        bool sc_directly = false;
-        std::unique_ptr<ChunkChanger> chunk_changer = nullptr;
-    };
-
     Status do_process_alter_tablet(const TAlterTabletReqV2& request);
     Status convert_historical_rowsets(const SchemaChangeParams& sc_params, TxnLogPB_OpSchemaChange* op_schema_change);
 

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -103,10 +103,6 @@ StatusOr<std::unique_ptr<TabletWriter>> Tablet::new_writer(WriterType type, int6
     }
 }
 
-StatusOr<std::shared_ptr<TabletReader>> Tablet::new_reader(int64_t version, Schema schema) {
-    return std::make_shared<TabletReader>(*this, version, std::move(schema));
-}
-
 StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema() {
     return _mgr->get_tablet_schema(_id, &_version_hint);
 }

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -87,8 +87,6 @@ public:
     StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id,
                                                        uint32_t max_rows_per_segment = 0);
 
-    StatusOr<std::shared_ptr<TabletReader>> new_reader(int64_t version, Schema schema);
-
     // NOTE: This method may update the version hint
     StatusOr<std::shared_ptr<const TabletSchema>> get_schema();
 

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -26,6 +26,7 @@
 #include "storage/empty_iterator.h"
 #include "storage/lake/rowset.h"
 #include "storage/lake/utils.h"
+#include "storage/lake/versioned_tablet.h"
 #include "storage/merge_iterator.h"
 #include "storage/predicate_parser.h"
 #include "storage/row_source_mask.h"
@@ -44,21 +45,22 @@ using Field = starrocks::Field;
 using PredicateParser = starrocks::PredicateParser;
 using ZonemapPredicatesRewriter = starrocks::ZonemapPredicatesRewriter;
 
-TabletReader::TabletReader(Tablet tablet, int64_t version, Schema schema)
-        : ChunkIterator(std::move(schema)), _tablet(tablet), _version(version) {}
+TabletReader::TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema)
+        : ChunkIterator(std::move(schema)), _tablet_mgr(tablet_mgr), _tablet_metadata(std::move(metadata)) {}
 
-TabletReader::TabletReader(Tablet tablet, int64_t version, Schema schema, std::vector<RowsetPtr> rowsets)
+TabletReader::TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema,
+                           std::vector<RowsetPtr> rowsets)
         : ChunkIterator(std::move(schema)),
-          _tablet(tablet),
-          _version(version),
+          _tablet_mgr(tablet_mgr),
+          _tablet_metadata(std::move(metadata)),
           _rowsets_inited(true),
           _rowsets(std::move(rowsets)) {}
 
-TabletReader::TabletReader(Tablet tablet, int64_t version, Schema schema, std::vector<RowsetPtr> rowsets, bool is_key,
-                           RowSourceMaskBuffer* mask_buffer)
+TabletReader::TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema,
+                           std::vector<RowsetPtr> rowsets, bool is_key, RowSourceMaskBuffer* mask_buffer)
         : ChunkIterator(std::move(schema)),
-          _tablet(tablet),
-          _version(version),
+          _tablet_mgr(tablet_mgr),
+          _tablet_metadata(std::move(metadata)),
           _rowsets_inited(true),
           _rowsets(std::move(rowsets)),
           _is_vertical_merge(true),
@@ -72,14 +74,12 @@ TabletReader::~TabletReader() {
 }
 
 Status TabletReader::prepare() {
-    ASSIGN_OR_RETURN(_tablet_metadata, _tablet.get_metadata(_version));
-    CHECK_EQ(_version, _tablet_metadata->version());
     _tablet_schema = GlobalTabletSchemaMap::Instance()->emplace(_tablet_metadata->schema()).first;
     if (UNLIKELY(_tablet_schema == nullptr)) {
         return Status::InternalError("failed to construct tablet schema");
     }
     if (!_rowsets_inited) {
-        ASSIGN_OR_RETURN(_rowsets, enhance_error_prompt(_tablet.get_rowsets(*_tablet_metadata)));
+        _rowsets = VersionedTablet::get_rowsets(_tablet_mgr, *_tablet_metadata);
         _rowsets_inited = true;
     }
     _stats.rowsets_read_count += _rowsets.size();
@@ -145,7 +145,7 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.fill_data_cache = params.fill_data_cache;
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
-        rs_opts.version = _version;
+        rs_opts.version = _tablet_metadata->version();
     }
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);

--- a/be/src/storage/lake/tablet_reader.h
+++ b/be/src/storage/lake/tablet_reader.h
@@ -17,7 +17,6 @@
 #include "runtime/mem_pool.h"
 #include "storage/chunk_iterator.h"
 #include "storage/delete_predicates.h"
-#include "storage/lake/tablet.h"
 #include "storage/tablet_reader_params.h"
 
 namespace starrocks {
@@ -30,10 +29,13 @@ struct RowSourceMask;
 class RowSourceMaskBuffer;
 class SeekRange;
 class SeekTuple;
+class TabletSchema;
 
 namespace lake {
 
 class Rowset;
+class TabletManager;
+class TabletMetadataPB;
 
 class TabletReader final : public ChunkIterator {
     using Chunk = starrocks::Chunk;
@@ -49,10 +51,11 @@ class TabletReader final : public ChunkIterator {
     using TabletReaderParams = starrocks::TabletReaderParams;
 
 public:
-    TabletReader(Tablet tablet, int64_t version, Schema schema);
-    TabletReader(Tablet tablet, int64_t version, Schema schema, std::vector<RowsetPtr> rowsets);
-    TabletReader(Tablet tablet, int64_t version, Schema schema, std::vector<RowsetPtr> rowsets, bool is_key,
-                 RowSourceMaskBuffer* mask_buffer);
+    TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema);
+    TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema,
+                 std::vector<RowsetPtr> rowsets);
+    TabletReader(TabletManager* tablet_mgr, std::shared_ptr<const TabletMetadataPB> metadata, Schema schema,
+                 std::vector<RowsetPtr> rowsets, bool is_key, RowSourceMaskBuffer* mask_buffer);
     ~TabletReader() override;
 
     DISALLOW_COPY_AND_MOVE(TabletReader);
@@ -94,8 +97,7 @@ private:
                                    const std::vector<OlapTuple>& range_end_key, std::vector<SeekRange>* ranges,
                                    MemPool* mempool);
 
-    Tablet _tablet;
-    int64_t _version;
+    TabletManager* _tablet_mgr;
     std::shared_ptr<const TabletMetadataPB> _tablet_metadata;
     std::shared_ptr<const TabletSchema> _tablet_schema;
 

--- a/be/src/storage/lake/versioned_tablet.h
+++ b/be/src/storage/lake/versioned_tablet.h
@@ -42,6 +42,8 @@ class VersionedTablet {
     using TabletSchemaPtr = std::shared_ptr<const TabletSchema>;
 
 public:
+    static RowsetList get_rowsets(TabletManager* tablet_mgr, const TabletMetadataPB& metadata);
+
     // Default constructor. After construction, valid() is false
     VersionedTablet() : _tablet_mgr(nullptr), _metadata() {}
 
@@ -62,7 +64,8 @@ public:
 
     TabletSchemaPtr get_schema() const;
 
-    StatusOr<RowsetList> get_rowsets() const;
+    // Prerequisite: valid() == true
+    RowsetList get_rowsets() const { return get_rowsets(_tablet_mgr, *_metadata); }
 
     // `segment_max_rows` is used in vertical writer
     StatusOr<std::unique_ptr<TabletWriter>> new_writer(WriterType type, int64_t txn_id,
@@ -71,6 +74,8 @@ public:
     StatusOr<std::unique_ptr<TabletReader>> new_reader(Schema schema);
 
     TabletManager* tablet_manager() const { return _tablet_mgr; }
+
+    bool has_delete_predicates() const;
 
 private:
     TabletManager* _tablet_mgr;

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -143,8 +143,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
                                                        ? ChunkHelper::convert_schema(_tablet_schema, column_group)
                                                        : ChunkHelper::get_sort_key_schema(_tablet_schema))
                                             : ChunkHelper::convert_schema(_tablet_schema, column_group);
-    Tablet tablet(_tablet.tablet_manager(), _tablet.id());
-    TabletReader reader(tablet, _tablet.version(), schema, _input_rowsets, is_key, mask_buffer);
+    TabletReader reader(_tablet.tablet_manager(), _tablet.metadata(), schema, _input_rowsets, is_key, mask_buffer);
     RETURN_IF_ERROR(reader.prepare());
     TabletReaderParams reader_params;
     reader_params.reader_type = READER_CUMULATIVE_COMPACTION;

--- a/be/src/storage/lake_meta_reader.cpp
+++ b/be/src/storage/lake_meta_reader.cpp
@@ -105,7 +105,7 @@ Status LakeMetaReader::_init_seg_meta_collecters(const lake::VersionedTablet& ta
 }
 
 Status LakeMetaReader::_get_segments(const lake::VersionedTablet& tablet, std::vector<SegmentSharedPtr>* segments) {
-    ASSIGN_OR_RETURN(auto rowsets, tablet.get_rowsets());
+    auto rowsets = tablet.get_rowsets();
     for (const auto& rowset : rowsets) {
         ASSIGN_OR_RETURN(auto rowset_segs, rowset->segments(false));
         segments->insert(segments->end(), rowset_segs.begin(), rowset_segs.end());

--- a/be/test/storage/lake/auto_increment_partial_update_test.cpp
+++ b/be/test/storage/lake/auto_increment_partial_update_test.cpp
@@ -142,8 +142,8 @@ public:
     }
 
     int64_t check(int64_t version, std::function<bool(int c0, int c1, int c2)> check_fn) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -125,8 +125,8 @@ protected:
     }
 
     int64_t read(int64_t version) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);
@@ -289,8 +289,8 @@ protected:
     }
 
     int64_t read(int64_t version) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);
@@ -377,8 +377,8 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     ASSERT_EQ(1, new_tablet_metadata->rowsets(0).segments_size());
 
     // check data
-    ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+    ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
     CHECK_OK(reader->prepare());
     CHECK_OK(reader->open(TabletReaderParams()));
     auto chunk = ChunkHelper::new_chunk(*_schema, 128);
@@ -470,8 +470,8 @@ protected:
     }
 
     int64_t read(int64_t version) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);
@@ -618,8 +618,8 @@ protected:
     }
 
     int64_t read(int64_t version) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);

--- a/be/test/storage/lake/condition_update_test.cpp
+++ b/be/test/storage/lake/condition_update_test.cpp
@@ -40,7 +40,7 @@ namespace starrocks::lake {
 class ConditionUpdateTest : public TestBase, testing::WithParamInterface<PrimaryKeyParam> {
 public:
     ConditionUpdateTest() : TestBase(kTestDirectory) {
-        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
         _tablet_metadata->set_next_rowset_id(1);
@@ -131,8 +131,8 @@ public:
     }
 
     int64_t check(int64_t version, std::function<bool(int c0, int c1, int c2)> check_fn) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);
@@ -158,7 +158,7 @@ protected:
     constexpr static const char* const kTestDirectory = "test_lake_condition_update";
     constexpr static const int kChunkSize = 12;
 
-    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<TabletSchema> _partial_tablet_schema;
     std::shared_ptr<Schema> _schema;

--- a/be/test/storage/lake/metacache_test.cpp
+++ b/be/test/storage/lake/metacache_test.cpp
@@ -40,7 +40,7 @@ using namespace starrocks;
 class LakeMetacacheTest : public TestBase {
 public:
     LakeMetacacheTest() : TestBase(kTestDirectory) {
-        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
         //
@@ -84,7 +84,7 @@ public:
 protected:
     constexpr static const char* const kTestDirectory = "test_lake_metadata_cache";
 
-    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
 };
@@ -220,7 +220,7 @@ TEST_F(LakeMetacacheTest, test_segment_cache) {
     // no segment
     auto sz0 = metacache->memory_usage();
 
-    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(2, *_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
     ASSERT_OK(reader->prepare());
     TabletReaderParams params;
     ASSERT_OK(reader->open(params));

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -146,8 +146,8 @@ public:
     }
 
     int64_t check(int64_t version, std::function<bool(int c0, int c1, int c2)> check_fn) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -145,8 +145,8 @@ protected:
     }
 
     int64_t read(int64_t version) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);
@@ -164,8 +164,8 @@ protected:
     }
 
     void get_key_list(int64_t version, std::vector<int>& key_list) {
-        ASSIGN_OR_ABORT(auto tablet, _tablet_mgr->get_tablet(_tablet_metadata->id()));
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *_schema));
+        ASSIGN_OR_ABORT(auto metadata, _tablet_mgr->get_tablet_metadata(_tablet_metadata->id(), version));
+        auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), metadata, *_schema);
         CHECK_OK(reader->prepare());
         CHECK_OK(reader->open(TabletReaderParams()));
         auto chunk = ChunkHelper::new_chunk(*_schema, 128);

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -71,7 +71,8 @@ public:
 protected:
     static std::shared_ptr<Chunk> read(Tablet tablet, int64_t version, bool sorted = false) {
         ASSIGN_OR_ABORT(auto schema, tablet.get_schema());
-        ASSIGN_OR_ABORT(auto reader, tablet.new_reader(version, *(schema->schema())));
+        ASSIGN_OR_ABORT(auto metadata, tablet.get_metadata(version));
+        auto reader = std::make_shared<TabletReader>(tablet.tablet_mgr(), metadata, *(schema->schema()));
         CHECK_OK(reader->prepare());
         TabletReaderParams params;
         params.sorted_by_keys_per_tablet = sorted;
@@ -837,8 +838,8 @@ TEST_P(SchemaChangeModifyColumnOrderTest, test_alter_key_order) {
     std::vector<int> rc0_0{1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4};
     std::vector<int> rc2_0{2, 8, 14, 20, 4, 10, 16, 22, 6, 12, 18, 24};
 
-    ASSIGN_OR_ABORT(auto new_tablet, _tablet_manager->get_tablet(new_tablet_id));
-    ASSIGN_OR_ABORT(auto reader, new_tablet.new_reader(version, *_new_schema));
+    ASSIGN_OR_ABORT(auto new_metadata, _tablet_manager->get_tablet_metadata(new_tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_manager.get(), new_metadata, *_new_schema);
     CHECK_OK(reader->prepare());
     CHECK_OK(reader->open(TabletReaderParams()));
 
@@ -1093,8 +1094,8 @@ TEST_P(SchemaChangeModifyColumnMultiSegmentOrderTest, test_alter_table) {
     std::vector<int> rc1{1, 2, 3, 4, 5, 6};
     std::vector<int> rc2{1, 2, 3, 4, 5, 6};
 
-    ASSIGN_OR_ABORT(auto new_tablet, _tablet_manager->get_tablet(new_tablet_id));
-    ASSIGN_OR_ABORT(auto reader, new_tablet.new_reader(version, *_new_schema));
+    ASSIGN_OR_ABORT(auto new_metadata, _tablet_manager->get_tablet_metadata(new_tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_manager.get(), new_metadata, *_new_schema);
     CHECK_OK(reader->prepare());
     CHECK_OK(reader->open(TabletReaderParams()));
 
@@ -1324,8 +1325,8 @@ TEST_P(SchemaChangeSortKeyReorderTest1, test_alter_sortkey_reorder_1) {
     std::vector<int> rc1_0{1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
     std::vector<int> rc2_0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
 
-    ASSIGN_OR_ABORT(auto new_tablet, _tablet_manager->get_tablet(new_tablet_id));
-    ASSIGN_OR_ABORT(auto reader, new_tablet.new_reader(version, *_new_schema));
+    ASSIGN_OR_ABORT(auto new_metadata, _tablet_manager->get_tablet_metadata(new_tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_manager.get(), new_metadata, *_new_schema);
     CHECK_OK(reader->prepare());
     CHECK_OK(reader->open(TabletReaderParams()));
 
@@ -1562,8 +1563,8 @@ TEST_P(SchemaChangeSortKeyReorderTest2, test_alter_sortkey_reorder2) {
     std::vector<int> rc1_0{1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3};
     std::vector<int> rc2_0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24};
 
-    ASSIGN_OR_ABORT(auto new_tablet, _tablet_manager->get_tablet(new_tablet_id));
-    ASSIGN_OR_ABORT(auto reader, new_tablet.new_reader(version, *_new_schema));
+    ASSIGN_OR_ABORT(auto new_metadata, _tablet_manager->get_tablet_metadata(new_tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_manager.get(), new_metadata, *_new_schema);
     CHECK_OK(reader->prepare());
     CHECK_OK(reader->open(TabletReaderParams()));
 
@@ -1798,8 +1799,8 @@ TEST_P(SchemaChangeSortKeyReorderTest3, test_alter_sortkey_reorder3) {
     std::vector<int> rc1_0{1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
     std::vector<int> rc2_0{2, 8, 14, 20, 4, 10, 16, 22, 6, 12, 18, 24};
 
-    ASSIGN_OR_ABORT(auto new_tablet, _tablet_manager->get_tablet(new_tablet_id));
-    ASSIGN_OR_ABORT(auto reader, new_tablet.new_reader(version, *_new_schema));
+    ASSIGN_OR_ABORT(auto new_metadata, _tablet_manager->get_tablet_metadata(new_tablet_id, version));
+    auto reader = std::make_shared<TabletReader>(_tablet_manager.get(), new_metadata, *_new_schema);
     CHECK_OK(reader->prepare());
     CHECK_OK(reader->open(TabletReaderParams()));
 

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -40,7 +40,7 @@ using namespace starrocks;
 class LakeDuplicateTabletReaderTest : public TestBase {
 public:
     LakeDuplicateTabletReaderTest() : TestBase(kTestDirectory) {
-        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
         //
@@ -84,7 +84,7 @@ public:
 protected:
     constexpr static const char* const kTestDirectory = "test_duplicate_lake_tablet_reader";
 
-    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
 };
@@ -149,7 +149,7 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_success) {
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
     // test reader
-    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(2, *_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
     ASSERT_OK(reader->prepare());
     TabletReaderParams params;
     ASSERT_OK(reader->open(params));
@@ -178,7 +178,7 @@ TEST_F(LakeDuplicateTabletReaderTest, test_read_success) {
 class LakeAggregateTabletReaderTest : public TestBase {
 public:
     LakeAggregateTabletReaderTest() : TestBase(kTestDirectory) {
-        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
         //
@@ -223,7 +223,7 @@ public:
 protected:
     constexpr static const char* const kTestDirectory = "test_aggregate_lake_tablet_reader";
 
-    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
 };
@@ -315,7 +315,7 @@ TEST_F(LakeAggregateTabletReaderTest, test_read_success) {
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
     // test reader
-    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(3, *_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
     ASSERT_OK(reader->prepare());
     TabletReaderParams params;
     ASSERT_OK(reader->open(params));
@@ -341,7 +341,7 @@ TEST_F(LakeAggregateTabletReaderTest, test_read_success) {
 class LakeDuplicateTabletReaderWithDeleteTest : public TestBase {
 public:
     LakeDuplicateTabletReaderWithDeleteTest() : TestBase(kTestDirectory) {
-        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
         //
@@ -385,7 +385,7 @@ public:
 protected:
     constexpr static const char* const kTestDirectory = "test_duplicate_lake_tablet_reader_with_delete";
 
-    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
 };
@@ -472,7 +472,7 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteTest, test_read_success) {
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
     // test reader
-    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(3, *_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
     ASSERT_OK(reader->prepare());
     TabletReaderParams params;
     ASSERT_OK(reader->open(params));
@@ -506,7 +506,7 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteTest, test_read_success) {
 class LakeDuplicateTabletReaderWithDeleteNotInOneValueTest : public TestBase {
 public:
     LakeDuplicateTabletReaderWithDeleteNotInOneValueTest() : TestBase(kTestDirectory) {
-        _tablet_metadata = std::make_unique<TabletMetadata>();
+        _tablet_metadata = std::make_shared<TabletMetadata>();
         _tablet_metadata->set_id(next_id());
         _tablet_metadata->set_version(1);
         //
@@ -550,7 +550,7 @@ public:
 protected:
     constexpr static const char* const kTestDirectory = "test_duplicate_lake_tablet_reader_with_delete_not_in_one";
 
-    std::unique_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
 };
@@ -613,7 +613,7 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteNotInOneValueTest, test_read_success) 
     CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
 
     // test reader
-    ASSIGN_OR_ABORT(auto reader, tablet.new_reader(3, *_schema));
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
     ASSERT_OK(reader->prepare());
     TabletReaderParams params;
     ASSERT_OK(reader->open(params));


### PR DESCRIPTION
This PR is part of the PR stack to support fast schema evolution in shared data mode.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
