### PR TITLE
[Enhancement] Enhance NormalizePredicateRule for many Or/And

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -55,34 +55,6 @@ public class CompoundPredicateOperator extends PredicateOperator {
         Preconditions.checkState(!CollectionUtils.isEmpty(arguments));
     }
 
-    public static ScalarOperator or(Collection<ScalarOperator> nodes) {
-        return Utils.createCompound(CompoundPredicateOperator.CompoundType.OR, nodes);
-    }
-
-    public static ScalarOperator or(ScalarOperator... nodes) {
-        return Utils.createCompound(CompoundPredicateOperator.CompoundType.OR, Arrays.asList(nodes));
-    }
-
-    public static ScalarOperator and(Collection<ScalarOperator> nodes) {
-        return Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, nodes);
-    }
-
-    public static ScalarOperator and(ScalarOperator... nodes) {
-        return Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, Arrays.asList(nodes));
-    }
-
-    public static ScalarOperator not(ScalarOperator node) {
-        return new CompoundPredicateOperator(CompoundType.NOT, node);
-    }
-
-    public int getCompoundTreeLeafNodeNumber() {
-        return compoundTreeLeafNodeNumber;
-    }
-
-    public void setCompoundTreeLeafNodeNumber(int compoundTreeLeafNodeNumber) {
-        this.compoundTreeLeafNodeNumber = compoundTreeLeafNodeNumber;
-    }
-
     public CompoundType getCompoundType() {
         return type;
     }
@@ -95,9 +67,23 @@ public class CompoundPredicateOperator extends PredicateOperator {
         this.compoundTreeUniqueLeaves = compoundTreeUniqueLeaves;
     }
 
