### PR TITLE
[BugFix] Aggregator check error state of aggragation function

### DIFF
--- a/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_blocking_sink_operator.cpp
@@ -74,19 +74,19 @@ Status AggregateBlockingSinkOperator::push_chunk(RuntimeState* state, const vect
         TRY_CATCH_BAD_ALLOC(_aggregator->try_convert_to_two_level_map());
     }
     if (_aggregator->is_none_group_by_exprs()) {
-        _aggregator->compute_single_agg_state(chunk_size);
+        RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk_size));
     } else {
         if (agg_group_by_with_limit) {
             // use `_aggregator->streaming_selection()` here to mark whether needs to filter key when compute agg states,
             // it's generated in `build_hash_map`
             size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection().data(), chunk_size);
             if (zero_count == chunk_size) {
-                _aggregator->compute_batch_agg_states(chunk_size);
+                RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk_size));
             } else {
-                _aggregator->compute_batch_agg_states_with_selection(chunk_size);
+                RETURN_IF_ERROR(_aggregator->compute_batch_agg_states_with_selection(chunk_size));
             }
         } else {
-            _aggregator->compute_batch_agg_states(chunk_size);
+            RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk_size));
         }
     }
     _aggregator->update_num_input_rows(chunk_size);

--- a/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/aggregate_distinct_streaming_sink_operator.cpp
@@ -54,7 +54,7 @@ Status AggregateDistinctStreamingSinkOperator::push_chunk(RuntimeState* state, c
 Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_force_streaming() {
     SCOPED_TIMER(_aggregator->streaming_timer());
     vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
-    _aggregator->output_chunk_by_streaming(&chunk);
+    RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(&chunk));
     _aggregator->offer_chunk_to_buffer(chunk);
     return Status::OK();
 }
@@ -99,11 +99,11 @@ Status AggregateDistinctStreamingSinkOperator::_push_chunk_by_auto(const size_t 
             size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());
             if (zero_count == 0) {
                 vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
-                _aggregator->output_chunk_by_streaming(&chunk);
+                RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(&chunk));
                 _aggregator->offer_chunk_to_buffer(chunk);
             } else if (zero_count != _aggregator->streaming_selection().size()) {
                 vectorized::ChunkPtr chunk = std::make_shared<vectorized::Chunk>();
-                _aggregator->output_chunk_by_streaming_with_selection(&chunk);
+                RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming_with_selection(&chunk));
                 _aggregator->offer_chunk_to_buffer(chunk);
             }
         }

--- a/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
+++ b/be/src/exec/vectorized/aggregate/aggregate_blocking_node.cpp
@@ -75,19 +75,19 @@ Status AggregateBlockingNode::open(RuntimeState* state) {
                 TRY_CATCH_ALLOC_SCOPE_END()
             }
             if (_aggregator->is_none_group_by_exprs()) {
-                _aggregator->compute_single_agg_state(chunk_size);
+                RETURN_IF_ERROR(_aggregator->compute_single_agg_state(chunk_size));
             } else {
                 if (agg_group_by_with_limit) {
                     // use `_aggregator->streaming_selection()` here to mark whether needs to filter key when compute agg states,
                     // it's generated in `build_hash_map`
                     size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection().data(), chunk_size);
                     if (zero_count == chunk_size) {
-                        _aggregator->compute_batch_agg_states(chunk_size);
+                        RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk_size));
                     } else {
-                        _aggregator->compute_batch_agg_states_with_selection(chunk_size);
+                        RETURN_IF_ERROR(_aggregator->compute_batch_agg_states_with_selection(chunk_size));
                     }
                 } else {
-                    _aggregator->compute_batch_agg_states(chunk_size);
+                    RETURN_IF_ERROR(_aggregator->compute_batch_agg_states(chunk_size));
                 }
             }
 

