### PR TITLE
[BugFix] create or replace view supports modifying comments (backport #37352)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -1179,7 +1179,8 @@ public class AlterJobMgr {
             db.dropTable(viewName);
             db.registerTableUnlocked(view);
 
-            AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), inlineViewDef, newFullSchema, sqlMode, comment);
+            AlterViewInfo alterViewInfo = new AlterViewInfo(db.getId(), view.getId(), inlineViewDef, newFullSchema,
+                    sqlMode, comment);
             GlobalStateMgr.getCurrentState().getEditLog().logModifyViewDef(alterViewInfo);
             LOG.info("modify view[{}] definition to {}", viewName, inlineViewDef);
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterViewInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterViewInfo.java
@@ -41,18 +41,22 @@ public class AlterViewInfo implements Writable {
     private long sqlMode;
     @SerializedName(value = "newFullSchema")
     private List<Column> newFullSchema;
+    @SerializedName(value = "comment")
+    private String comment;
 
     public AlterViewInfo() {
         // for persist
         newFullSchema = Lists.newArrayList();
     }
 
-    public AlterViewInfo(long dbId, long tableId, String inlineViewDef, List<Column> newFullSchema, long sqlMode) {
+    public AlterViewInfo(long dbId, long tableId, String inlineViewDef, List<Column> newFullSchema, long sqlMode,
+                         String comment) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.inlineViewDef = inlineViewDef;
         this.newFullSchema = newFullSchema;
         this.sqlMode = sqlMode;
+        this.comment = comment;
     }
 
     public long getDbId() {
@@ -75,6 +79,10 @@ public class AlterViewInfo implements Writable {
         return sqlMode;
     }
 
+    public String getComment() {
+        return comment;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(dbId, tableId, inlineViewDef, sqlMode, newFullSchema);
@@ -91,7 +99,7 @@ public class AlterViewInfo implements Writable {
         AlterViewInfo otherInfo = (AlterViewInfo) other;
         return dbId == otherInfo.getDbId() && tableId == otherInfo.getTableId() &&
                 inlineViewDef.equalsIgnoreCase(otherInfo.getInlineViewDef()) && sqlMode == otherInfo.getSqlMode() &&
-                newFullSchema.equals(otherInfo.getNewFullSchema());
+                newFullSchema.equals(otherInfo.getNewFullSchema()) && comment.equalsIgnoreCase(otherInfo.getComment());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterViewInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterViewInfo.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.persist.gson.GsonUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -99,7 +100,8 @@ public class AlterViewInfo implements Writable {
         AlterViewInfo otherInfo = (AlterViewInfo) other;
         return dbId == otherInfo.getDbId() && tableId == otherInfo.getTableId() &&
                 inlineViewDef.equalsIgnoreCase(otherInfo.getInlineViewDef()) && sqlMode == otherInfo.getSqlMode() &&
-                newFullSchema.equals(otherInfo.getNewFullSchema()) && comment.equalsIgnoreCase(otherInfo.getComment());
+                newFullSchema.equals(otherInfo.getNewFullSchema())
+                && StringUtils.equalsIgnoreCase(comment, otherInfo.getComment());
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewClause.java
@@ -26,7 +26,7 @@ public class AlterViewClause extends AlterClause {
 
     protected List<Column> columns;
     protected String inlineViewDef;
-
+    protected String comment;
     public AlterViewClause(List<ColWithComment> colWithComments, QueryStatement queryStatement, NodePosition nodePosition) {
         super(AlterOpType.ALTER_VIEW, nodePosition);
         this.colWithComments = colWithComments;
@@ -47,6 +47,14 @@ public class AlterViewClause extends AlterClause {
 
     public void setColumns(List<Column> columns) {
         this.columns = columns;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+
+    public void setComment(String comment) {
+        this.comment = comment;
     }
 
     public String getInlineViewDef() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/AlterViewStmt.java
@@ -33,6 +33,7 @@ public class AlterViewStmt extends DdlStmt {
                 stmt.getColWithComments(), stmt.getQueryStatement(), NodePosition.ZERO);
         alterViewClause.setInlineViewDef(stmt.getInlineViewDef());
         alterViewClause.setColumns(stmt.getColumns());
+        alterViewClause.setComment(stmt.getComment());
         return new AlterViewStmt(stmt.getTableName(), alterViewClause, NodePosition.ZERO);
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/persist/AlterViewInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/AlterViewInfoTest.java
@@ -74,7 +74,7 @@ public class AlterViewInfoTest {
         Column column2 = new Column("col2", Type.DOUBLE);
 
         AlterViewInfo alterViewInfo =
-                new AlterViewInfo(dbId, tableId, inlineViewDef, Lists.newArrayList(column1, column2), sqlMode);
+                new AlterViewInfo(dbId, tableId, inlineViewDef, Lists.newArrayList(column1, column2), sqlMode, null);
         alterViewInfo.write(out);
         out.flush();
         out.close();


### PR DESCRIPTION
Why I'm doing:
create or replace view does not have the function of modifying comments

What I'm doing:
Add and improve this feature.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

