### PR TITLE
[BugFix] create bitmap index failed if table already has another bitmap (#37116)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -2242,7 +2242,11 @@ public class SchemaChangeHandler extends AlterHandler {
         Set<String> newColset = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
         newColset.addAll(indexDef.getColumns());
         for (Index existedIdx : existedIndexes) {
-            if (existedIdx.getIndexId() >= newIndex.getIndexId()) {
+            // check the index id only if the index is CompatibleIndex(GIN)
+            // Bitmap index's id is always be -1
+            if (IndexDef.IndexType.isCompatibleIndex(existedIdx.getIndexType()) &&
+                    IndexDef.IndexType.isCompatibleIndex(newIndex.getIndexType()) &&
+                        existedIdx.getIndexId() >= newIndex.getIndexId()) {
                 throw new IllegalStateException(
                         String.format("New index id %s should be lg than existed idx %s in OlapTable",
                                 newIndex.getIndexId(), existedIdx.getIndexId()));

--- a/test/sql/test_inverted_index/R/test_inverted_index
+++ b/test/sql/test_inverted_index/R/test_inverted_index
@@ -1,0 +1,99 @@
+-- name: test_basic_create_index
+CREATE TABLE `t_test_basic_create_index_pk` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `id2` bigint(20) NOT NULL COMMENT "",
+  `id3` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE INDEX index_1 ON t_test_basic_create_index_pk (id2) USING BITMAP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+CREATE INDEX index_2 ON t_test_basic_create_index_pk (id3) USING BITMAP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+CREATE TABLE `t_test_basic_create_index_dup` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `id2` bigint(20) NOT NULL COMMENT "",
+  `id3` bigint(20) NOT NULL COMMENT "",
+  `id4` string NOT NULL COMMENT "",
+  `id5` string NOT NULL COMMENT "",
+  `id6` bigint(20) NOT NULL COMMENT "",
+  `id7` string NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE INDEX index_1 ON t_test_basic_create_index_dup (id2) USING BITMAP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+CREATE INDEX index_2 ON t_test_basic_create_index_dup (id3) USING BITMAP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+CREATE INDEX index_3 ON t_test_basic_create_index_dup (id4) USING GIN;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+CREATE INDEX index_4 ON t_test_basic_create_index_dup (id5) USING GIN;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+CREATE INDEX index_5 ON t_test_basic_create_index_dup (id6) USING BITMAP;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+CREATE INDEX index_6 ON t_test_basic_create_index_dup (id7) USING GIN;
+-- result:
+-- !result
+function: wait_alter_table_finish()
+-- result:
+None
+-- !result
+DROP TABLE t_test_basic_create_index_pk;
+-- result:
+-- !result
+DROP TABLE t_test_basic_create_index_dup;
+-- result:
+-- !result

--- a/test/sql/test_inverted_index/T/test_inverted_index
+++ b/test/sql/test_inverted_index/T/test_inverted_index
@@ -1,0 +1,62 @@
+-- name: test_basic_create_index
+CREATE TABLE `t_test_basic_create_index_pk` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `id2` bigint(20) NOT NULL COMMENT "",
+  `id3` bigint(20) NOT NULL COMMENT ""
+) ENGINE=OLAP 
+PRIMARY KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE INDEX index_1 ON t_test_basic_create_index_pk (id2) USING BITMAP;
+function: wait_alter_table_finish()
+
+CREATE INDEX index_2 ON t_test_basic_create_index_pk (id3) USING BITMAP;
+function: wait_alter_table_finish()
+
+
+CREATE TABLE `t_test_basic_create_index_dup` (
+  `id1` bigint(20) NOT NULL COMMENT "",
+  `id2` bigint(20) NOT NULL COMMENT "",
+  `id3` bigint(20) NOT NULL COMMENT "",
+  `id4` string NOT NULL COMMENT "",
+  `id5` string NOT NULL COMMENT "",
+  `id6` bigint(20) NOT NULL COMMENT "",
+  `id7` string NOT NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`id1`)
+DISTRIBUTED BY HASH(`id1`) BUCKETS 1 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"compression" = "LZ4"
+);
+
+CREATE INDEX index_1 ON t_test_basic_create_index_dup (id2) USING BITMAP;
+function: wait_alter_table_finish()
+
+CREATE INDEX index_2 ON t_test_basic_create_index_dup (id3) USING BITMAP;
+function: wait_alter_table_finish()
+
+CREATE INDEX index_3 ON t_test_basic_create_index_dup (id4) USING GIN;
+function: wait_alter_table_finish()
+
+CREATE INDEX index_4 ON t_test_basic_create_index_dup (id5) USING GIN;
+function: wait_alter_table_finish()
+
+CREATE INDEX index_5 ON t_test_basic_create_index_dup (id6) USING BITMAP;
+function: wait_alter_table_finish()
+
+CREATE INDEX index_6 ON t_test_basic_create_index_dup (id7) USING GIN;
+function: wait_alter_table_finish()
+
+DROP TABLE t_test_basic_create_index_pk;
+DROP TABLE t_test_basic_create_index_dup;


### PR DESCRIPTION
Why I'm doing:
If creating a Bitmap index for a table that already has a Bitmap index, it will fail. This problem is introduced by pr(#36765) which introduced the meta data for GIN(inverted index).

This pr add a index id for every index. Bitmap index always has id = -1 and GIN has id id >= 0 In the process of CREATE INDEX, it will check the new added index' id is larger than the existed index'id or not. This is make sense for GIN but not for BITMAP(always -1). If we add two bitmap indexes consecutively, it will trigger a failure cause by (-1 > -1) is FALSE.

What I'm doing:
Check the id for GIN only

Fixes #37116

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
