### PR TITLE
[BugFix][Cherry-pick][Branch-2.5] Fix pindex read/write confilict when enable pindex rebuild in compaction (backport #37197)

### DIFF
--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -1411,6 +1411,7 @@ Status PrimaryIndex::major_compaction(Tablet* tablet) {
 }
 
 Status PrimaryIndex::reset(Tablet* tablet, EditVersion version, PersistentIndexMetaPB* index_meta) {
+    std::lock_guard<std::mutex> lg(_lock);
     _table_id = tablet->belonged_table_id();
     _tablet_id = tablet->tablet_id();
     const TabletSchema& tablet_schema = tablet->tablet_schema();


### PR DESCRIPTION
Why I'm doing:

This bug is introduced by this pr(#36819), we will rebuild pindex if we pick all rowsets to do compaction. But in rebuild pindex, we try to reset pindex but doesn't hold the lock which may cause read/write conflict between compaction and data ingestion.

What I'm doing:

Hold the primary index lock when we reset primary index.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function

## Bugfix cherry-pick branch check:

- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
