### PR TITLE
[BugFix] Fix primary tablet does not cancel write segment brpc

### DIFF
--- a/be/src/runtime/local_tablets_channel.h
+++ b/be/src/runtime/local_tablets_channel.h
@@ -173,6 +173,9 @@ private:
     void _commit_tablets(const PTabletWriterAddChunkRequest& request,
                          const std::shared_ptr<LocalTabletsChannel::WriteContext>& context);
 
+    void _cancel_primary_tablets(const std::unordered_set<int64_t>& failed_primary_tablets,
+                                 const std::string& cancel_reason);
+
     void _abort_replica_tablets(const PTabletWriterAddChunkRequest& request, const std::string& abort_reason,
                                 const std::unordered_map<int64_t, std::vector<int64_t>>& node_id_to_abort_tablets);
 

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -481,7 +481,7 @@ Status DeltaWriter::flush_memtable_async(bool eos) {
                             if (!st.ok()) {
                                 LOG(WARNING) << "Failed to submit sync tablet " << _tablet->tablet_id()
                                              << " segment err=" << st;
-                                replicate_token->set_status(st);
+                                replicate_token->cancel(st);
                             }
                         });
             }


### PR DESCRIPTION
Why I'm doing:
In replicated storage,  an error may happen on the primary tablet writer when syncing segments to the secondary tablets. For example, the segment was flushed successfully on the primary tablet writer but failed when doing `UpdateManager#on_rowset_finished` because of the tablet is dropped. At this moment, `SegmentReplicateTask` may be waiting for the response from the secondary tablets for the brpc `tablet_writer_add_segment` which will block the `SegmentReplicateExecutor`. Currently, the primary tablet writer does not cancel the waiting as soon as possible which will block the thread and affect other loads.

What I'm doing:
After the primary tablet writer fails, cancel the `SegmentReplicateTask` which will interrupt the brpc response waiting

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
