### PR TITLE
[Enhancement] Add hive udf for handle bitmap types

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -397,7 +397,7 @@ cd ${STARROCKS_HOME}
 
 # Assesmble FE modules
 FE_MODULES=
-if [ ${BUILD_FE} -eq 1 ] ||  [ ${BUILD_SPARK_DPP} -eq 1 ] ||  [ ${BUILD_HIVE_UDF} -eq 1 ]; then
+if [ ${BUILD_FE} -eq 1 ] || [ ${BUILD_SPARK_DPP} -eq 1 ] || [ ${BUILD_HIVE_UDF} -eq 1 ]; then
     if [ ${BUILD_SPARK_DPP} -eq 1 ]; then
         FE_MODULES="fe-common,spark-dpp"
     fi

--- a/build.sh
+++ b/build.sh
@@ -202,6 +202,7 @@ if [ $# == 1 ] ; then
     BUILD_BE=1
     BUILD_FE=1
     BUILD_SPARK_DPP=1
+    BUILD_HIVE_UDF=1
     CLEAN=0
     RUN_UT=0
 elif [[ $OPTS =~ "-j " ]] && [ $# == 3 ]; then
@@ -209,6 +210,7 @@ elif [[ $OPTS =~ "-j " ]] && [ $# == 3 ]; then
     BUILD_BE=1
     BUILD_FE=1
     BUILD_SPARK_DPP=1
+    BUILD_HIVE_UDF=1
     CLEAN=0
     RUN_UT=0
     PARALLEL=$2
@@ -216,6 +218,7 @@ else
     BUILD_BE=0
     BUILD_FE=0
     BUILD_SPARK_DPP=0
+    BUILD_HIVE_UDF=0
     CLEAN=0
     RUN_UT=0
     while true; do

--- a/build.sh
+++ b/build.sh
@@ -26,6 +26,7 @@
 #    sh build.sh  --fe --clean                        clean and build Frontend and Spark Dpp application
 #    sh build.sh  --fe --be --clean                   clean and build Frontend, Spark Dpp application and Backend
 #    sh build.sh  --spark-dpp                         build Spark DPP application alone
+#    sh build.sh  --hive-udf                          build Hive UDF alone
 #    BUILD_TYPE=build_type ./build.sh --be            build Backend is different mode (build_type could be Release, Debug, or Asan. Default value is Release. To build Backend in Debug mode, you can execute: BUILD_TYPE=Debug ./build.sh --be)
 #
 # You need to make sure all thirdparty libraries have been
@@ -81,6 +82,7 @@ Usage: $0 <options>
      --be               build Backend
      --fe               build Frontend and Spark Dpp application
      --spark-dpp        build Spark DPP application
+     --hive-udf         build Hive UDF
      --clean            clean and build target
      --enable-shared-data
                         build Backend with shared-data feature support
@@ -98,6 +100,7 @@ Usage: $0 <options>
     $0 --fe --clean                              clean and build Frontend and Spark Dpp application
     $0 --fe --be --clean                         clean and build Frontend, Spark Dpp application and Backend
     $0 --spark-dpp                               build Spark DPP application alone
+    $0 --hive-udf                                build Hive UDF
     BUILD_TYPE=build_type ./build.sh --be        build Backend is different mode (build_type could be Release, Debug, or Asan. Default value is Release. To build Backend in Debug mode, you can execute: BUILD_TYPE=Debug ./build.sh --be)
   "
   exit 1
@@ -110,6 +113,7 @@ OPTS=$(getopt \
   -l 'be' \
   -l 'fe' \
   -l 'spark-dpp' \
+  -l 'hive-udf' \
   -l 'clean' \
   -l 'with-gcov' \
   -l 'with-bench' \
@@ -131,6 +135,7 @@ eval set -- "$OPTS"
 BUILD_BE=
 BUILD_FE=
 BUILD_SPARK_DPP=
+BUILD_HIVE_UDF=
 CLEAN=
 RUN_UT=
 WITH_GCOV=OFF
@@ -218,6 +223,7 @@ else
             --be) BUILD_BE=1 ; shift ;;
             --fe) BUILD_FE=1 ; shift ;;
             --spark-dpp) BUILD_SPARK_DPP=1 ; shift ;;
+            --hive-udf) BUILD_HIVE_UDF=1 ; shift ;;
             --clean) CLEAN=1 ; shift ;;
             --ut) RUN_UT=1   ; shift ;;
             --with-gcov) WITH_GCOV=ON; shift ;;
