### PR TITLE
[BugFix][Cherry-Pick][Branch-3.1] Fix parquet writer memory leak after exception (backport #26254)

### DIFF
--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -394,11 +394,7 @@ Status SyncFileWriter::_flush_row_group() {
             _chunk_writer->close();
         } catch (const ::parquet::ParquetStatusException& e) {
             _chunk_writer.reset();
-
-            // this is to avoid calling ParquetFileWriter.Close which incurs segfault
             _closed = true;
-            _writer.release();
-
             auto st = Status::IOError(fmt::format("{}: {}", "flush rowgroup error", e.what()));
             LOG(WARNING) << st;
             return st;

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -149,8 +149,9 @@ set(EXEC_FILES
         ./formats/avro/numeric_column_test.cpp
         ./formats/avro/nullable_column_test.cpp
         ./formats/orc/orc_chunk_reader_test.cpp
-        ./formats/orc/orc_lazy_load_test.cpp
         ./formats/orc/orc_column_reader_test.cpp
+        ./formats/orc/orc_lazy_load_test.cpp
+        ./formats/parquet/arrow_parquet_writer_test.cpp
         ./formats/parquet/parquet_schema_test.cpp
         ./formats/parquet/encoding_test.cpp
         ./formats/parquet/page_reader_test.cpp

--- a/be/test/formats/parquet/arrow_parquet_writer_test.cpp
+++ b/be/test/formats/parquet/arrow_parquet_writer_test.cpp
@@ -1,0 +1,122 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <parquet/api/writer.h>
+
+#include "util/slice.h"
+
+namespace starrocks::parquet {
+namespace {
+
+class MockOutputStream : public arrow::io::OutputStream {
+public:
+    MockOutputStream() = default;
+
+    ~MockOutputStream() override = default;
+
+    MOCK_METHOD(arrow::Status, Write, (const void* data, int64_t nbytes), (override));
+
+    arrow::Status Close() override { return arrow::Status::OK(); }
+
+    arrow::Result<int64_t> Tell() const override { return arrow::Result<int64_t>(0); }
+
+    bool closed() const override { return false; }
+};
+
+using ::testing::Return;
+
+TEST(ArrowParquetWriterTest, Normal) {
+    auto sink = std::make_shared<MockOutputStream>();
+
+    EXPECT_CALL(*sink, Write).WillRepeatedly(Return(arrow::Status::OK()));
+
+    auto node = ::parquet::schema::GroupNode::Make(
+            "schema", ::parquet::Repetition::REQUIRED,
+            {
+                    ::parquet::schema::PrimitiveNode::Make("id1", ::parquet::Repetition::REQUIRED,
+                                                           ::parquet::Type::INT32),
+                    ::parquet::schema::PrimitiveNode::Make("id2", ::parquet::Repetition::REQUIRED,
+                                                           ::parquet::Type::INT32),
+            });
+    auto schema = std::static_pointer_cast<::parquet::schema::GroupNode>(node);
+    auto writer = ::parquet::ParquetFileWriter::Open(sink, schema);
+
+    {
+        auto* rg_writer = writer->AppendBufferedRowGroup();
+        std::vector<int32_t> data = {0, 1, 2};
+
+        auto* col_writer = rg_writer->column(0);
+        auto* typed_col_writer = dynamic_cast<::parquet::TypedColumnWriter<::parquet::Int32Type>*>(col_writer);
+        typed_col_writer->WriteBatch(3, nullptr, nullptr, data.data());
+
+        col_writer = rg_writer->column(1);
+        typed_col_writer = dynamic_cast<::parquet::TypedColumnWriter<::parquet::Int32Type>*>(col_writer);
+        typed_col_writer->WriteBatch(3, nullptr, nullptr, data.data());
+
+        try {
+            rg_writer->Close();
+        } catch (const ::parquet::ParquetException& e) {
+            std::cout << "exception: " << e.what() << std::endl;
+        }
+    }
+
+    writer->Close();
+}
+
+TEST(ArrowParquetWriterTest, Exception) {
+    auto sink = std::make_shared<MockOutputStream>();
+
+    EXPECT_CALL(*sink, Write)
+            .WillOnce(Return(arrow::Status::OK()))
+            .WillOnce(Return(arrow::Status::OK()))
+            .WillOnce(Return(arrow::Status::IOError("io error"))) // error when flush 2nd column chunk
+            .WillRepeatedly(Return(arrow::Status::OK()));
+
+    auto node = ::parquet::schema::GroupNode::Make(
+            "schema", ::parquet::Repetition::REQUIRED,
+            {
+                    ::parquet::schema::PrimitiveNode::Make("id1", ::parquet::Repetition::REQUIRED,
+                                                           ::parquet::Type::INT32),
+                    ::parquet::schema::PrimitiveNode::Make("id2", ::parquet::Repetition::REQUIRED,
+                                                           ::parquet::Type::INT32),
+            });
+    auto schema = std::static_pointer_cast<::parquet::schema::GroupNode>(node);
+    auto writer = ::parquet::ParquetFileWriter::Open(sink, schema);
+
+    {
+        auto* rg_writer = writer->AppendBufferedRowGroup();
+        std::vector<int32_t> data = {0, 1, 2};
+
+        auto* col_writer = rg_writer->column(0);
+        auto* typed_col_writer = dynamic_cast<::parquet::TypedColumnWriter<::parquet::Int32Type>*>(col_writer);
+        typed_col_writer->WriteBatch(3, nullptr, nullptr, data.data());
+
+        col_writer = rg_writer->column(1);
+        typed_col_writer = dynamic_cast<::parquet::TypedColumnWriter<::parquet::Int32Type>*>(col_writer);
+        typed_col_writer->WriteBatch(3, nullptr, nullptr, data.data());
+
+        try {
+            rg_writer->Close();
+        } catch (const ::parquet::ParquetException& e) {
+            std::cout << "exception: " << e.what() << std::endl;
+        }
+    }
+
+    writer->Close();
+}
+
+} // namespace
+} // namespace starrocks::parquet


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

backport #26254
close https://github.com/StarRocks/StarRocksTest/issues/5080

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
