### PR TITLE
[Enhancement] support yield and direct io for spill

### DIFF
--- a/be/src/column/column_for_each.h
+++ b/be/src/column/column_for_each.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "column/column_visitor_adapter.h"
+#include "common/status.h"
+
+namespace starrocks {
+template <typename Func>
+concept IntCallable = std::invocable<Func, int>&& std::invocable<Func, int64_t>&& std::invocable<Func, size_t>&&
+        std::invocable<Func, int8_t>&& std::invocable<Func, int16_t>;
+
+template <class Applier>
+class ForEachElementVisitor final : public ColumnVisitorAdapter<ForEachElementVisitor<Applier>> {
+public:
+    Applier applier;
+    template <class ColumnType>
+    Status do_visit(const ColumnType& _) {
+        return Status::NotSupported("not supported");
+    }
+};
+
+} // namespace starrocks

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 
 #include "common/config.h"
+#include "gen_cpp/StatusCode_types.h"
 #include "gen_cpp/Status_types.h"  // for TStatus
 #include "gen_cpp/status.pb.h"     // for StatusPB
 #include "gutil/strings/fastmem.h" // for memcpy_inlined
@@ -252,6 +253,8 @@ std::string Status::code_as_string() const {
         return "Transaction not exist";
     case TStatusCode::TXN_IN_PROCESSING:
         return "Transaction in processing";
+    case TStatusCode::YIELD:
+        return "Task yield";
     }
     return {};
 }

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -193,10 +193,7 @@ public:
 
     bool is_eagain() const { return code() == TStatusCode::SR_EAGAIN; }
 
-    bool is_yield() const {
-        mark_checked();
-        return code() == TStatusCode::YIELD;
-    }
+    bool is_yield() const { return code() == TStatusCode::YIELD; }
 
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -145,6 +145,8 @@ public:
 
     static Status RemoteFileNotFound(std::string_view msg) { return Status(TStatusCode::REMOTE_FILE_NOT_FOUND, msg); }
 
+    static Status Yield() { return {TStatusCode::YIELD, ""}; }
+
     bool ok() const { return _state == nullptr; }
 
     bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }
@@ -190,6 +192,11 @@ public:
     bool is_time_out() const { return code() == TStatusCode::TIMEOUT; }
 
     bool is_eagain() const { return code() == TStatusCode::SR_EAGAIN; }
+
+    bool is_yield() const {
+        mark_checked();
+        return code() == TStatusCode::YIELD;
+    }
 
     // Convert into TStatus. Call this if 'status_container' contains an optional
     // TStatus field named 'status'. This also sets __isset.status.

--- a/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
+++ b/be/src/exec/pipeline/hashjoin/spillable_hash_join_probe_operator.cpp
@@ -249,7 +249,8 @@ Status SpillableHashJoinProbeOperator::_load_partition_build_side(workgroup::Yie
     auto builder = _builders[idx];
     bool finish = false;
     int64_t hash_table_mem_usage = builder->hash_table_mem_usage();
-    ctx.total_yield_point_cnt = 1;
+    enum SpillLoadPartitionStage { BEGIN = 0, FINISH = 1 };
+    ctx.total_yield_point_cnt = FINISH;
     auto wg = ctx.wg;
     int64_t time_spent_ns = 0;
     while (!finish && !_is_finished) {

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -61,6 +61,7 @@ struct AcquireBlockOptions {
     TUniqueId query_id;
     int32_t plan_node_id;
     std::string name;
+    bool direct_io = false;
 };
 
 // BlockManager is used to manage the life cycle of the Block.

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -129,6 +129,30 @@ struct SyncTaskExecutor {
         break;                                                                                  \
     }
 
+#define RETURN_IF_NEED_YIELD(wg, yield, time_spent_ns)                                          \
+    if (time_spent_ns >= workgroup::WorkGroup::YIELD_MAX_TIME_SPENT) {                          \
+        *yield = true;                                                                          \
+        return Status::Yield();                                                                 \
+    }                                                                                           \
+    if (wg != nullptr && time_spent_ns >= workgroup::WorkGroup::YIELD_PREEMPT_MAX_TIME_SPENT && \
+        wg->scan_sched_entity()->in_queue()->should_yield(wg, time_spent_ns)) {                 \
+        *yield = true;                                                                          \
+        return Status::Yield();                                                                 \
+    }
+
+#define RETURN_IF_ERROR_EXCEPT_YIELD(stmt)                                                            \
+    do {                                                                                              \
+        auto&& status__ = (stmt);                                                                     \
+        if (UNLIKELY(!status__.ok() && !status__.is_yield())) {                                       \
+            return to_status(status__).clone_and_append_context(__FILE__, __LINE__, AS_STRING(stmt)); \
+        }                                                                                             \
+    } while (false)
+
+#define RETURN_IF_YIELD(yield) \
+    if (*yield) {              \
+        return Status::OK();   \
+    }
+
 #define DEFER_GUARD_END(guard) auto VARNAME_LINENUM(defer) = DeferOp([&]() { guard.scoped_end(); });
 
 #define RESOURCE_TLS_MEMTRACER_GUARD(state, ...) \

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -77,7 +77,7 @@ public:
     StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable(size_t offset, size_t length);
 
     static StatusOr<LogBlockContainerPtr> create(Dir* dir, TUniqueId query_id, int32_t plan_node_id,
-                                                 const std::string& plan_node_name, uint64_t id, bool direct_io);
+                                                 const std::string& plan_node_name, uint64_t id, bool enable_direct_io);
 
 private:
     Dir* _dir;

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -36,12 +36,13 @@ namespace starrocks::spill {
 class LogBlockContainer {
 public:
     LogBlockContainer(Dir* dir, const TUniqueId& query_id, int32_t plan_node_id, std::string plan_node_name,
-                      uint64_t id)
+                      uint64_t id, bool direct_io)
             : _dir(dir),
               _query_id(query_id),
               _plan_node_id(plan_node_id),
               _plan_node_name(std::move(plan_node_name)),
-              _id(id) {}
+              _id(id),
+              _direct_io(direct_io) {}
 
     ~LogBlockContainer() {
         TRACE_SPILL_LOG << "delete spill container file: " << path();
@@ -69,8 +70,6 @@ public:
     std::string parent_path() const { return fmt::format("{}/{}", _dir->dir(), print_id(_query_id)); }
     uint64_t id() const { return _id; }
 
-    Status ensure_preallocate(size_t length);
-
     Status append_data(const std::vector<Slice>& data, size_t total_size);
 
     Status flush();
@@ -78,7 +77,7 @@ public:
     StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable(size_t offset, size_t length);
 
     static StatusOr<LogBlockContainerPtr> create(Dir* dir, TUniqueId query_id, int32_t plan_node_id,
-                                                 const std::string& plan_node_name, uint64_t id);
+                                                 const std::string& plan_node_name, uint64_t id, bool direct_io);
 
 private:
     Dir* _dir;
@@ -88,6 +87,7 @@ private:
     uint64_t _id;
     std::unique_ptr<WritableFile> _writable_file;
     bool _has_open = false;
+    bool _direct_io = false;
     size_t _data_size = 0;
 };
 
@@ -101,6 +101,7 @@ Status LogBlockContainer::open() {
     if (config::experimental_spill_skip_sync) {
         opt.sync_on_close = false;
     }
+    opt.direct_write = _direct_io;
     ASSIGN_OR_RETURN(_writable_file, _dir->fs()->new_writable_file(opt, file_path));
     TRACE_SPILL_LOG << "create new container file: " << file_path;
     _has_open = true;
@@ -112,11 +113,8 @@ Status LogBlockContainer::close() {
     return Status::OK();
 }
 
-Status LogBlockContainer::ensure_preallocate(size_t length) {
-    return _writable_file->pre_allocate(length);
-}
-
 Status LogBlockContainer::append_data(const std::vector<Slice>& data, size_t total_size) {
+    RETURN_IF_ERROR(_writable_file->pre_allocate(total_size));
     RETURN_IF_ERROR(_writable_file->appendv(data.data(), data.size()));
     _data_size += total_size;
     return Status::OK();
@@ -137,8 +135,9 @@ StatusOr<std::unique_ptr<io::InputStreamWrapper>> LogBlockContainer::get_readabl
 }
 
 StatusOr<LogBlockContainerPtr> LogBlockContainer::create(Dir* dir, TUniqueId query_id, int32_t plan_node_id,
-                                                         const std::string& plan_node_name, uint64_t id) {
-    auto container = std::make_shared<LogBlockContainer>(dir, query_id, plan_node_id, plan_node_name, id);
+                                                         const std::string& plan_node_name, uint64_t id,
+                                                         bool direct_io) {
+    auto container = std::make_shared<LogBlockContainer>(dir, query_id, plan_node_id, plan_node_name, id, direct_io);
     RETURN_IF_ERROR(container->open());
     return container;
 }
@@ -184,7 +183,6 @@ public:
                 _container->dir()->dec_size(total_size);
             }
         });
