### PR TITLE
[Enhancement] Support load segment parallel in shared_data

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -433,6 +433,10 @@ CONF_Int32(make_snapshot_rpc_timeout_ms, "20000");
 // OlapTableSink sender's send interval, should be less than the real response time of a tablet writer rpc.
 CONF_mInt32(olap_table_sink_send_interval_ms, "10");
 
+CONF_Bool(enable_load_segment_parallel, "false");
+CONF_Int32(load_segment_thread_pool_num_max, "128");
+CONF_Int32(load_segment_thread_pool_queue_size, "10240");
+
 // Fragment thread pool
 CONF_Int32(fragment_pool_thread_num_min, "64");
 CONF_Int32(fragment_pool_thread_num_max, "4096");

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -443,6 +443,26 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
         _load_path_mgr = new LoadPathMgr(this);
     }
 
+    std::unique_ptr<ThreadPool> load_rowset_pool;
+    std::unique_ptr<ThreadPool> load_segment_pool;
+    RETURN_IF_ERROR(
+            ThreadPoolBuilder("load_rowset_pool")
+                    .set_min_threads(0)
+                    .set_max_threads(connector_num_io_threads)
+                    .set_max_queue_size(config::load_segment_thread_pool_queue_size)
+                    .set_idle_timeout(MonoDelta::FromMilliseconds(config::streaming_load_thread_pool_idle_time_ms))
+                    .build(&load_rowset_pool));
+    _load_rowset_thread_pool = load_rowset_pool.release();
+
+    RETURN_IF_ERROR(
+            ThreadPoolBuilder("load_segment_pool")
+                    .set_min_threads(0)
+                    .set_max_threads(connector_num_io_threads)
+                    .set_max_queue_size(config::load_segment_thread_pool_queue_size)
+                    .set_idle_timeout(MonoDelta::FromMilliseconds(config::streaming_load_thread_pool_idle_time_ms))
+                    .build(&load_segment_pool));
+    _load_segment_thread_pool = load_segment_pool.release();
+
     _broker_mgr = new BrokerMgr(this);
 #ifndef BE_TEST
     _bfd_parser = BfdParser::create();
@@ -667,6 +687,7 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_connector_scan_executor);
     SAFE_DELETE(_thread_pool);
     SAFE_DELETE(_streaming_load_thread_pool);
