### PR TITLE
[Enhancement] enlarge execute_command wait time

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
@@ -85,7 +85,7 @@ public interface PBackendService {
             attachmentHandler = ThriftClientAttachmentHandler.class)
     Future<PMVMaintenanceTaskResult> submitMVMaintenanceTaskAsync(PMVMaintenanceTaskRequest request);
 
-    @ProtobufRPC(serviceName = "PInternalService", methodName = "execute_command", onceTalkTimeout = 60000)
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "execute_command", onceTalkTimeout = 600000)
     Future<ExecuteCommandResultPB> executeCommandAsync(ExecuteCommandRequestPB request);
 
     @ProtobufRPC(serviceName = "PInternalService", methodName = "update_fail_point_status", onceTalkTimeout = 60000)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExecuteScriptStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExecuteScriptStmt.java
@@ -19,7 +19,7 @@ import com.starrocks.sql.parser.NodePosition;
 
 // EXECUTE ON <BE_ID> <SCRIPT>
 public class ExecuteScriptStmt extends StatementBase {
-    static long TIMEOUT_SEC_DEFAULT = 60;
+    static long TIMEOUT_SEC_DEFAULT = 600;
 
     long beId;
     String script;


### PR DESCRIPTION
Why I'm doing:
some execute_command may cost more than one minute, such as heap profile, which will lead to exception.
What I'm doing:
enlarge execute_command wait time
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
