### PR TITLE
[Enhancement] add consistency test for persistent index

### DIFF
--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -86,6 +86,8 @@ option(WITH_STARCACHE "Build binary with starcache library" ON)
 
 option(WITH_BENCH "Build binary with bench" OFF)
 
+option(WITH_CONSISTENCY_TEST "Build binary with consistency test" OFF)
+
 option(USE_STAROS "Use StarOS to manager tablet info" OFF)
 
 option(USE_SSE4_2 "Build with SSE4.2 instruction" ON)
@@ -1055,11 +1057,15 @@ add_subdirectory(${SRC_DIR}/block_cache)
 add_subdirectory(${SRC_DIR}/tools)
 add_subdirectory(${SRC_DIR}/util)
 add_subdirectory(${SRC_DIR}/script)
-add_subdirectory(${SRC_DIR}/consistency_test)
 
 if (WITH_BENCH STREQUAL "ON")
      message(STATUS "Build binary with bench")
     add_subdirectory(${SRC_DIR}/bench)
+endif()
+
+if (WITH_CONSISTENCY_TEST STREQUAL "ON")
+    message(STATUS "Build binary with consistency test")
+    add_subdirectory(${SRC_DIR}/consistency_test)
 endif()
 
 if (${MAKE_TEST} STREQUAL "ON")

--- a/be/CMakeLists.txt
+++ b/be/CMakeLists.txt
@@ -1055,6 +1055,7 @@ add_subdirectory(${SRC_DIR}/block_cache)
 add_subdirectory(${SRC_DIR}/tools)
 add_subdirectory(${SRC_DIR}/util)
 add_subdirectory(${SRC_DIR}/script)
+add_subdirectory(${SRC_DIR}/consistency_test)
 
 if (WITH_BENCH STREQUAL "ON")
      message(STATUS "Build binary with bench")

--- a/be/src/consistency_test/CMakeLists.txt
+++ b/be/src/consistency_test/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (CLANG_TIDY_PATH)
+    set(CMAKE_CXX_CLANG_TIDY "${CLANG_TIDY_PATH}")
+endif()
+
+ADD_BE_BENCH(${SRC_DIR}/consistency_test/persistent_index_consistency_test)

