### PR TITLE
[Tool] remove `--use-staros` option in build/ut script

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -77,8 +77,6 @@ option(WITH_BLOCK_CACHE "Build binary with block cache feature" OFF)
 
 option(WITH_BENCH "Build binary with bench" OFF)
 
-option(USE_STAROS "Use StarOS to manager tablet info" OFF)
-
 # Check gcc
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS "4.8.2")
@@ -366,44 +364,6 @@ if (${WITH_BLOCK_CACHE} STREQUAL "ON")
     endforeach()
 endif()
 
-if ("${USE_STAROS}" STREQUAL "ON")
-     find_package(protobuf CONFIG REQUIRED)
-     message(STATUS "Using protobuf ${protobuf_VERSION}")
-     message(STATUS "protobuf include path: ${protobuf_INCLUDE_DIRS}")
-     message(STATUS "protobuf libs: ${protobuf_LIBS}")
-
-     find_package(gRPC CONFIG REQUIRED)
-     message(STATUS "Using gRPC ${gRPC_VERSION}")
-     get_target_property(gRPC_INCLUDE_DIR gRPC::grpc INTERFACE_INCLUDE_DIRECTORIES)
-     include_directories(SYSTEM ${gRPC_INCLUDE_DIR})
-
-     find_package(starlet CONFIG REQUIRED)
-     message(STATUS "Using starlet ${starlet_VERSION}")
-     message(STATUS "starlet inc dir: ${STARLET_INCLUDE_DIRS}")
-     message(STATUS "starlet lib dir: ${STARLET_LIBS}")
-     include_directories(SYSTEM ${STARLET_INCLUDE_DIRS})
-     add_library(starlet STATIC IMPORTED)
-     set_target_properties(starlet PROPERTIES IMPORTED_LOCATION ${STARLET_LIBS}/libstarlet.a)
-
-     find_package (prometheus-cpp CONFIG REQUIRED)
-     get_target_property(prometheus-cpp_INCLUDE_DIR prometheus-cpp::core INTERFACE_INCLUDE_DIRECTORIES)
-     message(STATUS "Using prometheus-cpp")
-     message(STATUS "  include: ${prometheus-cpp_INCLUDE_DIR}")
-     include_directories(SYSTEM ${prometheus-cpp_INCLUDE_DIR})
-
-     add_library(starlet_fslib_all STATIC IMPORTED GLOBAL)
-     set_target_properties(starlet_fslib_all PROPERTIES IMPORTED_LOCATION ${STARLET_LIBS}/libstarlet_fslib_all.a)
-
-     set(STARROCKS_DEPENDENCIES
-        ${STARROCKS_DEPENDENCIES}
-        starlet
-        gRPC::grpc++_reflection
-        gRPC::grpc++
-        starlet_fslib_all
-        prometheus-cpp::core
-        )
-endif()
-
 # Check if functions are supported in this platform. All flags will generated
 # in gensrc/build/common/env_config.h.
 # You can check funcion here which depends on platform. Don't forget add this
@@ -448,9 +408,6 @@ endif()
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBOOST_DATE_TIME_POSIX_TIME_STD_CONFIG")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DBOOST_SYSTEM_NO_DEPRECATED -DBOOST_UUID_RANDOM_PROVIDER_FORCE_POSIX")
 set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -Werror=return-type -Werror=switch")
-if (${USE_STAROS} STREQUAL "ON")
-    set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DUSE_STAROS")
-endif()
 if (${WITH_BLOCK_CACHE} STREQUAL "ON")
     set(CXX_COMMON_FLAGS "${CXX_COMMON_FLAGS} -DWITH_BLOCK_CACHE")
 endif()

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -331,9 +331,6 @@ set(EXEC_FILES
         ./service/lake_service_test.cpp
         )
 
-if ("${USE_STAROS}" STREQUAL "ON")
-    list(APPEND EXEC_FILES ./fs/fs_starlet_test.cpp)
-endif ()
 if ("${WITH_BLOCK_CACHE}" STREQUAL "ON")
     list(APPEND EXEC_FILES ./block_cache/block_cache_test.cpp)
     list(APPEND EXEC_FILES ./io/cache_input_stream_test.cpp)

