### PR TITLE
[BugFix] No merge redundant task runs if the task run is sync mode refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/ExecuteOption.java
@@ -48,7 +48,9 @@ public class ExecuteOption {
     }
 
     public boolean isMergeRedundant() {
-        return mergeRedundant;
+        // If old task run is a sync-mode task, skip to merge it to avoid sync-mode task
+        // hanging after removing it.
+        return !isSync && mergeRedundant;
     }
 
     public void setMergeRedundant(boolean mergeRedundant) {
@@ -63,8 +65,8 @@ public class ExecuteOption {
         return isManual;
     }
 
-    public void setManual() {
-        this.isManual = true;
+    public void setManual(boolean isManual) {
+        this.isManual = isManual;
     }
 
     public boolean getIsSync() {
@@ -73,5 +75,13 @@ public class ExecuteOption {
 
     public void setSync(boolean isSync) {
         this.isSync = isSync;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ExecuteOption{priority=%s, mergeRedundant=%s, isManual=%s, " +
+                        "isSync=%s, taskRunProperties={%s}}",
+                priority, mergeRedundant, isManual, isSync, taskRunProperties
+        );
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -389,6 +390,20 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                         "\nInsert Plan:\n" +
                         ((ExecPlan) args[1]).getExplainString(StatementBase.ExplainLevel.VERBOSE),
                 mvToRefreshedPartitions, execPlan);
+        // log the final mv refresh plan for each refresh for better trace and debug
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("MV Refresh Final Plan" +
+                            "\nMV: {}" +
+                            "\nMV PartitionsToRefresh: {}" +
+                            "\nBase PartitionsToScan: {}" +
+                            "\nInsert Plan:\n{}",
+                    materializedView.getName(),
+                    String.join(",", mvToRefreshedPartitions), refTablePartitionNames,
+                    execPlan.getExplainString(StatementBase.ExplainLevel.VERBOSE));
+        } else {
+            LOG.info("MV Refresh Final Plan, mv: {}, MV PartitionsToRefresh: {}, Base PartitionsToScan: {}",
+                    materializedView.getName(), String.join(",", mvToRefreshedPartitions), refTablePartitionNames);
+        }
         mvContext.setExecPlan(execPlan);
 
         return insertStmt;
@@ -1205,6 +1220,16 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     .collect(Collectors.toList());
             insertStmt.setTargetColumnNames(targetColumnNames);
         }
+        if (LOG.isDebugEnabled()) {
+            LOG.debug("Generate refresh materialized view {} insert-overwrite statement, " +
+                            "materialized view's target partition names:{}, " +
+                            "materialized view's target columns: {}, " +
+                            "definition:{}",
+                    materializedView.getName(),
+                    Joiner.on(",").join(materializedViewPartitions),
+                    insertStmt.getTargetColumnNames() == null ? "" : Joiner.on(",").join(insertStmt.getTargetColumnNames()),
+                    definition);
+        }
         return insertStmt;
     }
 
@@ -1227,6 +1252,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 TableRelation tableRelation = nameTableRelationEntry.getValue();
                 // external table doesn't support query with partitionNames
                 if (!tableRelation.getTable().isExternalTableWithFileSystem()) {
+                    LOG.info("Optimize materialized view {} refresh task, generate table relation {} target partition names:{} ",
+                            materializedView.getName(), tableRelation.getName(), Joiner.on(",").join(tablePartitionNames));
                     tableRelation.setPartitionNames(
                             new PartitionNames(false, new ArrayList<>(tablePartitionNames)));
                 }
@@ -1249,6 +1276,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     // try to push down into table relation
                     Scope tableRelationScope = tableRelation.getScope();
                     if (canResolveSlotsInTheScope(slots, tableRelationScope)) {
+                        LOG.info("Optimize materialized view {} refresh task, generate table relation {} " +
+                                        "partition predicate:{} ",
+                                materializedView.getName(), tableRelation.getName(), partitionPredicates.toSql());
                         tableRelation.setPartitionPredicate(partitionPredicates);
                     }
 
@@ -1259,9 +1289,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     QueryRelation queryRelation = queryStatement.getQueryRelation();
                     if (queryRelation instanceof SelectRelation) {
                         SelectRelation selectRelation = ((SelectRelation) queryStatement.getQueryRelation());
-                        selectRelation.setWhereClause(
-                                Expr.compoundAnd(Lists.newArrayList(selectRelation.getWhereClause(),
-                                        partitionPredicates)));
+                        Expr finalExpr = Expr.compoundAnd(Lists.newArrayList(selectRelation.getWhereClause(),
+                                partitionPredicates));
+                        selectRelation.setWhereClause(finalExpr);
+                        LOG.info("Optimize materialized view {} refresh task, generate table relation {} " +
+                                        "final predicate:{} ",
+                                materializedView.getName(), tableRelation.getName(), finalExpr.toSql());
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -690,7 +690,7 @@ public class TaskManager {
                 }
                 TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
                 taskRun.initStatus(status.getQueryId(), status.getCreateTime());
-                taskRunManager.arrangeTaskRun(taskRun, status.isMergeRedundant());
+                taskRunManager.arrangeTaskRun(taskRun);
                 break;
             // this will happen in build image
             case RUNNING:

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -22,6 +22,7 @@ import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.load.loadv2.InsertLoadJob;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
@@ -68,8 +69,11 @@ public class TaskRun implements Comparable<TaskRun> {
 
     private ExecuteOption executeOption;
 
+    private final String uuid;
+
     TaskRun() {
         future = new CompletableFuture<>();
+        uuid = UUIDUtil.genUUID().toString();
     }
 
     public long getTaskId() {
@@ -291,6 +295,9 @@ public class TaskRun implements Comparable<TaskRun> {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+        if (status.getDefinition() == null) {
+            return false;
+        }
         TaskRun taskRun = (TaskRun) o;
         return status.getDefinition().equals(taskRun.getStatus().getDefinition());
     }
@@ -304,10 +311,11 @@ public class TaskRun implements Comparable<TaskRun> {
     public String toString() {
         return "TaskRun{" +
                 "taskId=" + taskId +
-                ", properties=" + properties +
-                ", task=" + task +
-                ", status=" + status +
                 ", type=" + type +
+                ", uuid=" + uuid +
+                ", task_state=" + status.getState() +
+                ", properties=" + properties +
+                ", extra_message =" + status.getExtraMessage() +
                 '}';
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunManager.java
@@ -66,13 +66,13 @@ public class TaskRunManager {
         for (Long taskId : pendingTaskRunMap.keySet()) {
             PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.get(taskId);
             if (taskRuns != null && !taskRuns.isEmpty()) {
-                validPendingCount++;
+                validPendingCount += taskRuns.size();
             }
         }
 
         if (validPendingCount >= Config.task_runs_queue_length) {
-            LOG.warn("pending TaskRun exceeds task_runs_queue_length:{}, reject the submit.",
-                    Config.task_runs_queue_length);
+            LOG.warn("pending TaskRun exceeds task_runs_queue_length:{}, reject the submit: {}",
+                    Config.task_runs_queue_length, taskRun);
             return new SubmitResult(null, SubmitResult.SubmitStatus.REJECTED);
         }
 
@@ -82,7 +82,10 @@ public class TaskRunManager {
         status.setMergeRedundant(option.isMergeRedundant());
         status.setProperties(option.getTaskRunProperties());
         GlobalStateMgr.getCurrentState().getEditLog().logTaskRunCreateStatus(status);
-        arrangeTaskRun(taskRun, option.isMergeRedundant());
+        if (!arrangeTaskRun(taskRun)) {
+            LOG.warn("Submit task run to pending queue failed, reject the submit:{}", taskRun);
+            return new SubmitResult(null, SubmitResult.SubmitStatus.REJECTED);
+        }
         return new SubmitResult(queryId, SubmitResult.SubmitStatus.SUBMITTED, taskRun.getFuture());
     }
 
@@ -103,41 +106,60 @@ public class TaskRunManager {
     // The manual priority is higher. For manual tasks, we do not merge operations.
     // For automatic tasks, we will compare the definition, and if they are the same,
     // we will perform the merge operation.
-    public void arrangeTaskRun(TaskRun taskRun, boolean mergeRedundant) {
+    public boolean arrangeTaskRun(TaskRun taskRun) {
         if (!tryTaskRunLock()) {
-            return;
+            return false;
         }
         try {
             long taskId = taskRun.getTaskId();
             PriorityBlockingQueue<TaskRun> taskRuns = pendingTaskRunMap.computeIfAbsent(taskId,
                     u -> Queues.newPriorityBlockingQueue());
-            if (mergeRedundant) {
-                TaskRun oldTaskRun = getTaskRun(taskRuns, taskRun);
-                if (oldTaskRun != null) {
+            // If the task run is sync-mode, it will hang forever if the task run is merged because
+            // user's using `future.get()` to wait and the future will not be set forever.
+            ExecuteOption executeOption = taskRun.getExecuteOption();
+            if (executeOption.isMergeRedundant()) {
+                Iterator<TaskRun> iter = taskRuns.iterator();
+                while (iter.hasNext()) {
+                    TaskRun oldTaskRun = iter.next();
+                    if (oldTaskRun == null) {
+                        continue;
+                    }
+                    // If old task run is a sync-mode task, skip to merge it to avoid sync-mode task
+                    // hanging after removing it.
+                    if (!oldTaskRun.getExecuteOption().isMergeRedundant()) {
+                        continue;
+                    }
+                    // skip if old task run is not equal to the task run
                     // The remove here is actually remove the old TaskRun.
                     // Note that the old TaskRun and new TaskRun may have the same definition,
                     // but other attributes may be different, such as priority, creation time.
                     // higher priority and create time will be result after merge is complete
-                    // and queryId will be change.
-                    boolean isRemove = taskRuns.remove(taskRun);
-                    if (!isRemove) {
+                    // and queryId will be changed.
+                    if (!oldTaskRun.equals(taskRun)) {
                         LOG.warn("failed to remove TaskRun definition is [{}]",
                                 taskRun.getStatus().getDefinition());
+                        continue;
                     }
+
                     if (oldTaskRun.getStatus().getPriority() > taskRun.getStatus().getPriority()) {
                         taskRun.getStatus().setPriority(oldTaskRun.getStatus().getPriority());
                     }
                     if (oldTaskRun.getStatus().getCreateTime() > taskRun.getStatus().getCreateTime()) {
                         taskRun.getStatus().setCreateTime(oldTaskRun.getStatus().getCreateTime());
                     }
+                    LOG.info("Merge redundant task run, oldTaskRun: {}, taskRun: {}",
+                            oldTaskRun, taskRun);
+                    iter.remove();
                 }
             }
             if (!taskRuns.offer(taskRun)) {
-                LOG.warn("failed to offer task");
+                LOG.warn("failed to offer task: {}", taskRun);
+                return false;
             }
         } finally {
             taskRunUnlock();
         }
+        return true;
     }
 
     // Because java PriorityQueue does not provide an interface for searching by element,
@@ -168,6 +190,7 @@ public class TaskRunManager {
             Future<?> future = taskRun.getFuture();
             if (future.isDone()) {
                 runningIterator.remove();
+                LOG.info("Task run is done from state RUNNING to {}, {}", taskRun.getStatus().getState(), taskRun);
                 taskRunHistory.addHistory(taskRun.getStatus());
                 TaskRunStatusChange statusChange = new TaskRunStatusChange(taskRun.getTaskId(), taskRun.getStatus(),
                         Constants.TaskRunState.RUNNING, taskRun.getStatus().getState());
@@ -193,6 +216,7 @@ public class TaskRunManager {
                         break;
                     }
                     TaskRun pendingTaskRun = taskRunQueue.poll();
+                    LOG.info("start to schedule pending task run to execute: {}", pendingTaskRun);
                     taskRunExecutor.executeTaskRun(pendingTaskRun);
                     runningTaskRunMap.put(taskId, pendingTaskRun);
                     // RUNNING state persistence is for FE FOLLOWER update state

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -3612,9 +3612,13 @@ public class LocalMetastore implements ConnectorMetadata {
         new AlterMVJobExecutor().process(stmt, ConnectContext.get());
     }
 
-    private String executeRefreshMvTask(String dbName, MaterializedView materializedView, ExecuteOption executeOption)
+    private String executeRefreshMvTask(String dbName, MaterializedView materializedView,
+                                        ExecuteOption executeOption)
             throws DdlException {
         MaterializedView.RefreshType refreshType = materializedView.getRefreshScheme().getType();
+        LOG.info("Start to execute refresh materialized view task, mv: {}, refreshType: {}, executionOption:{}",
+                materializedView.getName(), refreshType, executeOption);
+
         if (refreshType.equals(MaterializedView.RefreshType.INCREMENTAL)) {
             MaterializedViewMgr.getInstance().onTxnPublish(materializedView);
         } else if (refreshType != MaterializedView.RefreshType.SYNC) {
@@ -3670,9 +3674,7 @@ public class LocalMetastore implements ConnectorMetadata {
         taskRunProperties.put(TaskRun.FORCE, Boolean.toString(force));
 
         ExecuteOption executeOption = new ExecuteOption(priority, mergeRedundant, taskRunProperties);
-        if (isManual) {
-            executeOption.setManual();
-        }
+        executeOption.setManual(isManual);
         executeOption.setSync(isSync);
         return executeRefreshMvTask(dbName, materializedView, executeOption);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -807,6 +807,8 @@ public class PublishVersionDaemon extends FrontendDaemon {
                         continue;
                     }
                     if (materializedView.shouldTriggeredRefreshBy(db.getFullName(), table.getName())) {
+                        LOG.info("Trigger auto materialized view refresh because of base table {} has changed, " +
+                                        "db:{}, mv:{}", table.getName(), mvDb.getFullName(), materializedView.getName());
                         GlobalStateMgr.getCurrentState().getLocalMetastore().refreshMaterializedView(
                                 mvDb.getFullName(), mvDb.getTable(mvId.getId()).getName(), false, null,
                                 Constants.TaskRunPriority.NORMAL.value(), true, false);

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/RefreshMaterializedViewTest.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.clone.DynamicPartitionScheduler;
 import com.starrocks.common.Config;
+import com.starrocks.common.FeConstants;
 import com.starrocks.pseudocluster.PseudoCluster;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.StmtExecutor;
@@ -75,6 +76,7 @@ public class RefreshMaterializedViewTest {
         connectContext = UtFrameUtils.createDefaultCtx();
         starRocksAssert = new StarRocksAssert(connectContext);
         starRocksAssert.withDatabase("test").useDatabase("test");
+        FeConstants.runningUnitTest = true;
 
         Config.enable_experimental_mv = true;
         starRocksAssert.useDatabase("test")

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/TaskManagerTest.java
@@ -54,7 +54,8 @@ public class TaskManagerTest {
 
     private static ConnectContext connectContext;
     private static StarRocksAssert starRocksAssert;
-
+    private static final ExecuteOption DEFAULT_MERGE_OPTION = makeExecuteOption(true, false);
+    private static final ExecuteOption DEFAULT_NO_MERGE_OPTION = makeExecuteOption(false, false);
     @Before
     public void setUp() {
         GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
@@ -215,21 +216,27 @@ public class TaskManagerTest {
 
         long taskId = 1;
 
-        TaskRun taskRun1 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun1 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(makeExecuteOption(true, false))
+                .build();
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now);
         taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
-        TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun2 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun1, true);
-        taskRunManager.arrangeTaskRun(taskRun2, true);
+        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun2);
 
         Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
@@ -247,21 +254,27 @@ public class TaskManagerTest {
 
         long taskId = 1;
 
-        TaskRun taskRun1 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun1 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now);
         taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
-        TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun2 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun2, true);
-        taskRunManager.arrangeTaskRun(taskRun1, true);
+        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1);
 
         Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
@@ -279,21 +292,27 @@ public class TaskManagerTest {
 
         long taskId = 1;
 
-        TaskRun taskRun1 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun1 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now + 10);
         taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
-        TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun2 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(0);
 
-        taskRunManager.arrangeTaskRun(taskRun1, true);
-        taskRunManager.arrangeTaskRun(taskRun2, true);
+        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun2);
 
         Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
@@ -311,21 +330,27 @@ public class TaskManagerTest {
 
         long taskId = 1;
 
-        TaskRun taskRun1 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun1 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now + 10);
         taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
-        TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun2 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_MERGE_OPTION)
+                .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(0);
 
-        taskRunManager.arrangeTaskRun(taskRun2, true);
-        taskRunManager.arrangeTaskRun(taskRun1, true);
+        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1);
 
         Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(1, pendingTaskRunMap.get(taskId).size());
@@ -343,32 +368,40 @@ public class TaskManagerTest {
 
         long taskId = 1;
 
-        TaskRun taskRun1 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun1 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_NO_MERGE_OPTION)
+                .build();
         long now = System.currentTimeMillis();
         taskRun1.setTaskId(taskId);
         taskRun1.initStatus("1", now);
         taskRun1.getStatus().setDefinition("select 1");
         taskRun1.getStatus().setPriority(0);
 
-        TaskRun taskRun2 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun2 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_NO_MERGE_OPTION)
+                .build();
         taskRun2.setTaskId(taskId);
         taskRun2.initStatus("2", now);
         taskRun2.getStatus().setDefinition("select 1");
         taskRun2.getStatus().setPriority(10);
 
-        TaskRun taskRun3 = TaskRunBuilder.newBuilder(task).build();
+        TaskRun taskRun3 = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(DEFAULT_NO_MERGE_OPTION)
+                .build();
         taskRun3.setTaskId(taskId);
         taskRun3.initStatus("3", now + 10);
         taskRun3.getStatus().setDefinition("select 1");
         taskRun3.getStatus().setPriority(10);
 
-        taskRunManager.arrangeTaskRun(taskRun2, false);
-        taskRunManager.arrangeTaskRun(taskRun1, false);
-        taskRunManager.arrangeTaskRun(taskRun3, false);
+        taskRunManager.arrangeTaskRun(taskRun2);
+        taskRunManager.arrangeTaskRun(taskRun1);
+        taskRunManager.arrangeTaskRun(taskRun3);
 
         Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
         Assert.assertEquals(3, pendingTaskRunMap.get(taskId).size());
-
     }
 
     @Test
@@ -445,5 +478,85 @@ public class TaskManagerTest {
                 parseLocalDateTime("2023-04-18 20:00:10")));
         Assert.assertEquals(0, TaskManager.getInitialDelayTime(20, parseLocalDateTime("2023-04-18 19:08:30"),
                 parseLocalDateTime("2023-04-18 21:00:10")));
+    }
+
+    private static ExecuteOption makeExecuteOption(boolean isMergeRedundant, boolean isSync) {
+        ExecuteOption executeOption = new ExecuteOption();
+        executeOption.setMergeRedundant(isMergeRedundant);
+        executeOption.setSync(isSync);
+        return  executeOption;
+    }
+
+    private TaskRun makeTaskRun(long taskId, Task task, ExecuteOption executeOption) {
+        TaskRun taskRun = TaskRunBuilder
+                .newBuilder(task)
+                .setExecuteOption(executeOption)
+                .build();
+        taskRun.setTaskId(taskId);
+        return taskRun;
+    }
+
+    @Test
+    public void testTaskRunMergeRedundant1() {
+        TaskRunManager taskRunManager = new TaskRunManager();
+        Task task = new Task("test");
+        task.setDefinition("select 1");
+        long taskId = 1;
+
+        TaskRun taskRun1 = makeTaskRun(taskId, task, makeExecuteOption(true, false));
+        TaskRun taskRun2 = makeTaskRun(taskId, task, makeExecuteOption(true, true));
+
+        // If it's a sync refresh, no merge redundant anyway
+        SubmitResult result = taskRunManager.submitTaskRun(taskRun1, taskRun1.getExecuteOption());
+        Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
+        result = taskRunManager.submitTaskRun(taskRun2, taskRun2.getExecuteOption());
+        Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
+
+        Map<Long, PriorityBlockingQueue<TaskRun>> pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Assert.assertEquals(2, pendingTaskRunMap.get(taskId).size());
+
+        // If it's a sync refresh, no merge redundant anyway
+        TaskRun taskRun3 = makeTaskRun(taskId, task, makeExecuteOption(false, true));
+        result = taskRunManager.submitTaskRun(taskRun3, taskRun3.getExecuteOption());
+        Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
+
+        pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Assert.assertEquals(3, pendingTaskRunMap.get(taskId).size());
+
+        // merge it
+        TaskRun taskRun4 = makeTaskRun(taskId, task, makeExecuteOption(true, false));
+        result = taskRunManager.submitTaskRun(taskRun4, taskRun4.getExecuteOption());
+        Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
+
+        pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Assert.assertEquals(3, pendingTaskRunMap.get(taskId).size());
+
+        // no merge it
+        TaskRun taskRun5 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
+        result = taskRunManager.submitTaskRun(taskRun5, taskRun5.getExecuteOption());
+        Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
+        pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Assert.assertEquals(4, pendingTaskRunMap.get(taskId).size());
+
+        for (int i = 4; i < Config.task_runs_queue_length; i++) {
+            TaskRun taskRun = makeTaskRun(taskId, task, makeExecuteOption(false, false));
+            result = taskRunManager.submitTaskRun(taskRun, taskRun.getExecuteOption());
+            Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.SUBMITTED);
+            pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+            Assert.assertEquals(i + 1, pendingTaskRunMap.get(taskId).size());
+        }
+        // no assign it: exceed queue's size
+        TaskRun taskRun6 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
+        result = taskRunManager.submitTaskRun(taskRun6, taskRun6.getExecuteOption());
+        Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.REJECTED);
+        pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Assert.assertEquals(Config.task_runs_queue_length, pendingTaskRunMap.get(taskId).size());
+
+        // no assign it: exceed queue's size
+        TaskRun taskRun7 = makeTaskRun(taskId, task, makeExecuteOption(false, false));
+        result = taskRunManager.submitTaskRun(taskRun7, taskRun7.getExecuteOption());
+        Assert.assertTrue(result.getStatus() == SubmitResult.SubmitStatus.REJECTED);
+        pendingTaskRunMap = taskRunManager.getPendingTaskRunMap();
+        Assert.assertEquals(Config.task_runs_queue_length, pendingTaskRunMap.get(taskId).size());
     }
 }


### PR DESCRIPTION
Why I'm doing:

When a mv's refresh type is `ASYNC` mode, it will be refreshed after new inputs are added. But when I refreshed the mv in parallel, the sync mode refresh maybe hanging forever.

This is because the sync mode refresh task run is merged redundant when the pending task queue already contains the refresh task. When the sync mode refresh task run is merged, the future will be removed and will not be set, and the `future.get()` will be hanging until query timeout.

What I'm doing:
- Avoid merging redundant for sync mode refresh task run.
- Add more logs for refreshing the materialized view task run.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
