### PR TITLE
[BugFix] Fixed the problem of early closing of the file system in the hdfs cache, which cause `FileSystem closed` error.

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -817,7 +817,7 @@ CONF_Bool(hdfs_client_enable_hedged_read, "false");
 CONF_Int32(hdfs_client_hedged_read_threadpool_size, "128");
 // dfs.client.hedged.read.threshold.millis
 CONF_Int32(hdfs_client_hedged_read_threshold_millis, "2500");
-CONF_Int32(hdfs_client_max_cache_size, "8");
+CONF_Int32(hdfs_client_max_cache_size, "64");
 CONF_Int32(hdfs_client_io_read_retry, "0");
 
 // Enable output trace logs in aws-sdk-cpp for diagnosis purpose.

--- a/be/src/fs/hdfs/hdfs_fs_cache.cpp
+++ b/be/src/fs/hdfs/hdfs_fs_cache.cpp
@@ -56,10 +56,8 @@ static Status create_hdfs_fs_handle(const std::string& namenode, const std::shar
         if (properties->__isset.hdfs_username) {
             hdfsBuilderSetUserName(hdfs_builder, properties->hdfs_username.data());
         }
-        if (properties->__isset.disable_cache && properties->disable_cache) {
-            hdfsBuilderSetForceNewInstance(hdfs_builder);
-        }
     }
+    hdfsBuilderSetForceNewInstance(hdfs_builder);
 
     // Insert cloud properties(key-value paired) into Hadoop configuration
     // TODO(SmithCruise): Should remove when using cpp sdk
@@ -92,7 +90,6 @@ static Status create_hdfs_fs_handle(const std::string& namenode, const std::shar
 
 Status HdfsFsCache::get_connection(const std::string& namenode, std::shared_ptr<HdfsFsClient>& hdfs_client,
                                    const FSOptions& options) {
-    std::lock_guard<std::mutex> l(_lock);
     std::string cache_key = namenode;
     const THdfsProperties* properties = options.hdfs_properties();
     if (properties != nullptr && properties->__isset.hdfs_username) {
@@ -108,26 +105,28 @@ Status HdfsFsCache::get_connection(const std::string& namenode, std::shared_ptr<
         }
     }
 
-    for (size_t idx = 0; idx < _cache_keys.size(); idx++) {
-        if (_cache_keys[idx] == cache_key) {
-            hdfs_client = _cache_clients[idx];
-            // Found a cache client, return directly
-            return Status::OK();
-        }
-    }
-    const uint32_t max_cache_clients = config::hdfs_client_max_cache_size;
+    std::lock_guard<std::mutex> l(_lock);
 
+    auto it = _cache_clients.find(cache_key);
+    if (it != _cache_clients.end()) {
+        hdfs_client = it->second;
+        // Found a cache client, return directly
+        return Status::OK();
+    }
+
+    const uint32_t max_cache_clients = config::hdfs_client_max_cache_size;
     // Not found a cached client, create a new one
     hdfs_client = std::make_shared<HdfsFsClient>();
     hdfs_client->namenode = namenode;
     RETURN_IF_ERROR(create_hdfs_fs_handle(namenode, hdfs_client, options));
     if (UNLIKELY(_cache_keys.size() >= max_cache_clients)) {
         uint32_t idx = _rand.Uniform(max_cache_clients);
-        _cache_keys[idx] = cache_key;
-        _cache_clients[idx] = hdfs_client;
+        _cache_clients.erase(_cache_keys[idx]);
+        _cache_clients[cache_key] = hdfs_client;
+        _cache_keys[idx].swap(cache_key);
     } else {
-        _cache_keys.emplace_back(cache_key);
-        _cache_clients.emplace_back(hdfs_client);
+        _cache_clients[cache_key] = hdfs_client;
+        _cache_keys.push_back(std::move(cache_key));
     }
     return Status::OK();
 }

--- a/be/src/fs/hdfs/hdfs_fs_cache.h
+++ b/be/src/fs/hdfs/hdfs_fs_cache.h
@@ -56,8 +56,8 @@ public:
 
 private:
     std::mutex _lock;
+    std::unordered_map<std::string, std::shared_ptr<HdfsFsClient>> _cache_clients;
     std::vector<std::string> _cache_keys;
-    std::vector<std::shared_ptr<HdfsFsClient>> _cache_clients;
     Random _rand{(uint32_t)time(nullptr)};
 
     HdfsFsCache() = default;


### PR DESCRIPTION
Why I'm doing:
Now we cache the hdfs client in `HdfsFsCache` and each client bind a hdfs filesystem instance. The hdfs client is managed by `shared_ptr`,  when the client is not referenced, it will be freed and filesystem will be closed.

Consider a situation like this:
If there are 10 namenodes in the hdfs system. As the current max cache size in StarRocks is 8, so the original client will be evicted from the cache after the system has been running for a period of time.

Assume that client1 ~ client8 corresponding to namenode1 ~ namenode8 are cached in the original StarRocks client cache.
1. If a new client9 comes at a certain moment, it evicts the original client1. If client1 is still held by a peripheral file handle, the reference count will not be reduced to 0 immediately, and client1 will not be destructed or disconnected until the entire reading is completed.
2. If a new request for namenode1 comes during this period, because the corresponding client no longer exists in the client cache, a new client10 will be created. Since we currently do not use the `disable cache` mode of hdfs, hdfs filesystem will actually return the previously cached filesystem instance to client10. Actually the filesystem is the one corresponding to client 1 previously.
3. When the file held by client1 is read completed, client1 is destructed and the disconnect function is called, causing the filesystem instance to be closed.
4. Because client10 and client1 use the same filesystem instance in hdfs, all subsequent accesses to client10 will suffer `FileSystem closed` problem.

What I'm doing:
1. Increase the default max cache size to reduce the cache eviction.
2. Use the `disable cache` mode in hdfs to make sure one filesystem instance will not be returned to different clients. This can help avoiding the above `FileSystem closed` problem. Because there is a local client cache in StarRocks layer, use `disable cache` in hdfs will be no significant impact on performance.
3. Use the hashtable to implement the local client cache, instead of original vector, to speed up cache lookups.
4. Move some operations without concurrency problem outside the lock scope to reduce lock competition.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
