### PR TITLE
[Enhancement] Create a new connection pool for broker RPC

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/ClientPool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/ClientPool.java
@@ -47,6 +47,9 @@ public class ClientPool {
     static GenericKeyedObjectPoolConfig backendConfig = new GenericKeyedObjectPoolConfig();
     static int backendTimeoutMs = 60000; // 1min
 
+    static GenericKeyedObjectPoolConfig brokerPoolConfig = new GenericKeyedObjectPoolConfig();
+    public static int brokerTimeoutMs = Config.broker_client_timeout_ms;
+
     static {
         heartbeatConfig.setLifo(true);            // set Last In First Out strategy
         heartbeatConfig.setMaxIdlePerKey(2);      // (default 2)
@@ -65,9 +68,6 @@ public class ClientPool {
         backendConfig.setMaxWaitMillis(500);    //  wait for the connection
     }
 
-    static GenericKeyedObjectPoolConfig brokerPoolConfig = new GenericKeyedObjectPoolConfig();
-    public static int brokerTimeoutMs = Config.broker_client_timeout_ms;
-
     static {
         brokerPoolConfig.setLifo(true);            // set Last In First Out strategy
         brokerPoolConfig.setMaxIdlePerKey(128);    // (default 128)
@@ -77,8 +77,10 @@ public class ClientPool {
         brokerPoolConfig.setMaxWaitMillis(500);    //  wait for the connection
     }
 
-    public static GenericPool<HeartbeatService.Client> heartbeatPool =
+    public static GenericPool<HeartbeatService.Client> beHeartbeatPool =
             new GenericPool("HeartbeatService", heartbeatConfig, heartbeatTimeoutMs);
+    public static GenericPool<TFileBrokerService.Client> brokerHeartbeatPool =
+            new GenericPool("TFileBrokerService", heartbeatConfig, heartbeatTimeoutMs);
     public static GenericPool<FrontendService.Client> frontendPool =
             new GenericPool("FrontendService", backendConfig, backendTimeoutMs);
     public static GenericPool<BackendService.Client> backendPool =

--- a/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/GenericPool.java
@@ -126,6 +126,10 @@ public class GenericPool<VALUE extends org.apache.thrift.TServiceClient> {
         }
     }
 
+    public void setTimeoutMs(int timeoutMs) {
+        this.timeoutMs = timeoutMs;
+    }
+
     private class ThriftClientFactory extends BaseKeyedPooledObjectFactory<TNetworkAddress, VALUE> {
 
         private Object newInstance(String className, TProtocol protocol) throws Exception {

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -181,6 +181,9 @@ public class HeartbeatMgr extends FrontendDaemon {
 
         // write edit log
         GlobalStateMgr.getCurrentState().getEditLog().logHeartbeat(hbPackage);
+
+        ClientPool.beHeartbeatPool.setTimeoutMs(Config.heartbeat_timeout_second * 1000);
+        ClientPool.brokerHeartbeatPool.setTimeoutMs(Config.heartbeat_timeout_second * 1000);
     }
 
     private boolean handleHbResponse(HeartbeatResponse response, boolean isReplay) {
@@ -262,7 +265,7 @@ public class HeartbeatMgr extends FrontendDaemon {
             TNetworkAddress beAddr = new TNetworkAddress(computeNode.getHost(), computeNode.getHeartbeatPort());
             boolean ok = false;
             try {
-                client = ClientPool.heartbeatPool.borrowObject(beAddr);
+                client = ClientPool.beHeartbeatPool.borrowObject(beAddr);
 
                 TMasterInfo copiedMasterInfo = new TMasterInfo(MASTER_INFO.get());
                 copiedMasterInfo.setBackend_ip(computeNode.getHost());
@@ -318,9 +321,9 @@ public class HeartbeatMgr extends FrontendDaemon {
                         Strings.isNullOrEmpty(e.getMessage()) ? "got exception" : e.getMessage());
             } finally {
                 if (ok) {
-                    ClientPool.heartbeatPool.returnObject(beAddr, client);
+                    ClientPool.beHeartbeatPool.returnObject(beAddr, client);
                 } else {
-                    ClientPool.heartbeatPool.invalidateObject(beAddr, client);
+                    ClientPool.beHeartbeatPool.invalidateObject(beAddr, client);
                 }
             }
         }
@@ -355,7 +358,8 @@ public class HeartbeatMgr extends FrontendDaemon {
             String url = "http://" + fe.getHost() + ":" + Config.http_port
                     + "/api/bootstrap?cluster_id=" + clusterId + "&token=" + token;
             try {
-                String result = Util.getResultForUrl(url, null, 2000, 2000);
+                String result = Util.getResultForUrl(url, null,
+                        Config.heartbeat_timeout_second * 1000, Config.heartbeat_timeout_second * 1000);
                 /*
                  * return:
                  * {"replayedJournalId":191224,"queryPort":9131,"rpcPort":9121,"status":"OK","msg":"Success"}
@@ -399,7 +403,7 @@ public class HeartbeatMgr extends FrontendDaemon {
             TNetworkAddress addr = new TNetworkAddress(broker.ip, broker.port);
             boolean ok = false;
             try {
-                client = ClientPool.brokerPool.borrowObject(addr);
+                client = ClientPool.brokerHeartbeatPool.borrowObject(addr);
                 TBrokerPingBrokerRequest request = new TBrokerPingBrokerRequest(TBrokerVersion.VERSION_ONE,
                         clientId);
                 TBrokerOperationStatus status = client.ping(request);
@@ -416,9 +420,9 @@ public class HeartbeatMgr extends FrontendDaemon {
                         Strings.isNullOrEmpty(e.getMessage()) ? "got exception" : e.getMessage());
             } finally {
                 if (ok) {
-                    ClientPool.brokerPool.returnObject(addr, client);
+                    ClientPool.brokerHeartbeatPool.returnObject(addr, client);
                 } else {
-                    ClientPool.brokerPool.invalidateObject(addr, client);
+                    ClientPool.brokerHeartbeatPool.invalidateObject(addr, client);
                 }
             }
         }

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/PseudoCluster.java
@@ -415,7 +415,7 @@ public class PseudoCluster {
         dataSource.setMaxIdle(40);
         cluster.dataSource = dataSource;
 
-        ClientPool.heartbeatPool = cluster.heartBeatPool;
+        ClientPool.beHeartbeatPool = cluster.heartBeatPool;
         ClientPool.backendPool = cluster.backendThriftPool;
         BrpcProxy.setInstance(cluster.brpcProxy);
 

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/MockedBackend.java
@@ -154,7 +154,7 @@ public class MockedBackend {
         thriftClient = new MockBeThriftClient(this);
         pbService = new MockPBackendService();
 
-        ((MockGenericPool<?>) ClientPool.heartbeatPool).register(this);
+        ((MockGenericPool<?>) ClientPool.beHeartbeatPool).register(this);
         ((MockGenericPool<?>) ClientPool.backendPool).register(this);
 
         new MockUp<BrpcProxy>() {

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/UtFrameUtils.java
@@ -242,7 +242,7 @@ public class UtFrameUtils {
             return;
         }
         try {
-            ClientPool.heartbeatPool = new MockGenericPool.HeatBeatPool("heartbeat");
+            ClientPool.beHeartbeatPool = new MockGenericPool.HeatBeatPool("heartbeat");
             ClientPool.backendPool = new MockGenericPool.BackendThriftPool("backend");
 
             startFEServer("fe/mocked/test/" + UUID.randomUUID().toString() + "/", startBDB);


### PR DESCRIPTION
Why I'm doing:
Timeout of 2min (`Config.broker_client_timeout_ms`) is too long for the heartbeat RPC.

What I'm doing:
Create a new connection pool for broker RPC, whose timeout is 5s (`Config.heartbeat_timeout_second`)

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
