### PR TITLE
[Enhancement] improve cloud native table conflict check

### DIFF
--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -524,8 +524,10 @@ Status RowsetUpdateState::rewrite_segment(const TxnLogPB_OpWrite& op_write, cons
 Status RowsetUpdateState::_resolve_conflict(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
                                             int64_t base_version, Tablet* tablet, const MetaFileBuilder* builder) {
     _builder = builder;
-    // check if base version is match and pk index has not been updated yet, and we can skip resolve conflict
-    if (base_version == _base_version && !_builder->has_update_index()) {
+    // There are two cases that we must resolve conflict here:
+    // 1. Current transaction's base version isn't equal latest base version, which means that conflict happens.
+    // 2. We use batch publish here. This transaction may conflict with a transaction in the same batch.
+    if (base_version == _base_version && base_version + 1 == metadata.version()) {
         return Status::OK();
     }
     _base_version = base_version;

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -47,6 +47,7 @@ Status RowsetUpdateState::load(const TxnLogPB_OpWrite& op_write, const TabletMet
         return _status;
     }
     std::call_once(_load_once_flag, [&] {
+        TRACE_COUNTER_SCOPE_LATENCY_US("update_state_load_latency_us");
         _base_version = base_version;
         _builder = builder;
         _tablet_id = metadata.id();
@@ -530,6 +531,7 @@ Status RowsetUpdateState::_resolve_conflict(const TxnLogPB_OpWrite& op_write, co
     if (base_version == _base_version && base_version + 1 == metadata.version()) {
         return Status::OK();
     }
+    TRACE_COUNTER_SCOPE_LATENCY_US("resolve_conflict_latency_us");
     _base_version = base_version;
     // skip resolve conflict when not partial update happen.
     if (!op_write.has_txn_meta() || op_write.rowset().segments_size() == 0 ||


### PR DESCRIPTION
Why I'm doing:
In previous implementation, we decide whether can skip conflict check by `base_version` and whether pk index has updated or no. But pk index will be set updated after `prepare_primary_index` is called, so `has_update_index()` will always be true.

What I'm doing:
There are two cases that we must resolve conflict here:
1. Current transaction's base version isn't equal latest base version, which means that conflict happens.
2. We use batch publish here. This transaction may conflict with a transaction in the same batch.

So I use base version and new version check instead of `has_update_index()` here.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
