### PR TITLE
[Enhancement][Branch-3.2] Use G1 GC by default on jdk8

### DIFF
--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -139,7 +139,7 @@ if [[ "$JAVA_VERSION" -lt 11 ]]; then
         export JAVA=${JAVA_HOME}/bin/java
         JAVA_UPDATE_VER=$(${JAVA} -version 2>&1 | sed -n 's/.* version "1\.8\.0_\([0-9]*\)".*/\1/p')
         if [[ $JAVA_UPDATE_VER -lt 192 ]]; then
-            echo "Tips: JAVA_UPDATE_VER is $JAVA_UPDATE_VER, Please upgrade the JAVA version to at least 1.8.0_192 ensure that G1 GC bugs are not triggered."
+            echo "Tips: JAVA_UPDATE_VER is $JAVA_UPDATE_VER, Please upgrade the JAVA version to at least 1.8.0_192 to avoid potential issues of G1 gc on jdk8."
         fi
     fi
 fi

--- a/bin/start_fe.sh
+++ b/bin/start_fe.sh
@@ -135,6 +135,13 @@ final_java_opt="${final_java_opt} ${xmx}"
 
 if [[ "$JAVA_VERSION" -lt 11 ]]; then
     echo "Tips: current JDK version is $JAVA_VERSION, JDK 11 or 17 is highly recommended for better GC performance(lower version JDK may not be supported in the future)"
+    if [[ "$JAVA_VERSION" == 8 ]]; then
+        export JAVA=${JAVA_HOME}/bin/java
+        JAVA_UPDATE_VER=$(${JAVA} -version 2>&1 | sed -n 's/.* version "1\.8\.0_\([0-9]*\)".*/\1/p')
+        if [[ $JAVA_UPDATE_VER -lt 192 ]]; then
+            echo "Tips: JAVA_UPDATE_VER is $JAVA_UPDATE_VER, Please upgrade the JAVA version to at least 1.8.0_192 ensure that G1 GC bugs are not triggered."
+        fi
+    fi
 fi
 
 if [ ${ENABLE_DEBUGGER} -eq 1 ]; then

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -24,7 +24,7 @@
 LOG_DIR = ${STARROCKS_HOME}/log
 
 DATE = "$(date +%Y%m%d-%H%M%S)"
-JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseMembar -XX:SurvivorRatio=8 -XX:MaxTenuringThreshold=7 -XX:+PrintGCDateStamps -XX:+PrintGCDetails -XX:+UseConcMarkSweepGC -XX:+UseParNewGC -XX:+CMSClassUnloadingEnabled -XX:-CMSParallelRemarkEnabled -XX:CMSInitiatingOccupancyFraction=80 -XX:SoftRefLRUPolicyMSPerMB=0 -Xloggc:${LOG_DIR}/fe.gc.log.$DATE -XX:+PrintConcurrentLocks -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
+JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xloggc:${LOG_DIR}/fe.gc.log.$DATE -XX:+PrintConcurrentLocks -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
 
 # For jdk 11+, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_11="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"

--- a/conf/fe.conf
+++ b/conf/fe.conf
@@ -24,7 +24,7 @@
 LOG_DIR = ${STARROCKS_HOME}/log
 
 DATE = "$(date +%Y%m%d-%H%M%S)"
-JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xloggc:${LOG_DIR}/fe.gc.log.$DATE -XX:+PrintConcurrentLocks -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
+JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:${LOG_DIR}/fe.gc.log.$DATE -XX:+PrintConcurrentLocks -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"
 
 # For jdk 11+, this JAVA_OPTS will be used as default JVM options
 JAVA_OPTS_FOR_JDK_11="-Dlog4j2.formatMsgNoLookups=true -Xmx8192m -XX:+UseG1GC -Xlog:gc*:${LOG_DIR}/fe.gc.log.$DATE:time -Djava.security.policy=${STARROCKS_HOME}/conf/udf_security.policy"


### PR DESCRIPTION
Why I'm doing:

G1GC performs better in most scenarios, so we should use G1GC as soon as possible.

What I'm doing:

G1GC has a bug in the lower version of JDK8. We will add a WARNING to remind users.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5

