### PR TITLE
[BugFix] Fix parameter configuration issues when create db

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/hive/IcebergHiveCatalog.java
@@ -120,8 +120,6 @@ public class IcebergHiveCatalog implements IcebergCatalog {
                     LOG.error("Invalid location URI: {}", value, e);
                     throw new StarRocksConnectorException("Invalid location URI: %s. msg: %s", value, e.getMessage());
                 }
-            } else {
-                throw new IllegalArgumentException("Unrecognized property: " + key);
             }
         }
 


### PR DESCRIPTION
When we use the Iceberg Hive Catalog, this piece of code causes many of our parameters to fail and result in errors.
For instance, in the convertToDatabase method of the class HiveCatalog, many meta parameters are used but cannot be passed through.

`Database convertToDatabase(Namespace namespace, Map<String, String> meta) {
  .......
  meta.forEach(
        (key, value) -> {
          if (key.equals("comment")) {
            database.setDescription(value);
          } else if (key.equals("location")) {
            database.setLocationUri(value);
          } else if (key.equals(HMS_DB_OWNER)) {
            database.setOwnerName(value);
          } else if (key.equals(HMS_DB_OWNER_TYPE) && value != null) {
            database.setOwnerType(PrincipalType.valueOf(value));
          } else {
            if (value != null) {
              parameter.put(key, value);
            }
          }
        });
}`

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.


## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
- [ ] 3.2
- [ ] 3.1
- [ ] 3.0
- [ ] 2.5