@@ -240,7 +246,7 @@ if [[ ${HELP} -eq 1 ]]; then
     exit
 fi
 
-if [ ${CLEAN} -eq 1 -a ${BUILD_BE} -eq 0 -a ${BUILD_FE} -eq 0 -a ${BUILD_SPARK_DPP} -eq 0 ]; then
+if [ ${CLEAN} -eq 1 -a ${BUILD_BE} -eq 0 -a ${BUILD_FE} -eq 0 -a ${BUILD_SPARK_DPP} -eq 0 -a ${BUILD_HIVE_UDF} -eq 0 ]; then
     echo "--clean can not be specified without --fe or --be or --spark-dpp"
     exit 1
 fi
@@ -250,6 +256,7 @@ echo "Get params:
     BE_CMAKE_TYPE       -- $BUILD_TYPE
     BUILD_FE            -- $BUILD_FE
     BUILD_SPARK_DPP     -- $BUILD_SPARK_DPP
+    BUILD_HIVE_UDF      -- $BUILD_HIVE_UDF
     CLEAN               -- $CLEAN
     RUN_UT              -- $RUN_UT
     WITH_GCOV           -- $WITH_GCOV
@@ -390,12 +397,15 @@ cd ${STARROCKS_HOME}
 
 # Assesmble FE modules
 FE_MODULES=
-if [ ${BUILD_FE} -eq 1 -o ${BUILD_SPARK_DPP} -eq 1 ]; then
+if [ ${BUILD_FE} -eq 1 ] ||  [ ${BUILD_SPARK_DPP} -eq 1 ] ||  [ ${BUILD_HIVE_UDF} -eq 1 ]; then
     if [ ${BUILD_SPARK_DPP} -eq 1 ]; then
         FE_MODULES="fe-common,spark-dpp"
     fi
+    if [ ${BUILD_HIVE_UDF} -eq 1 ]; then
+        FE_MODULES="fe-common,hive-udf"
+    fi
     if [ ${BUILD_FE} -eq 1 ]; then
-        FE_MODULES="fe-common,spark-dpp,fe-core"
+        FE_MODULES="hive-udf,fe-common,spark-dpp,fe-core"
     fi
 fi
 
@@ -422,7 +432,7 @@ if [ ${BUILD_FE} -eq 1 -o ${BUILD_SPARK_DPP} -eq 1 ]; then
     if [ ${BUILD_FE} -eq 1 ]; then
         install -d ${STARROCKS_OUTPUT}/fe/bin ${STARROCKS_OUTPUT}/fe/conf/ \
                    ${STARROCKS_OUTPUT}/fe/webroot/ ${STARROCKS_OUTPUT}/fe/lib/ \
