### PR TITLE
[Enhancement] Select from files support binary format

### DIFF
--- a/be/src/exec/parquet_schema_builder.cpp
+++ b/be/src/exec/parquet_schema_builder.cpp
@@ -89,7 +89,7 @@ static Status get_parquet_type_from_primitive(const ::parquet::schema::NodePtr& 
             *type_desc = TypeDescriptor::create_decimalv3_type(TYPE_DECIMAL128, decimal_logical_type->precision(),
                                                                decimal_logical_type->scale());
         } else {
-            *type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+            *type_desc = TypeDescriptor::create_varbinary_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
         }
         break;
     case parquet::Type::FIXED_LEN_BYTE_ARRAY: {
@@ -103,8 +103,8 @@ static Status get_parquet_type_from_primitive(const ::parquet::schema::NodePtr& 
         break;
     }
     default:
-        // Treat unsupported types as VARCHAR.
-        *type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
+        // Treat unsupported types as varbinary type.
+        *type_desc = TypeDescriptor::create_varbinary_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     }
 
     return Status::OK();

--- a/test/sql/test_sink/R/test_files_sink
+++ b/test/sql/test_sink/R/test_files_sink
@@ -3,23 +3,20 @@ insert into files (
 	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
 	"format"="parquet", 
 	"compression" = "uncompressed"
-) 
+)
 select 1 as k1, "A" as k2;
 -- result:
-[]
 -- !result
 set pipeline_sink_dop = 1;
 -- result:
-[]
 -- !result
 insert into files ( 
 	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
 	"format"="parquet", 
 	"compression" = "uncompressed"
-) 
+)
 select 2 as k1, "B" as k2;
 -- result:
-[]
 -- !result
 select * from files (
 	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
@@ -28,6 +25,66 @@ select * from files (
 -- result:
 1	A
 2	B
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result
+-- name: test_read_write_parquet_file
+create table t1 (c1 int, c2 binary);
+-- result:
+-- !result
+insert into t1 select 1, bitmap_to_binary(bitmap_agg(generate_series)) from TABLE(generate_series(1,10));
+-- result:
+-- !result
+insert into files (
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/",
+	"format"="parquet",
+	"compression" = "uncompressed"
+) select * from t1;
+-- result:
+-- !result
+create table t2 (c1 int, c2 binary);
+-- result:
+-- !result
+insert into t2 select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+-- result:
+-- !result
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t2;
+-- result:
+1	1,2,3,4,5,6,7,8,9,10
+-- !result
+create table t3 (c1 int, c2 string);
+-- result:
+-- !result
+insert into t3 select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+-- result:
+-- !result
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t3;
+-- result:
+1	1,2,3,4,5,6,7,8,9,10
+-- !result
+create table t4 as select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+-- result:
+-- !result
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t4;
+-- result:
+1	1,2,3,4,5,6,7,8,9,10
+-- !result
+desc t4;
+-- result:
+c1	int	YES	true	None	
+c2	varbinary	YES	false	None	
 -- !result
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null
 -- result:

--- a/test/sql/test_sink/T/test_files_sink
+++ b/test/sql/test_sink/T/test_files_sink
@@ -4,7 +4,7 @@ insert into files (
 	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
 	"format"="parquet", 
 	"compression" = "uncompressed"
-) 
+)
 select 1 as k1, "A" as k2;
 
 set pipeline_sink_dop = 1;
@@ -13,12 +13,51 @@ insert into files (
 	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/", 
 	"format"="parquet", 
 	"compression" = "uncompressed"
-) 
+)
 select 2 as k1, "B" as k2;
 
 select * from files (
 	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
 	"format" = "parquet"
 );
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+
+-- name: test_read_write_parquet_file
+
+-- src table
+create table t1 (c1 int, c2 binary);
+insert into t1 select 1, bitmap_to_binary(bitmap_agg(generate_series)) from TABLE(generate_series(1,10));
+
+insert into files (
+	"path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/",
+	"format"="parquet",
+	"compression" = "uncompressed"
+) select * from t1;
+
+-- insert into binary table
+create table t2 (c1 int, c2 binary);
+
+insert into t2 select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t2;
+
+-- insert into string table
+create table t3 (c1 int, c2 string);
+insert into t3 select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t3;
+
+-- create table as
+create table t4 as select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t4;
+desc t4;
 
 shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
Why I'm doing:

The Binary type of StarRocks corresponds to the Binary type of Parquet.
The String type of StarRocks corresponds to the String type of Parquet.

According to the definition of parquet format: https://github.com/apache/parquet-format/blob/master/LogicalTypes.md

STRING may only be used to annotate the binary primitive type and indicates that the byte array should be interpreted as a UTF-8 encoded character string.

So, the binary type should load as varbinary type, not string type.

What I'm doing:

Load binary type of parquet default to varbinary type of `StarRocks`.

e.g.

```
hive> show create table t1;
OK
CREATE TABLE `t1`(
  `c1` int, 
  `c2` binary)
ROW FORMAT SERDE 
  'org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe' 
STORED AS INPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat' 
OUTPUTFORMAT 
  'org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat'
LOCATION
  'hdfs://xxx:9000/user/hive/warehouse/lxh.db/t1'
TBLPROPERTIES (
  'transient_lastDdlTime'='1702608660')

create table t_tmp as select * from files ("path"="xxx:9000/user/hive/warehouse/lxh.db/t1/data_8ac1fa9b-9af4-11ee-bb43-2ea9721a9a2d_0_1.parquet", "format"="parquet");

mysql> show create table t_tmp;                                                                                                                                                                                                                                                   
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------+                                                                                                                                                                              
| Table | Create Table                                                                                                                                                                                                                                                            
                                                                                                   |                                                                                                                                                                              
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
---------------------------------------------------------------------------------------------------+                                                                                                                                                                              
| t_tmp | CREATE TABLE `t_tmp` (                                                                                                                                                                                                                                                  
  `c1` int(11) NULL COMMENT "",                                                                                                                                                                                                                                                   
  `c2` varbinary NULL COMMENT ""                                    
) ENGINE=OLAP                                                       
DUPLICATE KEY(`c1`)                                                 
DISTRIBUTED BY RANDOM                                               
PROPERTIES (                                                        
"replication_num" = "1",                                            
"bucket_size" = "4294967296",                                       
"in_memory" = "false",                                              
"enable_persistent_index" = "false",
"replicated_storage" = "true",                                      
"fast_schema_evolution" = "true",                                   
"compression" = "LZ4"                                               
); | 

mysql> select c1, bitmap_to_string(bitmap_from_binary(c2)) from t_tmp;
+------+------------------------------------------+
| c1   | bitmap_to_string(bitmap_from_binary(c2)) |
+------+------------------------------------------+
|    1 | 1,2,3,4,5,6,7,8,9,10                     |
+------+------------------------------------------+
1 row in set (0.01 sec)
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
