### PR TITLE
[Enhancement] Optimize heartbeat interval

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -115,6 +115,7 @@ public class HeartbeatMgr extends FrontendDaemon {
 
         List<Future<HeartbeatResponse>> hbResponses = Lists.newArrayList();
 
+        long startTime = System.currentTimeMillis();
         // send backend heartbeat
         for (Backend backend : idToBackendRef.values()) {
             BackendHeartbeatHandler handler = new BackendHeartbeatHandler(backend);
@@ -181,6 +182,10 @@ public class HeartbeatMgr extends FrontendDaemon {
 
         // write edit log
         GlobalStateMgr.getCurrentState().getEditLog().logHeartbeat(hbPackage);
+
+        // set sleep time to (heartbeat_timeout - timeUsed),
+        // so that the frequency of calling the heartbeat rpc can be stabilized at heartbeat_timeout
+        setInterval(Math.max(1L, Config.heartbeat_timeout_second * 1000L - (System.currentTimeMillis() - startTime)));
 
         ClientPool.beHeartbeatPool.setTimeoutMs(Config.heartbeat_timeout_second * 1000);
         ClientPool.brokerHeartbeatPool.setTimeoutMs(Config.heartbeat_timeout_second * 1000);


### PR DESCRIPTION
Why I'm doing:
In the case of machine shutdown, the heartbeat interval will be 2 * `Config.heartbeat_timeout_second`. As a result, the time to detect BE non-alive becomes longer.

What I'm doing:
Change the sleep time to (heartbeat_timeout - timeUsed), so that the frequency of calling the heartbeat rpc can be stabilized at `Config.heartbeat_timeout_second`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
