### PR TITLE
[BugFix] fix early remove query_context

### DIFF
--- a/be/src/exec/pipeline/query_context.cpp
+++ b/be/src/exec/pipeline/query_context.cpp
@@ -73,7 +73,7 @@ QueryContext::~QueryContext() noexcept {
 void QueryContext::count_down_fragments() {
     size_t old = _num_active_fragments.fetch_sub(1);
     DCHECK_GE(old, 1);
-    bool all_fragments_finished = old == 1;
+    bool all_fragments_finished = (_num_fragments == _total_fragments) && (old == 1);
     if (!all_fragments_finished) {
         return;
     }


### PR DESCRIPTION
Why I'm doing:

canceling fragments but the query_context is early removed, however, the unfinished fragments reports later.
```
cancel fragment, fragment_instance_id=d44def3a-9b9a-11ee-861c-e6475aa0dbb4, reason: UserCancel
QueryContext already destroyed: query_id=d44def3a-9b9a-11ee-861c-e6475aa0db47, fragment_instance_id=d44def3a-9b9a-11ee-861c-e6475aa0dbb4
[Driver] Fail to report exec state due to query not found: fragment_instance_id=d44def3a-9b9a-11ee-861c-e6475aa0dbb4
(thrift-server-pool-131|373) [QeProcessorImpl.reportExecStatus():179] ReportExecStatus() failed, query does not exist, fragment_instance_id=d44def3a-9b9a-11ee-861c-e6475aa0dbb4, query_id=d44def3a-9b9a-11ee-861c-e6475aa0db47,
```

What I'm doing:

avoid remove query_context early.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