--- a/be/src/consistency_test/persistent_index_consistency_test.cpp
+++ b/be/src/consistency_test/persistent_index_consistency_test.cpp
@@ -1,0 +1,524 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gflags/gflags.h>
+
+#include <cassert>
+#include <cstdlib>
+#include <random>
+
+#include "fs/fs_memory.h"
+#include "fs/fs_util.h"
+#include "storage/chunk_helper.h"
+#include "storage/persistent_index.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset_update_state.h"
+#include "storage/storage_engine.h"
+#include "storage/tablet_manager.h"
+#include "storage/update_manager.h"
+#include "testutil/assert.h"
+#include "testutil/parallel_test.h"
+#include "util/coding.h"
+#include "util/faststring.h"
+
+DEFINE_bool(debug, false, "debug mode");
+DEFINE_int64(seed, -1, "random seed");
+DEFINE_int64(second, 60, "custom run second");
+DEFINE_bool(fixlen, false, "fix len or not");
+
+namespace starrocks {
+
+#define ASSERT_CHECK(stmt)      \
+    do {                        \
+        Status st__ = stmt;     \
+        if (!st__.ok()) {       \
+            LOG(FATAL) << st__; \
+        }                       \
+    } while (0)
+
+enum PICT_OP {
+    UPSERT = 0,
+    ERASE = 1,
+    GET = 2,
+    MAJOR_COMPACT = 3,
+    REPLACE = 4,
+    RELOAD = 5,
+    MAX = 6,
+};
+
+struct TestParams {
+    int64_t max_number = 0;
+    int64_t max_n = 0;
+    size_t run_second = 0;
+    bool is_fixed_key_sz = false;
+    bool print_debug_info = false;
+};
+
+// There are several random val we need to generate:
+// 1. op type
+// 2. Batch entry count
+// 3. Keys and Values
+template <typename T>
+class DeterRandomGenerator {
+public:
+    DeterRandomGenerator(const TestParams& params, int seed, int64_t s, int64_t e)
+            : _params(params), _rng(seed), _distribution(s, e) {}
+    ~DeterRandomGenerator() = default;
+
+    int64_t random() { return _distribution(_rng); }
+
+    PICT_OP random_op() { return static_cast<PICT_OP>(random() % PICT_OP::MAX); }
+
+    int64_t random_n() { return (random() % _params.max_n) + 1; }
+
+    int64_t random_number(std::set<int64_t>& filter) {
+        int64_t r = 0;
+        do {
+            r = random() % _params.max_number;
+        } while (filter.count(r) > 0);
+        filter.insert(r);
+        return r;
+    }
+
+    int64_t random_number() { return random() % _params.max_number; }
+
+    // Template specialization for std::string
+    template <typename U = T>
+    typename std::enable_if<std::is_same<U, std::string>::value>::type assign_value(T& key, Slice& key_slice,
+                                                                                    std::set<int64_t>& filter) {
+        key = fmt::format("{:016x}", random_number(filter));
+        key_slice = key;
+    }
+
+    // Template specialization for integer
+    template <typename U = T>
+    typename std::enable_if<std::is_integral<U>::value>::type assign_value(T& key, Slice& key_slice,
+                                                                           std::set<int64_t>& filter) {
+        key = random_number(filter);
+        key_slice = Slice((uint8_t*)(&key), sizeof(T));
+    }
+
+    // vector<T> keys(N);
+    // vector<IndexValue> values(N);
+    void random_keys_values(int64_t N, vector<T>* keys, vector<Slice>* key_slices, vector<IndexValue>* values) {
+        keys->resize(N);
+        key_slices->resize(N);
+        if (values != nullptr) values->resize(N);
+        std::set<int64_t> filter;
+        for (int i = 0; i < N; i++) {
+            assign_value((*keys)[i], (*key_slices)[i], filter);
+            if (values != nullptr) (*values)[i] = random_number();
+        }
+    }
+
+private:
+    TestParams _params;
+    std::mt19937 _rng;
+    std::uniform_int_distribution<int64_t> _distribution;
+};
+
+template <typename T>
+class PersistentIndexWrapper {
+public:
+    PersistentIndexWrapper() {
+        FileSystem* fs = FileSystem::Default();
+        _index_dir = "./PersistentIndexConsistencyTest";
+        _db_dir = "./PersistentIndexConsistencyTest_db";
+        (void)fs::remove_all(_index_dir);
+        (void)fs::remove_all(_db_dir);
+        const std::string kIndexFile = "./PersistentIndexConsistencyTest/index.l0.0.0";
+        bool created;
+        ASSERT_CHECK(fs->create_dir_if_missing(_index_dir, &created));
+        ASSERT_CHECK(fs->create_dir_if_missing(_db_dir, &created));
+        _kv_store = std::make_unique<KVStore>(_db_dir);
+        ASSERT_CHECK(_kv_store->init());
+        {
+            ASSIGN_OR_ABORT(auto wfile, FileSystem::Default()->new_writable_file(kIndexFile));
+            ASSERT_CHECK(wfile->close());
+        }
+
+        // build index
+        EditVersion version(_cur_version, 0);
+        if (std::is_same<T, std::string>::value) {
+            _index_meta.set_key_size(0);
+        } else {
+            _index_meta.set_key_size(sizeof(T));
+        }
+        _index_meta.set_size(0);
+        version.to_pb(_index_meta.mutable_version());
+        MutableIndexMetaPB* l0_meta = _index_meta.mutable_l0_meta();
+        l0_meta->set_format_version(PERSISTENT_INDEX_VERSION_4);
+        IndexSnapshotMetaPB* snapshot_meta = l0_meta->mutable_snapshot();
+        version.to_pb(snapshot_meta->mutable_version());
+        _index = std::make_unique<PersistentIndex>(_index_dir);
+        ASSERT_CHECK(_index->load(_index_meta));
+    }
+
+    ~PersistentIndexWrapper() {
+        (void)fs::remove_all(_index_dir);
+        (void)fs::remove_all(_db_dir);
+    }
+
+    Status reload_index() {
+        _index = std::make_unique<PersistentIndex>(_index_dir);
+        return _index->load(_index_meta);
+    }
+
+    PersistentIndexMetaPB _index_meta;
+    std::string _index_dir;
+    std::string _db_dir;
+    int64_t _cur_version = 0;
+    std::unique_ptr<PersistentIndex> _index;
+    std::unique_ptr<KVStore> _kv_store;
+};
+
+template <typename T>
+class Replayer {
+public:
+    Replayer(bool print_debug_info) : _print_debug_info(print_debug_info) {}
+    void upsert(int64_t N, const vector<T>& keys, const vector<IndexValue>& values,
+                std::vector<IndexValue>* old_values) {
+        for (int i = 0; i < N; i++) {
+            auto result = _replayer_index.insert(std::make_pair(keys[i], values[i]));
+            if (result.second) {
+                // success
+                (*old_values)[i] = IndexValue(NullIndexValue);
+            } else {
+                (*old_values)[i] = result.first->second;
+                // cover it
+                result.first->second = values[i];
+            }
+            if (_print_debug_info) {
+                LOG(INFO) << "upsert: index: " << i << " key: " << keys[i] << " value: " << values[i].get_value();
+            }
+        }
+        LOG(INFO) << "Replayer [Upsert] sequence: " << _seq_no++;
+    }
+
+    void erase(int64_t N, const vector<T>& keys, std::vector<IndexValue>* old_values) {
+        for (int i = 0; i < N; i++) {
+            auto it = _replayer_index.find(keys[i]);
+            if (it != _replayer_index.end()) {
+                // erase and set old value
+                (*old_values)[i] = it->second;
+                _replayer_index.erase(it);
+            } else {
+                (*old_values)[i] = IndexValue(NullIndexValue);
+            }
+            if (_print_debug_info) {
+                LOG(INFO) << "erase: index: " << i << " key: " << keys[i];
+            }
+        }
+        LOG(INFO) << "Replayer [Erase] sequence: " << _seq_no++;
+    }
+
+    void get(int64_t N, const vector<T>& keys, std::vector<IndexValue>* old_values) {
+        for (int i = 0; i < N; i++) {
+            auto it = _replayer_index.find(keys[i]);
+            if (it != _replayer_index.end()) {
+                (*old_values)[i] = it->second;
+            } else {
+                (*old_values)[i] = IndexValue(NullIndexValue);
+            }
+            if (_print_debug_info) {
+                LOG(INFO) << "get: index: " << i << " key: " << keys[i] << " value: " << (*old_values)[i].get_value();
+            }
+        }
+        LOG(INFO) << "Replayer [Get] sequence: " << _seq_no++;
+    }
+
+    void try_replace(int64_t N, const vector<T>& keys, const vector<IndexValue>& values,
+                     std::vector<uint32_t>* failed) {
+        for (int i = 0; i < N; i++) {
+            auto it = _replayer_index.find(keys[i]);
+            if (it != _replayer_index.end()) {
+                // cover it
+                it->second = values[i];
+            } else {
+                failed->emplace_back(values[i].get_value() & 0xFFFFFFFF);
+            }
+            if (_print_debug_info) {
+                LOG(INFO) << "try_replace: index: " << i << " key: " << keys[i] << " value: " << values[i].get_value();
+            }
+        }
+        LOG(INFO) << "Replayer [TryReplace] sequence: " << _seq_no++;
+    }
+
+private:
+    std::map<T, IndexValue> _replayer_index;
+    uint64_t _seq_no = 0;
+    bool _print_debug_info = false;
+};
+
+class Checker {
+public:
+    Checker(int seed) : _seed(seed) {}
+    ~Checker() = default;
+
+    void check(const vector<IndexValue>& current, const vector<IndexValue>& expected) {
+        if (current.size() != expected.size()) {
+            LOG(FATAL) << "current size: " << current.size() << " expected size: " << expected.size()
+                       << " seed: " << _seed;
+        }
+        for (int i = 0; i < current.size(); i++) {
+            if (current[i] != expected[i]) {
+                LOG(FATAL) << "index: " << i << " current : " << current[i].get_value()
+                           << " expected : " << expected[i].get_value() << " seed: " << _seed;
+            }
+        }
+    }
+    void check(const vector<uint32_t>& current, const vector<uint32_t>& expected) {
+        if (current.size() != expected.size()) {
+            LOG(FATAL) << "current size: " << current.size() << " expected size: " << expected.size()
+                       << " seed: " << _seed;
+        }
+        for (int i = 0; i < current.size(); i++) {
+            if (current[i] != expected[i]) {
+                LOG(FATAL) << "index: " << i << " current : " << current[i] << " expected : " << expected[i]
+                           << " seed: " << _seed;
+            }
+        }
+    }
+
+private:
+    int _seed = 0;
+};
+
+template <typename T>
+class PictOpBase {
+public:
+    virtual ~PictOpBase() = 0;
+    virtual Status run(DeterRandomGenerator<T>* rand, PersistentIndexWrapper<T>* index, Replayer<T>* replayer,
+                       Checker* checker) = 0;
+};
+
+template <typename T>
+PictOpBase<T>::~PictOpBase() = default;
+
+template <typename T>
+class PictOpUpsert : public PictOpBase<T> {
+public:
+    Status run(DeterRandomGenerator<T>* rand, PersistentIndexWrapper<T>* index, Replayer<T>* replayer,
+               Checker* checker) override {
+        index->_cur_version++;
+        IOStat stat;
+        int64_t N = rand->random_n();
+
+        vector<T> keys;
+        vector<Slice> key_slices;
+        vector<IndexValue> values;
+        rand->random_keys_values(N, &keys, &key_slices, &values);
+        std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
+        ASSERT_CHECK(index->_index->prepare(EditVersion(index->_cur_version, 0), N));
+        ASSERT_CHECK(index->_index->upsert(N, key_slices.data(), values.data(), old_values.data(), &stat));
+        ASSERT_CHECK(index->_index->commit(&(index->_index_meta), &stat));
+        ASSERT_CHECK(index->_index->on_commited());
+        std::vector<IndexValue> expected_old_values(N, IndexValue(NullIndexValue));
+        replayer->upsert(N, keys, values, &expected_old_values);
+        checker->check(old_values, expected_old_values);
+        return Status::OK();
+    }
+};
+
+template <typename T>
+class PictOpErase : public PictOpBase<T> {
+public:
+    Status run(DeterRandomGenerator<T>* rand, PersistentIndexWrapper<T>* index, Replayer<T>* replayer,
+               Checker* checker) override {
+        index->_cur_version++;
+        IOStat stat;
+        int64_t N = rand->random_n();
+
+        vector<T> keys;
+        vector<Slice> key_slices;
+        rand->random_keys_values(N, &keys, &key_slices, nullptr);
+        std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
+        ASSERT_CHECK(index->_index->prepare(EditVersion(index->_cur_version, 0), N));
+        ASSERT_CHECK(index->_index->erase(N, key_slices.data(), old_values.data()));
+        ASSERT_CHECK(index->_index->commit(&(index->_index_meta), &stat));
+        ASSERT_CHECK(index->_index->on_commited());
+        std::vector<IndexValue> expected_old_values(N, IndexValue(NullIndexValue));
+        replayer->erase(N, keys, &expected_old_values);
+        checker->check(old_values, expected_old_values);
+        return Status::OK();
+    }
+};
+
+template <typename T>
+class PictOpGet : public PictOpBase<T> {
+public:
+    Status run(DeterRandomGenerator<T>* rand, PersistentIndexWrapper<T>* index, Replayer<T>* replayer,
+               Checker* checker) override {
+        int64_t N = rand->random_n();
+
+        vector<T> keys;
+        vector<Slice> key_slices;
+        rand->random_keys_values(N, &keys, &key_slices, nullptr);
+        std::vector<IndexValue> old_values(N, IndexValue(NullIndexValue));
+        ASSERT_CHECK(index->_index->get(N, key_slices.data(), old_values.data()));
+        std::vector<IndexValue> expected_old_values(N, IndexValue(NullIndexValue));
+        replayer->get(N, keys, &expected_old_values);
+        checker->check(old_values, expected_old_values);
+        return Status::OK();
+    }
+};
+
+template <typename T>
+class PictOpMajorCompact : public PictOpBase<T> {
+public:
+    Status run(DeterRandomGenerator<T>* rand, PersistentIndexWrapper<T>* index, Replayer<T>* replayer,
+               Checker* checker) override {
+        return index->_index->TEST_major_compaction(index->_index_meta);
+    }
+};
+
+template <typename T>
+class PictOpReplace : public PictOpBase<T> {
+public:
+    Status run(DeterRandomGenerator<T>* rand, PersistentIndexWrapper<T>* index, Replayer<T>* replayer,
+               Checker* checker) override {
+        index->_cur_version++;
+        IOStat stat;
+        int64_t N = rand->random_n();
+
+        vector<T> keys;
+        vector<Slice> key_slices;
+        vector<IndexValue> values;
+        rand->random_keys_values(N, &keys, &key_slices, &values);
+        std::vector<uint32_t> failed;
+        ASSERT_CHECK(index->_index->prepare(EditVersion(index->_cur_version, 0), N));
+        ASSERT_CHECK(index->_index->try_replace(N, key_slices.data(), values.data(), UINT32_MAX, &failed));
+        ASSERT_CHECK(index->_index->commit(&(index->_index_meta), &stat));
+        ASSERT_CHECK(index->_index->on_commited());
+        std::vector<uint32_t> expected_failed;
+        replayer->try_replace(N, keys, values, &expected_failed);
+        checker->check(failed, expected_failed);
+        return Status::OK();
+    }
+};
+
+template <typename T>
+class PictOpReload : public PictOpBase<T> {
+public:
+    Status run(DeterRandomGenerator<T>* rand, PersistentIndexWrapper<T>* index, Replayer<T>* replayer,
+               Checker* checker) override {
+        return index->reload_index();
+    }
+};
+
+template <typename T>
+class PersistentIndexConsistencyTest {
+public:
+    PersistentIndexConsistencyTest(const TestParams& params, int seed) {
+        _params = params;
+        _rand = std::make_unique<DeterRandomGenerator<T>>(params, seed, 0, INT64_MAX);
+        _index_wrapper = std::make_unique<PersistentIndexWrapper<T>>();
+        _replayer = std::make_unique<Replayer<T>>(params.print_debug_info);
+        _checker = std::make_unique<Checker>(seed);
+    }
+
+    ~PersistentIndexConsistencyTest() = default;
+
+    void init() {
+        // 5% of whole data
+        config::l0_max_mem_usage = _params.max_number * 16 * 5 / 100;
+        config::l0_l1_merge_ratio = 10;
+        config::l0_max_file_size = 209715200;
+        config::l0_snapshot_size = 16777216;
+        config::max_tmp_l1_num = 10;
+        config::enable_parallel_get_and_bf = false;
+        config::enable_pindex_minor_compaction = true;
+        config::max_allow_pindex_l2_num = 5;
+        config::pindex_major_compaction_num_threads = 2;
+        config::sync_tablet_meta = true;
+        config::enable_pindex_filter = true;
+        config::enable_pindex_compression = true;
+    }
+
+    void run() {
+        size_t start_second = time(nullptr);
+        do {
+            std::unique_ptr<PictOpBase<T>> op = generate_op();
+            ASSERT_CHECK(op->run(_rand.get(), _index_wrapper.get(), _replayer.get(), _checker.get()));
+        } while (start_second + _params.run_second >= time(nullptr));
+    }
+
+    std::unique_ptr<PictOpBase<T>> generate_op() {
+        PICT_OP op = _rand->random_op();
+        if (op == UPSERT) {
+            return std::make_unique<PictOpUpsert<T>>();
+        } else if (op == ERASE) {
+            return std::make_unique<PictOpErase<T>>();
+        } else if (op == GET) {
+            return std::make_unique<PictOpGet<T>>();
+        } else if (op == MAJOR_COMPACT) {
+            return std::make_unique<PictOpMajorCompact<T>>();
+        } else if (op == REPLACE) {
+            return std::make_unique<PictOpReplace<T>>();
+        } else if (op == RELOAD) {
+            return std::make_unique<PictOpReload<T>>();
+        }
+        return nullptr;
+    }
+
+private:
+    TestParams _params;
+    std::unique_ptr<DeterRandomGenerator<T>> _rand;
+    std::unique_ptr<PersistentIndexWrapper<T>> _index_wrapper;
+    std::unique_ptr<Replayer<T>> _replayer;
+    std::unique_ptr<Checker> _checker;
+};
+
+} // namespace starrocks
+
+static void test_func(int64_t max_number, int64_t max_n, size_t run_second, int seed, bool is_fixed_size) {
+    starrocks::TestParams params;
+    params.max_number = max_number;
+    params.max_n = max_n;
+    params.run_second = run_second;
+    params.print_debug_info = FLAGS_debug;
+    if (is_fixed_size) {
+        // fixed size
+        starrocks::PersistentIndexConsistencyTest<uint64_t> pict(params, seed);
+        pict.init();
+        pict.run();
+    } else {
+        starrocks::PersistentIndexConsistencyTest<std::string> pict(params, seed);
+        pict.init();
+        pict.run();
+    }
+}
+
+int main(int argc, char** argv) {
+    gflags::ParseCommandLineFlags(&argc, &argv, true);
+    if (FLAGS_seed == -1) {
+        // Total cost 10min
+        for (int i = 1; i <= 5; i++) {
+            int seed = time(nullptr);
+            test_func(1000000, 10000, 60, seed, true);
+        }
+        for (int i = 1; i <= 5; i++) {
+            int seed = time(nullptr);
+            test_func(1000000, 10000, 60, seed, false);
+        }
+    } else {
+        // custom run by specific seed
+        test_func(1000000, 10000, FLAGS_second, FLAGS_seed, FLAGS_fixlen);
+    }
+    gflags::ShutDownCommandLineFlags();
+    return 0;
+}

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -1042,10 +1042,6 @@ public:
             if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
                 _total_kv_pairs_usage += composite_key.size();
