### PR TITLE
[Enhancement] BitmapValue support set type

### DIFF
--- a/fe/plugin-common/src/main/java/com/starrocks/types/BitmapValue.java
+++ b/fe/plugin-common/src/main/java/com/starrocks/types/BitmapValue.java
@@ -103,7 +103,7 @@ public class BitmapValue {
         } catch (IOException e) {
             throw new IOException("Error serializing bitmap: ", e);
         } finally {
-            outputStream.close();;
+            outputStream.close();
         }
 
         try (DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()))) {
@@ -334,13 +334,13 @@ public class BitmapValue {
                         convertBitmapToSmallerType();
                         break;
                     case SET_VALUE:
-                        Set<Long> new_set = new HashSet<>();
+                        Set<Long> newSet = new HashSet<>();
                         for (Long v : set) {
                             if (other.bitmap.contains(v)) {
-                                new_set.add(v);
+                                newSet.add(v);
                             }
                         }
-                        set = new_set;
+                        set = newSet;
                         break;
                 }
                 break;
@@ -354,24 +354,24 @@ public class BitmapValue {
                         }
                         break;
                     case BITMAP_VALUE: {
-                        Set<Long> new_set = new HashSet<>();
+                        Set<Long> newSet = new HashSet<>();
                         for (Long v : other.set) {
                             if (this.bitmap.contains(v)) {
-                                new_set.add(v);
+                                newSet.add(v);
                             }
                         }
-                        set = new_set;
+                        set = newSet;
                         bitmapType = SET_VALUE;
                         break;
                     }
                     case SET_VALUE: {
-                        Set<Long> new_set = new HashSet<>();
+                        Set<Long> newSet = new HashSet<>();
                         for (Long v : other.set) {
                             if (this.set.contains(v)) {
-                                new_set.add(v);
+                                newSet.add(v);
                             }
                         }
-                        set = new_set;
+                        set = newSet;
                         break;
                     }
                 }

--- a/fe/plugin-common/src/main/java/com/starrocks/types/BitmapValue.java
+++ b/fe/plugin-common/src/main/java/com/starrocks/types/BitmapValue.java
@@ -29,6 +29,8 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * starrocks's own java version bitmap
@@ -45,15 +47,18 @@ public class BitmapValue {
     public static final int BITMAP32 = 2;
     public static final int SINGLE64 = 3;
     public static final int BITMAP64 = 4;
+    public static final int SET = 10;
 
     public static final int SINGLE_VALUE = 1;
     public static final int BITMAP_VALUE = 2;
+    public static final int SET_VALUE = 3;
 
     public static final long UNSIGNED_32BIT_INT_MAX_VALUE = 4294967295L;
 
     private int bitmapType;
     private long singleValue;
     private Roaring64Map bitmap;
+    private Set<Long> set;
 
     // for single value serialize and deserialize
     private final ByteBuffer buffer;
@@ -64,6 +69,48 @@ public class BitmapValue {
         buffer = ByteBuffer.allocate(8);
         // be deserializes by little endian
         buffer.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    public BitmapValue(long v) {
+        bitmapType = SINGLE_VALUE;
+        singleValue = v;
+
+        buffer = ByteBuffer.allocate(8);
+        // be deserializes by little endian
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    public BitmapValue(long start, long end) {
+        bitmapType = EMPTY;
+        buffer = ByteBuffer.allocate(8);
+        // be deserializes by little endian
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+
+        for (long i = start; i < end; i++) {
+            add(i);
+        }
+    }
+
+    public BitmapValue(BitmapValue other) throws IOException {
+        buffer = ByteBuffer.allocate(8);
+        // be deserializes by little endian
+        buffer.order(ByteOrder.LITTLE_ENDIAN);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        try {
+            DataOutput output = new DataOutputStream(outputStream);
+            other.serialize(output);
+        } catch (IOException e) {
+            throw new IOException("Error serializing bitmap: ", e);
+        } finally {
+            outputStream.close();;
+        }
+
+        try (DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()))) {
+            deserialize(inputStream);
+        } catch (IOException e) {
+            throw new IOException("Error deserializing bitmap: ", e);
+        }
     }
 
     public static byte[] bitmapToBytes(BitmapValue bitmap) throws IOException {
@@ -98,16 +145,33 @@ public class BitmapValue {
                 break;
             case SINGLE_VALUE:
                 if (this.singleValue != value) {
-                    bitmap = new Roaring64Map();
-                    bitmap.add(value);
-                    bitmap.add(singleValue);
-                    bitmapType = BITMAP_VALUE;
+                    set = new HashSet<>();
+                    set.add(value);
+                    set.add(singleValue);
+                    bitmapType = SET_VALUE;
                 }
                 break;
             case BITMAP_VALUE:
                 bitmap.addLong(value);
                 break;
+            case SET_VALUE:
+                if (set.size() < 32) {
+                    set.add(value);
+                } else {
+                    fromSetToBitmap();
+                    bitmap.add(value);
+                }
+                break;
         }
+    }
+
+    private void fromSetToBitmap() {
+        bitmap = new Roaring64Map();
+        for (Long v : set) {
+            bitmap.add(v);
+        }
+        set = null;
+        bitmapType = BITMAP_VALUE;
     }
 
     public boolean contains(int value) {
@@ -116,13 +180,14 @@ public class BitmapValue {
 
     public boolean contains(long value) {
         switch (bitmapType) {
-            case EMPTY:
-                return false;
             case SINGLE_VALUE:
                 return singleValue == value;
             case BITMAP_VALUE:
                 return bitmap.contains(value);
+            case SET_VALUE:
+                return set.contains(value);
             default:
+                // EMPTY
                 return false;
         }
     }
@@ -135,6 +200,8 @@ public class BitmapValue {
                 return 1;
             case BITMAP_VALUE:
                 return bitmap.getLongCardinality();
+            case SET_VALUE:
+                return set.size();
         }
         return 0;
     }
@@ -160,6 +227,14 @@ public class BitmapValue {
             case BITMAP_VALUE:
                 bitmap.serialize(output);
                 break;
+            case SET_VALUE: {
+                output.writeByte(SET);
+                output.writeInt(Integer.reverseBytes(set.size()));
+                for (Long v : set) {
+                    output.writeLong(Long.reverseBytes(v));
+                }
+                break;
+            }
         }
     }
 
@@ -194,6 +269,17 @@ public class BitmapValue {
                 bitmap.deserialize(input, bitmapType);
                 this.bitmapType = BITMAP_VALUE;
                 break;
+            case SET:
+                if (set == null) {
+                    set = new HashSet<>();
+                }
+                int size = Integer.reverseBytes(input.readInt());
+                for (int i = 0; i < size; i++) {
+                    Long v = Long.reverseBytes(input.readLong());
+                    set.add(v);
+                }
+                this.bitmapType = SET_VALUE;
+                break;
             default:
                 throw new RuntimeException(String.format("unknown bitmap type %s ", bitmapType));
         }
@@ -223,6 +309,15 @@ public class BitmapValue {
                             this.bitmapType = SINGLE_VALUE;
                         }
                         break;
+                    case SET_VALUE:
+                        if (!this.set.contains(other.singleValue)) {
+                            clear();
+                        } else {
+                            clear();
+                            this.singleValue = other.singleValue;
+                            this.bitmapType = SINGLE_VALUE;
+                        }
+                        break;
                 }
                 break;
             case BITMAP_VALUE:
