### PR TITLE
[Enhancement] Support Hive Table Formats that relies on SerDe properties to be correctly deserialized

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -582,6 +582,7 @@ HdfsScanner* HiveDataSource::_create_paimon_jni_scanner(const FSOptions& options
 
 HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) {
     const auto& scan_range = _scan_range;
+    static const char* serde_property_prefix = "SerDe.";
 
     std::string required_fields;
     for (auto const& slot : _materialize_slots) {
@@ -606,6 +607,7 @@ HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) 
     std::string hive_column_types;
     std::string serde;
     std::string input_format;
+    std::map<std::string, std::string> serde_properties;
 
     if (dynamic_cast<const FileTableDescriptor*>(_hive_table)) {
         const auto* file_table = dynamic_cast<const FileTableDescriptor*>(_hive_table);
@@ -627,6 +629,7 @@ HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) 
         hive_column_types = hdfs_table->get_hive_column_types();
         serde = hdfs_table->get_serde_lib();
         input_format = hdfs_table->get_input_format();
+        serde_properties = hdfs_table->get_serde_properties();
     }
 
     std::map<std::string, std::string> jni_scanner_params;
@@ -641,6 +644,10 @@ HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) 
     jni_scanner_params["serde"] = serde;
     jni_scanner_params["input_format"] = input_format;
     jni_scanner_params["fs_options_props"] = build_fs_options_properties(options);
+
+    for (const auto& pair : serde_properties) {
+        jni_scanner_params[serde_property_prefix + pair.first] = pair.second;
+    }
 
     std::string scanner_factory_class = "com/starrocks/hive/reader/HiveScannerFactory";
 

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -176,6 +176,7 @@ HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
     _hive_column_types = tdesc.hdfsTable.hive_column_types;
     _input_format = tdesc.hdfsTable.input_format;
     _serde_lib = tdesc.hdfsTable.serde_lib;
+    _serde_properties = tdesc.hdfsTable.serde_properties;
 }
 
 const std::string& HdfsTableDescriptor::get_hive_column_names() const {
@@ -192,6 +193,10 @@ const std::string& HdfsTableDescriptor::get_input_format() const {
 
 const std::string& HdfsTableDescriptor::get_serde_lib() const {
     return _serde_lib;
+}
+
+const std::map<std::string, std::string> HdfsTableDescriptor::get_serde_properties() const {
+    return _serde_properties;
 }
 
 FileTableDescriptor::FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -223,12 +223,14 @@ public:
     const std::string& get_hive_column_types() const;
     const std::string& get_input_format() const;
     const std::string& get_serde_lib() const;
+    const std::map<std::string, std::string> get_serde_properties() const;
 
 private:
     std::string _serde_lib;
     std::string _input_format;
     std::string _hive_column_names;
     std::string _hive_column_types;
+    std::map<std::string, std::string> _serde_properties;
 };
 
 class IcebergTableDescriptor : public HiveTableDescriptor {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -140,6 +140,8 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     private List<String> dataColumnNames = Lists.newArrayList();
     @SerializedName(value = "prop")
     private Map<String, String> hiveProperties = Maps.newHashMap();
+    @SerializedName(value = "sp")
+    private Map<String, String> serdeProperties = Maps.newHashMap();
 
     // For `insert into target_table select from hive_table, we set it to false when executing this kind of insert query.
     // 1. `useMetadataCache` is false means that this query need to list all selected partitions files from hdfs/s3.
@@ -159,7 +161,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
     public HiveTable(long id, String name, List<Column> fullSchema, String resourceName, String catalog,
                      String hiveDbName, String hiveTableName, String tableLocation, long createTime,
                      List<String> partColumnNames, List<String> dataColumnNames, Map<String, String> properties,
-                     HiveStorageFormat storageFormat, HiveTableType hiveTableType) {
+                     Map<String, String> serdeProperties, HiveStorageFormat storageFormat, HiveTableType hiveTableType) {
         super(id, name, TableType.HIVE, fullSchema);
         this.resourceName = resourceName;
         this.catalogName = catalog;
@@ -170,6 +172,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         this.partColumnNames = partColumnNames;
         this.dataColumnNames = dataColumnNames;
         this.hiveProperties = properties;
+        this.serdeProperties = serdeProperties;
         this.storageFormat = storageFormat;
         this.hiveTableType = hiveTableType;
     }
@@ -379,6 +382,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         tHdfsTable.setInput_format(hiveProperties.get(HIVE_TABLE_INPUT_FORMAT));
         tHdfsTable.setHive_column_names(hiveProperties.get(HIVE_TABLE_COLUMN_NAMES));
         tHdfsTable.setHive_column_types(hiveProperties.get(HIVE_TABLE_COLUMN_TYPES));
+        tHdfsTable.setSerde_properties(serdeProperties);
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.HDFS_TABLE, fullSchema.size(),
                 0, hiveTableName, hiveDbName);
@@ -571,6 +575,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         private List<String> partitionColNames = Lists.newArrayList();
         private List<String> dataColNames = Lists.newArrayList();
         private Map<String, String> properties = Maps.newHashMap();
+        private Map<String, String> serdeProperties = Maps.newHashMap();
         private HiveStorageFormat storageFormat;
         private HiveTableType hiveTableType = HiveTableType.MANAGED_TABLE;
 
@@ -637,6 +642,11 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
             return this;
         }
 
