### PR TITLE
[BugFix] Fix BE memory violation issue caused by microsecond formatter %f

### DIFF
--- a/be/src/runtime/datetime_value.cpp
+++ b/be/src/runtime/datetime_value.cpp
@@ -1485,7 +1485,7 @@ bool DateTimeValue::to_format_string(const char* format, int len, char* to) cons
             to = append_with_prefix(buf, pos - buf, '0', 1, to);
             break;
         case 'f':
-            if (write_size + 2 >= buffer_size) return false;
+            if (write_size + 6 >= buffer_size) return false;
             // Microseconds (000000..999999)
             pos = int_to_str(_microsecond, buf);
             to = append_with_prefix(buf, pos - buf, '0', 6, to);

--- a/test/sql/test_function/R/test_date_format
+++ b/test/sql/test_function/R/test_date_format
@@ -1,0 +1,29 @@
+-- name: test_date_format
+CREATE TABLE IF NOT EXISTS test_order (
+id varchar(150) NOT NULL COMMENT '',
+reset_period_data varchar(32) NULL COMMENT ""
+) ENGINE=olap PRIMARY KEY (id) COMMENT '' DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("enable_persistent_index" = "true", "replication_num" = "1");
+-- result:
+-- !result
+insert into test_order values('1','2023-10-11 00:00:01.030');
+-- result:
+-- !result
+select DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.%f') from test_order where id='1';
+-- result:
+2023-10-11 00:00:01.030000
+-- !result
+select LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%f'))
+from test_order where id='1';
+-- result:
+126
+-- !result
+select IFNULL(LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%f')),-1)
+from test_order where id='1';
+-- result:
+-1
+-- !result
+select IFNULL(LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%ftttttttt')),-1)
+from test_order where id='1';
+-- result:
+-1
+-- !result

--- a/test/sql/test_function/T/test_date_format
+++ b/test/sql/test_function/T/test_date_format
@@ -1,0 +1,18 @@
+-- name: test_date_format
+CREATE TABLE IF NOT EXISTS test_order (
+id varchar(150) NOT NULL COMMENT '',
+reset_period_data varchar(32) NULL COMMENT ""
+) ENGINE=olap PRIMARY KEY (id) COMMENT '' DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("enable_persistent_index" = "true", "replication_num" = "1");
+
+insert into test_order values('1','2023-10-11 00:00:01.030');
+
+select DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.%f') from test_order where id='1';
+
+select LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%f'))
+from test_order where id='1';
+
+select IFNULL(LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%f')),-1)
+from test_order where id='1';
+
+select IFNULL(LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%ftttttttt')),-1)
+from test_order where id='1';


### PR DESCRIPTION
Why I'm doing:

Fix A bug regarding the `date_format` function.

To reproduce:

```
CREATE TABLE IF NOT EXISTS test_order (
id varchar(150) NOT NULL COMMENT '',
reset_period_data varchar(32) NULL COMMENT ""
) ENGINE=olap PRIMARY KEY (id) COMMENT '' DISTRIBUTED BY HASH(id) BUCKETS 1 PROPERTIES("enable_persistent_index" = "true", "replication_num" = "1");

insert into test_order values('1','2023-10-11 00:00:01.030');
```

This sql:
```
select LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%ftttttttt'))
from test_order where id='1';
```
will cause the following error:
```
SQL Error [1064] [42000]: Memory of Query09f4282e-9985-11ee-b5c8-1e2c5c7e9bc0 exceed limit. try consume:21474836480 Used: 25080, Limit: 21474836480. Mem usage has exceed the limit of single query, You can change the limit by set session variable query_mem_limit.
```

It can also exceed the original 128 length limit:

```
select LENGTH(DATE_FORMAT(reset_period_data, '%Y-%m-%d %H:%i:%s.tttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt%f'))
from test_order where id='1';
```
Result:
Length: 130 (exceeds 128 which is hard-coded in BE as the buffer length, causing memory violations)
![image](https://github.com/StarRocks/starrocks/assets/44420324/cd8baf28-03d0-4842-ae25-6107e0490945)

What I'm doing:

Fixes this error by adjusting [%f'] formatter length (2 to 6)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
