### PR TITLE
[BugFix] remove the useless ConnectContext.remove in RefreshDictionaryCacheTaskDaemon(#37101)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RefreshDictionaryCacheTaskDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RefreshDictionaryCacheTaskDaemon.java
@@ -15,7 +15,6 @@
 package com.starrocks.catalog;
 
 import com.starrocks.common.util.FrontendDaemon;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
 
 public class RefreshDictionaryCacheTaskDaemon extends FrontendDaemon {
@@ -28,6 +27,5 @@ public class RefreshDictionaryCacheTaskDaemon extends FrontendDaemon {
     @Override
     protected void runAfterCatalogReady() {
         GlobalStateMgr.getCurrentState().getDictionaryMgr().scheduleTasks();
-        ConnectContext.remove();
     }
 }


### PR DESCRIPTION
Why I'm doing:
RefreshDictionaryCacheTaskDaemon is a thread pool to submit the dictionary cache refresh task into another executor thread pool. It is no need to reset ConnectContext threadlocal at all.

What I'm doing:
remove the ConnectContext.remove() in RefreshDictionaryCacheTaskDaemon

Fixes #37101

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