@@ -236,8 +331,49 @@ public class BitmapValue {
                         break;
                     case BITMAP_VALUE:
                         this.bitmap.and(other.bitmap);
-                        convertToSmallerType();
+                        convertBitmapToSmallerType();
                         break;
+                    case SET_VALUE:
+                        Set<Long> new_set = new HashSet<>();
+                        for (Long v : set) {
+                            if (other.bitmap.contains(v)) {
+                                new_set.add(v);
+                            }
+                        }
+                        set = new_set;
+                        break;
+                }
+                break;
+            case SET_VALUE:
+                switch (this.bitmapType) {
+                    case EMPTY:
+                        break;
+                    case SINGLE_VALUE:
+                        if (!other.set.contains(this.singleValue)) {
+                            clear();
+                        }
+                        break;
+                    case BITMAP_VALUE: {
+                        Set<Long> new_set = new HashSet<>();
+                        for (Long v : other.set) {
+                            if (this.bitmap.contains(v)) {
+                                new_set.add(v);
+                            }
+                        }
+                        set = new_set;
+                        bitmapType = SET_VALUE;
+                        break;
+                    }
+                    case SET_VALUE: {
+                        Set<Long> new_set = new HashSet<>();
+                        for (Long v : other.set) {
+                            if (this.set.contains(v)) {
+                                new_set.add(v);
+                            }
+                        }
+                        set = new_set;
+                        break;
+                    }
                 }
                 break;
         }
@@ -254,17 +390,62 @@ public class BitmapValue {
             case BITMAP_VALUE:
                 switch (this.bitmapType) {
                     case EMPTY:
-                        this.bitmap = other.bitmap;
+                        this.bitmap = new Roaring64Map();
+                        this.bitmap.or(other.bitmap);
                         this.bitmapType = BITMAP_VALUE;
                         break;
                     case SINGLE_VALUE:
-                        this.bitmap = other.bitmap;
+                        this.bitmap = new Roaring64Map();
+                        this.bitmap.or(other.bitmap);
                         this.bitmap.add(this.singleValue);
                         this.bitmapType = BITMAP_VALUE;
                         break;
                     case BITMAP_VALUE:
                         this.bitmap.or(other.bitmap);
                         break;
+                    case SET_VALUE: {
+                        this.bitmap = new Roaring64Map();
+                        this.bitmap.or(other.bitmap);
+                        for (Long v : this.set) {
+                            this.bitmap.add(v);
+                        }
+                        this.bitmapType = BITMAP_VALUE;
+                        this.set = null;
+                        break;
+                    }
+                }
+                break;
+            case SET_VALUE:
+                switch (this.bitmapType) {
+                    case EMPTY: {
+                        this.set = new HashSet<>();
+                        this.set.addAll(other.set);
+                        this.bitmapType = SET_VALUE;
+                        break;
+                    }
+                    case SINGLE_VALUE: {
+                        this.set = new HashSet<>(other.set);
+                        if (other.set.size() < 32) {
+                            this.set.add(singleValue);
+                            this.bitmapType = SET_VALUE;
+                        } else {
+                            fromSetToBitmap();
+                            this.bitmap.add(singleValue);
+                        }
+                        break;
+                    }
+                    case SET_VALUE: {
+                        for (Long v : other.set) {
+                            add(v);
+                        }
+                        break;
+                    }
+                    case BITMAP_VALUE: {
+                        for (Long v : other.set) {
+                            bitmap.add(v);
+                        }
+                        break;
+                    }
                 }
                 break;
         }
