### PR TITLE
[Feature] support refresh paimon mv by partition.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -20,26 +20,25 @@ import com.starrocks.planner.PaimonScanNode;
 import com.starrocks.thrift.TPaimonTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.apache.paimon.table.AbstractFileStoreTable;
 import org.apache.paimon.types.DataField;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
 
 
 public class PaimonTable extends Table {
-    private static final Logger LOG = LogManager.getLogger(PaimonTable.class);
     private final String catalogName;
     private final String databaseName;
     private final String tableName;
     private final AbstractFileStoreTable paimonNativeTable;
     private final List<String> partColumnNames;
     private final List<String> paimonFieldNames;
+    private long latestSnapshotId;
 
     public PaimonTable(String catalogName, String dbName, String tblName, List<Column> schema,
                        org.apache.paimon.table.Table paimonNativeTable, long createTime) {
@@ -120,5 +119,33 @@ public class PaimonTable extends Table {
                 fullSchema.size(), 0, tableName, databaseName);
         tTableDescriptor.setPaimonTable(tPaimonTable);
         return tTableDescriptor;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PaimonTable that = (PaimonTable) o;
+        return catalogName.equals(that.catalogName) &&
+                databaseName.equals(that.databaseName) &&
+                tableName.equals(that.tableName) &&
+                createTime == that.createTime;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(catalogName, databaseName, tableName, createTime);
+    }
+
+    public long getLatestSnapshotId() {
+        return latestSnapshotId;
+    }
+
+    public void setLatestSnapshotId(long latestSnapshotId) {
+        this.latestSnapshotId = latestSnapshotId;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -283,4 +283,9 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     public CloudConfiguration getCloudConfiguration() {
         return normal.getCloudConfiguration();
     }
+
+    @Override
+    public List<PartitionInfo> getChangedPartitionInfo(Table table, long mvSnapShotID) {
+        return normal.getChangedPartitionInfo(table, mvSnapShotID);
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -283,5 +283,9 @@ public interface ConnectorMetadata {
     default CloudConfiguration getCloudConfiguration() {
         throw new StarRocksConnectorException("This connector doesn't support getting cloud configuration");
     }
+
+    default List<PartitionInfo> getChangedPartitionInfo(Table table, long mvSnapShotID) {
+        return Lists.newArrayList();
+    }
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -449,8 +449,54 @@ public abstract class ConnectorPartitionTraits {
         @Override
         public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
                                                     MaterializedView.AsyncRefreshContext context) {
-            // TODO: implement
-            return null;
+            PaimonTable baseTable = (PaimonTable) table;
+            Set<String> result = Sets.newHashSet();
+            for (BaseTableInfo baseTableInfo : baseTables) {
+                if (!baseTableInfo.getTableIdentifier().equalsIgnoreCase(baseTable.getTableIdentifier())) {
+                    continue;
+                }
+                Optional<ConnectorMetadata> connectorMetadata = GlobalStateMgr.getCurrentState().getMetadataMgr().
+                        getOptionalMetadata(baseTable.getCatalogName());
+                if (!connectorMetadata.isPresent()) {
+                    LOG.error("Get paimon connectorMetadata failed : {}", baseTable.getCatalogName());
+                    throw new RuntimeException("Get paimon connectorMetadata failed :" + baseTable.getCatalogName());
+                }
+                Map<String, MaterializedView.BasePartitionInfo> partitionVersionMap =
+                        context.getBaseTableRefreshInfo(baseTableInfo);
+                Set<String> partitions = Sets.newHashSet(getPartitionNames());
+                long mvLatestSnapShotID = Long.MIN_VALUE;
+                for (Map.Entry<String, MaterializedView.BasePartitionInfo> entry : partitionVersionMap.entrySet()) {
+                    if (entry.getValue() != null) {
+                        mvLatestSnapShotID = Math.max(mvLatestSnapShotID, entry.getValue().getVersion());
+                    }
+                    // If there are partitions deleted, return all latest partitions.
+                    if (!partitions.contains(entry.getKey())) {
+                        result.addAll(partitions);
+                        LOG.info("Get paimon updated partition names {}, partition {} has been deleted, return all.",
+                                baseTables, entry.getKey());
+                        return result;
+                    }
+                }
+                for (String part : partitions) {
+                    if (!partitionVersionMap.containsKey(part)) {
+                        result.add(part);
+                    }
+                }
+                ConnectorMetadata metadata = connectorMetadata.get();
+                List<PartitionInfo> changedPartitionInfo = metadata.getChangedPartitionInfo(baseTable,
+                        mvLatestSnapShotID);
+                for (PartitionInfo partitionInfo : changedPartitionInfo) {
+                    com.starrocks.connector.paimon.Partition info =
+                            (com.starrocks.connector.paimon.Partition) partitionInfo;
+                    // Change log record partition which has been deleted.
+                    if (!partitions.contains(info.getPartitionName())) {
+                        continue;
+                    }
+                    result.add(info.getPartitionName());
+                }
+            }
+            LOG.debug("Get updated partition name of paimon table result: {}", result);
+            return result;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/PaimonMetadata.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Type;
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.ConnectorMetadata;
 import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileDesc;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
@@ -49,17 +50,25 @@ import org.apache.paimon.reader.RecordReader;
 import org.apache.paimon.reader.RecordReaderIterator;
 import org.apache.paimon.table.AbstractFileStoreTable;
 import org.apache.paimon.table.source.DataSplit;
+import org.apache.paimon.table.source.OutOfRangeException;
 import org.apache.paimon.table.source.ReadBuilder;
 import org.apache.paimon.table.source.Split;
+import org.apache.paimon.table.source.StreamTableScan;
+import org.apache.paimon.table.source.TableRead;
+import org.apache.paimon.table.source.TableScan;
+import org.apache.paimon.table.system.FileMonitorTable;
 import org.apache.paimon.table.system.SchemasTable;
 import org.apache.paimon.types.DataField;
 import org.apache.paimon.types.DataType;
 import org.apache.paimon.types.RowType;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
@@ -291,5 +300,105 @@ public class PaimonMetadata implements ConnectorMetadata {
             }
         }
         return 0;
+    }
+
+    public List<PartitionInfo> getChangedPartitionInfo(Table table, long mvSnapShotID) {
+        LOG.debug("Get changed partitionInfo start, table:{}, mvLatestSnapShotID {}", table, mvSnapShotID);
+        List<PartitionInfo> result = new ArrayList<>();
+        PaimonTable paimonTable = (PaimonTable) table;
+        Map<String, Long> partitionToSnapshotId = fetchChangedPartitionWithVersion(paimonTable, mvSnapShotID);
+        for (Map.Entry<String, Long> entry : partitionToSnapshotId.entrySet()) {
+            Partition partitionInfo = new Partition(entry.getKey(), entry.getValue());
+            result.add(partitionInfo);
+            if (entry.getValue() != null) {
+                mvSnapShotID = Math.max(mvSnapShotID, entry.getValue());
+            }
+        }
+        LOG.debug("Get changed partitionInfo:{}", result);
+        return result;
+    }
+
+    private Map<String, Long> fetchChangedPartitionWithVersion(PaimonTable paimonTable, long mvSnapshotId) {
+        Map<String, Long> partitionToSnapshotId = new HashMap<>();
+        FileMonitorTable fileMonitorTable = new FileMonitorTable(paimonTable.getNativeTable());
+        Long latestId = fileMonitorTable.snapshotManager().latestSnapshotId();
+        long latestSnapshotId = latestId == null ? Long.MIN_VALUE : latestId;
+        LOG.debug("Paimon table {} latest snapshotId {}, currentId {}",
+                paimonTable.getName(), latestSnapshotId, mvSnapshotId);
+        if (mvSnapshotId >= latestSnapshotId && latestSnapshotId != Long.MIN_VALUE) {
+            LOG.info("Paimon table {} currentId {} > latest snapshotId {} ",
+                    paimonTable.getName(), mvSnapshotId, latestSnapshotId);
+            return partitionToSnapshotId;
+        }
+        ReadBuilder readBuilder = fileMonitorTable.newReadBuilder();
+        StreamTableScan scan = readBuilder.newStreamScan();
+        TableRead read = readBuilder.newRead();
+        if (mvSnapshotId != Long.MIN_VALUE) {
+            scan.restore(mvSnapshotId + 1);
+        } else {
+            scan.restore(null);
+        }
+        try {
+            // It may cost too many time to scan rows if paimon snapshot too frequently or mv has long refresh interval.
+            while (true) {
+                if (!scanMonitorTable(paimonTable, scan, read, partitionToSnapshotId)) {
+                    break;
+                }
+            }
+        } catch (OutOfRangeException e) {
+            // If paimon clear its snapshot, return all latest partitions.
+            partitionToSnapshotId.clear();
+            List<String> parts = listPartitionNames(paimonTable.getDbName(), paimonTable.getTableName());
+            parts.forEach(part -> partitionToSnapshotId.put(part, latestSnapshotId));
+            LOG.warn("Paimon snapshot id {} has been out of date, return all latest partitions with latest id {}.",
+                    mvSnapshotId, latestSnapshotId);
+        }
+        return partitionToSnapshotId;
+    }
+
+    private boolean scanMonitorTable(PaimonTable paimonTable, StreamTableScan scan, TableRead read,
+                             Map<String, Long> partitionToSnapshotId) {
+        TableScan.Plan plan = scan.plan();
+        if (plan.splits().isEmpty()) {
+            return false;
+        }
+        try {
+            read.createReader(plan).forEachRemaining(new Consumer<InternalRow>() {
+                @Override
+                public void accept(InternalRow row) {
+                    try {
+                        FileMonitorTable.FileChange fileChange = FileMonitorTable.toFileChange(row);
+                        RowDataConverter converter = new RowDataConverter(paimonTable.getNativeTable().
+                                schema().logicalPartitionType());
+                        List<String> partitionValues = converter.convert(fileChange.partition(),
+                                paimonTable.getPartitionColumnNames());
+                        String partition = FileUtils.makePartName(paimonTable.getPartitionColumnNames(), partitionValues);
+                        partitionToSnapshotId.put(partition, scan.checkpoint());
+                    } catch (IOException e) {
+                        LOG.error("Get fileChange failed.", e);
+                        throw new RuntimeException("Get fileChange failed.", e);
+                    }
+                }
+            });
+        } catch (IOException e) {
+            LOG.error("Read plan failed.", e);
+            throw new RuntimeException("Read plan failed.", e);
+        }
+        return true;
+    }
+
+    /**
+     * Paimon does not provide interface to get selected partitions version, so we return latest snapshot ID
+     * to mark current version. This may not be accurate, but enough for meta refresh after partition refresh.
+     * TODO: Rewrite this method after paimon provide interface.
+     */
+    @Override
+    public List<com.starrocks.connector.PartitionInfo> getPartitions(Table table, List<String> partitionNames) {
+        PaimonTable paimonTable = (PaimonTable) table;
+        FileMonitorTable fileMonitorTable = new FileMonitorTable(paimonTable.getNativeTable());
+        Long latestSnapshotId = fileMonitorTable.snapshotManager().latestSnapshotId();
+        long latestId = latestSnapshotId == null ? Long.MIN_VALUE : latestSnapshotId;
+        return partitionNames.stream().map(
+                a -> new Partition(a, latestId)).collect(Collectors.toList());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/paimon/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/paimon/Partition.java
@@ -1,0 +1,46 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.connector.paimon;
+
+import com.starrocks.connector.PartitionInfo;
+
+public class Partition implements PartitionInfo {
+
+    private final String partitionName;
+    private final long version;
+
+    public Partition(String name, long version) {
+        this.partitionName = name;
+        this.version = version;
+    }
+
+    public String getPartitionName() {
+        return partitionName;
+    }
+
+    @Override
+    public long getModifiedTime() {
+        return version;
+    }
+
+    @Override
+    public String toString() {
+        return "PaimonPartitionInfo{" +
+                "partitionName='" + partitionName + '\'' +
+                ", version=" + version +
+                '}';
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -966,7 +966,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
      */
     private boolean unSupportRefreshByPartition(Table table) {
         return !table.isOlapTableOrMaterializedView() && !table.isHiveTable()
-                && !table.isJDBCTable() && !table.isIcebergTable() && !table.isCloudNativeTable();
+                && !table.isJDBCTable() && !table.isIcebergTable() && !table.isCloudNativeTable()
+                && !table.isPaimonTable();
     }
 
     /**
@@ -1867,7 +1868,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 partitionInfos.put(partition.getName(), basePartitionInfo);
             }
             return partitionInfos;
-        } else if (baseTable.isHiveTable() || baseTable.isIcebergTable() || baseTable.isJDBCTable()) {
+        } else if (baseTable.isHiveTable() || baseTable.isIcebergTable() || baseTable.isJDBCTable() ||
+                baseTable.isPaimonTable()) {
             return getSelectedPartitionInfos(baseTable, Lists.newArrayList(refreshedPartitionNames),
                     baseTableInfo);
         } else {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/PaimonTableTest.java
@@ -93,4 +93,16 @@ public class PaimonTableTest {
         Assert.assertEquals(tTableDescriptor.getTableName(), tableName);
     }
 
+    @Test
+    public void testEquals(@Mocked AbstractFileStoreTable paimonNativeTable) {
+        String dbName = "testDB";
+        String tableName = "testTable";
+        PaimonTable table = new PaimonTable("testCatalog", dbName, tableName, null,
+                paimonNativeTable, 100L);
+        PaimonTable table2 = new PaimonTable("testCatalog", dbName, tableName, null,
+                paimonNativeTable, 100L);
+        Assert.assertEquals(table, table2);
+        Assert.assertEquals(table, table);
+        Assert.assertNotEquals(table, null);
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -688,6 +688,17 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
         Assert.assertEquals(10, partitions.size());
+        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+
+        Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> versionMap =
+                partitionedMaterializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap();
+
+        BaseTableInfo baseTableInfo = new BaseTableInfo("paimon0", "pmn_db1", "partitioned_table", "partitioned_table");
+        versionMap.get(baseTableInfo).put("pt=2026-11-22", new MaterializedView.BasePartitionInfo(1, 2, -1));
+        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+
+        Assert.assertEquals(10, partitionedMaterializedView.getPartitions().size());
+        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
     }
 
     private static void trigerRefreshPaimonMv(Database testDb, MaterializedView partitionedMaterializedView)


### PR DESCRIPTION
Why I'm doing:
 support refresh paimon mv by partition.
What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