-                   ${STARROCKS_OUTPUT}/fe/spark-dpp/
+                   ${STARROCKS_OUTPUT}/fe/spark-dpp/ ${STARROCKS_OUTPUT}/fe/hive-udf
 
         cp -r -p ${STARROCKS_HOME}/bin/*_fe.sh ${STARROCKS_OUTPUT}/fe/bin/
         cp -r -p ${STARROCKS_HOME}/bin/show_fe_version.sh ${STARROCKS_OUTPUT}/fe/bin/
@@ -436,6 +446,7 @@ if [ ${BUILD_FE} -eq 1 -o ${BUILD_SPARK_DPP} -eq 1 ]; then
         cp -r -p ${STARROCKS_HOME}/java-extensions/hadoop-ext/target/starrocks-hadoop-ext.jar ${STARROCKS_OUTPUT}/fe/lib/
         cp -r -p ${STARROCKS_HOME}/webroot/* ${STARROCKS_OUTPUT}/fe/webroot/
         cp -r -p ${STARROCKS_HOME}/fe/spark-dpp/target/spark-dpp-*-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/fe/spark-dpp/
+        cp -r -p ${STARROCKS_HOME}/fe/hive-udf/target/hive-udf-1.0.0.jar ${STARROCKS_OUTPUT}/fe/hive-udf/
         cp -r -p ${STARROCKS_THIRDPARTY}/installed/jindosdk/* ${STARROCKS_OUTPUT}/fe/lib/
         cp -r -p ${STARROCKS_THIRDPARTY}/installed/async-profiler/* ${STARROCKS_OUTPUT}/fe/bin/
         MSG="${MSG} √ ${MSG_FE}"
@@ -443,6 +454,7 @@ if [ ${BUILD_FE} -eq 1 -o ${BUILD_SPARK_DPP} -eq 1 ]; then
         install -d ${STARROCKS_OUTPUT}/fe/spark-dpp/
         rm -rf ${STARROCKS_OUTPUT}/fe/spark-dpp/*
         cp -r -p ${STARROCKS_HOME}/fe/spark-dpp/target/spark-dpp-*-jar-with-dependencies.jar ${STARROCKS_OUTPUT}/fe/spark-dpp/
+        cp -r -p ${STARROCKS_HOME}/fe/hive-udf/target/hive-udf-1.0.0.jar ${STARROCKS_HOME}/fe/hive-udf/
         MSG="${MSG} √ ${MSG_DPP}"
     fi
 fi

--- a/build.sh
+++ b/build.sh
@@ -247,7 +247,7 @@ if [[ ${HELP} -eq 1 ]]; then
 fi
 
 if [ ${CLEAN} -eq 1 -a ${BUILD_BE} -eq 0 -a ${BUILD_FE} -eq 0 -a ${BUILD_SPARK_DPP} -eq 0 -a ${BUILD_HIVE_UDF} -eq 0 ]; then
-    echo "--clean can not be specified without --fe or --be or --spark-dpp"
+    echo "--clean can not be specified without --fe or --be or --spark-dpp or --hive-udf"
     exit 1
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -246,7 +246,7 @@ if [[ ${HELP} -eq 1 ]]; then
     exit
 fi
 
-if [ ${CLEAN} -eq 1 -a ${BUILD_BE} -eq 0 -a ${BUILD_FE} -eq 0 -a ${BUILD_SPARK_DPP} -eq 0 -a ${BUILD_HIVE_UDF} -eq 0 ]; then
+if [ ${CLEAN} -eq 1 ] && [ ${BUILD_BE} -eq 0 ] && [ ${BUILD_FE} -eq 0 ] && [ ${BUILD_SPARK_DPP} -eq 0 ] && [ ${BUILD_HIVE_UDF} -eq 0 ]; then
     echo "--clean can not be specified without --fe or --be or --spark-dpp or --hive-udf"
     exit 1
 fi

--- a/fe/hive-udf/pom.xml
+++ b/fe/hive-udf/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>starrocks-fe</artifactId>
+        <groupId>com.starrocks</groupId>
+        <version>3.4.0</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hive-udf</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.trino.hive</groupId>
+            <artifactId>hive-apache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>plugin-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <minimizeJar>true</minimizeJar>
+                    <relocations>
+                        <relocation>
+                            <pattern>org.roaringbitmap</pattern>
+                            <shadedPattern>shade.starrocks.org.roaringbitmap</shadedPattern>
+                        </relocation>
+                    </relocations>
+                    <filters>
+                        <filter>
+                            <artifact>org.apache.logging.log4j:*</artifact>
+                            <excludes>
+                                <exclude>**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.1</version>
+                    <configuration>
+                        <source>1.8</source>
+                        <target>1.8</target>
+                        <release>8</release>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDAFBitmapAgg.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDAFBitmapAgg.java
@@ -104,9 +104,9 @@ public class UDAFBitmapAgg extends AbstractGenericUDAFResolver {
         @Override
         public void merge(AggregationBuffer aggregationBuffer, Object o) throws HiveException {
             BitmapAggBuffer buf = (BitmapAggBuffer) aggregationBuffer;
-            byte[] tmp_buf = this.mergeInspector.getPrimitiveJavaObject(o);
+            byte[] tmpBuf = this.mergeInspector.getPrimitiveJavaObject(o);
             try {
-                buf.bitmap.or(BitmapValue.bitmapFromBytes(tmp_buf));
+                buf.bitmap.or(BitmapValue.bitmapFromBytes(tmpBuf));
             } catch (IOException e) {
                 throw new HiveException(e);
             }

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDAFBitmapAgg.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDAFBitmapAgg.java
@@ -1,0 +1,120 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.hive.udf;
+
+import com.starrocks.types.BitmapValue;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.parse.SemanticException;
+import org.apache.hadoop.hive.ql.udf.generic.AbstractGenericUDAFResolver;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDAFEvaluator;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+import org.apache.hadoop.hive.serde2.typeinfo.TypeInfo;
+
+import java.io.IOException;
+
+// This function similar to the aggregate function(bitmap_agg) of StarRocks
+public class UDAFBitmapAgg extends AbstractGenericUDAFResolver {
+    @Override
+    public BitmapAggEvaluator getEvaluator(TypeInfo[] info) throws SemanticException {
+        if (info.length != 1) {
+            throw new UDFArgumentException("Argument number of bitmap_agg should be 1.");
+        }
+        return new BitmapAggEvaluator();
+    }
+
+    public static class BitmapAggEvaluator extends GenericUDAFEvaluator {
+        private transient PrimitiveObjectInspector inputInspector;
+        private transient BinaryObjectInspector mergeInspector;
+
+        @AggregationType(estimable = true)
+        static class BitmapAggBuffer extends AbstractAggregationBuffer {
+            BitmapValue bitmap;
+
+            BitmapAggBuffer() {
+                bitmap = new BitmapValue();
+            }
+        }
+
+        @Override
+        public ObjectInspector init(Mode m, ObjectInspector[] parameters) throws HiveException {
+            if (parameters.length != 1) {
+                throw new UDFArgumentException("Argument number of bitmap_agg should be 1.");
+            }
+            super.init(m, parameters);
+            if (m == Mode.PARTIAL1 || m == Mode.COMPLETE) {
+                this.inputInspector = (PrimitiveObjectInspector) parameters[0];
+            } else {
+                this.mergeInspector = (BinaryObjectInspector) parameters[0];
+            }
+            return PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
+        }
+
+        @Override
+        public AggregationBuffer getNewAggregationBuffer() {
+            return new BitmapAggBuffer();
+        }
+
+        @Override
+        public void reset(AggregationBuffer aggregationBuffer) {
+            ((BitmapAggBuffer) aggregationBuffer).bitmap = new BitmapValue();
+        }
+
+        @Override
+        public void iterate(AggregationBuffer aggregationBuffer, Object[] objects) throws HiveException {
+            BitmapAggBuffer buf = (BitmapAggBuffer) aggregationBuffer;
+            try {
+                for (Object obj : objects) {
+                    if (obj != null) {
+                        long row = PrimitiveObjectInspectorUtils.getLong(obj, inputInspector);
+                        buf.bitmap.add(row);
+                    }
+                }
+            } catch (NumberFormatException e) {
+                throw new HiveException(e);
+            }
+        }
+
+        @Override
+        public Object terminate(AggregationBuffer aggregationBuffer) throws HiveException {
+            BitmapAggBuffer buf = (BitmapAggBuffer) aggregationBuffer;
+            try {
+                return BitmapValue.bitmapToBytes(buf.bitmap);
+            } catch (IOException e) {
+                throw new HiveException(e);
+            }
+        }
+
+        @Override
+        public void merge(AggregationBuffer aggregationBuffer, Object o) throws HiveException {
+            BitmapAggBuffer buf = (BitmapAggBuffer) aggregationBuffer;
+            byte[] tmp_buf = this.mergeInspector.getPrimitiveJavaObject(o);
+            try {
+                buf.bitmap.or(BitmapValue.bitmapFromBytes(tmp_buf));
+            } catch (IOException e) {
+                throw new HiveException(e);
+            }
+        }
+
+        @Override
+        public Object terminatePartial(AggregationBuffer aggregationBuffer) throws HiveException {
+            return terminate(aggregationBuffer);
+        }
+    }
+}

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
@@ -1,0 +1,66 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.hive.udf;
+
+import com.starrocks.types.BitmapValue;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+
+import java.io.IOException;
+
+// This function similar to the function(bitmap_count) of StarRocks
+public class UDFBitmapCount extends GenericUDF {
+    private transient BinaryObjectInspector inspector;
+
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] args) throws UDFArgumentException {
+        if (args.length != 1) {
+            throw new UDFArgumentException("Argument number of bitmap_count should be 1");
+        }
+
+        ObjectInspector arg0 = args[0];
+        if (!(arg0 instanceof BinaryObjectInspector)) {
+            throw new UDFArgumentException("First argument should be binary type");
+        }
+        this.inspector = (BinaryObjectInspector) arg0;
+
+        return PrimitiveObjectInspectorFactory.javaLongObjectInspector;
+    }
+
+    @Override
+    public Object evaluate(DeferredObject[] args) throws HiveException {
+        if (args[0] == null) {
+            return null;
+        }
+
+        byte[] bytes = PrimitiveObjectInspectorUtils.getBinary(args[0].get(), this.inspector).getBytes();
+        try {
+            BitmapValue bitmap = BitmapValue.bitmapFromBytes(bytes);
+            return bitmap.cardinality();
+        } catch (IOException e) {
+            throw new HiveException(e);
+        }
+    }
+
+    @Override
+    public String getDisplayString(String[] strings) {
+        return "USAGE: bitmap_count(bitmap)";
+    }
+}

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
@@ -50,7 +50,7 @@ public class UDFBitmapCount extends GenericUDF {
             return null;
         }
 
-        byte[] bytes = this.inspector.getPrimitiveJavaObject(args[0].get());
+        byte[] bytes = PrimitiveObjectInspectorUtils.getBinary(args[0].get(), this.inspector).getBytes();
         try {
             BitmapValue bitmap = BitmapValue.bitmapFromBytes(bytes);
             return bitmap.cardinality();

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
@@ -50,7 +50,7 @@ public class UDFBitmapCount extends GenericUDF {
             return null;
         }
 
-        byte[] bytes = PrimitiveObjectInspectorUtils.getBinary(args[0].get(), this.inspector).getBytes();
+        byte[] bytes = this.inspector.getPrimitiveJavaObject(args[0].get());
         try {
             BitmapValue bitmap = BitmapValue.bitmapFromBytes(bytes);
             return bitmap.cardinality();

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapFromString.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapFromString.java
@@ -52,8 +52,8 @@ public class UDFBitmapFromString extends GenericUDF {
 
         BitmapValue bitmap = new BitmapValue();
         try {
-            String[] str_array = str.split(",");
-            for (String s : str_array) {
+            String[] strArray = str.split(",");
+            for (String s : strArray) {
                 long v = Long.parseLong(s);
                 bitmap.add(v);
             }

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapFromString.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapFromString.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.hive.udf;
+
+import com.starrocks.types.BitmapValue;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.StringObjectInspector;
+
+import java.io.IOException;
+
+// This function similar to the function(bitmap_from_string) of StarRocks
+public class UDFBitmapFromString extends GenericUDF {
+    private transient StringObjectInspector inspector;
+
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] args) throws UDFArgumentException {
+        if (args.length != 1) {
+            throw new UDFArgumentException("Argument number of bitmap_from_string should be 1.");
+        }
+
+        if (!(args[0] instanceof StringObjectInspector)) {
+            throw new UDFArgumentException("First argument should be string type.");
+        }
+        this.inspector = (StringObjectInspector) args[0];
+
+        return PrimitiveObjectInspectorFactory.javaByteArrayObjectInspector;
+    }
+
+    @Override
+    public Object evaluate(DeferredObject[] args) throws HiveException {
+        if (args[0] == null) {
+            return null;
+        }
+
+        String str = inspector.getPrimitiveJavaObject(args[0].get());
+
+        BitmapValue bitmap = new BitmapValue();
+        try {
+            String[] str_array = str.split(",");
+            for (String s : str_array) {
+                long v = Long.parseLong(s);
+                bitmap.add(v);
+            }
+        } catch (NumberFormatException e) {
+            throw new HiveException(e);
+        }
+        try {
+            return BitmapValue.bitmapToBytes(bitmap);
+        } catch (IOException e) {
+            throw new HiveException(e);
+        }
+    }
+
+    @Override
+    public String getDisplayString(String[] children) {
+        return "USAGE: bitmap_from_string(string)";
+    }
+}

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.hive.udf;
+
+import com.starrocks.types.BitmapValue;
+import org.apache.hadoop.hive.ql.exec.UDFArgumentException;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.udf.generic.GenericUDF;
+import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.BinaryObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorFactory;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.PrimitiveObjectInspectorUtils;
+
+import java.io.IOException;
+
+// This function similar to the function(bitmap_to_string) of StarRocks
+public class UDFBitmapToString extends GenericUDF {
+    private transient BinaryObjectInspector inspector;
+
+    @Override
+    public ObjectInspector initialize(ObjectInspector[] args) throws UDFArgumentException {
+        if (args.length != 1) {
+            throw new UDFArgumentException("Argument number of bitmap_from_string should be 1.");
+        }
+
+        ObjectInspector arg0 = args[0];
+        if (!(arg0 instanceof BinaryObjectInspector)) {
+            throw new UDFArgumentException("First argument of bitmap_to_string should be binary or string type.");
+        }
+        this.inspector = (BinaryObjectInspector) arg0;
+
+        return PrimitiveObjectInspectorFactory.javaStringObjectInspector;
+    }
+
+    @Override
+    public Object evaluate(DeferredObject[] args) throws HiveException {
+        if (args[0] == null) {
+            return null;
+        }
+
+        byte[] bytes = PrimitiveObjectInspectorUtils.getBinary(args[0].get(), this.inspector).getBytes();
+
+        try {
+            BitmapValue bitmap = BitmapValue.bitmapFromBytes(bytes);
+            return bitmap.serializeToString();
+        } catch (IOException e) {
+            throw new HiveException(e);
+        }
+    }
+
+    @Override
+    public String getDisplayString(String[] children) {
+        return "USAGE: bitmap_to_string(bitmap)";
+    }
+}

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
@@ -50,7 +50,7 @@ public class UDFBitmapToString extends GenericUDF {
             return null;
         }
 
-        byte[] bytes = PrimitiveObjectInspectorUtils.getBinary(args[0].get(), this.inspector).getBytes();
+        byte[] bytes = this.inspector.getPrimitiveJavaObject(args[0].get());
 
         try {
             BitmapValue bitmap = BitmapValue.bitmapFromBytes(bytes);

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
@@ -50,7 +50,7 @@ public class UDFBitmapToString extends GenericUDF {
             return null;
         }
 
-        byte[] bytes = this.inspector.getPrimitiveJavaObject(args[0].get());
+        byte[] bytes = PrimitiveObjectInspectorUtils.getBinary(args[0].get(), this.inspector).getBytes();
 
         try {
             BitmapValue bitmap = BitmapValue.bitmapFromBytes(bytes);

--- a/fe/plugin-common/src/test/java/com/starrocks/types/BitmapValueTest.java
+++ b/fe/plugin-common/src/test/java/com/starrocks/types/BitmapValueTest.java
@@ -246,7 +246,6 @@ public class BitmapValueTest {
         bitmapValue9.and(bitmapValue9_1);
         assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue9.getBitmapType());
         assertEquals(bitmapValue9, bitmapValue9_1);
-
     }
 
     @Test

--- a/fe/plugin-common/src/test/java/com/starrocks/types/Roaring64MapTest.java
+++ b/fe/plugin-common/src/test/java/com/starrocks/types/Roaring64MapTest.java
@@ -24,7 +24,7 @@ public class Roaring64MapTest {
     @BeforeClass
     public static void beforeClass() throws Exception {
         largeBitmap = new BitmapValue();
-        for (long i=0; i < 20; i++) {
+        for (long i = 0; i < 20; i++) {
             largeBitmap.add(i);
         }
     }

--- a/fe/plugin-common/src/test/java/com/starrocks/types/Roaring64MapTest.java
+++ b/fe/plugin-common/src/test/java/com/starrocks/types/Roaring64MapTest.java
@@ -1,0 +1,36 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.types;
+
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class Roaring64MapTest {
+    static BitmapValue largeBitmap;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        largeBitmap = new BitmapValue();
+        for (long i=0; i < 20; i++) {
+            largeBitmap.add(i);
+        }
+    }
+
+    @Test
+    public void testSerializeToString() {
+        Assert.assertEquals("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19", largeBitmap.serializeToString());
+    }
+}

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -33,6 +33,7 @@ under the License.
         <module>fe-common</module>
         <module>spark-dpp</module>
         <module>fe-core</module>
+        <module>hive-udf</module>
     </modules>
 
     <name>starrocks-fe</name>
@@ -155,6 +156,12 @@ under the License.
             <dependency>
                 <groupId>com.starrocks</groupId>
                 <artifactId>plugin-common</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.starrocks</groupId>
+                <artifactId>hive-udf</artifactId>
                 <version>1.0.0</version>
             </dependency>
 


### PR DESCRIPTION
Why I'm doing:

Users often have this need:

1. Build the bitmap in hive/spark and then import it into `StarRocks` to reduce the construction pressure on StarRocks.
2. After building the bitmap in `StarRocks`, export it into a parquet file for use by hive/spark.

Hive can use the udf to import/export/process bitmap.

How to use:

```
# create table in starrocks
CREATE TABLE `t1` (
  `c1` int(11) NULL COMMENT "",
  `c2` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`)
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"fast_schema_evolution" = "true",
"compression" = "LZ4"
);

# prepare data
mysql> select c1, bitmap_to_string(c2) from t1;
+------+-------------------------------------------------------------------------------------------------------------+
| c1   | bitmap_to_string(c2)                                                                                        |
+------+-------------------------------------------------------------------------------------------------------------+
|    1 | 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39 |
+------+-------------------------------------------------------------------------------------------------------------+
1 row in set (0.02 sec)


# write to hdfs
 insert into files("path"="hdfs://xxx:9000/user/hive/warehouse/lxh.db/tmp/", "format"="parquet", "compression" = "uncompressed") select c1, bitmap_to_binary(c2) as c2 from t1;

# create table in hive
hive> create table t1(c1 int, c2 binary) stored as parquet;
OK

# load parquet file to hive table
load data inpath 'hdfs://xxxx:9000/user/hive/warehouse/lxh.db/tmp/data_1c3aff0b-9991-11ee-80ba-2ea9721a9a2d_0_1.parquet' into table lxh.t1;

# add udf.jar to hive
hive> add jar hdfs://xxxx:9000/user/hive/warehouse/lxh.db/hive-udf-1.0.0.jar;

# create hive udf
hive> create temporary function  bitmap_to_string as 'com.starrocks.hive.udf.UDFBitmapToString';
OK
Time taken: 0.091 seconds
hive> create temporary function  bitmap_count as 'com.starrocks.hive.udf.UDFBitmapCount';
OK
Time taken: 0.075 seconds
hive> create temporary function  bitmap_agg as 'com.starrocks.hive.udf.UDAFBitmapAgg';
OK
Time taken: 0.074 seconds
hive> create temporary function  bitmap_from_string as 'com.starrocks.hive.udf.UDFBitmapFromString';
OK
Time taken: 0.074 seconds

# use udf in hive
hive> select c1, bitmap_count(c2) from t1;
1       39

select c1, bitmap_to_string(c2) from t1;
1       1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39

# use bitmap_agg to generate bitmap
hive> select * from t2;
1       1
2       2
3       3

hive> select bitmap_to_string(bitmap_agg(c2)) from t2;
1,2,3
```

What I'm doing:

Add hive udf to handle bitmap type.

TODO 1: Currently the test framework don't support hive udf, i will add the test case to StarRocksTest framework later.
TODO 2: Add more bitmap function (BitmapAnd, BitmapOr, BitmapXor...)

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
