### PR TITLE
[BugFix] Add more checks when schema changing has referred materialized views

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -683,7 +683,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                                     "the column {} of the table {} was modified.", mv.getName(), mv.getId(),
                             mvColumn.getName(), tbl.getName());
                     mv.setInactiveAndReason(
-                            "base-table schema changed for columns: " + StringUtils.join(modifiedColumns, ","));
+                            "base table schema changed for columns: " + StringUtils.join(modifiedColumns, ","));
                     return;
                 }
             }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -57,8 +57,6 @@ import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexState;
 import com.starrocks.catalog.MaterializedIndexMeta;
-import com.starrocks.catalog.MaterializedView;
-import com.starrocks.catalog.MvId;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -103,7 +101,6 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.thrift.TTaskType;
 import io.opentelemetry.api.trace.StatusCode;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -122,6 +119,8 @@ import java.util.Set;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
+
+import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.inactiveRelatedMaterializedViews;
 
 /*
  * Version 2 of SchemaChangeJob.
@@ -782,7 +781,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             onFinished(tbl);
 
             // If schema changes include fields which defined in related mv, set those mv state to inactive.
-            inactiveRelatedMv(modifiedColumns, tbl);
+            inactiveRelatedMaterializedViews(db, tbl, modifiedColumns);
 
             pruneMeta();
             tbl.onReload();
@@ -831,30 +830,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
             }
         }
         return modifiedColumns;
-    }
-
-    private void inactiveRelatedMv(Set<String> modifiedColumns, OlapTable table) {
-        if (modifiedColumns.isEmpty()) {
-            return;
-        }
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-        for (MvId mvId : table.getRelatedMaterializedViews()) {
-            MaterializedView mv = (MaterializedView) db.getTable(mvId.getId());
-            if (mv == null) {
-                LOG.warn("Ignore materialized view {} does not exists", mvId);
-                continue;
-            }
-            for (Column mvColumn : mv.getColumns()) {
-                if (modifiedColumns.contains(mvColumn.getName())) {
-                    LOG.warn("Setting the materialized view {}({}) to invalid because " +
-                                    "the column {} of the table {} was modified.", mv.getName(), mv.getId(),
-                            mvColumn.getName(), table.getName());
-                    mv.setInactiveAndReason(
-                            "base-table schema changed for columns: " + StringUtils.join(modifiedColumns, ","));
-                    return;
-                }
-            }
-        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/CachingMvPlanContextBuilder.java
@@ -60,9 +60,8 @@ public class CachingMvPlanContextBuilder {
     }
 
     private MvPlanContext loadMvPlanContext(MaterializedView mv) {
-        MvPlanContextBuilder builder = new MvPlanContextBuilder();
         try {
-            return builder.getPlanContext(mv);
+            return MvPlanContextBuilder.getPlanContext(mv);
         } catch (Throwable e) {
             LOG.warn("load mv plan cache failed: {}", mv.getName(), e);
             return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -19,7 +19,7 @@ import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.qe.ConnectContext;
 
 public class MvPlanContextBuilder {
-    public MvPlanContext getPlanContext(MaterializedView mv) {
+    public static MvPlanContext getPlanContext(MaterializedView mv) {
         // build mv query logical plan
         MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
         ConnectContext connectContext = new ConnectContext();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/MvPlanContextBuilder.java
@@ -23,6 +23,11 @@ public class MvPlanContextBuilder {
         // build mv query logical plan
         MaterializedViewOptimizer mvOptimizer = new MaterializedViewOptimizer();
         ConnectContext connectContext = new ConnectContext();
+        // If the caller is not from query (eg. background schema change thread), set thread local info to avoid
+        // NPE in the planning.
+        if (ConnectContext.get() == null) {
+            connectContext.setThreadLocalInfo();
+        }
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(
                 ConnectContext.get().getSessionVariable().getOptimizerExecuteTimeout());
         return mvOptimizer.optimize(mv, connectContext);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -110,6 +110,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -1501,14 +1502,16 @@ public class MvUtils {
                         Table table = scan.getTable();
                         return table.getId() == olapTable.getId();
                     });
-                    Set<String> usedColNames = usedColRefs.stream().map(x -> x.getName()).collect(Collectors.toSet());
+                    Set<String> usedColNames = usedColRefs.stream()
+                            .map(x -> x.getName())
+                            .collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER)));
                     for (String modifiedColumn : modifiedColumns) {
                         if (usedColNames.contains(modifiedColumn)) {
                             LOG.warn("Setting the materialized view {}({}) to invalid because " +
                                             "the column {} of the table {} was modified.", mv.getName(), mv.getId(),
                                     modifiedColumn, olapTable.getName());
                             mv.setInactiveAndReason(
-                                    "base-table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
+                                    "base table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
                         }
                     }
                 }
@@ -1518,7 +1521,7 @@ public class MvUtils {
                                 "the columns  of the table {} was modified.", mv.getName(), mv.getId(),
                         olapTable.getName());
                 mv.setInactiveAndReason(
-                        "base-table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
+                        "base table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
             } catch (Exception e) {
                 LOG.warn("Get related materialized view {} failed:", mv.getName(), e);
                 // basic check: may lose some situations
@@ -1528,7 +1531,7 @@ public class MvUtils {
                                         "the column {} of the table {} was modified.", mv.getName(), mv.getId(),
                                 mvColumn.getName(), olapTable.getName());
                         mv.setInactiveAndReason(
-                                "base-table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
+                                "base table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
                         break;
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -15,7 +15,9 @@
 
 package com.starrocks.sql.optimizer.rule.transformation.materialization;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -37,6 +39,7 @@ import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.MvPlanContext;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionKey;
@@ -55,10 +58,12 @@ import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.QueryRelation;
 import com.starrocks.sql.ast.QueryStatement;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.MaterializationContext;
+import com.starrocks.sql.optimizer.MvPlanContextBuilder;
 import com.starrocks.sql.optimizer.OptExpression;
 import com.starrocks.sql.optimizer.OptExpressionVisitor;
 import com.starrocks.sql.optimizer.Optimizer;
@@ -106,6 +111,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static com.starrocks.sql.optimizer.OptimizerTraceUtil.logMVPrepare;
@@ -714,6 +720,12 @@ public class MvUtils {
     }
 
     public static List<ColumnRefOperator> collectScanColumn(OptExpression optExpression) {
+        return collectScanColumn(optExpression, Predicates.alwaysTrue());
+    }
+
+    public static List<ColumnRefOperator> collectScanColumn(OptExpression optExpression,
+                                                            Predicate<LogicalScanOperator> predicate) {
+
         List<ColumnRefOperator> columnRefOperators = Lists.newArrayList();
         OptExpressionVisitor visitor = new OptExpressionVisitor<Void, Void>() {
             @Override
@@ -727,7 +739,9 @@ public class MvUtils {
             @Override
             public Void visitLogicalTableScan(OptExpression optExpression, Void context) {
                 LogicalScanOperator scan = (LogicalScanOperator) optExpression.getOp();
-                columnRefOperators.addAll(scan.getColRefToColumnMetaMap().keySet());
+                if (predicate.test(scan)) {
+                    columnRefOperators.addAll(scan.getColRefToColumnMetaMap().keySet());
+                }
                 return null;
             }
         };
@@ -1454,5 +1468,71 @@ public class MvUtils {
         paritionExpr.collect(SlotRef.class, slotRefs);
         Preconditions.checkState(slotRefs.size() == 1);
         return slotRefs.get(0);
+    }
+
+    /**
+     * Inactive related mvs after modified columns have been done. Only inactive mvs after
+     * modified columns have done because the modified process may be failed and in this situation
+     * should not inactive mvs then.
+     */
+    public static void inactiveRelatedMaterializedViews(Database db,
+                                                        OlapTable olapTable,
+                                                        Set<String> modifiedColumns) {
+        if (modifiedColumns == null || modifiedColumns.isEmpty()) {
+            return;
+        }
+        // inactive related asynchronous mvs
+        for (MvId mvId : olapTable.getRelatedMaterializedViews()) {
+            MaterializedView mv = (MaterializedView) db.getTable(mvId.getId());
+            if (mv == null) {
+                LOG.warn("Ignore materialized view {} does not exists", mvId);
+                continue;
+
+            }
+            // TODO: support more types for base table's schema change.
+            try {
+                MvPlanContext mvPlanContext = MvPlanContextBuilder.getPlanContext(mv);
+                if (mvPlanContext != null) {
+                    OptExpression mvPlan = mvPlanContext.getLogicalPlan();
+                    List<ColumnRefOperator> usedColRefs = MvUtils.collectScanColumn(mvPlan, scan -> {
+                        if (scan == null) {
+                            return false;
+                        }
+                        Table table = scan.getTable();
+                        return table.getId() == olapTable.getId();
+                    });
+                    Set<String> usedColNames = usedColRefs.stream().map(x -> x.getName()).collect(Collectors.toSet());
+                    for (String modifiedColumn : modifiedColumns) {
+                        if (usedColNames.contains(modifiedColumn)) {
+                            LOG.warn("Setting the materialized view {}({}) to invalid because " +
+                                            "the column {} of the table {} was modified.", mv.getName(), mv.getId(),
+                                    modifiedColumn, olapTable.getName());
+                            mv.setInactiveAndReason(
+                                    "base-table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
+                        }
+                    }
+                }
+            } catch (SemanticException e) {
+                LOG.warn("Get related materialized view {} failed:", mv.getName(), e);
+                LOG.warn("Setting the materialized view {}({}) to invalid because " +
+                                "the columns  of the table {} was modified.", mv.getName(), mv.getId(),
+                        olapTable.getName());
+                mv.setInactiveAndReason(
+                        "base-table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
+            } catch (Exception e) {
+                LOG.warn("Get related materialized view {} failed:", mv.getName(), e);
+                // basic check: may lose some situations
+                for (Column mvColumn : mv.getColumns()) {
+                    if (modifiedColumns.contains(mvColumn.getName())) {
+                        LOG.warn("Setting the materialized view {}({}) to invalid because " +
+                                        "the column {} of the table {} was modified.", mv.getName(), mv.getId(),
+                                mvColumn.getName(), olapTable.getName());
+                        mv.setInactiveAndReason(
+                                "base-table schema changed for columns: " + Joiner.on(",").join(modifiedColumns));
+                        break;
+                    }
+                }
+            }
+        }
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -321,7 +321,7 @@ public class AlterJobV2Test {
                         .getCurrentState().getDb("test").getTable("mv4");
                 Assert.assertFalse(mv.isActive());
                 System.out.println(mv.getInactiveReason());
-                Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: k2"));
+                Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: k2"));
             }
         } catch (Exception e) {
             Assert.fail();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -310,7 +310,6 @@ public class AlterJobV2Test {
             }
 
             {
-                // TODO: How to distinguish columns used by MV?
                 // modify column which define in mv
                 String alterStmtStr = "alter table test.modify_column_test4 modify column k2 varchar(30) ";
                 AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(alterStmtStr,
@@ -320,7 +319,9 @@ public class AlterJobV2Test {
                 waitForSchemaChangeAlterJobFinish();
                 MaterializedView mv = (MaterializedView) GlobalStateMgr
                         .getCurrentState().getDb("test").getTable("mv4");
-                Assert.assertTrue(mv.isActive());
+                Assert.assertFalse(mv.isActive());
+                System.out.println(mv.getInactiveReason());
+                Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: k2"));
             }
         } catch (Exception e) {
             Assert.fail();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -1,0 +1,382 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.LocalTablet;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.OlapTable.OlapTableState;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.qe.StmtExecutor;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.ast.AlterTableStmt;
+import com.starrocks.sql.ast.DmlStmt;
+import com.starrocks.sql.ast.InsertStmt;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.TestWithFeService;
+import mockit.Mock;
+import mockit.MockUp;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.Assert;
+import org.junit.FixMethodOrder;
+import org.junit.Ignore;
+import org.junit.jupiter.api.Test;
+import org.junit.runners.MethodSorters;
+
+import java.util.List;
+import java.util.Map;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
+
+    private static final Logger LOG = LogManager.getLogger(SchemaChangeHandlerWithMVTest.class);
+    private int jobSize = 0;
+    private StarRocksAssert starRocksAssert;
+
+    @Override
+    public void runBeforeEach() throws Exception {
+        String createDupTbl2StmtStr = "CREATE TABLE IF NOT EXISTS sc_dup3 (\n" + "timestamp DATETIME,\n"
+                + "type INT,\n" + "error_code INT,\n" + "error_msg VARCHAR(1024),\n" + "op_id BIGINT,\n"
+                + "op_time DATETIME)\n" + "DUPLICATE  KEY(timestamp, type)\n" + "DISTRIBUTED BY HASH(type) BUCKETS 1\n"
+                + "PROPERTIES ('replication_num' = '1', 'fast_schema_evolution' = 'true');";
+        starRocksAssert.withTable(createDupTbl2StmtStr);
+    }
+
+    @Override
+    public void runAfterEach() throws Exception {
+        try {
+            starRocksAssert.dropTable("sc_dup3");
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    @Override
+    protected void runBeforeAll() throws Exception {
+        //create database db1
+        starRocksAssert = new StarRocksAssert(connectContext);
+        starRocksAssert.withDatabase("test");
+        starRocksAssert.useDatabase("test");
+
+        new MockUp<StmtExecutor>() {
+            @Mock
+            public void handleDMLStmt(ExecPlan execPlan, DmlStmt stmt) throws Exception {
+                if (stmt instanceof InsertStmt) {
+                    InsertStmt insertStmt = (InsertStmt) stmt;
+                    TableName tableName = insertStmt.getTableName();
+                    Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+                    OlapTable tbl = ((OlapTable) testDb.getTable(tableName.getTbl()));
+                    if (tbl != null) {
+                        for (Partition partition : tbl.getPartitions()) {
+                            if (insertStmt.getTargetPartitionIds().contains(partition.getId())) {
+                                setPartitionVersion(partition, partition.getVisibleVersion() + 1);
+                            }
+                        }
+                    }
+                }
+            }
+        };
+    }
+
+    private static void setPartitionVersion(Partition partition, long version) {
+        partition.setVisibleVersion(version, System.currentTimeMillis());
+        MaterializedIndex baseIndex = partition.getBaseIndex();
+        List<Tablet> tablets = baseIndex.getTablets();
+        for (Tablet tablet : tablets) {
+            List<Replica> replicas = ((LocalTablet) tablet).getImmutableReplicas();
+            for (Replica replica : replicas) {
+                replica.updateVersionInfo(version, -1, version);
+            }
+        }
+    }
+
+    private void waitAlterJobDone(Map<Long, AlterJobV2> alterJobs) throws Exception {
+        for (AlterJobV2 alterJobV2 : alterJobs.values()) {
+            while (!alterJobV2.getJobState().isFinalState()) {
+                LOG.info("alter job {} is running. state: {}", alterJobV2.getJobId(), alterJobV2.getJobState());
+                Thread.sleep(500);
+            }
+            LOG.info("alter job {} is done. state: {}", alterJobV2.getJobId(), alterJobV2.getJobState());
+            Assert.assertEquals(AlterJobV2.JobState.FINISHED, alterJobV2.getJobState());
+
+            OlapTable tbl = (OlapTable) starRocksAssert.getTable("test", alterJobV2.tableName);
+            while (tbl.getState() != OlapTableState.NORMAL) {
+                Thread.sleep(500);
+            }
+        }
+    }
+    private void checkModifyColumnsWithMaterializedViews(StarRocksAssert starRocksAssert,
+                                                         String mv, String alterColumn) throws Exception {
+        checkModifyColumnsWithMaterializedViews(starRocksAssert, mv, alterColumn, true);
+    }
+
+    private void checkModifyColumnsWithMaterializedViews(StarRocksAssert starRocksAssert,
+                                                         String mv, String alterColumn,
+                                                         boolean isDropMV) throws Exception {
+        String mvName = starRocksAssert.getMVName(mv);
+        try {
+            starRocksAssert.withRefreshedMaterializedView(mv);
+
+            AlterTableStmt dropValColStm = (AlterTableStmt) parseAndAnalyzeStmt(alterColumn);
+            GlobalStateMgr.getCurrentState().getAlterJobMgr().processAlterTable(dropValColStm);
+
+            Map<Long, AlterJobV2> alterJobs = GlobalStateMgr.getCurrentState().getSchemaChangeHandler().getAlterJobsV2();
+            waitAlterJobDone(alterJobs);
+        } finally {
+            if (isDropMV) {
+                try {
+                    starRocksAssert.dropMaterializedView(mvName);
+                } catch (Exception e) {
+                    // ignore.
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithNoAggregateRollup1() {
+        // drop column without aggregate
+        // no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select error_code, error_msg, " +
+                            "timestamp from sc_dup3",
+                    "alter table sc_dup3 drop column op_id");
+            jobSize++;
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithNoAggregateRollup2() {
+        // drop column without aggregate
+        // OK: associated column with drop column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select error_code, error_msg, timestamp from sc_dup3 ",
+                    "alter table sc_dup3 drop column error_code");
+            jobSize++;
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithNoAggregateRollup3() {
+        // drop column without aggregate
+        // OK: associated column with modify column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select error_code, error_msg, timestamp from sc_dup3",
+                    "alter table sc_dup3 modify column error_code BIGINT");
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithNoAggregateRollup4() throws Exception {
+        // drop column without aggregate
+        // OK: associated column with modify column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select error_code, error_msg, timestamp from sc_dup3 " +
+                            "where type > 10",
+                    "alter table sc_dup3 modify column error_code BIGINT");
+        } catch (Exception e) {
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithNoAggregateRollup5() {
+        // drop column without aggregate
+        // OK: associated column with modify column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select error_code, error_msg, timestamp from sc_dup3 " +
+                            "where type > 10",
+                    "alter table sc_dup3 modify column type BIGINT");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column type, because the column is used " +
+                    "in the related rollup mv1 with the where expr:`test`.`sc_dup3`.`type` > 10, " +
+                    "please drop the rollup index first."));
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithAggregateRollup1() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select timestamp, count(error_code), sum(type) from sc_dup3 " +
+                            "group by timestamp",
+                    "alter table sc_dup3 drop column op_id");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
+                    "is used in the related rollup mv1, please drop the rollup index first."));
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithAggregateRollup2() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select timestamp, count(error_code), sum(type) from sc_dup3 " +
+                            "group by timestamp",
+                    "alter table sc_dup3 drop column timestamp");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
+                    "is used in the related rollup mv1, please drop the rollup index first."));
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithAggregateRollup3() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select timestamp, count(error_code), sum(type) from sc_dup3 " +
+                            "group by timestamp",
+                    "alter table sc_dup3 drop column error_code");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column mv_count_error_code, because the column " +
+                    "is used in the related rollup mv1 with the define expr:" +
+                    "CASE WHEN `test`.`sc_dup3`.`error_code` IS NULL THEN 0 ELSE 1 END, please drop the rollup index first."));
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithAggregateRollup4() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select timestamp, count(error_code), sum(type) from sc_dup3 " +
+                            "group by timestamp",
+                    "alter table sc_dup3 modify column error_code BIGINT");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column mv_count_error_code, because " +
+                    "the column is used in the related rollup mv1 with the define expr:" +
+                    "CASE WHEN `test`.`sc_dup3`.`error_code` IS NULL THEN 0 ELSE 1 END, please drop the rollup index first."));
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithAggregateRollup5() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select timestamp, count(error_code)  from sc_dup3 " +
+                            "where type > 10 group by timestamp",
+                    "alter table sc_dup3 modify column type BIGINT");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column type, because the column is " +
+                    "used in the related rollup mv1 with the where expr:`test`.`sc_dup3`.`type` > 10, " +
+                    "please drop the rollup index first."));
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithAggregateRollup6() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 as select timestamp, count(error_code) from sc_dup3 " +
+                            "where type > 10 group by timestamp",
+                    "alter table sc_dup3 drop column type");
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column type, because the column is " +
+                    "used in the related rollup mv1 with the where expr:`test`.`sc_dup3`.`type` > 10, " +
+                    "please drop the rollup index first."));
+        }
+    }
+
+    @Test
+    public void testModifyColumnsWithAMV1() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 distributed by random refresh deferred manual " +
+                            "as select timestamp, count(error_code) from sc_dup3 " +
+                            "where op_id > 10 group by timestamp",
+                    "alter table sc_dup3 drop column op_id",
+                    false);
+            MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
+            Assert.assertFalse(mv.isActive());
+            System.out.println(mv.getInactiveReason());
+            Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: op_id"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+    @Test
+    public void testModifyColumnsWithAMV2() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 distributed by random refresh deferred manual " +
+                            "as select timestamp, count(error_code) as cnt from sc_dup3 " +
+                            "where op_id * 2 > 10 group by timestamp",
+                    "alter table sc_dup3 drop column error_code",
+                    false);
+            MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
+            Assert.assertFalse(mv.isActive());
+            System.out.println(mv.getInactiveReason());
+            Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: error_code"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+
+    @Test
+    @Ignore
+    public void testModifyColumnsWithAMV3() {
+        // drop column with aggregate: no associated column
+        try {
+            checkModifyColumnsWithMaterializedViews(starRocksAssert,
+                    "create materialized view mv1 distributed by random refresh deferred manual " +
+                            "as select timestamp, count(error_code) from sc_dup3 " +
+                            "where op_id * 2> 10 group by timestamp",
+                    "alter table sc_dup3 modify column error_code BIGINT",
+                    false);
+            MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
+            Assert.assertFalse(mv.isActive());
+            System.out.println(mv.getInactiveReason());
+            Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: error_code"));
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail();
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -321,7 +321,7 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
             System.out.println(mv.getInactiveReason());
-            Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: op_id"));
+            Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: op_id"));
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
@@ -346,7 +346,7 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
             System.out.println(mv.getInactiveReason());
-            Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: error_code"));
+            Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: error_code"));
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
@@ -371,7 +371,7 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
             System.out.println(mv.getInactiveReason());
-            Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: error_code"));
+            Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: error_code"));
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
@@ -396,7 +396,7 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
             System.out.println(mv.getInactiveReason());
-            Assert.assertTrue(mv.getInactiveReason().contains("base-table schema changed for columns: op_id"));
+            Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: op_id"));
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/TestWithFeService.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/TestWithFeService.java
@@ -34,6 +34,7 @@ import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.parser.SqlParser;
 import com.starrocks.system.Backend;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInstance;
@@ -93,6 +94,10 @@ public abstract class TestWithFeService {
         runBeforeEach();
     }
 
+    @AfterEach
+    public final void afterEach() throws Exception {
+        runAfterEach();
+    }
     protected void beforeCreatingConnectContext() throws Exception {
 
     }
@@ -104,6 +109,10 @@ public abstract class TestWithFeService {
     }
 
     protected void runBeforeEach() throws Exception {
+    }
+
+    protected void runAfterEach() throws Exception {
+
     }
 
     // Help to create a mocked ConnectContext.


### PR DESCRIPTION
Why I'm doing:

After schema changing(eg: drop a column referred by synchronous materialized views), it may throw NPE when in loading.
```
Caused by: java.lang.NullPointerException
        at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:903) ~[spark-dpp-1.0.0.jar:?]
        at com.starrocks.planner.OlapTableSink.createSchema(OlapTableSink.java:334) ~[starrocks-fe.jar:?]
        at com.starrocks.planner.OlapTableSink.complete(OlapTableSink.java:244) ~[starrocks-fe.jar:?]
        at com.starrocks.qe.StmtExecutor.handleDMLStmt(StmtExecutor.java:1881) ~[starrocks-fe.jar:?]
        ... 9 more
```
What I'm doing:

- Add more checks when schema changes have referred synchronous materialized views.
- Refactor inactive asynchronous materialized views policy to be better track with schema changings.

Fixes [#issue
](https://github.com/StarRocks/StarRocksTest/issues/5252)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
