### PR TITLE
[BugFix] Fix low-cardinality v2 in mv project bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -110,7 +110,7 @@ class DecodeContext {
             ColumnRefOperator stringRef = factory.getColumnRef(stringId);
             ColumnRefOperator dictRef = createNewDictColumn(stringRef);
             stringRefToDictRefMap.put(stringRef, dictRef);
-            ScalarOperator defineExpr = new DictMappingOperator(dictRef, stringRef.clone(), stringRef.getType());
+            ScalarOperator defineExpr = new DictMappingOperator(dictRef, stringRef.clone(), dictRef.getType());
             stringExprToDictExprMap.put(stringRef, defineExpr);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeContext.java
@@ -110,7 +110,7 @@ class DecodeContext {
             ColumnRefOperator stringRef = factory.getColumnRef(stringId);
             ColumnRefOperator dictRef = createNewDictColumn(stringRef);
             stringRefToDictRefMap.put(stringRef, dictRef);
-            ScalarOperator defineExpr = new DictMappingOperator(dictRef, stringRef.clone(), dictRef.getType());
+            ScalarOperator defineExpr = new DictMappingOperator(dictRef, stringRef.clone(), stringRef.getType());
             stringExprToDictExprMap.put(stringRef, defineExpr);
         }
 
@@ -120,8 +120,9 @@ class DecodeContext {
             ColumnRefOperator stringRef = factory.getColumnRef(stringId);
             ColumnRefOperator dictRef = stringRefToDictRefMap.get(stringRef);
 
-            if (stringDefineExpr.isColumnRef()) {
-                dictRefToDefineExprMap.put(dictRef, stringExprToDictExprMap.get(stringDefineExpr));
+            // may be a: b (just rename in projection)
+            if (stringDefineExpr.isColumnRef() && stringRef.equals(stringDefineExpr)) {
+                dictRefToDefineExprMap.put(dictRef, new DictMappingOperator(dictRef, stringRef.clone(), dictRef.getType()));
             } else {
                 List<ColumnRefOperator> useStringRefs = stringDefineExpr.getColumnRefs();
                 if (useStringRefs.stream().distinct().count() != 1) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
@@ -22,7 +22,6 @@ import com.starrocks.sql.plan.MockTpchStatisticStorage;
 import com.starrocks.sql.plan.PlanTestBase;
 import org.junit.BeforeClass;
 import org.junit.FixMethodOrder;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runners.MethodSorters;
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewLowCardTPCHTest.java
@@ -1,0 +1,79 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.FeConstants;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.common.QueryDebugOptions;
+import com.starrocks.sql.plan.MockTpchStatisticStorage;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class MaterializedViewLowCardTPCHTest extends MaterializedViewTestBase {
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        MaterializedViewTestBase.beforeClass();
+        starRocksAssert.useDatabase(MATERIALIZED_DB_NAME);
+
+        executeSqlFile("sql/materialized-view/tpch/ddl_tpch.sql");
+        executeSqlFile("sql/materialized-view/tpch/ddl_tpch_mv1.sql");
+        connectContext.getSessionVariable().setEnableMaterializedViewUnionRewrite(false);
+
+        int scale = 1;
+        GlobalStateMgr globalStateMgr = connectContext.getGlobalStateMgr();
+        connectContext.getGlobalStateMgr().setStatisticStorage(new MockTpchStatisticStorage(connectContext, scale));
+        OlapTable t4 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("customer");
+        setTableStatistics(t4, 150000 * scale);
+        OlapTable t7 = (OlapTable) globalStateMgr.getDb(MATERIALIZED_DB_NAME).getTable("lineitem");
+        setTableStatistics(t7, 6000000 * scale);
+
+        connectContext.getSessionVariable().setEnableLowCardinalityOptimize(true);
+        connectContext.getSessionVariable().setUseLowCardinalityOptimizeV2(true);
+    }
+
+    @Test
+    public void testQuery7() throws Exception {
+        QueryDebugOptions debugOptions = new QueryDebugOptions();
+        debugOptions.setEnableNormalizePredicateAfterMVRewrite(true);
+        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
+
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        String plan = getVerboseExplain(TpchSQL.Q07);
+        assertCContains(plan, "group by: [425: n_name, INT, true], " +
+                "[426: n_name, INT, true], " +
+                "[49: year, SMALLINT, false]");
+        connectContext.getSessionVariable().setQueryDebugOptions("");
+    }
+
+    @Test
+    public void testQuery12() throws Exception {
+        QueryDebugOptions debugOptions = new QueryDebugOptions();
+        debugOptions.setEnableNormalizePredicateAfterMVRewrite(true);
+        connectContext.getSessionVariable().setQueryDebugOptions(debugOptions.toString());
+
+        FeConstants.USE_MOCK_DICT_MANAGER = true;
+        System.out.println(TpchSQL.Q12);
+        String plan = getVerboseExplain(TpchSQL.Q12);
+        assertCContains(plan, "group by: [90: l_shipmode, INT, true]");
+        connectContext.getSessionVariable().setQueryDebugOptions("");
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/planner/TpchSQL.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/TpchSQL.java
@@ -1,0 +1,41 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.planner;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.Objects;
+
+public class TpchSQL {
+    private static String from(String name) {
+        String path = Objects.requireNonNull(ClassLoader.getSystemClassLoader().getResource("sql")).getPath();
+        File file = new File(path + "/tpchsql/q" + name + ".sql");
+        StringBuilder sb = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
+            String str;
+            while ((str = reader.readLine()) != null) {
+                sb.append(str).append("\n");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return sb.toString();
+    }
+
+    public static final String Q07 = from("7");
+    public static final String Q12 = from("12");
+}

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -16,10 +16,13 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
+import com.starrocks.sql.optimizer.operator.AggType;
+import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import mockit.Expectations;
+import org.apache.spark.sql.catalyst.planning.PhysicalAggregation;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -2039,4 +2042,5 @@ public class LowCardinalityTest2 extends PlanTestBase {
             connectContext.getSessionVariable().setNewPlanerAggStage(0);
         }
     }
+
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2040,4 +2040,13 @@ public class LowCardinalityTest2 extends PlanTestBase {
         }
     }
 
+    @Test
+    public void testDateDiff() throws Exception {
+        String sql = "select date_diff(S_COMMENT, '2017-02-28', S_ADDRESS), S_COMMENT, S_ADDRESS " +
+                "from supplier order by S_COMMENT, S_ADDRESS";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "date_diff(DictExpr(11: S_COMMENT,[<place-holder>]), " +
+                "'2017-02-28 00:00:00', " +
+                "DictExpr(10: S_ADDRESS,[CAST(<place-holder> AS DATETIME)]))");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -16,13 +16,10 @@ package com.starrocks.sql.plan;
 
 import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
-import com.starrocks.sql.optimizer.operator.AggType;
-import com.starrocks.sql.optimizer.operator.physical.PhysicalHashAggregateOperator;
 import com.starrocks.sql.optimizer.statistics.IDictManager;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.utframe.StarRocksAssert;
 import mockit.Expectations;
-import org.apache.spark.sql.catalyst.planning.PhysicalAggregation;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q12.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q12.sql
@@ -1,0 +1,28 @@
+select
+    l_shipmode,
+    sum(case
+            when o_orderpriority = '1-URGENT'
+                or o_orderpriority = '2-HIGH'
+                then cast (1 as bigint)
+            else cast(0 as bigint)
+        end) as high_line_count,
+    sum(case
+            when o_orderpriority <> '1-URGENT'
+                and o_orderpriority <> '2-HIGH'
+                then cast (1 as bigint)
+            else cast(0 as bigint)
+        end) as low_line_count
+from
+    orders,
+    lineitem
+where
+        o_orderkey = l_orderkey
+  and l_shipmode in ('REG AIR', 'MAIL')
+  and l_commitdate < l_receiptdate
+  and l_shipdate < l_commitdate
+  and l_receiptdate >= date '1997-01-01'
+  and l_receiptdate < date '1998-01-01'
+group by
+    l_shipmode
+order by
+    l_shipmode ;

--- a/fe/fe-core/src/test/resources/sql/tpchsql/q7.sql
+++ b/fe/fe-core/src/test/resources/sql/tpchsql/q7.sql
@@ -1,0 +1,39 @@
+select
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) as revenue
+from
+    (
+        select
+            n1.n_name as supp_nation,
+            n2.n_name as cust_nation,
+            extract(year from l_shipdate) as l_year,
+            l_extendedprice * (1 - l_discount) as volume
+        from
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2
+        where
+                s_suppkey = l_suppkey
+          and o_orderkey = l_orderkey
+          and c_custkey = o_custkey
+          and s_nationkey = n1.n_nationkey
+          and c_nationkey = n2.n_nationkey
+          and (
+                (n1.n_name = 'CANADA' and n2.n_name = 'IRAN')
+                or (n1.n_name = 'IRAN' and n2.n_name = 'CANADA')
+            )
+          and l_shipdate between date '1995-01-01' and date '1996-12-31'
+    ) as shipping
+group by
+    supp_nation,
+    cust_nation,
+    l_year
+order by
+    supp_nation,
+    cust_nation,
+    l_year ;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
In MV，will produce rename projection:
```
|   1:Project                                                                                                                                                                                                                      |
|   |  output columns:                                                                                                                                                                                                             |
|   |  5 <-> [8: t, VARCHAR, true]                                                                                                                                                                                                     |
|   |  6 <-> [9: lhs, VARCHAR, true]                                                                                                                                                                                                   |
|   |  7 <-> [10: rhs, VARCHAR, true]                                                                                                                       
```

rewrite to low-cardinality:
```
|   1:Project                                                                                                                                                                                                                      |
|   |  output columns:                                                                                                                                                                                                             |
|   |  5 (VARCHAR) <-> DictExpr([8: t, VARCHAR, true])                                                                                                                                                                                                    |
|   |  6 (VARCHAR) <-> DictExpr([9: lhs, VARCHAR, true])                                                                                                                                                                                                  |
|   |  7 (VARCHAR) <-> DictExpr([10: rhs, VARCHAR, true])                                                                                                                       
```
because the result of dict define expr error, should be

```
|   1:Project                                                                                                                                                                                                                      |
|   |  output columns:                                                                                                                                                                                                             |
|   |  5 (INT) <-> DictExpr([8: t, VARCHAR, true])                                                                                                                                                                                                    |
|   |  6 (INT) <-> DictExpr([9: lhs, VARCHAR, true])                                                                                                                                                                                                  |
|   |  7 (INT) <-> DictExpr([10: rhs, VARCHAR, true])                                                                                                                       
```

dict define expr should return INT type

Fixes https://github.com/StarRocks/StarRocksTest/issues/5266

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
