### PR TITLE
[Enhancement] Support refresh iceberg mv by partition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -45,21 +45,17 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.iceberg.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
-
-import static com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.ICEBERG_ALL_PARTITION;
 
 /**
  * Abstract the partition-related interfaces for different connectors, including Iceberg/Hive/....
@@ -425,46 +421,16 @@ public abstract class ConnectorPartitionTraits {
         }
 
         @Override
-        public Optional<Long> maxPartitionRefreshTs() {
+        public List<PartitionInfo> getPartitions(List<String> partitionNames) {
             IcebergTable icebergTable = (IcebergTable) table;
-            return icebergTable.getSnapshot().map(Snapshot::timestampMillis);
+            return GlobalStateMgr.getCurrentState().getMetadataMgr().
+                    getPartitions(icebergTable.getCatalogName(), table, partitionNames);
         }
 
         @Override
-        public Set<String> getUpdatedPartitionNames(List<BaseTableInfo> baseTables,
-                                                    MaterializedView.AsyncRefreshContext context) {
-            IcebergTable baseTable = (IcebergTable) table;
-
-            Set<String> result = Sets.newHashSet();
-            for (BaseTableInfo baseTableInfo : baseTables) {
-                if (!baseTableInfo.getTableIdentifier().equalsIgnoreCase(baseTable.getTableIdentifier())) {
-                    continue;
-                }
-                List<String> partitionNames = PartitionUtil.getPartitionNames(baseTable);
-                Snapshot snapshot = baseTable.getNativeTable().currentSnapshot();
-                long currentVersion = snapshot != null ? snapshot.timestampMillis() : -1;
-
-                Map<String, MaterializedView.BasePartitionInfo> baseTableInfoVisibleVersionMap =
-                        context.getBaseTableRefreshInfo(baseTableInfo);
-                MaterializedView.BasePartitionInfo basePartitionInfo =
-                        baseTableInfoVisibleVersionMap.get(ICEBERG_ALL_PARTITION);
-                if (basePartitionInfo == null) {
-                    return new HashSet<>(partitionNames);
-                }
-                // check if there are new partitions which are not in baseTableInfoVisibleVersionMap
-                for (String partitionName : partitionNames) {
-                    if (!baseTableInfoVisibleVersionMap.containsKey(partitionName)) {
-                        result.add(partitionName);
-                    }
-                }
-
-                long basePartitionVersion = basePartitionInfo.getVersion();
-                if (basePartitionVersion != currentVersion) {
-                    result.addAll(IcebergPartitionUtils.getChangedPartitionNames(baseTable.getNativeTable(),
-                            basePartitionVersion, snapshot));
-                }
-            }
-            return result;
+        public Optional<Long> maxPartitionRefreshTs() {
+            IcebergTable icebergTable = (IcebergTable) table;
+            return icebergTable.getSnapshot().map(Snapshot::timestampMillis);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -292,6 +292,16 @@ public class IcebergMetadata implements ConnectorMetadata {
         if (icebergTable.isUnPartitioned()) {
             try (CloseableIterable<FileScanTask> tasks = partitionsTable.newScan().planFiles()) {
                 for (FileScanTask task : tasks) {
+                    // partitionsTable Table schema :
+                    // record_count,
+                    // file_count,
+                    // total_data_file_size_in_bytes,
+                    // position_delete_record_count,
+                    // position_delete_file_count,
+                    // equality_delete_record_count,
+                    // equality_delete_file_count,
+                    // last_updated_at,
+                    // last_updated_snapshot_id
                     CloseableIterable<StructLike> rows = task.asDataTask().rows();
                     for (StructLike row : rows) {
                         long lastUpdated = row.get(7, Long.class);
@@ -306,6 +316,18 @@ public class IcebergMetadata implements ConnectorMetadata {
             // For partition table, we need to get all partitions from PartitionsTable.
             try (CloseableIterable<FileScanTask> tasks = partitionsTable.newScan().planFiles()) {
                 for (FileScanTask task : tasks) {
+                    // partitionsTable Table schema :
+                    // partition,
+                    // spec_id,
+                    // record_count,
+                    // file_count,
+                    // total_data_file_size_in_bytes,
+                    // position_delete_record_count,
+                    // position_delete_file_count,
+                    // equality_delete_record_count,
+                    // equality_delete_file_count,
+                    // last_updated_at,
+                    // last_updated_snapshot_id
                     CloseableIterable<StructLike> rows = task.asDataTask().rows();
                     for (StructLike row : rows) {
                         StructProjection partitionData = row.get(0, StructProjection.class);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -304,6 +304,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                     // last_updated_snapshot_id
                     CloseableIterable<StructLike> rows = task.asDataTask().rows();
                     for (StructLike row : rows) {
+                        // Get the last updated time of the table according to the table schema
                         long lastUpdated = row.get(7, Long.class);
                         Partition partition = new Partition(lastUpdated);
                         return ImmutableList.of(partition);
@@ -330,6 +331,7 @@ public class IcebergMetadata implements ConnectorMetadata {
                     // last_updated_snapshot_id
                     CloseableIterable<StructLike> rows = task.asDataTask().rows();
                     for (StructLike row : rows) {
+                        // Get the partition data/spec id/last updated time according to the table schema
                         StructProjection partitionData = row.get(0, StructProjection.class);
                         int specId = row.get(1, Integer.class);
                         long lastUpdated = row.get(9, Long.class);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
@@ -1,0 +1,30 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.connector.iceberg;
+
+import com.starrocks.connector.PartitionInfo;
+
+public class Partition implements PartitionInfo {
+    private final long modifiedTime;
+
+    @Override
+    public long getModifiedTime() {
+        return modifiedTime;
+    }
+
+    public Partition(long lastUpdatedAt) {
+        this.modifiedTime = lastUpdatedAt;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/Partition.java
@@ -24,7 +24,7 @@ public class Partition implements PartitionInfo {
         return modifiedTime;
     }
 
-    public Partition(long lastUpdatedAt) {
-        this.modifiedTime = lastUpdatedAt;
+    public Partition(long modifiedTime) {
+        this.modifiedTime = modifiedTime;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TableSnapshotInfo.java
@@ -29,16 +29,12 @@ public class TableSnapshotInfo {
     private final BaseTableInfo baseTableInfo;
     private final Table baseTable;
 
-    // used for iceberg table
-    private final long refreshSnapshotTime;
-
     // partition's base info to be used in `updateMeta`
     Map<String, MaterializedView.BasePartitionInfo> refreshedPartitionInfos = Maps.newHashMap();
 
-    public TableSnapshotInfo(BaseTableInfo baseTableInfo, Table baseTable, long refreshSnapshotTime) {
+    public TableSnapshotInfo(BaseTableInfo baseTableInfo, Table baseTable) {
         this.baseTableInfo = baseTableInfo;
         this.baseTable = baseTable;
-        this.refreshSnapshotTime = refreshSnapshotTime;
     }
 
     public BaseTableInfo getBaseTableInfo() {
@@ -47,10 +43,6 @@ public class TableSnapshotInfo {
 
     public Table getBaseTable() {
         return baseTable;
-    }
-
-    public long getRefreshSnapshotTime() {
-        return refreshSnapshotTime;
     }
 
     public Map<String, MaterializedView.BasePartitionInfo> getRefreshedPartitionInfos() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -66,7 +66,6 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static com.starrocks.scheduler.PartitionBasedMvRefreshProcessor.ICEBERG_ALL_PARTITION;
 import static com.starrocks.sql.common.TimeUnitUtils.DAY;
 import static com.starrocks.sql.common.TimeUnitUtils.HOUR;
 import static com.starrocks.sql.common.TimeUnitUtils.MINUTE;
@@ -825,10 +824,9 @@ public class SyncPartitionUtils {
     private static boolean isMVPartitionNameRefBaseTablePartitionMapEnough(
             Map<String, MaterializedView.BasePartitionInfo> baseTableVersionInfoMap,
             Map<String, Set<String>> mvPartitionNameRefBaseTablePartitionMap) {
-        long refreshedRefBaseTablePartitionSize = baseTableVersionInfoMap.keySet()
-                .stream().filter(x -> !x.equals(ICEBERG_ALL_PARTITION)).count();
+        long refreshedRefBaseTablePartitionSize = baseTableVersionInfoMap.keySet().size();
         long refreshAssociatedRefTablePartitionSize = mvPartitionNameRefBaseTablePartitionMap.values()
-                .stream().map(x -> x.size()).reduce(0, Integer::sum);
+                .stream().map(Set::size).reduce(0, Integer::sum);
         return refreshedRefBaseTablePartitionSize == refreshAssociatedRefTablePartitionSize;
     }
 
@@ -971,9 +969,6 @@ public class SyncPartitionUtils {
             if (baseTableVersionMap != null) {
                 baseTableVersionMap.keySet().removeIf(partitionName -> {
                     try {
-                        if (partitionName.equals(ICEBERG_ALL_PARTITION)) {
-                            return false;
-                        }
                         boolean isListPartition = mv.getPartitionInfo() instanceof ListPartitionInfo;
                         Set<String> partitionNames = PartitionUtil.getMVPartitionName(baseTable, partitionColumn,
                                 Lists.newArrayList(partitionName), isListPartition, expr);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -32,6 +33,7 @@ import com.starrocks.common.DdlException;
 import com.starrocks.common.ExceptionChecker;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.connector.HdfsEnvironment;
+import com.starrocks.connector.PartitionInfo;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.iceberg.hive.IcebergHiveCatalog;
@@ -999,6 +1001,27 @@ public class IcebergMetadataTest extends TableTestBase {
                 Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
         List<String> partitionNames = metadata.listPartitionNames("db", "table");
         Assert.assertEquals(partitionNames, Lists.newArrayList("k2=2", "k2=3"));
+    }
+
+    @Test
+    public void testGetPartitions() {
+        mockedNativeTableB.newAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
+
+        Map<String, String> config = new HashMap<>();
+        config.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732");
+        config.put(ICEBERG_CATALOG_TYPE, "hive");
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(icebergHiveCatalog, 3,
+                Executors.newSingleThreadExecutor());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, cachingIcebergCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog",
+                "resource_name", "db",
+                "table", Lists.newArrayList(), mockedNativeTableB, Maps.newHashMap());
+
+        List<PartitionInfo> partitions = metadata.getPartitions(icebergTable, ImmutableList.of("k2=2", "k2=3"));
+        Assert.assertEquals(2, partitions.size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -1004,7 +1004,7 @@ public class IcebergMetadataTest extends TableTestBase {
     }
 
     @Test
-    public void testGetPartitions() {
+    public void testGetPartitions1() {
         mockedNativeTableB.newAppend().appendFile(FILE_B_1).appendFile(FILE_B_2).commit();
 
         Map<String, String> config = new HashMap<>();
@@ -1022,6 +1022,27 @@ public class IcebergMetadataTest extends TableTestBase {
 
         List<PartitionInfo> partitions = metadata.getPartitions(icebergTable, ImmutableList.of("k2=2", "k2=3"));
         Assert.assertEquals(2, partitions.size());
+    }
+
+    @Test
+    public void testGetPartitions2() {
+        mockedNativeTableG.newAppend().appendFile(FILE_B_5).commit();
+
+        Map<String, String> config = new HashMap<>();
+        config.put(HIVE_METASTORE_URIS, "thrift://188.122.12.1:8732");
+        config.put(ICEBERG_CATALOG_TYPE, "hive");
+        IcebergHiveCatalog icebergHiveCatalog = new IcebergHiveCatalog("iceberg_catalog", new Configuration(), config);
+        CachingIcebergCatalog cachingIcebergCatalog = new CachingIcebergCatalog(icebergHiveCatalog, 3,
+                Executors.newSingleThreadExecutor());
+        IcebergMetadata metadata = new IcebergMetadata(CATALOG_NAME, HDFS_ENVIRONMENT, cachingIcebergCatalog,
+                Executors.newSingleThreadExecutor(), Executors.newSingleThreadExecutor());
+
+        IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog",
+                "resource_name", "db",
+                "table", Lists.newArrayList(), mockedNativeTableG, Maps.newHashMap());
+
+        List<PartitionInfo> partitions = metadata.getPartitions(icebergTable, Lists.newArrayList());
+        Assert.assertEquals(1, partitions.size());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.connector.iceberg;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.qe.ConnectContext;
@@ -81,8 +80,8 @@ public class IcebergPartitionUtilsTest {
 
         IcebergTable icebergTable = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr().
                 getTable("iceberg0", "partitioned_db", "t1");
-        mockIcebergMetadata.updatePartitions("partitioned_db", "t1",
-                ImmutableList.of("date=2020-01-02", "date=2020-01-03"));
+        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-02");
+        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-03");
         Set<IcebergPartitionUtils.IcebergPartition> partitions = IcebergPartitionUtils.
                 getAllPartition(icebergTable.getNativeTable());
         Assert.assertEquals(2, partitions.size());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.connector.iceberg;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.starrocks.catalog.IcebergTable;
 import com.starrocks.qe.ConnectContext;
@@ -78,10 +79,10 @@ public class IcebergPartitionUtilsTest {
                 (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                         getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
 
-        IcebergTable icebergTable = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr().getTable("iceberg0",
-                "partitioned_db", "t1");
-        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-02");
-        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-03");
+        IcebergTable icebergTable = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr().
+                getTable("iceberg0", "partitioned_db", "t1");
+        mockIcebergMetadata.updatePartitions("partitioned_db", "t1",
+                ImmutableList.of("date=2020-01-02", "date=2020-01-03"));
         Set<IcebergPartitionUtils.IcebergPartition> partitions = IcebergPartitionUtils.
                 getAllPartition(icebergTable.getNativeTable());
         Assert.assertEquals(2, partitions.size());

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
@@ -62,6 +62,8 @@ public class TableTestBase {
             PartitionSpec.builderFor(SCHEMA_A).bucket("data", BUCKETS_NUMBER).build();
     protected static final PartitionSpec SPEC_B =
             PartitionSpec.builderFor(SCHEMA_B).identity("k2").build();
+    protected static final PartitionSpec SPEC_B_1 = PartitionSpec.builderFor(SCHEMA_B).build();
+
     protected static final PartitionSpec SPEC_D =
             PartitionSpec.builderFor(SCHEMA_D).hour("ts").build();
 
@@ -142,6 +144,12 @@ public class TableTestBase {
                     .withMetrics(TABLE_B_METRICS)
                     .build();
 
+    public static final DataFile FILE_B_5 = DataFiles.builder(SPEC_B)
+            .withPath("/path/to/data-b5.parquet")
+            .withFileSizeInBytes(20)
+            .withRecordCount(4)
+            .build();
+
     public static final DeleteFile FILE_C_1 = FileMetadata.deleteFileBuilder(SPEC_B).ofPositionDeletes()
             .withPath("delete.orc")
             .withFileSizeInBytes(1024)
@@ -163,6 +171,7 @@ public class TableTestBase {
     public TestTables.TestTable mockedNativeTableD = null;
     public TestTables.TestTable mockedNativeTableE = null;
     public TestTables.TestTable mockedNativeTableF = null;
+    public TestTables.TestTable mockedNativeTableG = null;
 
     protected final int formatVersion = 1;
 
@@ -178,6 +187,7 @@ public class TableTestBase {
         this.mockedNativeTableD = create(SCHEMA_D, SPEC_D, "td", 1);
         this.mockedNativeTableE = create(SCHEMA_D, SPEC_D_1, "te", 1);
         this.mockedNativeTableF = create(SCHEMA_F, SPEC_F, "tf", 1);
+        this.mockedNativeTableG = create(SCHEMA_B, SPEC_B_1, "tg", 1);
     }
 
     @After

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TestTables.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TestTables.java
@@ -45,7 +45,8 @@ import static org.apache.iceberg.TableMetadata.newTableMetadata;
 import static org.apache.iceberg.TableProperties.FORMAT_VERSION;
 
 public class TestTables {
-
+    private static final String TEST_METADATA_LOCATION =
+            "s3://bucket/test/location/metadata/v1.metadata.json";
     private TestTables() {}
 
     private static TestTable upgrade(File temp, String name, int newFormatVersion) {
@@ -275,7 +276,8 @@ public class TestTables {
                     }
                     Integer version = VERSIONS.get(tableName);
                     // remove changes from the committed metadata
-                    this.current = TableMetadata.buildFrom(updatedMetadata).discardChanges().build();
+                    this.current = TableMetadata.buildFrom(updatedMetadata).discardChanges()
+                            .withMetadataLocation(TEST_METADATA_LOCATION).build();
                     VERSIONS.put(tableName, version == null ? 0 : version + 1);
                     METADATA.put(tableName, current);
                 } else {

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -788,7 +788,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         MockIcebergMetadata mockIcebergMetadata =
                 (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
                         getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
-        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-02");
+        mockIcebergMetadata.updatePartitions("partitioned_db", "t1",
+                ImmutableList.of("date=2020-01-02"));
         // refresh only one partition
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -810,7 +811,8 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                 ImmutableMap.copyOf(partitionVersionMap));
 
         // add new row and refresh again
-        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-01");
+        mockIcebergMetadata.updatePartitions("partitioned_db", "t1",
+                ImmutableList.of("date=2020-01-01"));
         taskRun = TaskRunBuilder.newBuilder(task).build();
         initAndExecuteTaskRun(taskRun);
         processor = (PartitionBasedMvRefreshProcessor)

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -1719,7 +1719,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied));
                 }
 
                 String renamePartitionSql = "ALTER TABLE test.tbl1 RENAME PARTITION p1 p1_1";
@@ -1771,7 +1771,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, olapTable, -1));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, olapTable));
                 }
 
                 try {
@@ -1831,7 +1831,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied));
                 }
 
                 String addPartitionSql =
@@ -1930,7 +1930,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                     if (!DeepCopy.copy(olapTable, copied, OlapTable.class)) {
                         throw new SemanticException("Failed to copy olap table: " + olapTable.getName());
                     }
-                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied, -1));
+                    olapTables.put(olapTable.getId(), new TableSnapshotInfo(baseTableInfo, copied));
                 }
 
                 String dropPartitionSql = "ALTER TABLE test.tbl1 DROP PARTITION p4";


### PR DESCRIPTION
Why I'm doing:
Icebegr mv do not support refresh by partition when base table has delete/update/insert overwrite operations
What I'm doing:
Support getPartitions interface for iceberg matadata, it will get last update timestamp
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
