### PR TITLE
[Enhancement] Improve partition changed error message for prepred statment execution

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -477,7 +477,16 @@ public class StmtExecutor {
                         PrepareStmt prepareStmt = prepareStmtContext.getStmt();
                         parsedStmt = prepareStmt.assignValues(executeStmt.getParamsExpr());
                         parsedStmt.setOrigStmt(originStmt);
-                        execPlan = StatementPlanner.plan(parsedStmt, context);
+                        try {
+                            execPlan = StatementPlanner.plan(parsedStmt, context);
+                        } catch (SemanticException e) {
+                            if (e.getMessage().contains("Unknown partition")) {
+                                throw new SemanticException(e.getMessage() +
+                                        " maybe table partition changed after prepared statement creation");
+                            } else {
+                                throw e;
+                            }
+                        }
                     } else {
                         execPlan = StatementPlanner.plan(parsedStmt, context);
                         if (parsedStmt instanceof QueryStatement && context.shouldDumpQuery()) {

--- a/test/sql/test_preparestatement/R/test_prepare_statment_partition_changed
+++ b/test/sql/test_preparestatement/R/test_prepare_statment_partition_changed
@@ -1,0 +1,26 @@
+-- name: test_prepare_statement_partition_changed
+CREATE TABLE IF NOT EXISTS prepare_stmt (
+    k1 INT,
+    k2 INT
+)
+PRIMARY KEY (k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES("replication_num" = "1");
+-- result:
+[]
+-- !result
+PREPARE stmt1 FROM insert overwrite prepare_stmt values (?, ?);
+-- result:
+[]
+-- !result
+set @i = 1;
+-- result:
+[]
+-- !result
+execute stmt1 using @i, @i;
+-- result:
+[]
+-- !result
+execute stmt1 using @i, @i;
+-- result:
+[REGEX].*maybe table partition changed after prepared statement creation.*
+-- !result

--- a/test/sql/test_preparestatement/T/test_prepare_statment_partition_changed
+++ b/test/sql/test_preparestatement/T/test_prepare_statment_partition_changed
@@ -1,0 +1,14 @@
+-- name: test_prepare_statement_partition_changed
+CREATE TABLE IF NOT EXISTS prepare_stmt (
+    k1 INT,
+    k2 INT
+)
+PRIMARY KEY (k1)
+DISTRIBUTED BY HASH(k1) BUCKETS 1 PROPERTIES("replication_num" = "1");
+
+PREPARE stmt1 FROM insert overwrite prepare_stmt values (?, ?);
+
+set @i = 1;
+
+execute stmt1 using @i, @i;
+execute stmt1 using @i, @i;


### PR DESCRIPTION
Why I'm doing:

When partition changed after prepared statement creation, execution will get error like:

```
1064, "Getting analyzing error. Detail message: Unknown partition 'aggregate_table_without_null_10594' in table 'aggregate_table_without_null'."
```

It's hard to understand and can be improved

What I'm doing:

Improe error message, adding `maybe table partition changed after prepared statement creation`

Fixes #34545

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
