### PR TITLE
[Enhancement] Optimize the performance of bitmap_to_array

### DIFF
--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -38,6 +38,7 @@
 #include "types/bitmap_value_detail.h"
 #include "util/defer_op.h"
 #include "util/phmap/phmap.h"
+#include "util/raw_container.h"
 
 namespace starrocks {
 
@@ -862,7 +863,7 @@ void BitmapValue::to_array(std::vector<int64_t>* array) const {
         array->emplace_back(_sv);
         break;
     case BITMAP: {
-        (*array).resize(_bitmap->cardinality());
+        raw::make_room(array, _bitmap->cardinality());
         _bitmap->toUint64Array((uint64_t*)(*array).data());
         break;
     }

--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -862,9 +862,8 @@ void BitmapValue::to_array(std::vector<int64_t>* array) const {
         array->emplace_back(_sv);
         break;
     case BITMAP: {
-        for (unsigned long ptr_value : *_bitmap) {
-            array->emplace_back(ptr_value);
-        }
+        (*array).resize(_bitmap->cardinality());
+        _bitmap->toUint64Array((uint64_t*)(*array).data());
         break;
     }
     case SET:

--- a/test/sql/test_bitmap_functions/R/test_bitmap_functions
+++ b/test/sql/test_bitmap_functions/R/test_bitmap_functions
@@ -882,3 +882,53 @@ select c1, bitmap_min(subdivide_bitmap) as min_value, bitmap_to_string(subdivide
 6	8589934592	8589934592,8589934593,8589934594,8589934595,8589934596,8589934597,8589934598,8589934599,8589934600,8589934601
 6	8589934602	8589934602,8589934603,8589934604,8589934605,8589934606,8589934607,8589934608,8589934609,8589934610
 -- !result
+-- name: test_bitmap_to_array
+CREATE TABLE `t1` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` bitmap BITMAP_UNION NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+truncate table t1;
+-- result:
+-- !result
+insert into t1 select 1, bitmap_empty();
+-- result:
+-- !result
+select bitmap_to_array(c2) from t1;
+-- result:
+[]
+-- !result
+truncate table t1;
+-- result:
+-- !result
+insert into t1 select 1, to_bitmap(1);
+-- result:
+-- !result
+select bitmap_to_array(c2) from t1;
+-- result:
+[1]
+-- !result
+truncate table t1;
+-- result:
+-- !result
+insert into t1 select 1, bitmap_agg(generate_series) from table(generate_series(1, 10));
+-- result:
+-- !result
+select bitmap_to_array(c2) from t1;
+-- result:
+[1,2,3,4,5,6,7,8,9,10]
+-- !result
+truncate table t1;
+-- result:
+-- !result
+insert into t1 select 1, bitmap_agg(generate_series) from table(generate_series(1, 40));
+-- result:
+-- !result
+select bitmap_to_array(c2) from t1;
+-- result:
+[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40]
+-- !result

--- a/test/sql/test_bitmap_functions/T/test_bitmap_functions
+++ b/test/sql/test_bitmap_functions/T/test_bitmap_functions
@@ -221,3 +221,34 @@ insert into t4 select 6, 10, bitmap_agg(generate_series) from table(generate_ser
 insert into t4 select 6, 10, bitmap_agg(generate_series) from table(generate_series(8589934592, 8589934610));
 
 select c1, bitmap_min(subdivide_bitmap) as min_value, bitmap_to_string(subdivide_bitmap) from t4, subdivide_bitmap(t4.c3, c2) order by c1, min_value;
+
+-- name: test_bitmap_to_array
+
+-- create table
+CREATE TABLE `t1` (
+  `c1` int(11) NULL COMMENT "",
+  `c2` bitmap BITMAP_UNION NULL COMMENT ""
+) ENGINE=OLAP
+AGGREGATE KEY(`c1`)
+DISTRIBUTED BY HASH(`c1`) BUCKETS 1
+PROPERTIES ("replication_num" = "1");
+
+-- bitmap(empty)
+truncate table t1;
+insert into t1 select 1, bitmap_empty();
+select bitmap_to_array(c2) from t1;
+
+-- bitmap(single)
+truncate table t1;
+insert into t1 select 1, to_bitmap(1);
+select bitmap_to_array(c2) from t1;
+
+-- bitmap(set)
+truncate table t1;
+insert into t1 select 1, bitmap_agg(generate_series) from table(generate_series(1, 10));
+select bitmap_to_array(c2) from t1;
+
+-- bitmap(bitmap)
+truncate table t1;
+insert into t1 select 1, bitmap_agg(generate_series) from table(generate_series(1, 40));
+select bitmap_to_array(c2) from t1;


### PR DESCRIPTION
Why I'm doing:

Use `BitmapValue`'s native `toUint64Array` function to optimize the performance of `bitmap_to_array`. It will reduce the number of function dispatches.

What I'm doing:

Optimize the performance of bitmap_to_array through using the native `toUint64Array` function of `BitmapValue`.

Before Optimization: 
- ExprComputeTime: 806.844ms

After Optimization:
- ExprComputeTime: 481.050ms

Performance test case:

```
CREATE TABLE `t1` (
  `c1` int(11) NULL COMMENT "",
  `c2` bitmap BITMAP_UNION NULL COMMENT ""
) ENGINE=OLAP 
AGGREGATE KEY(`c1`)
DISTRIBUTED BY HASH(`c1`)
PROPERTIES (
"replication_num" = "1",
"in_memory" = "false",
"enable_persistent_index" = "false",
"replicated_storage" = "true",
"fast_schema_evolution" = "true",
"compression" = "LZ4"
); 

insert into t1 select lo_quantity, bitmap_agg(lo_orderkey) from lineorder group by lo_quantity;

select c1, array_length(bitmap_to_array(c2)) from t1
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