-        RETURN_IF_ERROR(ret = _container->ensure_preallocate(total_size));
         RETURN_IF_ERROR(ret = _container->append_data(data, total_size));
         _size += total_size;
         return Status::OK();
@@ -257,7 +255,7 @@ StatusOr<BlockPtr> LogBlockManager::acquire_block(const AcquireBlockOptions& opt
     ASSIGN_OR_RETURN(auto dir, ExecEnv::GetInstance()->spill_dir_mgr()->acquire_writable_dir(acquire_dir_opts));
 #endif
 
-    ASSIGN_OR_RETURN(auto block_container, get_or_create_container(dir, opts.plan_node_id, opts.name));
+    ASSIGN_OR_RETURN(auto block_container, get_or_create_container(dir, opts.plan_node_id, opts.name, opts.direct_io));
     return std::make_shared<LogBlock>(block_container, block_container->size());
 }
 
@@ -288,7 +286,8 @@ Status LogBlockManager::release_block(const BlockPtr& block) {
 }
 
 StatusOr<LogBlockContainerPtr> LogBlockManager::get_or_create_container(Dir* dir, int32_t plan_node_id,
-                                                                        const std::string& plan_node_name) {
+                                                                        const std::string& plan_node_name,
+                                                                        bool direct_io) {
     TRACE_SPILL_LOG << "get_or_create_container at dir: " << dir->dir() << ", plan node:" << plan_node_id << ", "
                     << plan_node_name;
 
@@ -313,7 +312,8 @@ StatusOr<LogBlockContainerPtr> LogBlockManager::get_or_create_container(Dir* dir
     uint64_t id = _next_container_id++;
     std::string container_dir = dir->dir() + "/" + print_id(_query_id);
     RETURN_IF_ERROR(dir->fs()->create_dir_if_missing(container_dir));
-    ASSIGN_OR_RETURN(auto block_container, LogBlockContainer::create(dir, _query_id, plan_node_id, plan_node_name, id));
+    ASSIGN_OR_RETURN(auto block_container,
+                     LogBlockContainer::create(dir, _query_id, plan_node_id, plan_node_name, id, direct_io));
     RETURN_IF_ERROR(block_container->open());
     return block_container;
 }

--- a/be/src/exec/spill/log_block_manager.h
+++ b/be/src/exec/spill/log_block_manager.h
@@ -60,7 +60,7 @@ public:
 
 private:
     StatusOr<LogBlockContainerPtr> get_or_create_container(Dir* dir, int32_t plan_node_id,
-                                                           const std::string& plan_node_name);
+                                                           const std::string& plan_node_name, bool direct_io);
 
 private:
     typedef std::unordered_map<uint64_t, LogBlockContainerPtr> ContainerMap;

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -55,9 +55,10 @@ Status UnorderedMemTable::append_selective(const Chunk& src, const uint32_t* ind
 }
 
 Status UnorderedMemTable::flush(FlushCallBack callback) {
-    for (const auto& chunk : _chunks) {
-        RETURN_IF_ERROR(callback(chunk));
+    while (_processed_index < _chunks.size()) {
+        RETURN_IF_ERROR(callback(_chunks[_processed_index++]));
     }
+    _processed_index = {};
     int64_t consumption = _tracker->consumption();
     _tracker->release(consumption);
     COUNTER_ADD(_spiller->metrics().mem_table_peak_memory_usage, -consumption);

--- a/be/src/exec/spill/mem_table.h
+++ b/be/src/exec/spill/mem_table.h
@@ -67,6 +67,7 @@ public:
     virtual Status done() = 0;
     // flush all data to callback, then release the memory in memory table
     // flush will be called in IO threads
+    // flush needs to be designed to be reentrant. Because callbacks can return Status::Yield.
     virtual Status flush(FlushCallBack callback) = 0;
 
     virtual StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(bool shared) {
@@ -98,6 +99,7 @@ public:
     StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(bool shared) override;
 
 private:
+    size_t _processed_index{};
     std::vector<ChunkPtr> _chunks;
 };
 

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -88,7 +88,10 @@ Status ColumnarSerde::serialize_to_block(SerdeContext& ctx, const ChunkPtr& chun
     const auto& columns = chunk->columns();
     size_t max_serialized_size = _max_serialized_size(chunk);
     auto& serialize_buffer = ctx.aligned_buffer;
-    serialize_buffer.resize(ALIGN_UP(max_serialized_size + columns.size() * sizeof(uint32_t) + sizeof(size_t), 4096));
+    // DIRECT write require ALIGN TO page size
+    const size_t PAGE_SIZE = 4096;
+    serialize_buffer.resize(
+            ALIGN_UP(max_serialized_size + columns.size() * sizeof(uint32_t) + sizeof(size_t), PAGE_SIZE));
 
     uint8_t* buf = reinterpret_cast<uint8_t*>(serialize_buffer.data());
 

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -39,7 +39,7 @@ public:
         return Status::OK();
     }
 
-    Status serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) override;
+    Status serialize_to_block(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) override;
     StatusOr<ChunkUniquePtr> deserialize(SerdeContext& ctx, BlockReader* reader) override;
 
 private:
@@ -84,37 +84,41 @@ size_t ColumnarSerde::_max_serialized_size(const ChunkPtr& chunk) const {
     return total_size;
 }
 
-Status ColumnarSerde::serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) {
+Status ColumnarSerde::serialize_to_block(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) {
+    const auto& columns = chunk->columns();
     size_t max_serialized_size = _max_serialized_size(chunk);
-    auto& serialize_buffer = ctx.serialize_buffer;
-    serialize_buffer.resize(max_serialized_size);
+    auto& serialize_buffer = ctx.aligned_buffer;
+    serialize_buffer.resize(ALIGN_UP(max_serialized_size + columns.size() * sizeof(uint32_t) + sizeof(size_t), 4096));
 
     uint8_t* buf = reinterpret_cast<uint8_t*>(serialize_buffer.data());
-    uint8_t* head = buf;
 
-    const auto& columns = chunk->columns();
+    size_t meta_len = 0;
 
-    std::unique_ptr<uint8_t[]> meta_buf;
-    size_t meta_len;
     if (_encode_context == nullptr) {
         SCOPED_TIMER(_parent->metrics().serialize_timer);
+        meta_len = sizeof(size_t);
+        uint8_t* head = buf = buf + meta_len;
         for (const auto& column : columns) {
             buf = serde::ColumnArraySerde::serialize(*column, buf);
             if (UNLIKELY(buf == nullptr)) {
                 return Status::InternalError("unsupported column occurs in spill serialize phase");
             }
         }
-        serialize_buffer.resize(buf - head);
+        size_t content_length = buf - head;
+        auto align_size = ALIGN_UP(content_length + meta_len, 4096);
+        serialize_buffer.resize(align_size);
         // only 8 bytes for serialized size if encoding is disable
-        meta_len = sizeof(size_t);
-        meta_buf.reset(new uint8_t[meta_len]);
-        uint8_t* tmp_buf = meta_buf.get();
-        UNALIGNED_STORE64(tmp_buf, serialize_buffer.size());
+        UNALIGNED_STORE64(serialize_buffer.data(), align_size - meta_len);
     } else {
         SCOPED_TIMER(_parent->metrics().serialize_timer);
+        // 8 bytes for encoded size, 4 bytes for each column's encode level
+        // @TODO(silverbullet233): encode levels can be further encoded to save space if necessary.
+        meta_len = sizeof(size_t) + columns.size() * sizeof(uint32_t);
+        uint8_t* head = buf = buf + meta_len;
+
         auto encode_levels = _get_encode_levels();
-        std::vector<std::pair<uint64_t, uint64_t>>
-                column_stats; // used to record raw_bytes and encoded_bytes for each column
+        // used to record raw_bytes and encoded_bytes for each column
+        std::vector<std::pair<uint64_t, uint64_t>> column_stats;
         column_stats.reserve(columns.size());
         int padding_size = 0;
         for (size_t i = 0; i < columns.size(); i++) {
@@ -130,15 +134,13 @@ Status ColumnarSerde::serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockP
             }
         }
         _update_encode_stats(column_stats);
+        size_t content_length = buf - head;
+        auto align_size = ALIGN_UP(content_length + meta_len + padding_size, 4096);
+        serialize_buffer.resize(align_size);
 
-        serialize_buffer.resize(buf - head + padding_size);
-        // 8 bytes for encoded size, 4 bytes for each column's encode level
-        // @TODO(silverbullet233): encode levels can be further encoded to save space if necessary.
-        meta_len = sizeof(size_t) + columns.size() * sizeof(uint32_t);
-        meta_buf.reset(new uint8_t[meta_len]);
         // fill encoded size
-        uint8_t* tmp_buf = meta_buf.get();
-        UNALIGNED_STORE64(tmp_buf, serialize_buffer.size());
+        auto* tmp_buf = serialize_buffer.data();
+        UNALIGNED_STORE64(tmp_buf, serialize_buffer.size() - meta_len);
         tmp_buf += sizeof(size_t);
         // fill encode level
         for (auto encode_level : encode_levels) {
@@ -148,7 +150,6 @@ Status ColumnarSerde::serialize(SerdeContext& ctx, const ChunkPtr& chunk, BlockP
     }
 
     std::vector<Slice> data;
-    data.emplace_back(Slice(meta_buf.get(), meta_len));
     data.emplace_back(Slice(serialize_buffer.data(), serialize_buffer.size()));
     {
         SCOPED_TIMER(_parent->metrics().write_io_timer);

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -527,7 +527,6 @@ Status PartitionedSpillerWriter::_spill_input_partitions(workgroup::YieldContext
 Status PartitionedSpillerWriter::_split_input_partitions(workgroup::YieldContext& yield_ctx, SerdeContext& context,
                                                          const std::vector<SpilledPartition*>& splitting_partitions,
                                                          int64_t* time_spent_ns, int* yield) {
-    // TODO: implements yieldable
     SCOPED_TIMER(_spiller->metrics().split_partition_timer);
     auto& flush_ctx = std::any_cast<PartitionedFlushContextPtr>(yield_ctx.task_context_data)->split_stage_ctx;
     for (; flush_ctx.spliting_idx < splitting_partitions.size(); flush_ctx.spliting_idx++) {

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -14,11 +14,19 @@
 
 #include "exec/spill/spill_components.h"
 
+#include <any>
+#include <cstdint>
+#include <memory>
+
+#include "column/vectorized_fwd.h"
 #include "common/config.h"
 #include "exec/spill/executor.h"
 #include "exec/spill/serde.h"
 #include "exec/spill/spiller.h"
 #include "exec/spill/spiller.hpp"
+#include "exec/workgroup/scan_task_queue.h"
+#include "exec/workgroup/work_group.h"
+#include "exec/workgroup/work_group_fwd.h"
 #include "util/bit_util.h"
 
 namespace starrocks::spill {
@@ -59,31 +67,45 @@ void RawSpillerWriter::prepare(RuntimeState* state) {
     }
 }
 
-Status RawSpillerWriter::flush_task(RuntimeState* state, const MemTablePtr& mem_table) {
+Status RawSpillerWriter::yieldable_flush_task(workgroup::YieldContext& yield_ctx, RuntimeState* state,
+                                              const MemTablePtr& mem_table, int* yield) {
     if (state->is_cancelled()) {
         return Status::OK();
     }
-
     const auto& serde = _spiller->serde();
-    spill::AcquireBlockOptions opts;
-    opts.query_id = state->query_id();
-    opts.plan_node_id = options().plan_node_id;
-    opts.name = options().name;
-    ASSIGN_OR_RETURN(auto block, _spiller->block_manager()->acquire_block(opts));
-    COUNTER_UPDATE(_spiller->metrics().block_count, 1);
+
+    auto block_st = get_block_from_ctx([&]() -> StatusOr<BlockPtr> {
+        if (!yield_ctx.task_context_data.has_value()) {
+            spill::AcquireBlockOptions opts{.query_id = state->query_id(),
+                                            .plan_node_id = options().plan_node_id,
+                                            .name = options().name,
+                                            .direct_io = state->enable_spill_direct_io()};
+            ASSIGN_OR_RETURN(auto block, _spiller->block_manager()->acquire_block(opts));
+            COUNTER_UPDATE(_spiller->metrics().block_count, 1);
+            yield_ctx.task_context_data = FlushContext{block};
+        }
+        auto flush_ctx = std::any_cast<FlushContext>(yield_ctx.task_context_data);
+        return flush_ctx.block;
+    });
+    ASSIGN_OR_RETURN(auto block, std::move(block_st));
 
     // TODO: reuse io context
     SerdeContext spill_ctx;
+    int64_t time_spent_ns = 0;
+    yield_ctx.total_yield_point_cnt = 1;
     {
         TRY_CATCH_ALLOC_SCOPE_START()
         // flush all pending result to spilled files
         size_t num_rows_flushed = 0;
-        RETURN_IF_ERROR(mem_table->flush([&](const auto& chunk) {
+        RETURN_IF_ERROR_EXCEPT_YIELD(mem_table->flush([&](const auto& chunk) {
+            SCOPED_RAW_TIMER(&time_spent_ns);
             num_rows_flushed += chunk->num_rows();
-            RETURN_IF_ERROR(serde->serialize(spill_ctx, chunk, block));
+            RETURN_IF_ERROR(serde->serialize_to_block(spill_ctx, chunk, block));
+            RETURN_IF_NEED_YIELD(yield_ctx.wg, yield, time_spent_ns);
             return Status::OK();
         }));
         TRACE_SPILL_LOG << "spill flush rows:" << num_rows_flushed << ",spiller:" << this;
+        RETURN_IF_YIELD(yield);
         TRY_CATCH_ALLOC_SCOPE_END();
     }
 
@@ -374,6 +396,7 @@ void PartitionedSpillerWriter::shuffle(std::vector<uint32_t>& dst, const SpillHa
     }
 }
 
+// provider maybe yield. this function should be reentrant
 template <class ChunkProvider>
 Status PartitionedSpillerWriter::spill_partition(SerdeContext& ctx, SpilledPartition* partition,
                                                  ChunkProvider&& provider) {
@@ -384,6 +407,7 @@ Status PartitionedSpillerWriter::spill_partition(SerdeContext& ctx, SpilledParti
         opts.query_id = _runtime_state->query_id();
         opts.plan_node_id = options().plan_node_id;
         opts.name = options().name;
+        opts.direct_io = _runtime_state->enable_spill_direct_io();
         ASSIGN_OR_RETURN(auto block, _spiller->block_manager()->acquire_block(opts));
         std::lock_guard<std::mutex> l(_mutex);
         partition->spill_writer->block_group().append(block);
@@ -394,8 +418,8 @@ Status PartitionedSpillerWriter::spill_partition(SerdeContext& ctx, SpilledParti
     DCHECK(block != nullptr);
 
     auto consumer = [&](const auto& chunk) {
-        RETURN_IF_ERROR(serde->serialize(ctx, chunk, block));
         partition->bytes += chunk->memory_usage();
+        RETURN_IF_ERROR(serde->serialize_to_block(ctx, chunk, block));
         return Status::OK();
     };
 
@@ -441,6 +465,26 @@ private:
     ChunkPipelineAccumulator _accumulator;
 };
 
+template <class Consumer>
+struct YieldableConsumerAdaptor {
+    YieldableConsumerAdaptor(workgroup::YieldContext& yield_ctx, int64_t* time_spent_ns_, int* yield_,
+                             const Consumer& consumer_)
+            : wg(yield_ctx.wg), time_spent_ns(time_spent_ns_), yield(yield_), consumer(consumer_) {}
+    const workgroup::WorkGroup* wg;
+    int64_t* time_spent_ns;
+    int* yield;
+    const Consumer& consumer;
+
+    Status operator()(const ChunkPtr& chunk) {
+        {
+            SCOPED_RAW_TIMER(time_spent_ns);
+            RETURN_IF_ERROR(consumer(chunk));
+        }
+        RETURN_IF_NEED_YIELD(wg, yield, *time_spent_ns);
+        return Status::OK();
+    }
+};
+
 struct DoSpillPartition {
 public:
     DoSpillPartition(SerdeContext& spill_ctx_, SpilledPartition* partition_, PartitionedSpillerWriter* writer_)
@@ -460,52 +504,72 @@ private:
     PartitionedSpillerWriter* writer;
 };
 
-Status PartitionedSpillerWriter::_spill_input_partitions(SerdeContext& context,
-                                                         const std::vector<SpilledPartition*>& spilling_partitions) {
+Status PartitionedSpillerWriter::_spill_input_partitions(workgroup::YieldContext& yield_ctx, SerdeContext& context,
+                                                         const std::vector<SpilledPartition*>& spilling_partitions,
+                                                         int64_t* time_spent_ns, int* yield) {
     SCOPED_TIMER(_spiller->metrics().flush_timer);
-    for (auto partition : spilling_partitions) {
-        RETURN_IF_ERROR(spill_partition(context, partition, [&partition, this](auto& consumer) {
+    auto& flush_ctx = std::any_cast<PartitionedFlushContextPtr>(yield_ctx.task_context_data)->spill_stage_ctx;
+    for (; flush_ctx.processing_idx < spilling_partitions.size(); ++flush_ctx.processing_idx) {
+        auto partition = spilling_partitions[flush_ctx.processing_idx];
+        RETURN_IF_ERROR(spill_partition(context, partition, [&](auto& consumer) {
+            YieldableConsumerAdaptor adaptor(yield_ctx, time_spent_ns, yield, consumer);
             auto& mem_table = partition->spill_writer->mem_table();
-            RETURN_IF_ERROR(mem_table->flush(consumer));
+            RETURN_IF_ERROR_EXCEPT_YIELD(mem_table->flush(adaptor));
             COUNTER_SET(_spiller->metrics().partition_writer_peak_memory_usage, mem_consumption());
+            RETURN_IF_YIELD(yield);
             return Status::OK();
         }));
+        RETURN_IF_YIELD(yield);
     }
     return Status::OK();
 }
 
-Status PartitionedSpillerWriter::_split_input_partitions(SerdeContext& context,
-                                                         const std::vector<SpilledPartition*>& splitting_partitions) {
+Status PartitionedSpillerWriter::_split_input_partitions(workgroup::YieldContext& yield_ctx, SerdeContext& context,
+                                                         const std::vector<SpilledPartition*>& splitting_partitions,
+                                                         int64_t* time_spent_ns, int* yield) {
+    // TODO: implements yieldable
     SCOPED_TIMER(_spiller->metrics().split_partition_timer);
-    for (auto partition : splitting_partitions) {
-        auto [left, right] = partition->split();
-        left->spill_writer = std::make_unique<RawSpillerWriter>(_spiller, _runtime_state, _mem_tracker.get());
-        left->in_mem = false;
-        left->spill_writer->prepare(_runtime_state);
-        left->spill_writer->acquire_mem_table();
-        right->in_mem = false;
+    auto& flush_ctx = std::any_cast<PartitionedFlushContextPtr>(yield_ctx.task_context_data)->split_stage_ctx;
+    for (; flush_ctx.spliting_idx < splitting_partitions.size(); flush_ctx.spliting_idx++) {
+        // split stage
+        auto partition = splitting_partitions[flush_ctx.spliting_idx];
+        if (flush_ctx.reader == nullptr) {
+            auto [left, right] = partition->split();
+            left->spill_writer = std::make_unique<RawSpillerWriter>(_spiller, _runtime_state, _mem_tracker.get());
+            left->in_mem = false;
+            left->spill_writer->prepare(_runtime_state);
+            left->spill_writer->acquire_mem_table();
+            right->in_mem = false;
 
-        right->spill_writer = std::make_unique<RawSpillerWriter>(_spiller, _runtime_state, _mem_tracker.get());
-        right->spill_writer->prepare(_runtime_state);
-        right->spill_writer->acquire_mem_table();
+            right->spill_writer = std::make_unique<RawSpillerWriter>(_spiller, _runtime_state, _mem_tracker.get());
+            right->spill_writer->prepare(_runtime_state);
+            right->spill_writer->acquire_mem_table();
 
-        // write
-        std::shared_ptr<SpillInputStream> stream;
-        RETURN_IF_ERROR(partition->spill_writer->acquire_stream(&stream));
+            // write
+            std::shared_ptr<SpillInputStream> stream;
+            RETURN_IF_ERROR(partition->spill_writer->acquire_stream(&stream));
 
-        auto reader = std::make_unique<SpillerReader>(_spiller);
-        reader->set_stream(std::move(stream));
+            auto reader = std::make_unique<SpillerReader>(_spiller);
+            reader->set_stream(std::move(stream));
 
-        // split process may be generate many small chunks. we should fix it
-        auto st = _split_partition(context, reader.get(), partition, left.get(), right.get());
-        DCHECK(st.ok() || st.is_end_of_file());
-        DCHECK_EQ(left->num_rows + right->num_rows, partition->num_rows);
+            flush_ctx.reader = std::move(reader);
+            flush_ctx.left = std::move(left);
+            flush_ctx.right = std::move(right);
+        }
 
-        left->spill_writer->acquire_mem_table();
-        right->spill_writer->acquire_mem_table();
+        auto st = _split_partition(yield_ctx, context, flush_ctx.reader.get(), partition, flush_ctx.left.get(),
+                                   flush_ctx.right.get(), time_spent_ns, yield);
+        RETURN_IF_YIELD(yield);
+        RETURN_IF(!st.is_ok_or_eof(), st);
+        DCHECK_EQ(flush_ctx.left->num_rows + flush_ctx.right->num_rows, partition->num_rows);
 
-        _add_partition(std::move(right));
-        _add_partition(std::move(left));
+        flush_ctx.left->spill_writer->acquire_mem_table();
+        flush_ctx.right->spill_writer->acquire_mem_table();
+
+        _add_partition(std::move(flush_ctx.right));
+        _add_partition(std::move(flush_ctx.left));
+
+        flush_ctx.reset_read_context();
     }
 
     for (auto partition : splitting_partitions) {
@@ -514,11 +578,11 @@ Status PartitionedSpillerWriter::_split_input_partitions(SerdeContext& context,
     return Status::OK();
 }
 
-Status PartitionedSpillerWriter::_split_partition(SerdeContext& spill_ctx, SpillerReader* reader,
-                                                  SpilledPartition* partition, SpilledPartition* left_partition,
-                                                  SpilledPartition* right_partition) {
+Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield_ctx, SerdeContext& spill_ctx,
+                                                  SpillerReader* reader, SpilledPartition* partition,
+                                                  SpilledPartition* left_partition, SpilledPartition* right_partition,
+                                                  int64_t* time_spent_ns, int* yield) {
     size_t current_level = partition->level;
-    size_t restore_rows = 0;
 
     DoSpillPartition spill_left_partition(spill_ctx, left_partition, this);
     DoSpillPartition spill_right_partition(spill_ctx, right_partition, this);
@@ -533,79 +597,96 @@ Status PartitionedSpillerWriter::_split_partition(SerdeContext& spill_ctx, Spill
 
     TRY_CATCH_ALLOC_SCOPE_START()
     while (true) {
-        RETURN_IF_ERROR(reader->trigger_restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
-        if (!reader->has_output_data()) {
-            DCHECK_EQ(restore_rows, partition->num_rows);
-            break;
-        }
-        ASSIGN_OR_RETURN(auto chunk, reader->restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
-        restore_rows += chunk->num_rows();
-        if (chunk->is_empty()) {
-            continue;
-        }
-        auto hash_column = down_cast<SpillHashColumn*>(chunk->columns().back().get());
-        const auto& hash_data = hash_column->get_data();
-        // hash data
-        std::vector<uint32_t> shuffle_result;
-        shuffle_result.resize(hash_data.size());
-        size_t left_channel_size = 0;
-        for (size_t i = 0; i < hash_data.size(); ++i) {
-            shuffle_result[i] = hash_data[i] >> current_level & 0x01;
-            left_channel_size += !shuffle_result[i];
-        }
-        size_t left_cursor = 0;
-        size_t right_cursor = left_channel_size;
-        std::vector<uint32_t> selection(hash_data.size());
-        for (size_t i = 0; i < hash_data.size(); ++i) {
-            if (shuffle_result[i] == 0) {
-                selection[left_cursor++] = i;
-            } else {
-                selection[right_cursor++] = i;
+        {
+            SCOPED_RAW_TIMER(time_spent_ns);
+            RETURN_IF_ERROR(reader->trigger_restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
+            if (!reader->has_output_data()) {
+                break;
             }
-        }
+            ASSIGN_OR_RETURN(auto chunk, reader->restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
+            if (chunk->is_empty()) {
+                continue;
+            }
+            auto hash_column = down_cast<SpillHashColumn*>(chunk->columns().back().get());
+            const auto& hash_data = hash_column->get_data();
+            // hash data
+            std::vector<uint32_t> shuffle_result;
+            shuffle_result.resize(hash_data.size());
+            size_t left_channel_size = 0;
+            for (size_t i = 0; i < hash_data.size(); ++i) {
+                shuffle_result[i] = hash_data[i] >> current_level & 0x01;
+                left_channel_size += !shuffle_result[i];
+            }
+            size_t left_cursor = 0;
+            size_t right_cursor = left_channel_size;
+            std::vector<uint32_t> selection(hash_data.size());
+            for (size_t i = 0; i < hash_data.size(); ++i) {
+                if (shuffle_result[i] == 0) {
+                    selection[left_cursor++] = i;
+                } else {
+                    selection[right_cursor++] = i;
+                }
+            }
 
 #ifndef NDEBUG
-        for (size_t i = 0; i < left_cursor; i++) {
-            DCHECK_EQ(hash_data[selection[i]] & left_partition->mask(),
-                      left_partition->partition_id & left_partition->mask());
-        }
+            for (size_t i = 0; i < left_cursor; i++) {
+                DCHECK_EQ(hash_data[selection[i]] & left_partition->mask(),
+                          left_partition->partition_id & left_partition->mask());
+            }
 
-        for (size_t i = left_cursor; i < right_cursor; i++) {
-            DCHECK_EQ(hash_data[selection[i]] & right_partition->mask(),
-                      right_partition->partition_id & right_partition->mask());
-        }
+            for (size_t i = left_cursor; i < right_cursor; i++) {
+                DCHECK_EQ(hash_data[selection[i]] & right_partition->mask(),
+                          right_partition->partition_id & right_partition->mask());
+            }
 #endif
 
-        if (left_channel_size > 0) {
-            ChunkPtr left_chunk = chunk->clone_empty();
-            left_chunk->append_selective(*chunk, selection.data(), 0, left_channel_size);
-            RETURN_IF_ERROR(left_accumulate_writer.write(left_chunk));
+            if (left_channel_size > 0) {
+                ChunkPtr left_chunk = chunk->clone_empty();
+                left_chunk->append_selective(*chunk, selection.data(), 0, left_channel_size);
+                RETURN_IF_ERROR(left_accumulate_writer.write(left_chunk));
+            }
+            if (hash_data.size() != left_channel_size) {
+                ChunkPtr right_chunk = chunk->clone_empty();
+                right_chunk->append_selective(*chunk, selection.data(), left_channel_size,
+                                              hash_data.size() - left_channel_size);
+                RETURN_IF_ERROR(right_accumulate_writer.write(right_chunk));
+            }
         }
-        if (hash_data.size() != left_channel_size) {
-            ChunkPtr right_chunk = chunk->clone_empty();
-            right_chunk->append_selective(*chunk, selection.data(), left_channel_size,
-                                          hash_data.size() - left_channel_size);
-            RETURN_IF_ERROR(right_accumulate_writer.write(right_chunk));
-        }
+        BREAK_IF_YIELD(yield_ctx.wg, yield, *time_spent_ns);
     }
     TRY_CATCH_ALLOC_SCOPE_END()
-    DCHECK_EQ(restore_rows, partition->num_rows);
+    // TODO: add restore rows check
     return Status::OK();
 }
 
-Status PartitionedSpillerWriter::_flush_task(const std::vector<SpilledPartition*>& splitting_partitions,
-                                             const std::vector<SpilledPartition*>& spilling_partitions) {
+Status PartitionedSpillerWriter::yieldable_flush_task(workgroup::YieldContext& ctx,
+                                                      const std::vector<SpilledPartition*>& splitting_partitions,
+                                                      const std::vector<SpilledPartition*>& spilling_partitions,
+                                                      int* yield) {
+    ctx.total_yield_point_cnt = 2;
+    // init task context
+    if (!ctx.task_context_data.has_value()) {
+        ctx.task_context_data = std::make_shared<PartitionedFlushContext>();
+    }
+
     // partition memory usage
     // now we partitioned sorted spill
     SerdeContext spill_ctx;
-
-    RETURN_IF_ERROR(_spill_input_partitions(spill_ctx, spilling_partitions));
-    RETURN_IF_ERROR(_split_input_partitions(spill_ctx, splitting_partitions));
-    if (_need_final_flush) {
-        std::vector<SpilledPartition*> final_splitting_partitions, final_spilling_partitions;
-        RETURN_IF_ERROR(_choose_partitions_to_flush(true, final_splitting_partitions, final_splitting_partitions));
-        RETURN_IF_ERROR(_spill_input_partitions(spill_ctx, final_spilling_partitions));
-        RETURN_IF_ERROR(_split_input_partitions(spill_ctx, final_splitting_partitions));
+    int64_t time_spent_ns = 0;
+    switch (ctx.yield_point) {
+    case 0:
+        RETURN_IF_ERROR(_spill_input_partitions(ctx, spill_ctx, spilling_partitions, &time_spent_ns, yield));
+        RETURN_IF_YIELD(yield);
+        ctx.yield_point++;
+        [[fallthrough]];
+    case 1:
+        RETURN_IF_ERROR(_split_input_partitions(ctx, spill_ctx, splitting_partitions, &time_spent_ns, yield));
+        RETURN_IF_YIELD(yield);
+        ctx.yield_point++;
+        [[fallthrough]];
+    default: {
+        DCHECK_EQ(ctx.yield_point, 2);
+    }
     }
 
     return Status::OK();

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -79,7 +79,7 @@ Status RawSpillerWriter::yieldable_flush_task(workgroup::YieldContext& yield_ctx
             spill::AcquireBlockOptions opts{.query_id = state->query_id(),
                                             .plan_node_id = options().plan_node_id,
                                             .name = options().name,
-                                            .direct_io = state->enable_spill_direct_io()};
+                                            .direct_io = state->spill_enable_direct_io()};
             ASSIGN_OR_RETURN(auto block, _spiller->block_manager()->acquire_block(opts));
             COUNTER_UPDATE(_spiller->metrics().block_count, 1);
             yield_ctx.task_context_data = FlushContext{block};
@@ -407,7 +407,7 @@ Status PartitionedSpillerWriter::spill_partition(SerdeContext& ctx, SpilledParti
         opts.query_id = _runtime_state->query_id();
         opts.plan_node_id = options().plan_node_id;
         opts.name = options().name;
-        opts.direct_io = _runtime_state->enable_spill_direct_io();
+        opts.direct_io = _runtime_state->spill_enable_direct_io();
         ASSIGN_OR_RETURN(auto block, _spiller->block_manager()->acquire_block(opts));
         std::lock_guard<std::mutex> l(_mutex);
         partition->spill_writer->block_group().append(block);

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -26,6 +26,7 @@
 #include "exec/spill/options.h"
 #include "exec/spill/partition.h"
 #include "exec/spill/serde.h"
+#include "exec/workgroup/scan_task_queue.h"
 #include "fmt/format.h"
 #include "fs/fs.h"
 #include "runtime/runtime_state.h"
@@ -153,8 +154,6 @@ public:
 
     void prepare(RuntimeState* state) override;
 
-    Status flush_task(RuntimeState* state, const MemTablePtr& mem_table);
-
     void acquire_mem_table() {
         if (_mem_table == nullptr) {
             _mem_table = _acquire_mem_table_from_pool();
@@ -174,6 +173,20 @@ public:
     void cancel() override {}
 
     void get_spill_partitions(std::vector<const SpillPartitionInfo*>* partitions) override {}
+
+    Status yieldable_flush_task(workgroup::YieldContext& ctx, RuntimeState* state, const MemTablePtr& mem_table,
+                                int* yield);
+
+public:
+    struct FlushContext {
+        BlockPtr block;
+    };
+
+private:
+    template <class Provider>
+    StatusOr<BlockPtr> get_block_from_ctx(Provider&& provider) {
+        return provider();
+    }
 
 private:
     BlockGroup _block_group;
@@ -283,14 +296,53 @@ public:
 
     int64_t mem_consumption() const { return _mem_tracker->consumption(); }
 
+public:
+    struct PartitionedFlushContext {
+        // used in spill stage
+        struct SpillStageContext {
+            size_t processing_idx{};
+        };
+        // used in split stage
+        struct SplitStageContext {
+            SplitStageContext() = default;
+            SplitStageContext(SplitStageContext&&) = default;
+            SplitStageContext& operator=(SplitStageContext&&) = default;
+            size_t spliting_idx{};
+            SpilledPartitionPtr left;
+            SpilledPartitionPtr right;
+            std::unique_ptr<SpillerReader> reader;
+            void reset_read_context() {
+                left.reset();
+                right.reset();
+                reader.reset();
+            }
+        };
+
+        PartitionedFlushContext() = default;
+        PartitionedFlushContext(PartitionedFlushContext&&) = default;
+        PartitionedFlushContext& operator=(PartitionedFlushContext&&) = default;
+
+        SpillStageContext spill_stage_ctx;
+        SplitStageContext split_stage_ctx;
+    };
+    using PartitionedFlushContextPtr = std::shared_ptr<PartitionedFlushContext>;
+
+    Status yieldable_flush_task(workgroup::YieldContext& ctx,
+                                const std::vector<SpilledPartition*>& splitting_partitions,
+                                const std::vector<SpilledPartition*>& spilling_partitions, int* yield);
+
 private:
     void _init_with_partition_nums(RuntimeState* state, int num_partitions);
     // prepare and acquire mem_table for each partition in _id_to_partitions
     void _prepare_partitions(RuntimeState* state);
 
-    Status _spill_input_partitions(SerdeContext& context, const std::vector<SpilledPartition*>& spilling_partitions);
+    Status _spill_input_partitions(workgroup::YieldContext& ctx, SerdeContext& context,
+                                   const std::vector<SpilledPartition*>& spilling_partitions, int64_t* time_spent_ns,
+                                   int* yield);
 
-    Status _split_input_partitions(SerdeContext& context, const std::vector<SpilledPartition*>& splitting_partitions);
+    Status _split_input_partitions(workgroup::YieldContext& ctx, SerdeContext& context,
+                                   const std::vector<SpilledPartition*>& splitting_partitions, int64_t* time_spent_ns,
+                                   int* yield);
 
     // split partition by hash
     // hash-based partitioning can have significant degradation in the case of heavily skewed data.
@@ -298,17 +350,15 @@ private:
     // 1. We can actually split partitions based on blocks (they all belong to the same partition, but
     // can be executed in splitting out more parallel tasks). Process all blocks that hit this partition while processing the task
     // 2. If our input is ordered, we can use some sorting-based algorithm to split the partition. This way the probe side can do full streaming of the data
-    Status _split_partition(SerdeContext& context, SpillerReader* reader, SpilledPartition* partition,
-                            SpilledPartition* left_partition, SpilledPartition* right_partition);
+    Status _split_partition(workgroup::YieldContext& ctx, SerdeContext& context, SpillerReader* reader,
+                            SpilledPartition* partition, SpilledPartition* left_partition,
+                            SpilledPartition* right_partition, int64_t* time_spent_ns, int* yield);
 
     void _add_partition(SpilledPartitionPtr&& partition);
     void _remove_partition(const SpilledPartition* partition);
 
     Status _choose_partitions_to_flush(bool is_final_flush, std::vector<SpilledPartition*>& partitions_need_spilt,
                                        std::vector<SpilledPartition*>& partitions_need_flush);
-
-    Status _flush_task(const std::vector<SpilledPartition*>& splitting_partitions,
-                       const std::vector<SpilledPartition*>& spilling_partitions);
 
     size_t _partition_rows() {
         size_t total_rows = 0;

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -326,6 +326,5 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
 
     return Status::OK();
 }
-// test_profile
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -148,7 +148,7 @@ Status RawSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, Mem
     _running_flush_tasks++;
     // TODO: handle spill queue
     auto task = [this, state, guard = guard, mem_table = std::move(captured_mem_table),
-                 trace = TraceInfo(state)](auto& ctx) {
+                 trace = TraceInfo(state)](auto& yield_ctx) {
         SCOPED_SET_TRACE_INFO({}, trace.query_id, trace.fragment_id);
         RETURN_IF(!guard.scoped_begin(), Status::Cancelled("cancelled"));
         DEFER_GUARD_END(guard);
@@ -156,18 +156,25 @@ Status RawSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, Mem
         DCHECK_GT(_running_flush_tasks, 0);
         DCHECK(has_pending_data());
         //
-        auto defer = DeferOp([&]() {
+        auto defer = CancelableDefer([&]() {
             {
                 std::lock_guard _(_mutex);
                 _mem_table_pool.emplace(std::move(mem_table));
             }
-
             _spiller->update_spilled_task_status(_decrease_running_flush_tasks());
+            yield_ctx.set_finished();
         });
+
         if (_spiller->is_cancel() || !_spiller->task_status().ok()) {
             return Status::OK();
         }
-        _spiller->update_spilled_task_status(flush_task(state, mem_table));
+
+        int yield = false;
+        _spiller->update_spilled_task_status(yieldable_flush_task(yield_ctx, state, mem_table, &yield));
+        if (yield) {
+            defer.cancel();
+        }
+
         return Status::OK();
     };
     // submit io task
@@ -290,19 +297,26 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
     _running_flush_tasks++;
 
     auto task = [this, guard = guard, splitting_partitions = std::move(splitting_partitions),
-                 spilling_partitions = std::move(spilling_partitions), trace = TraceInfo(state)](auto& ctx) {
+                 spilling_partitions = std::move(spilling_partitions), trace = TraceInfo(state)](auto& yield_ctx) {
         SCOPED_SET_TRACE_INFO({}, trace.query_id, trace.fragment_id);
         RETURN_IF(!guard.scoped_begin(), Status::Cancelled("cancelled"));
         DEFER_GUARD_END(guard);
-        RACE_DETECT(detect_flush, var1);
         // concurrency test
-        auto defer = DeferOp([&]() { _spiller->update_spilled_task_status(_decrease_running_flush_tasks()); });
+        RACE_DETECT(detect_flush, var1);
+        auto defer = CancelableDefer([&]() {
+            _spiller->update_spilled_task_status(_decrease_running_flush_tasks());
+            yield_ctx.set_finished();
+        });
 
         if (_spiller->is_cancel() || !_spiller->task_status().ok()) {
             return Status::OK();
         }
-
-        _spiller->update_spilled_task_status(_flush_task(splitting_partitions, spilling_partitions));
+        int yield = false;
+        _spiller->update_spilled_task_status(
+                yieldable_flush_task(yield_ctx, splitting_partitions, spilling_partitions, &yield));
+        if (yield) {
+            defer.cancel();
+        }
         return Status::OK();
     };
 
@@ -312,4 +326,6 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
 
     return Status::OK();
 }
+// test_profile
+
 } // namespace starrocks::spill

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -35,6 +35,8 @@ struct ScanTaskGroup {
     int sub_queue_level = 0;
 };
 
+#define TO_NEXT_STAGE(yield_point) yield_point++;
+
 struct YieldContext {
     YieldContext() = default;
     YieldContext(size_t total_yield_point_cnt) : total_yield_point_cnt(total_yield_point_cnt) {}

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <any>
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
@@ -24,6 +25,7 @@
 #include "common/statusor.h"
 #include "exec/workgroup/work_group_fwd.h"
 #include "util/blocking_priority_queue.hpp"
+#include "util/race_detect.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks::workgroup {
@@ -44,8 +46,12 @@ struct YieldContext {
     YieldContext& operator=(YieldContext&&) = default;
 
     bool is_finished() const { return yield_point >= total_yield_point_cnt; }
-    void set_finished() { yield_point = total_yield_point_cnt = 0; }
+    void set_finished() {
+        yield_point = total_yield_point_cnt = 0;
+        task_context_data.reset();
+    }
 
+    std::any task_context_data;
     size_t yield_point{};
     size_t total_yield_point_cnt{};
     const workgroup::WorkGroup* wg = nullptr;

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -286,6 +286,9 @@ struct WritableFileOptions {
     bool sync_on_close = true;
     // For remote filesystem, skip filling local filesystem cache on write requests
     bool skip_fill_local_cache = false;
+
+    bool direct_write = false;
+
     // See OpenMode for details.
     FileSystem::OpenMode mode = FileSystem::MUST_CREATE;
 };

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -346,7 +346,7 @@ public:
     int64_t spill_operator_min_bytes() const { return _query_options.spill_operator_min_bytes; }
     int64_t spill_operator_max_bytes() const { return _query_options.spill_operator_max_bytes; }
     int64_t spill_revocable_max_bytes() const { return _query_options.spill_revocable_max_bytes; }
-    bool enable_spill_direct_io() const {
+    bool spill_enable_direct_io() const {
         return _query_options.__isset.spill_enable_direct_io && _query_options.spill_enable_direct_io;
     }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -346,6 +346,9 @@ public:
     int64_t spill_operator_min_bytes() const { return _query_options.spill_operator_min_bytes; }
     int64_t spill_operator_max_bytes() const { return _query_options.spill_operator_max_bytes; }
     int64_t spill_revocable_max_bytes() const { return _query_options.spill_revocable_max_bytes; }
+    bool enable_spill_direct_io() const {
+        return _query_options.__isset.spill_enable_direct_io && _query_options.spill_enable_direct_io;
+    }
 
     int32_t spill_encode_level() const { return _query_options.spill_encode_level; }
 

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -544,7 +544,7 @@ TEST_F(SpillTest, partition_process) {
             ASSERT_OK(spiller->_spilled_task_status);
             holder.push_back(chunk);
         }
-        ASSERT_OK(caller.flush(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
+        ASSERT_OK(spiller->flush(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
     }
 }
 

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -507,6 +507,7 @@ TEST_F(SpillTest, partition_process) {
     auto ctx_st = no_partition_context(&pool, &dummy_rt_st, {}, tuple_slots);
     ASSERT_OK(ctx_st.status());
     auto ctx = ctx_st.value();
+    (void)ctx;
 
     std::vector<ExprContext*> tuple;
     ASSERT_OK(Expr::create_expr_trees(&pool, tuple_slots, &tuple, &dummy_rt_st));

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -15,9 +15,11 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
 #include <iterator>
 #include <memory>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -37,6 +39,8 @@
 #include "exec/sorting/sorting.h"
 #include "exec/spill/executor.h"
 #include "exec/spill/log_block_manager.h"
+#include "exec/spill/mem_table.h"
+#include "exec/spill/spill_components.h"
 #include "exec/spill/spiller.h"
 #include "exec/spill/spiller.hpp"
 #include "exec/spill/spiller_factory.h"
@@ -46,6 +50,7 @@
 #include "fs/fs.h"
 #include "gen_cpp/Exprs_types.h"
 #include "gen_cpp/Types_types.h"
+#include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
 #include "testutil/assert.h"
 #include "types/logical_type.h"
@@ -269,6 +274,23 @@ struct SpillerCaller {
     spill::Spiller* _spiller;
 };
 
+bool chunk_equals(const ChunkPtr& l, const ChunkPtr& r) {
+    if (l->columns() != r->columns() || l->num_columns() != r->num_columns() ||
+        l->get_slot_id_to_index_map() != r->get_slot_id_to_index_map()) {
+        return false;
+    }
+    size_t num_rows = l->num_rows();
+    auto& lcolumns = l->columns();
+    auto& rcolumns = r->columns();
+    for (size_t i = 0; i < lcolumns.size(); ++i) {
+        if (!lcolumns[i]->equals(num_rows, *rcolumns[i], num_rows)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 TEST_F(SpillTest, unsorted_process) {
     ObjectPool pool;
 
@@ -363,6 +385,29 @@ TEST_F(SpillTest, unsorted_process) {
             }
         }
     }
+
+    {
+        // dummy_rt_st
+        // test schedule_mem_table_flush
+        size_t max_buffer_size = 1024 * 1024 * 1024;
+        std::shared_ptr<spill::SpillableMemTable> mem_table =
+                std::make_shared<spill::UnorderedMemTable>(&dummy_rt_st, max_buffer_size, nullptr, spiller.get());
+        std::vector<ChunkPtr> input;
+        for (size_t i = 0; i < 500; ++i) {
+            auto chunk = chunk_builder.gen(tuple, nullables);
+            input.emplace_back(chunk->clone_unique());
+            ASSERT_OK(mem_table->append(std::move(chunk)));
+        }
+        //
+        size_t next_index = 0;
+        while (next_index < 500) {
+            auto st = mem_table->flush([&](const auto& chunk) {
+                chunk_equals(input[next_index++], chunk);
+                return Status::Yield();
+            });
+            ASSERT_TRUE(st.is_yield() || st.ok());
+        }
+    }
 }
 
 TEST_F(SpillTest, order_by_process) {
@@ -443,6 +488,63 @@ TEST_F(SpillTest, order_by_process) {
             ASSERT_TRUE(chunk_st.status().is_end_of_file());
         }
         ASSERT_EQ(contain_rows, restored_rows);
+    }
+}
+
+TEST_F(SpillTest, partition_process) {
+    ObjectPool pool;
+
+    // order by id_int
+    TExprBuilder order_by_slots_builder;
+    order_by_slots_builder << TYPE_INT;
+    auto order_by_slots = order_by_slots_builder.get_res();
+    // full data id_int, id_smallint
+    std::vector<bool> nullables = {false, false};
+    TExprBuilder tuple_slots_builder;
+    tuple_slots_builder << TYPE_INT << TYPE_SMALLINT;
+    auto tuple_slots = tuple_slots_builder.get_res();
+
+    auto ctx_st = no_partition_context(&pool, &dummy_rt_st, order_by_slots, tuple_slots);
+    ASSERT_OK(ctx_st.status());
+    auto ctx = ctx_st.value();
+
+    auto& tuple = ctx->sort_exprs.sort_tuple_slot_expr_ctxs();
+
+    // create chunk
+    RandomChunkBuilder chunk_builder;
+
+    // create spilled factory
+    // auto factory_options = SpilledFactoryOptions(ctx->partition_nums, ctx->parition_exprs, ctx->sort_exprs, ctx->sort_descs, false);
+    auto factory = spill::make_spilled_factory();
+
+    // create spiller
+    SpilledOptions spill_options(4);
+    // 4 buffer chunk
+    spill_options.mem_table_pool_size = 1;
+    // file size: 1M
+    spill_options.spill_mem_table_bytes_size = 1 * 1024 * 1024;
+    // spill format type
+    spill_options.spill_type = spill::SpillFormaterType::SPILL_BY_COLUMN;
+
+    spill_options.block_manager = dummy_block_mgr.get();
+
+    auto chunk_empty = chunk_builder.gen(tuple, nullables);
+
+    auto spiller = factory->create(spill_options);
+    spiller->set_metrics(metrics);
+    SpillerCaller<spill::PartitionedSpillerWriter*, spill::SpillerReader*> caller(spiller.get());
+    ASSERT_OK(spiller->prepare(&dummy_rt_st));
+
+    size_t test_loop = 1024;
+    std::vector<ChunkPtr> holder;
+    {
+        for (size_t i = 0; i < test_loop; ++i) {
+            auto chunk = chunk_builder.gen(tuple, nullables);
+            ASSERT_OK(caller.spill(&dummy_rt_st, chunk, SyncExecutor{}, EmptyMemGuard{}));
+            ASSERT_OK(spiller->_spilled_task_status);
+            holder.push_back(chunk);
+        }
+        ASSERT_OK(caller.flush(&dummy_rt_st, SyncExecutor{}, EmptyMemGuard{}));
     }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -507,6 +507,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String SPILL_OPERATOR_MIN_BYTES = "spill_operator_min_bytes";
     public static final String SPILL_OPERATOR_MAX_BYTES = "spill_operator_max_bytes";
     public static final String SPILL_REVOCABLE_MAX_BYTES = "spill_revocable_max_bytes";
+    public static final String SPILL_ENABLE_DIRECT_IO = "spill_enable_direct_io";
     public static final String SPILL_ENCODE_LEVEL = "spill_encode_level";
 
     // full_sort_max_buffered_{rows,bytes} are thresholds that limits input size of partial_sort
@@ -928,6 +929,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     // see more details in the comment above transmissionEncodeLevel
     @VarAttr(name = SPILL_ENCODE_LEVEL)
     private int spillEncodeLevel = 7;
+    
+    @VarAttr(name = SPILL_ENABLE_DIRECT_IO)
+    private boolean spillEnableDirectIO = false;
 
     @VarAttr(name = ENABLE_AGG_SPILL_PREAGGREGATION, flag = VariableMgr.INVISIBLE)
     public boolean enableAggSpillPreaggregation = true;
@@ -2981,6 +2985,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setSpill_encode_level(spillEncodeLevel);
             tResult.setSpillable_operator_mask(spillableOperatorMask);
             tResult.setEnable_agg_spill_preaggregation(enableAggSpillPreaggregation);
+            tResult.setSpill_enable_direct_io(spillEnableDirectIO);
         }
 
         // Compression Type

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -203,6 +203,7 @@ struct TQueryOptions {
   77: optional i64 spill_operator_max_bytes;
   78: optional i32 spill_encode_level;
   79: optional i64 spill_revocable_max_bytes;
+  80: optional bool spill_enable_direct_io;
 
   85: optional TSpillMode spill_mode;
   

--- a/gensrc/thrift/StatusCode.thrift
+++ b/gensrc/thrift/StatusCode.thrift
@@ -104,6 +104,7 @@ enum TStatusCode {
 
     SR_EAGAIN = 54,
 
-    REMOTE_FILE_NOT_FOUND = 55 // for hive external table
+    REMOTE_FILE_NOT_FOUND = 55, // for hive external table
+    YIELD = 56 
 }
 


### PR DESCRIPTION
Why I'm doing:
similar with https://github.com/StarRocks/starrocks/pull/35751
We notice that the operating system may eviction page cache when memory usage is high. and at the same time spilling can cause page cache pollution. this time can lead to a high long tail of point queries.

What I'm doing:
1. Support for spill direct io. Controlled by session variable spill_enable_direct_io
2. Support yield for spill phase

TEST:
point-queries run with jmeter 8 threads
```
select  * from lineitem where lo_orderkey = ${}
```
spill query run once
```
set enable_spill=true;
set enable_per_bucket_optimize=false;
select
    count(l_shipdate),
    count(l_orderkey),
    count(l_linenumber),
    count(l_partkey),
    count(l_suppkey),
    count(l_quantity),
    count(l_extendedprice),
    count(l_discount),
    count(l_tax),
    count(l_returnflag),
    count(l_linestatus),
    count(l_commitdate),
    count(l_receiptdate),
    count(l_shipinstruct),
    count(l_shipmode),
    count(l_comment)
from
    (
        select
            distinct 
            l_shipdate,
            l_orderkey,
            l_linenumber,
            l_partkey,
            l_suppkey,
            l_quantity,
            l_extendedprice,
            l_discount,
            l_tax,
            l_returnflag,
            l_linestatus,
            l_commitdate,
            l_receiptdate,
            l_shipinstruct,
            l_shipmode,
            l_comment
        from
            lineitem
    ) tb;
```

baseline: jmeter result:
![image](https://github.com/StarRocks/starrocks/assets/34912776/70b4fc67-3433-47a9-a9f7-9cd3f388cb7c)
patched: jmeter result:
![image](https://github.com/StarRocks/starrocks/assets/34912776/82f70c63-4e82-49b9-8d9d-b0f3bb003077)
 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