--- a/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
+++ b/be/src/exec/vectorized/aggregate/distinct_streaming_node.cpp
@@ -60,7 +60,7 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
             if (_aggregator->streaming_preaggregation_mode() == TStreamingPreaggregationMode::FORCE_STREAMING) {
                 // force execute streaming
                 SCOPED_TIMER(_aggregator->streaming_timer());
-                _aggregator->output_chunk_by_streaming(chunk);
+                RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk));
                 break;
             } else if (_aggregator->streaming_preaggregation_mode() ==
                        TStreamingPreaggregationMode::FORCE_PREAGGREGATION) {
@@ -111,9 +111,9 @@ Status DistinctStreamingNode::get_next(RuntimeState* state, ChunkPtr* chunk, boo
                         SCOPED_TIMER(_aggregator->streaming_timer());
                         size_t zero_count = SIMD::count_zero(_aggregator->streaming_selection());
                         if (zero_count == 0) {
-                            _aggregator->output_chunk_by_streaming(chunk);
+                            RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming(chunk));
                         } else if (zero_count != _aggregator->streaming_selection().size()) {
-                            _aggregator->output_chunk_by_streaming_with_selection(chunk);
+                            RETURN_IF_ERROR(_aggregator->output_chunk_by_streaming_with_selection(chunk));
                         }
                     }
 

--- a/be/src/exec/vectorized/aggregator.cpp
+++ b/be/src/exec/vectorized/aggregator.cpp
@@ -460,7 +460,7 @@ bool Aggregator::should_expand_preagg_hash_tables(size_t prev_row_returned, size
     return current_reduction > min_reduction;
 }
 
-void Aggregator::compute_single_agg_state(size_t chunk_size) {
+Status Aggregator::compute_single_agg_state(size_t chunk_size) {
     SCOPED_TIMER(_agg_stat->agg_function_compute_timer);
     bool use_intermediate = _use_intermediate_as_input();
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
@@ -473,9 +473,11 @@ void Aggregator::compute_single_agg_state(size_t chunk_size) {
                                                         _single_agg_state + _agg_states_offsets[i]);
         }
     }
+    RETURN_IF_ERROR(check_has_error());
+    return Status::OK();
 }
 
-void Aggregator::compute_batch_agg_states(size_t chunk_size) {
+Status Aggregator::compute_batch_agg_states(size_t chunk_size) {
     SCOPED_TIMER(_agg_stat->agg_function_compute_timer);
     bool use_intermediate = _use_intermediate_as_input();
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
@@ -488,9 +490,11 @@ void Aggregator::compute_batch_agg_states(size_t chunk_size) {
                                            _agg_input_columns[i][0].get(), _tmp_agg_states.data());
         }
     }
+    RETURN_IF_ERROR(check_has_error());
+    return Status::OK();
 }
 
-void Aggregator::compute_batch_agg_states_with_selection(size_t chunk_size) {
+Status Aggregator::compute_batch_agg_states_with_selection(size_t chunk_size) {
     SCOPED_TIMER(_agg_stat->agg_function_compute_timer);
     bool use_intermediate = _use_intermediate_as_input();
     for (size_t i = 0; i < _agg_fn_ctxs.size(); i++) {
@@ -505,6 +509,8 @@ void Aggregator::compute_batch_agg_states_with_selection(size_t chunk_size) {
                                                        _tmp_agg_states.data(), _streaming_selection);
         }
     }
+    RETURN_IF_ERROR(check_has_error());
+    return Status::OK();
 }
 
 Status Aggregator::_evaluate_const_columns(int i) {
@@ -529,6 +535,7 @@ Status Aggregator::convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk) {
     } else {
         TRY_CATCH_BAD_ALLOC(_serialize_to_chunk(_single_agg_state, agg_result_column));
     }
+    RETURN_IF_ERROR(check_has_error());
 
     // For agg function column is non-nullable and table is empty
     // sum(zero_row) should be null, not 0.
@@ -571,7 +578,7 @@ Status Aggregator::evaluate_exprs(vectorized::Chunk* chunk) {
     return _evaluate_exprs(chunk);
 }
 
