### PR TITLE
[Feature] Support disk disable/decommission (part1)

### DIFF
--- a/be/src/agent/heartbeat_server.cpp
+++ b/be/src/agent/heartbeat_server.cpp
@@ -109,6 +109,14 @@ void HeartbeatServer::heartbeat(THeartbeatResult& heartbeat_result, const TMaste
         // nothing to do
     }
 
+    if (master_info.__isset.disabled_disks) {
+        _olap_engine->disable_disks(master_info.disabled_disks);
+    }
+
+    if (master_info.__isset.decommissioned_disks) {
+        _olap_engine->decommission_disks(master_info.decommissioned_disks);
+    }
+
     static auto num_hardware_cores = static_cast<int32_t>(CpuInfo::num_cores());
     if (res.ok()) {
         heartbeat_result.backend_info.__set_be_port(config::be_port);

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -56,6 +56,13 @@ class Tablet;
 class TabletManager;
 class TxnManager;
 
+enum DiskState {
+    ONLINE,
+    OFFLINE,       // detected by health_check, tablets on OFFLINE disk will be dropped.
+    DISABLED,      // set by user, tablets on DISABLED disk will be dropped.
+    DECOMMISSIONED // set by user, tablets on DECOMMISSIONED disk will be migrated to other disks.
+};
+
 // A DataDir used to manage data in same path.
 // Now, After DataDir was created, it will never be deleted for easy implementation.
 class DataDir {
@@ -72,8 +79,9 @@ public:
 
     const std::string& path() const { return _path; }
     int64_t path_hash() const { return _path_hash; }
-    bool is_used() const { return _is_used; }
-    void set_is_used(bool is_used) { _is_used = is_used; }
+    bool is_used() const { return _state == DiskState::ONLINE || _state == DiskState::DECOMMISSIONED; }
+    DiskState get_state() const { return _state; }
+    void set_state(DiskState state) { _state = state; }
     int32_t cluster_id() const { return _cluster_id_mgr->cluster_id(); }
 
     DataDirInfo get_dir_info() {
@@ -82,7 +90,7 @@ public:
         info.path_hash = _path_hash;
         info.disk_capacity = _disk_capacity_bytes;
         info.available = _available_bytes;
-        info.is_used = _is_used;
+        info.is_used = is_used();
         info.storage_medium = _storage_medium;
         return info;
     }
@@ -170,7 +178,7 @@ private:
     // the actual capacity of the disk of this data dir
     int64_t _disk_capacity_bytes;
     TStorageMedium::type _storage_medium;
-    bool _is_used;
+    DiskState _state;
 
     TabletManager* _tablet_manager;
     TxnManager* _txn_manager;

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -473,7 +473,7 @@ std::vector<DataDir*> StorageEngine::get_stores_for_create_tablet(TStorageMedium
     {
         std::lock_guard<std::mutex> l(_store_lock);
         for (auto& it : _store_map) {
-            if (it.second->is_used()) {
+            if (it.second->get_state() == DiskState::ONLINE) {
                 if (_available_storage_medium_type_count == 1 || it.second->storage_medium() == storage_medium) {
                     if (!it.second->capacity_limit_reached(0)) {
                         stores.push_back(it.second);
@@ -1539,6 +1539,39 @@ void StorageEngine::clear_rowset_delta_column_group_cache(const Rowset& rowset) 
         }
         return dcg_keys;
     }());
+}
+
+void StorageEngine::disable_disks(const std::vector<string>& disabled_disks) {
+    std::lock_guard<std::mutex> l(_store_lock);
+
+    for (auto& it : _store_map) {
+        if (std::find(disabled_disks.begin(), disabled_disks.end(), it.second->path()) != disabled_disks.end()) {
+            it.second->set_state(DiskState::DISABLED);
+            LOG(INFO) << "disk " << it.second->path << " is set to DISABLED";
+        } else {
+            if (it.second->get_state() == DiskState::DISABLED) {
+                it.second->set_state(DiskState::ONLINE);
+                LOG(INFO) << "disk " << it.second->path << " is recovered to ONLINE, previous state is DISABLED";
+            }
+        }
+    }
+}
+
+void StorageEngine::decommission_disks(const std::vector<string>& decommission_disks) {
+    std::lock_guard<std::mutex> l(_store_lock);
+
+    for (auto& it : _store_map) {
+        if (std::find(decommission_disks.begin(), decommission_disks.end(), it.second->path()) !=
+            decommission_disks.end()) {
+            it.second->set_state(DiskState::DECOMMISSIONED);
+            LOG(INFO) << "disk " << it.second->path << " is set to DECOMMISSIONED";
+        } else {
+            if (it.second->get_state() == DiskState::DECOMMISSIONED) {
+                it.second->set_state(DiskState::ONLINE); 
+                LOG(INFO) << "disk " << it.second->path << " is recovered to ONLINE, previous state is DECOMMISSIONED";
+            }
+        }
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1567,7 +1567,7 @@ void StorageEngine::decommission_disks(const std::vector<string>& decommission_d
             LOG(INFO) << "disk " << it.second->path << " is set to DECOMMISSIONED";
         } else {
             if (it.second->get_state() == DiskState::DECOMMISSIONED) {
-                it.second->set_state(DiskState::ONLINE); 
+                it.second->set_state(DiskState::ONLINE);
                 LOG(INFO) << "disk " << it.second->path << " is recovered to ONLINE, previous state is DECOMMISSIONED";
             }
         }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1568,7 +1568,8 @@ void StorageEngine::decommission_disks(const std::vector<string>& decommission_d
         } else {
             if (it.second->get_state() == DiskState::DECOMMISSIONED) {
                 it.second->set_state(DiskState::ONLINE);
-                LOG(INFO) << "disk " << it.second->path() << " is recovered to ONLINE, previous state is DECOMMISSIONED";
+                LOG(INFO) << "disk " << it.second->path()
+                          << " is recovered to ONLINE, previous state is DECOMMISSIONED";
             }
         }
     }

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -1547,11 +1547,11 @@ void StorageEngine::disable_disks(const std::vector<string>& disabled_disks) {
     for (auto& it : _store_map) {
         if (std::find(disabled_disks.begin(), disabled_disks.end(), it.second->path()) != disabled_disks.end()) {
             it.second->set_state(DiskState::DISABLED);
-            LOG(INFO) << "disk " << it.second->path << " is set to DISABLED";
+            LOG(INFO) << "disk " << it.second->path() << " is set to DISABLED";
         } else {
             if (it.second->get_state() == DiskState::DISABLED) {
                 it.second->set_state(DiskState::ONLINE);
-                LOG(INFO) << "disk " << it.second->path << " is recovered to ONLINE, previous state is DISABLED";
+                LOG(INFO) << "disk " << it.second->path() << " is recovered to ONLINE, previous state is DISABLED";
             }
         }
     }
@@ -1564,11 +1564,11 @@ void StorageEngine::decommission_disks(const std::vector<string>& decommission_d
         if (std::find(decommission_disks.begin(), decommission_disks.end(), it.second->path()) !=
             decommission_disks.end()) {
             it.second->set_state(DiskState::DECOMMISSIONED);
-            LOG(INFO) << "disk " << it.second->path << " is set to DECOMMISSIONED";
+            LOG(INFO) << "disk " << it.second->path() << " is set to DECOMMISSIONED";
         } else {
             if (it.second->get_state() == DiskState::DECOMMISSIONED) {
                 it.second->set_state(DiskState::ONLINE);
-                LOG(INFO) << "disk " << it.second->path << " is recovered to ONLINE, previous state is DECOMMISSIONED";
+                LOG(INFO) << "disk " << it.second->path() << " is recovered to ONLINE, previous state is DECOMMISSIONED";
             }
         }
     }

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -282,6 +282,10 @@ public:
 
     void clear_rowset_delta_column_group_cache(const Rowset& rowset);
 
+    void disable_disks(const std::vector<string>& disabled_disks);
+
+    void decommission_disks(const std::vector<string>& decommissioned_disks);
+
     void wake_finish_publish_vesion_thread() {
         std::unique_lock<std::mutex> wl(_finish_publish_version_mutex);
         _finish_publish_version_cv.notify_one();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DataProperty.java
@@ -91,7 +91,7 @@ public class DataProperty implements Writable {
         for (Backend backend : backends) {
             if (backend.hasPathHash()) {
                 mediumSet.addAll(backend.getDisks().values().stream()
-                        .filter(v -> v.getState() == DiskInfo.DiskState.ONLINE)
+                        .filter(DiskInfo::canCreateTablet)
                         .map(DiskInfo::getStorageMedium).collect(Collectors.toSet()));
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DiskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DiskInfo.java
@@ -49,7 +49,14 @@ import java.io.IOException;
 public class DiskInfo implements Writable {
     public enum DiskState {
         ONLINE,
-        OFFLINE
+        // Reported from BE, if disk is detected as unavailable, state will be OFFLINE.
+        // Tablets on OFFLINE disk will be dropped.
+        OFFLINE,
+        // Set by user, tablets on DISABLED disk will be dropped.
+        DISABLED,
+        // Set by user, tablets on DECOMMISSIONED disk will be cloned to other backends.
+        // Before the decommission finish, the disk is still usable, i.e. can provide read and write capability.
+        DECOMMISSIONED
     }
 
     private static final Logger LOG = LogManager.getLogger(DiskInfo.class);
@@ -127,6 +134,14 @@ public class DiskInfo implements Writable {
 
     public DiskState getState() {
         return state;
+    }
+
+    public boolean canReadWrite() {
+        return state == DiskState.ONLINE || state == DiskState.DECOMMISSIONED;
+    }
+
+    public boolean canCreateTablet() {
+        return state == DiskState.ONLINE;
     }
 
     // return true if changed

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -83,6 +83,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         COLOCATE_MISMATCH, // replicas do not all locate in right colocate backends set.
         COLOCATE_REDUNDANT, // replicas match the colocate backends set, but redundant.
         NEED_FURTHER_REPAIR, // one of replicas need a definite repair.
+        DISK_MIGRATION, // The disk where the replica is located is decommissioned.
     }
 
     // Most read only accesses to replicas should acquire db lock, to prevent
@@ -586,7 +587,8 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
 
         int alive = 0;
         int aliveAndVersionComplete = 0;
-        int stable = 0;
+        int backendStable = 0;
+        int diskStable = 0;
 
         Replica needFurtherRepairReplica = null;
         Set<String> hosts = Sets.newHashSet();
@@ -617,7 +619,13 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                 // this replica is alive, version complete, but backend is not available
                 continue;
             }
-            stable++;
+            backendStable++;
+
+            if (backend.isDiskDecommissioned(replica.getPathHash())) {
+                // disk in decommission state
+                continue;
+            }
+            diskStable++;
         }
 
         // 1. alive replicas are not enough
@@ -628,7 +636,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         if (needRecoverWithEmptyTablet(systemInfoService)) {
             LOG.info("need to forcefully recover with empty tablet for {}, replica info:{}",
                     id, getReplicaInfos());
-            return createRedundantSchedCtx(TabletStatus.FORCE_REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
+            return createRedundantSchedCtx(TabletStatus.FORCE_REDUNDANT, Priority.VERY_HIGH,
                     needFurtherRepairReplica);
         }
 
@@ -644,7 +652,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             //    at least one backend for new replica.
             // 4. replicationNum > 1: if replication num is set to 1, do not delete any replica, for safety reason
             // For example: 3 replica, 3 be, one set bad, we need to forcefully delete one first
-            return createRedundantSchedCtx(TabletStatus.FORCE_REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
+            return createRedundantSchedCtx(TabletStatus.FORCE_REDUNDANT, Priority.VERY_HIGH,
                     needFurtherRepairReplica);
         } else {
             List<Long> availableBEs = systemInfoService.getAvailableBackendIds();
@@ -654,26 +662,26 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             // of load task won't be blocked either.
             if (availableBEs.size() > alive) {
                 if (alive < (replicationNum / 2) + 1) {
-                    return Pair.create(TabletStatus.REPLICA_MISSING, TabletSchedCtx.Priority.HIGH);
+                    return Pair.create(TabletStatus.REPLICA_MISSING, Priority.HIGH);
                 } else if (alive < replicationNum) {
-                    return Pair.create(TabletStatus.REPLICA_MISSING, TabletSchedCtx.Priority.NORMAL);
+                    return Pair.create(TabletStatus.REPLICA_MISSING, Priority.NORMAL);
                 }
             }
         }
 
         // 2. version complete replicas are not enough
         if (aliveAndVersionComplete < (replicationNum / 2) + 1) {
-            return Pair.create(TabletStatus.VERSION_INCOMPLETE, TabletSchedCtx.Priority.HIGH);
+            return Pair.create(TabletStatus.VERSION_INCOMPLETE, Priority.HIGH);
         } else if (aliveAndVersionComplete < replicationNum) {
-            return Pair.create(TabletStatus.VERSION_INCOMPLETE, TabletSchedCtx.Priority.NORMAL);
+            return Pair.create(TabletStatus.VERSION_INCOMPLETE, Priority.NORMAL);
         } else if (aliveAndVersionComplete > replicationNum) {
             // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
-            return createRedundantSchedCtx(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
+            return createRedundantSchedCtx(TabletStatus.REDUNDANT, Priority.VERY_HIGH,
                     needFurtherRepairReplica);
         }
 
         // 3. replica is under relocating
-        if (stable < replicationNum) {
+        if (backendStable < replicationNum) {
             List<Long> replicaBeIds = replicas.stream()
                     .map(Replica::getBackendId).collect(Collectors.toList());
             List<Long> availableBeIds = aliveBeIdsInCluster.stream()
@@ -683,25 +691,30 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                     && availableBeIds.size() >= replicationNum
                     && replicationNum > 1) { // Doesn't have any BE that can be chosen to create a new replica
                 return createRedundantSchedCtx(TabletStatus.FORCE_REDUNDANT,
-                        stable < (replicationNum / 2) + 1 ? TabletSchedCtx.Priority.NORMAL :
-                                TabletSchedCtx.Priority.LOW, needFurtherRepairReplica);
+                        backendStable < (replicationNum / 2) + 1 ? Priority.NORMAL :
+                                Priority.LOW, needFurtherRepairReplica);
             }
-            if (stable < (replicationNum / 2) + 1) {
-                return Pair.create(TabletStatus.REPLICA_RELOCATING, TabletSchedCtx.Priority.NORMAL);
+            if (backendStable < (replicationNum / 2) + 1) {
+                return Pair.create(TabletStatus.REPLICA_RELOCATING, Priority.NORMAL);
             } else {
                 return Pair.create(TabletStatus.REPLICA_RELOCATING, Priority.LOW);
             }
         }
 
-        // 4. replica redundant
+        // 4. disk decommission
+        if (diskStable < replicationNum) {
+            return Pair.create(TabletStatus.DISK_MIGRATION, Priority.NORMAL);
+        }
+
+        // 5. replica redundant
         if (replicas.size() > replicationNum) {
             // we set REDUNDANT as VERY_HIGH, because delete redundant replicas can free the space quickly.
-            return createRedundantSchedCtx(TabletStatus.REDUNDANT, TabletSchedCtx.Priority.VERY_HIGH,
+            return createRedundantSchedCtx(TabletStatus.REDUNDANT, Priority.VERY_HIGH,
                     needFurtherRepairReplica);
         }
 
-        // 5. healthy
-        return Pair.create(TabletStatus.HEALTHY, TabletSchedCtx.Priority.NORMAL);
+        // 6. healthy
+        return Pair.create(TabletStatus.HEALTHY, Priority.NORMAL);
     }
 
     public TabletStatus getColocateHealthStatus(long visibleVersion,
@@ -752,6 +765,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
             }
         }
 
+        int diskStableCnt = 0;
         // 2. check version completeness
         for (Replica replica : replicas) {
             // do not check the replica that is not in the colocate backend set,
@@ -771,9 +785,19 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
                 // this replica is alive but version incomplete
                 return TabletStatus.VERSION_INCOMPLETE;
             }
+
+            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(replica.getBackendId());
+            if (backend != null && !backend.isDiskDecommissioned(replica.getPathHash())) {
+                diskStableCnt++;
+            }
         }
 
-        // 3. check redundant
+        // 3. check disk decommission
+        if (replicas.size() > diskStableCnt) {
+            return TabletStatus.DISK_MIGRATION;
+        }
+
+        // 4. check redundant
         if (replicas.size() > replicationNum) {
             return TabletStatus.COLOCATE_REDUNDANT;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -793,7 +793,7 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         }
 
         // 3. check disk decommission
-        if (replicas.size() > diskStableCnt) {
+        if (diskStableCnt < replicationNum) {
             return TabletStatus.DISK_MIGRATION;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/clone/RootPathLoadStatistic.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/RootPathLoadStatistic.java
@@ -46,18 +46,18 @@ import com.starrocks.thrift.TStorageMedium;
 public class RootPathLoadStatistic implements Comparable<RootPathLoadStatistic> {
 
     @SerializedName(value = "beId")
-    private long beId;
+    private final long beId;
     @SerializedName(value = "path")
-    private String path;
+    private final String path;
     @SerializedName(value = "pathHash")
-    private Long pathHash;
+    private final Long pathHash;
     @SerializedName(value = "storageMedium")
-    private TStorageMedium storageMedium;
+    private final TStorageMedium storageMedium;
     @SerializedName(value = "total")
-    private long capacityB;
+    private final long capacityB;
     @SerializedName(value = "used")
-    private long usedCapacityB;
-    private DiskState diskState;
+    private final long usedCapacityB;
+    private final DiskState diskState;
 
     private Classification clazz = Classification.INIT;
 
@@ -113,9 +113,9 @@ public class RootPathLoadStatistic implements Comparable<RootPathLoadStatistic> 
     }
 
     public BalanceStatus isFit(long tabletSize) {
-        if (diskState == DiskState.OFFLINE) {
+        if (diskState != DiskState.ONLINE) {
             return new BalanceStatus(ErrCode.COMMON_ERROR,
-                    toString() + " does not fit tablet with size: " + tabletSize + ", offline");
+                    toString() + " does not fit tablet with size: " + tabletSize + ", disk state: " + diskState);
         }
 
         if (DiskInfo.exceedLimit(capacityB - usedCapacityB - tabletSize, capacityB, false)) {

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletScheduler.java
@@ -46,7 +46,6 @@ import com.starrocks.catalog.ColocateTableIndex.GroupId;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
-import com.starrocks.catalog.DiskInfo.DiskState;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.LocalTablet.TabletStatus;
 import com.starrocks.catalog.MaterializedIndex;
@@ -235,7 +234,7 @@ public class TabletScheduler extends FrontendDaemon {
                     continue;
                 }
                 List<Long> pathHashes = disks.values().stream()
-                        .filter(v -> v.getState() == DiskState.ONLINE)
+                        .filter(DiskInfo::canReadWrite)
                         .map(DiskInfo::getPathHash).collect(Collectors.toList());
                 backendsWorkingSlots.get(beId).updatePaths(pathHashes, currentSlotPerPathConfig);
             } else {
@@ -893,6 +892,8 @@ public class TabletScheduler extends FrontendDaemon {
                 case COLOCATE_REDUNDANT:
                     handleColocateRedundant(tabletCtx);
                     break;
+                case DISK_MIGRATION:
+                    handleDiskMigration(tabletCtx, batchTask);
                 default:
                     break;
             }
@@ -1371,6 +1372,57 @@ public class TabletScheduler extends FrontendDaemon {
         tabletCtx.chooseSrcReplica(backendsWorkingSlots);
 
         // create clone task
+        batchTask.addTask(tabletCtx.createCloneReplicaAndTask());
+    }
+
+    private void handleDiskMigration(TabletSchedCtx tabletCtx, AgentBatchTask batchTask) throws SchedException {
+        Replica decommissionedReplica = null;
+        for (Replica replica : tabletCtx.getReplicas()) {
+            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackend(replica.getBackendId());
+            if (backend != null && backend.isDiskDecommissioned(replica.getPathHash())) {
+                decommissionedReplica = replica;
+                break;
+            }
+        }
+
+        if (decommissionedReplica == null) {
+            throw new SchedException(Status.UNRECOVERABLE, "there is no replica need to migrate");
+        }
+
+        // set source path
+        PathSlot pathSlot = backendsWorkingSlots.get(decommissionedReplica.getBackendId());
+        if (pathSlot == null) {
+            throw new SchedException(SchedException.Status.UNRECOVERABLE,
+                    "working slots not exist for be: " + decommissionedReplica.getBackendId());
+        }
+        if (pathSlot.takeSlot(decommissionedReplica.getPathHash()) == -1) {
+            throw new SchedException(Status.SCHEDULE_RETRY, "path busy, wait for next rand");
+        }
+        tabletCtx.setSrc(decommissionedReplica);
+
+        // set dest path
+        BackendLoadStatistic beLoad = loadStatistic.getBackendLoadStatistic(decommissionedReplica.getBackendId());
+        List<RootPathLoadStatistic> pathLoadStatistics = beLoad.getPathStatistics(tabletCtx.getStorageMedium());
+        if (pathLoadStatistics.size() < 2) {
+            throw new SchedException(SchedException.Status.UNRECOVERABLE, "there is only one path on backend "
+                    + decommissionedReplica.getBackendId() + ", unable to migrate tablet");
+        }
+        long destPathHash = -1L;
+        double lowestUserPercent = 1;
+        for (RootPathLoadStatistic loadStatistic : pathLoadStatistics) {
+            if (loadStatistic.getPathHash() == decommissionedReplica.getPathHash()) {
+                continue;
+            }
+            if (lowestUserPercent > loadStatistic.getUsedPercent()) {
+                lowestUserPercent = loadStatistic.getUsedPercent();
+                destPathHash = loadStatistic.getPathHash();
+            }
+        }
+        if (pathSlot.takeSlot(destPathHash) == -1) {
+            throw new SchedException(Status.SCHEDULE_RETRY, "path busy, wait for next rand");
+        }
+        tabletCtx.setDest(decommissionedReplica.getBackendId(), destPathHash);
+
         batchTask.addTask(tabletCtx.createCloneReplicaAndTask());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/io/JsonWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/io/JsonWriter.java
@@ -1,0 +1,27 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.common.io;
+
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class JsonWriter implements Writable {
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/CheckConsistencyJob.java
@@ -111,10 +111,6 @@ public class CheckConsistencyJob {
         return tabletId;
     }
 
-    public synchronized void setChecksum(long backendId, long checksum) {
-        this.checksumMap.put(backendId, checksum);
-    }
-
     /*
      * return:
      *  true: continue

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -78,8 +78,11 @@ import com.starrocks.persist.AuthUpgradeInfo;
 import com.starrocks.persist.AutoIncrementInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
 import com.starrocks.persist.BackendTabletsInfo;
+import com.starrocks.persist.BatchDeleteReplicaInfo;
 import com.starrocks.persist.BatchDropInfo;
 import com.starrocks.persist.BatchModifyPartitionsInfo;
+import com.starrocks.persist.CancelDecommissionDiskInfo;
+import com.starrocks.persist.CancelDisableDiskInfo;
 import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.ColumnRenameInfo;
@@ -89,7 +92,9 @@ import com.starrocks.persist.CreateInsertOverwriteJobLog;
 import com.starrocks.persist.CreateTableInfo;
 import com.starrocks.persist.CreateUserInfo;
 import com.starrocks.persist.DatabaseInfo;
+import com.starrocks.persist.DecommissionDiskInfo;
 import com.starrocks.persist.DictionaryMgrInfo;
+import com.starrocks.persist.DisableDiskInfo;
 import com.starrocks.persist.DropCatalogLog;
 import com.starrocks.persist.DropComputeNodeLog;
 import com.starrocks.persist.DropDbInfo;
@@ -464,6 +469,11 @@ public class JournalEntity implements Writable {
             case OperationType.OP_DELETE_REPLICA:
             case OperationType.OP_CLEAR_ROLLUP_INFO: {
                 data = ReplicaPersistInfo.read(in);
+                isRead = true;
+                break;
+            }
+            case OperationType.OP_BATCH_DELETE_REPLICA_BATCH: {
+                data = GsonUtils.GSON.fromJson(Text.readString(in), BatchDeleteReplicaInfo.class);
                 isRead = true;
                 break;
             }
@@ -1113,6 +1123,22 @@ public class JournalEntity implements Writable {
                 break;
             case OperationType.OP_MODIFY_DICTIONARY_MGR:
                 data = DictionaryMgrInfo.read(in);
+                isRead = true;
+                break;
+            case OperationType.OP_DECOMMISSION_DISK:
+                data = GsonUtils.GSON.fromJson(Text.readString(in), DecommissionDiskInfo.class);
+                isRead = true;
+                break;
+            case OperationType.OP_CANCEL_DECOMMISSION_DISK:
+                data = GsonUtils.GSON.fromJson(Text.readString(in), CancelDecommissionDiskInfo.class);
+                isRead = true;
+                break;
+            case OperationType.OP_DISABLE_DISK:
+                data = GsonUtils.GSON.fromJson(Text.readString(in), DisableDiskInfo.class);
+                isRead = true;
+                break;
+            case OperationType.OP_CANCEL_DISABLE_DISK:
+                data = GsonUtils.GSON.fromJson(Text.readString(in), CancelDisableDiskInfo.class);
                 isRead = true;
                 break;
             default: {

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -74,6 +74,7 @@ import com.starrocks.metric.GaugeMetric;
 import com.starrocks.metric.Metric.MetricUnit;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.BackendTabletsInfo;
+import com.starrocks.persist.BatchDeleteReplicaInfo;
 import com.starrocks.persist.ReplicaPersistInfo;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
@@ -115,6 +116,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.thrift.TException;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -717,6 +719,7 @@ public class ReportHandler extends Daemon {
         TabletInvertedIndex invertedIndex = GlobalStateMgr.getCurrentInvertedIndex();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
         final long MAX_DB_WLOCK_HOLDING_TIME_MS = 1000L;
+        List<Long> deleteTablets = new ArrayList<>();
         DB_TRAVERSE:
         for (Long dbId : tabletDeleteFromMeta.keySet()) {
             Database db = globalStateMgr.getDbIncludeRecycleBin(dbId);
@@ -866,12 +869,7 @@ public class ReportHandler extends Daemon {
 
                         // remove replica related tasks
                         AgentTaskQueue.removeReplicaRelatedTasks(backendId, tabletId);
-
-                        // write edit log
-                        ReplicaPersistInfo info = ReplicaPersistInfo.createForDelete(dbId, tableId, partitionId,
-                                indexId, tabletId, backendId);
-
-                        GlobalStateMgr.getCurrentState().getEditLog().logDeleteReplica(info);
+                        deleteTablets.add(tabletId);
                         LOG.warn("delete replica[{}] with state[{}] in tablet[{}] from meta. backend[{}]," +
                                         " report version: {}, current report version: {}",
                                 replica.getId(), replica.getState().name(), tabletId, backendId, backendReportVersion,
@@ -889,6 +887,11 @@ public class ReportHandler extends Daemon {
                 locker.unLockDatabase(db, LockType.WRITE);
             }
         } // end for dbs
+
+        if (deleteTablets.size() > 0) {
+            GlobalStateMgr.getCurrentState().getEditLog()
+                    .logBatchDeleteReplica(new BatchDeleteReplicaInfo(backendId, deleteTablets));
+        }
 
         if (Config.recover_with_empty_tablet && createReplicaBatchTask.getTaskNum() > 0) {
             // must add to queue, so that when task finish report, the task can be found in queue.

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -889,6 +889,7 @@ public class ReportHandler extends Daemon {
         } // end for dbs
 
         if (deleteTablets.size() > 0) {
+            // no need to be protected by db lock, if the related meta is dropped, the replay code will ignore that tablet
             GlobalStateMgr.getCurrentState().getEditLog()
                     .logBatchDeleteReplica(new BatchDeleteReplicaInfo(backendId, deleteTablets));
         }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/BatchDeleteReplicaInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/BatchDeleteReplicaInfo.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.JsonWriter;
+
+import java.util.List;
+
+public class BatchDeleteReplicaInfo extends JsonWriter {
+
+    @SerializedName("bId")
+    private long backendId;
+
+    @SerializedName("tablets")
+    private List<Long> tablets;
+
+    public BatchDeleteReplicaInfo() {
+    }
+
+    public BatchDeleteReplicaInfo(long backendId, List<Long> tablets) {
+        this.backendId = backendId;
+        this.tablets = tablets;
+    }
+
+    public long getBackendId() {
+        return backendId;
+    }
+
+    public List<Long> getTablets() {
+        return tablets;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/CancelDecommissionDiskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/CancelDecommissionDiskInfo.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.JsonWriter;
+
+import java.util.Map;
+
+public class CancelDecommissionDiskInfo extends JsonWriter {
+    // beId -> rootPath
+    @SerializedName("disks")
+    private final Map<Long, String> diskList;
+
+    public CancelDecommissionDiskInfo(Map<Long, String> diskList) {
+        this.diskList = diskList;
+    }
+
+    public Map<Long, String> getDiskList() {
+        return diskList;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/CancelDisableDiskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/CancelDisableDiskInfo.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.JsonWriter;
+
+import java.util.Map;
+
+public class CancelDisableDiskInfo extends JsonWriter {
+    // beId -> rootPath
+    @SerializedName("disks")
+    private final Map<Long, String> diskList;
+
+    public CancelDisableDiskInfo(Map<Long, String> diskList) {
+        this.diskList = diskList;
+    }
+
+    public Map<Long, String> getDiskList() {
+        return diskList;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/DecommissionDiskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/DecommissionDiskInfo.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.JsonWriter;
+
+import java.util.Map;
+
+public class DecommissionDiskInfo extends JsonWriter {
+    // beId -> rootPath
+    @SerializedName("disks")
+    private final Map<Long, String> diskList;
+
+    public DecommissionDiskInfo(Map<Long, String> diskList) {
+        this.diskList = diskList;
+    }
+
+    public Map<Long, String> getDiskList() {
+        return diskList;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/DisableDiskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/DisableDiskInfo.java
@@ -1,0 +1,34 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.JsonWriter;
+
+import java.util.Map;
+
+public class DisableDiskInfo extends JsonWriter {
+    // beId -> rootPath
+    @SerializedName("disks")
+    private final Map<Long, String> diskList;
+
+    public DisableDiskInfo(Map<Long, String> diskList) {
+        this.diskList = diskList;
+    }
+
+    public Map<Long, String> getDiskList() {
+        return diskList;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -484,6 +484,11 @@ public class EditLog {
                     globalStateMgr.replayDeleteReplica(info);
                     break;
                 }
+                case OperationType.OP_BATCH_DELETE_REPLICA_BATCH: {
+                    BatchDeleteReplicaInfo info = (BatchDeleteReplicaInfo) journal.getData();
+                    globalStateMgr.replayBatchDeleteReplica(info);
+                    break;
+                }
                 case OperationType.OP_ADD_COMPUTE_NODE: {
                     ComputeNode computeNode = (ComputeNode) journal.getData();
                     GlobalStateMgr.getCurrentSystemInfo().replayAddComputeNode(computeNode);
@@ -1169,6 +1174,26 @@ public class EditLog {
                     globalStateMgr.getDictionaryMgr().replayModifyDictionaryMgr(modifyInfo);
                     break;
                 }
+                case OperationType.OP_DECOMMISSION_DISK: {
+                    DecommissionDiskInfo info = (DecommissionDiskInfo) journal.getData();
+                    globalStateMgr.getClusterInfo().replayDecommissionDisks(info);
+                    break;
+                }
+                case OperationType.OP_CANCEL_DECOMMISSION_DISK: {
+                    CancelDecommissionDiskInfo info = (CancelDecommissionDiskInfo) journal.getData();
+                    globalStateMgr.getClusterInfo().replayCancelDecommissionDisks(info);
+                    break;
+                }
+                case OperationType.OP_DISABLE_DISK: {
+                    DisableDiskInfo info = (DisableDiskInfo) journal.getData();
+                    globalStateMgr.getClusterInfo().replayDisableDisks(info);
+                    break;
+                }
+                case OperationType.OP_CANCEL_DISABLE_DISK: {
+                    CancelDisableDiskInfo info = (CancelDisableDiskInfo) journal.getData();
+                    globalStateMgr.getClusterInfo().replayCancelDisableDisks(info);
+                    break;
+                }
                 default: {
                     if (Config.ignore_unknown_log_id) {
                         LOG.warn("UNKNOWN Operation Type {}", opCode);
@@ -1511,6 +1536,10 @@ public class EditLog {
         } else {
             logEdit(OperationType.OP_DELETE_REPLICA, info);
         }
+    }
+
+    public void logBatchDeleteReplica(BatchDeleteReplicaInfo info) {
+        logEdit(OperationType.OP_BATCH_DELETE_REPLICA_BATCH, info);
     }
 
     public void logTimestamp(Timestamp stamp) {
@@ -2206,5 +2235,21 @@ public class EditLog {
 
     public void logModifyDictionaryMgr(DictionaryMgrInfo info) {
         logEdit(OperationType.OP_MODIFY_DICTIONARY_MGR, info);
+    }
+
+    public void logDecommissionDisk(DecommissionDiskInfo info) {
+        logEdit(OperationType.OP_DECOMMISSION_DISK, info);
+    }
+
+    public void logCancelDecommissionDisk(CancelDecommissionDiskInfo info) {
+        logEdit(OperationType.OP_CANCEL_DECOMMISSION_DISK, info);
+    }
+
+    public void logDisableDisk(DisableDiskInfo info) {
+        logEdit(OperationType.OP_DISABLE_DISK, info);
+    }
+
+    public void logCancelDisableDisk(CancelDisableDiskInfo info) {
+        logEdit(OperationType.OP_CANCEL_DISABLE_DISK, info);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -482,6 +482,11 @@ public class OperationType {
     public static final short OP_UPDATE_FRONTEND_V2 = 13030;
     public static final short OP_ADD_BROKER_V2 = 13031;
     public static final short OP_DROP_BROKER_V2 = 13032;
+    public static final short OP_DECOMMISSION_DISK = 13033;
+    public static final short OP_CANCEL_DECOMMISSION_DISK = 13034;
+    public static final short OP_DISABLE_DISK = 13035;
+    public static final short OP_CANCEL_DISABLE_DISK = 13036;
+    public static final short OP_BATCH_DELETE_REPLICA_BATCH = 13037;
 
     public static final short OP_TIMESTAMP_V2 = 13040;
     public static final short OP_LEADER_INFO_CHANGE_V2 = 13041;

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -194,6 +194,7 @@ import com.starrocks.persist.AlterMaterializedViewStatusLog;
 import com.starrocks.persist.AuthUpgradeInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
 import com.starrocks.persist.BackendTabletsInfo;
+import com.starrocks.persist.BatchDeleteReplicaInfo;
 import com.starrocks.persist.ChangeMaterializedViewRefreshSchemeLog;
 import com.starrocks.persist.ColumnRenameInfo;
 import com.starrocks.persist.CreateTableInfo;
@@ -3113,6 +3114,10 @@ public class GlobalStateMgr {
 
     public void replayDeleteReplica(ReplicaPersistInfo info) {
         localMetastore.replayDeleteReplica(info);
+    }
+
+    public void replayBatchDeleteReplica(BatchDeleteReplicaInfo info) {
+        localMetastore.replayBatchDeleteReplica(info);
     }
 
     public void replayAddFrontend(Frontend fe) {

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -141,6 +141,7 @@ import com.starrocks.persist.AddSubPartitionsInfoV2;
 import com.starrocks.persist.AutoIncrementInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
 import com.starrocks.persist.BackendTabletsInfo;
+import com.starrocks.persist.BatchDeleteReplicaInfo;
 import com.starrocks.persist.ColocatePersistInfo;
 import com.starrocks.persist.ColumnRenameInfo;
 import com.starrocks.persist.CreateDbInfo;
@@ -2758,6 +2759,46 @@ public class LocalMetastore implements ConnectorMetadata {
             tablet.deleteReplicaByBackendId(info.getBackendId());
         } finally {
             locker.unLockDatabase(db, LockType.WRITE);
+        }
+    }
+
+    public void replayBatchDeleteReplica(BatchDeleteReplicaInfo info) {
+        for (long tabletId : info.getTablets()) {
+            TabletMeta meta = GlobalStateMgr.getCurrentInvertedIndex().getTabletMeta(tabletId);
+            if (meta == null) {
+                continue;
+            }
+            Database db = getDbIncludeRecycleBin(meta.getDbId());
+            if (db == null) {
+                LOG.warn("replay delete replica failed, db is null, meta: {}", meta);
+                continue;
+            }
+            db.writeLock();
+            try {
+                OlapTable olapTable = (OlapTable) getTableIncludeRecycleBin(db, meta.getTableId());
+                if (olapTable == null) {
+                    LOG.warn("replay delete replica failed, table is null, meta: {}", meta);
+                    continue;
+                }
+                Partition partition = getPartitionIncludeRecycleBin(olapTable, meta.getPartitionId());
+                if (partition == null) {
+                    LOG.warn("replay delete replica failed, partition is null, meta: {}", meta);
+                    continue;
+                }
+                MaterializedIndex materializedIndex = partition.getIndex(meta.getIndexId());
+                if (materializedIndex == null) {
+                    LOG.warn("replay delete replica failed, materializedIndex is null, meta: {}", meta);
+                    continue;
+                }
+                LocalTablet tablet = (LocalTablet) materializedIndex.getTablet(tabletId);
+                if (tablet == null) {
+                    LOG.warn("replay delete replica failed, tablet is null, meta: {}", meta);
+                    continue;
+                }
+                tablet.deleteReplicaByBackendId(info.getBackendId());
+            } finally {
+                db.writeUnlock();
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AnalyzerVisitor.java
@@ -560,13 +560,13 @@ public class AnalyzerVisitor extends AstVisitor<Void, ConnectContext> {
 
     @Override
     public Void visitAlterSystemStatement(AlterSystemStmt statement, ConnectContext context) {
-        AlterSystemStmtAnalyzer.analyze(statement, context);
+        new AlterSystemStmtAnalyzer().analyze(statement, context);
         return null;
     }
 
     @Override
     public Void visitCancelAlterSystemStatement(CancelAlterSystemStmt statement, ConnectContext context) {
-        AlterSystemStmtAnalyzer.analyze(statement, context);
+        new AlterSystemStmtAnalyzer().analyze(statement, context);
         return null;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -6781,6 +6781,26 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         return parameter;
     }
 
+    @Override
+    public ParseNode visitDecommissionDiskClause(StarRocksParser.DecommissionDiskClauseContext context) {
+        throw new SemanticException("not support");
+    }
+
+    @Override
+    public ParseNode visitCancelDecommissionDiskClause(StarRocksParser.CancelDecommissionDiskClauseContext context) {
+        throw new SemanticException("not support");
+    }
+
+    @Override
+    public ParseNode visitDisableDiskClause(StarRocksParser.DisableDiskClauseContext context) {
+        throw new SemanticException("not support");
+    }
+
+    @Override
+    public ParseNode visitCancelDisableDiskClause(StarRocksParser.CancelDisableDiskClauseContext context) {
+        throw new SemanticException("not support");
+    }
+
     // ------------------------------------------- Util Functions -------------------------------------------
 
     private <T> List<T> visit(List<? extends ParserRuleContext> contexts, Class<T> clazz) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -969,19 +969,19 @@ cleanTabletSchedQClause
     ;
 
 decommissionDiskClause
-    : DECOMMISSION DISK string (',' string)*
+    : DECOMMISSION DISK string (',' string)* ON BACKEND string
     ;
 
 cancelDecommissionDiskClause
-    : CANCEL DECOMMISSION DISK string (',' string)*
+    : CANCEL DECOMMISSION DISK string (',' string)* ON BACKEND string
     ;
 
 disableDiskClause
-    : DISABLE DISK string (',' string)*
+    : DISABLE DISK string (',' string)* ON BACKEND string
     ;
 
 cancelDisableDiskClause
-    : CANCEL DISABLE DISK string (',' string)*
+    : CANCEL DISABLE DISK string (',' string)* ON BACKEND string
     ;
 
 // ---------Alter table clause---------

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -876,6 +876,10 @@ alterClause
     | alterLoadErrorUrlClause
     | createImageClause
     | cleanTabletSchedQClause
+    | decommissionDiskClause
+    | cancelDecommissionDiskClause
+    | disableDiskClause
+    | cancelDisableDiskClause
 
     //Alter table clause
     | createIndexClause
@@ -962,6 +966,22 @@ createImageClause
 
 cleanTabletSchedQClause
     : CLEAN TABLET SCHEDULER QUEUE
+    ;
+
+decommissionDiskClause
+    : DECOMMISSION DISK string (',' string)*
+    ;
+
+cancelDecommissionDiskClause
+    : CANCEL DECOMMISSION DISK string (',' string)*
+    ;
+
+disableDiskClause
+    : DISABLE DISK string (',' string)*
+    ;
+
+cancelDisableDiskClause
+    : CANCEL DISABLE DISK string (',' string)*
     ;
 
 // ---------Alter table clause---------
@@ -2706,7 +2726,7 @@ nonReserved
     | CACHE | CAST | CANCEL | CATALOG | CATALOGS | CEIL | CHAIN | CHARSET | CLEAN | CLEAR | CLUSTER | CLUSTERS | CURRENT | COLLATION | COLUMNS
     | CUME_DIST | CUMULATIVE | COMMENT | COMMIT | COMMITTED | COMPUTE | CONNECTION | CONSISTENT | COSTS | COUNT
     | CONFIG | COMPACT
-    | DATA | DATE | DATACACHE | DATETIME | DAY | DECOMMISSION | DISABLE | DISTRIBUTION | DUPLICATE | DYNAMIC | DISTRIBUTED | DICTIONARY | DICTIONARY_GET | DEALLOCATE
+    | DATA | DATE | DATACACHE | DATETIME | DAY | DECOMMISSION | DISABLE | DISK | DISTRIBUTION | DUPLICATE | DYNAMIC | DISTRIBUTED | DICTIONARY | DICTIONARY_GET | DEALLOCATE
     | ENABLE | END | ENGINE | ENGINES | ERRORS | EVENTS | EXECUTE | EXTERNAL | EXTRACT | EVERY | ENCLOSE | ESCAPE | EXPORT
     | FAILPOINT | FAILPOINTS | FIELDS | FILE | FILTER | FIRST | FLOOR | FOLLOWING | FORMAT | FN | FRONTEND | FRONTENDS | FOLLOWER | FREE
     | FUNCTIONS

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocksLex.g4
@@ -467,6 +467,7 @@ YEAR: 'YEAR';
 LOCK: 'LOCK';
 UNLOCK: 'UNLOCK';
 LOW_PRIORITY: 'LOW_PRIORITY';
+DISK: 'DISK';
 
 EQ  : '=';
 NEQ : '<>' | '!=';

--- a/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/Backend.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.catalog.DiskInfo;
 import com.starrocks.catalog.DiskInfo.DiskState;
+import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TDisk;
@@ -57,6 +58,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 /**
  * This class extends the primary identifier of a Backend with ephemeral state,
@@ -112,7 +114,7 @@ public class Backend extends ComputeNode {
     public long getTotalCapacityB() {
         long totalCapacityB = 0L;
         for (DiskInfo diskInfo : disksRef.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE) {
+            if (diskInfo.canReadWrite()) {
                 totalCapacityB += diskInfo.getTotalCapacityB();
             }
         }
@@ -122,7 +124,7 @@ public class Backend extends ComputeNode {
     public long getDataTotalCapacityB() {
         long dataTotalCapacityB = 0L;
         for (DiskInfo diskInfo : disksRef.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE) {
+            if (diskInfo.canReadWrite()) {
                 dataTotalCapacityB += diskInfo.getDataTotalCapacityB();
             }
         }
@@ -133,7 +135,7 @@ public class Backend extends ComputeNode {
         // when cluster init, disks is empty, return 1L.
         long availableCapacityB = 1L;
         for (DiskInfo diskInfo : disksRef.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE) {
+            if (diskInfo.canReadWrite()) {
                 availableCapacityB += diskInfo.getAvailableCapacityB();
             }
         }
@@ -143,7 +145,7 @@ public class Backend extends ComputeNode {
     public long getDataUsedCapacityB() {
         long dataUsedCapacityB = 0L;
         for (DiskInfo diskInfo : disksRef.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE) {
+            if (diskInfo.canReadWrite()) {
                 dataUsedCapacityB += diskInfo.getDataUsedCapacityB();
             }
         }
@@ -153,7 +155,7 @@ public class Backend extends ComputeNode {
     public double getMaxDiskUsedPct() {
         double maxPct = 0.0;
         for (DiskInfo diskInfo : disksRef.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE) {
+            if (diskInfo.canReadWrite()) {
                 double percent = diskInfo.getUsedPct();
                 if (percent > maxPct) {
                     maxPct = percent;
@@ -163,13 +165,14 @@ public class Backend extends ComputeNode {
         return maxPct;
     }
 
-    public boolean diskExceedLimitByStorageMedium(TStorageMedium storageMedium) {
+    // For create table and the storageMedium should be specified
+    public boolean checkDiskExceedLimitForCreate(TStorageMedium storageMedium) {
         if (getDiskNumByStorageMedium(storageMedium) <= 0) {
             return true;
         }
         boolean exceedLimit = true;
         for (DiskInfo diskInfo : disksRef.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE && diskInfo.getStorageMedium() == storageMedium &&
+            if (diskInfo.canCreateTablet() && diskInfo.getStorageMedium() == storageMedium &&
                     !diskInfo.exceedLimit(true)) {
                 exceedLimit = false;
                 break;
@@ -178,13 +181,29 @@ public class Backend extends ComputeNode {
         return exceedLimit;
     }
 
-    public boolean diskExceedLimit() {
+    // For create table
+    public boolean checkDiskExceedLimitForCreate() {
         if (getDiskNum() <= 0) {
             return true;
         }
         boolean exceedLimit = true;
         for (DiskInfo diskInfo : disksRef.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE && !diskInfo.exceedLimit(true)) {
+            if (diskInfo.canCreateTablet() && !diskInfo.exceedLimit(true)) {
+                exceedLimit = false;
+                break;
+            }
+        }
+        return exceedLimit;
+    }
+
+    // For data load
+    public boolean checkDiskExceedLimit() {
+        if (getDiskNum() <= 0) {
+            return true;
+        }
+        boolean exceedLimit = true;
+        for (DiskInfo diskInfo : disksRef.values()) {
+            if (diskInfo.canReadWrite() && !diskInfo.exceedLimit(true)) {
                 exceedLimit = false;
                 break;
             }
@@ -245,13 +264,17 @@ public class Backend extends ComputeNode {
                 diskInfo.setStorageMedium(tDisk.getStorage_medium());
             }
 
-            if (isUsed) {
-                if (diskInfo.setState(DiskState.ONLINE)) {
-                    isChanged = true;
-                }
-            } else {
-                if (diskInfo.setState(DiskState.OFFLINE)) {
-                    isChanged = true;
+            // if the disk state is decommissioned/disable, ignore the report state from BE,
+            // because these states is set by user.
+            if (diskInfo.getState() != DiskState.DECOMMISSIONED && diskInfo.getState() != DiskState.DISABLED) {
+                if (isUsed) {
+                    if (diskInfo.setState(DiskState.ONLINE)) {
+                        isChanged = true;
+                    }
+                } else {
+                    if (diskInfo.setState(DiskState.OFFLINE)) {
+                        isChanged = true;
+                    }
                 }
             }
             LOG.debug("update disk info. backendId: {}, diskInfo: {}", getId(), diskInfo.toString());
@@ -273,6 +296,44 @@ public class Backend extends ComputeNode {
             GlobalStateMgr.getCurrentSystemInfo().updatePathInfo(addedDisks, removedDisks);
             // log disk changing
             GlobalStateMgr.getCurrentState().getEditLog().logBackendStateChange(this);
+        }
+    }
+
+    public void decommissionDisk(String rootPath) throws DdlException {
+        DiskInfo diskInfo = disksRef.get(rootPath);
+        if (diskInfo != null) {
+            if (diskInfo.getState() == DiskState.DISABLED) {
+                throw new DdlException("Disk " + rootPath + " is in DISABLED state, can not decommission");
+            }
+            diskInfo.setState(DiskState.DECOMMISSIONED);
+            LOG.info("disk {} is set to DECOMMISSIONED", rootPath);
+        }
+    }
+
+    public void cancelDecommissionDisk(String rootPath) {
+        DiskInfo diskInfo = disksRef.get(rootPath);
+        if (diskInfo != null && diskInfo.getState() == DiskState.DECOMMISSIONED) {
+            diskInfo.setState(DiskState.ONLINE);
+            LOG.info("disk {} is recovered to ONLINE, previous state is DECOMMISSIONED", rootPath);
+        }
+    }
+
+    public void disableDisk(String rootPath) throws DdlException {
+        DiskInfo diskInfo = disksRef.get(rootPath);
+        if (diskInfo != null) {
+            if (diskInfo.getState() == DiskState.DECOMMISSIONED) {
+                throw new DdlException("Disk " + rootPath + " is in DECOMMISSIONED state, can not disable");
+            }
+            diskInfo.setState(DiskState.DISABLED);
+            LOG.info("disk {} is set to DISABLED", rootPath);
+        }
+    }
+
+    public void cancelDisableDisk(String rootPath) {
+        DiskInfo diskInfo = disksRef.get(rootPath);
+        if (diskInfo != null && diskInfo.getState() == DiskState.DISABLED) {
+            diskInfo.setState(DiskState.ONLINE);
+            LOG.info("disk {} is recovered to ONLINE, previous state is DISABLED", rootPath);
         }
     }
 
@@ -401,7 +462,7 @@ public class Backend extends ComputeNode {
         ImmutableMap<String, DiskInfo> disks = this.getDisks();
         Set<TStorageMedium> set = Sets.newHashSet();
         for (DiskInfo diskInfo : disks.values()) {
-            if (diskInfo.getState() == DiskState.ONLINE) {
+            if (diskInfo.canCreateTablet()) {
                 set.add(diskInfo.getStorageMedium());
             }
         }
@@ -410,6 +471,29 @@ public class Backend extends ComputeNode {
 
     private int getDiskNum() {
         return disksRef.size();
+    }
+
+    public List<String> getDisabledDisks() {
+        return disksRef.values()
+                .stream()
+                .filter(diskInfo -> diskInfo.getState() == DiskState.DISABLED)
+                .map(DiskInfo::getRootPath)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getDecommissionedDisks() {
+        return disksRef.values()
+                .stream()
+                .filter(diskInfo -> diskInfo.getState() == DiskState.DECOMMISSIONED)
+                .map(DiskInfo::getRootPath)
+                .collect(Collectors.toList());
+    }
+
+    public boolean isDiskDecommissioned(long pathHash) {
+        return disksRef.values()
+                .stream()
+                .anyMatch(diskInfo -> (pathHash == diskInfo.getPathHash())
+                        && diskInfo.getState() == DiskState.DECOMMISSIONED);
     }
 
     /**

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -270,6 +270,10 @@ public class HeartbeatMgr extends FrontendDaemon {
                 copiedMasterInfo.setHeartbeat_flags(flags);
                 copiedMasterInfo.setBackend_id(computeNodeId);
                 copiedMasterInfo.setRun_mode(RunMode.toTRunMode(RunMode.getCurrentRunMode()));
+                if (computeNode instanceof Backend) {
+                    copiedMasterInfo.setDisabled_disks(((Backend) computeNode).getDisabledDisks());
+                    copiedMasterInfo.setDecommissioned_disks(((Backend) computeNode).getDecommissionedDisks());
+                }
                 THeartbeatResult result = client.heartbeat(copiedMasterInfo);
 
                 ok = true;

--- a/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/SystemInfoService.java
@@ -60,6 +60,10 @@ import com.starrocks.common.util.NetUtils;
 import com.starrocks.meta.lock.LockType;
 import com.starrocks.meta.lock.Locker;
 import com.starrocks.metric.MetricRepo;
+import com.starrocks.persist.CancelDecommissionDiskInfo;
+import com.starrocks.persist.CancelDisableDiskInfo;
+import com.starrocks.persist.DecommissionDiskInfo;
+import com.starrocks.persist.DisableDiskInfo;
 import com.starrocks.persist.DropComputeNodeLog;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -435,6 +439,137 @@ public class SystemInfoService implements GsonPostProcessable {
         MetricRepo.generateBackendsTabletMetrics();
     }
 
+    public void decommissionDisks(List<String> diskList) throws DdlException {
+        checkDisksParam(diskList);
+
+        Map<Long, String> diskMap = new HashMap<>();
+        for (String disk : diskList) {
+            String[] items = disk.split(":");
+            int port = Integer.parseInt(items[1]);
+            Backend backend = getBackendWithHeartbeatPort(items[0], port);
+            if (backend != null) {
+                backend.decommissionDisk(items[2]);
+                diskMap.put(backend.getId(), items[2]);
+            }
+        }
+
+        GlobalStateMgr.getCurrentState().getEditLog().logDecommissionDisk(new DecommissionDiskInfo(diskMap));
+    }
+
+    public void cancelDecommissionDisks(List<String> diskList) throws DdlException {
+        checkDisksParam(diskList);
+
+        Map<Long, String> diskMap = new HashMap<>();
+        for (String disk : diskList) {
+            String[] items = disk.split(":");
+            int port = Integer.parseInt(items[1]);
+            Backend backend = getBackendWithHeartbeatPort(items[0], port);
+            if (backend != null) {
+                backend.cancelDecommissionDisk(items[2]);
+                diskMap.put(backend.getId(), items[2]);
+            }
+        }
+
+        GlobalStateMgr.getCurrentState().getEditLog().logCancelDecommissionDisk(new CancelDecommissionDiskInfo(diskMap));
+    }
+
+    public void disableDisks(List<String> diskList) throws DdlException {
+        checkDisksParam(diskList);
+
+        Map<Long, String> diskMap = new HashMap<>();
+        for (String disk : diskList) {
+            String[] items = disk.split(":");
+            int port = Integer.parseInt(items[1]);
+            Backend backend = getBackendWithHeartbeatPort(items[0], port);
+            if (backend != null) {
+                backend.disableDisk(items[2]);
+                diskMap.put(backend.getId(), items[2]);
+            }
+        }
+
+        GlobalStateMgr.getCurrentState().getEditLog().logDisableDisk(new DisableDiskInfo(diskMap));
+    }
+
+    public void cancelDisableDisks(List<String> diskList) throws DdlException {
+        checkDisksParam(diskList);
+
+        Map<Long, String> diskMap = new HashMap<>();
+        for (String disk : diskList) {
+            String[] items = disk.split(":");
+            int port = Integer.parseInt(items[1]);
+            Backend backend = getBackendWithHeartbeatPort(items[0], port);
+            if (backend != null) {
+                backend.cancelDisableDisk(items[2]);
+                diskMap.put(backend.getId(), items[2]);
+            }
+        }
+
+        GlobalStateMgr.getCurrentState().getEditLog().logCancelDisableDisk(new CancelDisableDiskInfo(diskMap));
+    }
+
+    public void replayDecommissionDisks(DecommissionDiskInfo info) {
+        for (Map.Entry<Long, String> entry : info.getDiskList().entrySet()) {
+            Backend backend = getBackend(entry.getKey());
+            if (backend != null) {
+                try {
+                    backend.decommissionDisk(entry.getValue());
+                } catch (DdlException e) {
+                    LOG.warn("replay decommission disk failed", e);
+                }
+            }
+        }
+    }
+
+    public void replayCancelDecommissionDisks(CancelDecommissionDiskInfo info) {
+        for (Map.Entry<Long, String> entry : info.getDiskList().entrySet()) {
+            Backend backend = getBackend(entry.getKey());
+            if (backend != null) {
+                backend.cancelDecommissionDisk(entry.getValue());
+            }
+        }
+    }
+
+    public void replayDisableDisks(DisableDiskInfo info) {
+        for (Map.Entry<Long, String> entry : info.getDiskList().entrySet()) {
+            Backend backend = getBackend(entry.getKey());
+            if (backend != null) {
+                try {
+                    backend.disableDisk(entry.getValue());
+                } catch (DdlException e) {
+                    LOG.warn("replay disable disk failed", e);
+                }
+            }
+        }
+    }
+
+    public void replayCancelDisableDisks(CancelDisableDiskInfo info) {
+        for (Map.Entry<Long, String> entry : info.getDiskList().entrySet()) {
+            Backend backend = getBackend(entry.getKey());
+            if (backend != null) {
+                backend.cancelDisableDisk(entry.getValue());
+            }
+        }
+    }
+
+    private void checkDisksParam(List<String> diskList) throws DdlException {
+        for (String disk : diskList) {
+            String[] items = disk.split(":");
+            int port;
+            try {
+                port = Integer.parseInt(items[1]);
+            } catch (NumberFormatException e) {
+                throw new DdlException("invalid port format: " + items[1]);
+            }
+            Backend backend = getBackendWithHeartbeatPort(items[0], port);
+            if (backend == null) {
+                throw new DdlException("backend dose not exist: " + items[0] + ":" + items[1]);
+            }
+            if (!backend.getDisks().containsKey(items[2])) {
+                throw new DdlException("disk path dose not exits: " + items[2] + ", should be root path");
+            }
+        }
+    }
+
     // only for test
     public void dropAllBackend() {
         // update idToBackend
@@ -735,7 +870,7 @@ public class SystemInfoService implements GsonPostProcessable {
                                                          TStorageMedium storageMedium) {
 
         return seqChooseBackendIds(backendNum, needAvailable, isCreate,
-                v -> !v.diskExceedLimitByStorageMedium(storageMedium));
+                v -> !v.checkDiskExceedLimitForCreate(storageMedium));
     }
 
     public Long seqChooseBackendOrComputeId() throws UserException {
@@ -755,7 +890,11 @@ public class SystemInfoService implements GsonPostProcessable {
 
     public List<Long> seqChooseBackendIds(int backendNum, boolean needAvailable, boolean isCreate) {
 
-        return seqChooseBackendIds(backendNum, needAvailable, isCreate, v -> !v.diskExceedLimit());
+        if (isCreate) {
+            return seqChooseBackendIds(backendNum, needAvailable, true, v -> !v.checkDiskExceedLimitForCreate());
+        } else {
+            return seqChooseBackendIds(backendNum, needAvailable, false, v -> !v.checkDiskExceedLimit());
+        }
     }
 
     public List<Long> seqChooseComputeNodes(int computeNodeNum, boolean needAvailable, boolean isCreate) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AlterSystemStmtAnalyzerTest.java
@@ -54,8 +54,7 @@ public class AlterSystemStmtAnalyzerTest {
     @Test
     public void testVisitModifyBackendHostClause() {
         mockNet();
-        AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor visitor =
-                new AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor();
+        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
         ModifyBackendAddressClause clause = new ModifyBackendAddressClause("test", "fqdn");
         Void resutl = visitor.visitModifyBackendHostClause(clause, null);
         Assert.assertTrue(resutl == null);
@@ -64,8 +63,7 @@ public class AlterSystemStmtAnalyzerTest {
     @Test
     public void testVisitModifyFrontendHostClause() {
         mockNet();
-        AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor visitor =
-                new AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor();
+        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
         ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("test", "fqdn");
         Void resutl = visitor.visitModifyFrontendHostClause(clause, null);
         Assert.assertTrue(resutl == null);
@@ -73,16 +71,14 @@ public class AlterSystemStmtAnalyzerTest {
 
     @Test(expected = SemanticException.class)
     public void testVisitModifyBackendHostClauseException() {
-        AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor visitor =
-                new AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor();
+        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
         ModifyBackendAddressClause clause = new ModifyBackendAddressClause("127.0.0.2", "127.0.0.1");
         visitor.visitModifyBackendHostClause(clause, null);
     }
 
     @Test(expected = SemanticException.class)
     public void testVisitModifyFrontendHostClauseException() {
-        AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor visitor =
-                new AlterSystemStmtAnalyzer.AlterSystemStmtAnalyzerVisitor();
+        AlterSystemStmtAnalyzer visitor = new AlterSystemStmtAnalyzer();
         ModifyFrontendAddressClause clause = new ModifyFrontendAddressClause("127.0.0.2", "127.0.0.1");
         visitor.visitModifyFrontendHostClause(clause, null);
     }

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -31,6 +31,8 @@ struct TMasterInfo {
     8: optional i64 backend_id
     // 9: optional i64 min_active_txn_id = 0
     10: optional Types.TRunMode run_mode
+    11: optional list<string> disabled_disks
+    12: optional list<string> decommissioned_disks
 }
 
 struct TBackendInfo {


### PR DESCRIPTION
Why I'm doing:
1. In the case of disk damage, currently the tablet can only be repaired by modifying the disk configuration and restarting BE. However, for some customers, restarting BE is unacceptable.
2. For some reasons, such as disk performance, customers need to replace a disk. Currently, this is done by changing the configuration and restarting BE. Moreover, disk migration cannot yet be performed for single-replica tables.

What I'm doing:
1. Support disable disk: users can send a disable disk command: tablets on that disk will be removed, and a new replica of that tablet will be copied to health disks.
2. Support decommission disk: users can send a decommission disk command: tablets on that disk will be migrated to other disks on the same BE.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
