### PR TITLE
[Enhancement] support set_var in multiple query blocks

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -197,7 +197,6 @@ import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -746,7 +745,7 @@ public class StmtExecutor {
         if (parsedStmt == null) {
             return;
         }
-        Map<String, String> optHints = visitVarHintFromStatement();
+        Map<String, String> optHints = VarHintVisitor.extractAllHints(parsedStmt);
 
         if (MapUtils.isNotEmpty(optHints)) {
             SessionVariable sessionVariable = (SessionVariable) variables.clone();
@@ -791,7 +790,9 @@ public class StmtExecutor {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
                 this.hints.putAll(node.getOptHints());
             }
-            visit(node.getQueryStatement(), context);
+            if (node.getQueryStatement() != null) {
+                visit(node.getQueryStatement(), context);
+            }
             return null;
         }
 
@@ -800,7 +801,9 @@ public class StmtExecutor {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
                 this.hints.putAll(node.getOptHints());
             }
-            visit(node.getQueryStatement(), context);
+            if (node.getQueryStatement() != null) {
+                visit(node.getQueryStatement(), context);
+            }
             return null;
         }
 
@@ -809,7 +812,9 @@ public class StmtExecutor {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
                 this.hints.putAll(node.getOptHints());
             }
-            visit(node.getQueryStatement(), context);
+            if (node.getQueryStatement() != null) {
+                visit(node.getQueryStatement(), context);
+            }
             return null;
         }
 
@@ -820,13 +825,6 @@ public class StmtExecutor {
             }
             return null;
         }
-    }
-
-    @Nullable
-    private Map<String, String> visitVarHintFromStatement() {
-        Map<String, String> optHints = null;
-        optHints = VarHintVisitor.extractAllHints(parsedStmt);
-        return optHints;
     }
 
     private void handleCreateTableAsSelectStmt(long beginTimeInNanoSecond) throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -790,9 +790,7 @@ public class StmtExecutor {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
                 node.getOptHints().forEach(hints::putIfAbsent);
             }
-            if (node.getQueryStatement() != null) {
-                visit(node.getQueryStatement(), context);
-            }
+            super.visitInsertStatement(node, context);
             return null;
         }
 
@@ -801,9 +799,7 @@ public class StmtExecutor {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
                 node.getOptHints().forEach(hints::putIfAbsent);
             }
-            if (node.getQueryStatement() != null) {
-                visit(node.getQueryStatement(), context);
-            }
+            super.visitUpdateStatement(node, context);
             return null;
         }
 
@@ -812,9 +808,7 @@ public class StmtExecutor {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
                 node.getOptHints().forEach(hints::putIfAbsent);
             }
-            if (node.getQueryStatement() != null) {
-                visit(node.getQueryStatement(), context);
-            }
+            super.visitDeleteStatement(node, context);
             return null;
         }
 
@@ -823,6 +817,7 @@ public class StmtExecutor {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
                 node.getOptHints().forEach(hints::putIfAbsent);
             }
