### PR TITLE
[BugFix] COM_STMT_PREPARE has issues disable for now

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectProcessor.java
@@ -570,7 +570,6 @@ public class ConnectProcessor {
                 handleQuit();
                 break;
             case COM_QUERY:
-            case COM_STMT_PREPARE:
                 handleQuery();
                 ctx.setStartTime();
                 break;


### PR DESCRIPTION
Why I'm doing:

Having an issue connecting using some BI tool, which will send COM_STMT_PREPARE cmd, and the response is bad formatted.

What I'm doing:

Disable COM_STMT_PREPARE  for now, only can use prepare in text mode.
Fixes #37206

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
