### PR TITLE
[Enhancement] allow to ignore set invaid system variable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2648,6 +2648,8 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static long mv_plan_cache_max_size = 1000;
 
+    @ConfField(mutable = true)
+    public static boolean ignore_invalid_system_variable = false;
     /**
      * Checking the connectivity of port opened by FE,
      * mainly used for checking edit log port currently.

--- a/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/VariableMgrTest.java
@@ -39,6 +39,7 @@ import com.starrocks.analysis.IntLiteral;
 import com.starrocks.analysis.StringLiteral;
 import com.starrocks.analysis.VariableExpr;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.UserException;
 import com.starrocks.mysql.privilege.Auth;
@@ -268,6 +269,19 @@ public class VariableMgrTest {
         SystemVariable setVar = new SystemVariable(SetType.SESSION, "version_comment", null);
         VariableMgr.setSystemVariable(null, setVar, false);
         Assert.fail("No exception throws.");
+    }
+
+    @Test
+    public void testIgnoreInvalidSystemVar() throws AnalysisException, DdlException {
+        // Set global variable
+        SystemVariable setVar = new SystemVariable(SetType.SESSION, "test_ignore_invalid_var", null);
+        try {
+            Config.ignore_invalid_system_variable = true;
+            VariableMgr.setSystemVariable(null, setVar, false);
+            Config.ignore_invalid_system_variable = false;
+        } catch (DdlException e) {
+            Assert.fail("DDL exception throws.");
+        }
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
Currently we are not perfectly compatible with all system variables in mysql. We need a way that can, on some occasions, skip non-existent system variable settings and not return an error.

What I'm doing:
Add fe config `ignore_invalid_system_variable`, when it is true, skip set system variable and no return error.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
