### PR TITLE
[Enhancement] Fix replicated storage black list mechanism invalid when backend service down

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -107,6 +107,13 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
                 params.commitInfos.push_back(info);
             }
         }
+        if (!runtime_state->tablet_fail_infos().empty()) {
+            params.__isset.failInfos = true;
+            params.failInfos.reserve(runtime_state->tablet_fail_infos().size());
+            for (auto& info : runtime_state->tablet_fail_infos()) {
+                params.failInfos.push_back(info);
+            }
+        }
         if (!runtime_state->sink_commit_infos().empty()) {
             params.__isset.sink_commit_infos = true;
             params.sink_commit_infos.reserve(runtime_state->sink_commit_infos().size());

--- a/be/src/exec/tablet_sink.cpp
+++ b/be/src/exec/tablet_sink.cpp
@@ -320,6 +320,9 @@ Status OlapTableSink::_init_node_channels(RuntimeState* state, IndexIdToTabletBE
                             node_channel = it->second.get();
                         }
                         node_channel->add_tablet(index->index_id, tablet_info);
+                        if (_enable_replicated_storage && i == 0) {
+                            node_channel->set_has_primary_replica(true);
+                        }
                     }
                 }
 

--- a/be/src/exec/tablet_sink_index_channel.cpp
+++ b/be/src/exec/tablet_sink_index_channel.cpp
@@ -920,7 +920,9 @@ Status IndexChannel::init(RuntimeState* state, const std::vector<PTabletWithPart
             auto msg = fmt::format("Not found tablet: {}", tablet.tablet_id());
             return Status::NotFound(msg);
         }
-        for (auto& node_id : location->node_ids) {
+        auto node_ids_size = location->node_ids.size();
+        for (size_t i = 0; i < node_ids_size; ++i) {
+            auto& node_id = location->node_ids[i];
             NodeChannel* channel = nullptr;
             auto it = _node_channels.find(node_id);
             if (it == std::end(_node_channels)) {
@@ -934,6 +936,9 @@ Status IndexChannel::init(RuntimeState* state, const std::vector<PTabletWithPart
                 channel = it->second.get();
             }
             channel->add_tablet(_index_id, tablet);
+            if (_parent->_enable_replicated_storage && i == 0) {
+                channel->set_has_primary_replica(true);
+            }
         }
     }
     for (auto& it : _node_channels) {
@@ -947,7 +952,19 @@ Status IndexChannel::init(RuntimeState* state, const std::vector<PTabletWithPart
     return Status::OK();
 }
 
+void IndexChannel::mark_as_failed(const NodeChannel* ch) {
+    // primary replica use for replicated storage
+    // if primary replica failed, we should mark this index as failed
+    if (ch->has_primary_replica()) {
+        _has_intolerable_failure = true;
+    }
+    _failed_channels.insert(ch->node_id());
+}
+
 bool IndexChannel::has_intolerable_failure() {
+    if (_has_intolerable_failure) {
+        return _has_intolerable_failure;
+    }
     if (_write_quorum_type == TWriteQuorumType::ALL) {
         return _failed_channels.size() > 0;
     } else if (_write_quorum_type == TWriteQuorumType::ONE) {

--- a/be/src/exec/tablet_sink_index_channel.h
+++ b/be/src/exec/tablet_sink_index_channel.h
@@ -161,6 +161,9 @@ public:
     bool has_immutable_partition() { return !_immutable_partition_ids.empty(); }
     void reset_immutable_partition_ids() { _immutable_partition_ids.clear(); }
 
+    bool has_primary_replica() const { return _has_primary_replica; }
+    void set_has_primary_replica(bool has_primary_replica) { _has_primary_replica = has_primary_replica; }
+
 private:
     Status _wait_request(ReusableClosure<PTabletWriterAddBatchResult>* closure);
     Status _wait_all_prev_request();
@@ -244,6 +247,8 @@ private:
     std::set<int64_t> _immutable_partition_ids;
 
     ExprContext* _where_clause = nullptr;
+
+    bool _has_primary_replica = false;
 };
 
 class IndexChannel {
@@ -276,7 +281,7 @@ public:
         }
     }
 
-    void mark_as_failed(const NodeChannel* ch) { _failed_channels.insert(ch->node_id()); }
+    void mark_as_failed(const NodeChannel* ch);
 
     bool is_failed_channel(const NodeChannel* ch) { return _failed_channels.count(ch->node_id()) != 0; }
 
@@ -303,6 +308,8 @@ private:
 
     bool _has_incremental_node_channel = false;
     ExprContext* _where_clause = nullptr;
+
+    bool _has_intolerable_failure = false;
 };
 
 } // namespace stream_load

--- a/be/src/exec/tablet_sink_sender.cpp
+++ b/be/src/exec/tablet_sink_sender.cpp
@@ -173,8 +173,7 @@ Status TabletSinkSender::open_wait() {
             }
         });
 
-        // when enable replicated storage, we only send to primary replica, one node channel lead to indicate whole load fail
-        if (index_channel->has_intolerable_failure() || (_enable_replicated_storage && !err_st.ok())) {
+        if (index_channel->has_intolerable_failure()) {
             LOG(WARNING) << "Open channel failed. load_id: " << _load_id << ", error: " << err_st.to_string();
             return err_st;
         }
@@ -205,8 +204,7 @@ Status TabletSinkSender::try_close(RuntimeState* state) {
                 }
             });
 
-            // when enable replicated storage, we only send to primary replica, one node channel lead to indicate whole load fail
-            if (intolerable_failure || (_enable_replicated_storage && !err_st.ok())) {
+            if (intolerable_failure) {
                 break;
             }
 
@@ -256,7 +254,7 @@ Status TabletSinkSender::try_close(RuntimeState* state) {
     }
 
     // when enable replicated storage, we only send to primary replica, one node channel lead to indicate whole load fail
-    if (intolerable_failure || (_enable_replicated_storage && !err_st.ok())) {
+    if (intolerable_failure) {
         return err_st;
     } else {
         return Status::OK();
@@ -297,7 +295,7 @@ Status TabletSinkSender::close_wait(RuntimeState* state, Status close_status, Ta
                     ch->time_report(&node_add_batch_counter_map, &serialize_batch_ns, &actual_consume_ns);
                 });
                 // when enable replicated storage, we only send to primary replica, one node channel lead to indicate whole load fail
-                if (index_channel->has_intolerable_failure() || (_enable_replicated_storage && !err_st.ok())) {
+                if (index_channel->has_intolerable_failure()) {
                     status = err_st;
                     index_channel->for_each_node_channel([&status](NodeChannel* ch) { ch->cancel(status); });
                 }


### PR DESCRIPTION
## Why I'm doing:
when backend is down, the replicated storage black list mechanism will be invalid

## What I'm doing:
check if node channel has primary replica of replicated storage, if true fail load directly otherwise load can be success.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
