### PR TITLE
[Feature] Adds routine_load_unstable_threshold_second (backpor #36222) (branch-3.2)

### DIFF
--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -89,8 +89,10 @@ public:
 
     // partition -> begin offset, inclusive.
     std::map<int32_t, int64_t> begin_offset;
-    // partiton -> commit offset, inclusive.
+    // partition -> commit offset, inclusive.
     std::map<int32_t, int64_t> cmt_offset;
+    // partition -> commit offset timestamp, inclusive.
+    std::map<int32_t, int64_t> cmt_offset_timestamp;
     //custom kafka property key -> value
     std::map<std::string, std::string> properties;
 };

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -451,6 +451,7 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
 
         TKafkaRLTaskProgress kafka_progress;
         kafka_progress.partitionCmtOffset = ctx->kafka_info->cmt_offset;
+        kafka_progress.partitionCmtOffsetTimestamp = ctx->kafka_info->cmt_offset_timestamp;
 
         rl_attach.kafkaRLTaskProgress = kafka_progress;
         rl_attach.__isset.kafkaRLTaskProgress = true;

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2659,4 +2659,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static boolean allow_system_reserved_names = false;
+
+    @ConfField(mutable = true)
+    public static long routine_load_unstable_threshold_second = 3600;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/common/InternalErrorCode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/InternalErrorCode.java
@@ -35,7 +35,8 @@ public enum InternalErrorCode {
     MANUAL_STOP_ERR(101),
     TOO_MANY_FAILURE_ROWS_ERR(102),
     CREATE_TASKS_ERR(103),
-    TASKS_ABORT_ERR(104);
+    TASKS_ABORT_ERR(104),
+    SLOW_RUNNING_ERR(105);
 
     private long errCode;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaProgress.java
@@ -43,9 +43,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.UserException;
-import com.starrocks.common.util.DebugUtil;
 import com.starrocks.common.util.KafkaUtil;
-import com.starrocks.thrift.TKafkaRLTaskProgress;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,9 +78,11 @@ public class KafkaProgress extends RoutineLoadProgress {
         super(LoadDataSourceType.KAFKA);
     }
 
-    public KafkaProgress(TKafkaRLTaskProgress tKafkaRLTaskProgress) {
+    public KafkaProgress(Map<Integer, Long> partitionOffsets) {
         super(LoadDataSourceType.KAFKA);
-        this.partitionIdToOffset = tKafkaRLTaskProgress.getPartitionCmtOffset();
+        if (partitionOffsets != null) {
+            this.partitionIdToOffset = partitionOffsets;
+        }
     }
 
     public Map<Integer, Long> getPartitionIdToOffset(List<Integer> partitionIds) {
@@ -198,13 +198,11 @@ public class KafkaProgress extends RoutineLoadProgress {
     }
 
     @Override
-    public void update(RLTaskTxnCommitAttachment attachment) {
-        KafkaProgress newProgress = (KafkaProgress) attachment.getProgress();
+    public void update(RoutineLoadProgress progress) {
+        KafkaProgress newProgress = (KafkaProgress) progress;
         // + 1 to point to the next msg offset to be consumed
         newProgress.partitionIdToOffset.entrySet().stream()
                 .forEach(entity -> this.partitionIdToOffset.put(entity.getKey(), entity.getValue() + 1));
-        LOG.debug("update kafka progress: {}, task: {}, job: {}",
-                newProgress.toJsonString(), DebugUtil.printId(attachment.getTaskId()), attachment.getJobId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -126,6 +126,8 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     public KafkaRoutineLoadJob() {
         // for serialization, id is dummy
         super(-1, LoadDataSourceType.KAFKA);
+        this.progress = new KafkaProgress();
+        this.timestampProgress = new KafkaProgress();
     }
 
     public KafkaRoutineLoadJob(Long id, String name,
@@ -134,6 +136,7 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         this.brokerList = brokerList;
         this.topic = topic;
         this.progress = new KafkaProgress();
+        this.timestampProgress = new KafkaProgress();
     }
 
     public String getConfluentSchemaRegistryUrl() {
@@ -315,13 +318,14 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
     @Override
     protected void updateProgress(RLTaskTxnCommitAttachment attachment) throws UserException {
         super.updateProgress(attachment);
-        this.progress.update(attachment);
+        this.progress.update(attachment.getProgress());
+        this.timestampProgress.update(attachment.getTimestampProgress());
     }
 
     @Override
     protected void replayUpdateProgress(RLTaskTxnCommitAttachment attachment) {
         super.replayUpdateProgress(attachment);
-        this.progress.update(attachment);
+        this.progress.update(attachment.getProgress());
     }
 
     @Override
@@ -776,5 +780,26 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
 
         LOG.info("modify the data source properties of kafka routine load job: {}, datasource properties: {}",
                 this.id, dataSourceProperties);
+    }
+
+    // update substate according to the lag.
+    @Override
+    public void updateSubstate() throws UserException {
+        KafkaProgress progress = (KafkaProgress) getTimestampProgress();
+        Map<Integer, Long> partitionTimestamps = progress.getPartitionIdToOffset();
+        long now = System.currentTimeMillis();
+
+        for (Map.Entry<Integer, Long> entry : partitionTimestamps.entrySet()) {
+            int partition = entry.getKey();
+            long lag = (now - entry.getValue().longValue()) / 1000;
+            if (lag > Config.routine_load_unstable_threshold_second) {
+                updateSubstate(JobSubstate.UNSTABLE, new ErrorReason(InternalErrorCode.SLOW_RUNNING_ERR,
+                        String.format("The lag [%d] of partition [%d] exceeds " +
+                                        "Config.routine_load_unstable_threshold_second [%d]",
+                                lag,  partition, Config.routine_load_unstable_threshold_second)));
+                return;
+            }
+        }
+        updateSubstate(JobSubstate.STABLE, null);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarProgress.java
@@ -21,7 +21,6 @@ import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
-import com.starrocks.common.util.DebugUtil;
 import com.starrocks.thrift.TPulsarRLTaskProgress;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -126,8 +125,8 @@ public class PulsarProgress extends RoutineLoadProgress {
     }
 
     @Override
-    public void update(RLTaskTxnCommitAttachment attachment) {
-        PulsarProgress newProgress = (PulsarProgress) attachment.getProgress();
+    public void update(RoutineLoadProgress progress) {
+        PulsarProgress newProgress = (PulsarProgress) progress;
         for (Map.Entry<String, Long> entry : newProgress.partitionToBacklogNum.entrySet()) {
             String partition = entry.getKey();
             Long backlogNum = entry.getValue();
@@ -136,8 +135,6 @@ public class PulsarProgress extends RoutineLoadProgress {
             // Remove initial position if exists
             partitionToInitialPosition.remove(partition);
         }
-        LOG.debug("update pulsar progress: {}, task: {}, job: {}",
-                newProgress.toJsonString(), DebugUtil.printId(attachment.getTaskId()), attachment.getJobId());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/PulsarRoutineLoadJob.java
@@ -282,13 +282,14 @@ public class PulsarRoutineLoadJob extends RoutineLoadJob {
     @Override
     protected void updateProgress(RLTaskTxnCommitAttachment attachment) throws UserException {
         super.updateProgress(attachment);
-        this.progress.update(attachment);
+        this.progress.update(attachment.getProgress());
+        this.timestampProgress.update(attachment.getTimestampProgress());
     }
 
     @Override
     protected void replayUpdateProgress(RLTaskTxnCommitAttachment attachment) {
         super.replayUpdateProgress(attachment);
-        this.progress.update(attachment);
+        this.progress.update(attachment.getProgress());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
@@ -62,6 +62,8 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
     private long taskExecutionTimeMs;
     @SerializedName("progress")
     private RoutineLoadProgress progress;
+    @SerializedName("timestampProgress")
+    private RoutineLoadProgress timestampProgress;
     private String errorLogUrl;
     private long loadedBytes;
 
@@ -82,10 +84,14 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
         switch (rlTaskTxnCommitAttachment.getLoadSourceType()) {
             case KAFKA:
-                this.progress = new KafkaProgress(rlTaskTxnCommitAttachment.getKafkaRLTaskProgress());
+                this.progress = new KafkaProgress(rlTaskTxnCommitAttachment.getKafkaRLTaskProgress()
+                        .getPartitionCmtOffset());
+                this.timestampProgress = new KafkaProgress(rlTaskTxnCommitAttachment.getKafkaRLTaskProgress().
+                        getPartitionCmtOffsetTimestamp());
                 break;
             case PULSAR:
                 this.progress = new PulsarProgress(rlTaskTxnCommitAttachment.getPulsarRLTaskProgress());
+                this.timestampProgress = new PulsarProgress();
                 break;
             default:
                 break;
@@ -134,6 +140,10 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
 
     public RoutineLoadProgress getProgress() {
         return progress;
+    }
+
+    public RoutineLoadProgress getTimestampProgress() {
+        return timestampProgress;
     }
 
     public String getErrorLogUrl() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -168,6 +168,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         }
     }
 
+    public enum JobSubstate {
+        STABLE,
+        UNSTABLE
+    }
+
     @SerializedName("i")
     protected long id;
     @SerializedName("n")
@@ -188,6 +193,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     protected int desireTaskConcurrentNum; // optional
     @SerializedName("s")
     protected JobState state = JobState.NEED_SCHEDULE;
+    protected JobSubstate substate = JobSubstate.STABLE;
     @SerializedName("da")
     protected LoadDataSourceType dataSourceType;
     protected double maxFilterRatio = 1;
@@ -242,6 +248,9 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     @SerializedName("p")
     protected RoutineLoadProgress progress;
 
+    @SerializedName("tp")
+    protected RoutineLoadProgress timestampProgress;
+
     protected long firstResumeTimestamp; // the first resume time
     protected long autoResumeCount;
     protected boolean autoResumeLock = false; //it can't auto resume iff true
@@ -249,6 +258,8 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
     protected String otherMsg = "";
     protected ErrorReason pauseReason;
     protected ErrorReason cancelReason;
+
+    protected ErrorReason stateChangedReason;
 
     @SerializedName("c")
     protected long createTimestamp = System.currentTimeMillis();
@@ -597,6 +608,10 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
 
     public RoutineLoadProgress getProgress() {
         return progress;
+    }
+
+    public RoutineLoadProgress getTimestampProgress() {
+        return timestampProgress;
     }
 
     public double getMaxFilterRatio() {
@@ -1444,7 +1459,11 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             row.add(TimeUtils.longToTimeString(endTimestamp));
             row.add(db == null ? String.valueOf(dbId) : db.getFullName());
             row.add(tbl == null ? String.valueOf(tableId) : tbl.getName());
-            row.add(getState().name());
+            if (state == JobState.RUNNING) {
+                row.add(substate == JobSubstate.STABLE ? state.name() : substate.name());
+            } else {
+                row.add(state.name());
+            }
             row.add(dataSourceType.name());
             row.add(String.valueOf(getSizeOfRoutineLoadTaskInfoList()));
             row.add(jobPropertiesToJsonString());
@@ -1452,12 +1471,20 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             row.add(customPropertiesJsonToString());
             row.add(getStatistic());
             row.add(getProgress().toJsonString());
+            row.add(getTimestampProgress().toJsonString());
             switch (state) {
                 case PAUSED:
                     row.add(pauseReason == null ? "" : pauseReason.toString());
                     break;
                 case CANCELLED:
                     row.add(cancelReason == null ? "" : cancelReason.toString());
+                    break;
+                case RUNNING:
+                    if (substate == JobSubstate.UNSTABLE) {
+                        row.add(stateChangedReason == null ? "" : stateChangedReason.toString());
+                    } else {
+                        row.add("");
+                    }
                     break;
                 default:
                     row.add("");
@@ -1715,6 +1742,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         switch (dataSourceType) {
             case KAFKA: {
                 progress = new KafkaProgress();
+                timestampProgress = new KafkaProgress();
                 progress.readFields(in);
                 break;
             }
@@ -1922,5 +1950,27 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         } finally {
             readUnlock();
         }
+    }
+
+    protected void updateSubstate(JobSubstate substate, ErrorReason reason) throws UserException {
+        writeLock();
+        LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)
+                .add("current_job_substate", this.substate)
+                .add("desire_job_substate", substate)
+                .add("msg", reason)
+                .build());
+        try {
+            this.substate = substate;
+            this.stateChangedReason = reason;
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    public void updateSubstateStable() throws UserException {
+        updateSubstate(JobSubstate.STABLE, null);
+    }
+
+    public void updateSubstate() throws UserException {
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadProgress.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadProgress.java
@@ -56,7 +56,7 @@ public abstract class RoutineLoadProgress implements Writable {
         this.loadDataSourceType = loadDataSourceType;
     }
 
-    abstract void update(RLTaskTxnCommitAttachment attachment);
+    abstract void update(RoutineLoadProgress progress);
 
     abstract String toJsonString();
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -189,9 +189,14 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
                     msg = String.format("there is no new data in kafka/pulsar, wait for %d seconds to schedule again",
                             routineLoadTaskInfo.getTaskScheduleIntervalMs() / 1000);
                 }
+                // The job keeps up with source.
+                routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstateStable();
                 delayPutToQueue(routineLoadTaskInfo, msg);
                 return;
             }
+            // Update the job state is the job is too slow.
+            routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateSubstate();
+
         } catch (RoutineLoadPauseException e) {
             String msg = "fe abort task with reason: check task ready to execute failed, " + e.getMessage();
             routineLoadManager.getJob(routineLoadTaskInfo.getJobId()).updateState(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowRoutineLoadStmt.java
@@ -80,6 +80,7 @@ public class ShowRoutineLoadStmt extends ShowStmt {
                     .add("CustomProperties")
                     .add("Statistic")
                     .add("Progress")
+                    .add("TimestampProgress")
                     .add("ReasonOfStateChanged")
                     .add("ErrorLogUrls")
                     .add("TrackingSQL")

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRoutineLoadStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowRoutineLoadStmtTest.java
@@ -46,7 +46,7 @@ public class ShowRoutineLoadStmtTest {
         Assert.assertEquals("label", stmt.getName());
         Assert.assertEquals("testDb", stmt.getDbFullName());
         Assert.assertFalse(stmt.isIncludeHistory());
-        Assert.assertEquals(19, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(20, stmt.getMetaData().getColumnCount());
         Assert.assertEquals("Id", stmt.getMetaData().getColumn(0).getName());
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/RoutineLoadJobTest.java
@@ -114,10 +114,10 @@ public class RoutineLoadJobTest {
         RLTaskTxnCommitAttachment attachment = new RLTaskTxnCommitAttachment();
         TKafkaRLTaskProgress tKafkaRLTaskProgress = new TKafkaRLTaskProgress();
         tKafkaRLTaskProgress.partitionCmtOffset = Maps.newHashMap();
-        KafkaProgress kafkaProgress = new KafkaProgress(tKafkaRLTaskProgress);
+        KafkaProgress kafkaProgress = new KafkaProgress(tKafkaRLTaskProgress.getPartitionCmtOffset());
         Deencapsulation.setField(attachment, "progress", kafkaProgress);
 
-        KafkaProgress currentProgress = new KafkaProgress(tKafkaRLTaskProgress);
+        KafkaProgress currentProgress = new KafkaProgress(tKafkaRLTaskProgress.getPartitionCmtOffset());
 
         new Expectations() {
             {
@@ -158,17 +158,74 @@ public class RoutineLoadJobTest {
     }
 
     @Test
-    public void testGetShowInfo(@Mocked KafkaProgress kafkaProgress) {
-        RoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
-        Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
-        ErrorReason errorReason = new ErrorReason(InternalErrorCode.INTERNAL_ERR,
-                TransactionState.TxnStatusChangeReason.OFFSET_OUT_OF_RANGE.toString());
-        Deencapsulation.setField(routineLoadJob, "pauseReason", errorReason);
-        Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+    public void testGetShowInfo() throws UserException {
+        {
+            // PAUSE state
+            KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+            Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.PAUSED);
+            ErrorReason errorReason = new ErrorReason(InternalErrorCode.INTERNAL_ERR,
+                    TransactionState.TxnStatusChangeReason.OFFSET_OUT_OF_RANGE.toString());
+            Deencapsulation.setField(routineLoadJob, "pauseReason", errorReason);
 
-        List<String> showInfo = routineLoadJob.getShowInfo();
-        Assert.assertEquals(true, showInfo.stream().filter(entity -> !Strings.isNullOrEmpty(entity))
-                .anyMatch(entity -> entity.equals(errorReason.toString())));
+            List<String> showInfo = routineLoadJob.getShowInfo();
+            Assert.assertEquals(true, showInfo.stream().filter(entity -> !Strings.isNullOrEmpty(entity))
+                    .anyMatch(entity -> entity.equals(errorReason.toString())));
+        }
+
+        {
+            // Progress
+            KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+
+            Map<Integer, Long> partitionOffsets = Maps.newHashMap();
+            partitionOffsets.put(Integer.valueOf(0), Long.valueOf(1234));
+            KafkaProgress kafkaProgress = new KafkaProgress(partitionOffsets);
+            Deencapsulation.setField(routineLoadJob, "progress", kafkaProgress);
+
+            Map<Integer, Long> partitionOffsetTimestamps = Maps.newHashMap();
+            partitionOffsetTimestamps.put(Integer.valueOf(0), Long.valueOf(1701411708410L));
+            KafkaProgress kafkaTimestampProgress = new KafkaProgress(partitionOffsetTimestamps);
+            Deencapsulation.setField(routineLoadJob, "timestampProgress", kafkaTimestampProgress);
+
+            List<String> showInfo = routineLoadJob.getShowInfo();
+            //The displayed value is the actual value - 1
+            Assert.assertEquals("{\"0\":\"1233\"}", showInfo.get(14));
+            Assert.assertEquals("{\"0\":\"1701411708409\"}", showInfo.get(15));
+        }
+
+        {
+            // UNSTABLE substate
+            KafkaRoutineLoadJob routineLoadJob = new KafkaRoutineLoadJob();
+
+            Map<Integer, Long> partitionOffsetTimestamps = Maps.newHashMap();
+            partitionOffsetTimestamps.put(Integer.valueOf(0), Long.valueOf(1701411708410L));
+            KafkaProgress kafkaTimestampProgress = new KafkaProgress(partitionOffsetTimestamps);
+            Deencapsulation.setField(routineLoadJob, "timestampProgress", kafkaTimestampProgress);
+
+            routineLoadJob.updateState(RoutineLoadJob.JobState.RUNNING, null, false);
+            // The job is set unstable due to the progress is too slow.
+            routineLoadJob.updateSubstate();
+
+            List<String> showInfo = routineLoadJob.getShowInfo();
+            Assert.assertEquals("UNSTABLE", showInfo.get(7));
+            // The lag [xxx] of partition [0] exceeds Config.routine_load_unstable_threshold_second [3600]
+            Assert.assertTrue(showInfo.get(16).contains(
+                    "partition [0] exceeds Config.routine_load_unstable_threshold_second [3600]"));
+
+            partitionOffsetTimestamps.put(Integer.valueOf(0), Long.valueOf(System.currentTimeMillis()));
+            kafkaTimestampProgress = new KafkaProgress(partitionOffsetTimestamps);
+            Deencapsulation.setField(routineLoadJob, "timestampProgress", kafkaTimestampProgress);
+            // The job is set stable due to the progress is kept up.
+            routineLoadJob.updateSubstate();
+            showInfo = routineLoadJob.getShowInfo();
+            Assert.assertEquals("RUNNING", showInfo.get(7));
+            Assert.assertEquals("", showInfo.get(16));
+
+            // The job is set stable.
+            routineLoadJob.updateSubstateStable();
+            showInfo = routineLoadJob.getShowInfo();
+            Assert.assertEquals("RUNNING", showInfo.get(7));
+            Assert.assertEquals("", showInfo.get(16));
+        }
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/GlobalTransactionMgrTest.java
@@ -374,11 +374,17 @@ public class GlobalTransactionMgrTest {
         Map<Long, TransactionState> idToTransactionState = Maps.newHashMap();
         idToTransactionState.put(1L, transactionState);
         Deencapsulation.setField(routineLoadJob, "maxErrorNum", 10);
+
         Map<Integer, Long> oldKafkaProgressMap = Maps.newHashMap();
         oldKafkaProgressMap.put(1, 0L);
-        KafkaProgress oldkafkaProgress = new KafkaProgress();
-        Deencapsulation.setField(oldkafkaProgress, "partitionIdToOffset", oldKafkaProgressMap);
+        KafkaProgress oldkafkaProgress = new KafkaProgress(oldKafkaProgressMap);
         Deencapsulation.setField(routineLoadJob, "progress", oldkafkaProgress);
+
+        Map<Integer, Long> kafkaTimestampProgressMap = Maps.newHashMap();
+        kafkaTimestampProgressMap.put(1, 1701411701409L);
+        KafkaProgress oldKafkaTimestampProgress = new KafkaProgress(kafkaTimestampProgressMap);
+        Deencapsulation.setField(routineLoadJob, "timestampProgress", oldKafkaTimestampProgress);
+
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
 
         TRLTaskTxnCommitAttachment rlTaskTxnCommitAttachment = new TRLTaskTxnCommitAttachment();
@@ -387,11 +393,20 @@ public class GlobalTransactionMgrTest {
         rlTaskTxnCommitAttachment.setFilteredRows(1);
         rlTaskTxnCommitAttachment.setJobId(Deencapsulation.getField(routineLoadJob, "id"));
         rlTaskTxnCommitAttachment.setLoadSourceType(TLoadSourceType.KAFKA);
+
         TKafkaRLTaskProgress tKafkaRLTaskProgress = new TKafkaRLTaskProgress();
+
         Map<Integer, Long> kafkaProgress = Maps.newHashMap();
         kafkaProgress.put(1, 100L); // start from 0, so rows number is 101, and consumed offset is 100
         tKafkaRLTaskProgress.setPartitionCmtOffset(kafkaProgress);
         rlTaskTxnCommitAttachment.setKafkaRLTaskProgress(tKafkaRLTaskProgress);
+
+        Map<Integer, Long> kafkaTimestampProgress = Maps.newHashMap();
+        kafkaTimestampProgress.put(1, 1701411701509L); // start from 0, so rows number is 101, and consumed offset is 100
+        tKafkaRLTaskProgress.setPartitionCmtOffsetTimestamp(kafkaTimestampProgress);
+
+        rlTaskTxnCommitAttachment.setKafkaRLTaskProgress(tKafkaRLTaskProgress);
+
         TxnCommitAttachment txnCommitAttachment = new RLTaskTxnCommitAttachment(rlTaskTxnCommitAttachment);
 
         RoutineLoadMgr routineLoadManager = new RoutineLoadMgr();
@@ -449,11 +464,17 @@ public class GlobalTransactionMgrTest {
         Map<Long, TransactionState> idToTransactionState = Maps.newHashMap();
         idToTransactionState.put(1L, transactionState);
         Deencapsulation.setField(routineLoadJob, "maxErrorNum", 10);
+
         Map<Integer, Long> oldKafkaProgressMap = Maps.newHashMap();
         oldKafkaProgressMap.put(1, 0L);
-        KafkaProgress oldkafkaProgress = new KafkaProgress();
-        Deencapsulation.setField(oldkafkaProgress, "partitionIdToOffset", oldKafkaProgressMap);
+        KafkaProgress oldkafkaProgress = new KafkaProgress(oldKafkaProgressMap);
         Deencapsulation.setField(routineLoadJob, "progress", oldkafkaProgress);
+
+        Map<Integer, Long> oldKafkaTimestampProgressMap = Maps.newHashMap();
+        oldKafkaTimestampProgressMap.put(1, 1701411701409L);
+        KafkaProgress oldKafkaTimestampProgress = new KafkaProgress(oldKafkaTimestampProgressMap);
+        Deencapsulation.setField(routineLoadJob, "timestampProgress", oldKafkaTimestampProgress);
+
         Deencapsulation.setField(routineLoadJob, "state", RoutineLoadJob.JobState.RUNNING);
 
         TRLTaskTxnCommitAttachment rlTaskTxnCommitAttachment = new TRLTaskTxnCommitAttachment();
@@ -462,11 +483,20 @@ public class GlobalTransactionMgrTest {
         rlTaskTxnCommitAttachment.setFilteredRows(11);
         rlTaskTxnCommitAttachment.setJobId(Deencapsulation.getField(routineLoadJob, "id"));
         rlTaskTxnCommitAttachment.setLoadSourceType(TLoadSourceType.KAFKA);
+
         TKafkaRLTaskProgress tKafkaRLTaskProgress = new TKafkaRLTaskProgress();
+
         Map<Integer, Long> kafkaProgress = Maps.newHashMap();
-        kafkaProgress.put(1, 110L); // start from 0, so rows number is 111, consumed offset is 110
+        kafkaProgress.put(1, 110L); // start from 0, so rows number is 101, and consumed offset is 100
         tKafkaRLTaskProgress.setPartitionCmtOffset(kafkaProgress);
         rlTaskTxnCommitAttachment.setKafkaRLTaskProgress(tKafkaRLTaskProgress);
+
+        Map<Integer, Long> kafkaTimestampProgress = Maps.newHashMap();
+        kafkaTimestampProgress.put(1, 1701411701609L); // start from 0, so rows number is 101, and consumed offset is 100
+        tKafkaRLTaskProgress.setPartitionCmtOffsetTimestamp(kafkaTimestampProgress);
+
+        rlTaskTxnCommitAttachment.setKafkaRLTaskProgress(tKafkaRLTaskProgress);
+
         TxnCommitAttachment txnCommitAttachment = new RLTaskTxnCommitAttachment(rlTaskTxnCommitAttachment);
 
         RoutineLoadMgr routineLoadManager = new RoutineLoadMgr();

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -907,6 +907,7 @@ struct TStreamLoadPutResult {
 
 struct TKafkaRLTaskProgress {
     1: required map<i32,i64> partitionCmtOffset
+    2: optional map<i32,i64> partitionCmtOffsetTimestamp
 }
 
 struct TPulsarRLTaskProgress {


### PR DESCRIPTION
This is a backport of pull request https://github.com/StarRocks/starrocks/pull/36222 to branch-3.2

Why I'm doing:
When a routine load job gets sustained failure, the retention of the Kafka partition may expire, which leads to data loss.

What I'm doing:
1. adding TimeProgress to the result of `show routine load`.
The TimestampProgress denotes the latest partition timestamp of the consumed message.

2. adding FE config `routine_load_unstable_threshold_second`.
When the time latency is more than this config value, the job would be set as `UNSTABLE` state.
In this state, the routine load job would be scheduled continuously, and the `ReasonOfChangeState` would be set.  

Fixes https://github.com/StarRocks/starrocks/issues/35296
## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
  https://github.com/StarRocks/starrocks/pull/36967

