### PR TITLE
[BugFix] fix Timestamp cast exception when Hive-Serde with version 2.x.x is used

### DIFF
--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -103,6 +104,8 @@ public class HiveColumnValue implements ColumnValue {
                     Instant.ofEpochSecond(localTimestampWritable.getSeconds(), localTimestampWritable.getNanos()),
                     ZoneId.systemDefault());
             return localDateTime.format(DATETIME_FORMATTER);
+        } else if (fieldData instanceof Timestamp) {
+            return fieldData.toString();
         } else {
             return inspectObject().toString();
         }


### PR DESCRIPTION

Why I'm doing:

The current version of Hive-Serde used by Hive JNI Reader is over 3.0.0.
The function `getPrimitiveJavaObject` resides in `org.apache.hadoop.hive.serde2.objectinspector.primitive` returns an object with type = `org.apache.hadoop.hive.common.type.Timestamp`.
However, with Hive-Serde version = 2.3.9 or 2.3.5, it returns with type = `java.sql.Timestamp`

What I'm doing:

This pr supports to deserialize`java.sql.Timestamp` type of data.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
