### PR TITLE
[BugFix] Fix bug metric not using bytes unit  (backport #36221)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/JvmMonitorProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/JvmMonitorProcDir.java
@@ -62,23 +62,23 @@ public class JvmMonitorProcDir implements ProcNodeInterface {
         result.addRow(genRow("classes total loaded", jvmStats.getClasses().getTotalLoadedClassCount()));
         result.addRow(genRow("classes unloaded", jvmStats.getClasses().getUnloadedClassCount()));
 
-        result.addRow(genRow("mem heap committed", jvmStats.getMem().getHeapCommitted().getBytes()));
-        result.addRow(genRow("mem heap used", jvmStats.getMem().getHeapUsed().getBytes()));
-        result.addRow(genRow("mem non heap committed", jvmStats.getMem().getNonHeapCommitted().getBytes()));
-        result.addRow(genRow("mem non heap used", jvmStats.getMem().getNonHeapUsed().getBytes()));
+        result.addRow(genRow("mem heap committed", jvmStats.getMem().getHeapCommitted()));
+        result.addRow(genRow("mem heap used", jvmStats.getMem().getHeapUsed()));
+        result.addRow(genRow("mem non heap committed", jvmStats.getMem().getNonHeapCommitted()));
+        result.addRow(genRow("mem non heap used", jvmStats.getMem().getNonHeapUsed()));
 
         for (MemoryPool memPool : jvmStats.getMem()) {
-            result.addRow(genRow("mem pool " + memPool.getName() + " committed", memPool.getCommitted().getBytes()));
-            result.addRow(genRow("mem pool " + memPool.getName() + " used", memPool.getUsed().getBytes()));
-            result.addRow(genRow("mem pool " + memPool.getName() + " max", memPool.getMax().getBytes()));
-            result.addRow(genRow("mem pool " + memPool.getName() + " peak used", memPool.getPeakUsed().getBytes()));
-            result.addRow(genRow("mem pool " + memPool.getName() + " peak max", memPool.getPeakMax().getBytes()));
+            result.addRow(genRow("mem pool " + memPool.getName() + " committed", memPool.getCommitted()));
+            result.addRow(genRow("mem pool " + memPool.getName() + " used", memPool.getUsed()));
+            result.addRow(genRow("mem pool " + memPool.getName() + " max", memPool.getMax()));
+            result.addRow(genRow("mem pool " + memPool.getName() + " peak used", memPool.getPeakUsed()));
+            result.addRow(genRow("mem pool " + memPool.getName() + " peak max", memPool.getPeakMax()));
         }
 
         for (BufferPool bp : jvmStats.getBufferPools()) {
             result.addRow(genRow("buffer pool " + bp.getName() + " count", bp.getCount()));
-            result.addRow(genRow("buffer pool " + bp.getName() + " used", bp.getUsed().getBytes()));
-            result.addRow(genRow("buffer pool " + bp.getName() + " capacity", bp.getTotalCapacity().getBytes()));
+            result.addRow(genRow("buffer pool " + bp.getName() + " used", bp.getUsed()));
+            result.addRow(genRow("buffer pool " + bp.getName() + " capacity", bp.getTotalCapacity()));
         }
 
         for (GarbageCollector gc : jvmStats.getGc()) {

--- a/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/JsonMetricVisitor.java
@@ -89,15 +89,15 @@ public class JsonMetricVisitor extends MetricVisitor {
         for (JvmStats.MemoryPool memPool : jvmStats.getMem()) {
             if (memPool.getName().equalsIgnoreCase(GcNames.PERM)) {
                 double percent = 0.0;
-                if (memPool.getCommitted().getBytes() > 0) {
-                    percent = 100 * ((double) memPool.getUsed().getBytes() / memPool.getCommitted().getBytes());
+                if (memPool.getCommitted() > 0) {
+                    percent = 100 * ((double) memPool.getUsed() / memPool.getCommitted());
                 }
                 buildMetric("jvm_size_percent", "percent", String.valueOf(percent),
                         Collections.singletonList(new MetricLabel("type", GcNames.PERM)));
             } else if (memPool.getName().equalsIgnoreCase(GcNames.OLD)) {
                 double percent = 0.0;
-                if (memPool.getCommitted().getBytes() > 0) {
-                    percent = 100 * ((double) memPool.getUsed().getBytes() / memPool.getCommitted().getBytes());
+                if (memPool.getCommitted() > 0) {
+                    percent = 100 * ((double) memPool.getUsed() / memPool.getCommitted());
                 }
                 // **NOTICE**: We shouldn't use 'jvm_size_percent' as a metric name, it should be a type,
                 // but for compatibility reason, we won't remove it.

--- a/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/PrometheusMetricVisitor.java
@@ -82,19 +82,19 @@ public class PrometheusMetricVisitor extends MetricVisitor {
         // heap
         sb.append(Joiner.on(" ").join(HELP, JVM_HEAP_SIZE_BYTES, "jvm heap stat\n"));
         sb.append(Joiner.on(" ").join(TYPE, JVM_HEAP_SIZE_BYTES, "gauge\n"));
-        sb.append(JVM_HEAP_SIZE_BYTES).append("{type=\"max\"} ").append(jvmStats.getMem().getHeapMax().getBytes())
+        sb.append(JVM_HEAP_SIZE_BYTES).append("{type=\"max\"} ").append(jvmStats.getMem().getHeapMax())
                 .append("\n");
         sb.append(JVM_HEAP_SIZE_BYTES).append("{type=\"committed\"} ")
-                .append(jvmStats.getMem().getHeapCommitted().getBytes()).append("\n");
-        sb.append(JVM_HEAP_SIZE_BYTES).append("{type=\"used\"} ").append(jvmStats.getMem().getHeapUsed().getBytes())
+                .append(jvmStats.getMem().getHeapCommitted()).append("\n");
+        sb.append(JVM_HEAP_SIZE_BYTES).append("{type=\"used\"} ").append(jvmStats.getMem().getHeapUsed())
                 .append("\n");
         // non heap
         sb.append(Joiner.on(" ").join(HELP, JVM_NON_HEAP_SIZE_BYTES, "jvm non heap stat\n"));
         sb.append(Joiner.on(" ").join(TYPE, JVM_NON_HEAP_SIZE_BYTES, "gauge\n"));
         sb.append(JVM_NON_HEAP_SIZE_BYTES).append("{type=\"committed\"} ")
-                .append(jvmStats.getMem().getNonHeapCommitted().getBytes()).append("\n");
+                .append(jvmStats.getMem().getNonHeapCommitted()).append("\n");
         sb.append(JVM_NON_HEAP_SIZE_BYTES).append("{type=\"used\"} ")
-                .append(jvmStats.getMem().getNonHeapUsed().getBytes()).append("\n");
+                .append(jvmStats.getMem().getNonHeapUsed()).append("\n");
 
         // mem pool
         for (MemoryPool memPool : jvmStats.getMem()) {
@@ -114,9 +114,9 @@ public class PrometheusMetricVisitor extends MetricVisitor {
                 sb.append(JVM_DIRECT_BUFFER_POOL_SIZE_BYTES).append("{type=\"count\"} ").append(pool.getCount())
                         .append("\n");
                 sb.append(JVM_DIRECT_BUFFER_POOL_SIZE_BYTES).append("{type=\"used\"} ")
-                        .append(pool.getUsed().getBytes()).append("\n");
+                        .append(pool.getUsed()).append("\n");
                 sb.append(JVM_DIRECT_BUFFER_POOL_SIZE_BYTES).append("{type=\"capacity\"} ")
-                        .append(pool.getTotalCapacity().getBytes()).append("\n");
+                        .append(pool.getTotalCapacity()).append("\n");
             }
         }
 
@@ -149,13 +149,13 @@ public class PrometheusMetricVisitor extends MetricVisitor {
     private void addMemPoolMetrics(MemoryPool memPool, String metricName, String desc) {
         sb.append(Joiner.on(" ").join(HELP, metricName, desc));
         sb.append(Joiner.on(" ").join(TYPE, metricName, "gauge\n"));
-        sb.append(metricName).append("{type=\"committed\"} ").append(memPool.getCommitted().getBytes())
+        sb.append(metricName).append("{type=\"committed\"} ").append(memPool.getCommitted())
                 .append("\n");
-        sb.append(metricName).append("{type=\"used\"} ").append(memPool.getUsed().getBytes())
+        sb.append(metricName).append("{type=\"used\"} ").append(memPool.getUsed())
                 .append("\n");
-        sb.append(metricName).append("{type=\"peak_used\"} ").append(memPool.getPeakUsed().getBytes())
+        sb.append(metricName).append("{type=\"peak_used\"} ").append(memPool.getPeakUsed())
                 .append("\n");
-        sb.append(metricName).append("{type=\"max\"} ").append(memPool.getMax().getBytes())
+        sb.append(metricName).append("{type=\"max\"} ").append(memPool.getMax())
                 .append("\n");
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/SimpleCoreMetricVisitor.java
@@ -62,7 +62,7 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
     public static final String JVM_OLD_USED_PERCENT = "jvm_old_used_percent";
     public static final String JVM_THREAD = "jvm_thread";
 
-    public static final String MAX_JOURMAL_ID = "max_journal_id";
+    public static final String MAX_JOURNAL_ID = "max_journal_id";
     public static final String CONNECTION_TOTAL = "connection_total";
     public static final String QUERY_LATENCY_MS = "query_latency_ms";
 
@@ -75,7 +75,7 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
     private static final Map<String, String> CORE_METRICS = Maps.newHashMap();
 
     static {
-        CORE_METRICS.put(MAX_JOURMAL_ID, TYPE_LONG);
+        CORE_METRICS.put(MAX_JOURNAL_ID, TYPE_LONG);
         CORE_METRICS.put(CONNECTION_TOTAL, TYPE_LONG);
         CORE_METRICS.put(QUERY_LATENCY_MS, TYPE_LONG);
         CORE_METRICS.put(QUERY_PER_SECOND, TYPE_DOUBLE);
@@ -97,13 +97,13 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
         while (memIter.hasNext()) {
             MemoryPool memPool = memIter.next();
             if (memPool.getName().equalsIgnoreCase("young")) {
-                long used = memPool.getUsed().getBytes();
-                long max = memPool.getMax().getBytes();
+                long used = memPool.getUsed();
+                long max = memPool.getMax();
                 String percent = String.format("%.1f", (double) used / (max + 1) * 100);
                 sb.append(Joiner.on(" ").join(JVM_YOUNG_USED_PERCENT, TYPE_DOUBLE, percent)).append("\n");
             } else if (memPool.getName().equalsIgnoreCase("old")) {
-                long used = memPool.getUsed().getBytes();
-                long max = memPool.getMax().getBytes();
+                long used = memPool.getUsed();
+                long max = memPool.getMax();
                 String percent = String.format("%.1f", (double) used / (max + 1) * 100);
                 sb.append(Joiner.on(" ").join(JVM_OLD_USED_PERCENT, TYPE_DOUBLE, percent)).append("\n");
             }
@@ -154,9 +154,9 @@ public class SimpleCoreMetricVisitor extends MetricVisitor {
         long brokerDeadNum =
                 GlobalStateMgr.getCurrentState().getBrokerMgr().getAllBrokers().stream().filter(b -> !b.isAlive)
                         .count();
-        sb.append(prefix + "_frontend_dead_num").append(" ").append(String.valueOf(feDeadNum)).append("\n");
-        sb.append(prefix + "_backend_dead_num").append(" ").append(String.valueOf(beDeadNum)).append("\n");
-        sb.append(prefix + "_broker_dead_num").append(" ").append(String.valueOf(brokerDeadNum)).append("\n");
+        sb.append(prefix).append("_frontend_dead_num").append(" ").append(feDeadNum).append("\n");
+        sb.append(prefix).append("_backend_dead_num").append(" ").append(beDeadNum).append("\n");
+        sb.append(prefix).append("_broker_dead_num").append(" ").append(brokerDeadNum).append("\n");
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmStats.java
+++ b/fe/fe-core/src/main/java/com/starrocks/monitor/jvm/JvmStats.java
@@ -328,32 +328,54 @@ public class JvmStats {
             return this.name;
         }
 
-        public ByteSizeValue getUsed() {
+        public long getUsed() {
+            return used;
+        }
+
+        public ByteSizeValue getByteSizeUsed() {
             return new ByteSizeValue(used);
         }
 
-        public ByteSizeValue getMax() {
+        public long getMax() {
+            return max;
+        }
+
+        public ByteSizeValue getByteSizeMax() {
             return new ByteSizeValue(max);
         }
 
-        public ByteSizeValue getCommitted() {
+
+        public long getCommitted() {
+            return committed;
+        }
+
+        public ByteSizeValue getByteSizeCommitted() {
             return new ByteSizeValue(committed);
         }
 
-        public ByteSizeValue getPeakUsed() {
+        public long getPeakUsed() {
+            return peakUsed;
+        }
+
+        public ByteSizeValue getByteSizePeakUsed() {
             return new ByteSizeValue(peakUsed);
         }
 
-        public ByteSizeValue getPeakMax() {
+        public long getPeakMax() {
+            return peakMax;
+        }
+
+        public ByteSizeValue getByteSizePeakMax() {
             return new ByteSizeValue(peakMax);
         }
 
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append("name: ").append(name).append(", used: ").append(getUsed().toString());
-            sb.append(", max: ").append(getMax().toString()).append(", peak used: ").append(getPeakUsed().toString());
-            sb.append(", peak max: ").append(getPeakMax().toString());
+            sb.append("name: ").append(name).append(", used: ").append(getByteSizeUsed().toString());
+            sb.append(", max: ").append(getByteSizeMax().toString())
+                    .append(", peak used: ").append(getByteSizePeakUsed().toString());
+            sb.append(", peak max: ").append(getByteSizePeakMax().toString());
             return sb.toString();
         }
     }
@@ -383,18 +405,30 @@ public class JvmStats {
             return pools.iterator();
         }
 
-        public ByteSizeValue getHeapCommitted() {
+        public long getHeapCommitted() {
+            return heapCommitted;
+        }
+
+        public ByteSizeValue getByteSizeHeapCommitted() {
             return new ByteSizeValue(heapCommitted);
         }
 
-        public ByteSizeValue getHeapUsed() {
+        public long getHeapUsed() {
+            return heapUsed;
+        }
+
+        public ByteSizeValue getByteSizeHeapUsed() {
             return new ByteSizeValue(heapUsed);
+        }
+
+        public long getHeapMax() {
+            return heapMax;
         }
 
         /**
          * returns the maximum heap size. 0 bytes signals unknown.
          */
-        public ByteSizeValue getHeapMax() {
+        public ByteSizeValue getByteSizeHeapMax() {
             return new ByteSizeValue(heapMax);
         }
 
@@ -408,22 +442,30 @@ public class JvmStats {
             return (short) (heapUsed * 100 / heapMax);
         }
 
-        public ByteSizeValue getNonHeapCommitted() {
+        public long getNonHeapCommitted() {
+            return nonHeapCommitted;
+        }
+
+        public ByteSizeValue getByteSizeNonHeapCommitted() {
             return new ByteSizeValue(nonHeapCommitted);
         }
 
-        public ByteSizeValue getNonHeapUsed() {
+        public long getNonHeapUsed() {
+            return nonHeapUsed;
+        }
+
+        public ByteSizeValue getByteSizeNonHeapUsed() {
             return new ByteSizeValue(nonHeapUsed);
         }
 
         @Override
         public String toString() {
             StringBuilder sb = new StringBuilder();
-            sb.append("heap committed: ").append(getHeapCommitted().toString());
-            sb.append(", heap used: ").append(getHeapUsed().toString());
-            sb.append(", heap max: ").append(getHeapMax().toString());
-            sb.append(", non heap committed: ").append(getNonHeapCommitted().toString());
-            sb.append(", non heap used: ").append(getNonHeapUsed().toString());
+            sb.append("heap committed: ").append(getByteSizeHeapCommitted().toString());
+            sb.append(", heap used: ").append(getByteSizeHeapUsed().toString());
+            sb.append(", heap max: ").append(getByteSizeHeapMax().toString());
+            sb.append(", non heap committed: ").append(getByteSizeNonHeapCommitted().toString());
+            sb.append(", non heap used: ").append(getByteSizeNonHeapUsed().toString());
             sb.append("\nMem pools: ");
             for (MemoryPool memoryPool : pools) {
                 sb.append(memoryPool.toString()).append("\n");
@@ -454,11 +496,19 @@ public class JvmStats {
             return this.count;
         }
 
-        public ByteSizeValue getTotalCapacity() {
+        public long getTotalCapacity() {
+            return totalCapacity;
+        }
+
+        public ByteSizeValue getByteSizeTotalCapacity() {
             return new ByteSizeValue(totalCapacity);
         }
 
-        public ByteSizeValue getUsed() {
+        public long getUsed() {
+            return used;
+        }
+
+        public ByteSizeValue getByteSizeUsed() {
             return new ByteSizeValue(used);
         }
 


### PR DESCRIPTION
Why I'm doing:
The metric units all end in bytes, but the actual display is indeed converted.

What I'm doing:
There is no need to go back and forth, just use the original bytes value, which saves memory but not calculation.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