-                if (659248 == value.get_value()) {
-                    LOG(INFO) << "upsert 659248 new "
-                              << " " << this;
-                }
             } else {
                 const auto& old_compose_key = *it;
                 auto old_value = UNALIGNED_LOAD64(old_compose_key.data() + old_compose_key.size() - kIndexValueSize);
@@ -1053,10 +1049,6 @@ public:
                 nfound += old_value != NullIndexValue;
                 _set.erase(it);
                 _set.emplace_with_hash(hash, composite_key);
-                if (659248 == value.get_value()) {
-                    LOG(INFO) << "upsert 659248 old "
-                              << " " << this;
-                }
             }
         }
         *num_found = nfound;
@@ -1077,10 +1069,6 @@ public:
             if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
                 _total_kv_pairs_usage += composite_key.size();
-                if (659248 == value.get_value()) {
-                    LOG(INFO) << "upsert 659248 new "
-                              << " " << this;
-                }
             } else {
                 const auto& old_compose_key = *it;
                 const auto old_value =
@@ -1089,10 +1077,6 @@ public:
                 // TODO: find a way to modify iterator directly, currently just erase then re-insert
                 _set.erase(it);
                 _set.emplace_with_hash(hash, composite_key);
-                if (659248 == value.get_value()) {
-                    LOG(INFO) << "upsert 659248 old "
-                              << " " << this;
-                }
             }
         }
         *num_found = nfound;
