### PR TITLE
[BugFix] make pipeline sink dop configurable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -309,10 +309,9 @@ public class FragmentInstance {
         } else {
             int sessionVarSinkDop = ConnectContext.get().getSessionVariable().getPipelineSinkDop();
             if (sessionVarSinkDop > 0) {
-                return Math.min(dop, sessionVarSinkDop);
-            } else {
-                return Math.min(dop, IcebergTableSink.ICEBERG_SINK_MAX_DOP);
+                return sessionVarSinkDop;
             }
+            return dop;
         }
     }
 

--- a/test/sql/test_sink/R/test_files_sink
+++ b/test/sql/test_sink/R/test_files_sink
@@ -1,0 +1,36 @@
+-- name: testFilesSink
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+	"format"="parquet", 
+	"compression" = "uncompressed"
+) 
+select 1 as k1, "A" as k2;
+-- result:
+[]
+-- !result
+set pipeline_sink_dop = 1;
+-- result:
+[]
+-- !result
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+	"format"="parquet", 
+	"compression" = "uncompressed"
+) 
+select 2 as k1, "B" as k2;
+-- result:
+[]
+-- !result
+select * from files (
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+	"format" = "parquet"
+);
+-- result:
+1	A
+2	B
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_sink/T/test_files_sink
+++ b/test/sql/test_sink/T/test_files_sink
@@ -1,0 +1,24 @@
+-- name: testFilesSink
+
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+	"format"="parquet", 
+	"compression" = "uncompressed"
+) 
+select 1 as k1, "A" as k2;
+
+set pipeline_sink_dop = 1;
+
+insert into files ( 
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
+	"format"="parquet", 
+	"compression" = "uncompressed"
+) 
+select 2 as k1, "B" as k2;
+
+select * from files (
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+	"format" = "parquet"
+);
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
Why I'm doing:

Make pipeline sink dop configurable and effective. 

What I'm doing:

If the user sets a positive pipeline sink dop, use it as the dop of sink operators. 

And pipeline sink dop could be larger than the pipeline dop of the sink fragment. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
