### PR TITLE
[BugFix] Fix dictionary problem and refactor rpc interface (#35559)

### DIFF
--- a/be/src/exec/dictionary_cache_writer.cpp
+++ b/be/src/exec/dictionary_cache_writer.cpp
@@ -174,6 +174,8 @@ Status DictionaryCacheWriter::_send_request(ChunkPB* pchunk, POlapTableSchemaPar
 
         auto res = HttpBrpcStubCache::getInstance()->get_http_stub(nodes[i]);
         if (!res.ok()) {
+            request.release_chunk();
+            request.release_schema();
             LOG(WARNING) << "create brpc stub failed, " << res.status().message();
             return res.status();
         }

--- a/be/src/exec/dictionary_cache_writer.h
+++ b/be/src/exec/dictionary_cache_writer.h
@@ -61,9 +61,9 @@ public:
 
 private:
     Status _send_request(ChunkPB* pchunk, POlapTableSchemaParam* pschema,
-                         std::vector<RefCountClosure<PRefreshDictionaryCacheResult>*>& closures);
+                         std::vector<RefCountClosure<PProcessDictionaryCacheResult>*>& closures);
 
-    Status _wait_response(std::vector<RefCountClosure<PRefreshDictionaryCacheResult>*>& closures);
+    Status _wait_response(std::vector<RefCountClosure<PProcessDictionaryCacheResult>*>& closures);
 
     Status _submit();
 

--- a/be/src/exec/exec_node.cpp
+++ b/be/src/exec/exec_node.cpp
@@ -72,7 +72,7 @@
 #include "exec/table_function_node.h"
 #include "exec/topn_node.h"
 #include "exec/union_node.h"
-#include "exprs/dictionary_expr.h"
+#include "exprs/dictionary_get_expr.h"
 #include "exprs/expr_context.h"
 #include "gutil/strings/substitute.h"
 #include "runtime/descriptors.h"

--- a/be/src/exprs/CMakeLists.txt
+++ b/be/src/exprs/CMakeLists.txt
@@ -99,7 +99,7 @@ set(EXPR_FILES
   substring_index.cpp
   dict_query_expr.cpp
   runtime_filter_layout.cpp
-  dictionary_expr.cpp
+  dictionary_get_expr.cpp
 )
 
 add_library(Exprs ${EXPR_FILES})

--- a/be/src/exprs/dictionary_get_expr.cpp
+++ b/be/src/exprs/dictionary_get_expr.cpp
@@ -74,12 +74,7 @@ StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Ch
 Status DictionaryGetExpr::prepare(RuntimeState* state, ExprContext* context) {
     RETURN_IF_ERROR(Expr::prepare(state, context));
     _runtime_state = state;
-    return Status::OK();
-}
 
-Status DictionaryGetExpr::open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
-    // init parent open
-    RETURN_IF_ERROR(Expr::open(state, context, scope));
     _schema = StorageEngine::instance()->dictionary_cache_manager()->get_dictionary_schema_by_id(
             _dictionary_get_expr.dict_id);
     if (_schema == nullptr) {
@@ -125,10 +120,6 @@ Status DictionaryGetExpr::open(RuntimeState* state, ExprContext* context, Functi
     DCHECK(_struct_column != nullptr);
 
     return Status::OK();
-}
-
-void DictionaryGetExpr::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
-    Expr::close(state, context, scope);
 }
 
 } // namespace starrocks

--- a/be/src/exprs/dictionary_get_expr.cpp
+++ b/be/src/exprs/dictionary_get_expr.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "exprs/dictionary_expr.h"
+#include "exprs/dictionary_get_expr.h"
 
 #include <fmt/format.h>
 
@@ -23,9 +23,9 @@
 
 namespace starrocks {
 
-DictionaryExpr::DictionaryExpr(const TExprNode& node) : Expr(node), _dictionary_expr(node.dictionary_expr) {}
+DictionaryGetExpr::DictionaryGetExpr(const TExprNode& node) : Expr(node), _dictionary_get_expr(node.dictionary_get_expr) {}
 
-StatusOr<ColumnPtr> DictionaryExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
+StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
     Columns columns(children().size());
     // calculate all child expression which used to construct keys
     size_t size = ptr != nullptr ? ptr->num_rows() : 1;
@@ -51,7 +51,7 @@ StatusOr<ColumnPtr> DictionaryExpr::evaluate_checked(ExprContext* context, Chunk
 
     key_chunk->set_num_rows(size);
     // assign the key chunk
-    for (int i = 0; i < _dictionary_expr.key_size; ++i) {
+    for (int i = 0; i < _dictionary_get_expr.key_size; ++i) {
         ColumnPtr key_column = columns[1 + i];
         key_chunk->update_column_by_index(key_column, i);
     }
@@ -70,23 +70,23 @@ StatusOr<ColumnPtr> DictionaryExpr::evaluate_checked(ExprContext* context, Chunk
     return struct_column;
 }
 
-Status DictionaryExpr::prepare(RuntimeState* state, ExprContext* context) {
+Status DictionaryGetExpr::prepare(RuntimeState* state, ExprContext* context) {
     RETURN_IF_ERROR(Expr::prepare(state, context));
     _runtime_state = state;
     return Status::OK();
 }
 
-Status DictionaryExpr::open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+Status DictionaryGetExpr::open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
     // init parent open
     RETURN_IF_ERROR(Expr::open(state, context, scope));
     _schema = StorageEngine::instance()->dictionary_cache_manager()->get_dictionary_schema_by_id(
-            _dictionary_expr.dict_id);
+            _dictionary_get_expr.dict_id);
     if (_schema == nullptr) {
         return Status::InternalError(fmt::format(
-                "open dictionary expression failed, there is no cache for dictionary: {}", _dictionary_expr.dict_id));
+                "open dictionary expression failed, there is no cache for dictionary: {}", _dictionary_get_expr.dict_id));
     }
     auto res = StorageEngine::instance()->dictionary_cache_manager()->get_dictionary_by_version(
-            _dictionary_expr.dict_id, _dictionary_expr.txn_id);
+            _dictionary_get_expr.dict_id, _dictionary_get_expr.txn_id);
     if (!res.ok()) {
         return Status::InternalError(fmt::format("open dictionary expression failed {}", res.status().message()));
     }
@@ -94,15 +94,13 @@ Status DictionaryExpr::open(RuntimeState* state, ExprContext* context, FunctionC
     DCHECK(_dictionary != nullptr);
 
     // init key / value chunk and struct column template for evaluation
-    std::vector<ColumnId> key_cids(_dictionary_expr.key_size);
+    std::vector<ColumnId> key_cids(_dictionary_get_expr.key_size);
     std::iota(key_cids.begin(), key_cids.end(), 0);
     _key_chunk = ChunkHelper::new_chunk(Schema(_schema.get(), key_cids), 0);
-    _key_chunk->reset();
 
-    std::vector<ColumnId> value_cids(_schema->fields().size() - _dictionary_expr.key_size);
-    std::iota(value_cids.begin(), value_cids.end(), _dictionary_expr.key_size);
+    std::vector<ColumnId> value_cids(_schema->fields().size() - _dictionary_get_expr.key_size);
+    std::iota(value_cids.begin(), value_cids.end(), _dictionary_get_expr.key_size);
     _value_chunk = ChunkHelper::new_chunk(Schema(_schema.get(), value_cids), 0);
-    _value_chunk->reset();
 
     DCHECK(_key_chunk != nullptr);
     DCHECK(_value_chunk != nullptr);
@@ -127,7 +125,7 @@ Status DictionaryExpr::open(RuntimeState* state, ExprContext* context, FunctionC
     return Status::OK();
 }
 
-void DictionaryExpr::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
+void DictionaryGetExpr::close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) {
     Expr::close(state, context, scope);
 }
 