+            super.visitDDLStatement(node, context);
             return null;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -788,7 +788,7 @@ public class StmtExecutor {
         @Override
         public Void visitInsertStatement(InsertStmt node, Void context) {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
-                this.hints.putAll(node.getOptHints());
+                node.getOptHints().forEach(hints::putIfAbsent);
             }
             if (node.getQueryStatement() != null) {
                 visit(node.getQueryStatement(), context);
@@ -799,7 +799,7 @@ public class StmtExecutor {
         @Override
         public Void visitUpdateStatement(UpdateStmt node, Void context) {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
-                this.hints.putAll(node.getOptHints());
+                node.getOptHints().forEach(hints::putIfAbsent);
             }
             if (node.getQueryStatement() != null) {
                 visit(node.getQueryStatement(), context);
@@ -810,7 +810,7 @@ public class StmtExecutor {
         @Override
         public Void visitDeleteStatement(DeleteStmt node, Void context) {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
-                this.hints.putAll(node.getOptHints());
+                node.getOptHints().forEach(hints::putIfAbsent);
             }
             if (node.getQueryStatement() != null) {
                 visit(node.getQueryStatement(), context);
@@ -821,7 +821,7 @@ public class StmtExecutor {
         @Override
         public Void visitDDLStatement(DdlStmt node, Void context) {
             if (MapUtils.isNotEmpty(node.getOptHints())) {
-                this.hints.putAll(node.getOptHints());
+                node.getOptHints().forEach(hints::putIfAbsent);
             }
             return null;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -36,6 +36,7 @@ import com.starrocks.sql.ast.SubqueryRelation;
 import com.starrocks.sql.ast.TableFunctionRelation;
 import com.starrocks.sql.ast.TableRelation;
 import com.starrocks.sql.ast.ViewRelation;
+import org.apache.commons.collections.MapUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 
@@ -138,6 +139,16 @@ public class AstToSQLBuilder {
             StringBuilder sqlBuilder = new StringBuilder();
             SelectList selectList = stmt.getSelectList();
             sqlBuilder.append("SELECT ");
+
+            // set_var
+            if (MapUtils.isNotEmpty(selectList.getOptHints())) {
+                sqlBuilder.append("/*+SET_VAR(");
+                sqlBuilder.append(selectList.getOptHints().entrySet().stream()
+                        .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+                        .collect(Collectors.joining(",")));
+                sqlBuilder.append(")*/ ");
+            }
+
             if (selectList.isDistinct()) {
                 sqlBuilder.append("DISTINCT ");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToSQLBuilder.java
@@ -138,7 +138,7 @@ public class AstToSQLBuilder {
             if (MapUtils.isNotEmpty(hints)) {
                 sqlBuilder.append("/*+SET_VAR(");
                 sqlBuilder.append(hints.entrySet().stream()
-                        .map(entry -> String.format("%s=%s", entry.getKey(), entry.getValue()))
+                        .map(entry -> String.format("%s='%s'", entry.getKey(), entry.getValue()))
                         .collect(Collectors.joining(",")));
                 sqlBuilder.append(")*/ ");
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstTraverser.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.ast;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.OrderByElement;
 import com.starrocks.analysis.Subquery;
+import com.starrocks.sql.ast.pipe.CreatePipeStmt;
 
 public class AstTraverser<R, C> extends AstVisitor<R, C> {
 
@@ -32,7 +33,10 @@ public class AstTraverser<R, C> extends AstVisitor<R, C> {
 
     @Override
     public R visitInsertStatement(InsertStmt statement, C context) {
-        return visit(statement.getQueryStatement());
+        if (statement.getQueryStatement() != null) {
+            visit(statement.getQueryStatement());
+        }
+        return null;
     }
 
     @Override
@@ -49,6 +53,36 @@ public class AstTraverser<R, C> extends AstVisitor<R, C> {
         //Delete Statement after analyze, all information will be used to build QueryStatement, so it is enough to traverse Query
         if (statement.getQueryStatement() != null) {
             visit(statement.getQueryStatement());
+        }
+        return null;
+    }
+
+    @Override
+    public R visitSubmitTaskStatement(SubmitTaskStmt statement, C context) {
+        if (statement.getInsertStmt() != null) {
+            visit(statement.getInsertStmt());
+        }
+        if (statement.getCreateTableAsSelectStmt() != null) {
+            visit(statement.getCreateTableAsSelectStmt());
+        }
+        return null;
+    }
+
+    @Override
+    public R visitCreatePipeStatement(CreatePipeStmt statement, C context) {
+        if (statement.getInsertStmt() != null) {
+            visit(statement.getInsertStmt());
+        }
+        return null;
+    }
+
+    @Override
+    public R visitCreateTableAsSelectStatement(CreateTableAsSelectStmt statement, C context) {
+        if (statement.getQueryStatement() != null) {
+            visit(statement.getQueryStatement());
+        }
+        if (statement.getInsertStmt() != null) {
+            visit(statement.getInsertStmt());
         }
         return null;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -204,6 +204,7 @@ public class ShowCreateMaterializedViewStmtTest {
         Assertions.assertTrue(createTableStmt.get(0).contains(property), createTableStmt.get(0));
         Assertions.assertTrue(createTableStmt.get(0).contains(partitionBy), createTableStmt.get(0));
         Assertions.assertTrue(createTableStmt.get(0).contains(distribute), createTableStmt.get(0));
+        Assertions.assertTrue(createTableStmt.get(0).contains(select), createTableStmt.get(0));
     }
 
     public static Stream<Arguments> genTestArguments() {
@@ -228,7 +229,8 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k3`)",
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10");
         List<String> selectList = Lists.newArrayList(
-                "select k1 as k3, k2 from tbl1"
+                "SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`",
+                "SELECT /*+SET_VAR(query_timeout=1)*/ `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`"
         );
 
         // basic combinations

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateMaterializedViewStmtTest.java
@@ -230,7 +230,7 @@ public class ShowCreateMaterializedViewStmtTest {
                 "DISTRIBUTED BY HASH(`k3`) BUCKETS 10");
         List<String> selectList = Lists.newArrayList(
                 "SELECT `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`",
-                "SELECT /*+SET_VAR(query_timeout=1)*/ `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`"
+                "SELECT /*+SET_VAR(query_timeout='1')*/ `tbl1`.`k1` AS `k3`, `tbl1`.`k2`\nFROM `test`.`tbl1`"
         );
 
         // basic combinations

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -586,7 +586,7 @@ public class MaterializedViewTest {
         Assert.assertTrue(taskProperties.containsKey("query_timeout"));
         Assert.assertEquals("500", taskProperties.get("query_timeout"));
         Assert.assertEquals(Constants.TaskType.EVENT_TRIGGERED, task.getType());
-        Assert.assertTrue(task.getDefinition(), task.getDefinition().contains("query_timeout=500"));
+        Assert.assertTrue(task.getDefinition(), task.getDefinition().contains("query_timeout='500'"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/MaterializedViewTest.java
@@ -586,6 +586,7 @@ public class MaterializedViewTest {
         Assert.assertTrue(taskProperties.containsKey("query_timeout"));
         Assert.assertEquals("500", taskProperties.get("query_timeout"));
         Assert.assertEquals(Constants.TaskType.EVENT_TRIGGERED, task.getType());
+        Assert.assertTrue(task.getDefinition(), task.getDefinition().contains("query_timeout=500"));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SetVarTest.java
@@ -21,12 +21,33 @@ import com.starrocks.qe.ShowResultSet;
 import com.starrocks.qe.StmtExecutor;
 import com.starrocks.sql.ast.DmlStmt;
 import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import junit.framework.Assert;
 import mockit.Mock;
 import mockit.MockUp;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 public class SetVarTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        PlanTestBase.beforeClass();
+    }
+
+    @AfterAll
+    public static void afterAll() throws Exception {
+        PlanTestBase.afterClass();
+    }
 
     @Test
     public void testInsertStmt() throws Exception {
@@ -77,11 +98,51 @@ public class SetVarTest extends PlanTestBase {
         {
             boolean enableAdaptiveSinkDop = variable.getEnableAdaptiveSinkDop();
             String sql = "LOAD /*+set_var(enable_adaptive_sink_dop=false)*/ "
-                          + "LABEL label0 (DATA INFILE('/path1/file') INTO TABLE tbl)";
+                    + "LABEL label0 (DATA INFILE('/path1/file') INTO TABLE tbl)";
             starRocksAssert.getCtx().executeSql(sql);
             Assert.assertEquals(enableAdaptiveSinkDop, variable.getEnableAdaptiveSinkDop());
         }
 
         starRocksAssert.dropTable("tbl");
+    }
+
+    @ParameterizedTest
+    @MethodSource("genArguments")
+    public void testMultiQueryBlocks(String query, Map<String, String> hints) throws Exception {
+        starRocksAssert.withTable("create table if not exists tbl (c1 int) properties('replication_num'='1')");
+
+        Assertions.assertEquals(hints, parseAndGetHints(query));
+    }
+
+    public static Stream<Arguments> genArguments() {
+        Map<String, String> hints2 = Map.of("query_timeout", "1");
+        Map<String, String> hints3 = Map.of("query_timeout", "10", "query_mem_limit", "1");
+
+        return Stream.of(
+                // multi-block select
+                Arguments.of("(select /*+set_var(query_timeout=1)*/avg(c1) from tbl) " +
+                        "union all (select /*+set_var(query_timeout=10)*/sum(c1) from tbl) ", hints2),
+                Arguments.of("(select /*+set_var(query_timeout=10)*/avg(c1) from tbl) " +
+                        "union all (select /*+set_var(query_mem_limit=1)*/sum(c1) from tbl) ", hints3),
+                Arguments.of("(select /*+set_var(query_timeout=10)*/ avg(c1) from tbl ) " +
+                        "union (" +
+                        "   select s1+1 from (" +
+                        "       select /*+set_var(query_mem_limit=1)*/ sum(c1) as s1 from tbl " +
+                        "   ) r1 " +
+                        ") ", hints3),
+                Arguments.of("insert /*+set_var(query_timeout=1) */ into tbl values(1) ", hints2),
+
+                // insert select
+                Arguments.of("insert into tbl select /*+set_var(query_timeout=1) */ * from tbl", hints2),
+                Arguments.of("insert /*+set_var(query_timeout=1)*/ into tbl " +
+                        "select /*+set_var(query_timeout=10) */ * from tbl", hints2),
+                Arguments.of("insert /*+set_var(query_timeout=10)*/ into tbl " +
+                        "select /*+set_var(query_mem_limit=1) */ * from tbl", hints3)
+        );
+    }
+
+    private static Map<String, String> parseAndGetHints(String sql) {
+        List<StatementBase> stmts = SqlParser.parse(sql, new SessionVariable());
+        return StmtExecutor.VarHintVisitor.extractAllHints(stmts.get(0));
     }
 }


### PR DESCRIPTION
Why I'm doing:
- SR only processes the top-level variables in the statement, but not in multiple blocks like `insert-select`, `subquery`...
- But there're some scenarios user would write hints in the subquery, or `insert-select` statement


What I'm doing:
- Support use `set_var` hint in multiple query blocks, including `insert-select`, `subquery`, `union`...
- If several duplicated variables in different blocks, the first one would be used
- The `set_var` only affects the single statement execution, which means it only takes effects during the query execution
- The `set_var` only affects the global scope, which means variables in subquery have the same effects with top-level statement

Example:
```sql
INSERT /*+set_var(query_timeout=1)*/
INTO t1
SELECT /*+set_var(query_timeout=2)*/ * from t2
UNION ALL
SELECT /*+set_var(query_timeout=3)*/ * from t3
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
