### PR TITLE
[BugFix] fix mv rewrite bug when mv has column reorder (#36891)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -767,6 +767,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         if (this.partitionRefTableExprs != null) {
             mv.partitionRefTableExprs = Lists.newArrayList(this.partitionRefTableExprs);
         }
+        if (!queryOutputIndices.isEmpty()) {
+            mv.setQueryOutputIndices(Lists.newArrayList(queryOutputIndices));
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -376,7 +376,7 @@ public class MvRewritePreprocessor {
         materializationContext.setScanMvOperator(scanMvOp);
         // should keep the sequence of schema
         List<ColumnRefOperator> scanMvOutputColumns = Lists.newArrayList();
-        for (Column column : copiedMV.getBaseSchema()) {
+        for (Column column : getMvOutputColumns(copiedMV)) {
             scanMvOutputColumns.add(scanMvOp.getColumnReference(column));
         }
         Preconditions.checkState(mvOutputColumns.size() == scanMvOutputColumns.size());
@@ -394,6 +394,19 @@ public class MvRewritePreprocessor {
         materializationContext.setOutputMapping(outputMapping);
         context.addCandidateMvs(materializationContext);
         logMVPrepare(connectContext, copiedMV, "Prepare MV {} success", copiedMV.getName());
+    }
+
+    public List<Column> getMvOutputColumns(MaterializedView mv) {
+        if (mv.getQueryOutputIndices() == null || mv.getQueryOutputIndices().isEmpty()) {
+            return mv.getBaseSchema();
+        } else {
+            List<Column> schema = mv.getBaseSchema();
+            List<Column> outputColumns = Lists.newArrayList();
+            for (Integer index : mv.getQueryOutputIndices()) {
+                outputColumns.add(schema.get(index));
+            }
+            return outputColumns;
+        }
     }
 
     /**

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewManualTest.java
@@ -280,4 +280,23 @@ public class MaterializedViewManualTest extends MaterializedViewTestBase {
         starRocksAssert.dropMaterializedView("test_partition_expr_mv1");
         starRocksAssert.dropTable("test_partition_expr_tbl1");
     }
+
+    @Test
+    public void testMvRewriteForColumnReorder() throws Exception {
+        {
+            starRocksAssert.withMaterializedView("create materialized view mv0" +
+                    " distributed by hash(t1a, t1b)" +
+                    " order by (t1a, t1b)" +
+                    " as" +
+                    " select sum(t1f) as total, t1a, t1b from test.test_all_type group by t1a, t1b");
+            String query = "select sum(t1f) as total, t1a, t1b from test.test_all_type group by t1a, t1b;";
+            {
+                sql(query, true).match("mv0")
+                        .containsIgnoreColRefs("1:t1a := 12:t1a\n" +
+                                "            2:t1b := 14:t1b\n" +
+                                "            11:sum := 13:total");
+            }
+            starRocksAssert.dropMaterializedView("mv0");
+        }
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -235,9 +235,15 @@ public class MaterializedViewTestBase extends PlanTestBase {
         private Exception exception;
         private String properties;
         private String traceLog;
+        private boolean isLogical;
 
         public MVRewriteChecker(String query) {
+            this(query, false);
+        }
+
+        public MVRewriteChecker(String query, boolean isLogical) {
             this.query = query;
+            this.isLogical = isLogical;
         }
 
         public MVRewriteChecker(String mv, String query) {
@@ -270,7 +276,11 @@ public class MaterializedViewTestBase extends PlanTestBase {
                     starRocksAssert.withMaterializedView(mvSQL);
                 }
 
-                this.rewritePlan = getFragmentPlan(query);
+                if (isLogical) {
+                    this.rewritePlan = getLogicalPlan(query);
+                } else {
+                    this.rewritePlan = getFragmentPlan(query);
+                }
             } catch (Exception e) {
                 LOG.warn("test rewrite failed:", e);
                 this.exception = e;
@@ -383,6 +393,11 @@ public class MaterializedViewTestBase extends PlanTestBase {
 
     protected MVRewriteChecker sql(String query) {
         MVRewriteChecker fixture = new MVRewriteChecker(query);
+        return fixture.rewrite();
+    }
+
+    protected MVRewriteChecker sql(String query, boolean isLogical) {
+        MVRewriteChecker fixture = new MVRewriteChecker(query, isLogical);
         return fixture.rewrite();
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -142,6 +142,11 @@ public class PlanTestNoneDBBase {
                 connectContext, sql).second.getPhysicalPlan());
     }
 
+    public String getLogicalPlan(String sql) throws Exception {
+        Pair<String, ExecPlan> pair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
+        return pair.second.getExplainString(StatementBase.ExplainLevel.LOGICAL);
+    }
+
     public String getVerboseExplain(String sql) throws Exception {
         return UtFrameUtils.getPlanAndFragment(connectContext, sql).second.
                 getExplainString(TExplainLevel.VERBOSE);


### PR DESCRIPTION
Why I'm doing:
mv rewriter will use the definition output sequence to decide the mapping of output expressions and mv's base schema. Later mv's column reorder is introduced as a new feature. it means when materialized view's first columns can not be used as sort key, mv will reorder the columns of schema. So the base schema will be different from the definition output of mv sql, which leads to this bug.
What I'm doing:
use the QueryOutputIndices of mv to decide the mapping of output columns and mv's base schema and add a ut to test it.

Fixes https://github.com/StarRocks/starrocks/issues/36868

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
