### PR TITLE
[Enhancement] adjust the BE and CN resource usage

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -480,10 +480,10 @@ public class CoordinatorPreprocessor {
             return GlobalStateMgr.getCurrentWarehouseMgr().getComputeNodesFromWarehouse();
         }
 
-        //define CN Resource Pool
+        //define Resource Pool
         Map<Long, ComputeNode> computeNodes = new HashMap<>();
 
-        //add CN to CN Resource Pool
+        //add CN to Resource Pool
         ImmutableMap<Long, ComputeNode> idToComputeNode
                 = ImmutableMap.copyOf(GlobalStateMgr.getCurrentSystemInfo().getIdComputeNode());
         int useComputeNodeNumber = connectContext.getSessionVariable().getUseComputeNodes();
@@ -505,7 +505,7 @@ public class CoordinatorPreprocessor {
             }
         }
 
-        //add BE to CN Resource Pool
+        //add BE to Resource Pool
         ImmutableMap<Long, ComputeNode> idToBackend
                 = ImmutableMap.copyOf(GlobalStateMgr.getCurrentSystemInfo().getIdToBackend());
         for (int i = 0; i < idToBackend.size(); i++) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -480,7 +480,7 @@ public class CoordinatorPreprocessor {
             return GlobalStateMgr.getCurrentWarehouseMgr().getComputeNodesFromWarehouse();
         }
 
-        //define Resource Pool
+        //define Resource Pool 
         Map<Long, ComputeNode> computeNodes = new HashMap<>();
 
         //add CN to Resource Pool

--- a/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/CoordinatorPreprocessor.java
@@ -516,7 +516,7 @@ public class CoordinatorPreprocessor {
             computeNodes.put(backend.getId(), backend);
         }
 
-        //return the whole CN Resource Pool
+        //return Resource Pool
         return ImmutableMap.copyOf(computeNodes);
     }
 


### PR DESCRIPTION
Why I'm doing:
In shared nothing mode，when deploy both BE and CN，also set FE param prefer_compute_node=true，current BE and CN resource usage mechanism is not very feel perfect:
 1)when query internal table ，except scan fragment allocate to BE，other calculate fragment would allocate to CN;
 2)when query external table ，all fragment would allocate to CN.

In general，BE machine have high configuration，CN machine have low configuration(for example deploy on k8s or virtual machine)，current BE and CN resource usage mechanism would cause BE machine use low resource usage ratio，CN machine use high resource usage ratio，especially when business type belongs to computational tasks.

What I'm doing:
Then adjust the current BE and CN resource usage mechanism，as follows：
 1)when query internal table ，scan fragment allocate to BE，other calculate fragment would allocate to both BE and CN;
 2)when query external table ，all fragment would allocate to both BE and CN.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [] 3.2
  - [x] 3.1
  - [] 3.0
  - [] 2.5