### PR TITLE
[Enhancement] Force local exchange to resolve data skew

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -963,13 +963,9 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
                 thrift_sink.iceberg_table_sink, partition_expr_ctxs);
 
         if (iceberg_table_desc->is_unpartitioned_table() || thrift_sink.iceberg_table_sink.is_static_partition_sink) {
-            if (desired_iceberg_sink_dop != source_operator_dop) {
-                context->maybe_interpolate_local_passthrough_exchange_for_sink(
-                        runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, iceberg_table_sink_op,
-                        source_operator_dop, desired_iceberg_sink_dop);
-            } else {
-                fragment_ctx->pipelines().back()->get_op_factories().emplace_back(std::move(iceberg_table_sink_op));
-            }
+            context->maybe_interpolate_local_passthrough_exchange_for_sink(
+                    runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, iceberg_table_sink_op,
+                    source_operator_dop, desired_iceberg_sink_dop);
         } else {
             context->maybe_interpolate_local_key_partition_exchange_for_sink(
                     runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, iceberg_table_sink_op,
@@ -996,13 +992,9 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
                 hive_table_sink->get_output_expr(), partition_expr_ctxs);
 
         if (t_hive_sink.partition_column_names.size() == 0 || t_hive_sink.is_static_partition_sink) {
-            if (source_operator_dop != desired_hive_sink_dop) {
-                context->maybe_interpolate_local_passthrough_exchange_for_sink(
-                        runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, hive_table_sink_op,
-                        source_operator_dop, desired_hive_sink_dop);
-            } else {
-                fragment_ctx->pipelines().back()->get_op_factories().emplace_back(std::move(hive_table_sink_op));
-            }
+            context->maybe_interpolate_local_passthrough_exchange_for_sink(
+                    runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, hive_table_sink_op,
+                    source_operator_dop, desired_hive_sink_dop);
         } else {
             context->maybe_interpolate_local_key_partition_exchange_for_sink(
                     runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, hive_table_sink_op,
@@ -1054,13 +1046,9 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
         }
 
         if (partition_expr_ctxs.empty()) {
-            if (sink_dop != source_dop) {
-                context->maybe_interpolate_local_passthrough_exchange_for_sink(
-                        runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, std::move(op), source_dop,
-                        sink_dop);
-            } else {
-                fragment_ctx->pipelines().back()->get_op_factories().emplace_back(std::move(op));
-            }
+            context->maybe_interpolate_local_passthrough_exchange_for_sink(
+                    runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, std::move(op), source_dop,
+                    sink_dop);
         } else {
             context->maybe_interpolate_local_key_partition_exchange_for_sink(
                     runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, op, partition_expr_ctxs, source_dop,

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -1047,8 +1047,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
 
         if (partition_expr_ctxs.empty()) {
             context->maybe_interpolate_local_passthrough_exchange_for_sink(
-                    runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, std::move(op), source_dop,
-                    sink_dop);
+                    runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, std::move(op), source_dop, sink_dop);
         } else {
             context->maybe_interpolate_local_key_partition_exchange_for_sink(
                     runtime_state, Operator::s_pseudo_plan_node_id_for_final_sink, op, partition_expr_ctxs, source_dop,

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -128,10 +128,6 @@ void PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange_for_si
                                                                                    OpFactoryPtr table_sink_operator,
                                                                                    int32_t source_operator_dop,
                                                                                    int32_t desired_sink_dop) {
-    if (source_operator_dop == desired_sink_dop) {
-        return;
-    }
-
     auto* source_operator =
             down_cast<SourceOperatorFactory*>(_fragment_context->pipelines().back()->source_operator_factory());
     auto mem_mgr = std::make_shared<ChunkBufferMemoryManager>(source_operator_dop,


### PR DESCRIPTION
Why I'm doing:

There could be data skew among different pipeline drivers, which can be resolved by a local exchange. 

And the overhead of the local passthrough exchange is neglectable.

In the future, we can also use this exchange to scale writers based on throughput. 

What I'm doing:

Insert a local exchange between the source and sink operators, even if their desired dop(s) are identical.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