--- a/build.sh
+++ b/build.sh
@@ -58,7 +58,6 @@ Usage: $0 <options>
      --fe               build Frontend and Spark Dpp application
      --spark-dpp        build Spark DPP application
      --clean            clean and build target
-     --use-staros       build Backend with staros
      --with-gcov        build Backend with gcov, has an impact on performance
      --without-gcov     build Backend without gcov(default)
      --with-bench       build Backend with bench(default without bench)
@@ -86,7 +85,6 @@ OPTS=$(getopt \
   -l 'with-gcov' \
   -l 'with-bench' \
   -l 'without-gcov' \
-  -l 'use-staros' \
   -o 'j:' \
   -l 'help' \
   -- "$@")
@@ -104,7 +102,6 @@ CLEAN=
 RUN_UT=
 WITH_GCOV=OFF
 WITH_BENCH=OFF
-USE_STAROS=OFF
 if [[ -z ${USE_AVX2} ]]; then
     USE_AVX2=ON
 fi
@@ -171,7 +168,6 @@ else
             --ut) RUN_UT=1   ; shift ;;
             --with-gcov) WITH_GCOV=ON; shift ;;
             --without-gcov) WITH_GCOV=OFF; shift ;;
-            --use-staros) USE_STAROS=ON; shift ;;
             --with-bench) WITH_BENCH=ON; shift ;;
             -h) HELP=1; shift ;;
             --help) HELP=1; shift ;;
@@ -201,7 +197,6 @@ echo "Get params:
     RUN_UT              -- $RUN_UT
     WITH_GCOV           -- $WITH_GCOV
     WITH_BENCH          -- $WITH_BENCH
-    USE_STAROS          -- $USE_STAROS
     USE_AVX2            -- $USE_AVX2
     PARALLEL            -- $PARALLEL
     ENABLE_QUERY_DEBUG_TRACE -- $ENABLE_QUERY_DEBUG_TRACE
@@ -241,43 +236,18 @@ if [ ${BUILD_BE} -eq 1 ] ; then
     fi
     mkdir -p ${CMAKE_BUILD_DIR}
     cd ${CMAKE_BUILD_DIR}
-    if [ "${USE_STAROS}" == "ON"  ]; then
-      if [ -z "$STARLET_INSTALL_DIR" ] ; then
-        # assume starlet_thirdparty is installed to ${STARROCKS_THIRDPARTY}/installed/starlet/
-        STARLET_INSTALL_DIR=${STARROCKS_THIRDPARTY}/installed/starlet
-      fi
-      ${CMAKE_CMD} -G "${CMAKE_GENERATOR}" \
-                    -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY} \
-                    -DSTARROCKS_HOME=${STARROCKS_HOME} \
-                    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-                    -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV}\
-                    -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
-                    -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE \
-                    -DUSE_JEMALLOC=$USE_JEMALLOC \
-                    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-                    -DUSE_STAROS=${USE_STAROS} \
-                    -DWITH_BENCH=${WITH_BENCH} \
-                    -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
-                    -Dprotobuf_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/protobuf \
-                    -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
-                    -DgRPC_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/grpc \
-                    -Dprometheus-cpp_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/prometheus-cpp \
-                    -Dstarlet_DIR=${STARLET_INSTALL_DIR}/starlet_install/lib64/cmake ..
-    else
-      ${CMAKE_CMD} -G "${CMAKE_GENERATOR}" \
-                    -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY} \
-                    -DSTARROCKS_HOME=${STARROCKS_HOME} \
-                    -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-                    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-                    -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV}\
-                    -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
-                    -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE \
-                    -DUSE_JEMALLOC=$USE_JEMALLOC \
-                    -DWITH_BENCH=${WITH_BENCH} \
-                    -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
-                    -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..
-    fi
+    ${CMAKE_CMD} -G "${CMAKE_GENERATOR}" \
+                  -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY} \
+                  -DSTARROCKS_HOME=${STARROCKS_HOME} \
+                  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+                  -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+                  -DMAKE_TEST=OFF -DWITH_GCOV=${WITH_GCOV}\
+                  -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
+                  -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE \
+                  -DUSE_JEMALLOC=$USE_JEMALLOC \
+                  -DWITH_BENCH=${WITH_BENCH} \
+                  -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
+                  -DCMAKE_EXPORT_COMPILE_COMMANDS=ON  ..
     time ${BUILD_SYSTEM} -j${PARALLEL}
     ${BUILD_SYSTEM} install
 

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -40,7 +40,6 @@ Usage: $0 <options>
      --with-bench                   enable to build with benchmark
      --with-gcov                    enable to build with gcov
      --module                       module to run uts
