### PR TITLE
[BugFix] Not use query cache if the plan contains non-deterministic time function(backport #36854)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -51,6 +51,7 @@ public class FunctionSet {
     // Date functions:
     public static final String CONVERT_TZ = "convert_tz";
     public static final String CURDATE = "curdate";
+    public static final String CURRENT_DATE = "current_date";
     public static final String CURRENT_TIMESTAMP = "current_timestamp";
     public static final String CURTIME = "curtime";
     public static final String CURRENT_TIME = "current_time";
@@ -80,6 +81,9 @@ public class FunctionSet {
     public static final String TO_DAYS = "to_days";
     public static final String UNIX_TIMESTAMP = "unix_timestamp";
     public static final String UTC_TIMESTAMP = "utc_timestamp";
+    public static final String UTC_TIME = "utc_time";
+    public static final String LOCALTIME = "localtime";
+    public static final String LOCALTIMESTAMP = "localtimestamp";
     public static final String WEEKOFYEAR = "weekofyear";
     public static final String YEAR = "year";
     public static final String MINUTES_DIFF = "minutes_diff";
@@ -537,6 +541,25 @@ public class FunctionSet {
                     .add(RANDOM)
                     .add(UUID)
                     .add(SLEEP)
+                    .build();
+
+    // Only use query cache if these time function can be reduced into a constant
+    // date/datetime value after applying FoldConstantRule, otherwise BE would yield
+    // non-deterministic result when these function is delivered to BE.
+    public static final Set<String> nonDeterministicTimeFunctions =
+            ImmutableSet.<String>builder()
+                    .add(CURTIME)
+                    .add(CURDATE)
+                    .add(CURRENT_DATE)
+                    .add(CURRENT_TIMESTAMP)
+                    .add(CURRENT_TIME)
+                    .add(NOW)
+                    .add(UNIX_TIMESTAMP)
+                    .add(UTC_TIMESTAMP)
+                    .add(UTC_TIME)
+                    .add(LOCALTIME)
+                    .add(LOCALTIMESTAMP)
+                    .add()
                     .build();
 
     public static final Set<String> onlyAnalyticUsedFunctions = ImmutableSet.<String>builder()

--- a/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/FragmentNormalizer.java
@@ -336,11 +336,18 @@ public class FragmentNormalizer {
     boolean hasNonDeterministicFunctions(Expr expr) {
         if (expr instanceof FunctionCallExpr) {
             FunctionCallExpr callExpr = (FunctionCallExpr) expr;
-            if (FunctionSet.nonDeterministicFunctions.contains(callExpr.getFn().functionName())) {
+            String funcName = callExpr.getFn().functionName();
+            if (FunctionSet.nonDeterministicFunctions.contains(funcName)) {
+                return true;
+            }
+            if (FunctionSet.NOW.equals(funcName)) {
+                return true;
+            }
+            if (FunctionSet.nonDeterministicTimeFunctions.contains(funcName) && callExpr.getChildren().isEmpty()) {
                 return true;
             }
         }
-        return expr.getChildren().stream().anyMatch(e -> hasNonDeterministicFunctions(e));
+        return expr.getChildren().stream().anyMatch(this::hasNonDeterministicFunctions);
     }
 
     List<Range<PartitionKey>> convertPredicateToRange(Column partitionColumn, Expr expr) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/FragmentNormalizerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/FragmentNormalizerTest.java
@@ -4,21 +4,28 @@ package com.starrocks.planner;
 
 import com.google.common.collect.Range;
 import com.starrocks.analysis.DateLiteral;
+import com.starrocks.analysis.Expr;
+import com.starrocks.analysis.FunctionCallExpr;
 import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.LargeIntLiteral;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.catalog.Column;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.SelectRelation;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.Test;
 
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
-
-import org.junit.Assert;
-import org.junit.Test;
 
 public class FragmentNormalizerTest {
 
@@ -109,5 +116,46 @@ public class FragmentNormalizerTest {
         LiteralExpr upperSucc =
                 new LargeIntLiteral(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.valueOf(1)).toString());
         testHelper(partitionColumn, lower, lowerSucc, upper, upperSucc);
+    }
+
+    @Test
+    public void testNondetermisticTimeFunction() {
+        FragmentNormalizer fragmentNormalizer = new FragmentNormalizer(null, null);
+        ConnectContext ctx = UtFrameUtils.createDefaultCtx();
+        for (String funcName : FunctionSet.nonDeterministicTimeFunctions) {
+            String sql = String.format("select %s()", funcName);
+            StatementBase statementBase;
+            try {
+                statementBase = com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
+                com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
+            } catch (Throwable ignored) {
+                continue;
+            }
+            QueryStatement queryStatement = (QueryStatement) statementBase;
+            SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            Expr expr = selectRelation.getSelectList().getItems().get(0).getExpr();
+            Assert.assertTrue(expr instanceof FunctionCallExpr);
+            Assert.assertTrue(fragmentNormalizer.hasNonDeterministicFunctions(expr));
+        }
+
+        for (String funcName : FunctionSet.nonDeterministicTimeFunctions) {
+            String sql = String.format("select %s('2022-12-01')", funcName);
+            StatementBase statementBase;
+            try {
+                statementBase = com.starrocks.sql.parser.SqlParser.parse(sql, ctx.getSessionVariable()).get(0);
+                com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
+            } catch (Throwable ignored) {
+                continue;
+            }
+            QueryStatement queryStatement = (QueryStatement) statementBase;
+            SelectRelation selectRelation = (SelectRelation) queryStatement.getQueryRelation();
+            Expr expr = selectRelation.getSelectList().getItems().get(0).getExpr();
+            Assert.assertTrue(expr instanceof FunctionCallExpr);
+            if (funcName.equals(FunctionSet.NOW)) {
+                Assert.assertTrue(fragmentNormalizer.hasNonDeterministicFunctions(expr));
+            } else {
+                Assert.assertFalse(fragmentNormalizer.hasNonDeterministicFunctions(expr));
+            }
+        }
     }
 }


### PR DESCRIPTION
cherry-pick #36854 