--- a/be/src/exprs/dictionary_get_expr.cpp
+++ b/be/src/exprs/dictionary_get_expr.cpp
@@ -23,7 +23,8 @@
 
 namespace starrocks {
 
-DictionaryGetExpr::DictionaryGetExpr(const TExprNode& node) : Expr(node), _dictionary_get_expr(node.dictionary_get_expr) {}
+DictionaryGetExpr::DictionaryGetExpr(const TExprNode& node)
+        : Expr(node), _dictionary_get_expr(node.dictionary_get_expr) {}
 
 StatusOr<ColumnPtr> DictionaryGetExpr::evaluate_checked(ExprContext* context, Chunk* ptr) {
     Columns columns(children().size());
@@ -82,8 +83,9 @@ Status DictionaryGetExpr::open(RuntimeState* state, ExprContext* context, Functi
     _schema = StorageEngine::instance()->dictionary_cache_manager()->get_dictionary_schema_by_id(
             _dictionary_get_expr.dict_id);
     if (_schema == nullptr) {
-        return Status::InternalError(fmt::format(
-                "open dictionary expression failed, there is no cache for dictionary: {}", _dictionary_get_expr.dict_id));
+        return Status::InternalError(
+                fmt::format("open dictionary expression failed, there is no cache for dictionary: {}",
+                            _dictionary_get_expr.dict_id));
     }
     auto res = StorageEngine::instance()->dictionary_cache_manager()->get_dictionary_by_version(
             _dictionary_get_expr.dict_id, _dictionary_get_expr.txn_id);

--- a/be/src/exprs/dictionary_get_expr.h
+++ b/be/src/exprs/dictionary_get_expr.h
@@ -30,8 +30,6 @@ public:
     Expr* clone(ObjectPool* pool) const override { return pool->add(new DictionaryGetExpr(*this)); }
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
     Status prepare(RuntimeState* state, ExprContext* context) override;
-    Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
-    void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
 
     int64_t get_dict_id() { return _dictionary_get_expr.dict_id; }
     int64_t get_txn_id() { return _dictionary_get_expr.txn_id; }

--- a/be/src/exprs/dictionary_get_expr.h
+++ b/be/src/exprs/dictionary_get_expr.h
@@ -23,22 +23,22 @@
 
 namespace starrocks {
 
-class DictionaryExpr final : public Expr {
+class DictionaryGetExpr final : public Expr {
 public:
-    DictionaryExpr(const TExprNode& node);
+    DictionaryGetExpr(const TExprNode& node);
 
-    Expr* clone(ObjectPool* pool) const override { return pool->add(new DictionaryExpr(*this)); }
+    Expr* clone(ObjectPool* pool) const override { return pool->add(new DictionaryGetExpr(*this)); }
     StatusOr<ColumnPtr> evaluate_checked(ExprContext* context, Chunk* ptr) override;
     Status prepare(RuntimeState* state, ExprContext* context) override;
     Status open(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
     void close(RuntimeState* state, ExprContext* context, FunctionContext::FunctionStateScope scope) override;
 
-    int64_t get_dict_id() { return _dictionary_expr.dict_id; }
-    int64_t get_txn_id() { return _dictionary_expr.txn_id; }
+    int64_t get_dict_id() { return _dictionary_get_expr.dict_id; }
+    int64_t get_txn_id() { return _dictionary_get_expr.txn_id; }
 
 private:
     RuntimeState* _runtime_state;
-    TDictionaryExpr _dictionary_expr;
+    TDictionaryGetExpr _dictionary_get_expr;
 
     SchemaPtr _schema = nullptr;
     DictionaryCachePtr _dictionary = nullptr;

--- a/be/src/exprs/expr.cpp
+++ b/be/src/exprs/expr.cpp
@@ -55,7 +55,7 @@
 #include "exprs/compound_predicate.h"
 #include "exprs/condition_expr.h"
 #include "exprs/dict_query_expr.h"
-#include "exprs/dictionary_expr.h"
+#include "exprs/dictionary_get_expr.h"
 #include "exprs/dictmapping_expr.h"
 #include "exprs/function_call_expr.h"
 #include "exprs/in_predicate.h"
@@ -392,8 +392,8 @@ Status Expr::create_vectorized_expr(starrocks::ObjectPool* pool, const starrocks
     case TExprNodeType::DICT_QUERY_EXPR:
         *expr = pool->add(new DictQueryExpr(texpr_node));
         break;
-    case TExprNodeType::DICTIONARY_EXPR:
-        *expr = pool->add(new DictionaryExpr(texpr_node));
+    case TExprNodeType::DICTIONARY_GET_EXPR:
+        *expr = pool->add(new DictionaryGetExpr(texpr_node));
         break;
     case TExprNodeType::ARRAY_SLICE_EXPR:
     case TExprNodeType::AGG_EXPR:

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -54,7 +54,6 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/query_statistics.h"
 #include "runtime/runtime_filter_worker.h"
-#include "storage/storage_engine.h"
 #include "util/pretty_printer.h"
 #include "util/timezone_utils.h"
 #include "util/uid_util.h"

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -846,6 +846,7 @@ void PInternalServiceImplBase<T>::process_dictionary_cache(google::protobuf::Rpc
         Status::InternalError(ss.str()).to_protobuf(response->mutable_status());
         break;
     }
+    }
     return;
 }
 

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -832,7 +832,6 @@ void PInternalServiceImplBase<T>::process_dictionary_cache(google::protobuf::Rpc
         break;
     }
     }
-    return;
 }
 
 template <typename T>

--- a/be/src/service/internal_service.cpp
+++ b/be/src/service/internal_service.cpp
@@ -805,6 +805,7 @@ void PInternalServiceImplBase<T>::refresh_dictionary_cache_begin(google::protobu
     if (!st.ok()) {
         LOG(WARNING) << st.message();
         Status::InternalError(st.message()).to_protobuf(response->mutable_status());
+        return;
     }
 
     Status::OK().to_protobuf(response->mutable_status());
@@ -830,6 +831,7 @@ void PInternalServiceImplBase<T>::refresh_dictionary_cache_commit(google::protob
     if (!st.ok()) {
         LOG(WARNING) << st.message();
         Status::InternalError(st.message()).to_protobuf(response->mutable_status());
+        return;
     }
     Status::OK().to_protobuf(response->mutable_status());
 }

--- a/be/src/service/internal_service.h
+++ b/be/src/service/internal_service.h
@@ -166,27 +166,9 @@ public:
     void exec_short_circuit(google::protobuf::RpcController* controller, const PExecShortCircuitRequest* request,
                             PExecShortCircuitResult* response, google::protobuf::Closure* done) override;
 
-    void refresh_dictionary_cache(google::protobuf::RpcController* controller,
-                                  const PRefreshDictionaryCacheRequest* request,
-                                  PRefreshDictionaryCacheResult* response, google::protobuf::Closure* done) override;
-
-    void refresh_dictionary_cache_begin(google::protobuf::RpcController* controller,
-                                        const PRefreshDictionaryCacheBeginRequest* request,
-                                        PRefreshDictionaryCacheBeginResult* response,
-                                        google::protobuf::Closure* done) override;
-
-    void refresh_dictionary_cache_commit(google::protobuf::RpcController* controller,
-                                         const PRefreshDictionaryCacheCommitRequest* request,
-                                         PRefreshDictionaryCacheCommitResult* response,
-                                         google::protobuf::Closure* done) override;
-
-    void clear_dictionary_cache(google::protobuf::RpcController* controller,
-                                const PClearDictionaryCacheRequest* request, PClearDictionaryCacheResult* response,
-                                google::protobuf::Closure* done) override;
-
-    void get_dictionary_statistic(google::protobuf::RpcController* controller,
-                                  const PGetDictionaryStatisticRequest* request,
-                                  PGetDictionaryStatisticResult* response, google::protobuf::Closure* done) override;
+    void process_dictionary_cache(google::protobuf::RpcController* controller,
+                                  const PProcessDictionaryCacheRequest* request,
+                                  PProcessDictionaryCacheResult* response, google::protobuf::Closure* done) override;
 
 private:
     void _transmit_chunk(::google::protobuf::RpcController* controller,

--- a/be/src/storage/dictionary_cache_manager.cpp
+++ b/be/src/storage/dictionary_cache_manager.cpp
@@ -18,7 +18,9 @@
 
 namespace starrocks {
 
-Status DictionaryCacheManager::begin(DictionaryId dict_id, DictionaryCacheTxnId txn_id) {
+Status DictionaryCacheManager::begin(const PProcessDictionaryCacheRequest* request) {
+    auto dict_id = request->dict_id();
+    auto txn_id = request->txn_id();
     std::unique_lock wlock(_refresh_lock);
     if (LIKELY(_mutable_dict_caches.find(dict_id) == _mutable_dict_caches.end())) {
         _mutable_dict_caches[dict_id] = std::make_shared<OrderedMutableDictionaryCache>();
@@ -203,7 +205,9 @@ Status DictionaryCacheManager::_refresh_encoded_chunk(DictionaryId dict_id, Dict
     return Status::OK();
 }
 
-Status DictionaryCacheManager::commit(DictionaryId dict_id, DictionaryCacheTxnId txn_id) {
+Status DictionaryCacheManager::commit(const PProcessDictionaryCacheRequest* request) {
+    auto dict_id = request->dict_id();
+    auto txn_id = request->txn_id();
     std::unique_lock wlock1(_lock);
     std::unique_lock wlock2(_refresh_lock);
 

--- a/be/src/storage/dictionary_cache_manager.cpp
+++ b/be/src/storage/dictionary_cache_manager.cpp
@@ -34,8 +34,8 @@ Status DictionaryCacheManager::begin(DictionaryId dict_id, DictionaryCacheTxnId 
     return Status::OK();
 }
 
-Status DictionaryCacheManager::refresh(const PRefreshDictionaryCacheRequest* request) {
-    const auto& dictionary_id = request->dictionary_id();
+Status DictionaryCacheManager::refresh(const PProcessDictionaryCacheRequest* request) {
+    const auto& dict_id = request->dict_id();
     const auto& txn_id = request->txn_id();
     const auto& pchunk = request->chunk();
     const auto& pschema = request->schema();
@@ -116,14 +116,14 @@ Status DictionaryCacheManager::refresh(const PRefreshDictionaryCacheRequest* req
     if (encoded_key_column == nullptr) {
         return Status::InternalError(
                 fmt::format("encode key chunk failed when refreshing dictionary cache, dictionary id: {}, txn id: {}",
-                            dictionary_id, txn_id));
+                            dict_id, txn_id));
     }
 
     auto encoded_value_column = DictionaryCacheUtil::encode_columns(*value_schema.get(), value_chunk.get());
     if (encoded_value_column == nullptr) {
         return Status::InternalError(
                 fmt::format("encode value chunk failed when refreshing dictionary cache, dictionary id: {}, txn id: {}",
-                            dictionary_id, txn_id));
+                            dict_id, txn_id));
     }
 
     // release memory after get the encoded column
@@ -132,7 +132,7 @@ Status DictionaryCacheManager::refresh(const PRefreshDictionaryCacheRequest* req
     chunk.reset();
 
     // 4. refresh
-    return _refresh_encoded_chunk(dictionary_id, txn_id, encoded_key_column.get(), encoded_value_column.get(),
+    return _refresh_encoded_chunk(dict_id, txn_id, encoded_key_column.get(), encoded_value_column.get(),
                                   dictionary_schema, DictionaryCacheUtil::get_encoded_type(*key_schema.get()),
                                   DictionaryCacheUtil::get_encoded_type(*value_schema.get()), memory_limit);
 }
@@ -260,7 +260,7 @@ void DictionaryCacheManager::clear(DictionaryId dict_id, bool is_cancel) {
     }
 }
 
-void DictionaryCacheManager::get_info(DictionaryId dict_id, PGetDictionaryStatisticResult& response) {
+void DictionaryCacheManager::get_info(DictionaryId dict_id, PProcessDictionaryCacheResult& response) {
     std::shared_lock wlock1(_lock);
 
     long dictionary_memory_usage = 0;

--- a/be/src/storage/dictionary_cache_manager.cpp
+++ b/be/src/storage/dictionary_cache_manager.cpp
@@ -126,10 +126,10 @@ Status DictionaryCacheManager::refresh(const PRefreshDictionaryCacheRequest* req
                             dictionary_id, txn_id));
     }
 
-    // release after get the encoded column
-    key_chunk->reset();
-    value_chunk->reset();
-    chunk->reset();
+    // release memory after get the encoded column
+    key_chunk.reset();
+    value_chunk.reset();
+    chunk.reset();
 
     // 4. refresh
     return _refresh_encoded_chunk(dictionary_id, txn_id, encoded_key_column.get(), encoded_value_column.get(),

--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -265,11 +265,11 @@ public:
     DictionaryCacheManager(const DictionaryCacheManager&) = delete;
     const DictionaryCacheManager& operator=(const DictionaryCacheManager&) = delete;
 
-    Status begin(DictionaryId dict_id, DictionaryCacheTxnId txn_id);
+    Status begin(const PProcessDictionaryCacheRequest* request);
 
     Status refresh(const PProcessDictionaryCacheRequest* request);
 
-    Status commit(DictionaryId dict_id, DictionaryCacheTxnId txn_id);
+    Status commit(const PProcessDictionaryCacheRequest* request);
 
     void clear(DictionaryId dict_id, bool is_cancel = false /* trigger cancel */);
 

--- a/be/src/storage/dictionary_cache_manager.h
+++ b/be/src/storage/dictionary_cache_manager.h
@@ -267,13 +267,13 @@ public:
 
     Status begin(DictionaryId dict_id, DictionaryCacheTxnId txn_id);
 
-    Status refresh(const PRefreshDictionaryCacheRequest* request);
+    Status refresh(const PProcessDictionaryCacheRequest* request);
 
     Status commit(DictionaryId dict_id, DictionaryCacheTxnId txn_id);
 
     void clear(DictionaryId dict_id, bool is_cancel = false /* trigger cancel */);
 
-    void get_info(DictionaryId dict_id, PGetDictionaryStatisticResult& response);
+    void get_info(DictionaryId dict_id, PProcessDictionaryCacheResult& response);
 
     SchemaPtr get_dictionary_schema_by_id(const DictionaryId& dict_id);
     StatusOr<DictionaryCachePtr> get_dictionary_by_version(const DictionaryId& dict_id,

--- a/be/test/storage/dictionary_cache_manager_test.cpp
+++ b/be/test/storage/dictionary_cache_manager_test.cpp
@@ -24,6 +24,7 @@
 #include "runtime/descriptor_helper.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
+#include "testutil/assert.h"
 
 namespace starrocks {
 
@@ -35,10 +36,6 @@ public:
         if (dictionary_cache_manager == nullptr) {
             dictionary_cache_manager = new starrocks::DictionaryCacheManager();
         }
-        if (test_tablet == nullptr) {
-            test_tablet = _create_tablet();
-        }
-        create_new_dictionary_cache(dictionary_cache_manager, 1, 1, test_tablet);
     }
 
     void TearDown() override {
@@ -47,13 +44,14 @@ public:
             test_tablet.reset();
             test_tablet = nullptr;
         }
+
         if (dictionary_cache_manager) {
             delete dictionary_cache_manager;
             dictionary_cache_manager = nullptr;
         }
     }
 
-    static TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int64_t schema_hash) {
+    static TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int64_t schema_hash, const std::vector<TColumn>* tcolumns = nullptr) {
         TCreateTabletReq request;
         request.tablet_id = tablet_id;
         request.__set_version(1);
@@ -82,16 +80,29 @@ public:
         k3.column_type.type = TPrimitiveType::BIGINT;
         request.tablet_schema.columns.push_back(k3);
 
+        if (tcolumns != nullptr) {
+            for (auto tcolumn : *tcolumns) {
+                request.tablet_schema.columns.push_back(tcolumn);
+            }
+        }
+
         return request;
     }
 
     static void create_new_dictionary_cache(starrocks::DictionaryCacheManager* dictionary_cache_manager, int64_t dict,
-                                            int64_t txn_id, TabletSharedPtr tablet) {
+                                            int64_t txn_id, TabletSharedPtr tablet, const std::vector<TColumn>* tcolumns = nullptr) {
+        sleep(30);
         auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
         auto chunk = ChunkHelper::new_chunk(schema, 0);
         for (size_t i = 0; i < chunk->num_columns(); ++i) {
             chunk->set_slot_id_to_index(i, i);
-            chunk->get_column_by_index(i)->append_default();
+            if (i < 3) {
+                down_cast<Int64Column*>(chunk->get_column_by_index(i).get())->append(i);
+            } else {
+                std::string s(60000, 'a');
+                down_cast<BinaryColumnBase<uint32_t>*>(chunk->get_column_by_index(i).get())->append_string(s);
+
+            }
         }
 
         std::unique_ptr<ChunkPB> pchunk = std::make_unique<ChunkPB>();
@@ -111,6 +122,13 @@ public:
             tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("k1").column_pos(2).build());
             tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("k1").column_pos(3).build());
 
+            if (tcolumns != nullptr) {
+                for (int i = 0; i < tcolumns->size(); ++i) {
+                    std::string column_name = "large_column_" + std::to_string(i);
+                    tuple_builder.add_slot(TSlotDescriptorBuilder().string_type(60000).column_name(column_name).column_pos(i + 4).build());
+                }
+            }
+
             tuple_builder.build(&dtb);
 
             auto desc_tbl = dtb.desc_tbl();
@@ -121,56 +139,133 @@ public:
         tschema.indexes.resize(1);
         tschema.indexes[0].id = 4;
         tschema.indexes[0].columns = {"k1", "k2", "k3"};
-        auto req = get_create_tablet_request(0, 0);
+        if (tcolumns != nullptr) {
+            for (auto tcolumn : *tcolumns) {
+                tschema.indexes[0].columns.emplace_back(tcolumn.column_name);
+            }
+        }
+        auto req = get_create_tablet_request(0, 0, tcolumns);
         TOlapTableColumnParam column_param;
         column_param.columns = (req.tablet_schema).columns;
         tschema.indexes[0].__set_column_param(column_param);
 
         OlapTableSchemaParam olap_schema;
         olap_schema.init(tschema);
+        auto pschema = std::make_unique<POlapTableSchemaParam>();
+        olap_schema.to_protobuf(pschema.get());
 
         PProcessDictionaryCacheRequest request;
         request.set_allocated_chunk(pchunk.get());
-        request.set_dictionary_id(dict);
+        request.set_dict_id(dict);
         request.set_txn_id(txn_id);
-        request.set_allocated_schema(olap_schema.to_protobuf());
-        request.set_memory_limit(1024 * 1024);
+        request.set_allocated_schema(pschema.get());
+        int64_t memory_limit = 1;
+        memory_limit *= 1024;
+        memory_limit *= 1024;
+        memory_limit *= 1024;
+        memory_limit *= 1024;
+
+        request.set_memory_limit(memory_limit);
         request.set_key_size(1);
         request.set_type(PProcessDictionaryCacheRequestType::REFRESH);
 
-        dictionary_cache_manager->begin(dict, txn_id);
-        dictionary_cache_manager->refresh(&request);
-        dictionary_cache_manager->commit(dict, txn_id);
+        ASSERT_TRUE(dictionary_cache_manager->begin(dict, txn_id).ok());
+        ASSERT_TRUE(dictionary_cache_manager->refresh(&request).ok());
+        ASSERT_TRUE(dictionary_cache_manager->commit(dict, txn_id).ok());
 
         request.release_chunk();
         request.release_schema();
     }
 
-    starrocks::DictionaryCacheManager* dictionary_cache_manager = nullptr;
-    TabletSharedPtr test_tablet = nullptr;
-
-private:
-    TabletSharedPtr _create_tablet() {
-        auto st = StorageEngine::instance()->create_tablet(get_create_tablet_request(_tablet_id, _schema_hash));
+    static TabletSharedPtr create_tablet(int64_t tablet_id, int64_t schema_hash, const std::vector<TColumn>* tcolumns = nullptr) {
+        auto st = StorageEngine::instance()->create_tablet(get_create_tablet_request(tablet_id, schema_hash, tcolumns));
         CHECK(st.ok()) << st.to_string();
-        return StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id, false);
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
     }
 
-    const int64_t _tablet_id = 9143;
-    const int64_t _schema_hash = 6542;
+    static void read_dictionary(starrocks::DictionaryCacheManager* dictionary_cache_manager, TabletSharedPtr tablet, int64_t dict_id, int64_t txn_id) {
+        auto res = dictionary_cache_manager->get_dictionary_by_version(dict_id, txn_id);
+        ASSERT_TRUE(res.ok());
+        DictionaryCachePtr dictionary = std::move(res.value());
+        ASSERT_TRUE(dictionary.get() != nullptr);
+
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, 0);
+        for (size_t i = 0; i < chunk->num_columns(); ++i) {
+            chunk->set_slot_id_to_index(i, i);
+            if (i < 3) {
+                down_cast<Int64Column*>(chunk->get_column_by_index(i).get())->append(i);
+            } else {
+                std::string s(60000, 'a');
+                down_cast<BinaryColumnBase<uint32_t>*>(chunk->get_column_by_index(i).get())->append_string(s);
+
+            }
+        }
+        std::vector<ColumnId> kids{0};
+        std::vector<ColumnId> vids;
+        for (ColumnId id = 1; id < chunk->num_columns(); id++) {
+            vids.emplace_back(id);
+        }
+
+        ChunkPtr key_chunk = ChunkHelper::new_chunk(Schema(&schema, kids), 0);
+        key_chunk->get_column_by_index(0)->append(*chunk->get_column_by_index(0));
+
+        ChunkPtr value_chunk = ChunkHelper::new_chunk(Schema(&schema, vids), 0);
+        auto st = DictionaryCacheManager::probe_given_dictionary_cache(*key_chunk->schema().get(),
+                    *value_chunk->schema().get(), dictionary, key_chunk, value_chunk);
+        ASSERT_TRUE(st.ok());
+        ASSERT_TRUE(value_chunk->num_rows() == 1);
+        for (int i = 0; i < value_chunk->num_columns(); ++i) {
+            auto column_1 = value_chunk->get_column_by_index(i);
+            auto column_2 = chunk->get_column_by_index(i + 1);
+            ASSERT_TRUE(column_1->equals(0, *column_2, 0));
+        }
+    }
+
+    starrocks::DictionaryCacheManager* dictionary_cache_manager = nullptr;
+    TabletSharedPtr test_tablet = nullptr;
 };
 
 // NOLINTNEXTLINE
-TEST_F(DictionaryCacheManagerTest, concurrent_refresh) {
+TEST_F(DictionaryCacheManagerTest, concurrent_refresh_and_read) {
+    auto test_tablet = create_tablet(9143, 6543);
+
     int N = 100;
     std::vector<std::thread> pool;
     for (int i = 0; i < N; ++i) {
-        pool.emplace_back(create_new_dictionary_cache, dictionary_cache_manager, i + N, 1, test_tablet);
+        pool.emplace_back(create_new_dictionary_cache, dictionary_cache_manager, i + N, 1, test_tablet, nullptr);
     }
 
     for (int i = 0; i < N; ++i) {
         pool[i].join();
     }
+
+    std::vector<std::thread> read_pool;
+    for (int i = 0; i < 1; ++i) {
+        read_pool.emplace_back(read_dictionary, dictionary_cache_manager, test_tablet, i + N, 1);
+    }
+
+    for (int i = 0; i < 1; ++i) {
+        read_pool[i].join();
+    }
+}
+
+// NOLINTNEXTLINE
+TEST_F(DictionaryCacheManagerTest, large_column_refresh_and_read) {
+    int N = 100;
+    std::vector<TColumn> large_string_column;
+    for (size_t i = 0; i < N; i++) {
+        TColumn k;
+        k.column_name = "large_column_" + std::to_string(i);
+        k.__set_is_key(false);
+        k.__set_default_value("");
+        k.column_type.type = TPrimitiveType::VARCHAR;
+        large_string_column.push_back(k);
+    }
+
+    auto test_tablet = create_tablet(9144, 6544, &large_string_column);
+    create_new_dictionary_cache(dictionary_cache_manager, 300, 301, test_tablet, &large_string_column);
+    read_dictionary(dictionary_cache_manager, test_tablet, 300, 301);
 }
 
 } // namespace starrocks

--- a/be/test/storage/dictionary_cache_manager_test.cpp
+++ b/be/test/storage/dictionary_cache_manager_test.cpp
@@ -129,13 +129,14 @@ public:
         OlapTableSchemaParam olap_schema;
         olap_schema.init(tschema);
 
-        PRefreshDictionaryCacheRequest request;
+        PProcessDictionaryCacheRequest request;
         request.set_allocated_chunk(pchunk.get());
         request.set_dictionary_id(dict);
         request.set_txn_id(txn_id);
         request.set_allocated_schema(olap_schema.to_protobuf());
         request.set_memory_limit(1024 * 1024);
         request.set_key_size(1);
+        request.set_type(PProcessDictionaryCacheRequestType::REFRESH);
 
         dictionary_cache_manager->begin(dict, txn_id);
         dictionary_cache_manager->refresh(&request);

--- a/be/test/storage/dictionary_cache_manager_test.cpp
+++ b/be/test/storage/dictionary_cache_manager_test.cpp
@@ -174,9 +174,9 @@ public:
         request.set_key_size(1);
         request.set_type(PProcessDictionaryCacheRequestType::REFRESH);
 
-        ASSERT_TRUE(dictionary_cache_manager->begin(dict, txn_id).ok());
+        ASSERT_TRUE(dictionary_cache_manager->begin(&request).ok());
         ASSERT_TRUE(dictionary_cache_manager->refresh(&request).ok());
-        ASSERT_TRUE(dictionary_cache_manager->commit(dict, txn_id).ok());
+        ASSERT_TRUE(dictionary_cache_manager->commit(&request).ok());
 
         request.release_chunk();
         request.release_schema();

--- a/be/test/storage/dictionary_cache_manager_test.cpp
+++ b/be/test/storage/dictionary_cache_manager_test.cpp
@@ -120,8 +120,8 @@ public:
             TTupleDescriptorBuilder tuple_builder;
 
             tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("k1").column_pos(1).build());
-            tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("k1").column_pos(2).build());
-            tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("k1").column_pos(3).build());
+            tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("k2").column_pos(2).build());
+            tuple_builder.add_slot(TSlotDescriptorBuilder().type(TYPE_BIGINT).column_name("k3").column_pos(3).build());
 
             if (tcolumns != nullptr) {
                 for (int i = 0; i < tcolumns->size(); ++i) {

--- a/be/test/storage/lake/local_pk_index_manager_test.cpp
+++ b/be/test/storage/lake/local_pk_index_manager_test.cpp
@@ -91,6 +91,7 @@ protected:
     int64_t _partition_id = next_id();
 };
 
+/*
 TEST_F(LocalPkIndexManagerTest, test_gc) {
     SyncPoint::GetInstance()->EnableProcessing();
     SyncPoint::GetInstance()->SetCallBack("is_tablet_in_worker:1", [](void* arg) { *(bool*)arg = false; });
@@ -256,5 +257,6 @@ TEST_F(LocalPkIndexManagerTest, test_evict) {
     // publish again should be successful, persistent index will be reloaded.
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
 }
+*/
 
 } // namespace starrocks::lake

--- a/be/test/storage/lake/local_pk_index_manager_test.cpp
+++ b/be/test/storage/lake/local_pk_index_manager_test.cpp
@@ -91,7 +91,6 @@ protected:
     int64_t _partition_id = next_id();
 };
 
-/*
 TEST_F(LocalPkIndexManagerTest, test_gc) {
     SyncPoint::GetInstance()->EnableProcessing();
     SyncPoint::GetInstance()->SetCallBack("is_tablet_in_worker:1", [](void* arg) { *(bool*)arg = false; });
@@ -257,6 +256,5 @@ TEST_F(LocalPkIndexManagerTest, test_evict) {
     // publish again should be successful, persistent index will be reloaded.
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), 2, txn_id).status());
 }
-*/
 
 } // namespace starrocks::lake

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/BackendServiceClient.java
@@ -42,25 +42,19 @@ import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
 import com.starrocks.proto.PCancelPlanFragmentResult;
-import com.starrocks.proto.PClearDictionaryCacheRequest;
-import com.starrocks.proto.PClearDictionaryCacheResult;
 import com.starrocks.proto.PCollectQueryStatisticsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PFetchDataResult;
-import com.starrocks.proto.PGetDictionaryStatisticRequest;
-import com.starrocks.proto.PGetDictionaryStatisticResult;
 import com.starrocks.proto.PGetFileSchemaResult;
 import com.starrocks.proto.PListFailPointResponse;
 import com.starrocks.proto.PMVMaintenanceTaskResult;
 import com.starrocks.proto.PPlanFragmentCancelReason;
+import com.starrocks.proto.PProcessDictionaryCacheRequest;
+import com.starrocks.proto.PProcessDictionaryCacheResult;
 import com.starrocks.proto.PProxyRequest;
 import com.starrocks.proto.PProxyResult;
 import com.starrocks.proto.PPulsarProxyRequest;
 import com.starrocks.proto.PPulsarProxyResult;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginResult;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitResult;
 import com.starrocks.proto.PTriggerProfileReportResult;
 import com.starrocks.proto.PUniqueId;
 import com.starrocks.proto.PUpdateFailPointStatusRequest;
@@ -307,49 +301,13 @@ public class BackendServiceClient {
         }
     }
 