-     --use-staros                   enable to build with staros
      -j                             build parallel
 
   Eg.
@@ -64,7 +63,6 @@ OPTS=$(getopt \
   -l 'module:' \
   -l 'with-aws' \
   -l 'with-bench' \
-  -l 'use-staros' \
   -o 'j:' \
   -l 'help' \
   -l 'run' \
@@ -83,7 +81,6 @@ TEST_NAME=*
 TEST_MODULE=".*"
 HELP=0
 WITH_AWS=OFF
-USE_STAROS=OFF
 WITH_BLOCK_CACHE=ON
 WITH_GCOV=OFF
 while true; do
@@ -97,7 +94,6 @@ while true; do
         --help) HELP=1 ; shift ;;
         --with-aws) WITH_AWS=ON; shift ;;
         --with-gcov) WITH_GCOV=ON; shift ;;
-        --use-staros) USE_STAROS=ON; shift ;;
         -j) PARALLEL=$2; shift 2 ;;
         --) shift ;  break ;;
         *) echo "Internal error" ; exit 1 ;;
@@ -131,36 +127,15 @@ fi
 
 cd ${CMAKE_BUILD_DIR}
 
-if [ "${USE_STAROS}" == "ON"  ]; then
-  if [ -z "$STARLET_INSTALL_DIR" ] ; then
-    # assume starlet_thirdparty is installed to ${STARROCKS_THIRDPARTY}/installed/starlet/
-    STARLET_INSTALL_DIR=${STARROCKS_THIRDPARTY}/installed/starlet
-  fi
-  ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
-              -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY}\
-              -DSTARROCKS_HOME=${STARROCKS_HOME} \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-              -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
-              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-              -DUSE_STAROS=${USE_STAROS} -DWITH_GCOV=${WITH_GCOV} \
-              -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
-              -Dprotobuf_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/protobuf \
-              -Dabsl_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/absl \
-              -DgRPC_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/grpc \
-              -Dprometheus-cpp_DIR=${STARLET_INSTALL_DIR}/third_party/lib/cmake/prometheus-cpp \
-              -Dstarlet_DIR=${STARLET_INSTALL_DIR}/starlet_install/lib64/cmake ..
-else
-  ${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
-              -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY}\
-              -DSTARROCKS_HOME=${STARROCKS_HOME} \
-              -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-              -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
-              -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
-              -DWITH_GCOV=${WITH_GCOV} \
-              -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
-              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
-fi
+${CMAKE_CMD}  -G "${CMAKE_GENERATOR}" \
+            -DSTARROCKS_THIRDPARTY=${STARROCKS_THIRDPARTY}\
+            -DSTARROCKS_HOME=${STARROCKS_HOME} \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+            -DMAKE_TEST=ON -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
+            -DUSE_AVX2=$USE_AVX2 -DUSE_SSE4_2=$USE_SSE4_2 \
+            -DWITH_GCOV=${WITH_GCOV} \
+            -DWITH_BLOCK_CACHE=${WITH_BLOCK_CACHE} \
+            -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
 ${BUILD_SYSTEM} -j${PARALLEL}
 
 echo "*********************************"


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [X] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
