### PR TITLE
[BugFix] Forbidden to create a new column with the same name as the physical column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -849,6 +849,15 @@ public class SchemaChangeHandler extends AlterHandler {
             fastSchemaEvolution = false;
         }
 
+        // check if the new column already exist in base schema.
+        // do not support adding new column which already exist in base schema.
+        Optional<Column> foundColumn = olapTable.getBaseSchema().stream()
+                .filter(c -> c.getName().equalsIgnoreCase(newColName)).findFirst();
+        if (foundColumn.isPresent() && newColumn.equals(foundColumn.get())) {
+            throw new DdlException(
+                    "Can not add column which already exists in base table: " + newColName);
+        }
+
         // check if the new column already exist in physical column.
         // do not support adding new column which already exist in physical column.
         Optional<Column> foundPhysicalColumn = olapTable.getBaseSchema().stream()
@@ -857,15 +866,6 @@ public class SchemaChangeHandler extends AlterHandler {
             throw new DdlException(
                     "Can not add column which already exists in physical column: " + newColName
                             + ", you can remove " + foundPhysicalColumn.get() + " and try again.");
-        }
-
-        // check if the new column already exist in base schema.
-        // do not support adding new column which already exist in base schema.
-        Optional<Column> foundColumn = olapTable.getBaseSchema().stream()
-                .filter(c -> c.getName().equalsIgnoreCase(newColName)).findFirst();
-        if (foundColumn.isPresent() && newColumn.equals(foundColumn.get())) {
-            throw new DdlException(
-                    "Can not add column which already exists in base table: " + newColName);
         }
 
         /*

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -861,7 +861,7 @@ public class SchemaChangeHandler extends AlterHandler {
         // check if the new column already exist in physical column.
         // do not support adding new column which already exist in physical column.
         Optional<Column> foundPhysicalColumn = olapTable.getBaseSchema().stream()
-                .filter(c -> c.getPhysicalName().equalsIgnoreCase(newColName)).findFirst();
+                .filter(c -> c.getDirectPhysicalName().equalsIgnoreCase(newColName)).findFirst();
         if (foundPhysicalColumn.isPresent()) {
             throw new DdlException(
                     "Can not add column which already exists in physical column: " + newColName

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -849,6 +849,16 @@ public class SchemaChangeHandler extends AlterHandler {
             fastSchemaEvolution = false;
         }
 
+        // check if the new column already exist in physical column.
+        // do not support adding new column which already exist in physical column.
+        Optional<Column> foundPhysicalColumn = olapTable.getBaseSchema().stream()
+                .filter(c -> c.getPhysicalName().equalsIgnoreCase(newColName)).findFirst();
+        if (foundPhysicalColumn.isPresent()) {
+            throw new DdlException(
+                    "Can not add column which already exists in physical column: " + newColName
+                            + ", you can remove " + foundPhysicalColumn.get() + " and try again.");
+        }
+
         // check if the new column already exist in base schema.
         // do not support adding new column which already exist in base schema.
         Optional<Column> foundColumn = olapTable.getBaseSchema().stream()

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Column.java
@@ -782,6 +782,10 @@ public class Column implements Writable, GsonPreProcessable, GsonPostProcessable
         return physicalName != null ? physicalName : name;
     }
 
+    public String getDirectPhysicalName() {
+        return physicalName != null ? physicalName : "";
+    }
+
     public void renameColumn(String newName) {
         if (physicalName == null) {
             physicalName = name;

--- a/test/sql/test_column_rename/R/test_column_rename2
+++ b/test/sql/test_column_rename/R/test_column_rename2
@@ -78,3 +78,32 @@ select * from bf_table;
 -- result:
 1	1000000000000000	example_string	20
 -- !result
+drop table site_access if exists;
+-- result:
+E: (1064, "Getting syntax error at line 1, column 23. Detail message: Unexpected input 'if', the most similar input is {<EOF>, ';'}.")
+-- !result
+CREATE TABLE site_access(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT DEFAULT '0'
+)
+DUPLICATE KEY(event_day, site_id, city_code, user_name)
+PARTITION BY RANGE(event_day) (
+START ("2015-06-01") END ("2022-12-01") EVERY (INTERVAL 1 month)
+)
+DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Table 'site_access' already exists.")
+-- !result
+alter table site_access rename column site_id to id;
+-- result:
+-- !result
+alter table site_access add column site_id int;
+-- result:
+E: (1064, 'Unexpected exception: Can not add column which already exists in physical column: site_id, you can remove `id` int(11) NULL DEFAULT "10" COMMENT "" and try again.')
+-- !result

--- a/test/sql/test_column_rename/T/test_column_rename2
+++ b/test/sql/test_column_rename/T/test_column_rename2
@@ -41,3 +41,21 @@ INSERT INTO `bf_table` (`k3`, `k2`, `v1`, `v2`)
 VALUES (1, 1000000000000000, 'example_string', 20);
 desc bf_table;
 select * from bf_table;
+drop table site_access if exists;
+CREATE TABLE site_access(
+    event_day DATE,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT DEFAULT '0'
+)
+DUPLICATE KEY(event_day, site_id, city_code, user_name)
+PARTITION BY RANGE(event_day) (
+START ("2015-06-01") END ("2022-12-01") EVERY (INTERVAL 1 month)
+)
+DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 32
+PROPERTIES (
+"replication_num" = "1"
+);
+alter table site_access rename column site_id to id;
+alter table site_access add column site_id int;


### PR DESCRIPTION

Why I'm doing:
According to the way we implement column rename now, if column a->b is added first and then a is added, there will be two identical column names, which will eventually cause be to crash.

What I'm doing:
Check every time a column is added to prevent this from happening. If the user has such a scenario later, then optimize based on this scenario.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
