### PR TITLE
[BugFix] Fix ConcurrentModificationException for ConnectorTableInfo

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorTableInfo.java
@@ -34,7 +34,7 @@ public class ConnectorTableInfo {
 
     public void updateMetaInfo(ConnectorTableInfo tableInfo) {
         if (relatedMaterializedViews == null) {
-            relatedMaterializedViews = Sets.newHashSet(tableInfo.relatedMaterializedViews);
+            relatedMaterializedViews = Sets.newConcurrentHashSet(tableInfo.relatedMaterializedViews);
         } else {
             relatedMaterializedViews.addAll(tableInfo.relatedMaterializedViews);
         }
@@ -74,10 +74,10 @@ public class ConnectorTableInfo {
     }
 
     public static class Builder {
-        private Set<MvId> relatedMaterializedViews = Sets.newHashSet();
+        private Set<MvId> relatedMaterializedViews = Sets.newConcurrentHashSet();
 
         public Builder setRelatedMaterializedViews(Set<MvId> relatedMaterializedViews) {
-            this.relatedMaterializedViews = relatedMaterializedViews;
+            this.relatedMaterializedViews = Sets.newConcurrentHashSet(relatedMaterializedViews);
             return this;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorTblMetaInfoMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/ConnectorTblMetaInfoMgrTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.gson.JsonElement;
 import com.starrocks.catalog.MvId;
 import com.starrocks.server.GlobalStateMgr;
 import org.junit.Assert;
@@ -42,5 +43,10 @@ public class ConnectorTblMetaInfoMgrTest {
         mgr.removeConnectorTableInfo("cat", "db", "tbl", tableInfo);
         json = mgr.inspect();
         Assert.assertEquals("{}", json);
+
+        ConnectorTableInfo tableInfo1 = new ConnectorTableInfo(null);
+        tableInfo1.updateMetaInfo(tableInfo);
+        JsonElement element = tableInfo1.inspect();
+        Assert.assertEquals("[{\"dbId\":1,\"id\":1},{\"dbId\":1,\"id\":2}]", element.toString());
     }
 }


### PR DESCRIPTION
Why I'm doing:
meet this error
```
6508116:2023-12-11 08:31:13,298 WARN (starrocks-mysql-nio-pool-728|46746) [StmtExecutor.execute():715] execute Exception, sql SELECT count(*) FROM abnormal_catalog_iceberg.abnormal_iceberg.iceberg_external_abnormal_200_table
6508117-java.util.ConcurrentModificationException: null
6508118-	at java.util.HashMap$HashIterator.nextNode(HashMap.java:1493) ~[?:?]
6508119-	at java.util.HashMap$KeyIterator.next(HashMap.java:1516) ~[?:?]
6508120-	at com.starrocks.connector.ConnectorTableInfo.seTableInfoForConnectorTable(ConnectorTableInfo.java:66) ~[starrocks-fe.jar:?]
6508121-	at com.starrocks.connector.ConnectorTblMetaInfoMgr.setTableInfoForConnectorTable(ConnectorTblMetaInfoMgr.java:110) ~[starrocks-fe.jar:?]
6508122-	at com.starrocks.server.MetadataMgr.getTable(MetadataMgr.java:293) ~[starrocks-fe.jar:?]
```
What I'm doing:

Fixes https://github.com/StarRocks/StarRocksTest/issues/5132

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
