### PR TITLE
[Enhancement] Querying for non-existing partitions should report an error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -556,6 +556,9 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
     public Partition getPartition(String partitionName) {
         return null;
     }
+    public Partition getPartition(String partitionName, boolean isTempPartition) {
+        return null;
+    }
 
     public Partition getPartition(long partitionId) {
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -62,6 +62,7 @@ import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
+import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -983,17 +984,20 @@ public class QueryAnalyzer {
                 ErrorReport.reportAnalysisException(ErrorCode.ERR_BAD_TABLE_STATE, "RESTORING");
             }
 
-            if (table.isExternalTableWithFileSystem() && tableRelation.getPartitionNames() != null) {
+            PartitionNames partitionNamesObject = tableRelation.getPartitionNames();
+            if (table.isExternalTableWithFileSystem() && partitionNamesObject != null) {
                 throw unsupportedException("Unsupported table type for partition clause, type: " + table.getType());
             }
 
-            List<String> partitionNames = tableRelation.getPartitionNames().getPartitionNames();
-            if (partitionNames != null) {
-                for (String partitionName : partitionNames) {
-                    Partition partition = table.getPartition(partitionName);
-                    if (partition == null) {
-                        throw new SemanticException("Unknown partition '%s' in table '%s'", partitionName,
-                                table.getName());
+            if (partitionNamesObject != null) {
+                List<String> partitionNames = partitionNamesObject.getPartitionNames();
+                if (partitionNames != null) {
+                    for (String partitionName : partitionNames) {
+                        Partition partition = table.getPartition(partitionName);
+                        if (partition == null) {
+                            throw new SemanticException("Unknown partition '%s' in table '%s'", partitionName,
+                                    table.getName());
+                        }
                     }
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -36,6 +36,7 @@ import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.HiveView;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Resource;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunction;
@@ -61,6 +62,7 @@ import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
+import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;
@@ -984,6 +986,17 @@ public class QueryAnalyzer {
 
             if (table.isExternalTableWithFileSystem() && tableRelation.getPartitionNames() != null) {
                 throw unsupportedException("Unsupported table type for partition clause, type: " + table.getType());
+            }
+
+            List<String> partitionNames = tableRelation.getPartitionNames().getPartitionNames();
+            if (partitionNames != null) {
+                for (String partitionName : partitionNames) {
+                    Partition partition = table.getPartition(partitionName);
+                    if (partition == null) {
+                        throw new SemanticException("Unknown partition '%s' in table '%s'", partitionName,
+                                table.getName());
+                    }
+                }
             }
 
             return table;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -989,7 +989,7 @@ public class QueryAnalyzer {
                 throw unsupportedException("Unsupported table type for partition clause, type: " + table.getType());
             }
 
-            if (partitionNamesObject != null) {
+            if (partitionNamesObject != null && table.isNativeTable()) {
                 List<String> partitionNames = partitionNamesObject.getPartitionNames();
                 if (partitionNames != null) {
                     boolean isTemp = partitionNamesObject.isTemp();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -992,11 +992,12 @@ public class QueryAnalyzer {
             if (partitionNamesObject != null) {
                 List<String> partitionNames = partitionNamesObject.getPartitionNames();
                 if (partitionNames != null) {
+                    boolean isTemp = partitionNamesObject.isTemp();
                     for (String partitionName : partitionNames) {
-                        Partition partition = table.getPartition(partitionName);
+                        Partition partition = table.getPartition(partitionName, isTemp);
                         if (partition == null) {
                             throw new SemanticException("Unknown partition '%s' in table '%s'", partitionName,
-                                    table.getName());
+                                        table.getName());
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -62,7 +62,6 @@ import com.starrocks.sql.ast.FileTableFunctionRelation;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.NormalizedTableFunctionRelation;
-import com.starrocks.sql.ast.PartitionNames;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.Relation;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -69,7 +69,7 @@ public class AnalyzeSingleTest {
         analyzeFail("select error from t0");
         analyzeFail("select v1 from t_error");
 
-        analyzeSuccess("select v1 from t0 temporary partition(t1,t2)");
+        analyzeFail("select v1 from t0 temporary partition(t1,t2)");
         analyzeFail("SELECT v1,v2,v3 FROM t0 INTO OUTFILE \"hdfs://path/to/result_\""
                 + "FORMAT AS PARQUET PROPERTIES" +
                 "(\"broker.name\" = \"my_broker\"," +


### PR DESCRIPTION
Why I'm doing:
Mysql will report an error if you query a non-existent partition.
![image](https://github.com/StarRocks/starrocks/assets/4392280/b4f73a3e-e038-4470-9d65-9af9a077232d)

What I'm doing:
We should behave the same as mysql. It is more reasonable to report an error rather than not reporting an error.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
