### PR TITLE
[BugFix] fix bad plan cache with invalid sql

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -570,6 +570,10 @@ public class Database extends MetaObject implements Writable {
         return idToTable.get(tableId);
     }
 
+    public Optional<Table> mayGetTable(long tableId) {
+        return Optional.ofNullable(getTable(tableId));
+    }
+
     public static Database read(DataInput in) throws IOException {
         Database db = new Database();
         db.readFields(in);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -780,6 +780,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         mv.active = this.active;
         mv.refreshScheme = this.refreshScheme.copy();
         mv.maxMVRewriteStaleness = this.maxMVRewriteStaleness;
+        mv.viewDefineSql = this.viewDefineSql;
         if (this.baseTableIds != null) {
             mv.baseTableIds = Sets.newHashSet(this.baseTableIds);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -20,10 +20,14 @@ import com.google.common.annotations.VisibleForTesting;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.common.Config;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.concurrent.TimeUnit;
 
 public class CachingMvPlanContextBuilder {
+
+    private static final Logger LOG = LogManager.getLogger(CachingMvPlanContextBuilder.class);
     private static final CachingMvPlanContextBuilder INSTANCE = new CachingMvPlanContextBuilder();
 
     private Cache<MaterializedView, MvPlanContext> mvPlanContextCache = buildCache();
@@ -57,8 +61,12 @@ public class CachingMvPlanContextBuilder {
 
     private MvPlanContext loadMvPlanContext(MaterializedView mv) {
         MvPlanContextBuilder builder = new MvPlanContextBuilder();
-        MvPlanContext result = builder.getPlanContext(mv);
-        return result;
+        try {
+            return builder.getPlanContext(mv);
+        } catch (Throwable e) {
+            LOG.warn("load mv plan cache failed: {}", mv.getName(), e);
+            return null;
+        }
     }
 
     @VisibleForTesting


### PR DESCRIPTION
Why I'm doing:
- MV plan cache use the cached MaterializedView, which would be a copied one since optimistic lock optimization
- But the `MaterializedView::viewDefinitionSql` would be null since it's not copied.
- As a result the optimizer would throw NPE

What I'm doing:
- Copy the `viewDefinitionSql` when `copyForQuery`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
