### PR TITLE
[BugFix] NPE threw when getting stream load tasks from information_schema table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/streamload/StreamLoadMgr.java
@@ -546,14 +546,19 @@ public class StreamLoadMgr {
     }
 
     // return all of stream load task named label in all of db
+    // return all tasks if label is null
     public List<StreamLoadTask> getTaskByName(String label) {
         List<StreamLoadTask> result = Lists.newArrayList();
         readLock();
         try {
-            for (Map<String, StreamLoadTask> labelToStreamLoadTask : dbToLabelToStreamLoadTask.values()) {
-                if (labelToStreamLoadTask.containsKey(label)) {
-                    result.add(labelToStreamLoadTask.get(label));
+            if (label != null) {
+                StreamLoadTask task = idToStreamLoadTask.get(label);
+                if (task != null) {
+                    result.add(task);
                 }
+            } else {
+                // return all stream load tasks
+                result.addAll(idToStreamLoadTask.values());
             }
         } finally {
             readUnlock();

--- a/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/streamload/StreamLoadManagerTest.java
@@ -183,10 +183,31 @@ public class StreamLoadManagerTest {
         List<StreamLoadTask> tasks = streamLoadManager.getTaskByName(labelName);
         Assert.assertEquals(1, tasks.size());
         Assert.assertEquals("label1", tasks.get(0).getLabel());
-        Assert.assertEquals("label1", tasks.get(0).getLabel());
         Assert.assertEquals("test_db", tasks.get(0).getDBName());
         Assert.assertEquals(20000, tasks.get(0).getDBId());
         Assert.assertEquals("test_tbl", tasks.get(0).getTableName());
+    }
+
+    @Test
+    public void testGetTaskByNameWithNullLabelName() throws UserException {
+        StreamLoadMgr streamLoadManager = new StreamLoadMgr();
+
+        String dbName = "test_db";
+        String tableName = "test_tbl";
+        String labelName1 = "label1";
+        String labelName2 = "label2";
+        long timeoutMillis = 100000;
+        int channelNum = 5;
+        int channelId = 0;
+
+        TransactionResult resp = new TransactionResult();
+        streamLoadManager.beginLoadTask(dbName, tableName, labelName1, timeoutMillis, channelNum, channelId, resp);
+        streamLoadManager.beginLoadTask(dbName, tableName, labelName2, timeoutMillis, channelNum, channelId, resp);
+
+        List<StreamLoadTask> tasks = streamLoadManager.getTaskByName(null);
+        Assert.assertEquals(2, tasks.size());
+        Assert.assertEquals("label1", tasks.get(0).getLabel());
+        Assert.assertEquals("label2", tasks.get(1).getLabel());
     }
 
     @Test


### PR DESCRIPTION

Why I'm doing:

What I'm doing:

Fixes #37357

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [x] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
