### PR TITLE
[BugFix] fix enable sync publish when clone

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1093,7 +1093,10 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
                     "replica does not exist. backend id: " + destBackendId);
         }
 
-        replica.updateRowCount(reportedTablet.getVersion(), reportedTablet.getMin_readable_version(),
+        long beVisibleVersion = Config.enable_sync_publish ? reportedTablet.getMax_readable_version() :
+                reportedTablet.getVersion();
+
+        replica.updateRowCount(beVisibleVersion, reportedTablet.getMin_readable_version(),
                 reportedTablet.getData_size(), reportedTablet.getRow_count());
         if (reportedTablet.isSetPath_hash()) {
             replica.setPathHash(reportedTablet.getPath_hash());
@@ -1112,7 +1115,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(dbId, tblId, partitionId, indexId,
                 tabletId, destBackendId, replica.getId(),
-                reportedTablet.getVersion(),
+                beVisibleVersion,
                 reportedTablet.getSchema_hash(),
                 reportedTablet.getData_size(),
                 reportedTablet.getRow_count(),

--- a/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
+++ b/fe/fe-core/src/main/java/com/starrocks/clone/TabletSchedCtx.java
@@ -1115,7 +1115,7 @@ public class TabletSchedCtx implements Comparable<TabletSchedCtx> {
 
         ReplicaPersistInfo info = ReplicaPersistInfo.createForClone(dbId, tblId, partitionId, indexId,
                 tabletId, destBackendId, replica.getId(),
-                beVisibleVersion,
+                replica.getVersion(),
                 reportedTablet.getSchema_hash(),
                 reportedTablet.getData_size(),
                 reportedTablet.getRow_count(),

--- a/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Tablet.java
+++ b/fe/fe-core/src/test/java/com/starrocks/pseudocluster/Tablet.java
@@ -103,6 +103,7 @@ public class Tablet {
         info.setPath_hash(PseudoBackend.PATH_HASH);
         info.setIs_in_memory(false);
         info.setVersion(maxContinuousVersion());
+        info.setMax_readable_version(maxContinuousVersion());
         info.setMin_readable_version(minVersion());
         info.setVersion_miss(!pendingRowsets.isEmpty());
         info.setRow_count(getRowCount());
@@ -337,6 +338,7 @@ public class Tablet {
 
     public TTabletInfo getTabletInfo() {
         TTabletInfo info = new TTabletInfo(id, schemaHash, maxContinuousVersion(), 0, getRowCount(), getDataSize());
+        info.setMax_readable_version(maxContinuousVersion());
         info.setMin_readable_version(minVersion());
         return info;
     }


### PR DESCRIPTION
Why I'm doing:
In previous PR #27055 , we add config `enable_sync_publish`. When it is true, BE will return publish version request success until all version is queryable. 

But when clone happen, BE report both `version` and `max_readable_version` to FE in finish clone request,  and FE will use `version` instead of `max_readable_version` to update replica version, so it will broken the rule that `enable_sync_publish` define, because `version` may not queryable yet.

What I'm doing:
Using `max_readable_version` instead of `version` to update replica version when clone finish.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
