### PR TITLE
[Enhancement] Expr enhance with cache hash

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/CompoundPredicateOperator.java
@@ -25,10 +25,23 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class CompoundPredicateOperator extends PredicateOperator {
     private final CompoundType type;
+
+    // These two filed are used in NormalizePredicateRule to eliminate common CompoundPredicate
+    // For Expr tree like below, the CompoundTreeLeafNodeNumber is 5, and compoundTreeUniqueLeave's size is 4.
+    //           AND
+    //        /        \
+    //      AND         AND
+    //     /   \       /  \
+    // subT1   a+1  And  subT5
+    //               /   \
+    //             subT3  a+1
+    private int compoundTreeLeafNodeNumber;
+    private Set<ScalarOperator> compoundTreeUniqueLeaves;
 
     public CompoundPredicateOperator(CompoundType compoundType, ScalarOperator... arguments) {
         super(OperatorType.COMPOUND, arguments);
@@ -44,6 +57,22 @@ public class CompoundPredicateOperator extends PredicateOperator {
 
     public CompoundType getCompoundType() {
         return type;
+    }
+
+    public Set<ScalarOperator> getCompoundTreeUniqueLeaves() {
+        return compoundTreeUniqueLeaves;
+    }
+
+    public void setCompoundTreeUniqueLeaves(Set<ScalarOperator> compoundTreeUniqueLeaves) {
+        this.compoundTreeUniqueLeaves = compoundTreeUniqueLeaves;
+    }
+
+    public int getCompoundTreeLeafNodeNumber() {
+        return compoundTreeLeafNodeNumber;
+    }
+
+    public void setCompoundTreeLeafNodeNumber(int compoundTreeLeafNodeNumber) {
+        this.compoundTreeLeafNodeNumber = compoundTreeLeafNodeNumber;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
@@ -1,0 +1,99 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.operator.scalar;
+
+import com.starrocks.sql.optimizer.base.ColumnRefSet;
+
+import java.util.List;
+import java.util.Objects;
+
+public class HashCachedScalarOperator extends ScalarOperator {
+    public ScalarOperator operator;
+    private int hashValue = 0;
+
+    public HashCachedScalarOperator(ScalarOperator operator) {
+        super(operator.getOpType(), operator.getType());
+        this.operator = operator;
+    }
+
+    public int getHashValue() {
+        return hashValue;
+    }
+
+    public void setHashValue(int hashValue) {
+        this.hashValue = hashValue;
+    }
+
+    public ScalarOperator getOperator() {
+        return operator;
+    }
+
+    @Override
+    public int hashCode() {
+        if (this.getHashValue() != 0) {
+            return this.getHashValue();
+        }
+
+        this.setHashValue(operator.hashCode());
+        return this.getHashValue();
+
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        HashCachedScalarOperator that = (HashCachedScalarOperator) o;
+        return Objects.equals(this.getOperator(), that.getOperator());
+    }
+
+    @Override
+    public boolean isNullable() {
+        return false;
+    }
+
+    @Override
+    public List<ScalarOperator> getChildren() {
+        return null;
+    }
+
+    @Override
+    public ScalarOperator getChild(int index) {
+        return null;
+    }
+
+    @Override
+    public void setChild(int index, ScalarOperator child) {
+    }
+
+    @Override
+    public String toString() {
+        return null;
+    }
+
+    @Override
+    public <R, C> R accept(ScalarOperatorVisitor<R, C> visitor, C context) {
+        return null;
+    }
+
+    @Override
+    public ColumnRefSet getUsedColumns() {
+        return null;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/HashCachedScalarOperator.java
@@ -21,19 +21,11 @@ import java.util.Objects;
 
 public class HashCachedScalarOperator extends ScalarOperator {
     public ScalarOperator operator;
-    private int hashValue = 0;
+    private transient Integer hashValue = null;
 
     public HashCachedScalarOperator(ScalarOperator operator) {
         super(operator.getOpType(), operator.getType());
         this.operator = operator;
-    }
-
-    public int getHashValue() {
-        return hashValue;
-    }
-
-    public void setHashValue(int hashValue) {
-        this.hashValue = hashValue;
     }
 
     public ScalarOperator getOperator() {
@@ -42,13 +34,10 @@ public class HashCachedScalarOperator extends ScalarOperator {
 
     @Override
     public int hashCode() {
-        if (this.getHashValue() != 0) {
-            return this.getHashValue();
+        if (hashValue == null) {
+            hashValue = operator.hashCode();
         }
-
-        this.setHashValue(operator.hashCode());
-        return this.getHashValue();
-
+        return hashValue;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorRewriter.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.sql.optimizer.rewrite;
 
 import com.google.common.collect.Lists;
@@ -37,7 +36,6 @@ public class ScalarOperatorRewriter {
     public static final List<ScalarOperatorRewriteRule> DEFAULT_TYPE_CAST_RULE = Lists.newArrayList(
             new ImplicitCastRule()
     );
-
     public static final List<ScalarOperatorRewriteRule> DEFAULT_REWRITE_RULES = Lists.newArrayList(
             // required
             new ImplicitCastRule(),
@@ -49,7 +47,6 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
-
     public static final List<ScalarOperatorRewriteRule> DEFAULT_REWRITE_SCAN_PREDICATE_RULES = Lists.newArrayList(
             // required
             new ImplicitCastRule(),
@@ -62,7 +59,6 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
-
     public static final List<ScalarOperatorRewriteRule> MV_SCALAR_REWRITE_RULES = Lists.newArrayList(
             // required
             new ImplicitCastRule(),
@@ -74,7 +70,6 @@ public class ScalarOperatorRewriter {
             new ExtractCommonPredicateRule(),
             new ArithmeticCommutativeRule()
     );
-
     private final ScalarOperatorRewriteContext context;
 
     public ScalarOperatorRewriter() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/NormalizePredicateRule.java
@@ -136,17 +136,14 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
     public ScalarOperator visitCompoundPredicate(CompoundPredicateOperator predicate,
                                                  ScalarOperatorRewriteContext context) {
         if (predicate.isAnd() || predicate.isOr()) {
-            ScalarOperator newTree = getOptimizedCompoundTree(predicate);
-            if (newTree != null) {
-                return newTree;
-            }
+            return getOptimizedCompoundTree(predicate).orElse(predicate);
         }
 
         return predicate;
     }
 
     @Nullable
-    private ScalarOperator getOptimizedCompoundTree(CompoundPredicateOperator parent) {
+    private Optional<ScalarOperator> getOptimizedCompoundTree(CompoundPredicateOperator parent) {
         // reset node first So we can apply NormalizePredicateRule to one tree many times
         parent.setCompoundTreeUniqueLeaves(Sets.newLinkedHashSet());
         parent.setCompoundTreeLeafNodeNumber(0);
@@ -199,10 +196,10 @@ public class NormalizePredicateRule extends BottomUpScalarOperatorRewriteRule {
                 compoundNewTree.setCompoundTreeUniqueLeaves(compoundTreeUniqueLeaves);
             }
 
-            return newTree;
+            return Optional.of(newTree);
         }
         // this tree can't be optimized
-        return null;
+        return Optional.empty();
     }
 
     /*

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/NormalizePredicateBench.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/NormalizePredicateBench.java
@@ -25,6 +25,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rewrite.ScalarOperatorRewriter;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -64,7 +65,7 @@ import static com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOpera
 @Measurement(time = 1, timeUnit = TimeUnit.SECONDS)
 public class NormalizePredicateBench {
 
-    @Param({"10", "20", "40", "80", "160"})
+    @Param({"10", "20", "40", "80", "160", "2000"})
     private int predicateSize;
 
     private ScalarOperator randomPredicate;
@@ -157,6 +158,12 @@ public class NormalizePredicateBench {
         ScalarOperator res = MvUtils.canonizePredicateForRewrite(randomPredicate);
     }
 
+    @Benchmark
+    public void bench_NormalizePredicate_Random_Non_MV() {
+        ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+        ScalarOperator res = scalarRewriter.rewrite(randomPredicate, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
+    }
+
     /**
      * (a = 1 and b = 2 and c = 3)
      * OR (a = 2 and b = 3 and c = 4)
@@ -166,5 +173,11 @@ public class NormalizePredicateBench {
     @Benchmark
     public void bench_NormalizePredicate_Disjunctive() {
         ScalarOperator res = MvUtils.canonizePredicateForRewrite(disjunctive);
+    }
+
+    @Benchmark
+    public void bench_NormalizePredicate_Disjunctive_Non_MV() {
+        ScalarOperatorRewriter scalarRewriter = new ScalarOperatorRewriter();
+        ScalarOperator res = scalarRewriter.rewrite(disjunctive, ScalarOperatorRewriter.DEFAULT_REWRITE_RULES);
     }
 }


### PR DESCRIPTION
Why I'm doing:
Expr like 100 or takes too long in transform phase, Especially NormalizePredicateRule‘s visitCompoundPredicate, because its time complexity is O(n^2) n is tree node numbers.

What I'm doing:
when visit expr tree bottom up, if child is compound operator, cache child's unique compound tree leaf node in set and child's hash value to eliminate duplicate calculations

benchmark with 2000 predicate: 

without any optimization：
`NormalizePredicateBench.bench_NormalizePredicate_Random_Non_MV                  2000  avgt    5   205.584 ±   27.420  ms/op`

without cache hash value:
`NormalizePredicateBench.bench_NormalizePredicate_Random_Non_MV                  2000  avgt    5   195.232 ±    0.440  ms/op`

cache hash value:
`NormalizePredicateBench.bench_NormalizePredicate_Random_Non_MV                  2000  avgt    5   108.491 ±   6.336  ms/op`


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