+    public int getCompoundTreeLeafNodeNumber() {
+        return compoundTreeLeafNodeNumber;
+    }
+
+    public void setCompoundTreeLeafNodeNumber(int compoundTreeLeafNodeNumber) {
+        this.compoundTreeLeafNodeNumber = compoundTreeLeafNodeNumber;
+    }
+
     @Override
     public <R, C> R accept(ScalarOperatorVisitor<R, C> visitor, C context) {
         return visitor.visitCompoundPredicate(this, context);
+    }
+
+    public enum CompoundType {
+        AND,
+        OR,
+        NOT
     }
 
     public boolean isAnd() {
@@ -176,9 +162,23 @@ public class CompoundPredicateOperator extends PredicateOperator {
         return Objects.hash(opType, type, h);
     }
 
-    public enum CompoundType {
-        AND,
-        OR,
-        NOT
+    public static ScalarOperator or(Collection<ScalarOperator> nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.OR, nodes);
+    }
+
+    public static ScalarOperator or(ScalarOperator... nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.OR, Arrays.asList(nodes));
+    }
+
+    public static ScalarOperator and(Collection<ScalarOperator> nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, nodes);
+    }
+
+    public static ScalarOperator and(ScalarOperator... nodes) {
+        return Utils.createCompound(CompoundPredicateOperator.CompoundType.AND, Arrays.asList(nodes));
+    }
+
+    public static ScalarOperator not(ScalarOperator node) {
+        return new CompoundPredicateOperator(CompoundType.NOT, node);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -46,14 +46,12 @@ public class CompoundPredicateOperator extends PredicateOperator {
     public CompoundPredicateOperator(CompoundType compoundType, ScalarOperator... arguments) {
         super(OperatorType.COMPOUND, arguments);
         this.type = compoundType;
-        compoundTreeLeafNodeNumber = 0;
         Preconditions.checkState(arguments.length >= 1);
     }
 
     public CompoundPredicateOperator(CompoundType compoundType, List<ScalarOperator> arguments) {
         super(OperatorType.COMPOUND, arguments);
         this.type = compoundType;
-        compoundTreeLeafNodeNumber = 0;
         Preconditions.checkState(!CollectionUtils.isEmpty(arguments));
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedCompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedCompoundPredicateOperator.java
@@ -1,0 +1,64 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.scalar;
+
+import com.starrocks.sql.optimizer.operator.OperatorType;
+
+import java.util.ArrayList;
+
+public class HashCachedCompoundPredicateOperator extends PredicateOperator {
+    public CompoundPredicateOperator operator;
+    private int hashValue = 0;
+
+    public HashCachedCompoundPredicateOperator(CompoundPredicateOperator operator) {
+        super(OperatorType.COMPOUND, new ArrayList<>());
+        this.operator = operator;
+    }
+
+    public int getHashValue() {
+        return hashValue;
+    }
+
+    public void setHashValue(int hashValue) {
+        this.hashValue = hashValue;
+    }
+
+    public CompoundPredicateOperator getOperator() {
+        return operator;
+    }
+
+    @Override
+    public int hashCode() {
+        if (this.getHashValue() != 0) {
+            return this.getHashValue();
+        }
+
+        this.setHashValue(operator.hashCode());
+        return this.getHashValue();
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HashCachedCompoundPredicateOperator that = (HashCachedCompoundPredicateOperator) o;
+        return this.getOperator() == that.getOperator();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.optimizer.operator.scalar;
 import com.starrocks.sql.optimizer.base.ColumnRefSet;
 
 import java.util.List;
+import java.util.Objects;
 
 public class HashCachedScalarOperator extends ScalarOperator {
     public ScalarOperator operator;
@@ -59,7 +60,7 @@ public class HashCachedScalarOperator extends ScalarOperator {
             return false;
         }
         HashCachedScalarOperator that = (HashCachedScalarOperator) o;
-        return this.getOperator() == that.getOperator();
+        return Objects.equals(this.getOperator(), that.getOperator());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
@@ -14,16 +14,16 @@
 
 package com.starrocks.sql.optimizer.operator.scalar;
 
-import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
 
-import java.util.ArrayList;
+import java.util.List;
 
-public class HashCachedCompoundPredicateOperator extends PredicateOperator {
-    public CompoundPredicateOperator operator;
+public class HashCachedScalarOperator extends ScalarOperator {
+    public ScalarOperator operator;
     private int hashValue = 0;
 
-    public HashCachedCompoundPredicateOperator(CompoundPredicateOperator operator) {
-        super(OperatorType.COMPOUND, new ArrayList<>());
+    public HashCachedScalarOperator(ScalarOperator operator) {
+        super(operator.getOpType(), operator.getType());
         this.operator = operator;
     }
 
@@ -35,7 +35,7 @@ public class HashCachedCompoundPredicateOperator extends PredicateOperator {
         this.hashValue = hashValue;
     }
 
-    public CompoundPredicateOperator getOperator() {
+    public ScalarOperator getOperator() {
         return operator;
     }
 
@@ -58,7 +58,41 @@ public class HashCachedCompoundPredicateOperator extends PredicateOperator {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        HashCachedCompoundPredicateOperator that = (HashCachedCompoundPredicateOperator) o;
+        HashCachedScalarOperator that = (HashCachedScalarOperator) o;
         return this.getOperator() == that.getOperator();
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public List<ScalarOperator> getChildren() {
+        return null;
+    }
+
+    @Override
+    public ScalarOperator getChild(int index) {
+        return null;
+    }
+
+    @Override
+    public void setChild(int index, ScalarOperator child) {
+    }
+
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    @Override
+    public <R, C> R accept(ScalarOperatorVisitor<R, C> visitor, C context) {
+        return null;
+    }
+
+    @Override
+    public ColumnRefSet getUsedColumns() {
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -29,8 +29,6 @@ import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
@@ -72,7 +70,6 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
-    private static final Logger LOG = LogManager.getLogger(ScalarOperatorRewriter.class);
     private final ScalarOperatorRewriteContext context;
 
     public ScalarOperatorRewriter() {
@@ -87,11 +84,7 @@ public class ScalarOperatorRewriter {
         do {
             changeNums = context.changeNum();
             for (ScalarOperatorRewriteRule rule : ruleList) {
-                long begin = System.currentTimeMillis();
                 result = rewriteByRule(result, rule);
-                long end = System.currentTimeMillis();
-                long duration = end - begin;
-                LOG.info("rule:" + rule + " time:" + duration);
             }
 
             if (changeNums > Config.max_planner_scalar_rewrite_num) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.Lists;
@@ -30,6 +29,8 @@ import com.starrocks.sql.optimizer.rewrite.scalar.ReduceCastRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.ScalarOperatorRewriteRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedPredicateRule;
 import com.starrocks.sql.optimizer.rewrite.scalar.SimplifiedScanColumnRule;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 
@@ -37,7 +38,6 @@ public class ScalarOperatorRewriter {
     public static final List<ScalarOperatorRewriteRule> DEFAULT_TYPE_CAST_RULE = Lists.newArrayList(
             new ImplicitCastRule()
     );
-
     public static final List<ScalarOperatorRewriteRule> DEFAULT_REWRITE_RULES = Lists.newArrayList(
             // required
             new ImplicitCastRule(),
@@ -49,7 +49,6 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
-
     public static final List<ScalarOperatorRewriteRule> DEFAULT_REWRITE_SCAN_PREDICATE_RULES = Lists.newArrayList(
             // required
             new ImplicitCastRule(),
@@ -62,7 +61,6 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
-
     public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = Lists.newArrayList(
             // required
             new ImplicitCastRule(),
@@ -74,7 +72,7 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
-
+    private static final Logger LOG = LogManager.getLogger(ScalarOperatorRewriter.class);
     private final ScalarOperatorRewriteContext context;
 
     public ScalarOperatorRewriter() {
@@ -89,7 +87,11 @@ public class ScalarOperatorRewriter {
         do {
             changeNums = context.changeNum();
             for (ScalarOperatorRewriteRule rule : ruleList) {
+                long begin = System.currentTimeMillis();
                 result = rewriteByRule(result, rule);
+                long end = System.currentTimeMillis();
+                long duration = end - begin;
+                LOG.info("rule:" + rule + " time:" + duration);
             }
 
             if (changeNums > Config.max_planner_scalar_rewrite_num) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
+import com.starrocks.sql.optimizer.operator.scalar.HashCachedCompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
@@ -97,18 +98,22 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
                                                 ScalarOperatorRewriteContext context) {
         if (predicate.isNotBetween()) {
             ScalarOperator lower =
-                    new BinaryPredicateOperator(BinaryType.LT, predicate.getChild(0), predicate.getChild(1));
+                    new BinaryPredicateOperator(BinaryType.LT, predicate.getChild(0),
+                            predicate.getChild(1));
 
             ScalarOperator upper =
-                    new BinaryPredicateOperator(BinaryType.GT, predicate.getChild(0), predicate.getChild(2));
+                    new BinaryPredicateOperator(BinaryType.GT, predicate.getChild(0),
+                            predicate.getChild(2));
 
             return new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.OR, lower, upper);
         } else {
             ScalarOperator lower =
-                    new BinaryPredicateOperator(BinaryType.GE, predicate.getChild(0), predicate.getChild(1));
+                    new BinaryPredicateOperator(BinaryType.GE, predicate.getChild(0),
+                            predicate.getChild(1));
 
             ScalarOperator upper =
-                    new BinaryPredicateOperator(BinaryType.LE, predicate.getChild(0), predicate.getChild(2));
+                    new BinaryPredicateOperator(BinaryType.LE, predicate.getChild(0),
+                            predicate.getChild(2));
 
             return new CompoundPredicateOperator(CompoundPredicateOperator.CompoundType.AND, lower, upper);
         }
@@ -140,13 +145,14 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
 
     @Nullable
     private ScalarOperator getOptimizedCompoundTree(CompoundPredicateOperator parent) {
+        // reset node first So we can apply NormalizePredicateRule to one tree many times
         parent.setCompoundTreeUniqueLeaves(Sets.newLinkedHashSet());
         parent.setCompoundTreeLeafNodeNumber(0);
         Set<ScalarOperator> compoundTreeUniqueLeaves = parent.getCompoundTreeUniqueLeaves();
 
         for (ScalarOperator child : parent.getChildren()) {
             if (child != null) {
-                // child is not leaf node in Compound tree whose root is 'parent'
+                // child is not leaf node in Compound tree
                 if ((parent.isAnd() && OperatorType.COMPOUND.equals(child.getOpType()) &&
                         ((CompoundPredicateOperator) child).isAnd()) ||
                         (parent.isOr() && OperatorType.COMPOUND.equals(child.getOpType()) &&
@@ -160,15 +166,18 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
                     compoundChild.setCompoundTreeUniqueLeaves(null);
                     compoundChild.setCompoundTreeLeafNodeNumber(0);
                 } else {
-                    // leaf node
-                    compoundTreeUniqueLeaves.add(child);
-                    parent.setCompoundTreeLeafNodeNumber(1 + parent.getCompoundTreeLeafNodeNumber());
+                    // child is leaf node in compound tree
                     if (OperatorType.COMPOUND.equals(child.getOpType())) {
                         CompoundPredicateOperator compoundChild = (CompoundPredicateOperator) (child);
+                        // we cache CompoundPredicate's hash value to eliminate duplicate calculations
+                        compoundTreeUniqueLeaves.add(new HashCachedCompoundPredicateOperator(compoundChild));
                         // clear child's set to save memory
                         compoundChild.setCompoundTreeUniqueLeaves(null);
                         compoundChild.setCompoundTreeLeafNodeNumber(0);
+                    } else {
+                        compoundTreeUniqueLeaves.add(child);
                     }
+                    parent.setCompoundTreeLeafNodeNumber(1 + parent.getCompoundTreeLeafNodeNumber());
                 }
             }
         }
@@ -176,12 +185,18 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
         // this tree can be optimized
         if (compoundTreeUniqueLeaves.size() != parent.getCompoundTreeLeafNodeNumber()) {
             CompoundPredicateOperator newTree =
-                    (CompoundPredicateOperator) Utils.compoundOr(Lists.newArrayList(compoundTreeUniqueLeaves));
+                    (CompoundPredicateOperator) Utils.createCompound(parent.getCompoundType(),
+                            compoundTreeUniqueLeaves.stream().map(
+                                    node -> {
+                                        if (node instanceof HashCachedCompoundPredicateOperator) {
+                                            return ((HashCachedCompoundPredicateOperator) node).getOperator();
+                                        }
+                                        return node;
+                                    }).collect(Collectors.toCollection(Lists::newLinkedList)));
             newTree.setCompoundTreeLeafNodeNumber(compoundTreeUniqueLeaves.size());
             newTree.setCompoundTreeUniqueLeaves(compoundTreeUniqueLeaves);
             return newTree;
         }
-
         // this tree can't be optimized
         return null;
     }
@@ -213,7 +228,8 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
         List<ScalarOperator> constants = predicate.getChildren().stream().skip(1).filter(ScalarOperator::isConstant)
                 .collect(Collectors.toList());
         if (constants.size() == 1) {
-            BinaryType op = isIn ? BinaryType.EQ : BinaryType.NE;
+            BinaryType op =
+                    isIn ? BinaryType.EQ : BinaryType.NE;
             result.add(new BinaryPredicateOperator(op, lhs, constants.get(0)));
         } else if (!constants.isEmpty()) {
             constants.add(0, lhs);
@@ -258,7 +274,8 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
                 throw new SemanticException("Invalid index for struct element: " + collectionElement);
             }
 
-            return SubfieldOperator.build(collectionElement.getChild(0), collectionElement.getChild(0).getType(),
+            return SubfieldOperator.build(collectionElement.getChild(0),
+                    collectionElement.getChild(0).getType(),
                     Lists.newArrayList(index));
         }
         return collectionElement;
@@ -271,14 +288,13 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
     public ScalarOperator visitIsNullPredicate(IsNullPredicateOperator predicate,
                                                ScalarOperatorRewriteContext context) {
         if (predicate.getChild(0).getType().isMapType()) {
-            Function fn = Expr.getBuiltinFunction(FunctionSet.MAP_SIZE, new Type[] {predicate.getChild(0).getType()},
-                    Function.CompareMode.IS_SUPERTYPE_OF);
+            Function fn = Expr.getBuiltinFunction(FunctionSet.MAP_SIZE,
+                    new Type[] {predicate.getChild(0).getType()}, Function.CompareMode.IS_SUPERTYPE_OF);
             CallOperator call = new CallOperator(fn.functionName(), fn.getReturnType(), predicate.getChildren(), fn);
             return new IsNullPredicateOperator(predicate.isNotNull(), call);
         } else if (predicate.getChild(0).getType().isArrayType()) {
-            Function fn =
-                    Expr.getBuiltinFunction(FunctionSet.ARRAY_LENGTH, new Type[] {predicate.getChild(0).getType()},
-                            Function.CompareMode.IS_SUPERTYPE_OF);
+            Function fn = Expr.getBuiltinFunction(FunctionSet.ARRAY_LENGTH,
+                    new Type[] {predicate.getChild(0).getType()}, Function.CompareMode.IS_SUPERTYPE_OF);
             CallOperator call = new CallOperator(fn.functionName(), fn.getReturnType(), predicate.getChildren(), fn);
             return new IsNullPredicateOperator(predicate.isNotNull(), call);
         }


### PR DESCRIPTION
Why I'm doing:
Expr like 100 or takes too long in transform phase, Especially NormalizePredicateRule‘s visitCompoundPredicate, because its time complexity is O(n^2) n is tree node numbers.

What I'm doing:
when visit expr tree bottom up, if child is compound operator, cache child's unique compound tree leaf node in set and child's hash value to eliminate duplicate calculations

before this pr:
```
+-------------------------------------------------------+
| Explain String                                        |
+-------------------------------------------------------+
|   37ms|-- Total[1] 4s479ms                            |
|   37ms|    -- Analyzer[1] 5ms                         |
|   44ms|    -- Transformer[1] 2s892ms                  |
| 2936ms|    -- Optimizer[1] 990ms                      |
| 2936ms|        -- preprocessMvs[1] 0                  |
| 2936ms|        -- RuleBaseOptimize[1] 967ms           |
| 3906ms|        -- CostBaseOptimize[1] 18ms            |
| 3924ms|        -- PhysicalRewrite[1] 0                |
| 3925ms|        -- PlanValidate[1] 1ms                 |
| 3925ms|            -- InputDependenciesChecker[1] 1ms |
| 3926ms|            -- TypeChecker[1] 0                |
| 3926ms|            -- CTEUniqueChecker[1] 0           |
| 3926ms|            -- ColumnReuseChecker[1] 0         |
| 3926ms|    -- ExecPlanBuild[1] 589ms                  |
| Tracer Cost: 63us                                     |
+-------------------------------------------------------+
15 rows in set (4.52 sec)
```

after:
```
+-------------------------------------------------------+
| Explain String                                        |
+-------------------------------------------------------+
|   41ms|-- Total[1] 2s297ms                            |
|   41ms|    -- Analyzer[1] 6ms                         |
|   49ms|    -- Transformer[1] 1s209ms                  |
| 1258ms|    -- Optimizer[1] 273ms                      |
| 1258ms|        -- preprocessMvs[1] 0                  |
| 1258ms|        -- RuleBaseOptimize[1] 236ms           |
| 1497ms|        -- CostBaseOptimize[1] 31ms            |
| 1529ms|        -- PhysicalRewrite[1] 0                |
| 1529ms|        -- PlanValidate[1] 1ms                 |
| 1529ms|            -- InputDependenciesChecker[1] 1ms |
| 1531ms|            -- TypeChecker[1] 0                |
| 1531ms|            -- CTEUniqueChecker[1] 0           |
| 1531ms|            -- ColumnReuseChecker[1] 0         |
| 1531ms|    -- ExecPlanBuild[1] 807ms                  |
| Tracer Cost: 63us                                     |
+-------------------------------------------------------+
15 rows in set (2.35 sec)
```


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
