### PR TITLE
[BugFix] reduce lock contention in connector mem limiter

### DIFF
--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -27,42 +27,51 @@ namespace starrocks::pipeline {
 // ==================== ConnectorScanOperatorFactory ====================
 
 struct ConnectorScanOperatorIOTasksMemLimiter {
-    mutable std::shared_mutex lock;
+    mutable std::mutex lock;
 
-    size_t dop = 0;
-    int64_t mem_limit = 0;
-    int64_t running_chunk_source_count = 0;
-    int64_t estimated_mem_usage_update_count = 0;
-    double estimated_mem_usage_per_chunk_source = 0;
+    const int64_t dop = 0;
+    std::atomic<int64_t> scan_mem_limit = 0;
+    std::atomic<int64_t> running_chunk_source_count = 0;
+    std::atomic<int64_t> chunk_source_mem_bytes = 0;
+    int64_t chunk_source_mem_bytes_update_count = 0;
 
-    int available_chunk_source_count() const {
-        std::shared_lock<std::shared_mutex> L(lock);
+    ConnectorScanOperatorIOTasksMemLimiter(int64_t dop) : dop(dop) {}
 
-        int64_t max_count = mem_limit / estimated_mem_usage_per_chunk_source;
-        int64_t avail_count = (max_count - running_chunk_source_count) / static_cast<int64_t>(dop);
-        avail_count = std::max<int64_t>(avail_count, 0);
-        if (avail_count == 0 && running_chunk_source_count == 0) {
-            avail_count = 1;
+    int available_chunk_source_count(int driver_sequence) const {
+        int64_t scan_mem_limit_value = scan_mem_limit.load(std::memory_order_relaxed);
+        int64_t chunk_source_mem_bytes_value = chunk_source_mem_bytes.load(std::memory_order_relaxed);
+        int64_t running_count = running_chunk_source_count.load(std::memory_order_relaxed);
+
+        int64_t max_count = std::max(1L, scan_mem_limit_value / chunk_source_mem_bytes_value);
+        int64_t avail_count = std::max(0L, max_count - running_count);
+        int64_t per_count = avail_count / dop;
+
+        if (per_count == 0 && driver_sequence < avail_count) {
+            per_count += 1;
         }
-        // VLOG_FILE << "available_chunk_source_count. max_count=" << max_count << "(" << mem_limit << "/"
-        //           << int64_t(estimated_mem_usage_per_chunk_source) << ")"
-        //           << ", running_chunk_source_count = " << running_chunk_source_count << ", dop=" << dop
-        //           << ", avail_count = " << avail_count;
-        return avail_count;
+        if (per_count < 0) {
+            per_count = 0;
+        }
+
+        // VLOG_FILE << "available_chunk_source_count. max_count=" << max_count << "(" << scan_mem_limit_value << "/"
+        //           << chunk_source_mem_bytes_value << ")"
+        //           << ", running_count = " << running_count << ", dop = " << dop << ", avail_count = " << avail_count
+        //           << ", seq = " << driver_sequence << ", per_count = " << per_count;
+        return per_count;
     }
 
     void update_running_chunk_source_count(int delta) {
-        std::unique_lock<std::shared_mutex> L(lock);
-        running_chunk_source_count += delta;
+        running_chunk_source_count.fetch_add(delta, std::memory_order_relaxed);
     }
 
-    void update_estimated_mem_usage_per_chunk_source(int64_t value) {
+    void update_chunk_source_mem_bytes(int64_t value) {
         if (value == 0) return;
 
-        std::unique_lock<std::shared_mutex> L(lock);
-        double total = estimated_mem_usage_per_chunk_source * estimated_mem_usage_update_count + value;
-        estimated_mem_usage_update_count += 1;
-        estimated_mem_usage_per_chunk_source = total / estimated_mem_usage_update_count;
+        std::lock_guard<std::mutex> L(lock);
+        int64_t total =
+                chunk_source_mem_bytes.load(std::memory_order_relaxed) * chunk_source_mem_bytes_update_count + value;
+        chunk_source_mem_bytes_update_count += 1;
+        chunk_source_mem_bytes.store(total / chunk_source_mem_bytes_update_count, std::memory_order_relaxed);
     }
 };
 
@@ -71,8 +80,7 @@ ConnectorScanOperatorFactory::ConnectorScanOperatorFactory(int32_t id, ScanNode*
         : ScanOperatorFactory(id, scan_node),
           _chunk_buffer(scan_node->is_shared_scan_enabled() ? BalanceStrategy::kRoundRobin : BalanceStrategy::kDirect,
                         dop, std::move(buffer_limiter)) {
-    _io_tasks_mem_limiter = state->obj_pool()->add(new ConnectorScanOperatorIOTasksMemLimiter());
-    _io_tasks_mem_limiter->dop = dop;
+    _io_tasks_mem_limiter = state->obj_pool()->add(new ConnectorScanOperatorIOTasksMemLimiter(dop));
 }
 
 Status ConnectorScanOperatorFactory::do_prepare(RuntimeState* state) {
@@ -98,11 +106,11 @@ const std::vector<ExprContext*>& ConnectorScanOperatorFactory::partition_exprs()
 }
 
 void ConnectorScanOperatorFactory::set_estimated_mem_usage_per_chunk_source(int64_t value) {
-    _io_tasks_mem_limiter->estimated_mem_usage_per_chunk_source = value;
+    _io_tasks_mem_limiter->update_chunk_source_mem_bytes(value);
 }
 
 void ConnectorScanOperatorFactory::set_scan_mem_limit(int64_t value) {
-    _io_tasks_mem_limiter->mem_limit = value;
+    _io_tasks_mem_limiter->scan_mem_limit = value;
 }
 
 // ===============================================================
@@ -318,7 +326,7 @@ int ConnectorScanOperator::available_pickup_morsel_count() {
     int min_io_tasks = config::connector_io_tasks_min_size;
     auto* factory = down_cast<ConnectorScanOperatorFactory*>(_factory);
     ConnectorScanOperatorIOTasksMemLimiter* L = factory->_io_tasks_mem_limiter;
-    int max_io_tasks = L->available_chunk_source_count();
+    int max_io_tasks = L->available_chunk_source_count(_driver_sequence);
     max_io_tasks = std::min(max_io_tasks, _io_tasks_per_scan_operator);
     min_io_tasks = std::min(min_io_tasks, max_io_tasks);
 
@@ -496,7 +504,7 @@ void ConnectorChunkSource::close(RuntimeState* state) {
 
     ConnectorScanOperatorIOTasksMemLimiter* limiter = _get_io_tasks_mem_limiter();
     limiter->update_running_chunk_source_count(-1);
-    limiter->update_estimated_mem_usage_per_chunk_source(_data_source->estimated_mem_usage());
+    limiter->update_chunk_source_mem_bytes(_data_source->estimated_mem_usage());
 
     _closed = true;
     _data_source->close(state);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1274,7 +1274,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private int connectorIoTasksPerScanOperator = 16;
 
     @VariableMgr.VarAttr(name = ENABLE_CONNECTOR_ADAPTIVE_IO_TASKS)
-    private boolean enableConnectorAdaptiveIoTasks = false;
+    private boolean enableConnectorAdaptiveIoTasks = true;
 
     @VariableMgr.VarAttr(name = CONNECTOR_IO_TASKS_SLOW_IO_LATENCY_MS, flag = VariableMgr.INVISIBLE)
     private int connectorIoTasksSlowIoLatency = 50;


### PR DESCRIPTION
> Why I'm doing:

We have found there are serious lock contention (read/write) in connector io task  mem limiter

> What I'm doing:

Reduce lock contention scope:

For some variables, we don't need to maintain the at-point consistency. Eventual consistency works for us. 

This is just a small portion of cherry-pick from this PR: https://github.com/StarRocks/starrocks/pull/36526

And we are gonna re-enable adaptive io task by default which was disabled in this pr: https://github.com/StarRocks/starrocks/pull/34838

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