@@ -1135,18 +1119,11 @@ public:
                 old_values[idx] = NullIndexValue;
                 not_found->key_infos.emplace_back((uint32_t)idx, hash);
                 _total_kv_pairs_usage += composite_key.size();
-                if (659248 == old_values[idx].get_value()) {
-                    LOG(INFO) << "erase 659248: not found. " << this;
-                }
             } else {
                 auto& old_compose_key = *it;
                 auto old_value = UNALIGNED_LOAD64(old_compose_key.data() + old_compose_key.size() - kIndexValueSize);
                 old_values[idx] = old_value;
                 nfound += old_value != NullIndexValue;
-                if (659248 == old_value) {
-                    LOG(INFO) << "erase 659248: found: "
-                              << " " << this;
-                }
                 // TODO: find a way to modify iterator directly, currently just erase then re-insert
                 _set.erase(it);
                 _set.emplace_with_hash(hash, composite_key);

--- a/build.sh
+++ b/build.sh
@@ -90,6 +90,7 @@ Usage: $0 <options>
      --with-gcov        build Backend with gcov, has an impact on performance
      --without-gcov     build Backend without gcov(default)
      --with-bench       build Backend with bench(default without bench)
+     --with-consistency-test  build Backend with consistency test(default without consistency test)
      --with-clang-tidy  build Backend with clang-tidy(default without clang-tidy)
      --without-java-ext build Backend without java-extensions(default with java-extensions)
      -j                 build Backend parallel
@@ -117,6 +118,7 @@ OPTS=$(getopt \
   -l 'clean' \
   -l 'with-gcov' \
   -l 'with-bench' \
+  -l 'with-consistency-test' \
   -l 'with-clang-tidy' \
   -l 'without-gcov' \
   -l 'without-java-ext' \
@@ -140,6 +142,7 @@ CLEAN=
 RUN_UT=
 WITH_GCOV=OFF
 WITH_BENCH=OFF
+WITH_CONSISTENCY_TEST=OFF
 WITH_CLANG_TIDY=OFF
 USE_STAROS=OFF
 BUILD_JAVA_EXT=ON
@@ -233,6 +236,7 @@ else
             --without-gcov) WITH_GCOV=OFF; shift ;;
             --enable-shared-data|--use-staros) USE_STAROS=ON; shift ;;
             --with-bench) WITH_BENCH=ON; shift ;;