+    SAFE_DELETE(_load_segment_thread_pool);
 
     if (_lake_tablet_manager != nullptr) {
         _lake_tablet_manager->prune_metacache();

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -448,7 +448,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     RETURN_IF_ERROR(
             ThreadPoolBuilder("load_rowset_pool")
                     .set_min_threads(0)
-                    .set_max_threads(connector_num_io_threads)
+                    .set_max_threads(config::load_segment_thread_pool_num_max)
                     .set_max_queue_size(config::load_segment_thread_pool_queue_size)
                     .set_idle_timeout(MonoDelta::FromMilliseconds(config::streaming_load_thread_pool_idle_time_ms))
                     .build(&load_rowset_pool));
@@ -457,7 +457,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     RETURN_IF_ERROR(
             ThreadPoolBuilder("load_segment_pool")
                     .set_min_threads(0)
-                    .set_max_threads(connector_num_io_threads)
+                    .set_max_threads(config::load_segment_thread_pool_num_max)
                     .set_max_queue_size(config::load_segment_thread_pool_queue_size)
                     .set_idle_timeout(MonoDelta::FromMilliseconds(config::streaming_load_thread_pool_idle_time_ms))
                     .build(&load_segment_pool));

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -270,6 +270,8 @@ public:
     ThreadPool* streaming_load_thread_pool() { return _streaming_load_thread_pool; }
     workgroup::ScanExecutor* scan_executor() { return _scan_executor; }
     workgroup::ScanExecutor* connector_scan_executor() { return _connector_scan_executor; }
+    ThreadPool* load_rowset_thread_pool() { return _load_rowset_thread_pool; }
+    ThreadPool* load_segment_thread_pool() { return _load_segment_thread_pool; };
 
     PriorityThreadPool* udf_call_pool() { return _udf_call_pool; }
     PriorityThreadPool* pipeline_prepare_pool() { return _pipeline_prepare_pool; }
@@ -349,6 +351,9 @@ private:
 
     PriorityThreadPool* _thread_pool = nullptr;
     ThreadPool* _streaming_load_thread_pool = nullptr;
+
+    ThreadPool* _load_segment_thread_pool = nullptr;
+    ThreadPool* _load_rowset_thread_pool = nullptr;
 
     workgroup::ScanExecutor* _scan_executor = nullptr;
     workgroup::ScanExecutor* _connector_scan_executor = nullptr;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -284,7 +284,7 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
             }
             segment_futures.push_back(task->get_future());
         } else {
-            auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, fill_data_cache,
+            auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, lake_io_opts,
                                                         fill_metadata_cache, _tablet_schema);
             if (auto status = check_status(segment_or, seg_name); !status.ok()) {
                 return status;

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/lake/rowset.h"
 
+#include <future>
+
 #include "storage/chunk_helper.h"
 #include "storage/delete_predicates.h"
 #include "storage/lake/tablet.h"
@@ -248,6 +250,18 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
     const auto& files_to_size = metadata().segment_size();
     int index = 0;
 
+    std::vector<std::future<std::pair<StatusOr<SegmentPtr>, std::string>>> segment_futures;
+    auto check_status = [&](StatusOr<SegmentPtr>& segment_or, const std::string& seg_name) -> Status {
+        if (segment_or.ok()) {
+            segments->emplace_back(std::move(segment_or.value()));
+        } else if (segment_or.status().is_not_found() && ignore_lost_segment) {
+            LOG(WARNING) << "Ignored lost segment " << seg_name;
+        } else {
+            return segment_or.status();
+        }
+        return Status::OK();
+    };
+
     for (const auto& seg_name : metadata().segments()) {
         auto segment_path = _tablet_mgr->segment_location(tablet_id(), seg_name);
         auto segment_info = FileInfo{.path = segment_path};
@@ -256,15 +270,33 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOpti
         }
         index++;
 
-        auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, lake_io_opts,
-                                                    fill_metadata_cache, _tablet_schema);
-        if (segment_or.ok()) {
-            segments->emplace_back(std::move(segment_or.value()));
-        } else if (segment_or.status().is_not_found() && ignore_lost_segment) {
-            LOG(WARNING) << "Ignored lost segment " << seg_name;
-            continue;
+        if (config::enable_load_segment_parallel) {
+            auto task = std::make_shared<std::packaged_task<std::pair<StatusOr<SegmentPtr>, std::string>()>>([&]() {
+                auto result = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, lake_io_opts,
+                                                        fill_metadata_cache, _tablet_schema);
+                return std::make_pair(std::move(result), seg_name);
+            });
+
+            auto packaged_func = [task]() { (*task)(); };
+            if (auto st = ExecEnv::GetInstance()->load_segment_thread_pool()->submit_func(std::move(packaged_func));
+                !st.ok()) {
+                return st;
+            }
+            segment_futures.push_back(task->get_future());
         } else {
-            return segment_or.status();
+            auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, fill_data_cache,
+                                                        fill_metadata_cache, _tablet_schema);
+            if (auto status = check_status(segment_or, seg_name); !status.ok()) {
+                return status;
+            }
+        }
+    }
+
+    for (auto& fut : segment_futures) {
+        auto result_pair = fut.get();
+        auto segment_or = result_pair.first;
+        if (auto status = check_status(segment_or, result_pair.second); !status.ok()) {
+            return status;
         }
     }
     return Status::OK();

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -596,7 +596,8 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
                                                  const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
                                                  TabletSchemaPtr tablet_schema) {
     size_t footer_size_hint = 16 * 1024;
-    return load_segment(segment_info, segment_id, &footer_size_hint, lake_io_opts, fill_metadata_cache, tablet_schema);
+    return load_segment(segment_info, segment_id, &footer_size_hint, lake_io_opts, fill_metadata_cache,
+                        std::move(tablet_schema));
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -596,7 +596,7 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
                                                  const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
                                                  TabletSchemaPtr tablet_schema) {
     size_t footer_size_hint = 16 * 1024;
-    return load_segment(segemnt_info, segemnt_id, &footer_size_hint, lake_io_opts, fill_metadata_cache, tablet_schema);
+    return load_segment(segment_info, segment_id, &footer_size_hint, lake_io_opts, fill_metadata_cache, tablet_schema);
 }
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -592,4 +592,11 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
     return segment;
 }
 
+StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, int segment_id,
+                                                 const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
+                                                 TabletSchemaPtr tablet_schema) {
+    size_t footer_size_hint = 16 * 1024;
+    return load_segment(segemnt_info, segemnt_id, &footer_size_hint, lake_io_opts, fill_metadata_cache, tablet_schema);
+}
+
 } // namespace starrocks::lake

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -136,22 +136,16 @@ public:
 
     std::string delvec_location(int64_t tablet_id, std::string_view delvec_filename) const;
 
-    const LocationProvider* location_provider() const {
-        return _location_provider;
-    }
+    const LocationProvider* location_provider() const { return _location_provider; }
 
     UpdateManager* update_mgr();
 
-    CompactionScheduler* compaction_scheduler() {
-        return _compaction_scheduler.get();
-    }
+    CompactionScheduler* compaction_scheduler() { return _compaction_scheduler.get(); }
 
     void update_metacache_limit(size_t limit);
 
     // The return value will never be null.
-    Metacache* metacache() {
-        return _metacache.get();
-    }
+    Metacache* metacache() { return _metacache.get(); }
 
     StatusOr<int64_t> get_tablet_data_size(int64_t tablet_id, int64_t* version_hint);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -136,16 +136,22 @@ public:
 
     std::string delvec_location(int64_t tablet_id, std::string_view delvec_filename) const;
 
-    const LocationProvider* location_provider() const { return _location_provider; }
+    const LocationProvider* location_provider() const {
+        return _location_provider;
+    }
 
     UpdateManager* update_mgr();
 
-    CompactionScheduler* compaction_scheduler() { return _compaction_scheduler.get(); }
+    CompactionScheduler* compaction_scheduler() {
+        return _compaction_scheduler.get();
+    }
 
     void update_metacache_limit(size_t limit);
 
     // The return value will never be null.
-    Metacache* metacache() { return _metacache.get(); }
+    Metacache* metacache() {
+        return _metacache.get();
+    }
 
     StatusOr<int64_t> get_tablet_data_size(int64_t tablet_id, int64_t* version_hint);
 
@@ -167,6 +173,9 @@ public:
     StatusOr<SegmentPtr> load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
                                       const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
                                       TabletSchemaPtr tablet_schema);
+    // for load segment parallel
+    StatusOr<SegmentPtr> load_segment(const FileInfo& segment_info, int segment_id, const LakeIOOptions& lake_io_opts,
+                                      bool fill_metadata_cache, TabletSchemaPtr tablet_schema);
 
 private:
     static std::string global_schema_cache_key(int64_t index_id);

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -162,6 +162,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
             if (auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func(std::move(packaged_func));
                 !st.ok()) {
                 // try load rowset serially if sumbit_func failed
+                LOG(WARNING) << "sumbit_func failed: " << st.code_as_string()
+                             << ", try to load rowset serially, rowset_id: " << rowset->id();
                 ASSIGN_OR_RETURN(auto seg_iters, enhance_error_prompt(rowset->read(schema(), rs_opts)));
                 iters->insert(iters->end(), seg_iters.begin(), seg_iters.end());
             } else {

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -14,6 +14,7 @@
 
 #include "storage/lake/tablet_reader.h"
 
+#include <future>
 #include <utility>
 
 #include "column/datum_convert.h"
@@ -150,9 +151,31 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     }
 
     SCOPED_RAW_TIMER(&_stats.create_segment_iter_ns);
