### PR TITLE
[BugFix] Fix subQuery must have alias when CTAS

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -4691,7 +4691,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
             Identifier identifier = (Identifier) visit(context.alias);
             subqueryRelation.setAlias(new TableName(null, identifier.getValue()));
         } else {
-            subqueryRelation.setAlias(new TableName(null, null));
+            subqueryRelation.setAlias(null);
         }
 
         subqueryRelation.setColumnOutputNames(getColumnNames(context.columnAliases()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeJoinTest.java
@@ -197,7 +197,7 @@ public class AnalyzeJoinTest {
         analyzeFail(sql, "Not unique table/alias: 'a'");
 
         sql = "select * from (t0 a, (select * from t1))";
-        analyzeFail(sql, "Every derived table must have its own alias");
+        analyzeSuccess(sql);
 
         sql = "select * from t0, t0";
         analyzeFail(sql, "Not unique table/alias: 't0'");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSubqueryTest.java
@@ -46,7 +46,7 @@ public class AnalyzeSubqueryTest {
         analyzeFail("select a.k1 from (select k1, k2 from (select v1 as k1, v2 as k2 from t0) a) b");
 
         analyzeSuccess("select * from (select count(v1) from t0) a");
-        analyzeFail("select * from (select count(v1) from t0)");
+        analyzeSuccess("select * from (select count(v1) from t0)");
 
         analyzeSuccess(
                 "select v1 from t0 where v2 in (select v4 from t1 where v3 = v5) or v2 = (select v4 from t1 where v3 = v5)");


### PR DESCRIPTION
Why I'm doing:
When querying, subQuery does not have an alias and no error will be reported.
However, when subQuery does not have an alias in CTAS, an error will be reported.

example:
```sql
mysql> select * from ( select * from ( select 1, 2, 3 ) );
+------+------+------+
| 1    | 2    | 3    |
+------+------+------+
|    1 |    2 |    3 |
+------+------+------+
1 row in set (0.09 sec)

mysql> create table temp.zeno_test as
    -> select * from ( select * from ( select 1, 2, 3 ) );
ERROR 1064 (HY000): Getting analyzing error. Detail message: Every derived table must have its own alias.
```

What I'm doing:
https://github.com/StarRocks/starrocks/blob/6d8dcea3e894c4d2ea60e8b358310ae63b38d98a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java#L645
In the `QueryAnalyzer#visitSubquery` method, if alias(i.e. getResolveTableName) is not `null` and `getResolveTableName().getTbl()` is `null`, an error will be included: ERR_DERIVED_MUST_HAVE_ALIAS.
Therefore, use `null` instead of `new TableName(null, null)`.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
