### PR TITLE
[Enhancement] Meta Image supports out-of-order reading

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -44,7 +44,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.alter.AlterJobMgr;
-import com.starrocks.alter.AlterJobV2;
 import com.starrocks.alter.MaterializedViewHandler;
 import com.starrocks.alter.SchemaChangeHandler;
 import com.starrocks.analysis.LiteralExpr;
@@ -122,7 +121,6 @@ import com.starrocks.common.FeConstants;
 import com.starrocks.common.InvalidConfException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.Pair;
-import com.starrocks.common.StarRocksFEMetaVersion;
 import com.starrocks.common.ThreadPoolManager;
 import com.starrocks.common.UserException;
 import com.starrocks.common.io.Text;
@@ -333,7 +331,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.Iterator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1501,20 +1499,6 @@ public class GlobalStateMgr {
         feType = newType;
     }
 
-    void checkOpTypeValid() throws IOException {
-        try {
-            for (Field field : OperationType.class.getDeclaredFields()) {
-                short id = field.getShort(null);
-                if (id > OperationType.OP_TYPE_EOF) {
-                    throw new IOException("OperationType cannot use a value exceeding 20000, " +
-                            "and an error will be reported if it exceeds : " + field.getName() + " = " + id);
-                }
-            }
-        } catch (IllegalAccessException e) {
-            throw new IOException(e);
-        }
-    }
-
     public void loadImage(String imageDir) throws IOException, DdlException {
         Storage storage = new Storage(imageDir);
         nodeMgr.setClusterId(storage.getClusterID());
@@ -1528,164 +1512,82 @@ public class GlobalStateMgr {
         LOG.info("start load image from {}. is ckpt: {}", curFile.getAbsolutePath(),
                 GlobalStateMgr.isCheckpointThread());
         long loadImageStartTime = System.currentTimeMillis();
-        DataInputStream dis = new DataInputStream(new BufferedInputStream(Files.newInputStream(curFile.toPath())));
 
-        long checksum = 0;
-        long remoteChecksum = -1;  // in case of empty image file checksum match
-        try {
-            checksum = loadVersion(dis, checksum);
-            checkOpTypeValid();
+        Map<SRMetaBlockID, SRMetaBlockLoader> loadImages = ImmutableMap.<SRMetaBlockID, SRMetaBlockLoader>builder()
+                .put(SRMetaBlockID.NODE_MGR, nodeMgr::load)
+                .put(SRMetaBlockID.LOCAL_META_STORE, localMetastore::load)
+                .put(SRMetaBlockID.ALTER_MGR, alterJobMgr::load)
+                .put(SRMetaBlockID.CATALOG_RECYCLE_BIN, recycleBin::load)
+                .put(SRMetaBlockID.VARIABLE_MGR, VariableMgr::load)
+                .put(SRMetaBlockID.RESOURCE_MGR, resourceMgr::loadResourcesV2)
+                .put(SRMetaBlockID.EXPORT_MGR, exportMgr::loadExportJobV2)
+                .put(SRMetaBlockID.BACKUP_MGR, backupHandler::loadBackupHandlerV2)
+                .put(SRMetaBlockID.AUTH, auth::load)
+                .put(SRMetaBlockID.GLOBAL_TRANSACTION_MGR, globalTransactionMgr::loadTransactionStateV2)
+                .put(SRMetaBlockID.COLOCATE_TABLE_INDEX, colocateTableIndex::loadColocateTableIndexV2)
+                .put(SRMetaBlockID.ROUTINE_LOAD_MGR, routineLoadMgr::loadRoutineLoadJobsV2)
+                .put(SRMetaBlockID.LOAD_MGR, loadMgr::loadLoadJobsV2JsonFormat)
+                .put(SRMetaBlockID.SMALL_FILE_MGR, smallFileMgr::loadSmallFilesV2)
+                .put(SRMetaBlockID.PLUGIN_MGR, pluginMgr::load)
+                .put(SRMetaBlockID.DELETE_MGR, deleteMgr::load)
+                .put(SRMetaBlockID.ANALYZE_MGR, analyzeMgr::load)
+                .put(SRMetaBlockID.RESOURCE_GROUP_MGR, resourceGroupMgr::load)
+                .put(SRMetaBlockID.AUTHENTICATION_MGR, authenticationMgr::loadV2)
+                .put(SRMetaBlockID.AUTHORIZATION_MGR, authorizationMgr::loadV2)
+                .put(SRMetaBlockID.TASK_MGR, taskManager::loadTasksV2)
+                .put(SRMetaBlockID.CATALOG_MGR, catalogMgr::load)
+                .put(SRMetaBlockID.INSERT_OVERWRITE_JOB_MGR, insertOverwriteJobMgr::load)
+                .put(SRMetaBlockID.COMPACTION_MGR, compactionMgr::load)
+                .put(SRMetaBlockID.STREAM_LOAD_MGR, streamLoadMgr::load)
+                .put(SRMetaBlockID.MATERIALIZED_VIEW_MGR, MaterializedViewMgr.getInstance()::load)
+                .put(SRMetaBlockID.GLOBAL_FUNCTION_MGR, globalFunctionMgr::load)
+                .put(SRMetaBlockID.STORAGE_VOLUME_MGR, storageVolumeMgr::load)
+                .put(SRMetaBlockID.DICTIONARY_MGR, dictionaryMgr::load)
+                .build();
 
-            if (GlobalStateMgr.getCurrentStateStarRocksMetaVersion() >= StarRocksFEMetaVersion.VERSION_4) {
-                Map<SRMetaBlockID, SRMetaBlockLoader> loadImages = ImmutableMap.<SRMetaBlockID, SRMetaBlockLoader>builder()
-                        .put(SRMetaBlockID.NODE_MGR, nodeMgr::load)
-                        .put(SRMetaBlockID.LOCAL_META_STORE, localMetastore::load)
-                        .put(SRMetaBlockID.ALTER_MGR, alterJobMgr::load)
-                        .put(SRMetaBlockID.CATALOG_RECYCLE_BIN, recycleBin::load)
-                        .put(SRMetaBlockID.VARIABLE_MGR, VariableMgr::load)
-                        .put(SRMetaBlockID.RESOURCE_MGR, resourceMgr::loadResourcesV2)
-                        .put(SRMetaBlockID.EXPORT_MGR, exportMgr::loadExportJobV2)
-                        .put(SRMetaBlockID.BACKUP_MGR, backupHandler::loadBackupHandlerV2)
-                        .put(SRMetaBlockID.AUTH, auth::load)
-                        .put(SRMetaBlockID.GLOBAL_TRANSACTION_MGR, globalTransactionMgr::loadTransactionStateV2)
-                        .put(SRMetaBlockID.COLOCATE_TABLE_INDEX, colocateTableIndex::loadColocateTableIndexV2)
-                        .put(SRMetaBlockID.ROUTINE_LOAD_MGR, routineLoadMgr::loadRoutineLoadJobsV2)
-                        .put(SRMetaBlockID.LOAD_MGR, loadMgr::loadLoadJobsV2JsonFormat)
-                        .put(SRMetaBlockID.SMALL_FILE_MGR, smallFileMgr::loadSmallFilesV2)
-                        .put(SRMetaBlockID.PLUGIN_MGR, pluginMgr::load)
-                        .put(SRMetaBlockID.DELETE_MGR, deleteMgr::load)
-                        .put(SRMetaBlockID.ANALYZE_MGR, analyzeMgr::load)
-                        .put(SRMetaBlockID.RESOURCE_GROUP_MGR, resourceGroupMgr::load)
-                        .put(SRMetaBlockID.AUTHENTICATION_MGR, authenticationMgr::loadV2)
-                        .put(SRMetaBlockID.AUTHORIZATION_MGR, authorizationMgr::loadV2)
-                        .put(SRMetaBlockID.TASK_MGR, taskManager::loadTasksV2)
-                        .put(SRMetaBlockID.CATALOG_MGR, catalogMgr::load)
-                        .put(SRMetaBlockID.INSERT_OVERWRITE_JOB_MGR, insertOverwriteJobMgr::load)
-                        .put(SRMetaBlockID.COMPACTION_MGR, compactionMgr::load)
-                        .put(SRMetaBlockID.STREAM_LOAD_MGR, streamLoadMgr::load)
-                        .put(SRMetaBlockID.MATERIALIZED_VIEW_MGR, MaterializedViewMgr.getInstance()::load)
-                        .put(SRMetaBlockID.GLOBAL_FUNCTION_MGR, globalFunctionMgr::load)
-                        .put(SRMetaBlockID.STORAGE_VOLUME_MGR, storageVolumeMgr::load)
-                        .put(SRMetaBlockID.DICTIONARY_MGR, dictionaryMgr::load)
-                        .build();
+        Set<SRMetaBlockID> metaMgrMustExists = new HashSet<>(loadImages.keySet());
+        try (DataInputStream dis = new DataInputStream(new BufferedInputStream(Files.newInputStream(curFile.toPath())))) {
+            loadHeader(dis);
+            while (true) {
+                SRMetaBlockReader reader = new SRMetaBlockReader(dis);
                 try {
-                    loadHeaderV2(dis);
-
-                    Iterator<Map.Entry<SRMetaBlockID, SRMetaBlockLoader>> iterator = loadImages.entrySet().iterator();
-                    Map.Entry<SRMetaBlockID, SRMetaBlockLoader> entry = iterator.next();
-                    while (true) {
-                        SRMetaBlockID srMetaBlockID = entry.getKey();
-                        SRMetaBlockReader reader = new SRMetaBlockReader(dis);
-                        if (!reader.getHeader().getSrMetaBlockID().equals(srMetaBlockID)) {
-                            /*
-                              The expected read module does not match the module stored in the image,
-                              and the json chunk is skipped directly. This usually occurs in several situations.
-                              1. When the obsolete image code is deleted.
-                              2. When the new version rolls back to the old version,
-                                 the old version ignores the functions of the new version
-                             */
-                            LOG.warn(String.format("Ignore this invalid meta block, sr meta block id mismatch" +
-                                    "(expect %s actual %s)", srMetaBlockID, reader.getHeader().getSrMetaBlockID()));
-                            reader.close();
-                            continue;
-                        }
-
-                        try {
-                            SRMetaBlockLoader imageLoader = entry.getValue();
-                            imageLoader.apply(reader);
-                            LOG.info("Success load StarRocks meta block " + srMetaBlockID + " from image");
-                        } catch (SRMetaBlockEOFException srMetaBlockEOFException) {
-                            /*
-                              The number of json expected to be read is more than the number of json actually stored
-                              in the image, which usually occurs when the module adds new functions.
-                             */
-                            LOG.warn("Got EOF exception, ignore, ", srMetaBlockEOFException);
-                        } catch (SRMetaBlockException srMetaBlockException) {
-                            LOG.error("Load meta block failed ", srMetaBlockException);
-                            throw new IOException("Load meta block failed ", srMetaBlockException);
-                        } finally {
-                            reader.close();
-                        }
-                        if (iterator.hasNext()) {
-                            entry = iterator.next();
-                        } else {
-                            break;
-                        }
+                    SRMetaBlockID srMetaBlockID = reader.getHeader().getSrMetaBlockID();
+                    SRMetaBlockLoader imageLoader = loadImages.get(srMetaBlockID);
+                    if (imageLoader == null) {
+                        /*
+                         * The expected read module does not match the module stored in the image,
+                         * and the json chunk is skipped directly. This usually occurs in several situations.
+                         * 1. When the obsolete image code is deleted.
+                         * 2. When the new version rolls back to the old version,
+                         *    the old version ignores the functions of the new version
+                         */
+                        LOG.warn(String.format("Ignore this invalid meta block, sr meta block id mismatch" +
+                                "(expect sr meta block id %s)", srMetaBlockID));
+                        continue;
                     }
-                } catch (SRMetaBlockException e) {
-                    LOG.error("load meta block failed ", e);
-                    throw new IOException("load meta block failed ", e);
+
+                    imageLoader.apply(reader);
+                    metaMgrMustExists.remove(srMetaBlockID);
+                    LOG.info("Success load StarRocks meta block " + srMetaBlockID + " from image");
+                } catch (SRMetaBlockEOFException srMetaBlockEOFException) {
+                    /*
+                     * The number of json expected to be read is more than the number of json actually stored in the image
+                     */
+                    LOG.warn("Got EOF exception, ignore, ", srMetaBlockEOFException);
+                } finally {
+                    reader.close();
                 }
-            } else {
-                checksum = loadHeaderV1(dis, checksum);
-                checksum = nodeMgr.loadLeaderInfo(dis, checksum);
-                checksum = nodeMgr.loadFrontends(dis, checksum);
-                checksum = nodeMgr.loadBackends(dis, checksum);
-                checksum = localMetastore.loadDb(dis, checksum);
-                // ATTN: this should be done after load Db, and before loadAlterJob
-                localMetastore.recreateTabletInvertIndex();
-                // rebuild es state state
-                esRepository.loadTableFromCatalog();
-
-                checksum = load.loadLoadJob(dis, checksum);
-                checksum = loadAlterJob(dis, checksum);
-                checksum = recycleBin.loadRecycleBin(dis, checksum);
-                checksum = VariableMgr.loadGlobalVariable(dis, checksum);
-                checksum = localMetastore.loadCluster(dis, checksum);
-                checksum = nodeMgr.loadBrokers(dis, checksum);
-                checksum = loadResources(dis, checksum);
-                checksum = exportMgr.loadExportJob(dis, checksum);
-                checksum = backupHandler.loadBackupHandler(dis, checksum, this);
-                checksum = auth.loadAuth(dis, checksum);
-                // global transaction must be replayed before load jobs v2
-                checksum = globalTransactionMgr.loadTransactionState(dis, checksum);
-                checksum = colocateTableIndex.loadColocateTableIndex(dis, checksum);
-                checksum = routineLoadMgr.loadRoutineLoadJobs(dis, checksum);
-                checksum = loadMgr.loadLoadJobsV2(dis, checksum);
-                checksum = smallFileMgr.loadSmallFiles(dis, checksum);
-                checksum = pluginMgr.loadPlugins(dis, checksum);
-                checksum = loadDeleteHandler(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = analyzeMgr.loadAnalyze(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = resourceGroupMgr.loadResourceGroups(dis, checksum);
-                checksum = auth.readAsGson(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = taskManager.loadTasks(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = catalogMgr.loadCatalogs(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = loadInsertOverwriteJobs(dis, checksum);
-                checksum = nodeMgr.loadComputeNodes(dis, checksum);
-                remoteChecksum = dis.readLong();
-                // ShardManager DEPRECATED, keep it for backward compatible
-                checksum = loadShardManager(dis, checksum);
-                remoteChecksum = dis.readLong();
-
-                checksum = loadCompactionManager(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = loadStreamLoadManager(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = MaterializedViewMgr.getInstance().reload(dis, checksum);
-                remoteChecksum = dis.readLong();
-                globalFunctionMgr.loadGlobalFunctions(dis, checksum);
-                loadRBACPrivilege(dis);
-                checksum = warehouseMgr.loadWarehouses(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = localMetastore.loadAutoIncrementId(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = loadStorageVolumes(dis, checksum);
-                remoteChecksum = dis.readLong();
-                checksum = pipeManager.getRepo().loadImage(dis, checksum);
-                remoteChecksum = dis.readLong();
-                // ** NOTICE **: always add new code at the end
-
-                Preconditions.checkState(remoteChecksum == checksum, remoteChecksum + " vs. " + checksum);
             }
         } catch (EOFException exception) {
-            LOG.warn("load image eof.", exception);
-        } finally {
-            dis.close();
+            if (!metaMgrMustExists.isEmpty()) {
+                throw new IOException("Load meta block failed, miss meta block [" +
+                        Joiner.on(",").join(new ArrayList<>(metaMgrMustExists)) + "]");
+            } else {
+                LOG.info("Load meta-image EOF, successful loading all requires meta module");
+            }
+        } catch (SRMetaBlockException e) {
+            LOG.error("load meta block failed ", e);
+            throw new IOException("load meta block failed ", e);
         }
 
         if (isUsingNewPrivilege() && needUpgradedToNewPrivilege() && !isLeader() && !isCheckpointThread()) {
@@ -1760,17 +1662,28 @@ public class GlobalStateMgr {
         }
     }
 
-    public long loadVersion(DataInputStream dis, long checksum) throws IOException {
+    private void checkOpTypeValid() throws IOException {
+        try {
+            for (Field field : OperationType.class.getDeclaredFields()) {
+                short id = field.getShort(null);
+                if (id > OperationType.OP_TYPE_EOF) {
+                    throw new IOException("OperationType cannot use a value exceeding 20000, " +
+                            "and an error will be reported if it exceeds : " + field.getName() + " = " + id);
+                }
+            }
+        } catch (IllegalAccessException e) {
+            throw new IOException(e);
+        }
+    }
+
+    public void loadHeader(DataInputStream dis) throws IOException {
         // for new format, version schema is [starrocksMetaVersion], and the int value must be positive
         // for old format, version schema is [-1, metaVersion, starrocksMetaVersion]
         // so we can check the first int to determine the version schema
         int flag = dis.readInt();
-        checksum = checksum ^ flag;
         int starrocksMetaVersion;
         if (flag < 0) {
-            checksum ^= dis.readInt();
             starrocksMetaVersion = dis.readInt();
-            checksum ^= starrocksMetaVersion;
         } else {
             // when flag is positive, this is new version format
             starrocksMetaVersion = flag;
@@ -1783,143 +1696,11 @@ public class GlobalStateMgr {
         }
 
         MetaContext.get().setStarRocksMetaVersion(starrocksMetaVersion);
-
-        return checksum;
-    }
-
-    public long loadHeaderV1(DataInputStream dis, long checksum) throws IOException {
-        long replayedJournalId = dis.readLong();
-        checksum ^= replayedJournalId;
-
-        long batchEndId = dis.readLong();
-        checksum ^= batchEndId;
-        idGenerator.setId(batchEndId);
-
-        isDefaultClusterCreated = dis.readBoolean();
-
-        LOG.info("finished to replay header from image");
-        return checksum;
-    }
-
-    public void loadHeaderV2(DataInputStream dis) throws IOException {
+        checkOpTypeValid();
         ImageHeader header = GsonUtils.GSON.fromJson(Text.readString(dis), ImageHeader.class);
         idGenerator.setId(header.getBatchEndId());
         isDefaultClusterCreated = header.isDefaultClusterCreated();
         LOG.info("finished to replay header from image");
-    }
-
-    public long loadAlterJob(DataInputStream dis, long checksum) throws IOException {
-        long newChecksum = checksum;
-        for (AlterJobV2.JobType type : AlterJobV2.JobType.values()) {
-            newChecksum = loadAlterJob(dis, newChecksum, type);
-        }
-        LOG.info("finished replay alterJob from image");
-        return newChecksum;
-    }
-
-    public void loadRBACPrivilege(DataInputStream dis) throws IOException, DdlException {
-        if (USING_NEW_PRIVILEGE) {
-            this.authenticationMgr = AuthenticationMgr.load(dis);
-            this.authorizationMgr = AuthorizationMgr.load(dis, this, null);
-            this.domainResolver = new DomainResolver(authenticationMgr);
-        }
-    }
-
-    public long loadAlterJob(DataInputStream dis, long checksum, AlterJobV2.JobType type) throws IOException {
-        // alter jobs
-        int size = dis.readInt();
-        if (size > 0) {
-            // It may be upgraded from an earlier version, which is dangerous
-            throw new RuntimeException("Old metadata was found, please upgrade to version 2.4 first " +
-                    "and then from version 2.4 to the current version.");
-        }
-
-        // finished or cancelled jobs
-        size = dis.readInt();
-        if (size > 0) {
-            // It may be upgraded from an earlier version, which is dangerous
-            throw new RuntimeException("Old metadata was found, please upgrade to version 2.4 first " +
-                    "and then from version 2.4 to the current version.");
-        }
-
-        long newChecksum = checksum;
-        // alter job v2
-        size = dis.readInt();
-        newChecksum ^= size;
-        for (int i = 0; i < size; i++) {
-            AlterJobV2 alterJobV2 = AlterJobV2.read(dis);
-            if (type == AlterJobV2.JobType.ROLLUP || type == AlterJobV2.JobType.SCHEMA_CHANGE) {
-                if (type == AlterJobV2.JobType.ROLLUP) {
-                    this.getRollupHandler().addAlterJobV2(alterJobV2);
-                } else {
-                    this.getSchemaChangeHandler().addAlterJobV2(alterJobV2);
-                }
-                // ATTN : we just want to add tablet into TabletInvertedIndex when only PendingJob is checkpoint
-                // to prevent TabletInvertedIndex data loss,
-                // So just use AlterJob.replay() instead of AlterHandler.replay().
-                if (alterJobV2.getJobState() == AlterJobV2.JobState.PENDING) {
-                    alterJobV2.replay(alterJobV2);
-                    LOG.info("replay pending alter job when load alter job {} ", alterJobV2.getJobId());
-                }
-            } else {
-                LOG.warn("Unknown job type:" + type.name());
-            }
-        }
-
-        return newChecksum;
-    }
-
-    public long loadDeleteHandler(DataInputStream dis, long checksum) throws IOException {
-        this.deleteMgr = DeleteMgr.read(dis);
-        LOG.info("finished replay deleteHandler from image");
-        return checksum;
-    }
-
-    public long loadInsertOverwriteJobs(DataInputStream dis, long checksum) throws IOException {
-        try {
-            this.insertOverwriteJobMgr = InsertOverwriteJobMgr.read(dis);
-        } catch (EOFException e) {
-            LOG.warn("no InsertOverwriteJobManager to replay.", e);
-        }
-        return checksum;
-    }
-
-    public long saveInsertOverwriteJobs(DataOutputStream dos, long checksum) throws IOException {
-        getInsertOverwriteJobMgr().write(dos);
-        return checksum;
-    }
-
-    public long loadResources(DataInputStream in, long checksum) throws IOException {
-        resourceMgr = ResourceMgr.read(in);
-        LOG.info("finished replay resources from image");
-
-        LOG.info("start to replay resource mapping catalog");
-        catalogMgr.loadResourceMappingCatalog();
-        LOG.info("finished replaying resource mapping catalogs from resources");
-        return checksum;
-    }
-
-    public long loadShardManager(DataInputStream in, long checksum) throws IOException {
-        shardManager = ShardManager.read(in);
-        LOG.info("finished replay shardManager from image");
-        return checksum;
-    }
-
-    public long loadCompactionManager(DataInputStream in, long checksum) throws IOException {
-        compactionMgr = CompactionMgr.loadCompactionManager(in);
-        checksum ^= compactionMgr.getChecksum();
-        return checksum;
-    }
-
-    public long loadStreamLoadManager(DataInputStream in, long checksum) throws IOException {
-        streamLoadMgr = StreamLoadMgr.loadStreamLoadManager(in);
-        checksum ^= streamLoadMgr.getChecksum();
-        return checksum;
-    }
-
-    public long loadStorageVolumes(DataInputStream in, long checksum) throws IOException {
-        storageVolumeMgr.load(in);
-        return checksum;
     }
 
     // Only called by checkpoint thread
@@ -1952,194 +1733,55 @@ public class GlobalStateMgr {
 
         long saveImageStartTime = System.currentTimeMillis();
         try (DataOutputStream dos = new DataOutputStream(Files.newOutputStream(curFile.toPath()))) {
-            // ** NOTICE **: always add new code at the end
-            if (FeConstants.STARROCKS_META_VERSION >= StarRocksFEMetaVersion.VERSION_4) {
-                try {
-                    saveVersionV2(dos);
-                    saveHeaderV2(dos);
-                    nodeMgr.save(dos);
-                    localMetastore.save(dos);
-                    alterJobMgr.save(dos);
-                    recycleBin.save(dos);
-                    VariableMgr.save(dos);
-                    resourceMgr.saveResourcesV2(dos);
-                    exportMgr.saveExportJobV2(dos);
-                    backupHandler.saveBackupHandlerV2(dos);
-                    auth.save(dos);
-                    globalTransactionMgr.saveTransactionStateV2(dos);
-                    colocateTableIndex.saveColocateTableIndexV2(dos);
-                    routineLoadMgr.saveRoutineLoadJobsV2(dos);
-                    loadMgr.saveLoadJobsV2JsonFormat(dos);
-                    smallFileMgr.saveSmallFilesV2(dos);
-                    pluginMgr.save(dos);
-                    deleteMgr.save(dos);
-                    analyzeMgr.save(dos);
-                    resourceGroupMgr.save(dos);
-                    authenticationMgr.saveV2(dos);
-                    authorizationMgr.saveV2(dos);
-                    taskManager.saveTasksV2(dos);
-                    catalogMgr.save(dos);
-                    insertOverwriteJobMgr.save(dos);
-                    compactionMgr.save(dos);
-                    streamLoadMgr.save(dos);
-                    MaterializedViewMgr.getInstance().save(dos);
-                    globalFunctionMgr.save(dos);
-                    storageVolumeMgr.save(dos);
-                    dictionaryMgr.save(dos);
-                } catch (SRMetaBlockException e) {
-                    LOG.error("Save meta block failed ", e);
-                    throw new IOException("Save meta block failed ", e);
-                }
-
-                long saveImageEndTime = System.currentTimeMillis();
-                LOG.info("Finished save meta block {} in {} ms.",
-                        curFile.getAbsolutePath(), (saveImageEndTime - saveImageStartTime));
-            } else {
-                long checksum = 0;
-                checksum = saveVersion(dos, checksum);
-                checksum = saveHeader(dos, replayedJournalId, checksum);
-                checksum = nodeMgr.saveLeaderInfo(dos, checksum);
-                checksum = nodeMgr.saveFrontends(dos, checksum);
-                checksum = nodeMgr.saveBackends(dos, checksum);
-                checksum = localMetastore.saveDb(dos, checksum);
-                checksum = load.saveLoadJob(dos, checksum);
-                checksum = saveAlterJob(dos, checksum);
-                checksum = recycleBin.saveRecycleBin(dos, checksum);
-                checksum = VariableMgr.saveGlobalVariable(dos, checksum);
-                checksum = localMetastore.saveCluster(dos, checksum);
-                checksum = nodeMgr.saveBrokers(dos, checksum);
-                checksum = resourceMgr.saveResources(dos, checksum);
-                checksum = exportMgr.saveExportJob(dos, checksum);
-                checksum = backupHandler.saveBackupHandler(dos, checksum);
-                checksum = auth.saveAuth(dos, checksum);
-                checksum = globalTransactionMgr.saveTransactionState(dos, checksum);
-                checksum = colocateTableIndex.saveColocateTableIndex(dos, checksum);
-                checksum = routineLoadMgr.saveRoutineLoadJobs(dos, checksum);
-                checksum = loadMgr.saveLoadJobsV2(dos, checksum);
-                checksum = smallFileMgr.saveSmallFiles(dos, checksum);
-
-                checksum = pluginMgr.savePlugins(dos, checksum);
-                checksum = deleteMgr.saveDeleteHandler(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = analyzeMgr.saveAnalyze(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = resourceGroupMgr.saveResourceGroups(dos, checksum);
-                checksum = auth.writeAsGson(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = taskManager.saveTasks(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = catalogMgr.saveCatalogs(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = saveInsertOverwriteJobs(dos, checksum);
-                checksum = nodeMgr.saveComputeNodes(dos, checksum);
-                dos.writeLong(checksum);
-                // ShardManager Deprecated, keep it for backward compatible
-                checksum = shardManager.saveShardManager(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = compactionMgr.saveCompactionManager(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = streamLoadMgr.saveStreamLoadManager(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = MaterializedViewMgr.getInstance().store(dos, checksum);
-                dos.writeLong(checksum);
-                globalFunctionMgr.saveGlobalFunctions(dos, checksum);
-                saveRBACPrivilege(dos);
-                checksum = warehouseMgr.saveWarehouses(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = localMetastore.saveAutoIncrementId(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = storageVolumeMgr.saveStorageVolumes(dos, checksum);
-                dos.writeLong(checksum);
-                checksum = pipeManager.getRepo().saveImage(dos, checksum);
-                dos.writeLong(checksum);
-                // ** NOTICE **: always add new code at the end
-
-                long saveImageEndTime = System.currentTimeMillis();
-                LOG.info("finished save image {} in {} ms. checksum is {}",
-                        curFile.getAbsolutePath(), (saveImageEndTime - saveImageStartTime), checksum);
+            try {
+                saveHeader(dos);
+                nodeMgr.save(dos);
+                localMetastore.save(dos);
+                alterJobMgr.save(dos);
+                recycleBin.save(dos);
+                VariableMgr.save(dos);
+                resourceMgr.saveResourcesV2(dos);
+                exportMgr.saveExportJobV2(dos);
+                backupHandler.saveBackupHandlerV2(dos);
+                auth.save(dos);
+                globalTransactionMgr.saveTransactionStateV2(dos);
+                colocateTableIndex.saveColocateTableIndexV2(dos);
+                routineLoadMgr.saveRoutineLoadJobsV2(dos);
+                loadMgr.saveLoadJobsV2JsonFormat(dos);
+                smallFileMgr.saveSmallFilesV2(dos);
+                pluginMgr.save(dos);
+                deleteMgr.save(dos);
+                analyzeMgr.save(dos);
+                resourceGroupMgr.save(dos);
+                authenticationMgr.saveV2(dos);
+                authorizationMgr.saveV2(dos);
+                taskManager.saveTasksV2(dos);
+                catalogMgr.save(dos);
+                insertOverwriteJobMgr.save(dos);
+                compactionMgr.save(dos);
+                streamLoadMgr.save(dos);
+                MaterializedViewMgr.getInstance().save(dos);
+                globalFunctionMgr.save(dos);
+                storageVolumeMgr.save(dos);
+                dictionaryMgr.save(dos);
+            } catch (SRMetaBlockException e) {
+                LOG.error("Save meta block failed ", e);
+                throw new IOException("Save meta block failed ", e);
             }
+
+            long saveImageEndTime = System.currentTimeMillis();
+            LOG.info("Finished save meta block {} in {} ms.",
+                    curFile.getAbsolutePath(), (saveImageEndTime - saveImageStartTime));
         }
     }
 
-    public long saveVersion(DataOutputStream dos, long checksum) throws IOException {
-        // Write meta version
-        checksum ^= -1;
-        dos.writeInt(-1);
-        checksum ^= FeConstants.META_VERSION;
-        dos.writeInt(FeConstants.META_VERSION);
-        checksum ^= FeConstants.STARROCKS_META_VERSION;
+    public void saveHeader(DataOutputStream dos) throws IOException {
         dos.writeInt(FeConstants.STARROCKS_META_VERSION);
-        return checksum;
-    }
-
-    // TODO [meta-format-change]
-    public void saveVersionV2(DataOutputStream dos) throws IOException {
-        dos.writeInt(FeConstants.STARROCKS_META_VERSION);
-    }
-
-    public long saveHeader(DataOutputStream dos, long replayedJournalId, long checksum) throws IOException {
-        // Write replayed journal id
-        checksum ^= replayedJournalId;
-        dos.writeLong(replayedJournalId);
-
-        // Write id
-        long id = idGenerator.getBatchEndId();
-        checksum ^= id;
-        dos.writeLong(id);
-
-        dos.writeBoolean(isDefaultClusterCreated);
-
-        return checksum;
-    }
-
-    // TODO [meta-format-change]
-    public void saveHeaderV2(DataOutputStream dos) throws IOException {
         ImageHeader header = new ImageHeader();
         long id = idGenerator.getBatchEndId();
         header.setBatchEndId(id);
         header.setDefaultClusterCreated(isDefaultClusterCreated);
         Text.writeString(dos, GsonUtils.GSON.toJson(header));
-    }
-
-    public long saveAlterJob(DataOutputStream dos, long checksum) throws IOException {
-        for (AlterJobV2.JobType type : AlterJobV2.JobType.values()) {
-            checksum = saveAlterJob(dos, checksum, type);
-        }
-        return checksum;
-    }
-
-    public void saveRBACPrivilege(DataOutputStream dos) throws IOException {
-        if (USING_NEW_PRIVILEGE) {
-            this.authenticationMgr.save(dos);
-            this.authorizationMgr.save(dos);
-        }
-    }
-
-    public long saveAlterJob(DataOutputStream dos, long checksum, AlterJobV2.JobType type) throws IOException {
-        Map<Long, AlterJobV2> alterJobsV2 = Maps.newHashMap();
-        if (type == AlterJobV2.JobType.ROLLUP) {
-            alterJobsV2 = this.getRollupHandler().getAlterJobsV2();
-        } else if (type == AlterJobV2.JobType.SCHEMA_CHANGE) {
-            alterJobsV2 = this.getSchemaChangeHandler().getAlterJobsV2();
-        }
-
-        // alter jobs just for compatibility
-        int size = 0;
-        checksum ^= size;
-        dos.writeInt(size);
-        // finished or cancelled jobs just for compatibility
-        checksum ^= size;
-        dos.writeInt(size);
-
-        // alter job v2
-        size = alterJobsV2.size();
-        checksum ^= size;
-        dos.writeInt(size);
-        for (AlterJobV2 alterJobV2 : alterJobsV2.values()) {
-            alterJobV2.write(dos);
-        }
-
-        return checksum;
     }
 
     public void replayGlobalVariable(SessionVariable variable) throws IOException, DdlException {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/GlobalStateMgrTest.java
@@ -62,10 +62,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.DataInputStream;
 import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class GlobalStateMgrTest {
@@ -80,24 +78,15 @@ public class GlobalStateMgrTest {
         MetaContext.remove();
     }
 
-
     @Test
     public void testSaveLoadHeader() throws Exception {
-        UtFrameUtils.PseudoImage image1 = new UtFrameUtils.PseudoImage();
         GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-        long checksum1 = globalStateMgr.saveVersion(image1.getDataOutputStream(), 0);
-        checksum1 = globalStateMgr.saveHeader(image1.getDataOutputStream(), new Random().nextLong(), checksum1);
-
-        DataInputStream dis = image1.getDataInputStream();
-        long checksum2 = globalStateMgr.loadVersion(dis, 0);
-        checksum2 = globalStateMgr.loadHeaderV1(dis, checksum2);
-        Assert.assertEquals(checksum1, checksum2);
 
         // test json-format header
         UtFrameUtils.PseudoImage image2 = new UtFrameUtils.PseudoImage();
-        globalStateMgr.saveHeaderV2(image2.getDataOutputStream());
+        globalStateMgr.saveHeader(image2.getDataOutputStream());
         MetaContext.get().setStarRocksMetaVersion(StarRocksFEMetaVersion.VERSION_4);
-        globalStateMgr.loadHeaderV2(image2.getDataInputStream());
+        globalStateMgr.loadHeader(image2.getDataInputStream());
     }
 
     private GlobalStateMgr mockGlobalStateMgr() throws Exception {


### PR DESCRIPTION
Why I'm doing:
Meta Image supports out-of-order reading
What I'm doing:
From the original sequential reading, it is modified to first read the meta id stored in the header, and then load the corresponding reading module on demand based on the meta id.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
