### PR TITLE
[BugFix] fix pipe_file_list replication_num issue

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/PipeManager.java
@@ -211,8 +211,12 @@ public class PipeManager {
         return repo;
     }
 
-    protected CloseableLock writeLock() {
+    protected CloseableLock takeWriteLock() {
         return CloseableLock.lock(this.lock.writeLock());
+    }
+
+    protected CloseableLock takeReadLock() {
+        return CloseableLock.lock(this.lock.readLock());
     }
 
     //============================== RAW CRUD ===========================================

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/filelist/RepoCreator.java
@@ -29,8 +29,8 @@ public class RepoCreator {
     private static final RepoCreator INSTANCE = new RepoCreator();
 
     private static boolean databaseExists = false;
-    private boolean tableExists = false;
-    private boolean tableCorrected = false;
+    private static boolean tableExists = false;
+    private static boolean tableCorrected = false;
 
     public static RepoCreator getInstance() {
         return INSTANCE;
@@ -50,8 +50,7 @@ public class RepoCreator {
                 LOG.info("table created: " + FileListTableRepo.FILE_LIST_TABLE_NAME);
                 tableExists = true;
             }
-            if (!tableCorrected) {
-                correctTable();
+            if (!tableCorrected && correctTable()) {
                 LOG.info("table corrected: " + FileListTableRepo.FILE_LIST_TABLE_NAME);
                 tableCorrected = true;
             }
@@ -69,20 +68,25 @@ public class RepoCreator {
         RepoExecutor.getInstance().executeDDL(sql);
     }
 
-    public static void correctTable() {
+    public static boolean correctTable() {
         int numBackends = GlobalStateMgr.getCurrentSystemInfo().getTotalBackendNumber();
         int replica = GlobalStateMgr.getCurrentState()
                 .mayGetDb(FileListTableRepo.FILE_LIST_DB_NAME)
                 .flatMap(db -> db.mayGetTable(FileListTableRepo.FILE_LIST_TABLE_NAME))
                 .map(tbl -> ((OlapTable) tbl).getPartitionInfo().getMinReplicationNum())
                 .orElse((short) 1);
-        if (numBackends >= 3 && replica < 3) {
+        if (numBackends < 3) {
+            LOG.info("not enough backends in the cluster, expected 3 but got {}", numBackends);
+            return false;
+        }
+        if (replica < 3) {
             String sql = FileListTableRepo.SQLBuilder.buildAlterTableSql();
             RepoExecutor.getInstance().executeDDL(sql);
         } else {
             LOG.info("table {} already has {} replicas, no need to alter replication_num",
                     FileListTableRepo.FILE_LIST_FULL_NAME, replica);
         }
+        return true;
     }
 
     public boolean isDatabaseExists() {


### PR DESCRIPTION
Why I'm doing:
- The lock order in `Pipe::finalizeTask` is Pipe then PipeManager, which would lead to deadlock when having concurrent operations
- The RepoCreator cannot correct the replica numbers when backend num is not enough

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