@@ -297,6 +478,11 @@ public class BitmapValue {
                 break;
             case BITMAP_VALUE:
                 ret = bitmap.equals(otherBitmap.bitmap);
+                break;
+            case SET_VALUE: {
+                ret = set.equals(otherBitmap.set);
+                break;
+            }
         }
         return ret;
     }
@@ -313,8 +499,23 @@ public class BitmapValue {
             case BITMAP_VALUE:
                 toStringStr = this.bitmap.toString();
                 break;
+            case SET_VALUE:
+                toStringStr = String.format("{%s}", setToString());
+                break;
+
         }
         return toStringStr;
+    }
+
+    public String setToString() {
+        final StringBuilder answer = new StringBuilder();
+        for (Long v : this.set) {
+            if (answer.length() > 0) {
+                answer.append(",");
+            }
+            answer.append(v);
+        }
+        return answer.toString();
     }
 
     public String serializeToString() {
@@ -325,6 +526,8 @@ public class BitmapValue {
                 return String.format("%s", singleValue);
             case BITMAP_VALUE:
                 return this.bitmap.serializeToString();
+            case SET_VALUE:
+                return setToString();
         }
         return "";
     }
@@ -333,18 +536,17 @@ public class BitmapValue {
         this.bitmapType = EMPTY;
         this.singleValue = -1;
         this.bitmap = null;
+        this.set = null;
     }
 
