### PR TITLE
[Enhancement] Reduce blacklist lock scope  (branch-3.1) (backport #37259)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
@@ -261,7 +261,7 @@ public class SimpleScheduler {
                                 Collections.addAll(ports, backend.getBePort(), backend.getBrpcPort(), backend.getHttpPort());
                                 if (NetUtils.checkAccessibleForAllPorts(host, ports)) {
                                     iterator.remove();
-                                    LOG.warn("remove backendID {} from blacklist", backendId);;
+                                    LOG.warn("remove backendID {} from blacklist", backendId);
                                 }
                             } else {
                                 Integer retryTimes = entry.getValue();

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SimpleSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SimpleSchedulerTest.java
@@ -44,8 +44,10 @@ import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.RunMode;
 import com.starrocks.system.Backend;
 import com.starrocks.system.ComputeNode;
+import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TScanRangeLocation;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
@@ -68,6 +70,8 @@ public class SimpleSchedulerTest {
 
     @Before
     public void setUp() {
+        // disable updateBlackListThread
+        SimpleScheduler.disableUpdateBlacklistThread();
     }
 
     // Comment out these code temporatily.
@@ -298,6 +302,70 @@ public class SimpleSchedulerTest {
         ImmutableMap.Builder<Long, ComputeNode> builder = ImmutableMap.builder();
         address = SimpleScheduler.getComputeNodeHost(builder.build(), idRef);
         Assert.assertNull(address);
+    }
+
+    @Test
+    public void testUpdateBlacklist(@Mocked GlobalStateMgr globalStateMgr,
+                                    @Mocked SystemInfoService systemInfoService,
+                                    @Mocked NetUtils utils) {
+        Config.heartbeat_timeout_second = 1;
+
+        SimpleScheduler.addToBlacklist(10001L);
+        SimpleScheduler.addToBlacklist(10002L);
+        SimpleScheduler.addToBlacklist(10003L);
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentSystemInfo();
+                result = systemInfoService;
+                times = 2;
+
+                // backend 10001 will be removed
+                systemInfoService.getBackend(10001L);
+                result = null;
+                times = 1;
+
+                // backend 10002 will be removed
+                Backend backend1 = new Backend();
+                backend1.setAlive(true);
+                backend1.setHost("host10002");
+                backend1.setBrpcPort(10002);
+                backend1.setHttpPort(10012);
+                systemInfoService.getBackend(10002L);
+                result = backend1;
+                times = 1;
+
+                systemInfoService.checkBackendAvailable(10002L);
+                result = true;
+                times = 1;
+
+                NetUtils.checkAccessibleForAllPorts("host10002", (List<Integer>) any);
+                result = true;
+                times = 1;
+
+                // backend 10003, which is not available, will not be be removed
+                Backend backend2 = new Backend();
+                backend2.setAlive(false);
+                backend2.setHost("host10003");
+                backend2.setBrpcPort(10003);
+                backend2.setHttpPort(10013);
+                systemInfoService.getBackend(10003L);
+                result = backend2;
+                times = 2;
+
+                systemInfoService.checkBackendAvailable(10003L);
+                result = false;
+                times = 2;
+            }
+        };
+        SimpleScheduler.updateBlacklist();
+
+        Assert.assertFalse(SimpleScheduler.isInBlacklist(10001L));
+        Assert.assertFalse(SimpleScheduler.isInBlacklist(10002L));
+        Assert.assertTrue(SimpleScheduler.isInBlacklist(10003L));
+
+        //Having retried for Config.heartbeat_timeout_second + 1 times, backend 10003 will be removed.
+        SimpleScheduler.updateBlacklist();
+        Assert.assertFalse(SimpleScheduler.isInBlacklist(10003L));
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
https://github.com/StarRocks/starrocks/blob/1ace19da5a6241f9ced788c1e59c1e58a519db26/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java#L258-L265
The `NetUtils.checkAccessibleForAllPorts` needs 1000ms to return when the host is down, which holds the lock for a long time.

What I'm doing:
This PR reduces the lock scope by call `NetUtils.checkAccessibleForAllPorts` outside the lock.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5