-void Aggregator::output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
+Status Aggregator::output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
     // The input chunk is already intermediate-typed, so there is no need to convert it again.
     // Only when the input chunk is input-typed, we should convert it into intermediate-typed chunk.
     // is_passthrough is on indicate that the chunk is input-typed.
@@ -599,6 +606,7 @@ void Aggregator::output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
                 result_chunk->append_column(std::move(agg_result_column[i]), slot_id);
             }
         }
+        RETURN_IF_ERROR(check_has_error());
     }
 
     _num_pass_through_rows += result_chunk->num_rows();
@@ -606,9 +614,10 @@ void Aggregator::output_chunk_by_streaming(vectorized::ChunkPtr* chunk) {
     _num_rows_processed += result_chunk->num_rows();
     *chunk = std::move(result_chunk);
     COUNTER_SET(_agg_stat->pass_through_row_count, _num_pass_through_rows);
+    return Status::OK();
 }
 
-void Aggregator::output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* chunk) {
+Status Aggregator::output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* chunk) {
     // Streaming aggregate at least has one group by column
     size_t chunk_size = _group_by_columns[0]->size();
     for (auto& _group_by_column : _group_by_columns) {
@@ -637,7 +646,8 @@ void Aggregator::output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* 
             }
         }
     }
-    output_chunk_by_streaming(chunk);
+    RETURN_IF_ERROR(output_chunk_by_streaming(chunk));
+    return Status::OK();
 }
 
 void Aggregator::try_convert_to_two_level_map() {
@@ -1030,6 +1040,7 @@ Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::Chu
             }
         }
 
+        RETURN_IF_ERROR(check_has_error());
         _is_ht_eos = (it == end);
 
         // If there is null key, output it last
@@ -1048,6 +1059,7 @@ Status Aggregator::convert_hash_map_to_chunk(int32_t chunk_size, vectorized::Chu
                         TRY_CATCH_BAD_ALLOC(_serialize_to_chunk(hash_map_with_key.null_key_data, agg_result_columns));
                     }
 
+                    RETURN_IF_ERROR(check_has_error());
                     ++read_index;
                 } else {
                     // Output null key in next round

--- a/be/src/exec/vectorized/aggregator.h
+++ b/be/src/exec/vectorized/aggregator.h
@@ -199,10 +199,10 @@ public:
                                           int64_t ht_rows) const;
 
     // For aggregate without group by
-    void compute_single_agg_state(size_t chunk_size);
+    Status compute_single_agg_state(size_t chunk_size);
     // For aggregate with group by
-    void compute_batch_agg_states(size_t chunk_size);
-    void compute_batch_agg_states_with_selection(size_t chunk_size);
+    Status compute_batch_agg_states(size_t chunk_size);
+    Status compute_batch_agg_states_with_selection(size_t chunk_size);
 
     // Convert one row agg states to chunk
     Status convert_to_chunk_no_groupby(vectorized::ChunkPtr* chunk);
@@ -211,14 +211,14 @@ public:
 
     Status evaluate_exprs(vectorized::Chunk* chunk);
 
-    void output_chunk_by_streaming(vectorized::ChunkPtr* chunk);
+    Status output_chunk_by_streaming(vectorized::ChunkPtr* chunk);
 
     // Elements queried in HashTable will be added to HashTable,
     // elements that cannot be queried are not processed,
     // and are mainly used in the first stage of two-stage aggregation when aggr reduction is low
     // selection[i] = 0: found in hash table
     // selection[1] = 1: not found in hash table
-    void output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* chunk);
+    Status output_chunk_by_streaming_with_selection(vectorized::ChunkPtr* chunk);
 
     // At first, we use single hash map, if hash map is too big,
     // we convert the single hash map to two level hash map.


### PR DESCRIPTION
Why I'm doing:

Backport PR: https://github.com/StarRocks/starrocks/pull/36804 return error state when overflow, but the aggregator don't check the error state in branch-2.5;

What I'm doing:

Aggreagator check the error state of aggragate function.