+        public Builder setSerdeProperties(Map<String, String> serdeProperties) {
+            this.serdeProperties = serdeProperties;
+            return this;
+        }
+
         public Builder setStorageFormat(HiveStorageFormat storageFormat) {
             this.storageFormat = storageFormat;
             return this;
@@ -649,7 +659,8 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
 
         public HiveTable build() {
             return new HiveTable(id, tableName, fullSchema, resourceName, catalogName, hiveDbName, hiveTableName,
-                    tableLocation, createTime, partitionColNames, dataColNames, properties, storageFormat, hiveTableType);
+                    tableLocation, createTime, partitionColNames, dataColNames, properties, serdeProperties,
+                    storageFormat, hiveTableType);
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreApiConverter.java
@@ -56,6 +56,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -145,6 +146,7 @@ public class HiveMetastoreApiConverter {
                 .setTableLocation(toTableLocation(table.getSd(), table.getParameters()))
                 .setProperties(toHiveProperties(table,
                         HiveStorageFormat.get(fromHdfsInputFormatClass(table.getSd().getInputFormat()).name())))
+                .setSerdeProperties(toSerDeProperties(table))
                 .setStorageFormat(
                         HiveStorageFormat.get(fromHdfsInputFormatClass(table.getSd().getInputFormat()).name()))
                 .setCreateTime(table.getCreateTime())
@@ -361,6 +363,15 @@ public class HiveMetastoreApiConverter {
         }
 
         return hiveProperties;
+    }
+
+    public static Map<String, String> toSerDeProperties(Table table) {
+        Map<String, String> serdeProperties = new HashMap<>();
+        if (table.getSd() != null && table.getSd().getSerdeInfo() != null &&
+                table.getSd().getSerdeInfo().getParameters() != null) {
+            serdeProperties = table.getSd().getSerdeInfo().getParameters();
+        }
+        return serdeProperties;
     }
 
     public static List<Column> toFullSchemasForHiveTable(Table table) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowCreateTableStmtTest.java
@@ -130,7 +130,7 @@ public class ShowCreateTableStmtTest {
 
         HiveTable table = new HiveTable(100, "test", fullSchema, "aa", "bb", "cc", "dd", "hdfs://xxx",
                 0, new ArrayList<>(), fullSchema.stream().map(x -> x.getName()).collect(Collectors.toList()),
-                props, HiveStorageFormat.ORC, HiveTable.HiveTableType.MANAGED_TABLE);
+                props, new HashMap<>(),  HiveStorageFormat.ORC, HiveTable.HiveTableType.MANAGED_TABLE);
         List<String> result = new ArrayList<>();
         GlobalStateMgr.getDdlStmt(table, result, null, null, false, true);
         Assert.assertEquals(result.size(), 1);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeStmtTest.java
@@ -149,7 +149,7 @@ public class AnalyzeStmtTest {
                 return new HiveTable(1, "customer", Lists.newArrayList(), "resource_name",
                         CatalogMgr.ResourceMappingCatalog.getResourceMappingCatalogName("resource_name", "hive"),
                         "hive", "tpch", "", 0, Lists.newArrayList(), Lists.newArrayList(), Maps.newHashMap(),
-                        null, null);
+                        Maps.newHashMap(), null, null);
             }
         };
         String sql = "analyze table tpch.customer";

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -403,6 +403,9 @@ struct THdfsTable {
 
     // hive table serde_lib
     9: optional string serde_lib
+
+    // hive table serde properties
+    10: optional map<string, string> serde_properties
 }
 
 struct TFileTable {

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
@@ -51,8 +51,12 @@ import static com.google.common.base.Preconditions.checkArgument;
 public class HiveScanner extends ConnectorScanner {
 
     private static final Logger LOG = LogManager.getLogger(HiveScanner.class);
+
+    private static final String SERDE_PROPERTY_PREFIX = "SerDe.";
+
     private final String hiveColumnNames;
     private final String[] hiveColumnTypes;
+    private Map<String, String> serdeProperties = new HashMap<>();
     private final String[] requiredFields;
     private int[] requiredColumnIds;
     private ColumnType[] requiredTypes;
@@ -98,6 +102,9 @@ public class HiveScanner extends ConnectorScanner {
         this.classLoader = this.getClass().getClassLoader();
         this.fsOptionsProps = params.get("fs_options_props");
         for (Map.Entry<String, String> kv : params.entrySet()) {
+            if (kv.getKey().startsWith(SERDE_PROPERTY_PREFIX)) {
+                this.serdeProperties.put(kv.getKey().substring(SERDE_PROPERTY_PREFIX.length()), kv.getValue());
+            }
             LOG.debug("key = " + kv.getKey() + ", value = " + kv.getValue());
         }
     }
@@ -164,6 +171,7 @@ public class HiveScanner extends ConnectorScanner {
         }
         properties.setProperty("columns.types", types.stream().collect(Collectors.joining(",")));
         properties.setProperty("serialization.lib", this.serde);
+        properties.putAll(serdeProperties);
 
         ScannerHelper.parseFSOptionsProps(fsOptionsProps, kv -> {
             properties.put(kv[0], kv[1]);
@@ -294,6 +302,9 @@ public class HiveScanner extends ConnectorScanner {
         sb.append("\n");
         sb.append("serde: ");
         sb.append(serde);
+        sb.append("\n");
+        sb.append("serdeProperties: ");
+        sb.append(serdeProperties.toString());
         sb.append("\n");
         sb.append("inputFormat: ");
         sb.append(inputFormat);

--- a/java-extensions/hive-reader/src/test/java/com/starrocks/hive/reader/TestHiveScanner.java
+++ b/java-extensions/hive-reader/src/test/java/com/starrocks/hive/reader/TestHiveScanner.java
@@ -2,6 +2,7 @@ package com.starrocks.hive.reader;
 
 import com.starrocks.jni.connector.OffHeapTable;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -39,12 +40,14 @@ public class TestHiveScanner {
         params.put("input_format", "org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat");
         params.put("serde", "org.apache.hadoop.hive.serde2.avro.AvroSerDe");
         params.put("required_fields", "col_tinyint,col_smallint,col_int,col_bigint,col_float,col_double,col_decimal");
+        params.put("SerDe.mongo.columns.mapping", "{\n\"id\":\"_id\",\n\"status\":\"status\"}");
         return params;
     }
 
     String runScanOnParams(Map<String, String> params) throws IOException {
         HiveScanner scanner = new HiveScanner(4096, params);
         System.out.println(scanner.toString());
+        Assert.assertTrue(scanner.toString().contains("mongo.columns.mapping"));
         scanner.open();
         StringBuilder sb = new StringBuilder();
         while (true) {


### PR DESCRIPTION
Why I'm doing:
To support Hive table formats that relies on SerDe properties, e.g. BSON

What I'm doing:
Pass SerDe properties of a hive table through BE to JNI reader so that SerDe properties could be utilized when deserializing row data.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
