### PR TITLE
[BugFix] Compensate extra predicates after union all pull up rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/QueryDebugOptions.java
@@ -28,6 +28,9 @@ public class QueryDebugOptions {
     @SerializedName(value = "maxRefreshMaterializedViewRetryNum")
     private int maxRefreshMaterializedViewRetryNum = 1;
 
+    @SerializedName(value = "enableMVEagerUnionAllRewrite")
+    private boolean enableMVEagerUnionAllRewrite = false;
+
     public QueryDebugOptions() {
         // To make unit test more stable, add retry times for refreshing materialized views.
         if (FeConstants.runningUnitTest) {
@@ -49,6 +52,14 @@ public class QueryDebugOptions {
 
     public void setMaxRefreshMaterializedViewRetryNum(int maxRefreshMaterializedViewRetryNum) {
         this.maxRefreshMaterializedViewRetryNum = maxRefreshMaterializedViewRetryNum;
+    }
+
+    public boolean isEnableMVEagerUnionAllRewrite() {
+        return enableMVEagerUnionAllRewrite;
+    }
+
+    public void setEnableMVEagerUnionAllRewrite(boolean enableMVEagerUnionAllRewrite) {
+        this.enableMVEagerUnionAllRewrite = enableMVEagerUnionAllRewrite;
     }
 
     public static QueryDebugOptions getInstance() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvRewritePreprocessor.java
@@ -409,10 +409,12 @@ public class MvRewritePreprocessor {
             mvPartialPartitionPredicates = getMvPartialPartitionPredicates(mv, mvPlan, partitionNamesToRefresh);
             if (mvPartialPartitionPredicates == null) {
                 logMVPrepare(connectContext, mv, "Partitioned MV {} is outdated which contains some partitions " +
-                        "to be refreshed: {}", mv.getName(), partitionNamesToRefresh);
+                        "to be refreshed: {}, and cannot compensate it to predicate", mv.getName(), partitionNamesToRefresh);
                 return;
             }
         }
+        logMVPrepare(connectContext, mv, "MV' partitions to refresh: {}", partitionNamesToRefresh);
+        logMVPrepare(connectContext, mv, "MV compensate partition predicate: {}", mvPartialPartitionPredicates);
 
         // Add mv info into dump info
         if (connectContext.getDumpInfo() != null) {
@@ -430,7 +432,10 @@ public class MvRewritePreprocessor {
         if (mvPartialPartitionPredicates != null) {
             Table refBaseTable = partitionTableAndColumns.first;
             refTableUpdatedPartitionNames = mv.getUpdatedPartitionNamesOfTable(refBaseTable, true);
+            logMVPrepare(connectContext, mv, "Ref table {} partitions to refresh: {}", refBaseTable.getName(),
+                    refTableUpdatedPartitionNames);
         }
+
 
         // If query tables are set which means use related mv for non lock optimization,
         // copy mv's metadata into a ready-only object.

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/OptimizerTraceUtil.java
@@ -68,7 +68,7 @@ public class OptimizerTraceUtil {
         Tracers.log(Tracers.Module.MV, input -> {
             Object[] args = new Object[] {
                     rule.type().name(),
-                    String.format(format, object)
+                    MessageFormatter.arrayFormat(format, object).getMessage()
             };
             return MessageFormatter.arrayFormat("[MV TRACE] [REWRITE {}] {}", args).getMessage();
         });

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/Operator.java
@@ -24,7 +24,6 @@ import com.starrocks.sql.optimizer.operator.physical.PhysicalJoinOperator;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
-import java.util.BitSet;
 import java.util.List;
 import java.util.Objects;
 
@@ -61,7 +60,8 @@ public abstract class Operator {
     //  OP -->   EXTRA-OP    MV-SCAN  -->     UNION    MV-SCAN     ---> ....
     //                                       /      \
     //                                  EXTRA-OP    MV-SCAN
-    protected BitSet opBitSet = new BitSet();
+    protected int opRuleMask = 0;
+
     public Operator(OperatorType opType) {
         this.opType = opType;
     }
@@ -143,12 +143,12 @@ public abstract class Operator {
     }
 
 
-    public boolean isOpBitApplied(int b) {
-        return opBitSet.get(b);
+    public int getOpRuleMask() {
+        return opRuleMask;
     }
 
-    public void setOpBit(int b) {
-        this.opBitSet.set(b);
+    public void setOpRuleMask(int b) {
+        this.opRuleMask = b;
     }
 
     public RowOutputInfo getRowOutputInfo(List<OptExpression> inputs) {
@@ -219,7 +219,7 @@ public abstract class Operator {
             builder.predicate = operator.predicate;
             builder.projection = operator.projection;
             builder.salt = operator.salt;
-            builder.opBitSet = operator.opBitSet;
+            builder.opRuleMask = operator.opRuleMask;
             return (B) this;
         }
 
@@ -265,8 +265,8 @@ public abstract class Operator {
             return (B) this;
         }
 
-        public B setOpBitSet(BitSet bitSet) {
-            builder.opBitSet = bitSet;
+        public B setOpBitSet(int opRuleMask) {
+            builder.opRuleMask = opRuleMask;
             return (B) this;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/AggregatedMaterializedViewRewriter.java
@@ -37,7 +37,6 @@ import com.starrocks.sql.optimizer.operator.Operator;
 import com.starrocks.sql.optimizer.operator.OperatorBuilderFactory;
 import com.starrocks.sql.optimizer.operator.Projection;
 import com.starrocks.sql.optimizer.operator.logical.LogicalAggregationOperator;
-import com.starrocks.sql.optimizer.operator.logical.LogicalFilterOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalScanOperator;
 import com.starrocks.sql.optimizer.operator.logical.LogicalUnionOperator;
 import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
@@ -483,10 +482,9 @@ public class AggregatedMaterializedViewRewriter extends MaterializedViewRewriter
         }
         OptExpression result = createNewAggregate(rewriteContext, queryAgg, newAggregations, aggregateMapping,
                 unionExpr, newProjection);
+        // Add extra union all predicates above union all operator.
         if (rewriteContext.getUnionRewriteQueryExtraPredicate() != null) {
-            LogicalFilterOperator filter =
-                    new LogicalFilterOperator(rewriteContext.getUnionRewriteQueryExtraPredicate());
-            result = OptExpression.create(filter, result);
+            addUnionAllExtraPredicate(result.getOp(), rewriteContext.getUnionRewriteQueryExtraPredicate());
         }
         deriveLogicalProperty(result);
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -43,8 +43,17 @@ public class MVColumnPruner {
 
     public OptExpression pruneColumns(OptExpression queryExpression) {
         if (queryExpression.getOp() instanceof LogicalFilterOperator) {
-            queryExpression = queryExpression.inputAt(0);
+            OptExpression projectExpression = queryExpression.inputAt(0);
+            OptExpression prunedExpression = pruneProjectExpression(projectExpression);
+            // For pull-up union all rewrite, ensure add the filter operator after column prune,
+            // otherwise maybe cause a wrong result.
+            return OptExpression.create(queryExpression.getOp(), prunedExpression);
+        } else {
+            return pruneProjectExpression(queryExpression);
         }
+    }
+
+    private OptExpression pruneProjectExpression(OptExpression queryExpression) {
         Projection projection = queryExpression.getOp().getProjection();
         // OptExpression after mv rewrite must have projection.
         Preconditions.checkState(projection != null);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MVColumnPruner.java
@@ -42,18 +42,6 @@ public class MVColumnPruner {
     private ColumnRefSet requiredOutputColumns;
 
     public OptExpression pruneColumns(OptExpression queryExpression) {
-        if (queryExpression.getOp() instanceof LogicalFilterOperator) {
-            OptExpression projectExpression = queryExpression.inputAt(0);
-            OptExpression prunedExpression = pruneProjectExpression(projectExpression);
-            // For pull-up union all rewrite, ensure add the filter operator after column prune,
-            // otherwise maybe cause a wrong result.
-            return OptExpression.create(queryExpression.getOp(), prunedExpression);
-        } else {
-            return pruneProjectExpression(queryExpression);
-        }
-    }
-
-    private OptExpression pruneProjectExpression(OptExpression queryExpression) {
         Projection projection = queryExpression.getOp().getProjection();
         // OptExpression after mv rewrite must have projection.
         Preconditions.checkState(projection != null);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MaterializedViewRewriter.java
@@ -46,6 +46,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.common.ErrorType;
 import com.starrocks.sql.common.PermutationGenerator;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.common.StarRocksPlannerException;
 import com.starrocks.sql.optimizer.ExpressionContext;
 import com.starrocks.sql.optimizer.MaterializationContext;
@@ -108,6 +109,7 @@ public class MaterializedViewRewriter {
     protected final OptimizerContext optimizerContext;
     // Mark whether query's plan is rewritten by materialized view.
     public static final String REWRITE_SUCCESS = "Rewrite Succeed";
+    public static final int OP_UNION_ALL_BIT = 1;
 
     private static final Map<JoinOperator, List<JoinOperator>> JOIN_COMPATIBLE_MAP =
             ImmutableMap.<JoinOperator, List<JoinOperator>>builder()
@@ -630,6 +632,8 @@ public class MaterializedViewRewriter {
         ScalarOperator mvPredicate = MvUtils.rewriteOptExprCompoundPredicate(mvConjuncts, mvColumnRefRewriter);
         final PredicateSplit mvPredicateSplit = PredicateSplit.splitPredicate(mvPredicate);
 
+        logMVRewrite(mvRewriteContext, "\nTry to rewrite query with mv:{}, match mode:{}",
+                materializationContext.getMv().getName(), matchMode);
         if (matchMode == MatchMode.VIEW_DELTA) {
             return rewriteViewDelta(queryTables, mvTables, mvPredicateSplit, mvColumnRefRewriter,
                     queryExpression, mvExpression);
@@ -647,18 +651,26 @@ public class MaterializedViewRewriter {
      */
     private ScalarOperator compensateMVPartitionPredicate(List<ScalarOperator> mvPredicates,
                                                           ReplaceColumnRefRewriter mvColumnRefRewriter) {
-        if (mvRewriteContext.isCompensatePartitionPredicate()
-                && materializationContext.getMvPartialPartitionPredicate() != null) {
+        ScalarOperator mvPrunedPartitionPredicate = getMVCompensatePartitionPredicate();
+        if (mvPrunedPartitionPredicate != null) {
             List<ScalarOperator> partitionPredicates =
                     getPartitionRelatedPredicates(mvPredicates, mvRewriteContext.getMaterializationContext().getMv());
             if (partitionPredicates.stream().noneMatch(p -> (p instanceof IsNullPredicateOperator)
                     && !((IsNullPredicateOperator) p).isNotNull())) {
                 // there is no partition column is null predicate
                 // add latest partition predicate to mv predicate
-                return mvColumnRefRewriter.rewrite(materializationContext.getMvPartialPartitionPredicate());
+                return mvColumnRefRewriter.rewrite(mvPrunedPartitionPredicate);
             }
         }
         return ConstantOperator.TRUE;
+    }
+
+    private ScalarOperator getMVCompensatePartitionPredicate() {
+        if (mvRewriteContext.isCompensatePartitionPredicate()) {
+            return materializationContext.getMvPartialPartitionPredicate();
+        } else {
+            return null;
+        }
     }
 
     private OptExpression rewriteViewDelta(List<Table> queryTables,
@@ -788,6 +800,8 @@ public class MaterializedViewRewriter {
         // used to prune partition and buckets after mv rewrite
         ScalarOperator mvPrunePredicate = collectMvPrunePredicate(materializationContext);
 
+        logMVRewrite(mvRewriteContext, "MV predicate split:{}", mvPredicateSplit);
+        logMVRewrite(mvRewriteContext, "Query predicate split:{}", queryPredicateSplit);
         logMVRewrite(mvRewriteContext, "Construct {} relation id mappings from query to mv", relationIdMappings.size());
         for (BiMap<Integer, Integer> relationIdMapping : relationIdMappings) {
             mvRewriteContext.setMvPruneConjunct(mvPrunePredicate);
@@ -1536,6 +1550,42 @@ public class MaterializedViewRewriter {
         return Utils.compoundAnd(candidates);
     }
 
+    private boolean isPullUpQueryPredicate(ScalarOperator predicate,
+                                           Set<ColumnRefOperator> mvPredicateUsedColRefs,
+                                           ColumnRefSet queryOnPredicateUsedColRefs,
+                                           ColumnRefSet queryOutputColumnRefs) {
+        return predicate.getColumnRefs().stream()
+                .filter(col -> {
+                    //  pull-up extra predicates should not contain any non-(inner/cross) join on-predicates
+                    if (queryOnPredicateUsedColRefs != null && queryOnPredicateUsedColRefs.contains(col)) {
+                        return false;
+                    }
+                    return true;
+                })
+                .anyMatch(col -> {
+                    // filter out query's predicates that its column refs are not contained in mv's predicate:
+                    // when column ref is not contained in mv's predicates, query's predicate cannot be rewritten.
+                    // eg:
+                    //    query: select dt, k1, k2 from tblA where dt >= '2023-11-01' and k2 > 1
+                    //      mv : select dt, k2 from tblA where dt = '2023-11-01'
+                    // we can rewrite by Union-All after rewrite as below:
+                    //    query: select * from ( select dt, k1, k2 from tblA where dt >= '2023-11-01' ) t where k2 > 1
+                    if (mvPredicateUsedColRefs != null && !mvPredicateUsedColRefs.contains(col)) {
+                        return true;
+                    }
+
+                    // 2. filter out predicates whose column refs are in query's output columns because we can always compensate
+                    // by output column using Union-All.
+                    // eg:
+                    //    query: select dt, k2 from tblA where dt >= '2023-11-01'
+                    //      mv : select dt, k2 from tblA
+                    if (queryOutputColumnRefs != null && queryOutputColumnRefs.contains(col)) {
+                        return true;
+                    }
+                    return false;
+                });
+    }
+
     private PredicateSplit getUnionRewriteQueryCompensation(RewriteContext rewriteContext,
                                                             ColumnRewriter columnRewriter) {
         final PredicateSplit mvCompensationToQuery = getCompensationPredicates(columnRewriter,
@@ -1547,6 +1597,10 @@ public class MaterializedViewRewriter {
         if (mvCompensationToQuery != null) {
             return mvCompensationToQuery;
         }
+        // To avoid dead-loop rewrite, no rewrite when query extra predicate is not changed
+        if (rewriteContext.getQueryExpression().getOp().isOpBitApplied(OP_UNION_ALL_BIT)) {
+            return null;
+        }
 
         // try to pull up query's predicates to make possible for rewrite from mv to query.
         PredicateSplit mvPredicateSplit = rewriteContext.getMvPredicateSplit();
@@ -1556,43 +1610,27 @@ public class MaterializedViewRewriter {
                 .map(colRef -> (ColumnRefOperator) columnRewriter.rewriteViewToQuery(colRef))
                 .collect(Collectors.toSet());
 
-        // filter out query's predicates that its column refs are not contained in mv's predicate:
-        // when column ref is not contained in mv's predicates, query's predicate cannot be rewritten.
-        List<ScalarOperator> queryRangePredicates = Utils.extractConjuncts(queryPredicateSplit.getRangePredicates());
-        Map<Boolean, List<ScalarOperator>> queryRangePredicateSplits =
-                queryRangePredicates.stream().collect(Collectors.partitioningBy(pred ->
-                        pred.getColumnRefs().stream().anyMatch(col -> mvPredicateUsedColRefs.contains(col))));
-        List<ScalarOperator> queryOtherRangePredicates = Utils.extractConjuncts(queryPredicateSplit.getResidualPredicates());
-        Map<Boolean, List<ScalarOperator>> queryOtherPredicateSplits =
-                queryOtherRangePredicates.stream().collect(Collectors.partitioningBy(pred ->
-                        pred.getColumnRefs().stream().anyMatch(col -> mvPredicateUsedColRefs.contains(col))));
+        List<ScalarOperator> queryPredicates = Lists.newArrayList();
+        queryPredicates.addAll(Utils.extractConjuncts(queryPredicateSplit.getRangePredicates()));
+        queryPredicates.addAll(Utils.extractConjuncts(queryPredicateSplit.getResidualPredicates()));
 
-        // To avoid deadlock rewrite, no rewrite when query extra predicate is not changed
-        if (queryRangePredicateSplits.get(true).isEmpty() && queryOtherPredicateSplits.get(true).isEmpty()) {
-            return null;
-        }
-        List<ScalarOperator> queryExtraPredicates = Lists.newArrayList();
-        if (queryRangePredicateSplits.get(false) != null) {
-            queryExtraPredicates.addAll(queryRangePredicateSplits.get(false));
-        }
-        if (queryOtherPredicateSplits.get(false) != null) {
-            queryExtraPredicates.addAll(queryOtherPredicateSplits.get(false));
-        }
+        List<ScalarOperator> queryOnPredicates = MvUtils.getJoinOnPredicates(rewriteContext.getQueryExpression());
+        ColumnRefSet queryOnPredicateUsedColRefs = Optional.ofNullable(Utils.compoundAnd(queryOnPredicates))
+                .map(x -> x.getUsedColumns())
+                .orElse(new ColumnRefSet());
+        // use union-all rewrite eagerly if union-all rewrite can be used.
+        QueryDebugOptions debugOptions  = optimizerContext.getSessionVariable().getQueryDebugOptions();
+        ColumnRefSet queryOutputColumnRefs = debugOptions.isEnableMVEagerUnionAllRewrite() ?
+                rewriteContext.getQueryExpression().getOutputColumns() : null;
+        Set<ScalarOperator> queryExtraPredicates = queryPredicates.stream()
+                .filter(pred -> isPullUpQueryPredicate(pred, mvPredicateUsedColRefs,
+                        queryOnPredicateUsedColRefs, queryOutputColumnRefs))
+                .collect(Collectors.toSet());
+
         if (queryExtraPredicates.isEmpty()) {
             return null;
         }
 
-        // pull-up extra predicates should not contain any non-(inner/cross) join on-predicates
-        List<ScalarOperator> queryOnPredicates = MvUtils.getJoinOnPredicates(rewriteContext.getQueryExpression());
-        if (queryOnPredicates != null && !queryOnPredicates.isEmpty()) {
-            ColumnRefSet queryOnPredicateUsedColRefs = Utils.compoundAnd(queryOnPredicates).getUsedColumns();
-            queryExtraPredicates = queryExtraPredicates.stream()
-                    .filter(extra -> !queryOnPredicateUsedColRefs.isIntersect(extra.getUsedColumns()))
-                    .collect(Collectors.toList());
-            if (queryExtraPredicates.isEmpty()) {
-                return null;
-            }
-        }
         final ScalarOperator queryExtraPredicate = Utils.compoundAnd(queryExtraPredicates);
 
         // query's output should contain all the extra predicates otherwise it cannot be pulled then.
@@ -1600,11 +1638,22 @@ public class MaterializedViewRewriter {
         if (!queryOutputColumnSet.containsAll(queryExtraPredicate.getUsedColumns())) {
             return null;
         }
-
         // update query predicate after pull up
-        final PredicateSplit newQuerySplit = PredicateSplit.of(queryPredicateSplit.getEqualPredicates(),
-                Utils.compoundAnd(queryRangePredicateSplits.get(true)),
-                Utils.compoundAnd(queryOtherPredicateSplits.get(true)));
+        Set<ScalarOperator> queryRetainPredicates = queryPredicates.stream()
+                .filter(pred -> !queryExtraPredicates.contains(pred))
+                .collect(Collectors.toSet());
+        queryRetainPredicates.add(queryPredicateSplit.getEqualPredicates());
+        // To avoid dead-loop rewrite, no rewrite when query extra predicate is not changed.
+        // eg: MV's UNION-ALL RULE:
+        //                 UNION                         UNION
+        //               /        \                    /       \
+        //  OP -->   EXTRA-OP    MV-SCAN  -->     UNION    MV-SCAN     ---> ....
+        //                                       /      \
+        //                                  EXTRA-OP    MV-SCAN
+        if (queryRetainPredicates.isEmpty()) {
+            return null;
+        }
+        final PredicateSplit newQuerySplit = PredicateSplit.splitPredicate(Utils.compoundAnd(queryRetainPredicates));
         rewriteContext.setQueryPredicateSplit(newQuerySplit);
         // update union rewrite extra predicate by pull up predicates
         rewriteContext.setUnionRewriteQueryExtraPredicate(queryExtraPredicate);
@@ -1705,6 +1754,15 @@ public class MaterializedViewRewriter {
             logMVRewrite(mvRewriteContext, "Rewrite union failed: cannot rewrite query based on MV");
             return null;
         }
+
+
+        // Avoid UNION_ALL rule's dead loop, set a bit mask for the new query operator:
+        //                 UNION                         UNION
+        //               /        \                    /       \
+        //  OP -->   EXTRA-OP    MV-SCAN  -->     UNION    MV-SCAN     ---> ....
+        //                                       /      \
+        //                                  EXTRA-OP    MV-SCAN
+        queryInput.getOp().setOpBit(OP_UNION_ALL_BIT);
 
         // createUnion will return the union all result of queryInput and viewInput
         //           Union

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
@@ -19,6 +19,7 @@ import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class PredicateSplit {
     // column equality predicates conjuncts
@@ -67,14 +68,27 @@ public class PredicateSplit {
         return Lists.newArrayList(equalPredicates, rangePredicates, residualPredicates);
     }
 
+    private static ScalarOperator filterPredicate(ScalarOperator predicate) {
+        if (predicate == null) {
+            return null;
+        }
+        List<ScalarOperator> filterPredicate = Utils.extractConjuncts(predicate)
+                .stream()
+                .filter(x -> !x.isConstantTrue())
+                .collect(Collectors.toList());
+        return Utils.compoundAnd(filterPredicate);
+    }
+
     // split predicate into three parts: equal columns predicates, range predicates, and residual predicates
     public static PredicateSplit splitPredicate(ScalarOperator predicate) {
-        if (predicate == null) {
+        ScalarOperator normaPredicate = filterPredicate(predicate);
+        if (normaPredicate == null) {
             return PredicateSplit.of(null, null, null);
         }
+
         PredicateExtractor extractor = new PredicateExtractor();
         RangePredicate rangePredicate =
-                predicate.accept(extractor, new PredicateExtractor.PredicateExtractorContext());
+                normaPredicate.accept(extractor, new PredicateExtractor.PredicateExtractorContext());
         ScalarOperator equalityConjunct = Utils.compoundAnd(extractor.getColumnEqualityPredicates());
         ScalarOperator rangeConjunct = null;
         ScalarOperator residualConjunct = Utils.compoundAnd(extractor.getResidualPredicates());
@@ -82,8 +96,17 @@ public class PredicateSplit {
             // convert rangePredicate to rangeConjunct
             rangeConjunct = rangePredicate.toScalarOperator();
         } else if (extractor.getColumnEqualityPredicates().isEmpty() && extractor.getResidualPredicates().isEmpty()) {
-            residualConjunct = Utils.compoundAnd(residualConjunct, predicate);
+            residualConjunct = Utils.compoundAnd(residualConjunct, normaPredicate);
         }
         return PredicateSplit.of(equalityConjunct, rangeConjunct, residualConjunct);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("equalPredicates=%s, rangePredicates=%s, residualPredicates=%s",
+                equalPredicates == null ? "" : equalPredicates,
+                rangePredicates == null ? "" : rangePredicates,
+                residualPredicates == null ? "" : residualPredicates
+        );
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/PredicateSplit.java
@@ -81,14 +81,14 @@ public class PredicateSplit {
 
     // split predicate into three parts: equal columns predicates, range predicates, and residual predicates
     public static PredicateSplit splitPredicate(ScalarOperator predicate) {
-        ScalarOperator normaPredicate = filterPredicate(predicate);
-        if (normaPredicate == null) {
+        ScalarOperator normalPredicate = filterPredicate(predicate);
+        if (normalPredicate == null) {
             return PredicateSplit.of(null, null, null);
         }
 
         PredicateExtractor extractor = new PredicateExtractor();
         RangePredicate rangePredicate =
-                normaPredicate.accept(extractor, new PredicateExtractor.PredicateExtractorContext());
+                normalPredicate.accept(extractor, new PredicateExtractor.PredicateExtractorContext());
         ScalarOperator equalityConjunct = Utils.compoundAnd(extractor.getColumnEqualityPredicates());
         ScalarOperator rangeConjunct = null;
         ScalarOperator residualConjunct = Utils.compoundAnd(extractor.getResidualPredicates());
@@ -96,7 +96,7 @@ public class PredicateSplit {
             // convert rangePredicate to rangeConjunct
             rangeConjunct = rangePredicate.toScalarOperator();
         } else if (extractor.getColumnEqualityPredicates().isEmpty() && extractor.getResidualPredicates().isEmpty()) {
-            residualConjunct = Utils.compoundAnd(residualConjunct, normaPredicate);
+            residualConjunct = Utils.compoundAnd(residualConjunct, normalPredicate);
         }
         return PredicateSplit.of(equalityConjunct, rangeConjunct, residualConjunct);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/rule/BaseMaterializedViewRewriteRule.java
@@ -175,6 +175,8 @@ public abstract class BaseMaterializedViewRewriteRule extends TransformationRule
         // only add valid predicates into query split predicate
         List<ScalarOperator> queryConjuncts = MvUtils.getAllValidPredicates(queryExpression);
         if (!ConstantOperator.TRUE.equals(queryPartitionPredicate)) {
+            logMVRewrite(mvContext.getOptimizerContext(), this, "Query compensate partition predicate:{}",
+                    queryPartitionPredicate);
             queryConjuncts.addAll(MvUtils.getAllValidPredicates(queryPartitionPredicate));
         }
         ScalarOperator queryPredicate =

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTestBase.java
@@ -185,6 +185,9 @@ public class MaterializedViewTestBase extends PlanTestBase {
                 } else {
                     this.rewritePlan = planAndTrace.first.getExplainString(TExplainLevel.NORMAL);
                 }
+                if (!Strings.isNullOrEmpty(traceLogModule)) {
+                    System.out.println(this.rewritePlan);
+                }
                 this.traceLog = planAndTrace.second;
             } catch (Exception e) {
                 LOG.warn("test rewrite failed:", e);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -17,7 +17,10 @@ package com.starrocks.sql.optimizer.rule.transformation.materialization;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
+import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.QueryDebugOptions;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.operator.physical.PhysicalScanOperator;
 import com.starrocks.sql.plan.PlanTestBase;
@@ -28,6 +31,7 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 
 import java.util.List;
+import java.util.Set;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class MvRewriteUnionTest extends MvRewriteTestBase {
@@ -342,5 +346,100 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
         String plan6 = getFragmentPlan(query6);
         PlanTestBase.assertContains(plan6, "mv_agg_1", "emps", "UNION");
         dropMv("test", "mv_agg_1");
+    }
+
+    @Test
+    public void testExtraUnionRewrite1() {
+        starRocksAssert.withTable(new MTable("mt1", "k1",
+                        List.of(
+                                "k1 INT",
+                                "k2 string",
+                                "v1 INT",
+                                "v2 INT"
+                        ),
+                        "k1",
+                        List.of(
+                                "PARTITION `p1` VALUES LESS THAN ('3')",
+                                "PARTITION `p2` VALUES LESS THAN ('6')",
+                                "PARTITION `p3` VALUES LESS THAN ('9')",
+                                "PARTITION `p4` VALUES LESS THAN ('12')",
+                                "PARTITION `p5` VALUES LESS THAN ('15')",
+                                "PARTITION `p6` VALUES LESS THAN ('18')"
+                        )
+                ),
+                () -> {
+                    cluster.runSql("test", "insert into mt1 values (1,1, 1,1), (4,2, 1,1),(8,3,1,1),(11,4,1,1);");
+                    starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW union_mv0 " +
+                            " PARTITION BY (k1) " +
+                            " DISTRIBUTED BY HASH(k1) " +
+                            " REFRESH DEFERRED MANUAL " +
+                            " AS SELECT k1,k2, v1,v2 from mt1;");
+                    starRocksAssert.refreshMvPartition(String.format("REFRESH MATERIALIZED VIEW union_mv0 \n" +
+                            "PARTITION START ('%s') END ('%s')", "1", "3"));
+                    MaterializedView mv1 = getMv("test", "union_mv0");
+                    Set<String> mvNames = mv1.getPartitionNames();
+
+                    {
+                        String[] sqls = {
+                                "SELECT k1,k2, v1,v2 from mt1 where k1=1",
+                                "SELECT k1,k2, v1,v2 from mt1 where k1<3",
+                                "SELECT k1,k2, v1,v2 from mt1 where k1<2",
+                        };
+                        for (String query : sqls) {
+                            String plan = getFragmentPlan(query, "MV");
+                            PlanTestBase.assertNotContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "union_mv0");
+                        }
+                    }
+                    {
+                        String query = "SELECT k1,k2, v1,v2 from mt1 where k1<6";
+                        String plan = getFragmentPlan(query, "MV");
+                        PlanTestBase.assertContains(plan, ":UNION");
+                        PlanTestBase.assertContains(plan, "union_mv0");
+                    }
+
+                    {
+                        List<Pair<String, String>> sqls = List.of(
+                                Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 like 'a%'",
+                                        "7:SELECT\n" +
+                                                "  |  predicates: 2: k2 LIKE 'a%'"),
+                                Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1 != 3 and k2 like 'a%'",
+                                        "7:SELECT\n" +
+                                                "  |  predicates: 2: k2 LIKE 'a%'")
+                        );
+                        for (Pair<String, String> p: sqls) {
+                            String query = p.first;
+                            String plan = getFragmentPlan(query, "MV");
+                            PlanTestBase.assertContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "union_mv0", p.second);
+                        }
+                    }
+                    {
+                        String query = "SELECT k1,k2, v1,v2 from mt1 where k1 > 0 and k2 like 'a%'";
+                        String plan = getFragmentPlan(query, "MV");
+                        PlanTestBase.assertNotContains(plan, ":UNION", "union_mv0");
+                    }
+                    {
+                        List<Pair<String, String>> sqls = List.of(
+                                Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>1 and k2 like 'a%'",
+                                        "7:SELECT\n" +
+                                                "  |  predicates: 1: k1 > 1, 2: k2 LIKE 'a%'"),
+                                Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 like 'a%'",
+                                        "7:SELECT\n" +
+                                                "  |  predicates: 1: k1 > 0, 2: k2 LIKE 'a%'")
+                                );
+                        QueryDebugOptions debugOptions = new QueryDebugOptions();
+                        debugOptions.setEnableMVEagerUnionAllRewrite(true);
+                        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
+                        for (Pair<String, String> p: sqls) {
+                            String query = p.first;
+                            String plan = getFragmentPlan(query, "MV");
+                            PlanTestBase.assertContains(plan, ":UNION");
+                            PlanTestBase.assertContains(plan, "union_mv0", p.second);
+                        }
+                    }
+                    starRocksAssert.dropMaterializedView("union_mv0");
+                }
+        );
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -407,7 +407,7 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                                         "7:SELECT\n" +
                                                 "  |  predicates: 2: k2 LIKE 'a%'")
                         );
-                        for (Pair<String, String> p: sqls) {
+                        for (Pair<String, String> p : sqls) {
                             String query = p.first;
                             String plan = getFragmentPlan(query, "MV");
                             PlanTestBase.assertContains(plan, ":UNION");
@@ -431,7 +431,7 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                         QueryDebugOptions debugOptions = new QueryDebugOptions();
                         debugOptions.setEnableMVEagerUnionAllRewrite(true);
                         connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
-                        for (Pair<String, String> p: sqls) {
+                        for (Pair<String, String> p : sqls) {
                             String query = p.first;
                             String plan = getFragmentPlan(query, "MV");
                             PlanTestBase.assertContains(plan, ":UNION");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -378,7 +378,7 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                             "PARTITION START ('%s') END ('%s')", "1", "3"));
                     MaterializedView mv1 = getMv("test", "union_mv0");
                     Set<String> mvNames = mv1.getPartitionNames();
-                    System.out.println(mvNames.stream().sorted());
+                    Assert.assertEquals("[p1]", mvNames.toString());
 
                     {
                         String[] sqls = {
@@ -425,6 +425,9 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>1 and k2 like 'a%'",
                                         "7:SELECT\n" +
                                                 "  |  predicates: 1: k1 > 1, 2: k2 LIKE 'a%'"),
+                                Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>1 and k2 like 'a%'",
+                                        "7:SELECT\n" +
+                                                "  |   predicates: 2: k2 LIKE 'a%', 1: k1 > 1"),
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 like 'a%'",
                                         "7:SELECT\n" +
                                                 "  |  predicates: 1: k1 > 0, 2: k2 LIKE 'a%'")
@@ -442,5 +445,14 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                     starRocksAssert.dropMaterializedView("union_mv0");
                 }
         );
+    }
+    @Test
+    public void testAssertContainsIgnoreColRefs() {
+        String p1 = "7:SELECT\n" +
+                "  |  predicates: 1: k1 > 1, 2: k2 LIKE 'a%'";
+        String p =
+                "7:SELECT\n" +
+                "  |   predicates: 2: k2 LIKE 'a%', 1: k1 > 1";
+        PlanTestBase.assertContainsIgnoreColRefs(p1, p);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -349,7 +349,7 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
     }
 
     @Test
-    public void testExtraUnionRewrite1() {
+    public void testUnionAllRewriteWithExtraPredicates() {
         starRocksAssert.withTable(new MTable("mt1", "k1",
                         List.of(
                                 "k1 INT",
@@ -361,14 +361,11 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                         List.of(
                                 "PARTITION `p1` VALUES LESS THAN ('3')",
                                 "PARTITION `p2` VALUES LESS THAN ('6')",
-                                "PARTITION `p3` VALUES LESS THAN ('9')",
-                                "PARTITION `p4` VALUES LESS THAN ('12')",
-                                "PARTITION `p5` VALUES LESS THAN ('15')",
-                                "PARTITION `p6` VALUES LESS THAN ('18')"
+                                "PARTITION `p3` VALUES LESS THAN ('9')"
                         )
                 ),
                 () -> {
-                    cluster.runSql("test", "insert into mt1 values (1,1, 1,1), (4,2, 1,1),(8,3,1,1),(11,4,1,1);");
+                    cluster.runSql("test", "insert into mt1 values (1,1,1,1), (4,2,1,1);");
                     starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW union_mv0 " +
                             " PARTITION BY (k1) " +
                             " DISTRIBUTED BY HASH(k1) " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -399,11 +399,16 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                     {
                         List<Pair<String, String>> sqls = List.of(
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 like 'a%'",
-                                        "7:SELECT\n" +
-                                                "  |  predicates: 2: k2 LIKE 'a%'"),
+                                        "1:OlapScanNode\n" +
+                                                "     TABLE: mt1\n" +
+                                                "     PREAGGREGATION: ON\n" +
+                                                "     PREDICATES: 10: k2 LIKE 'a%'"),
+                                // TODO: remove redundant predicates
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1 != 3 and k2 like 'a%'",
-                                        "7:SELECT\n" +
-                                                "  |  predicates: 2: k2 LIKE 'a%'")
+                                        "TABLE: mt1\n" +
+                                                "     PREAGGREGATION: ON\n" +
+                                                "     PREDICATES: 9: k1 != 3, (9: k1 < 3) OR (9: k1 > 3), 10: k2 LIKE 'a%'\n" +
+                                                "     partitions=2/3")
                         );
                         for (Pair<String, String> p : sqls) {
                             String query = p.first;
@@ -420,14 +425,20 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                     {
                         List<Pair<String, String>> sqls = List.of(
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>1 and k2 like 'a%'",
-                                        "7:SELECT\n" +
-                                                "  |  predicates: 1: k1 > 1, 2: k2 LIKE 'a%'"),
+                                        "1:OlapScanNode\n" +
+                                                "     TABLE: mt1\n" +
+                                                "     PREAGGREGATION: ON\n" +
+                                                "     PREDICATES: 9: k1 > 1, (9: k1 >= 3) OR (9: k1 IS NULL), 10: k2 LIKE 'a%'"),
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>1 and k2 like 'a%'",
-                                        "7:SELECT\n" +
-                                                "  |   predicates: 2: k2 LIKE 'a%', 1: k1 > 1"),
+                                        "1:OlapScanNode\n" +
+                                                "     TABLE: mt1\n" +
+                                                "     PREAGGREGATION: ON\n" +
+                                                "     PREDICATES: 9: k1 > 1, 10: k2 LIKE 'a%', (9: k1 >= 3) OR (9: k1 IS NULL)"),
                                 Pair.create("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 like 'a%'",
-                                        "7:SELECT\n" +
-                                                "  |  predicates: 1: k1 > 0, 2: k2 LIKE 'a%'")
+                                        "1:OlapScanNode\n" +
+                                                "     TABLE: mt1\n" +
+                                                "     PREAGGREGATION: ON\n" +
+                                                "     PREDICATES: 9: k1 > 0, 10: k2 LIKE 'a%', (9: k1 >= 3) OR (9: k1 IS NULL)")
                                 );
                         QueryDebugOptions debugOptions = new QueryDebugOptions();
                         debugOptions.setEnableMVEagerUnionAllRewrite(true);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteUnionTest.java
@@ -378,6 +378,7 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                             "PARTITION START ('%s') END ('%s')", "1", "3"));
                     MaterializedView mv1 = getMv("test", "union_mv0");
                     Set<String> mvNames = mv1.getPartitionNames();
+                    System.out.println(mvNames.stream().sorted());
 
                     {
                         String[] sqls = {
@@ -386,14 +387,14 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                                 "SELECT k1,k2, v1,v2 from mt1 where k1<2",
                         };
                         for (String query : sqls) {
-                            String plan = getFragmentPlan(query, "MV");
+                            String plan = getFragmentPlan(query);
                             PlanTestBase.assertNotContains(plan, ":UNION");
                             PlanTestBase.assertContains(plan, "union_mv0");
                         }
                     }
                     {
                         String query = "SELECT k1,k2, v1,v2 from mt1 where k1<6";
-                        String plan = getFragmentPlan(query, "MV");
+                        String plan = getFragmentPlan(query);
                         PlanTestBase.assertContains(plan, ":UNION");
                         PlanTestBase.assertContains(plan, "union_mv0");
                     }
@@ -409,14 +410,14 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                         );
                         for (Pair<String, String> p : sqls) {
                             String query = p.first;
-                            String plan = getFragmentPlan(query, "MV");
+                            String plan = getFragmentPlan(query);
                             PlanTestBase.assertContains(plan, ":UNION");
-                            PlanTestBase.assertContains(plan, "union_mv0", p.second);
+                            PlanTestBase.assertContainsIgnoreColRefs(plan, "union_mv0", p.second);
                         }
                     }
                     {
                         String query = "SELECT k1,k2, v1,v2 from mt1 where k1 > 0 and k2 like 'a%'";
-                        String plan = getFragmentPlan(query, "MV");
+                        String plan = getFragmentPlan(query);
                         PlanTestBase.assertNotContains(plan, ":UNION", "union_mv0");
                     }
                     {
@@ -433,9 +434,9 @@ public class MvRewriteUnionTest extends MvRewriteTestBase {
                         connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
                         for (Pair<String, String> p : sqls) {
                             String query = p.first;
-                            String plan = getFragmentPlan(query, "MV");
+                            String plan = getFragmentPlan(query);
                             PlanTestBase.assertContains(plan, ":UNION");
-                            PlanTestBase.assertContains(plan, "union_mv0", p.second);
+                            PlanTestBase.assertContainsIgnoreColRefs(plan, "union_mv0", p.second);
                         }
                     }
                     starRocksAssert.dropMaterializedView("union_mv0");

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -135,6 +135,12 @@ public class PlanTestNoneDBBase {
         Assert.assertFalse(text, text.contains(pattern));
     }
 
+    public static void assertNotContains(String text, String... pattern) {
+        for (String s : pattern) {
+            Assert.assertFalse(text, text.contains(s));
+        }
+    }
+
     public static void setTableStatistics(OlapTable table, long rowCount) {
         for (Partition partition : table.getAllPartitions()) {
             partition.getBaseIndex().setRowCount(rowCount);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -114,11 +114,11 @@ public class PlanTestNoneDBBase {
         //  |  predicates: 2: k2 LIKE 'a%'
         // to
         //  |  predicates: $: k2 LIKE 'a%'
-        String str = s.replaceAll("\\d+:", "\\$");
+        String str = s.replaceAll("\\d+: ", "\\$ ");
         // ignore predicate order
         // |  predicates: 2: k2 LIKE 'a%' or 1: k1 > 1
         // TODO: only reorder predicates rather than the whole line.
-        return Arrays.stream(str.split(" ")).sorted().collect(Collectors.joining());
+        return Arrays.stream(StringUtils.split(str, " ,;")).sorted().collect(Collectors.joining(" "));
     }
 
     public static void assertContainsIgnoreColRefs(String text, String... pattern) {
@@ -128,7 +128,7 @@ public class PlanTestNoneDBBase {
         for (String s : pattern) {
             // If pattern contains multi lines, only check line by line.
             for (String line : s.split("\n")) {
-                String normS = ignoreColRefs(line);
+                String normS = ignoreColRefs(line).trim();
                 Assert.assertTrue(text, normT.contains(normS));
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -465,14 +465,19 @@ public class UtFrameUtils {
             Pair<ExecPlan, String> planAndTrace = Pair.create(planPair.second, "");
             return Pair.create(planPair.first, planAndTrace);
         } else {
+            Tracers.register(connectContext);
+            Tracers.init(connectContext, Tracers.Mode.LOGS, module);
             try {
-                Tracers.register(connectContext);
-                Tracers.init(connectContext, Tracers.Mode.LOGS, module);
+
                 Pair<String, ExecPlan> planPair = UtFrameUtils.getPlanAndFragment(connectContext, sql);
                 String pr = Tracers.printLogs();
                 Pair<ExecPlan, String> planAndTrace = Pair.create(planPair.second, pr);
                 return Pair.create(planPair.first, planAndTrace);
             } catch (Exception e) {
+                String pr = Tracers.printLogs();
+                if (!Strings.isNullOrEmpty(pr)) {
+                    System.out.println(pr);
+                }
                 throw e;
             } finally {
                 Tracers.close();

--- a/test/sql/test_materialized_view/R/test_materialized_view_union_all_rewrite
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union_all_rewrite
@@ -1,0 +1,77 @@
+-- name: test_materialized_view_union_all_rewrite
+CREATE TABLE `mt1` (
+ k1 INT,
+  k2 string,
+  v1 INT,
+  v2 INT
+) ENGINE=OLAP
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION `p1` VALUES LESS THAN ('3'),
+  PARTITION `p2` VALUES LESS THAN ('6'),
+  PARTITION `p3` VALUES LESS THAN ('9')
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into mt1 values (1,'a',1,1), (4,'aa',1,1);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW union_mv0 
+PARTITION BY (k1) 
+DISTRIBUTED BY HASH(k1) 
+REFRESH DEFERRED MANUAL 
+AS SELECT k1,k2, v1,v2 from mt1;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW union_mv0 PARTITION START ('1') END ('3') with sync mode;
+function: check_hit_materialized_view("select * from mt1 where k1 < 3", "union_mv0")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("select * from mt1 where k1 = 1", "union_mv0")
+-- result:
+None
+-- !result
+function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 like 'a%'", "union_mv0")
+-- result:
+None
+-- !result
+function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 like 'a%'", "union_mv0")
+-- result:
+None
+-- !result
+set query_debug_options = "{'enableMVEagerUnionAllRewrite':true}";
+-- result:
+-- !result
+function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 like 'a%'", "union_mv0")
+-- result:
+None
+-- !result
+select * from mt1 where k1 < 3 order by 1;
+-- result:
+1	a	1	1
+-- !result
+select * from mt1 where k1 = 1 order by 1;
+-- result:
+1	a	1	1
+-- !result
+select * from mt1 where k1<6 and k2  like 'a%' order by 1;
+-- result:
+1	a	1	1
+4	aa	1	1
+-- !result
+select * from mt1 where k1>0 and k2  like 'a%' order by 1;
+-- result:
+1	a	1	1
+4	aa	1	1
+-- !result
+drop table mt1;
+-- result:
+-- !result
+drop materialized view union_mv0;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_union_all_rewrite
+++ b/test/sql/test_materialized_view/T/test_materialized_view_union_all_rewrite
@@ -1,0 +1,39 @@
+-- name: test_materialized_view_union_all_rewrite
+CREATE TABLE `mt1` (
+ k1 INT,
+  k2 string,
+  v1 INT,
+  v2 INT
+) ENGINE=OLAP
+PARTITION BY RANGE(`k1`)
+(
+  PARTITION `p1` VALUES LESS THAN ('3'),
+  PARTITION `p2` VALUES LESS THAN ('6'),
+  PARTITION `p3` VALUES LESS THAN ('9')
+)
+DISTRIBUTED BY HASH(`k1`) BUCKETS 3
+PROPERTIES (
+"replication_num" = "1"
+);
+insert into mt1 values (1,'a',1,1), (4,'aa',1,1);
+CREATE MATERIALIZED VIEW union_mv0 
+PARTITION BY (k1) 
+DISTRIBUTED BY HASH(k1) 
+REFRESH DEFERRED MANUAL 
+AS SELECT k1,k2, v1,v2 from mt1;
+
+REFRESH MATERIALIZED VIEW union_mv0 PARTITION START ('1') END ('3') with sync mode;
+
+function: check_hit_materialized_view("select * from mt1 where k1 < 3", "union_mv0")
+function: check_hit_materialized_view("select * from mt1 where k1 = 1", "union_mv0")
+function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1<6 and k2 like 'a%'", "union_mv0")
+function: check_no_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 like 'a%'", "union_mv0")
+set query_debug_options = "{'enableMVEagerUnionAllRewrite':true}";
+function: check_hit_materialized_view("SELECT k1,k2, v1,v2 from mt1 where k1>0 and k2 like 'a%'", "union_mv0")
+select * from mt1 where k1 < 3 order by 1;
+select * from mt1 where k1 = 1 order by 1;
+select * from mt1 where k1<6 and k2  like 'a%' order by 1;
+select * from mt1 where k1>0 and k2  like 'a%' order by 1;
+
+drop table mt1;
+drop materialized view union_mv0;


### PR DESCRIPTION
Why I'm doing:

- PruneColumner should not ignore the original filter operator, otherwise will cause the wrong result.
- Push extra union all predicates into UnionAll Operator.

What I'm doing:
- Refactor extra union all rewrite codes.

Two cases are supported for now:
case1(default)         :  only pull up predicates that its column refs are not contained in mv's predicate
case2(eager mode): filter out predicates whose column refs are in query's output columns because we can always compensate.

case2 may cause dead-loop union all rewrite and generate some bad cases, is not visible for users by default.
```
     .filter(col -> {
                    //  pull-up extra predicates should not contain any non-(inner/cross) join on-predicates
                    if (queryOnPredicateUsedColRefs != null && queryOnPredicateUsedColRefs.contains(col)) {
                        return false;
                    }
                    return true;
                })
                .anyMatch(col -> {
                    // 1. filter out query's predicates that its column refs are not contained in mv's predicate:
                    // when column ref is not contained in mv's predicates, query's predicate cannot be rewritten.
                    // eg:
                    //    query: select dt, k1, k2 from tblA where dt >= '2023-11-01' and k2 > 1
                    //      mv : select dt, k2 from tblA where dt = '2023-11-01'
                    // we can rewrite by Union-All after rewrite as below:
                    //    query: select * from ( select dt, k1, k2 from tblA where dt >= '2023-11-01' ) t where k2 > 1
                    if (mvPredicateUsedColRefs != null && !mvPredicateUsedColRefs.contains(col)) {
                        return true;
                    }

                    // 2. filter out predicates whose column refs are in query's output columns because we can always compensate
                    // by output column using Union-All.
                    // eg:
                    //    query: select dt, k2 from tblA where date_trunc('day', dt) >= '2023-11-01'
                    //      mv : select dt, k2 from tblA where dt = '2023-11-01'
                    // NOTE: This is not supported by default because it can generate some bad cases (not the best plan):
                    // eg:
                    //    query: select dt, k2 from tblA where a < 1
                    //    mv   : select dt, k2 from tblA where a > 2
                    // this rule still can rewrite query by mv like this:
                    //    select * from (select dt, k2 from tblA) t where t.a < 1
                    // rewrite to:
                    //    select * from (select * from mv union all select dt, k2 from tblA where a <= 2 or a is null)
                    //          t where t.a < 1
                    // If you want to use this feature, you can use it by the setting:
                    //      set query_debug_options = "{'enableMVEagerUnionAllRewrite':true}";
                    if (queryOutputColumnRefs != null && queryOutputColumnRefs.contains(col)) {
                        return true;
                    }
                    return false;
```

- Add more trace logs for debugging.
- Support eager union all rewrite by using MV if possible, you can use it as below:
```
set query_debug_options = "{'enableMVEagerUnionAllRewrite':true}";
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