+            --with-consistency-test) WITH_CONSISTENCY_TEST=ON; shift ;;
             --with-clang-tidy) WITH_CLANG_TIDY=ON; shift ;;
             --without-java-ext) BUILD_JAVA_EXT=OFF; shift ;;
             -h) HELP=1; shift ;;
@@ -264,6 +268,7 @@ echo "Get params:
     RUN_UT              -- $RUN_UT
     WITH_GCOV           -- $WITH_GCOV
     WITH_BENCH          -- $WITH_BENCH
+    WITH_CONSISTENCY_TEST -- $WITH_CONSISTENCY_TEST
     WITH_CLANG_TIDY     -- $WITH_CLANG_TIDY
     ENABLE_SHARED_DATA  -- $USE_STAROS
     USE_AVX2            -- $USE_AVX2
@@ -367,6 +372,7 @@ if [ ${BUILD_BE} -eq 1 ] ; then
                   -DJEMALLOC_DEBUG=$JEMALLOC_DEBUG  \
                   -DENABLE_QUERY_DEBUG_TRACE=$ENABLE_QUERY_DEBUG_TRACE  \
                   -DWITH_BENCH=${WITH_BENCH}                            \
+                  -DWITH_CONSISTENCY_TEST=${WITH_CONSISTENCY_TEST}                       \
                   -DWITH_CLANG_TIDY=${WITH_CLANG_TIDY}                  \
                   -DWITH_COMPRESS=${WITH_COMPRESS}                      \
                   -DWITH_CACHELIB=${WITH_CACHELIB}                      \