-    private void convertToSmallerType() {
-        if (bitmapType == BITMAP_VALUE) {
-            if (bitmap.getLongCardinality() == 0) {
-                this.bitmap = null;
-                this.bitmapType = EMPTY;
-            } else if (bitmap.getLongCardinality() == 1) {
-                this.singleValue = bitmap.select(0);
-                this.bitmapType = SINGLE_VALUE;
-                this.bitmap = null;
-            }
+    private void convertBitmapToSmallerType() {
+        if (bitmap.getLongCardinality() == 0) {
+            this.bitmap = null;
+            this.bitmapType = EMPTY;
+        } else if (bitmap.getLongCardinality() == 1) {
+            this.singleValue = bitmap.select(0);
+            this.bitmapType = SINGLE_VALUE;
+            this.bitmap = null;
         }
     }
 
@@ -366,6 +568,14 @@ public class BitmapValue {
                 return isLongValue32bitEnough(singleValue);
             case BITMAP_VALUE:
                 return bitmap.is32BitsEnough();
+            case SET_VALUE: {
+                for (Long v : set) {
+                    if (!isLongValue32bitEnough(v)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
             default:
                 return false;
         }

--- a/fe/plugin-common/src/main/java/com/starrocks/types/Roaring64Map.java
+++ b/fe/plugin-common/src/main/java/com/starrocks/types/Roaring64Map.java
@@ -34,8 +34,6 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Comparator;

--- a/fe/plugin-common/src/main/java/com/starrocks/types/Roaring64Map.java
+++ b/fe/plugin-common/src/main/java/com/starrocks/types/Roaring64Map.java
@@ -34,6 +34,8 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Comparator;

--- a/fe/plugin-common/src/test/java/com/starrocks/types/BitmapValueTest.java
+++ b/fe/plugin-common/src/test/java/com/starrocks/types/BitmapValueTest.java
@@ -34,22 +34,40 @@ import static org.junit.Assert.assertEquals;
 public class BitmapValueTest {
     static BitmapValue emptyBitmap;
     static BitmapValue singleBitmap;
+    static BitmapValue mediumBitmap;
     static BitmapValue largeBitmap;
 
     @BeforeClass
     public static void beforeClass() throws Exception {
         emptyBitmap = new BitmapValue();
         singleBitmap = new BitmapValue();
-        singleBitmap.add(1);
+        mediumBitmap = new BitmapValue();
         largeBitmap = new BitmapValue();
-        for (long i = 0; i < 20; i++) {
+
+        singleBitmap.add(1);
+        for (long i = 0; i < 10; i++) {
+            mediumBitmap.add(i);
+        }
+        for (long i = 0; i < 40; i++) {
             largeBitmap.add(i);
         }
     }
 
-    private void check_bitmap(BitmapValue bitmap, long start, long end) {
+    private void check_bitmap(BitmapValue bitmap, int bitmapType, long start, long end) {
+        Assert.assertEquals(bitmap.getBitmapType(), bitmapType);
         Assert.assertEquals(bitmap.cardinality(), end - start);
         for (long i = start; i < end; i++) {
+            Assert.assertTrue(bitmap.contains(i));
+        }
+    }
+
+    private void check_bitmap(BitmapValue bitmap, int bitmapType, long start1, long end1, long start2, long end2) {
+        Assert.assertEquals(bitmap.getBitmapType(), bitmapType);
+        Assert.assertEquals(bitmap.cardinality(), (end1 - start1) + (end2 - start2));
+        for (long i = start1; i < end1; i++) {
+            Assert.assertTrue(bitmap.contains(i));
+        }
+        for (long i = start2; i < end2; i++) {
             Assert.assertTrue(bitmap.contains(i));
         }
     }
@@ -57,13 +75,16 @@ public class BitmapValueTest {
     @Test
     public void testBitmapToBytesAndBitmapFromBytes() throws IOException {
         BitmapValue bitmap = BitmapValue.bitmapFromBytes(BitmapValue.bitmapToBytes(emptyBitmap));
-        check_bitmap(bitmap, 0, 0);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
         bitmap = BitmapValue.bitmapFromBytes(BitmapValue.bitmapToBytes(singleBitmap));
-        check_bitmap(bitmap, 1, 2);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
+
+        bitmap = BitmapValue.bitmapFromBytes(BitmapValue.bitmapToBytes(mediumBitmap));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 0, 10);
 
         bitmap = BitmapValue.bitmapFromBytes(BitmapValue.bitmapToBytes(largeBitmap));
-        check_bitmap(bitmap, 0, 20);
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 40);
     }
 
     @Test
@@ -83,10 +104,17 @@ public class BitmapValueTest {
         BitmapValue bitmapValue = new BitmapValue();
         assertEquals(BitmapValue.EMPTY, bitmapValue.getBitmapType());
 
-        bitmapValue.add(1);
+        bitmapValue.add(0);
         assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue.getBitmapType());
 
-        bitmapValue.add(2);
+        bitmapValue.add(1);
+        assertEquals(BitmapValue.SET_VALUE, bitmapValue.getBitmapType());
+
+        for (long i = 2; i < 32; i++) {
+            bitmapValue.add(i);
+            assertEquals(BitmapValue.SET_VALUE, bitmapValue.getBitmapType());
+        }
+        bitmapValue.add(32);
         assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue.getBitmapType());
 
         bitmapValue.clear();
@@ -100,312 +128,329 @@ public class BitmapValueTest {
         for (int i = 0; i < 10; i++) {
             bitmapValue1.add(i);
         }
-        for (int i = 0; i < 10; i++) {
-            Assert.assertTrue(bitmapValue1.contains(i));
-        }
-        Assert.assertFalse(bitmapValue1.contains(11));
+        check_bitmap(bitmapValue1, BitmapValue.SET_VALUE, 0, 10);
 
         // test add long
         BitmapValue bitmapValue2 = new BitmapValue();
-        for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 10; i--) {
+        for (long i = Long.MAX_VALUE - 1; i > Long.MAX_VALUE - 11; i--) {
             bitmapValue2.add(i);
         }
-        for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 10; i--) {
-            Assert.assertTrue(bitmapValue2.contains(i));
-        }
-        Assert.assertFalse(bitmapValue2.contains(0));
+        check_bitmap(bitmapValue2, BitmapValue.SET_VALUE, Long.MAX_VALUE - 10, Long.MAX_VALUE);
 
         // test add int and long
         for (int i = 0; i < 10; i++) {
             bitmapValue2.add(i);
         }
-
-        for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 10; i--) {
-            Assert.assertTrue(bitmapValue2.contains(i));
-        }
-        for (int i = 0; i < 10; i++) {
-            Assert.assertTrue(bitmapValue2.contains(i));
-        }
-        Assert.assertFalse(bitmapValue2.contains(100));
+        check_bitmap(bitmapValue2, BitmapValue.SET_VALUE, 0, 10, Long.MAX_VALUE - 10, Long.MAX_VALUE);
 
         // test distinct
         BitmapValue bitmapValue = new BitmapValue();
         bitmapValue.add(1);
         bitmapValue.add(1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue.getBitmapType());
-        assertEquals(1, bitmapValue.cardinality());
+        check_bitmap(bitmapValue, BitmapValue.SINGLE_VALUE, 1, 2);
     }
 
     @Test
-    public void testBitmapValueAnd() {
+    public void testBitmapValueAnd() throws IOException {
         // empty and empty
-        BitmapValue bitmapValue1 = new BitmapValue();
-        BitmapValue bitmapValue1_1 = new BitmapValue();
-        bitmapValue1.and(bitmapValue1_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue1.getBitmapType());
-        assertEquals(0, bitmapValue1.cardinality());
+        BitmapValue bitmap = new BitmapValue(emptyBitmap);
+        bitmap.and(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        // empty and single value
-        BitmapValue bitmapValue2 = new BitmapValue();
-        BitmapValue bitmapValue2_1 = new BitmapValue();
-        bitmapValue2_1.add(1);
-        bitmapValue2.and(bitmapValue2_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue2.getBitmapType());
-        assertEquals(0, bitmapValue2.cardinality());
+        // empty and single
+        bitmap = new BitmapValue(emptyBitmap);
+        bitmap.and(singleBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
+
+        // empty and set
+        bitmap = new BitmapValue(emptyBitmap);
+        bitmap.and(mediumBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
         // empty and bitmap
-        BitmapValue bitmapValue3 = new BitmapValue();
-        BitmapValue bitmapValue3_1 = new BitmapValue();
-        bitmapValue3_1.add(1);
-        bitmapValue3_1.add(2);
-        bitmapValue3.and(bitmapValue3_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue2.getBitmapType());
-        assertEquals(0, bitmapValue3.cardinality());
+        bitmap = new BitmapValue(emptyBitmap);
+        bitmap.and(largeBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        // single value and empty
-        BitmapValue bitmapValue4 = new BitmapValue();
-        bitmapValue4.add(1);
-        BitmapValue bitmapValue4_1 = new BitmapValue();
-        bitmapValue4.and(bitmapValue4_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue4.getBitmapType());
-        assertEquals(0, bitmapValue4.cardinality());
+        // single and empty
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.and(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        // single value and single value
-        BitmapValue bitmapValue5 = new BitmapValue();
-        bitmapValue5.add(1);
-        BitmapValue bitmapValue5_1 = new BitmapValue();
-        bitmapValue5_1.add(1);
-        bitmapValue5.and(bitmapValue5_1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue5.getBitmapType());
-        Assert.assertTrue(bitmapValue5.contains(1));
+        // single and single (equal)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.and(new BitmapValue(2));
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        bitmapValue5.clear();
-        bitmapValue5_1.clear();
-        bitmapValue5.add(1);
-        bitmapValue5_1.add(2);
-        bitmapValue5.and(bitmapValue5_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue5.getBitmapType());
+        // single and single (not equal)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.and(new BitmapValue(1));
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
 
-        // single value and bitmap
-        BitmapValue bitmapValue6 = new BitmapValue();
-        bitmapValue6.add(1);
-        BitmapValue bitmapValue6_1 = new BitmapValue();
-        bitmapValue6_1.add(1);
-        bitmapValue6_1.add(2);
-        bitmapValue6.and(bitmapValue6_1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue6.getBitmapType());
+        // single and bitmap (not contains)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.and(new BitmapValue(2, 4));
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        bitmapValue6.clear();
-        bitmapValue6.add(3);
-        bitmapValue6.and(bitmapValue6_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue6.getBitmapType());
+        // single and bitmap (contains)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.and(largeBitmap);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
+
+        // single and set (not contains)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.and(new BitmapValue(100, 101));
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
+
+        // single and set (contains)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.and(mediumBitmap);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
 
         // bitmap and empty
-        BitmapValue bitmapValue7 = new BitmapValue();
-        bitmapValue7.add(1);
-        bitmapValue7.add(2);
-        BitmapValue bitmapValue7_1 = new BitmapValue();
-        bitmapValue7.and(bitmapValue7_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue7.getBitmapType());
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        // bitmap and single value
-        BitmapValue bitmapValue8 = new BitmapValue();
-        bitmapValue8.add(1);
-        bitmapValue8.add(2);
-        BitmapValue bitmapValue8_1 = new BitmapValue();
-        bitmapValue8_1.add(1);
-        bitmapValue8.and(bitmapValue8_1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue8.getBitmapType());
+        // bitmap and single (contains)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(singleBitmap);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
 
-        bitmapValue8.clear();
-        bitmapValue8.add(2);
-        bitmapValue8.add(3);
-        bitmapValue8.and(bitmapValue8_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue8.getBitmapType());
+        // bitmap and single (not contains)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(new BitmapValue(1000));
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        // bitmap and bitmap
-        BitmapValue bitmapValue9 = new BitmapValue();
-        bitmapValue9.add(1);
-        bitmapValue9.add(2);
-        BitmapValue bitmapValue9_1 = new BitmapValue();
-        bitmapValue9_1.add(2);
-        bitmapValue9_1.add(3);
-        bitmapValue9.and(bitmapValue9_1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue9.getBitmapType());
+        // bitmap and bitmap (-> bitmap)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(new BitmapValue(20, 60));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 20, 40);
 
-        bitmapValue9.clear();
-        bitmapValue9.add(4);
-        bitmapValue9.add(5);
-        bitmapValue9.and(bitmapValue9_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue9.getBitmapType());
+        // bitmap and bitmap (-> empty)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(new BitmapValue(100, 180));
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        bitmapValue9.clear();
-        bitmapValue9.add(2);
-        bitmapValue9.add(3);
-        bitmapValue9.add(4);
-        bitmapValue9.and(bitmapValue9_1);
-        assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue9.getBitmapType());
-        assertEquals(bitmapValue9, bitmapValue9_1);
+        // bitmap and bitmap (-> single)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(new BitmapValue(39, 100));
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 39, 40);
+
+        // bitmap and set (->set)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(mediumBitmap);
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 0, 10);
+
+        // bitmap and set (->empty)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(new BitmapValue(100, 120));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 0, 0);
+
+        // bitmap and set (->single)
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.and(new BitmapValue(30, 50));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 30, 40);
+
+        // set and empty
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.and(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
+
+        // set and single (contains)
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.and(singleBitmap);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
+
+        // set and single (not contains)
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.and(new BitmapValue(100));
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
+
+        // set and set
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.and(new BitmapValue(5, 20));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 5, 10);
     }
 
     @Test
-    public void testBitmapValueOr() {
+    public void testBitmapValueOr() throws IOException {
         // empty or empty
-        BitmapValue bitmapValue1 = new BitmapValue();
-        BitmapValue bitmapValue1_1 = new BitmapValue();
-        bitmapValue1.or(bitmapValue1_1);
-        assertEquals(BitmapValue.EMPTY, bitmapValue1.getBitmapType());
+        BitmapValue bitmap = new BitmapValue(emptyBitmap);
+        bitmap.or(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.EMPTY, 0, 0);
 
-        // empty or single value
-        BitmapValue bitmapValue2 = new BitmapValue();
-        BitmapValue bitmapValue2_1 = new BitmapValue();
-        bitmapValue2_1.add(1);
-        bitmapValue2.or(bitmapValue2_1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue2.getBitmapType());
+        // empty or single
+        bitmap = new BitmapValue(emptyBitmap);
+        bitmap.or(singleBitmap);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
+
+        // empty or set
+        bitmap = new BitmapValue(emptyBitmap);
+        bitmap.or(mediumBitmap);
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 0, 10);
 
         // empty or bitmap
-        BitmapValue bitmapValue3 = new BitmapValue();
-        BitmapValue bitmapValue3_1 = new BitmapValue();
-        bitmapValue3_1.add(1);
-        bitmapValue3_1.add(2);
-        bitmapValue3.or(bitmapValue3_1);
-        assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue3.getBitmapType());
+        bitmap = new BitmapValue(emptyBitmap);
+        bitmap.or(largeBitmap);
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 40);
 
-        // single or and empty
-        BitmapValue bitmapValue4 = new BitmapValue();
-        BitmapValue bitmapValue4_1 = new BitmapValue();
-        bitmapValue4.add(1);
-        bitmapValue4.or(bitmapValue4_1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue4.getBitmapType());
+        // single or empty
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.or(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
 
-        // single or and single value
-        BitmapValue bitmapValue5 = new BitmapValue();
-        BitmapValue bitmapValue5_1 = new BitmapValue();
-        bitmapValue5.add(1);
-        bitmapValue5_1.add(1);
-        bitmapValue5.or(bitmapValue5_1);
-        assertEquals(BitmapValue.SINGLE_VALUE, bitmapValue5.getBitmapType());
+        // single or single (equal)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.or(singleBitmap);
+        check_bitmap(bitmap, BitmapValue.SINGLE_VALUE, 1, 2);
 
-        bitmapValue5.clear();
-        bitmapValue5.add(2);
-        bitmapValue5.or(bitmapValue5_1);
-        assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue5.getBitmapType());
+        // single or single (not equal)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.or(new BitmapValue(2));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 1, 3);
 
-        // single or and bitmap
-        BitmapValue bitmapValue6 = new BitmapValue();
-        BitmapValue bitmapValue6_1 = new BitmapValue();
-        bitmapValue6.add(1);
-        bitmapValue6_1.add(1);
-        bitmapValue6_1.add(2);
-        bitmapValue6.or(bitmapValue6_1);
-        assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue6.getBitmapType());
+        // single or bitmap
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.or(new BitmapValue(10, 70));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 1, 2, 10, 70);
+
+        // single or set (->set)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.or(new BitmapValue(10, 20));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 1, 2, 10, 20);
+
+        // single or set (->bitmap)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.or(new BitmapValue(10, 42));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 1, 2, 10, 42);
+
+        // single or set (->set)
+        bitmap = new BitmapValue(singleBitmap);
+        bitmap.or(new BitmapValue(5, 10));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 1, 2, 5, 10);
 
         // bitmap or empty
-        BitmapValue bitmapValue7 = new BitmapValue();
-        bitmapValue7.add(1);
-        bitmapValue7.add(2);
-        BitmapValue bitmapValue7_1 = new BitmapValue();
-        bitmapValue7.or(bitmapValue7_1);
-        assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue7.getBitmapType());
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.or(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 40);
 
-        // bitmap or single value
-        BitmapValue bitmapValue8 = new BitmapValue();
-        bitmapValue8.add(1);
-        bitmapValue8.add(2);
-        BitmapValue bitmapValue8_1 = new BitmapValue();
-        bitmapValue8_1.add(1);
-        bitmapValue8.or(bitmapValue8_1);
-        assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue8.getBitmapType());
+        // bitmap or single
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.or(new BitmapValue(100));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 40, 100, 101);
 
         // bitmap or bitmap
