### PR TITLE
[Enhancement] refactor error msg for manual compact in shared_data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -96,7 +96,6 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
-import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -684,10 +683,6 @@ public class AlterJobMgr {
                     throw new DdlException("Invalid alter operation: " + alterClause.getOpType());
                 }
             } else if (alterClause instanceof CompactionClause) {
-                // not support in Shared_data mode
-                if (RunMode.isSharedDataMode()) {
-                    throw new DdlException("not supported command in SHARED_DATA runMode");
-                }
                 String s = (((CompactionClause) alterClause).isBaseCompaction() ? "base" : "cumulative")
                         + " compact " + tableName + " partitions: " + ((CompactionClause) alterClause).getPartitionNames();
                 compactionHandler.process(alterClauses, db, olapTable);

--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -96,6 +96,7 @@ import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.LocalMetastore;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.MaterializedViewAnalyzer;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -683,6 +684,10 @@ public class AlterJobMgr {
                     throw new DdlException("Invalid alter operation: " + alterClause.getOpType());
                 }
             } else if (alterClause instanceof CompactionClause) {
+                // not support in Shared_data mode
+                if (RunMode.isSharedDataMode()) {
+                    throw new DdlException("not supported command in SHARED_DATA runMode");
+                }
                 String s = (((CompactionClause) alterClause).isBaseCompaction() ? "base" : "cumulative")
                         + " compact " + tableName + " partitions: " + ((CompactionClause) alterClause).getPartitionNames();
                 compactionHandler.process(alterClauses, db, olapTable);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AlterTableStatementAnalyzer.java
@@ -21,10 +21,12 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableColumnClause;
 import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.CompactionClause;
 import com.starrocks.sql.ast.CreateIndexClause;
 import com.starrocks.sql.ast.DropColumnClause;
 import com.starrocks.sql.ast.DropIndexClause;
@@ -62,6 +64,9 @@ public class AlterTableStatementAnalyzer {
                     (alterClause instanceof AddColumnClause || alterClause instanceof DropColumnClause ||
                             alterClause instanceof AlterTableColumnClause)) {
                 throw new SemanticException(String.format("row store table %s can't do schema change", table.getName()));
+            }
+            if (RunMode.isSharedDataMode() && alterClause instanceof CompactionClause) {
+                throw new SemanticException("manually compact not supported in SHARED_DATA runMode");
             }
             alterTableClauseAnalyzerVisitor.analyze(alterClause, context);
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAlterTableStatementTest.java
@@ -21,10 +21,15 @@ import com.starrocks.common.Config;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.QueryState;
 import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.AlterClause;
 import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.CompactionClause;
 import com.starrocks.sql.ast.TableRenameClause;
+import com.starrocks.sql.parser.NodePosition;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -65,6 +70,22 @@ public class AnalyzeAlterTableStatementTest {
     @Test(expected = SemanticException.class)
     public void testNoClause() {
         List<AlterClause> ops = Lists.newArrayList();
+        AlterTableStmt alterTableStmt = new AlterTableStmt(new TableName("testDb", "testTbl"), ops);
+        AlterTableStatementAnalyzer.analyze(alterTableStmt, AnalyzeTestUtil.getConnectContext());
+    }
+
+    @Test(expected = SemanticException.class)
+    public void testCompactionClause()  {
+        new MockUp<RunMode>() {
+            @Mock
+            public RunMode getCurrentRunMode() {
+                return RunMode.SHARED_DATA;
+            }
+        };
+
+        List<AlterClause> ops = Lists.newArrayList();
+        NodePosition pos = new NodePosition(1, 23, 1, 48);
+        ops.add(new CompactionClause(true, pos));
         AlterTableStmt alterTableStmt = new AlterTableStmt(new TableName("testDb", "testTbl"), ops);
         AlterTableStatementAnalyzer.analyze(alterTableStmt, AnalyzeTestUtil.getConnectContext());
     }


### PR DESCRIPTION
Why I'm doing:
when you execute "atler table xxx compact" in shared_data runMode,  it will return error like this:
![image](https://github.com/StarRocks/starrocks/assets/10295131/d81e5271-db79-4e95-b316-edc63092429d)
user may be confused about it.
What I'm doing:

refactor error msg for manual compact in shared_data mode

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
