### PR TITLE
[BugFix] CTAS supports trino dialect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/AstBuilder.java
@@ -65,11 +65,14 @@ import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.CTERelation;
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
+import com.starrocks.sql.ast.CreateTableStmt;
 import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.IntersectRelation;
 import com.starrocks.sql.ast.JoinRelation;
 import com.starrocks.sql.ast.LambdaArgument;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
+import com.starrocks.sql.ast.Property;
 import com.starrocks.sql.ast.QualifiedName;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
@@ -99,6 +102,7 @@ import io.trino.sql.tree.BooleanLiteral;
 import io.trino.sql.tree.Cast;
 import io.trino.sql.tree.CoalesceExpression;
 import io.trino.sql.tree.ComparisonExpression;
+import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.Cube;
 import io.trino.sql.tree.CurrentTime;
 import io.trino.sql.tree.CurrentUser;
@@ -177,8 +181,10 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -1166,6 +1172,34 @@ public class AstBuilder extends AstVisitor<ParseNode, ParseTreeContext> {
     @Override
     protected ParseNode visitCast(Cast node, ParseTreeContext context) {
         return new CastExpr(new TypeDef(getType(node.getType())), (Expr) visit(node.getExpression(), context));
+    }
+
+    @Override
+    protected ParseNode visitCreateTableAsSelect(CreateTableAsSelect node, ParseTreeContext context) {
+        Map<String, String> properties = new HashMap<>();
+        if (node.getProperties() != null) {
+            List<Property> propertyList = visit(node.getProperties(), context, Property.class);
+            for (Property property : propertyList) {
+                properties.put(property.getKey(), property.getValue());
+            }
+        }
+
+        CreateTableStmt createTableStmt = new CreateTableStmt(node.isNotExists(),
+                false,
+                qualifiedNameToTableName(convertQualifiedName(node.getName())),
+                null,
+                "",
+                null,
+                null,
+                null,
+                properties,
+                null,
+                node.getComment().isPresent() ? node.getComment().get() : null);
+
+        return new CreateTableAsSelectStmt(
+                createTableStmt,
+                null,
+                (QueryStatement) visit(node.getQuery(), context));
     }
 
     public Type getType(DataType dataType) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/TrinoParserUtils.java
@@ -15,6 +15,7 @@
 package com.starrocks.connector.parser.trino;
 
 import com.starrocks.sql.ast.StatementBase;
+import io.trino.sql.tree.CreateTableAsSelect;
 import io.trino.sql.tree.Explain;
 import io.trino.sql.tree.ExplainAnalyze;
 import io.trino.sql.tree.Query;
@@ -24,7 +25,8 @@ public class TrinoParserUtils {
     public static StatementBase toStatement(String query, long sqlMode) {
         String trimmedQuery = query.trim();
         Statement statement = TrinoParser.parse(trimmedQuery);
-        if (statement instanceof Query || statement instanceof Explain || statement instanceof ExplainAnalyze) {
+        if (statement instanceof Query || statement instanceof Explain || statement instanceof ExplainAnalyze
+                || statement instanceof CreateTableAsSelect) {
             return (StatementBase) statement.accept(new AstBuilder(sqlMode), new ParseTreeContext());
         } else {
             throw new UnsupportedOperationException("Unsupported statement type: " + statement.getClass().getName());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoCtasTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoCtasTest.java
@@ -1,0 +1,44 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.parser.trino;
+
+import com.starrocks.sql.ast.CreateTableAsSelectStmt;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class TrinoCtasTest extends TrinoTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        TrinoTestBase.beforeClass();
+    }
+
+    @Test
+    public void testCtasTrinoDialect() throws Exception {
+        String ctasSql = "create table test.t_doy as select doy(date '2022-03-06')";
+
+        // test starrocks dialect
+        connectContext.getSessionVariable().setSqlDialect("starrocks");
+        analyzeFail(ctasSql, "No matching function with signature: doy(date)");
+
+        // test trino dialect
+        connectContext.getSessionVariable().setSqlDialect("trino");
+        CreateTableAsSelectStmt ctasStmt =
+                (CreateTableAsSelectStmt) UtFrameUtils.parseStmtWithNewParser(ctasSql, connectContext);
+        QueryStatement queryStmt = ctasStmt.getQueryStatement();
+        assertPlanContains(queryStmt, "dayofyear('2022-03-06 00:00:00')");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoTestBase.java
@@ -353,6 +353,16 @@ public class TrinoTestBase {
         }
     }
 
+    protected void assertPlanContains(StatementBase stmt, String... explain) throws Exception {
+        ExecPlan execPlan = StatementPlanner.plan(stmt, connectContext);
+        String explainString = execPlan.getExplainString(TExplainLevel.NORMAL);
+
+        for (String expected : explain) {
+            Assert.assertTrue("expected is: " + expected + " but plan is \n" + explainString,
+                    StringUtils.containsIgnoreCase(explainString.toLowerCase(), expected));
+        }
+    }
+
     public void runFileUnitTest(String filename) {
         String path = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("sql")).getPath();
         File file = new File(path + "/" + filename + ".sql");

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -184,7 +184,7 @@ public class UtFrameUtils {
         StatementBase statementBase;
         try {
             statementBase =
-                    com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
+                    com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
         } catch (ParsingException | SemanticException e) {
             System.err.println("parse failed: " + e.getMessage());

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -184,7 +184,7 @@ public class UtFrameUtils {
         StatementBase statementBase;
         try {
             statementBase =
-                    com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable()).get(0);
+                    com.starrocks.sql.parser.SqlParser.parse(originStmt, ctx.getSessionVariable().getSqlMode()).get(0);
             com.starrocks.sql.analyzer.Analyzer.analyze(statementBase, ctx);
         } catch (ParsingException | SemanticException e) {
             System.err.println("parse failed: " + e.getMessage());


### PR DESCRIPTION
Why I'm doing:
CTAS not support trino dialect.

example:
```sql
set sql_dialect='trino';

select doy(date '2022-03-06');
+-------------------------+
| dayofyear('2022-03-06') |
+-------------------------+
|                      65 |
+-------------------------+
1 row in set (0.04 sec)

create table temp.zeno_test_doy as select doy(date '2022-03-06');
ERROR 1064 (HY000): Getting analyzing error from line 1, column 42 to line 1, column 63. Detail message: No matching function with signature: doy(date).
```

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