+
+    std::vector<std::future<StatusOr<std::vector<ChunkIteratorPtr>>>> futures;
     for (auto& rowset : _rowsets) {
-        ASSIGN_OR_RETURN(auto seg_iters, enhance_error_prompt(rowset->read(schema(), rs_opts)));
-        iters->insert(iters->end(), seg_iters.begin(), seg_iters.end());
+        if (config::enable_load_segment_parallel) {
+            auto task = std::make_shared<std::packaged_task<StatusOr<std::vector<ChunkIteratorPtr>>()>>(
+                    [&, rowset]() { return enhance_error_prompt(rowset->read(schema(), rs_opts)); });
+
+            auto packaged_func = [task]() { (*task)(); };
+            if (auto st = ExecEnv::GetInstance()->load_rowset_thread_pool()->submit_func(std::move(packaged_func));
+                !st.ok()) {
+                return st;
+            }
+            futures.push_back(task->get_future());
+        } else {
+            ASSIGN_OR_RETURN(auto seg_iters, enhance_error_prompt(rowset->read(schema(), rs_opts)));
+            iters->insert(iters->end(), seg_iters.begin(), seg_iters.end());
+        }
+    }
+
+    for (auto& future : futures) {
+        auto seg_iters_or = future.get();
+        if (!seg_iters_or.ok()) {
+            return seg_iters_or.status();
+        }
+        iters->insert(iters->end(), seg_iters_or.value().begin(), seg_iters_or.value().end());
     }
     return Status::OK();
 }

--- a/be/test/storage/lake/tablet_reader_test.cpp
+++ b/be/test/storage/lake/tablet_reader_test.cpp
@@ -520,4 +520,144 @@ TEST_F(LakeDuplicateTabletReaderWithDeleteNotInOneValueTest, test_read_success) 
     reader->close();
 }
 
