### PR TITLE
[BugFix] Fix create mv with multi select star

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SlotRefResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SlotRefResolver.java
@@ -111,12 +111,14 @@ public class SlotRefResolver {
 
         @Override
         public Expr visitSubquery(SubqueryRelation node, SlotRef slot) {
-            String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
-            if (!node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
-                return null;
+            if (slot.getTblNameWithoutAnalyzed() != null) {
+                String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
+                if (!node.getAlias().getTbl().equalsIgnoreCase(tableName)) {
+                    return null;
+                }
+                slot = (SlotRef) slot.clone();
+                slot.setTblName(null); //clear table name here, not check it inside
             }
-            slot = (SlotRef) slot.clone();
-            slot.setTblName(null); //clear table name here, not check it inside
             return node.getQueryStatement().getQueryRelation().accept(this, slot);
         }
 
@@ -173,13 +175,15 @@ public class SlotRefResolver {
 
         @Override
         public Expr visitCTE(CTERelation node, SlotRef slot) {
-            String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
-            String cteName = node.getAlias() != null ? node.getAlias().getTbl() : node.getName();
-            if (!cteName.equalsIgnoreCase(tableName)) {
-                return null;
+            if (slot.getTblNameWithoutAnalyzed() != null) {
+                String tableName = slot.getTblNameWithoutAnalyzed().getTbl();
+                String cteName = node.getAlias() != null ? node.getAlias().getTbl() : node.getName();
+                if (!cteName.equalsIgnoreCase(tableName)) {
+                    return null;
+                }
+                slot = (SlotRef) slot.clone();
+                slot.setTblName(null); //clear table name here, not check it inside
             }
-            slot = (SlotRef) slot.clone();
-            slot.setTblName(null); //clear table name here, not check it inside
             return node.getCteQueryStatement().getQueryRelation().accept(this, slot);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/CreateMaterializedViewTest.java
@@ -40,6 +40,7 @@ import com.starrocks.scheduler.Constants;
 import com.starrocks.scheduler.TaskBuilder;
 import com.starrocks.scheduler.TaskManager;
 import com.starrocks.scheduler.persist.TaskRunStatus;
+import com.starrocks.schema.MTable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.SemanticException;
@@ -2549,32 +2550,6 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testUseSubQueryWithStar1() {
-        String sql = "create materialized view mv1 " +
-                "distributed by hash(k2) buckets 10 " +
-                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select * from (select * from tbl1) tbl";
-
-        starRocksAssert.withMaterializedView(sql, () -> {});
-    }
-
-    @Test
-    public void testUseSubQueryWithStar2() {
-        String sql = "create materialized view mv1 " +
-                "partition by k1 " +
-                "distributed by random " +
-                "refresh deferred manual " +
-                "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ") " +
-                "as select * from (select * from tbl1 where k1 > '19930101') tbl";
-        starRocksAssert.withMaterializedView(sql, () -> {});
-    }
-
-    @Test
     public void testUseSubQueryWithPartition() throws Exception {
         String sql1 = "create materialized view mv1 " +
                 "partition by k1 " +
@@ -3991,7 +3966,7 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testCreateMvWithCTE1() throws Exception {
+    public void testCreateMvWithCTE() throws Exception {
         starRocksAssert.withView("create view view_1 as select tb1.k1, k2 s2 from tbl1 tb1;");
         {
             String sql = "create materialized view mv1\n" +
@@ -4086,7 +4061,33 @@ public class CreateMaterializedViewTest {
     }
 
     @Test
-    public void testCreateMvWithCTE2() throws Exception {
+    public void testUseSubQueryWithStar1() {
+        String sql = "create materialized view mv1 " +
+                "distributed by hash(k2) buckets 10 " +
+                "refresh async START('2122-12-31') EVERY(INTERVAL 1 HOUR) " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select * from (select * from tbl1) tbl";
+
+        starRocksAssert.withMaterializedView(sql, () -> {});
+    }
+
+    @Test
+    public void testUseSubQueryWithStar2() {
+        String sql = "create materialized view mv1 " +
+                "partition by k1 " +
+                "distributed by random " +
+                "refresh deferred manual " +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\"\n" +
+                ") " +
+                "as select * from (select * from tbl1 where k1 > '19930101') tbl";
+        starRocksAssert.withMaterializedView(sql, () -> {});
+    }
+
+    @Test
+    public void testUseSubQueryWithStar3() throws Exception {
         starRocksAssert.withView("create view view_1 as select tb1.k1, k2 s2 from tbl1 tb1;",
                 () -> {
                     String sql = "create materialized view mv1\n" +
@@ -4097,6 +4098,38 @@ public class CreateMaterializedViewTest {
                             ")\n" +
                             "as with cte1 as (select * from (select * from tbl1 tb1) t where t.k1 > 10) " +
                             " select * from cte1;";
+                    starRocksAssert.withMaterializedView(sql, () -> {});
+                });
+    }
+
+    @Test
+    public void testPartitionByWithOrderBy1() {
+        starRocksAssert.withTable(new MTable("tt1", "k1",
+                        List.of(
+                                "k1 datetime",
+                                "k2 string",
+                                "v1 int"
+                        ),
+
+                        "k1",
+                        List.of(
+                                "PARTITION p0 values [('2021-12-01'),('2022-01-01'))",
+                                "PARTITION p1 values [('2022-01-01'),('2022-02-01'))",
+                                "PARTITION p2 values [('2022-02-01'),('2022-03-01'))",
+                                "PARTITION p3 values [('2022-03-01'),('2022-04-01'))",
+                                "PARTITION p4 values [('2022-04-01'),('2022-05-01'))"
+                        )
+                ),
+                () -> {
+                    String sql = "create materialized view mv1 " +
+                            "partition by date_trunc('day', k1) " +
+                            "distributed by random " +
+                            "order by (k3) \n" +
+                            "refresh deferred manual " +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\"\n" +
+                            ") " +
+                            "as select k1, v1, concat(k2, 'xxx') as k3 from (select * from tt1 where k1 > '19930101') tbl";
                     starRocksAssert.withMaterializedView(sql, () -> {});
                 });
     }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -470,6 +470,30 @@ public class StarRocksAssert {
         return withMaterializedView(sql, false);
     }
 
+    public StarRocksAssert withMaterializedView(String sql, ExceptionRunnable action) {
+        String mvName = null;
+        try {
+            StatementBase stmt = UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+            Preconditions.checkState(stmt instanceof CreateMaterializedViewStatement);
+            CreateMaterializedViewStatement createMaterializedViewStatement = (CreateMaterializedViewStatement) stmt;
+            mvName = createMaterializedViewStatement.getTableName().getTbl();
+            withMaterializedView(sql);
+            action.run();
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        } finally {
+            if (!Strings.isNullOrEmpty(mvName)) {
+                try {
+                    dropMaterializedView(mvName);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return this;
+    }
+
     public void assertMVWithoutComplexExpression(String dbName, String tableName) {
         Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
         Table table = db.getTable(tableName);
@@ -493,8 +517,7 @@ public class StarRocksAssert {
             checkAlterJob();
         } else {
             Preconditions.checkState(stmt instanceof CreateMaterializedViewStatement);
-            CreateMaterializedViewStatement createMaterializedViewStatement =
-                    (CreateMaterializedViewStatement) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+            CreateMaterializedViewStatement createMaterializedViewStatement = (CreateMaterializedViewStatement) stmt;
             if (isOnlySingleReplica) {
                 createMaterializedViewStatement.getProperties().put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "1");
             }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -477,18 +477,18 @@ public class StarRocksAssert {
             Preconditions.checkState(stmt instanceof CreateMaterializedViewStatement);
             CreateMaterializedViewStatement createMaterializedViewStatement = (CreateMaterializedViewStatement) stmt;
             mvName = createMaterializedViewStatement.getTableName().getTbl();
+            System.out.println(sql);
             withMaterializedView(sql);
             action.run();
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
         } finally {
-            if (!Strings.isNullOrEmpty(mvName)) {
-                try {
-                    dropMaterializedView(mvName);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                }
+            Preconditions.checkState(!Strings.isNullOrEmpty(mvName));
+            try {
+                dropMaterializedView(mvName);
+            } catch (Exception e) {
+                e.printStackTrace();
             }
         }
         return this;


### PR DESCRIPTION
Why I'm doing:

```
2023-12-15 14:32:21,528 WARN (starrocks-mysql-nio-pool-2|459) [StmtExecutor.handleDdlStmt():1562] DDL statement (CREATE MATERIALIZED VIEW if not exists test_mv0
PARTITION BY lo_orderdate
DISTRIBUTED BY RANDOM
REFRESH DEFERRED MANUAL
PROPERTIES (  "replication_num"="1") AS
 select * from (select * from lineorder where lo_orderdate >= '19930101' and lo_orderdate < '19980101' and lo_orderkey > 1000 and lo_orderkey < 10000) tt) process failed.
java.lang.NullPointerException: Cannot invoke "com.starrocks.analysis.TableName.getTbl()" because the return value of "com.starrocks.analysis.SlotRef.getTblNameWithoutAnalyzed()" is null
        at com.starrocks.sql.analyzer.SlotRefResolver$2.visitSubquery(SlotRefResolver.java:114) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.SlotRefResolver$2.visitSubquery(SlotRefResolver.java:81) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.SubqueryRelation.accept(SubqueryRelation.java:62) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.SlotRefResolver$2.visitSelect(SlotRefResolver.java:109) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.SlotRefResolver$2.visitSelect(SlotRefResolver.java:81) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.SelectRelation.accept(SelectRelation.java:242) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.SlotRefResolver$1.visitSlot(SlotRefResolver.java:62) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.SlotRefResolver$1.visitSlot(SlotRefResolver.java:39) ~[starrocks-fe.jar:?]
        at com.starrocks.analysis.SlotRef.accept(SlotRef.java:511) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.SlotRefResolver.resolveExpr(SlotRefResolver.java:197) ~[starrocks-fe.jar:?]
        at com.starrocks.catalog.MvJoinFilter.getPartitionJoinMap(MvJoinFilter.java:179) ~[starrocks-fe.jar:?]
        at com.starrocks.server.LocalMetastore.createMaterializedView(LocalMetastore.java:3243) ~[starrocks-fe.jar:?]
        at com.starrocks.server.GlobalStateMgr.createMaterializedView(GlobalStateMgr.java:3468) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.lambda$visitCreateMaterializedViewStatement$8(DDLStmtExecutor.java:285) ~[starrocks-fe.jar:?]
        at com.starrocks.common.ErrorReport.wrapWithRuntimeException(ErrorReport.java:112) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:284) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor$StmtExecutorVisitor.visitCreateMaterializedViewStatement(DDLStmtExecutor.java:161) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.CreateMaterializedViewStatement.accept(CreateMaterializedViewStatement.java:269) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.DDLStmtExecutor.execute(DDLStmtExecutor.java:147) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDdlStmt(StmtExecutor.java:1536) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.execute(StmtExecutor.java:658) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.handleQuery(ConnectProcessor.java:381) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.dispatch(ConnectProcessor.java:574) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.ConnectProcessor.processOnce(ConnectProcessor.java:853) ~[starrocks-fe.jar:?]
        at com.starrocks.mysql.nio.ReadListener.lambda$handleEvent$0(ReadListener.java:69) ~[starrocks-fe.jar:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
What I'm doing:
- Support create mv with nested select star;
- Add more Uts;
- Add create mv with sort by uts.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
