### PR TITLE
[BugFix] No need to evalute rollup index when chunk is empty after where-expr evaluation

### DIFF
--- a/be/src/storage/schema_change_utils.cpp
+++ b/be/src/storage/schema_change_utils.cpp
@@ -244,8 +244,14 @@ bool ChunkChanger::change_chunk_v2(ChunkPtr& base_chunk, ChunkPtr& new_chunk, co
         }
         if (_where_expr) {
             auto filter = _execute_where_expr(base_chunk);
+            // If no filtered rows are left, return directly
+            if (SIMD::count_nonzero(filter) == 0) {
+                base_chunk->set_num_rows(0);
+                return true;
+            }
             base_chunk->filter(filter);
         }
+        DCHECK(!base_chunk->is_empty());
     }
 
     for (size_t i = 0; i < new_chunk->num_columns(); ++i) {


### PR DESCRIPTION

Why I'm doing:
- Broken in asan mode because an empty chunk is called to evaluate expr context.
```
*** Aborted at 1702356316 (unix time) try "date -d @1702356316" if you are using GNU date ***
PC: @     0x7f435adfc387 __GI_raise
*** SIGABRT (@0x3e800005fb6) received by PID 24502 (TID 0x7f40ed548700) from PID 24502; stack trace: ***
   @         0x1604cd32 google::(anonymous namespace)::FailureSignalHandler()
   @     0x7f435bacb630 (unknown)
   @     0x7f435adfc387 __GI_raise
   @     0x7f435adfda78 __GI_abort
   @          0xa7741fd starrocks::failure_function()
   @         0x1604070d google::LogMessage::Fail()
   @         0x16042b7f google::LogMessage::SendToLog()
   @         0x1604025e google::LogMessage::Flush()
   @         0x16043189 google::LogMessageFatal::~LogMessageFatal()
   @         0x10c0aea7 starrocks::ExprContext::evaluate()
   @         0x10c0a82b starrocks::ExprContext::evaluate()
   @         0x12cf1043 starrocks::ChunkChanger::change_chunk_v2()
   @         0x12cbf4c6 starrocks::SchemaChangeWithSorting::process()
   @         0x12cce393 starrocks::SchemaChangeHandler::_convert_historical_rowsets()
   @         0x12cca152 starrocks::SchemaChangeHandler::_do_process_alter_tablet_v2_normal()
   @         0x12cc6acc starrocks::SchemaChangeHandler::_do_process_alter_tablet_v2()
   @         0x12cc2e4e starrocks::SchemaChangeHandler::process_alter_tablet_v2()
   @         0x12bee182 starrocks::EngineAlterTabletTask::execute()
   @         0x127c5698 starrocks::StorageEngine::execute_task()
   @          0xbfafe9e starrocks::alter_tablet()
   @          0xbfb3e80 starrocks::run_alter_tablet_task()
   @          0xbf4be24 std::__invoke_impl<>()
   @          0xbf44cf3 std::__invoke<>()
   @          0xbf3fbfc _ZNSt5_BindIFPFvRKSt10shared_ptrIN9starrocks27AgentTaskRequestWithReqBodyINS1_17TAlterTabletReqV2EEEEPNS1_7ExecEnvEES5_S9_EE6__callIvJEJLm0ELm1EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
   @          0xbf3814c std::_Bind<>::operator()<>()
   @          0xbf30912 std::__invoke_impl<>()
   @          0xbf29cea _ZSt10__invoke_rIvRSt5_BindIFPFvRKSt10shared_ptrIN9starrocks27AgentTaskRequestWithReqBodyINS2_17TAlterTabletReqV2EEEEPNS2_7ExecEnvEES6_SA_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESH_E4typeEOSI_DpOSJ_
   @          0xbf23311 std::_Function_handler<>::_M_invoke()
   @          0xa6631f8 std::function<>::operator()()
   @          0xb10c4b6 starrocks::FunctionRunnable::run()
   @          0xb108f69 starrocks::ThreadPool::dispatch_thread()
   @          0xb125ef4 std::__invoke_impl<>()
```
What I'm doing:
- Short-cut when base chunk becomes empty after where expression evaluated.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5164

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