### PR DESCRIPTION
Why I'm doing:
Persistent index is crucial for primary key table now, if it contains consistency bug, and when it shows up, there will be a data inconsistency error.

What I'm doing:
I borrowed the strategy from deterministic simulation, and add consistency test for persistent index, we generate a serial deterministic random random to check persistent index's consistency. If bug happen, we can reproduce this bug easily through same random seed.

The code contains three parts:

1. `DeterRandomGenerator`. Used to generate a sequence of deterministic random numbers.
2. `Replayer`. Based on `std::map`, and re-implement the PersistentIndex interface
3. `Checker`. Compares the results of PersistentIndex with the output of `Replayer`.

How to build it:
```
./build.sh --be --with-consistency-test
```

How to run it:

1. Run random seed test:
```
LD_LIBRARY_PATH=./output/be/lib/ ./be/build_Release/src/consistency_test/output/persistent_index_consistency_test
```
2. Run specific seed test:
```
LD_LIBRARY_PATH=./output/be/lib/ ./be/build_Release/src/consistency_test/output/persistent_index_consistency_test --seed [seed]
```
3. You can also custom run seconds and whether test fixed length key:
```
LD_LIBRARY_PATH=./output/be/lib/ ./be/build_Release/src/consistency_test/output/persistent_index_consistency_test --seed [seed] --second [run second] --fixlen [true or false] 
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