-        BitmapValue bitmapValue9 = new BitmapValue();
-        bitmapValue9.add(1);
-        bitmapValue9.add(2);
-        BitmapValue bitmapValue9_1 = new BitmapValue();
-        bitmapValue9.or(bitmapValue9_1);
-        assertEquals(BitmapValue.BITMAP_VALUE, bitmapValue9.getBitmapType());
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.or(new BitmapValue(30, 80));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 80);
+
+        // bitmap or set
+        bitmap = new BitmapValue(largeBitmap);
+        bitmap.or(new BitmapValue(30, 50));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 50);
+
+        // set or empty
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.or(emptyBitmap);
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 0, 10);
+
+        // set or single (->map)
+        bitmap = new BitmapValue(0, 32);
+        bitmap.or(new BitmapValue(32));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 33);
+
+        // set or single (->set)
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.or(new BitmapValue(10));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 0, 11);
+
+        // set or bitmap
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.or(new BitmapValue(8, 100));
+        check_bitmap(bitmap, BitmapValue.BITMAP_VALUE, 0, 100);
+
+        // set or set
+        bitmap = new BitmapValue(mediumBitmap);
+        bitmap.or(new BitmapValue(3, 15));
+        check_bitmap(bitmap, BitmapValue.SET_VALUE, 0, 15);
     }
 
     @Test
     public void testBitmapValueSerializeAndDeserialize() throws IOException {
         // empty
-        BitmapValue serializeBitmapValue = new BitmapValue();
-        ByteArrayOutputStream emptyOutputStream = new ByteArrayOutputStream();
-        DataOutput output = new DataOutputStream(emptyOutputStream);
-        serializeBitmapValue.serialize(output);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        DataOutput output = new DataOutputStream(outputStream);
+        emptyBitmap.serialize(output);
+        Assert.assertEquals("[0]", Arrays.toString(outputStream.toByteArray()));
 
-        DataInputStream emptyInputStream =
-                new DataInputStream(new ByteArrayInputStream(emptyOutputStream.toByteArray()));
-        BitmapValue deserializeBitmapValue = new BitmapValue();
-        deserializeBitmapValue.deserialize(emptyInputStream);
+        DataInputStream inputStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+        BitmapValue outputBitmap = new BitmapValue();
+        outputBitmap.deserialize(inputStream);
+        assertEquals(emptyBitmap, outputBitmap);
 
-        assertEquals(serializeBitmapValue, deserializeBitmapValue);
-
-        // single value
-        BitmapValue serializeSingleValueBitmapValue = new BitmapValue();
-        // unsigned 32-bit
-        long unsigned32bit = Integer.MAX_VALUE;
-        serializeSingleValueBitmapValue.add(unsigned32bit + 1);
-        ByteArrayOutputStream singleValueOutputStream = new ByteArrayOutputStream();
-        DataOutput singleValueOutput = new DataOutputStream(singleValueOutputStream);
-        serializeSingleValueBitmapValue.serialize(singleValueOutput);
+        // single value (uint32)
+        BitmapValue inputBitmap = new BitmapValue((long) Integer.MAX_VALUE + 1);
+        outputStream = new ByteArrayOutputStream();
+        output = new DataOutputStream(outputStream);
+        inputBitmap.serialize(output);
         // check serialize by little endian
-        Assert.assertEquals("[1, 0, 0, 0, -128]", Arrays.toString(singleValueOutputStream.toByteArray()));
+        Assert.assertEquals("[1, 0, 0, 0, -128]", Arrays.toString(outputStream.toByteArray()));
 
-        DataInputStream singleValueInputStream =
-                new DataInputStream(new ByteArrayInputStream(singleValueOutputStream.toByteArray()));
-        BitmapValue deserializeSingleValueBitmapValue = new BitmapValue();
-        deserializeSingleValueBitmapValue.deserialize(singleValueInputStream);
-        assertEquals(serializeSingleValueBitmapValue, deserializeSingleValueBitmapValue);
+        inputStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+        outputBitmap = new BitmapValue();
+        outputBitmap.deserialize(inputStream);
+        assertEquals(inputBitmap, outputBitmap);
 
         // unsigned 64-bit
-        serializeSingleValueBitmapValue = new BitmapValue();
+        inputBitmap = new BitmapValue();
         long unsigned64bit = 4294967297L; // 2^32 + 1
-        serializeSingleValueBitmapValue.add(unsigned64bit);
-        singleValueOutputStream = new ByteArrayOutputStream();
-        singleValueOutput = new DataOutputStream(singleValueOutputStream);
-        serializeSingleValueBitmapValue.serialize(singleValueOutput);
+        inputBitmap.add(unsigned64bit);
+        outputStream = new ByteArrayOutputStream();
+        output = new DataOutputStream(outputStream);
+        inputBitmap.serialize(output);
         // check serialize by little endian
-        Assert.assertEquals("[3, 1, 0, 0, 0, 1, 0, 0, 0]", Arrays.toString(singleValueOutputStream.toByteArray()));
+        Assert.assertEquals("[3, 1, 0, 0, 0, 1, 0, 0, 0]", Arrays.toString(outputStream.toByteArray()));
 
-        singleValueInputStream = new DataInputStream(new ByteArrayInputStream(singleValueOutputStream.toByteArray()));
-        deserializeSingleValueBitmapValue = new BitmapValue();
-        deserializeSingleValueBitmapValue.deserialize(singleValueInputStream);
-        assertEquals(serializeSingleValueBitmapValue, deserializeSingleValueBitmapValue);
+        inputStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+        outputBitmap = new BitmapValue();
+        outputBitmap.deserialize(inputStream);
+        assertEquals(inputBitmap, outputBitmap);
+
+        // set
+        inputBitmap = new BitmapValue(1, 3);
+        outputStream = new ByteArrayOutputStream();
+        output = new DataOutputStream(outputStream);
+        inputBitmap.serialize(output);
+        Assert.assertEquals("[10, 2, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0]",
+                Arrays.toString(outputStream.toByteArray()));
 
         // bitmap
         // case 1 : 32-bit bitmap
-        BitmapValue serializeBitmapBitmapValue = new BitmapValue();
-        for (int i = 0; i < 10; i++) {
-            serializeBitmapBitmapValue.add(i);
-        }
-        ByteArrayOutputStream bitmapOutputStream = new ByteArrayOutputStream();
-        DataOutput bitmapOutput = new DataOutputStream(bitmapOutputStream);
-        serializeBitmapBitmapValue.serialize(bitmapOutput);
+        inputBitmap = new BitmapValue(0, 10);
+        outputStream = new ByteArrayOutputStream();
+        output = new DataOutputStream(outputStream);
+        inputBitmap.serialize(output);
 
-        DataInputStream bitmapInputStream =
-                new DataInputStream(new ByteArrayInputStream(bitmapOutputStream.toByteArray()));
-        BitmapValue deserializeBitmapBitmapValue = new BitmapValue();
-        deserializeBitmapBitmapValue.deserialize(bitmapInputStream);
+        inputStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+        outputBitmap = new BitmapValue();
+        outputBitmap.deserialize(inputStream);
 
-        assertEquals(serializeBitmapBitmapValue, deserializeBitmapBitmapValue);
+        assertEquals(inputBitmap, outputBitmap);
 
         // bitmap
         // case 2 : 64-bit bitmap
-        BitmapValue serializeBitmapBitmapValue64 = new BitmapValue();
-        for (long i = Long.MAX_VALUE; i > Long.MAX_VALUE - 10; i--) {
-            serializeBitmapBitmapValue64.add(i);
-        }
-        ByteArrayOutputStream bitmapOutputStream64 = new ByteArrayOutputStream();
-        DataOutput bitmapOutput64 = new DataOutputStream(bitmapOutputStream64);
-        serializeBitmapBitmapValue64.serialize(bitmapOutput64);
+        inputBitmap = new BitmapValue(Long.MAX_VALUE - 9, Long.MAX_VALUE);
+        inputBitmap.add(Long.MAX_VALUE);
+        outputStream = new ByteArrayOutputStream();
+        output = new DataOutputStream(outputStream);
+        inputBitmap.serialize(output);
 
-        DataInputStream bitmapInputStream64 =
-                new DataInputStream(new ByteArrayInputStream(bitmapOutputStream64.toByteArray()));
-        BitmapValue deserializeBitmapBitmapValue64 = new BitmapValue();
-        deserializeBitmapBitmapValue64.deserialize(bitmapInputStream64);
+        inputStream = new DataInputStream(new ByteArrayInputStream(outputStream.toByteArray()));
+        outputBitmap = new BitmapValue();
+        outputBitmap.deserialize(inputStream);
 
-        assertEquals(serializeBitmapBitmapValue64, deserializeBitmapBitmapValue64);
+        assertEquals(inputBitmap, outputBitmap);
     }
 
     @Test