+class LakeLoadSegmentParallelTest : public TestBase {
+public:
+    LakeLoadSegmentParallelTest() : TestBase(kTestDirectory) {
+        _tablet_metadata = std::make_shared<TabletMetadata>();
+        _tablet_metadata->set_id(next_id());
+        _tablet_metadata->set_version(1);
+        //
+        //  | column | type | KEY | NULL |
+        //  +--------+------+-----+------+
+        //  |   c0   |  INT | YES |  NO  |
+        //  |   c1   |  INT | NO  |  NO  |
+        auto schema = _tablet_metadata->mutable_schema();
+        schema->set_id(next_id());
+        schema->set_num_short_key_columns(1);
+        schema->set_keys_type(DUP_KEYS);
+        schema->set_num_rows_per_row_block(65535);
+        auto c0 = schema->add_column();
+        {
+            c0->set_unique_id(next_id());
+            c0->set_name("c0");
+            c0->set_type("INT");
+            c0->set_is_key(true);
+            c0->set_is_nullable(false);
+        }
+        auto c1 = schema->add_column();
+        {
+            c1->set_unique_id(next_id());
+            c1->set_name("c1");
+            c1->set_type("INT");
+            c1->set_is_key(false);
+            c1->set_is_nullable(false);
+        }
+
+        _tablet_schema = TabletSchema::create(*schema);
+        _schema = std::make_shared<Schema>(ChunkHelper::convert_schema(_tablet_schema));
+    }
+
+    void SetUp() override {
+        clear_and_init_test_dir();
+        CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+    }
+
+    void TearDown() override { remove_test_dir_ignore_error(); }
+
+protected:
+    constexpr static const char* const kTestDirectory = "test_lake_load_segment_parallel_test";
+
+    std::shared_ptr<TabletMetadata> _tablet_metadata;
+    std::shared_ptr<TabletSchema> _tablet_schema;
+    std::shared_ptr<Schema> _schema;
+};
+
+TEST_F(LakeLoadSegmentParallelTest, test_normal) {
+    std::vector<int> k0{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22};
+    std::vector<int> v0{2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 26, 28, 30, 32, 34, 36, 38, 40, 41, 44};
+
+    std::vector<int> k1{30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41};
+    std::vector<int> v1{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+
+    auto c0 = Int32Column::create();
+    auto c1 = Int32Column::create();
+    auto c2 = Int32Column::create();
+    auto c3 = Int32Column::create();
+    c0->append_numbers(k0.data(), k0.size() * sizeof(int));
+    c1->append_numbers(v0.data(), v0.size() * sizeof(int));
+    c2->append_numbers(k1.data(), k1.size() * sizeof(int));
+    c3->append_numbers(v1.data(), v1.size() * sizeof(int));
+
+    Chunk chunk0({c0, c1}, _schema);
+    Chunk chunk1({c2, c3}, _schema);
+
+    const int segment_rows = chunk0.num_rows() + chunk1.num_rows();
+
+    VersionedTablet tablet(_tablet_mgr.get(), _tablet_metadata);
+    {
+        int64_t txn_id = next_id();
+        // write rowset 1 with 2 segments
+        ASSIGN_OR_ABORT(auto writer, tablet.new_writer(kHorizontal, txn_id));
+        ASSERT_OK(writer->open());
+
+        // write rowset data
+        // segment #1
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        // segment #2
+        ASSERT_OK(writer->write(chunk0));
+        ASSERT_OK(writer->write(chunk1));
+        ASSERT_OK(writer->finish());
+
+        auto files = writer->files();
+        ASSERT_EQ(2, files.size());
+
+        // add rowset metadata
+        auto* rowset = _tablet_metadata->add_rowsets();
+        rowset->set_overlapped(true);
+        rowset->set_id(1);
+        auto* segs = rowset->mutable_segments();
+        auto* segs_size = rowset->mutable_segment_size();
+        for (auto& file : writer->files()) {
+            segs->Add(std::move(file.path));
+            segs_size->Add(std::move(file.size.value()));
+        }
+
+        writer->close();
+    }
+
+    // write tablet metadata
+    _tablet_metadata->set_version(2);
+    CHECK_OK(_tablet_mgr->put_tablet_metadata(*_tablet_metadata));
+
+    // test reader
+    auto reader = std::make_shared<TabletReader>(_tablet_mgr.get(), _tablet_metadata, *_schema);
+    config::enable_load_segment_parallel = true;
+    ASSERT_OK(reader->prepare());
+    TabletReaderParams params;
+    ASSERT_OK(reader->open(params));
+
+    auto read_chunk_ptr = ChunkHelper::new_chunk(*_schema, 1024);
+    for (int j = 0; j < 2; ++j) {
+        read_chunk_ptr->reset();
+        ASSERT_OK(reader->get_next(read_chunk_ptr.get()));
+        ASSERT_EQ(segment_rows, read_chunk_ptr->num_rows());
+        for (int i = 0, sz = k0.size(); i < sz; i++) {
+            EXPECT_EQ(k0[i], read_chunk_ptr->get(i)[0].get_int32());
+            EXPECT_EQ(v0[i], read_chunk_ptr->get(i)[1].get_int32());
+        }
+        for (int i = 0, sz = k1.size(); i < sz; i++) {
+            EXPECT_EQ(k1[i], read_chunk_ptr->get(k0.size() + i)[0].get_int32());
+            EXPECT_EQ(v1[i], read_chunk_ptr->get(k0.size() + i)[1].get_int32());
+        }
+    }
+
+    read_chunk_ptr->reset();
+    ASSERT_TRUE(reader->get_next(read_chunk_ptr.get()).is_end_of_file());
+
+    reader->close();
+}
+
 } // namespace starrocks::lake


### PR DESCRIPTION
Why I'm doing:
Query may be slow when cache miss if there are many rowset or segments, for Initialization  of segment is serial。 
What I'm doing:
Initialization of Rowsets and segments asynchronous 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