-    public Future<PRefreshDictionaryCacheBeginResult> refreshDictionaryCacheBegin(
-            TNetworkAddress address, PRefreshDictionaryCacheBeginRequest request) throws RpcException {
+    public Future<PProcessDictionaryCacheResult> processDictionaryCache(
+            TNetworkAddress address, PProcessDictionaryCacheRequest request) throws RpcException {
         try {
             final PBackendService service = BrpcProxy.getBackendService(address);
-            return service.refreshDictionaryCacheBegin(request);
+            return service.processDictionaryCache(request);
         } catch (Throwable e) {
-            LOG.warn("failed to execute refreshDictionaryCacheBegin, address={}:{}", address.getHostname(), address.getPort(), e);
-            throw new RpcException(address.hostname, e.getMessage());
-        }
-    }
-
-    public Future<PRefreshDictionaryCacheCommitResult> refreshDictionaryCacheCommit(
-            TNetworkAddress address, PRefreshDictionaryCacheCommitRequest request) throws RpcException {
-        try {
-            final PBackendService service = BrpcProxy.getBackendService(address);
-            return service.refreshDictionaryCacheCommit(request);
-        } catch (Throwable e) {
-            LOG.warn("failed to execute refreshDictionaryCacheCommit, address={}:{}",
-                     address.getHostname(), address.getPort(), e);
-            throw new RpcException(address.hostname, e.getMessage());
-        }
-    }
-
-    public Future<PClearDictionaryCacheResult> clearDictionaryCache(
-            TNetworkAddress address, PClearDictionaryCacheRequest request) throws RpcException {
-        try {
-            final PBackendService service = BrpcProxy.getBackendService(address);
-            return service.clearDictionaryCache(request);
-        } catch (Throwable e) {
-            LOG.warn("failed to execute clearDictionaryCache, address={}:{}",
-                     address.getHostname(), address.getPort(), e);
-            throw new RpcException(address.hostname, e.getMessage());
-        }
-    }
-
-    public Future<PGetDictionaryStatisticResult> getDictionaryStatistic(
-            TNetworkAddress address, PGetDictionaryStatisticRequest request) throws RpcException {
-        try {
-            final PBackendService service = BrpcProxy.getBackendService(address);
-            return service.getDictionaryStatistic(request);
-        } catch (Throwable e) {
-            LOG.warn("failed to execute getDictionaryStatistic, address={}:{}",
-                     address.getHostname(), address.getPort(), e);
+            LOG.warn("failed to execute processDictionaryCache, address={}:{}", address.getHostname(), address.getPort(), e);
             throw new RpcException(address.hostname, e.getMessage());
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
+++ b/fe/fe-core/src/main/java/com/starrocks/rpc/PBackendService.java
@@ -19,26 +19,20 @@ import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
 import com.starrocks.proto.PCancelPlanFragmentResult;
-import com.starrocks.proto.PClearDictionaryCacheRequest;
-import com.starrocks.proto.PClearDictionaryCacheResult;
 import com.starrocks.proto.PCollectQueryStatisticsResult;
 import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PExecShortCircuitResult;
 import com.starrocks.proto.PFetchDataResult;
-import com.starrocks.proto.PGetDictionaryStatisticRequest;
-import com.starrocks.proto.PGetDictionaryStatisticResult;
 import com.starrocks.proto.PGetFileSchemaResult;
 import com.starrocks.proto.PListFailPointResponse;
 import com.starrocks.proto.PMVMaintenanceTaskResult;
+import com.starrocks.proto.PProcessDictionaryCacheRequest;
+import com.starrocks.proto.PProcessDictionaryCacheResult;
 import com.starrocks.proto.PProxyRequest;
 import com.starrocks.proto.PProxyResult;
 import com.starrocks.proto.PPulsarProxyRequest;
 import com.starrocks.proto.PPulsarProxyResult;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginResult;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitResult;
 import com.starrocks.proto.PTriggerProfileReportResult;
 import com.starrocks.proto.PUpdateFailPointStatusRequest;
 import com.starrocks.proto.PUpdateFailPointStatusResponse;
@@ -99,16 +93,7 @@ public interface PBackendService {
             attachmentHandler = ThriftClientAttachmentHandler.class, onceTalkTimeout = 60000)
     Future<PExecShortCircuitResult> execShortCircuit(PExecShortCircuitRequest request);
 
-    @ProtobufRPC(serviceName = "PInternalService", methodName = "refresh_dictionary_cache_begin", onceTalkTimeout = 600000)
-    Future<PRefreshDictionaryCacheBeginResult> refreshDictionaryCacheBegin(PRefreshDictionaryCacheBeginRequest request);
-
-    @ProtobufRPC(serviceName = "PInternalService", methodName = "refresh_dictionary_cache_commit", onceTalkTimeout = 600000)
-    Future<PRefreshDictionaryCacheCommitResult> refreshDictionaryCacheCommit(PRefreshDictionaryCacheCommitRequest request);
-
-    @ProtobufRPC(serviceName = "PInternalService", methodName = "clear_dictionary_cache", onceTalkTimeout = 600000)
-    Future<PClearDictionaryCacheResult> clearDictionaryCache(PClearDictionaryCacheRequest request);
-
-    @ProtobufRPC(serviceName = "PInternalService", methodName = "get_dictionary_statistic", onceTalkTimeout = 600000)
-    Future<PGetDictionaryStatisticResult> getDictionaryStatistic(PGetDictionaryStatisticRequest request);
+    @ProtobufRPC(serviceName = "PInternalService", methodName = "process_dictionary_cache", onceTalkTimeout = 600000)
+    Future<PProcessDictionaryCacheResult> processDictionaryCache(PProcessDictionaryCacheRequest request);
 }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -47,7 +47,7 @@ import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.DictionaryExpr;
+import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
 import com.starrocks.sql.ast.QueryStatement;
 
@@ -344,7 +344,7 @@ public class AggregationAnalyzer {
         }
 
         @Override
-        public Boolean visitDictionaryExpr(DictionaryExpr node, Void context) {
+        public Boolean visitDictionaryGetExpr(DictionaryGetExpr node, Void context) {
             return node.getChildren().stream().allMatch(this::visit);
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -68,7 +68,7 @@ import com.starrocks.sql.ast.CreateStorageVolumeStmt;
 import com.starrocks.sql.ast.CreateUserStmt;
 import com.starrocks.sql.ast.DataDescription;
 import com.starrocks.sql.ast.DefaultValueExpr;
-import com.starrocks.sql.ast.DictionaryExpr;
+import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.DropMaterializedViewStmt;
 import com.starrocks.sql.ast.ExceptRelation;
 import com.starrocks.sql.ast.ExportStmt;
@@ -1204,7 +1204,7 @@ public class AstToStringBuilder {
         }
 
         @Override
-        public String visitDictionaryExpr(DictionaryExpr node, Void context) {
+        public String visitDictionaryGetExpr(DictionaryGetExpr node, Void context) {
             return "DICTIONARY_GET";
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/CreateTableAnalyzer.java
@@ -46,7 +46,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.sql.ast.ColumnDef;
 import com.starrocks.sql.ast.CreateTableStmt;
-import com.starrocks.sql.ast.DictionaryExpr;
+import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.ExpressionPartitionDesc;
 import com.starrocks.sql.ast.HashDistributionDesc;
@@ -457,11 +457,11 @@ public class CreateTableAnalyzer {
                 if (column.isGeneratedColumn()) {
                     Expr expr = column.generatedColumnExpr();
 
-                    List<DictionaryExpr> dictionaryExprs = Lists.newArrayList();
-                    expr.collect(DictionaryExpr.class, dictionaryExprs);
-                    if (dictionaryExprs.size() != 0) {
-                        for (DictionaryExpr dictionaryExpr : dictionaryExprs) {
-                            dictionaryExpr.setSkipStateCheck(true);
+                    List<DictionaryGetExpr> dictionaryGetExprs = Lists.newArrayList();
+                    expr.collect(DictionaryGetExpr.class, dictionaryGetExprs);
+                    if (dictionaryGetExprs.size() != 0) {
+                        for (DictionaryGetExpr dictionaryGetExpr : dictionaryGetExprs) {
+                            dictionaryGetExpr.setSkipStateCheck(true);
                         }
                     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -93,7 +93,7 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.DefaultValueExpr;
-import com.starrocks.sql.ast.DictionaryExpr;
+import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.LambdaArgument;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
@@ -1852,7 +1852,7 @@ public class ExpressionAnalyzer {
         }
 
         @Override
-        public Void visitDictionaryExpr(DictionaryExpr node, Scope context) {
+        public Void visitDictionaryGetExpr(DictionaryGetExpr node, Scope context) {
             List<Expr> params = node.getChildren();
             if (params.size() < 2) {
                 throw new SemanticException("dictionary_get function get illegal param list");

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AstVisitor.java
@@ -1248,7 +1248,7 @@ public abstract class AstVisitor<R, C> {
         return visitExpression(node, context);
     }
 
-    public R visitDictionaryExpr(DictionaryExpr node, C context) {
+    public R visitDictionaryGetExpr(DictionaryGetExpr node, C context) {
         return visitExpression(node, context);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/DictionaryGetExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/DictionaryGetExpr.java
@@ -18,31 +18,31 @@ package com.starrocks.sql.ast;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.Expr;
 import com.starrocks.sql.parser.NodePosition;
-import com.starrocks.thrift.TDictionaryExpr;
+import com.starrocks.thrift.TDictionaryGetExpr;
 import com.starrocks.thrift.TExprNode;
 import com.starrocks.thrift.TExprNodeType;
 
 import java.util.List;
 
-public class DictionaryExpr extends Expr {
+public class DictionaryGetExpr extends Expr {
 
-    private TDictionaryExpr dictionaryExpr;
+    private TDictionaryGetExpr dictionaryGetExpr;
     private boolean skipStateCheck;
     private long dictionaryId;
     private long dictionaryTxnId;
     private int keySize;
 
-    public DictionaryExpr(List<Expr> params) {
+    public DictionaryGetExpr(List<Expr> params) {
         this(params, NodePosition.ZERO);
     }
 
-    public DictionaryExpr(List<Expr> params, NodePosition pos) {
+    public DictionaryGetExpr(List<Expr> params, NodePosition pos) {
         super(pos);
         this.children.addAll(params);
         this.skipStateCheck = false;
     }
 
-    protected DictionaryExpr(DictionaryExpr other) {
+    protected DictionaryGetExpr(DictionaryGetExpr other) {
         List<Expr> newChildren = Lists.newArrayList();
         for (Expr child : other.getChildren()) {
             newChildren.add(child.clone());
@@ -70,27 +70,27 @@ public class DictionaryExpr extends Expr {
 
     @Override
     protected void toThrift(TExprNode msg) {
-        TDictionaryExpr dictionaryExpr = new TDictionaryExpr();
-        dictionaryExpr.setDict_id(dictionaryId);
-        dictionaryExpr.setTxn_id(dictionaryTxnId);
-        dictionaryExpr.setKey_size(keySize);
-        setDictionaryExpr(dictionaryExpr);
+        TDictionaryGetExpr dictionaryGetExpr = new TDictionaryGetExpr();
+        dictionaryGetExpr.setDict_id(dictionaryId);
+        dictionaryGetExpr.setTxn_id(dictionaryTxnId);
+        dictionaryGetExpr.setKey_size(keySize);
+        setDictionaryGetExpr(dictionaryGetExpr);
 
-        msg.setNode_type(TExprNodeType.DICTIONARY_EXPR);
-        msg.setDictionary_expr(dictionaryExpr);
+        msg.setNode_type(TExprNodeType.DICTIONARY_GET_EXPR);
+        msg.setDictionary_get_expr(dictionaryGetExpr);
     }
 
     @Override
     public Expr clone() {
-        return new DictionaryExpr(this);
+        return new DictionaryGetExpr(this);
     }
 
-    public TDictionaryExpr getDictionaryExpr() {
-        return dictionaryExpr;
+    public TDictionaryGetExpr getDictionaryGetExpr() {
+        return dictionaryGetExpr;
     }
 
-    public void setDictionaryExpr(TDictionaryExpr dictionaryExpr) {
-        this.dictionaryExpr = dictionaryExpr;
+    public void setDictionaryGetExpr(TDictionaryGetExpr dictionaryGetExpr) {
+        this.dictionaryGetExpr = dictionaryGetExpr;
     }
 
     public void setSkipStateCheck(boolean skipStateCheck) {
@@ -127,6 +127,6 @@ public class DictionaryExpr extends Expr {
 
     @Override
     public <R, C> R accept(AstVisitor<R, C> visitor, C context) {
-        return visitor.visitDictionaryExpr(this, context);
+        return visitor.visitDictionaryGetExpr(this, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictionaryGetOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/DictionaryGetOperator.java
@@ -25,13 +25,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 
-public class DictionaryExprOperator extends ScalarOperator {
+public class DictionaryGetOperator extends ScalarOperator {
     private List<ScalarOperator> arguments;
     private long dictionaryId;
     private long dictionaryTxnId;
     private int keySize;
 
-    public DictionaryExprOperator(List<ScalarOperator> arguments, Type returnType, long dictionaryId, long dictionaryTxnId,
+    public DictionaryGetOperator(List<ScalarOperator> arguments, Type returnType, long dictionaryId, long dictionaryTxnId,
                                   int keySize) {
         super(OperatorType.DICTIONARY_GET, returnType);
         this.arguments = new ArrayList<>(arguments);
@@ -62,7 +62,7 @@ public class DictionaryExprOperator extends ScalarOperator {
 
     @Override
     public String toString() {
-        return "DICTIONAR_GET";
+        return "DICTIONARY_GET";
     }
 
     @Override
@@ -78,8 +78,8 @@ public class DictionaryExprOperator extends ScalarOperator {
         if (this == other) {
             return true;
         }
-        if (other instanceof DictionaryExprOperator) {
-            final DictionaryExprOperator dictionaryOp = (DictionaryExprOperator) other;
+        if (other instanceof DictionaryGetOperator) {
+            final DictionaryGetOperator dictionaryOp = (DictionaryGetOperator) other;
             return Objects.equals(arguments, dictionaryOp.arguments) && dictionaryOp.getType().equals(getType()) &&
                    this.dictionaryId == dictionaryOp.getDictionaryId() &&
                    this.dictionaryTxnId == dictionaryOp.getDictionaryTxnId() &&
@@ -90,7 +90,7 @@ public class DictionaryExprOperator extends ScalarOperator {
 
     @Override
     public ScalarOperator clone() {
-        DictionaryExprOperator operator = (DictionaryExprOperator) super.clone();
+        DictionaryGetOperator operator = (DictionaryGetOperator) super.clone();
         // Deep copy here
         List<ScalarOperator> newArguments = Lists.newArrayList();
         this.arguments.forEach(p -> newArguments.add(p.clone()));
@@ -124,7 +124,7 @@ public class DictionaryExprOperator extends ScalarOperator {
 
     @Override
     public <R, C> R accept(ScalarOperatorVisitor<R, C> visitor, C context) {
-        return visitor.visitDictionaryExprOperator(this, context);
+        return visitor.visitDictionaryGetOperator(this, context);
     }
 
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorVisitor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperatorVisitor.java
@@ -119,7 +119,7 @@ public abstract class ScalarOperatorVisitor<R, C> {
         return visit(operator, context);
     }
 
-    public R visitDictionaryExprOperator(DictionaryExprOperator operator, C context) {
+    public R visitDictionaryGetOperator(DictionaryGetOperator operator, C context) {
         return visit(operator, context);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -59,7 +59,7 @@ import com.starrocks.sql.analyzer.Scope;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.AstVisitor;
-import com.starrocks.sql.ast.DictionaryExpr;
+import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.LambdaArgument;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
@@ -86,7 +86,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictQueryOperator;
-import com.starrocks.sql.optimizer.operator.scalar.DictionaryExprOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictionaryGetOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -843,14 +843,14 @@ public final class SqlToScalarOperatorTranslator {
         }
 
         @Override
-        public ScalarOperator visitDictionaryExpr(DictionaryExpr node, Context context) {
+        public ScalarOperator visitDictionaryGetExpr(DictionaryGetExpr node, Context context) {
             List<ScalarOperator> arguments = node.getChildren()
                     .stream()
                     .map(child -> visit(child, context.clone(node)))
                     .collect(Collectors.toList());
             
-            DictionaryExprOperator op = new DictionaryExprOperator(arguments, node.getType(), node.getDictionaryId(),
-                                                                   node.getDictionaryTxnId(), node.getKeySize());
+            DictionaryGetOperator op = new DictionaryGetOperator(arguments, node.getType(), node.getDictionaryId(),
+                                                                 node.getDictionaryTxnId(), node.getKeySize());
             return op;
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -197,7 +197,7 @@ import com.starrocks.sql.ast.DelSqlBlackListStmt;
 import com.starrocks.sql.ast.DeleteStmt;
 import com.starrocks.sql.ast.DescStorageVolumeStmt;
 import com.starrocks.sql.ast.DescribeStmt;
-import com.starrocks.sql.ast.DictionaryExpr;
+import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.DistributionDesc;
 import com.starrocks.sql.ast.DropAnalyzeJobStmt;
 import com.starrocks.sql.ast.DropBackendClause;
@@ -6406,7 +6406,7 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
     @Override
     public ParseNode visitDictionaryGetExpr(StarRocksParser.DictionaryGetExprContext context) {
         List<Expr> params = visit(context.expressionList().expression(), Expr.class);
-        return new DictionaryExpr(params);
+        return new DictionaryGetExpr(params);
     }
 
     // ------------------------------------------- COMMON AST --------------------------------------------------------------

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/ScalarOperatorToExpr.java
@@ -57,7 +57,7 @@ import com.starrocks.catalog.Function;
 import com.starrocks.catalog.Type;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.ast.ArrayExpr;
-import com.starrocks.sql.ast.DictionaryExpr;
+import com.starrocks.sql.ast.DictionaryGetExpr;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
 import com.starrocks.sql.ast.MapExpr;
 import com.starrocks.sql.optimizer.operator.scalar.ArrayOperator;
@@ -74,7 +74,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictMappingOperator;
 import com.starrocks.sql.optimizer.operator.scalar.DictQueryOperator;
-import com.starrocks.sql.optimizer.operator.scalar.DictionaryExprOperator;
+import com.starrocks.sql.optimizer.operator.scalar.DictionaryGetOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ExistsPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.IsNullPredicateOperator;
@@ -618,16 +618,16 @@ public class ScalarOperatorToExpr {
         }
 
         @Override
-        public Expr visitDictionaryExprOperator(DictionaryExprOperator operator, FormatterContext context) {
+        public Expr visitDictionaryGetOperator(DictionaryGetOperator operator, FormatterContext context) {
             List<Expr> arg = operator.getChildren().stream()
                     .map(expr -> buildExpr.build(expr, context))
                     .collect(Collectors.toList());
-            DictionaryExpr dictionaryExpr = new DictionaryExpr(arg);
-            dictionaryExpr.setType(operator.getType());
-            dictionaryExpr.setDictionaryId(operator.getDictionaryId());
-            dictionaryExpr.setDictionaryTxnId(operator.getDictionaryTxnId());
-            dictionaryExpr.setKeySize(operator.getKeySize());
-            return dictionaryExpr;
+            DictionaryGetExpr dictionaryGetExpr = new DictionaryGetExpr(arg);
+            dictionaryGetExpr.setType(operator.getType());
+            dictionaryGetExpr.setDictionaryId(operator.getDictionaryId());
+            dictionaryGetExpr.setDictionaryTxnId(operator.getDictionaryTxnId());
+            dictionaryGetExpr.setKeySize(operator.getKeySize());
+            return dictionaryGetExpr;
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoBackend.java
@@ -42,27 +42,21 @@ import com.starrocks.proto.LockTabletMetadataRequest;
 import com.starrocks.proto.LockTabletMetadataResponse;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
 import com.starrocks.proto.PCancelPlanFragmentResult;
-import com.starrocks.proto.PClearDictionaryCacheRequest;
-import com.starrocks.proto.PClearDictionaryCacheResult;
 import com.starrocks.proto.PCollectQueryStatisticsResult;
 import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PExecShortCircuitResult;
 import com.starrocks.proto.PFetchDataResult;
-import com.starrocks.proto.PGetDictionaryStatisticRequest;
-import com.starrocks.proto.PGetDictionaryStatisticResult;
 import com.starrocks.proto.PGetFileSchemaResult;
 import com.starrocks.proto.PListFailPointResponse;
 import com.starrocks.proto.PMVMaintenanceTaskResult;
+import com.starrocks.proto.PProcessDictionaryCacheRequest;
+import com.starrocks.proto.PProcessDictionaryCacheResult;
 import com.starrocks.proto.PProxyRequest;
 import com.starrocks.proto.PProxyResult;
 import com.starrocks.proto.PPulsarProxyRequest;
 import com.starrocks.proto.PPulsarProxyResult;
 import com.starrocks.proto.PQueryStatistics;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginResult;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitResult;
 import com.starrocks.proto.PTabletInfo;
 import com.starrocks.proto.PTabletWithPartition;
 import com.starrocks.proto.PTabletWriterAddBatchResult;
@@ -1041,26 +1035,7 @@ public class PseudoBackend {
         }
 
         @Override
-        public Future<PRefreshDictionaryCacheBeginResult> refreshDictionaryCacheBegin(
-                PRefreshDictionaryCacheBeginRequest request) {
-            return null;
-        }
-
-        @Override
-        public Future<PRefreshDictionaryCacheCommitResult> refreshDictionaryCacheCommit(
-                PRefreshDictionaryCacheCommitRequest request) {
-            return null;
-        }
-
-        @Override
-        public Future<PClearDictionaryCacheResult> clearDictionaryCache(
-                PClearDictionaryCacheRequest request) {
-            return null;
-        }
-
-        @Override
-        public Future<PGetDictionaryStatisticResult> getDictionaryStatistic(
-                PGetDictionaryStatisticRequest request) {
+        public Future<PProcessDictionaryCacheResult> processDictionaryCache(PProcessDictionaryCacheRequest request) {
             return null;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -24,27 +24,21 @@ import com.starrocks.proto.ExecuteCommandRequestPB;
 import com.starrocks.proto.ExecuteCommandResultPB;
 import com.starrocks.proto.PCancelPlanFragmentRequest;
 import com.starrocks.proto.PCancelPlanFragmentResult;
-import com.starrocks.proto.PClearDictionaryCacheRequest;
-import com.starrocks.proto.PClearDictionaryCacheResult;
 import com.starrocks.proto.PCollectQueryStatisticsResult;
 import com.starrocks.proto.PExecBatchPlanFragmentsResult;
 import com.starrocks.proto.PExecPlanFragmentResult;
 import com.starrocks.proto.PExecShortCircuitResult;
 import com.starrocks.proto.PFetchDataResult;
-import com.starrocks.proto.PGetDictionaryStatisticRequest;
-import com.starrocks.proto.PGetDictionaryStatisticResult;
 import com.starrocks.proto.PGetFileSchemaResult;
 import com.starrocks.proto.PListFailPointResponse;
 import com.starrocks.proto.PMVMaintenanceTaskResult;
+import com.starrocks.proto.PProcessDictionaryCacheRequest;
+import com.starrocks.proto.PProcessDictionaryCacheResult;
 import com.starrocks.proto.PProxyRequest;
 import com.starrocks.proto.PProxyResult;
 import com.starrocks.proto.PPulsarProxyRequest;
 import com.starrocks.proto.PPulsarProxyResult;
 import com.starrocks.proto.PQueryStatistics;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheBeginResult;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitRequest;
-import com.starrocks.proto.PRefreshDictionaryCacheCommitResult;
 import com.starrocks.proto.PTriggerProfileReportResult;
 import com.starrocks.proto.PUpdateFailPointStatusRequest;
 import com.starrocks.proto.PUpdateFailPointStatusResponse;
@@ -468,26 +462,7 @@ public class MockedBackend {
             return null;
         }
 
-        public Future<PRefreshDictionaryCacheBeginResult> refreshDictionaryCacheBegin(
-                PRefreshDictionaryCacheBeginRequest request) {
-            return null;
-        }
-
-        @Override
-        public Future<PRefreshDictionaryCacheCommitResult> refreshDictionaryCacheCommit(
-                PRefreshDictionaryCacheCommitRequest request) {
-            return null;
-        }
-
-        @Override
-        public Future<PClearDictionaryCacheResult> clearDictionaryCache(
-                PClearDictionaryCacheRequest request) {
-            return null;
-        }
-
-        @Override
-        public Future<PGetDictionaryStatisticResult> getDictionaryStatistic(
-                PGetDictionaryStatisticRequest request) {
+        public Future<PProcessDictionaryCacheResult> processDictionaryCache(PProcessDictionaryCacheRequest request) {
             return null;
         }
     }

--- a/gensrc/proto/doris_internal_service.proto
+++ b/gensrc/proto/doris_internal_service.proto
@@ -70,8 +70,6 @@ service PBackendService {
     // NOTE(murphy) check if it's really necessary
     rpc submit_mv_maintenance_task(starrocks.PMVMaintenanceTaskRequest) returns (starrocks.PMVMaintenanceTaskResult);
 
-    rpc refresh_dictionary_cache(starrocks.PRefreshDictionaryCacheRequest) returns (starrocks.PRefreshDictionaryCacheResult);
-
     // local tablet reader
     rpc local_tablet_reader_open(starrocks.PTabletReaderOpenRequest) returns (starrocks.PTabletReaderOpenResult);
     rpc local_tablet_reader_close(starrocks.PTabletReaderCloseRequest) returns (starrocks.PTabletReaderCloseResult);
@@ -83,9 +81,5 @@ service PBackendService {
     rpc update_fail_point_status(starrocks.PUpdateFailPointStatusRequest) returns (starrocks.PUpdateFailPointStatusResponse);
     rpc list_fail_point(starrocks.PListFailPointRequest) returns (starrocks.PListFailPointResponse);
 
-    rpc refresh_dictionary_cache_begin(starrocks.PRefreshDictionaryCacheBeginRequest) returns (starrocks.PRefreshDictionaryCacheBeginResult);
-    rpc refresh_dictionary_cache_commit(starrocks.PRefreshDictionaryCacheCommitRequest) returns (starrocks.PRefreshDictionaryCacheCommitResult);
-
-    rpc clear_dictionary_cache(starrocks.PClearDictionaryCacheRequest) returns (starrocks.PClearDictionaryCacheResult);
-    rpc get_dictionary_statistic(starrocks.PGetDictionaryStatisticRequest) returns (starrocks.PGetDictionaryStatisticResult);
+    rpc process_dictionary_cache(starrocks.PProcessDictionaryCacheRequest) returns (starrocks.PProcessDictionaryCacheResult);
 };

--- a/gensrc/proto/internal_service.proto
+++ b/gensrc/proto/internal_service.proto
@@ -267,19 +267,6 @@ message PTabletWriterAddSegmentResult {
     repeated PTabletInfo failed_tablet_vec = 4;
 };
 
-message PRefreshDictionaryCacheRequest {
-    optional ChunkPB chunk = 1;
-    optional int64 dictionary_id = 2;
-    optional int64 txn_id = 3;
-    optional POlapTableSchemaParam schema = 4;
-    optional int64 memory_limit = 5;
-    optional int32 key_size = 6;
-};
-
-message PRefreshDictionaryCacheResult {
-    optional StatusPB status = 1;
-};
-
 // Tablet writer cancel.
 message PTabletWriterCancelRequest {
     required PUniqueId id = 1;
@@ -595,41 +582,29 @@ message PExecShortCircuitResult {
 message PExecShortCircuitRequest {
 }
 
-message PRefreshDictionaryCacheBeginRequest {
-    optional int64 dict_id = 1;
-    optional int64 txn_id = 2;
-}
+enum PProcessDictionaryCacheRequestType {
+    BEGIN = 1;
+    REFRESH = 2;
+    COMMIT = 3;
+    CLEAR = 4;
+    STATISTIC = 5;
+};
 
-message PRefreshDictionaryCacheBeginResult {
-    optional StatusPB status = 1;
-}
+message PProcessDictionaryCacheRequest {
+    optional ChunkPB chunk = 1;
+    optional int64 dict_id = 2;
+    optional int64 txn_id = 3;
+    optional POlapTableSchemaParam schema = 4;
+    optional int64 memory_limit = 5;
+    optional int32 key_size = 6;
+    optional bool is_cancel = 7;
+    optional PProcessDictionaryCacheRequestType type = 8;
+};
 
-message PClearDictionaryCacheRequest {
-    optional int64 dict_id = 1;
-    optional bool is_cancel = 2;
-}
-
-message PClearDictionaryCacheResult {
-    optional StatusPB status = 1;
-}
-
-message PRefreshDictionaryCacheCommitRequest {
-    optional int64 dict_id = 1;
-    optional int64 txn_id = 2;
-}
-
-message PRefreshDictionaryCacheCommitResult {
-    optional StatusPB status = 1;
-}
-
-message PGetDictionaryStatisticRequest {
-    optional int64 dict_id = 1;
-}
-
-message PGetDictionaryStatisticResult {
+message PProcessDictionaryCacheResult {
     optional StatusPB status = 1;
     optional int64 dictionary_memory_usage = 2;
-}
+};
 
 // NOTE(zc): If you want to add new method here,
 // you must add same method to 'doris_internal_service.proto'.
@@ -658,8 +633,6 @@ service PInternalService {
 
     rpc submit_mv_maintenance_task(PMVMaintenanceTaskRequest) returns (PMVMaintenanceTaskResult);
 
-    rpc refresh_dictionary_cache(starrocks.PRefreshDictionaryCacheRequest) returns (starrocks.PRefreshDictionaryCacheResult);
-
     // local tablet reader
     rpc local_tablet_reader_open(PTabletReaderOpenRequest) returns (PTabletReaderOpenResult);
     rpc local_tablet_reader_close(PTabletReaderCloseRequest) returns (PTabletReaderCloseResult);
@@ -674,9 +647,5 @@ service PInternalService {
 
     rpc exec_short_circuit(PExecShortCircuitRequest) returns (PExecShortCircuitResult);
 
-    rpc refresh_dictionary_cache_begin(PRefreshDictionaryCacheBeginRequest) returns (PRefreshDictionaryCacheBeginResult);
-    rpc refresh_dictionary_cache_commit(PRefreshDictionaryCacheCommitRequest) returns (PRefreshDictionaryCacheCommitResult);
-
-    rpc clear_dictionary_cache(starrocks.PClearDictionaryCacheRequest) returns (starrocks.PClearDictionaryCacheResult);
-    rpc get_dictionary_statistic(starrocks.PGetDictionaryStatisticRequest) returns (starrocks.PGetDictionaryStatisticResult);
+    rpc process_dictionary_cache(starrocks.PProcessDictionaryCacheRequest) returns (starrocks.PProcessDictionaryCacheResult);
 };

--- a/gensrc/thrift/Exprs.thrift
+++ b/gensrc/thrift/Exprs.thrift
@@ -85,7 +85,7 @@ enum TExprNodeType {
   DICT_QUERY_EXPR,
 
   // query DICTIONARY object
-  DICTIONARY_EXPR,
+  DICTIONARY_GET_EXPR,
 }
 
 struct TAggregateExpr {
@@ -184,7 +184,7 @@ struct TDictQueryExpr {
   6: required bool strict_mode
 }
 
-struct TDictionaryExpr {
+struct TDictionaryGetExpr {
   1: optional i64 dict_id
   2: optional i64 txn_id
   3: optional i32 key_size
@@ -242,7 +242,7 @@ struct TExprNode {
 
   55: optional TDictQueryExpr dict_query_expr
 
-  56: optional TDictionaryExpr dictionary_expr
+  56: optional TDictionaryGetExpr dictionary_get_expr
 }
 
 struct TPartitionLiteral {


### PR DESCRIPTION
What I'm doing:
(1) Fix problem:
    1. rename DictionaryExpr into DictionaryGetExpr (be, fe, TExprNodeType, TDictionaryExpr -> TDictionaryGetExpr)
    2. rename DictionaryExprOperator -> DictionaryGetOperator
    3. return if error happen in refresh_dictionary_cache_begin/refresh_dictionary_cache_commit
    4. use .reset instead of ->reset in DictionaryCacheManager::refresh to release the memory consume
    5. remove storage_engine.h in rumtime_state.cpp
    6. release chunk and schea when get http stub failed in dictionary_writer
    7. remove useless scope in dictionary_get_expr

(2) Refactor, merge rpc function into one

(3) add more Be UT

Fixes #35559

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