@@ -449,19 +494,19 @@ public class BitmapValueTest {
     @Test
     public void testContains() {
         // empty
-        BitmapValue bitmapValue = new BitmapValue();
-        Assert.assertFalse(bitmapValue.contains(1));
+        Assert.assertFalse(emptyBitmap.contains(1));
 
         // single value
-        bitmapValue.add(1);
-        Assert.assertTrue(bitmapValue.contains(1));
-        Assert.assertFalse(bitmapValue.contains(2));
+        Assert.assertTrue(singleBitmap.contains(1));
+        Assert.assertFalse(singleBitmap.contains(2));
 
         // bitmap
-        bitmapValue.add(2);
-        Assert.assertTrue(bitmapValue.contains(1));
-        Assert.assertTrue(bitmapValue.contains(2));
-        Assert.assertFalse(bitmapValue.contains(12));
+        Assert.assertTrue(largeBitmap.contains(1));
+        Assert.assertFalse(largeBitmap.contains(100));
+
+        // set
+        Assert.assertTrue(mediumBitmap.contains(1));
+        Assert.assertFalse(mediumBitmap.contains(20));
     }
 
     @Test
@@ -470,6 +515,7 @@ public class BitmapValueTest {
         BitmapValue emp1 = new BitmapValue();
         BitmapValue emp2 = new BitmapValue();
         assertEquals(emp1, emp2);
+
         // empty == single value
         emp2.add(1);
         Assert.assertNotEquals(emp1, emp2);
@@ -517,13 +563,17 @@ public class BitmapValueTest {
     public void testToString() {
         Assert.assertEquals(emptyBitmap.toString(), "{}");
         Assert.assertEquals(singleBitmap.toString(), "{1}");
-        Assert.assertEquals(largeBitmap.toString(), "{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19}");
+        Assert.assertEquals(mediumBitmap.toString(), "{0,1,2,3,4,5,6,7,8,9}");
+        Assert.assertEquals(largeBitmap.toString(), "{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22," +
+                "23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39}");
     }
 
     @Test
     public void testSerializeToString() {
         Assert.assertEquals(emptyBitmap.serializeToString(), "");
         Assert.assertEquals(singleBitmap.serializeToString(), "1");
-        Assert.assertEquals(largeBitmap.serializeToString(), "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19");
+        Assert.assertEquals(mediumBitmap.serializeToString(), "0,1,2,3,4,5,6,7,8,9");
+        Assert.assertEquals(largeBitmap.serializeToString(), "0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20," +
+                "21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39");
     }
 }


### PR DESCRIPTION
Why I'm doing:

Current `StarRocks` kernel uses hash set to represent small bitmap, but `BitmapValue (java)` does not support it. In this way, the small bitmap exported by `StarRocks` cannot be recognized by `HiveUDF`, so the Java version needs to add support for the set type.

What I'm doing:

BitmapValue support set type

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
