### PR TITLE
[Feature] support to read iceberg equality delete file for mor.

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -82,7 +82,7 @@ protected:
     RuntimeFilterProbeCollector* _runtime_filters = nullptr;
     RuntimeBloomFilterEvalContext runtime_bloom_filter_eval_context;
     RuntimeProfile* _runtime_profile = nullptr;
-    const TupleDescriptor* _tuple_desc = nullptr;
+    TupleDescriptor* _tuple_desc = nullptr;
     void _init_chunk(ChunkPtr* chunk, size_t n) { *chunk = ChunkHelper::new_chunk(*_tuple_desc, n); }
 };
 

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -263,7 +263,7 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
         std::vector<SlotDescriptor*> equality_delete_slots;
         for (SlotDescriptor* d_slot_desc : delete_column_tuple_desc->slots()) {
             _equality_delete_slots.emplace_back(d_slot_desc);
-            if (id_to_slots.contains(d_slot_desc->id())) {
+            if (!id_to_slots.contains(d_slot_desc->id())) {
                 _materialize_slots.push_back(d_slot_desc);
                 _materialize_index_in_chunk.push_back(delete_column_index++);
             }

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -731,12 +731,11 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();
 
     if (!_equality_delete_slots.empty()) {
-        MORParams mor_params;
+        MORParams& mor_params = scanner_params.mor_params;
         mor_params.tuple_desc = _tuple_desc;
         mor_params.equality_slots = _equality_delete_slots;
         mor_params.mor_tuple_id = _provider->_hdfs_scan_node.mor_tuple_id;
         mor_params.runtime_profile = _runtime_profile;
-        scanner_params.mor_params = mor_params;
     }
 
     for (const auto& delete_file : scan_range.delete_files) {

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -251,18 +251,19 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     }
 
     if (_scan_range.__isset.delete_column_slot_ids && !_scan_range.delete_column_slot_ids.empty()) {
+        std::map<SlotId, SlotDescriptor*> id_to_slots;
+        for (const auto& slot : _materialize_slots) {
+            id_to_slots.emplace(slot->id(), slot);
+        }
+
         int32_t delete_column_index = slots.size();
         auto* delete_column_tuple_desc =
                 state->desc_tbl().get_tuple_descriptor(_provider->_hdfs_scan_node.mor_tuple_id);
-        std::vector<SlotId> materialize_slot_ids;
-        std::ranges::transform(_materialize_slots.begin(), _materialize_slots.end(),
-                               std::back_inserter(materialize_slot_ids),
-                               [](const SlotDescriptor* slot_desc) { return slot_desc->id(); });
 
+        std::vector<SlotDescriptor*> equality_delete_slots;
         for (SlotDescriptor* d_slot_desc : delete_column_tuple_desc->slots()) {
             _equality_delete_slots.emplace_back(d_slot_desc);
-            if (std::ranges::find(materialize_slot_ids.begin(), materialize_slot_ids.end(), d_slot_desc->id()) ==
-                materialize_slot_ids.end()) {
+            if (id_to_slots.contains(d_slot_desc->id())) {
                 _materialize_slots.push_back(d_slot_desc);
                 _materialize_index_in_chunk.push_back(delete_column_index++);
             }

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -731,8 +731,12 @@ Status HiveDataSource::_init_scanner(RuntimeState* state) {
     scanner_params.lazy_column_coalesce_counter = get_lazy_column_coalesce_counter();
 
     if (!_equality_delete_slots.empty()) {
-        scanner_params.equality_slots = _equality_delete_slots;
-        scanner_params.mor_tuple_id = _provider->_hdfs_scan_node.mor_tuple_id;
+        MORParams mor_params;
+        mor_params.tuple_desc = _tuple_desc;
+        mor_params.equality_slots = _equality_delete_slots;
+        mor_params.mor_tuple_id = _provider->_hdfs_scan_node.mor_tuple_id;
+        mor_params.runtime_profile = _runtime_profile;
+        scanner_params.mor_params = mor_params;
     }
 
     for (const auto& delete_file : scan_range.delete_files) {

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -131,6 +131,9 @@ private:
     // partition columns.
     std::vector<SlotDescriptor*> _partition_slots;
 
+    // iceberg equality delete column slots.
+    std::vector<SlotDescriptor*> _equality_delete_slots;
+
     // partition column index in `tuple_desc`
     std::vector<int> _partition_index_in_chunk;
     // partition index in hdfs partition columns

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -99,6 +99,7 @@ set(EXEC_FILES
     hdfs_scanner_parquet.cpp
     hdfs_scanner_text.cpp
     hdfs_scanner_partition.cpp
+    mor_processor.cpp
     json_scanner.cpp
     json_parser.cpp
     avro_scanner.cpp

--- a/be/src/exec/hash_join_node.cpp
+++ b/be/src/exec/hash_join_node.cpp
@@ -191,7 +191,8 @@ void HashJoinNode::_init_hash_table_param(HashTableParam* param) {
     param->search_ht_timer = _search_ht_timer;
     param->output_build_column_timer = _output_build_column_timer;
     param->output_probe_column_timer = _output_probe_column_timer;
-    param->output_slots = _output_slots;
+    param->build_output_slots = _output_slots;
+    param->probe_output_slots = _output_slots;
 
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {
@@ -466,7 +467,7 @@ pipeline::OpFactories HashJoinNode::_decompose_to_pipeline(pipeline::PipelineBui
     HashJoinerParam param(pool, _hash_join_node, _id, _type, _is_null_safes, _build_expr_ctxs, _probe_expr_ctxs,
                           _other_join_conjunct_ctxs, _conjunct_ctxs, child(1)->row_desc(), child(0)->row_desc(),
                           _row_descriptor, child(1)->type(), child(0)->type(), child(1)->conjunct_ctxs().empty(),
-                          _build_runtime_filters, _output_slots, _distribution_mode);
+                          _build_runtime_filters, _output_slots, _output_slots, _distribution_mode, false);
     auto hash_joiner_factory = std::make_shared<starrocks::pipeline::HashJoinerFactory>(param);
 
     // add placeholder into RuntimeFilterHub, HashJoinBuildOperator will generate runtime filters and fill it,

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -70,7 +70,7 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _build_output_slots(param._build_output_slots),
           _probe_output_slots(param._probe_output_slots),
           _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()),
-          _with_external_table_mor(param._with_external_table_mor) {
+          _mor_reader_mode(param._mor_reader_mode) {
     _is_push_down = param._hash_join_node.is_push_down;
     if (_join_type == TJoinOp::LEFT_ANTI_JOIN && param._hash_join_node.is_rewritten_from_not_in) {
         _join_type = TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
@@ -142,7 +142,7 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->probe_row_desc = &_probe_row_descriptor;
     param->build_output_slots = _build_output_slots;
     param->probe_output_slots = _probe_output_slots;
-    param->with_external_table_mor = _with_external_table_mor;
+    param->mor_reader_mode = _mor_reader_mode;
 
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {

--- a/be/src/exec/hash_joiner.cpp
+++ b/be/src/exec/hash_joiner.cpp
@@ -28,7 +28,6 @@
 #include "gutil/strings/substitute.h"
 #include "runtime/current_thread.h"
 #include "simd/simd.h"
-#include "util/debug_util.h"
 #include "util/runtime_profile.h"
 
 namespace starrocks {
@@ -68,8 +67,10 @@ HashJoiner::HashJoiner(const HashJoinerParam& param)
           _build_node_type(param._build_node_type),
           _probe_node_type(param._probe_node_type),
           _build_conjunct_ctxs_is_empty(param._build_conjunct_ctxs_is_empty),
-          _output_slots(param._output_slots),
-          _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()) {
+          _build_output_slots(param._build_output_slots),
+          _probe_output_slots(param._probe_output_slots),
+          _build_runtime_filters(param._build_runtime_filters.begin(), param._build_runtime_filters.end()),
+          _with_external_table_mor(param._with_external_table_mor) {
     _is_push_down = param._hash_join_node.is_push_down;
     if (_join_type == TJoinOp::LEFT_ANTI_JOIN && param._hash_join_node.is_rewritten_from_not_in) {
         _join_type = TJoinOp::NULL_AWARE_LEFT_ANTI_JOIN;
@@ -139,7 +140,10 @@ void HashJoiner::_init_hash_table_param(HashTableParam* param) {
     param->row_desc = &_row_descriptor;
     param->build_row_desc = &_build_row_descriptor;
     param->probe_row_desc = &_probe_row_descriptor;
-    param->output_slots = _output_slots;
+    param->build_output_slots = _build_output_slots;
+    param->probe_output_slots = _probe_output_slots;
+    param->with_external_table_mor = _with_external_table_mor;
+
     std::set<SlotId> predicate_slots;
     for (ExprContext* expr_context : _conjunct_ctxs) {
         std::vector<SlotId> expr_slots;

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -18,12 +18,10 @@
 #include <utility>
 
 #include "column/chunk.h"
-#include "column/fixed_length_column.h"
 #include "column/vectorized_fwd.h"
 #include "common/statusor.h"
 #include "exec/exec_node.h"
 #include "exec/hash_join_components.h"
-#include "exec/hash_join_node.h"
 #include "exec/join_hash_map.h"
 #include "exec/pipeline/context_with_dependency.h"
 #include "exec/pipeline/runtime_filter_types.h"
@@ -73,8 +71,9 @@ struct HashJoinerParam {
                     const RowDescriptor& build_row_descriptor, const RowDescriptor& probe_row_descriptor,
                     const RowDescriptor& row_descriptor, TPlanNodeType::type build_node_type,
                     TPlanNodeType::type probe_node_type, bool build_conjunct_ctxs_is_empty,
-                    std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters, std::set<SlotId> output_slots,
-                    const TJoinDistributionMode::type distribution_mode)
+                    std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters, std::set<SlotId> build_output_slots,
+                    std::set<SlotId> probe_output_slots, const TJoinDistributionMode::type distribution_mode,
+                    bool with_external_table_mor)
             : _pool(pool),
               _hash_join_node(hash_join_node),
               _node_id(node_id),
@@ -91,8 +90,10 @@ struct HashJoinerParam {
               _probe_node_type(probe_node_type),
               _build_conjunct_ctxs_is_empty(build_conjunct_ctxs_is_empty),
               _build_runtime_filters(std::move(build_runtime_filters)),
-              _output_slots(std::move(output_slots)),
-              _distribution_mode(distribution_mode) {}
+              _build_output_slots(std::move(build_output_slots)),
+              _probe_output_slots(std::move(probe_output_slots)),
+              _distribution_mode(distribution_mode),
+              _with_external_table_mor(with_external_table_mor) {}
 
     HashJoinerParam(HashJoinerParam&&) = default;
     HashJoinerParam(HashJoinerParam&) = default;
@@ -114,9 +115,11 @@ struct HashJoinerParam {
     TPlanNodeType::type _probe_node_type;
     bool _build_conjunct_ctxs_is_empty;
     std::list<RuntimeFilterBuildDescriptor*> _build_runtime_filters;
-    std::set<SlotId> _output_slots;
+    std::set<SlotId> _build_output_slots;
+    std::set<SlotId> _probe_output_slots;
 
     const TJoinDistributionMode::type _distribution_mode;
+    const bool _with_external_table_mor;
 };
 
 inline bool could_short_circuit(TJoinOp::type join_type) {
@@ -409,7 +412,8 @@ private:
     const TPlanNodeType::type _build_node_type;
     const TPlanNodeType::type _probe_node_type;
     const bool _build_conjunct_ctxs_is_empty;
-    const std::set<SlotId>& _output_slots;
+    const std::set<SlotId>& _build_output_slots;
+    const std::set<SlotId>& _probe_output_slots;
 
     pipeline::RuntimeInFilters _runtime_in_filters;
     pipeline::RuntimeBloomFilters _build_runtime_filters;
@@ -448,6 +452,7 @@ private:
     HashJoinBuildMetrics* _build_metrics;
     HashJoinProbeMetrics* _probe_metrics;
     size_t _hash_table_build_rows{};
+    bool _with_external_table_mor = false;
 };
 
 } // namespace starrocks

--- a/be/src/exec/hash_joiner.h
+++ b/be/src/exec/hash_joiner.h
@@ -73,7 +73,7 @@ struct HashJoinerParam {
                     TPlanNodeType::type probe_node_type, bool build_conjunct_ctxs_is_empty,
                     std::list<RuntimeFilterBuildDescriptor*> build_runtime_filters, std::set<SlotId> build_output_slots,
                     std::set<SlotId> probe_output_slots, const TJoinDistributionMode::type distribution_mode,
-                    bool with_external_table_mor)
+                    bool mor_reader_mode)
             : _pool(pool),
               _hash_join_node(hash_join_node),
               _node_id(node_id),
@@ -93,7 +93,7 @@ struct HashJoinerParam {
               _build_output_slots(std::move(build_output_slots)),
               _probe_output_slots(std::move(probe_output_slots)),
               _distribution_mode(distribution_mode),
-              _with_external_table_mor(with_external_table_mor) {}
+              _mor_reader_mode(mor_reader_mode) {}
 
     HashJoinerParam(HashJoinerParam&&) = default;
     HashJoinerParam(HashJoinerParam&) = default;
@@ -119,7 +119,7 @@ struct HashJoinerParam {
     std::set<SlotId> _probe_output_slots;
 
     const TJoinDistributionMode::type _distribution_mode;
-    const bool _with_external_table_mor;
+    const bool _mor_reader_mode;
 };
 
 inline bool could_short_circuit(TJoinOp::type join_type) {
@@ -452,7 +452,7 @@ private:
     HashJoinBuildMetrics* _build_metrics;
     HashJoinProbeMetrics* _probe_metrics;
     size_t _hash_table_build_rows{};
-    bool _with_external_table_mor = false;
+    bool _mor_reader_mode = false;
 };
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner.cpp
+++ b/be/src/exec/hdfs_scanner.cpp
@@ -81,7 +81,14 @@ bool HdfsScannerParams::is_lazy_materialization_slot(SlotId slot_id) const {
 Status HdfsScanner::init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) {
     _runtime_state = runtime_state;
     _scanner_params = scanner_params;
+
+    RETURN_IF_ERROR(_build_hash_joiner_for_mor_if_needed());
     Status status = do_init(runtime_state, scanner_params);
+
+    if (!scanner_params.equality_slots.empty()) {
+        RETURN_IF_ERROR(_hash_joiner->build_ht(runtime_state));
+        _hash_joiner->enter_probe_phase();
+    }
     return status;
 }
 
@@ -146,6 +153,49 @@ Status HdfsScanner::_build_scanner_context() {
     return Status::OK();
 }
 
+Status HdfsScanner::_build_hash_joiner_for_mor_if_needed() {
+    if (_scanner_params.equality_slots.empty()) {
+        return Status::OK();
+    }
+
+    THashJoinNode hash_join_node;
+    hash_join_node.__set_join_op(TJoinOp::LEFT_ANTI_JOIN);
+    hash_join_node.__set_distribution_mode(TJoinDistributionMode::PARTITIONED);
+    hash_join_node.__set_is_push_down(false);
+    hash_join_node.__set_build_runtime_filters_from_planner(false);
+    hash_join_node.__set_output_columns(std::vector<SlotId>());
+
+    std::set<SlotId> probe_output_slot_ids;
+    for (const auto slot_desc : _scanner_params.tuple_desc->slots()) {
+        probe_output_slot_ids.insert(slot_desc->id());
+    }
+
+    for (const SlotDescriptor* slot_desc : _scanner_params.equality_slots) {
+        const auto column_ref = _runtime_state->obj_pool()->add(new ColumnRef(slot_desc));
+        auto expr_context = _runtime_state->obj_pool()->add(new ExprContext(column_ref));
+        _join_exprs.emplace_back(expr_context);
+    }
+
+    RETURN_IF_ERROR(Expr::prepare(_join_exprs, _runtime_state));
+    RETURN_IF_ERROR(Expr::open(_join_exprs, _runtime_state));
+
+    _build_row_desc = std::make_unique<RowDescriptor>(
+            _runtime_state->desc_tbl().get_tuple_descriptor(_scanner_params.mor_tuple_id), false);
+    _probe_row_desc = std::make_unique<RowDescriptor>(_scanner_params.tuple_desc, false);
+
+    auto param = _runtime_state->obj_pool()->add(
+            new HashJoinerParam(_runtime_state->obj_pool(), hash_join_node, 1, TPlanNodeType::HASH_JOIN_NODE,
+                                std::vector<bool>(_scanner_params.equality_slots.size(), false), _join_exprs,
+                                _join_exprs, std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc,
+                                *_probe_row_desc, *_probe_row_desc, TPlanNodeType::HDFS_SCAN_NODE,
+                                TPlanNodeType::HDFS_SCAN_NODE, true, std::list<RuntimeFilterBuildDescriptor*>(),
+                                std::set<SlotId>(), probe_output_slot_ids, TJoinDistributionMode::PARTITIONED, true));
+    _hash_joiner = std::make_shared<HashJoiner>(*param);
+
+    RETURN_IF_ERROR(_hash_joiner->prepare_builder(_runtime_state, _scanner_params.profile->runtime_profile));
+    return Status::OK();
+}
+
 Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
     SCOPED_RAW_TIMER(&_total_running_time);
     RETURN_IF_CANCELLED(_runtime_state);
@@ -155,6 +205,15 @@ Status HdfsScanner::get_next(RuntimeState* runtime_state, ChunkPtr* chunk) {
         if (!_scanner_params.conjunct_ctxs.empty() && _scanner_params.eval_conjunct_ctxs) {
             SCOPED_RAW_TIMER(&_app_stats.expr_filter_ns);
             RETURN_IF_ERROR(ExecNode::eval_conjuncts(_scanner_params.conjunct_ctxs, (*chunk).get()));
+        }
+
+        if (!_scanner_params.equality_slots.empty()) {
+            if (!_prepared_probe.load()) {
+                RETURN_IF_ERROR(_hash_joiner->prepare_prober(runtime_state, _scanner_params.profile->runtime_profile));
+                _prepared_probe.store(true);
+            }
+            RETURN_IF_ERROR(_hash_joiner->push_chunk(runtime_state, std::move(*chunk)));
+            *chunk = std::move(_hash_joiner->pull_chunk(runtime_state)).value();
         }
     } else if (status.is_end_of_file()) {
         // do nothing.
@@ -195,6 +254,13 @@ void HdfsScanner::close() noexcept {
     _file.reset(nullptr);
     if (_opened && _scanner_params.open_limit != nullptr) {
         _scanner_params.open_limit->fetch_sub(1, std::memory_order_relaxed);
+    }
+
+    if (_hash_joiner && !_scanner_params.equality_slots.empty()) {
+        _hash_joiner->enter_eos_phase();
+        _hash_joiner->set_prober_finished();
+        _hash_joiner->close(_runtime_state);
+        Expr::close(_join_exprs, _runtime_state);
     }
 }
 

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -17,7 +17,6 @@
 #include <atomic>
 #include <boost/algorithm/string.hpp>
 
-#include "exec/hash_joiner.h"
 #include "exec/mor_processor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
@@ -164,9 +163,6 @@ struct HdfsScannerParams {
     std::vector<SlotDescriptor*> materialize_slots;
     std::vector<int> materialize_index_in_chunk;
 
-    // equality column slots
-    std::vector<SlotDescriptor*> equality_slots;
-
     // columns of partition info
     std::vector<SlotDescriptor*> partition_slots;
     std::vector<int> partition_index_in_chunk;
@@ -203,7 +199,7 @@ struct HdfsScannerParams {
     bool can_use_any_column = false;
     bool can_use_min_max_count_opt = false;
     bool use_file_metacache = false;
-    int mor_tuple_id;
+    MORParams mor_params;
 };
 
 struct HdfsScannerContext {
@@ -359,7 +355,7 @@ private:
     Status _build_scanner_context();
     MonotonicStopWatch _pending_queue_sw;
     void update_hdfs_counter(HdfsScanProfile* profile);
-    Status _init_mor_processor(RuntimeState* runtime_state, const HdfsScannerParams& params);
+    Status _init_mor_processor(RuntimeState* runtime_state, const MORParams& params);
 
 protected:
     std::atomic_bool _pending_token = false;
@@ -376,7 +372,7 @@ protected:
     std::shared_ptr<io::SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
     int64_t _total_running_time = 0;
 
-    std::shared_ptr<MorProcessor> _mor_processor;
+    std::shared_ptr<DefaultMORProcessor> _mor_processor;
 };
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -18,6 +18,7 @@
 #include <boost/algorithm/string.hpp>
 
 #include "exec/hash_joiner.h"
+#include "exec/mor_processor.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/runtime_filter_bank.h"
@@ -356,11 +357,9 @@ private:
     std::atomic<bool> _closed = false;
     bool _keep_priority = false;
     Status _build_scanner_context();
-    Status _build_hash_joiner_for_mor_if_needed();
     MonotonicStopWatch _pending_queue_sw;
     void update_hdfs_counter(HdfsScanProfile* profile);
-
-    std::atomic<bool> _prepared_probe = false;
+    Status _init_mor_processor(RuntimeState* runtime_state, const HdfsScannerParams& params);
 
 protected:
     std::atomic_bool _pending_token = false;
@@ -376,10 +375,8 @@ protected:
     std::shared_ptr<io::CacheInputStream> _cache_input_stream = nullptr;
     std::shared_ptr<io::SharedBufferedInputStream> _shared_buffered_input_stream = nullptr;
     int64_t _total_running_time = 0;
-    std::shared_ptr<HashJoiner> _hash_joiner = nullptr;
-    std::vector<ExprContext*> _join_exprs;
-    std::unique_ptr<RowDescriptor> _build_row_desc;
-    std::unique_ptr<RowDescriptor> _probe_row_desc;
+
+    std::shared_ptr<MorProcessor> _mor_processor;
 };
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -543,8 +543,8 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
 
         for (const auto& tdelete_file : scanner_params.deletes) {
             RETURN_IF_ERROR(iceberg_delete_builder.build_orc(runtime_state->timezone(), *tdelete_file,
-                                                             scanner_params.equality_slots, runtime_state,
-                                                             _mor_processor->hash_joiner()));
+                                                             scanner_params.mor_params.equality_slots, runtime_state,
+                                                             _mor_processor));
         }
         _app_stats.iceberg_delete_files_per_scan += scanner_params.deletes.size();
     }

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -534,13 +534,17 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
     _should_skip_file = false;
     _use_orc_sargs = true;
     // todo: build predicate hook and ranges hook.
+
     if (!scanner_params.deletes.empty()) {
         SCOPED_RAW_TIMER(&_app_stats.iceberg_delete_file_build_ns);
-        IcebergDeleteBuilder iceberg_delete_builder(scanner_params.fs, scanner_params.path,
-                                                    scanner_params.conjunct_ctxs, scanner_params.materialize_slots,
-                                                    &_need_skip_rowids);
+        const IcebergDeleteBuilder iceberg_delete_builder(scanner_params.fs, scanner_params.path,
+                                                          scanner_params.conjunct_ctxs,
+                                                          scanner_params.materialize_slots, &_need_skip_rowids);
+
         for (const auto& tdelete_file : scanner_params.deletes) {
-            RETURN_IF_ERROR(iceberg_delete_builder.build_orc(runtime_state->timezone(), *tdelete_file));
+            RETURN_IF_ERROR(iceberg_delete_builder.build_orc(runtime_state->timezone(), *tdelete_file,
+                                                             scanner_params.equality_slots, runtime_state,
+                                                             _hash_joiner));
         }
         _app_stats.iceberg_delete_files_per_scan += scanner_params.deletes.size();
     }

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -544,7 +544,7 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
         for (const auto& tdelete_file : scanner_params.deletes) {
             RETURN_IF_ERROR(iceberg_delete_builder.build_orc(runtime_state->timezone(), *tdelete_file,
                                                              scanner_params.equality_slots, runtime_state,
-                                                             _hash_joiner));
+                                                             _mor_processor->hash_joiner()));
         }
         _app_stats.iceberg_delete_files_per_scan += scanner_params.deletes.size();
     }

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -131,7 +131,7 @@ Status ORCPositionDeleteBuilder::build(const std::string& timezone, const std::s
 }
 
 Status ORCEqualityDeleteBuilder::build(const std::string& timezone, const std::string& delete_file_path,
-                                       int64_t file_length, const std::shared_ptr<HashJoiner> hash_joiner,
+                                       int64_t file_length, const std::shared_ptr<DefaultMORProcessor> mor_processor,
                                        std::vector<SlotDescriptor*> slot_descs, RuntimeState* state) {
     std::unique_ptr<RandomAccessFile> file;
     ASSIGN_OR_RETURN(file, _fs->new_random_access_file(delete_file_path));
@@ -170,7 +170,7 @@ Status ORCEqualityDeleteBuilder::build(const std::string& timezone, const std::s
         }
 
         ChunkPtr chunk = ret.value();
-        RETURN_IF_ERROR(hash_joiner->append_chunk_to_ht(chunk));
+        RETURN_IF_ERROR(mor_processor->append_chunk_to_ht(chunk));
     }
     return Status::OK();
 }

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -130,6 +130,51 @@ Status ORCPositionDeleteBuilder::build(const std::string& timezone, const std::s
     }
 }
 
+Status ORCEqualityDeleteBuilder::build(const std::string& timezone, const std::string& delete_file_path,
+                                       int64_t file_length, const std::shared_ptr<HashJoiner> hash_joiner,
+                                       std::vector<SlotDescriptor*> slot_descs, RuntimeState* state) {
+    std::unique_ptr<RandomAccessFile> file;
+    ASSIGN_OR_RETURN(file, _fs->new_random_access_file(delete_file_path));
+
+    auto input_stream = std::make_unique<ORCHdfsFileStream>(file.get(), file_length, nullptr);
+    std::unique_ptr<orc::Reader> reader;
+    try {
+        const orc::ReaderOptions options;
+        reader = createReader(std::move(input_stream), options);
+    } catch (std::exception& e) {
+        const auto s =
+                strings::Substitute("ORCEqualityDeleteBuilder::build create orc::Reader failed. reason = $0", e.what());
+        LOG(WARNING) << s;
+        return Status::InternalError(s);
+    }
+
+    const auto orc_reader = std::make_unique<OrcChunkReader>(4096, slot_descs);
+    orc_reader->disable_broker_load_mode();
+    orc_reader->set_current_file_name(delete_file_path);
+    RETURN_IF_ERROR(orc_reader->set_timezone(timezone));
+    RETURN_IF_ERROR(orc_reader->init(std::move(reader)));
+
+    orc::RowReader::ReadPosition position;
+
+    while (true) {
+        Status status = orc_reader->read_next(&position);
+        if (status.is_end_of_file()) {
+            break;
+        }
+
+        RETURN_IF_ERROR(status);
+
+        auto ret = orc_reader->get_chunk();
+        if (!ret.ok()) {
+            return ret.status();
+        }
+
+        ChunkPtr chunk = ret.value();
+        RETURN_IF_ERROR(hash_joiner->append_chunk_to_ht(chunk));
+    }
+    return Status::OK();
+}
+
 SlotDescriptor IcebergDeleteFileMeta::gen_slot_helper(const IcebergColumnMeta& meta) {
     TSlotDescriptor desc;
     desc.__set_id(meta.id);
@@ -161,5 +206,4 @@ SlotDescriptor& IcebergDeleteFileMeta::get_delete_file_pos_slot() {
 
     return k_delete_file_pos_slot;
 }
-
 } // namespace starrocks

--- a/be/src/exec/iceberg/iceberg_delete_builder.cpp
+++ b/be/src/exec/iceberg/iceberg_delete_builder.cpp
@@ -170,7 +170,7 @@ Status ORCEqualityDeleteBuilder::build(const std::string& timezone, const std::s
         }
 
         ChunkPtr chunk = ret.value();
-        RETURN_IF_ERROR(mor_processor->append_chunk_to_ht(chunk));
+        RETURN_IF_ERROR(mor_processor->append_chunk_to_hashtable(chunk));
     }
     return Status::OK();
 }

--- a/be/src/exec/iceberg/iceberg_delete_builder.h
+++ b/be/src/exec/iceberg/iceberg_delete_builder.h
@@ -14,7 +14,10 @@
 
 #pragma once
 
+#include <utility>
+
 #include "common/status.h"
+#include "exec/hash_joiner.h"
 #include "exec/parquet_scanner.h"
 #include "fs/fs.h"
 #include "gutil/strings/substitute.h"
@@ -30,6 +33,31 @@ public:
 
     virtual Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
                          std::set<int64_t>* need_skip_rowids) = 0;
+};
+
+class EqualityDeleteBuilder {
+public:
+    EqualityDeleteBuilder() = default;
+    virtual ~EqualityDeleteBuilder() = default;
+
+    virtual Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
+                         std::shared_ptr<HashJoiner> hash_joiner, std::vector<SlotDescriptor*> slots,
+                         RuntimeState* state) = 0;
+};
+
+class ORCEqualityDeleteBuilder : public EqualityDeleteBuilder {
+public:
+    ORCEqualityDeleteBuilder(FileSystem* fs, std::string datafile_path)
+            : _fs(fs), _datafile_path(std::move(datafile_path)) {}
+    ~ORCEqualityDeleteBuilder() override = default;
+
+    Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
+                 std::shared_ptr<HashJoiner> hash_joiner, std::vector<SlotDescriptor*> slots,
+                 RuntimeState* stage) override;
+
+private:
+    FileSystem* _fs;
+    std::string _datafile_path;
 };
 
 class ORCPositionDeleteBuilder : public PositionDeleteBuilder {
@@ -71,18 +99,24 @@ public:
               _need_skip_rowids(need_skip_rowids) {}
     ~IcebergDeleteBuilder() = default;
 
-    Status build_orc(const std::string& timezone, const TIcebergDeleteFile& delete_file) {
+    Status build_orc(const std::string& timezone, const TIcebergDeleteFile& delete_file,
+                     const std::vector<SlotDescriptor*>& slots, RuntimeState* state,
+                     std::shared_ptr<HashJoiner> hash_joiner) const {
         if (delete_file.file_content == TIcebergFileContent::POSITION_DELETES) {
             return ORCPositionDeleteBuilder(_fs, _datafile_path)
                     .build(timezone, delete_file.full_path, delete_file.length, _need_skip_rowids);
+        } else if (delete_file.file_content == TIcebergFileContent::EQUALITY_DELETES) {
+            return ORCEqualityDeleteBuilder(_fs, _datafile_path)
+                    .build(timezone, delete_file.full_path, delete_file.length, std::move(hash_joiner),
+                           std::move(slots), state);
         } else {
-            auto s = strings::Substitute("Unsupported iceberg file content: $0", delete_file.file_content);
+            const auto s = strings::Substitute("Unsupported iceberg file content: $0", delete_file.file_content);
             LOG(WARNING) << s;
             return Status::InternalError(s);
         }
     }
 
-    Status build_parquet(const std::string& timezone, const TIcebergDeleteFile& delete_file) {
+    Status build_parquet(const std::string& timezone, const TIcebergDeleteFile& delete_file) const {
         if (delete_file.file_content == TIcebergFileContent::POSITION_DELETES) {
             return ParquetPositionDeleteBuilder(_fs, _datafile_path)
                     .build(timezone, delete_file.full_path, delete_file.length, _need_skip_rowids);

--- a/be/src/exec/iceberg/iceberg_delete_builder.h
+++ b/be/src/exec/iceberg/iceberg_delete_builder.h
@@ -17,7 +17,7 @@
 #include <utility>
 
 #include "common/status.h"
-#include "exec/hash_joiner.h"
+#include "exec/mor_processor.h"
 #include "exec/parquet_scanner.h"
 #include "fs/fs.h"
 #include "gutil/strings/substitute.h"
@@ -41,7 +41,7 @@ public:
     virtual ~EqualityDeleteBuilder() = default;
 
     virtual Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
-                         std::shared_ptr<HashJoiner> hash_joiner, std::vector<SlotDescriptor*> slots,
+                         std::shared_ptr<DefaultMORProcessor> mor_processor, std::vector<SlotDescriptor*> slots,
                          RuntimeState* state) = 0;
 };
 
@@ -52,7 +52,7 @@ public:
     ~ORCEqualityDeleteBuilder() override = default;
 
     Status build(const std::string& timezone, const std::string& file_path, int64_t file_length,
-                 std::shared_ptr<HashJoiner> hash_joiner, std::vector<SlotDescriptor*> slots,
+                 std::shared_ptr<DefaultMORProcessor> mor_processor, std::vector<SlotDescriptor*> slots,
                  RuntimeState* stage) override;
 
 private:
@@ -101,13 +101,13 @@ public:
 
     Status build_orc(const std::string& timezone, const TIcebergDeleteFile& delete_file,
                      const std::vector<SlotDescriptor*>& slots, RuntimeState* state,
-                     std::shared_ptr<HashJoiner> hash_joiner) const {
+                     std::shared_ptr<DefaultMORProcessor> mor_processor) const {
         if (delete_file.file_content == TIcebergFileContent::POSITION_DELETES) {
             return ORCPositionDeleteBuilder(_fs, _datafile_path)
                     .build(timezone, delete_file.full_path, delete_file.length, _need_skip_rowids);
         } else if (delete_file.file_content == TIcebergFileContent::EQUALITY_DELETES) {
             return ORCEqualityDeleteBuilder(_fs, _datafile_path)
-                    .build(timezone, delete_file.full_path, delete_file.length, std::move(hash_joiner),
+                    .build(timezone, delete_file.full_path, delete_file.length, std::move(mor_processor),
                            std::move(slots), state);
         } else {
             const auto s = strings::Substitute("Unsupported iceberg file content: $0", delete_file.file_content);

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -320,6 +320,8 @@ void JoinHashTable::create(const HashTableParam& param) {
     _table_items->with_other_conjunct = param.with_other_conjunct;
     _table_items->join_type = param.join_type;
     _table_items->row_desc = param.row_desc;
+    _table_items->with_external_table_mor = param.with_external_table_mor;
+
     if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN || _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN ||
         _table_items->join_type == TJoinOp::RIGHT_OUTER_JOIN) {
         _table_items->left_to_nullable = true;
@@ -339,9 +341,9 @@ void JoinHashTable::create(const HashTableParam& param) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (param.output_slots.empty() ||
-                std::find(param.output_slots.begin(), param.output_slots.end(), slot->id()) !=
-                        param.output_slots.end() ||
+            if (param.probe_output_slots.empty() ||
+                std::find(param.probe_output_slots.begin(), param.probe_output_slots.end(), slot->id()) !=
+                        param.probe_output_slots.end() ||
                 std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
                         param.predicate_slots.end()) {
                 hash_table_slot.need_output = true;
@@ -359,11 +361,12 @@ void JoinHashTable::create(const HashTableParam& param) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (param.output_slots.empty() ||
-                std::find(param.output_slots.begin(), param.output_slots.end(), slot->id()) !=
-                        param.output_slots.end() ||
-                std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
-                        param.predicate_slots.end()) {
+            if (!param.with_external_table_mor &&
+                (param.build_output_slots.empty() ||
+                 std::find(param.build_output_slots.begin(), param.build_output_slots.end(), slot->id()) !=
+                         param.build_output_slots.end() ||
+                 std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
+                         param.predicate_slots.end())) {
                 hash_table_slot.need_output = true;
             } else {
                 hash_table_slot.need_output = false;
@@ -379,6 +382,27 @@ void JoinHashTable::create(const HashTableParam& param) {
             }
             _table_items->build_chunk->append_column(std::move(column), slot->id());
             _table_items->build_column_count++;
+        }
+    }
+
+    if (param.with_external_table_mor) {
+        for (const auto& build_slot : _table_items->build_slots) {
+            bool found_build_slot = false;
+            for (auto probe_slot : _table_items->probe_slots) {
+                if (probe_slot.slot->id() == build_slot.slot->id()) {
+                    found_build_slot = true;
+                    break;
+                }
+            }
+
+            if (!found_build_slot) {
+                HashTableSlotDescriptor hash_table_slot;
+                hash_table_slot.slot = build_slot.slot;
+                hash_table_slot.need_output = true;
+
+                _table_items->probe_slots.emplace_back(hash_table_slot);
+                _table_items->probe_column_count++;
+            }
         }
     }
 

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -320,7 +320,7 @@ void JoinHashTable::create(const HashTableParam& param) {
     _table_items->with_other_conjunct = param.with_other_conjunct;
     _table_items->join_type = param.join_type;
     _table_items->row_desc = param.row_desc;
-    _table_items->with_external_table_mor = param.with_external_table_mor;
+    _table_items->mor_reader_mode = param.mor_reader_mode;
 
     if (_table_items->join_type == TJoinOp::RIGHT_SEMI_JOIN || _table_items->join_type == TJoinOp::RIGHT_ANTI_JOIN ||
         _table_items->join_type == TJoinOp::RIGHT_OUTER_JOIN) {
@@ -361,7 +361,7 @@ void JoinHashTable::create(const HashTableParam& param) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (!param.with_external_table_mor &&
+            if (!param.mor_reader_mode &&
                 (param.build_output_slots.empty() ||
                  std::find(param.build_output_slots.begin(), param.build_output_slots.end(), slot->id()) !=
                          param.build_output_slots.end() ||
@@ -385,7 +385,7 @@ void JoinHashTable::create(const HashTableParam& param) {
         }
     }
 
-    if (param.with_external_table_mor) {
+    if (param.mor_reader_mode) {
         for (const auto& build_slot : _table_items->build_slots) {
             bool found_build_slot = false;
             for (auto probe_slot : _table_items->probe_slots) {

--- a/be/src/exec/join_hash_map.cpp
+++ b/be/src/exec/join_hash_map.cpp
@@ -361,12 +361,11 @@ void JoinHashTable::create(const HashTableParam& param) {
         for (const auto& slot : tuple_desc->slots()) {
             HashTableSlotDescriptor hash_table_slot;
             hash_table_slot.slot = slot;
-            if (!param.mor_reader_mode &&
-                (param.build_output_slots.empty() ||
-                 std::find(param.build_output_slots.begin(), param.build_output_slots.end(), slot->id()) !=
-                         param.build_output_slots.end() ||
-                 std::find(param.predicate_slots.begin(), param.predicate_slots.end(), slot->id()) !=
-                         param.predicate_slots.end())) {
+            if (!param.mor_reader_mode && (param.build_output_slots.empty() ||
+                                           std::find(param.build_output_slots.begin(), param.build_output_slots.end(),
+                                                     slot->id()) != param.build_output_slots.end() ||
+                                           std::find(param.predicate_slots.begin(), param.predicate_slots.end(),
+                                                     slot->id()) != param.predicate_slots.end())) {
                 hash_table_slot.need_output = true;
             } else {
                 hash_table_slot.need_output = false;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -124,7 +124,7 @@ struct JoinHashTableItems {
     float keys_per_bucket = 0;
     size_t used_buckets = 0;
     bool cache_miss_serious = false;
-    bool with_external_table_mor = false;
+    bool mor_reader_mode = false;
 
     float get_keys_per_bucket() const { return keys_per_bucket; }
     bool ht_cache_miss_serious() const { return cache_miss_serious; }
@@ -266,7 +266,7 @@ struct HashTableParam {
     RuntimeProfile::Counter* search_ht_timer = nullptr;
     RuntimeProfile::Counter* output_build_column_timer = nullptr;
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
-    bool with_external_table_mor = false;
+    bool mor_reader_mode = false;
 };
 
 template <class T>
@@ -562,7 +562,7 @@ private:
     void _build_output(ChunkPtr* chunk) {
         SCOPED_TIMER(_probe_state->output_build_column_timer);
 
-        if (_table_items->with_external_table_mor) {
+        if (_table_items->mor_reader_mode) {
             return;
         }
         bool to_nullable = _table_items->right_to_nullable;

--- a/be/src/exec/join_hash_map.h
+++ b/be/src/exec/join_hash_map.h
@@ -124,6 +124,7 @@ struct JoinHashTableItems {
     float keys_per_bucket = 0;
     size_t used_buckets = 0;
     bool cache_miss_serious = false;
+    bool with_external_table_mor = false;
 
     float get_keys_per_bucket() const { return keys_per_bucket; }
     bool ht_cache_miss_serious() const { return cache_miss_serious; }
@@ -257,13 +258,15 @@ struct HashTableParam {
     const RowDescriptor* row_desc = nullptr;
     const RowDescriptor* build_row_desc = nullptr;
     const RowDescriptor* probe_row_desc = nullptr;
-    std::set<SlotId> output_slots;
+    std::set<SlotId> build_output_slots;
+    std::set<SlotId> probe_output_slots;
     std::set<SlotId> predicate_slots;
     std::vector<JoinKeyDesc> join_keys;
 
     RuntimeProfile::Counter* search_ht_timer = nullptr;
     RuntimeProfile::Counter* output_build_column_timer = nullptr;
     RuntimeProfile::Counter* output_probe_column_timer = nullptr;
+    bool with_external_table_mor = false;
 };
 
 template <class T>
@@ -558,7 +561,12 @@ private:
     }
     void _build_output(ChunkPtr* chunk) {
         SCOPED_TIMER(_probe_state->output_build_column_timer);
+
+        if (_table_items->with_external_table_mor) {
+            return;
+        }
         bool to_nullable = _table_items->right_to_nullable;
+
         for (size_t i = 0; i < _table_items->build_column_count; i++) {
             HashTableSlotDescriptor hash_table_slot = _table_items->build_slots[i];
             SlotDescriptor* slot = hash_table_slot.slot;

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -468,7 +468,7 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         {
             // output default values for build-columns as placeholder.
             SCOPED_TIMER(_probe_state->output_build_column_timer);
-            if (_table_items->with_external_table_mor) {
+            if (_table_items->mor_reader_mode) {
                 return;
             }
 

--- a/be/src/exec/join_hash_map.tpp
+++ b/be/src/exec/join_hash_map.tpp
@@ -468,6 +468,10 @@ void JoinHashMap<LT, BuildFunc, ProbeFunc>::probe(RuntimeState* state, const Col
         {
             // output default values for build-columns as placeholder.
             SCOPED_TIMER(_probe_state->output_build_column_timer);
+            if (_table_items->with_external_table_mor) {
+                return;
+            }
+
             if (!_table_items->with_other_conjunct) {
                 _build_default_output(chunk, _probe_state->count);
             } else {

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -61,7 +61,7 @@ Status IcebergMORProcessor::build_hash_table(RuntimeState* runtime_state) {
     return Status::OK();
 }
 
-Status IcebergMORProcessor::append_chunk_to_ht(ChunkPtr& chunk) {
+Status IcebergMORProcessor::append_chunk_to_hashtable(ChunkPtr& chunk) {
     return _hash_joiner->append_chunk_to_ht(chunk);
 }
 

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -57,19 +57,19 @@ Status IcebergMorProcessor::init(RuntimeState* runtime_state, const HdfsScannerP
 }
 
 Status IcebergMorProcessor::build_hash_table(RuntimeState* runtime_state) {
-        RETURN_IF_ERROR(_hash_joiner->build_ht(runtime_state));
-        _hash_joiner->enter_probe_phase();
-        return Status::OK();
+    RETURN_IF_ERROR(_hash_joiner->build_ht(runtime_state));
+    _hash_joiner->enter_probe_phase();
+    return Status::OK();
 }
 
 Status IcebergMorProcessor::get_next(RuntimeState* state, RuntimeProfile* prorile, ChunkPtr* chunk) {
-        if (!_prepared_probe.load()) {
-            RETURN_IF_ERROR(_hash_joiner->prepare_prober(state, prorile));
-            _prepared_probe.store(true);
-        }
-        RETURN_IF_ERROR(_hash_joiner->push_chunk(state, std::move(*chunk)));
-        *chunk = std::move(_hash_joiner->pull_chunk(state)).value();
-        return Status::OK();
+    if (!_prepared_probe.load()) {
+        RETURN_IF_ERROR(_hash_joiner->prepare_prober(state, prorile));
+        _prepared_probe.store(true);
+    }
+    RETURN_IF_ERROR(_hash_joiner->push_chunk(state, std::move(*chunk)));
+    *chunk = std::move(_hash_joiner->pull_chunk(state)).value();
+    return Status::OK();
 }
 
 void IcebergMorProcessor::close(RuntimeState* runtime_state) {

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "exec/hdfs_scanner.h"
 #include "exec/mor_processor.h"
 
 namespace starrocks {
 
-Status IcebergMorProcessor::init(RuntimeState* runtime_state, const HdfsScannerParams &scanner_params) {
+Status IcebergMORProcessor::init(RuntimeState* runtime_state, const MORParams& params) {
     THashJoinNode hash_join_node;
     hash_join_node.__set_join_op(TJoinOp::LEFT_ANTI_JOIN);
     hash_join_node.__set_distribution_mode(TJoinDistributionMode::PARTITIONED);
@@ -26,11 +25,11 @@ Status IcebergMorProcessor::init(RuntimeState* runtime_state, const HdfsScannerP
     hash_join_node.__set_output_columns(std::vector<SlotId>());
 
     std::set<SlotId> probe_output_slot_ids;
-    for (const auto slot_desc : scanner_params.tuple_desc->slots()) {
+    for (const auto slot_desc : params.tuple_desc->slots()) {
         probe_output_slot_ids.insert(slot_desc->id());
     }
 
-    for (const SlotDescriptor* slot_desc : scanner_params.equality_slots) {
+    for (const SlotDescriptor* slot_desc : params.equality_slots) {
         const auto column_ref = _pool.add(new ColumnRef(slot_desc));
         const auto expr_context = _pool.add(new ExprContext(column_ref));
         _join_exprs.emplace_back(expr_context);
@@ -39,32 +38,36 @@ Status IcebergMorProcessor::init(RuntimeState* runtime_state, const HdfsScannerP
     RETURN_IF_ERROR(Expr::prepare(_join_exprs, runtime_state));
     RETURN_IF_ERROR(Expr::open(_join_exprs, runtime_state));
 
-    _build_row_desc = std::make_unique<RowDescriptor>(
-            runtime_state->desc_tbl().get_tuple_descriptor(scanner_params.mor_tuple_id), false);
-    _probe_row_desc = std::make_unique<RowDescriptor>(scanner_params.tuple_desc, false);
+    _build_row_desc =
+            std::make_unique<RowDescriptor>(runtime_state->desc_tbl().get_tuple_descriptor(params.mor_tuple_id), false);
+    _probe_row_desc = std::make_unique<RowDescriptor>(params.tuple_desc, false);
 
     const auto param = _pool.add(
             new HashJoinerParam(&_pool, hash_join_node, 1, TPlanNodeType::HASH_JOIN_NODE,
-                                std::vector<bool>(scanner_params.equality_slots.size(), false), _join_exprs,
-                                _join_exprs, std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc,
+                                std::vector<bool>(params.equality_slots.size(), false), _join_exprs, _join_exprs,
+                                std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc,
                                 *_probe_row_desc, *_probe_row_desc, TPlanNodeType::HDFS_SCAN_NODE,
                                 TPlanNodeType::HDFS_SCAN_NODE, true, std::list<RuntimeFilterBuildDescriptor*>(),
                                 std::set<SlotId>(), probe_output_slot_ids, TJoinDistributionMode::PARTITIONED, true));
-    _hash_joiner = std::make_shared<HashJoiner>(*param);
 
-    RETURN_IF_ERROR(_hash_joiner->prepare_builder(runtime_state, scanner_params.profile->runtime_profile));
+    _hash_joiner = _pool.add(new HashJoiner(*param));
+    RETURN_IF_ERROR(_hash_joiner->prepare_builder(runtime_state, _runtime_profile));
     return Status::OK();
 }
 
-Status IcebergMorProcessor::build_hash_table(RuntimeState* runtime_state) {
+Status IcebergMORProcessor::build_hash_table(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(_hash_joiner->build_ht(runtime_state));
     _hash_joiner->enter_probe_phase();
     return Status::OK();
 }
 
-Status IcebergMorProcessor::get_next(RuntimeState* state, RuntimeProfile* prorile, ChunkPtr* chunk) {
+Status IcebergMORProcessor::append_chunk_to_ht(ChunkPtr& chunk) {
+    return _hash_joiner->append_chunk_to_ht(chunk);
+}
+
+Status IcebergMORProcessor::get_next(RuntimeState* state, ChunkPtr* chunk) {
     if (!_prepared_probe.load()) {
-        RETURN_IF_ERROR(_hash_joiner->prepare_prober(state, prorile));
+        RETURN_IF_ERROR(_hash_joiner->prepare_prober(state, _runtime_profile));
         _prepared_probe.store(true);
     }
     RETURN_IF_ERROR(_hash_joiner->push_chunk(state, std::move(*chunk)));
@@ -72,7 +75,7 @@ Status IcebergMorProcessor::get_next(RuntimeState* state, RuntimeProfile* proril
     return Status::OK();
 }
 
-void IcebergMorProcessor::close(RuntimeState* runtime_state) {
+void IcebergMORProcessor::close(RuntimeState* runtime_state) {
     if (_hash_joiner) {
         _hash_joiner->enter_eos_phase();
         _hash_joiner->set_prober_finished();
@@ -81,6 +84,4 @@ void IcebergMorProcessor::close(RuntimeState* runtime_state) {
     }
 }
 
-}
-
-
+} // namespace starrocks

--- a/be/src/exec/mor_processor.cpp
+++ b/be/src/exec/mor_processor.cpp
@@ -1,0 +1,86 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/hdfs_scanner.h"
+#include "exec/mor_processor.h"
+
+namespace starrocks {
+
+Status IcebergMorProcessor::init(RuntimeState* runtime_state, const HdfsScannerParams &scanner_params) {
+    THashJoinNode hash_join_node;
+    hash_join_node.__set_join_op(TJoinOp::LEFT_ANTI_JOIN);
+    hash_join_node.__set_distribution_mode(TJoinDistributionMode::PARTITIONED);
+    hash_join_node.__set_is_push_down(false);
+    hash_join_node.__set_build_runtime_filters_from_planner(false);
+    hash_join_node.__set_output_columns(std::vector<SlotId>());
+
+    std::set<SlotId> probe_output_slot_ids;
+    for (const auto slot_desc : scanner_params.tuple_desc->slots()) {
+        probe_output_slot_ids.insert(slot_desc->id());
+    }
+
+    for (const SlotDescriptor* slot_desc : scanner_params.equality_slots) {
+        const auto column_ref = _pool.add(new ColumnRef(slot_desc));
+        const auto expr_context = _pool.add(new ExprContext(column_ref));
+        _join_exprs.emplace_back(expr_context);
+    }
+
+    RETURN_IF_ERROR(Expr::prepare(_join_exprs, runtime_state));
+    RETURN_IF_ERROR(Expr::open(_join_exprs, runtime_state));
+
+    _build_row_desc = std::make_unique<RowDescriptor>(
+            runtime_state->desc_tbl().get_tuple_descriptor(scanner_params.mor_tuple_id), false);
+    _probe_row_desc = std::make_unique<RowDescriptor>(scanner_params.tuple_desc, false);
+
+    const auto param = _pool.add(
+            new HashJoinerParam(&_pool, hash_join_node, 1, TPlanNodeType::HASH_JOIN_NODE,
+                                std::vector<bool>(scanner_params.equality_slots.size(), false), _join_exprs,
+                                _join_exprs, std::vector<ExprContext*>(), std::vector<ExprContext*>(), *_build_row_desc,
+                                *_probe_row_desc, *_probe_row_desc, TPlanNodeType::HDFS_SCAN_NODE,
+                                TPlanNodeType::HDFS_SCAN_NODE, true, std::list<RuntimeFilterBuildDescriptor*>(),
+                                std::set<SlotId>(), probe_output_slot_ids, TJoinDistributionMode::PARTITIONED, true));
+    _hash_joiner = std::make_shared<HashJoiner>(*param);
+
+    RETURN_IF_ERROR(_hash_joiner->prepare_builder(runtime_state, scanner_params.profile->runtime_profile));
+    return Status::OK();
+}
+
+Status IcebergMorProcessor::build_hash_table(RuntimeState* runtime_state) {
+        RETURN_IF_ERROR(_hash_joiner->build_ht(runtime_state));
+        _hash_joiner->enter_probe_phase();
+        return Status::OK();
+}
+
+Status IcebergMorProcessor::get_next(RuntimeState* state, RuntimeProfile* prorile, ChunkPtr* chunk) {
+        if (!_prepared_probe.load()) {
+            RETURN_IF_ERROR(_hash_joiner->prepare_prober(state, prorile));
+            _prepared_probe.store(true);
+        }
+        RETURN_IF_ERROR(_hash_joiner->push_chunk(state, std::move(*chunk)));
+        *chunk = std::move(_hash_joiner->pull_chunk(state)).value();
+        return Status::OK();
+}
+
+void IcebergMorProcessor::close(RuntimeState* runtime_state) {
+    if (_hash_joiner) {
+        _hash_joiner->enter_eos_phase();
+        _hash_joiner->set_prober_finished();
+        _hash_joiner->close(runtime_state);
+        Expr::close(_join_exprs, runtime_state);
+    }
+}
+
+}
+
+

--- a/be/src/exec/mor_processor.h
+++ b/be/src/exec/mor_processor.h
@@ -41,9 +41,8 @@ public:
     virtual void close(RuntimeState* runtime_state) {}
 
     virtual Status build_hash_table(RuntimeState* runtime_state) { return Status::OK(); }
-    virtual Status append_chunk_to_ht(ChunkPtr& chunk) { return Status::OK(); }
+    virtual Status append_chunk_to_hashtable(ChunkPtr& chunk) { return Status::OK(); }
 
-    virtual std::shared_ptr<HashJoiner> hash_joiner() { return nullptr; }
 };
 
 class IcebergMORProcessor final : public DefaultMORProcessor {
@@ -54,8 +53,8 @@ public:
     Status init(RuntimeState* runtime_state, const MORParams& params) override;
     Status get_next(RuntimeState* state, ChunkPtr* chunk) override;
     void close(RuntimeState* runtime_state) override;
-    Status append_chunk_to_ht(ChunkPtr& chunk) override;
     Status build_hash_table(RuntimeState* runtime_state) override;
+    Status append_chunk_to_hashtable(ChunkPtr& chunk) override;
 
 protected:
     std::vector<ExprContext*> _join_exprs;

--- a/be/src/exec/mor_processor.h
+++ b/be/src/exec/mor_processor.h
@@ -1,0 +1,69 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <atomic>
+
+#include "exec/hash_joiner.h"
+#include "exprs/expr_context.h"
+#include "runtime/descriptors.h"
+#include "util/runtime_profile.h"
+
+namespace starrocks {
+
+struct HdfsScannerParams;
+class MorProcessor {
+public:
+    MorProcessor() = default;
+    virtual ~MorProcessor() = default;
+
+    virtual Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) { return Status::OK(); }
+    virtual Status get_next(RuntimeState* state, RuntimeProfile* profile, ChunkPtr* chunk) { return Status::OK(); }
+
+    virtual void close(RuntimeState* runtime_state) { }
+
+    virtual Status build_hash_table(RuntimeState* runtime_state) { return Status::OK(); }
+
+    virtual std::shared_ptr<HashJoiner> hash_joiner() {
+        return nullptr;
+    }
+};
+
+class IcebergMorProcessor final: public MorProcessor {
+public:
+    IcebergMorProcessor() = default;
+    ~IcebergMorProcessor() override = default;
+
+    Status init(RuntimeState* runtime_state, const HdfsScannerParams& scanner_params) override;
+    Status get_next(RuntimeState* state, RuntimeProfile* prifile, ChunkPtr* chunk) override;
+    void close(RuntimeState* runtime_state) override;
+    Status build_hash_table(RuntimeState* runtime_state) override;
+
+    std::shared_ptr<HashJoiner> hash_joiner() override {
+        return _hash_joiner;
+    }
+
+protected:
+    std::vector<ExprContext*> _join_exprs;
+
+private:
+    std::shared_ptr<HashJoiner> _hash_joiner = nullptr;
+    std::unique_ptr<RowDescriptor> _build_row_desc;
+    std::unique_ptr<RowDescriptor> _probe_row_desc;
+    ObjectPool _pool;
+    std::atomic<bool> _prepared_probe = false;
+};
+
+}

--- a/be/src/exec/mor_processor.h
+++ b/be/src/exec/mor_processor.h
@@ -42,7 +42,6 @@ public:
 
     virtual Status build_hash_table(RuntimeState* runtime_state) { return Status::OK(); }
     virtual Status append_chunk_to_hashtable(ChunkPtr& chunk) { return Status::OK(); }
-
 };
 
 class IcebergMORProcessor final : public DefaultMORProcessor {

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -467,7 +467,6 @@ void ChunkHelper::reorder_chunk(const TupleDescriptor& tuple_desc, Chunk* chunk)
 }
 
 void ChunkHelper::reorder_chunk(const std::vector<SlotDescriptor*>& slots, Chunk* chunk) {
-    DCHECK(chunk->columns().size() == slots.size());
     auto reordered_chunk = Chunk();
     auto& original_chunk = (*chunk);
     for (auto slot : slots) {

--- a/be/test/exec/hdfs_scanner_test.cpp
+++ b/be/test/exec/hdfs_scanner_test.cpp
@@ -50,7 +50,7 @@ protected:
     void _create_runtime_state(const std::string& timezone);
     void _create_runtime_profile();
     Status _init_datacache(size_t mem_size, const std::string& engine);
-    HdfsScannerParams* _create_param(const std::string& file, THdfsScanRange* range, const TupleDescriptor* tuple_desc);
+    HdfsScannerParams* _create_param(const std::string& file, THdfsScanRange* range, TupleDescriptor* tuple_desc);
     void build_hive_column_names(HdfsScannerParams* params, const TupleDescriptor* tuple_desc,
                                  bool diff_case_sensitive = false);
 
@@ -106,7 +106,7 @@ THdfsScanRange* HdfsScannerTest::_create_scan_range(const std::string& file, uin
 }
 
 HdfsScannerParams* HdfsScannerTest::_create_param(const std::string& file, THdfsScanRange* range,
-                                                  const TupleDescriptor* tuple_desc) {
+                                                  TupleDescriptor* tuple_desc) {
     auto* param = _pool.add(new HdfsScannerParams());
     auto* lazy_column_coalesce_counter = _pool.add(new std::atomic<int32_t>(0));
     param->fs = FileSystem::Default();

--- a/be/test/exec/join_hash_map_test.cpp
+++ b/be/test/exec/join_hash_map_test.cpp
@@ -1061,8 +1061,10 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFunc) {
     param.row_desc = row_desc.get();
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
-    param.output_slots.emplace(0);
-    param.output_slots.emplace(1);
+    param.build_output_slots.emplace(0);
+    param.build_output_slots.emplace(1);
+    param.probe_output_slots.emplace(0);
+    param.probe_output_slots.emplace(1);
     param.join_keys.emplace_back(JoinKeyDesc{&_tinyint_type, false, nullptr});
     param.search_ht_timer = ADD_TIMER(_runtime_profile, "search_ht");
     param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_build_column");
@@ -1119,8 +1121,10 @@ TEST_F(JoinHashMapTest, DirectMappingJoinBuildProbeFuncNullable) {
     param.row_desc = row_desc.get();
     param.probe_row_desc = probe_row_desc.get();
     param.build_row_desc = build_row_desc.get();
-    param.output_slots.emplace(0);
-    param.output_slots.emplace(1);
+    param.build_output_slots.emplace(0);
+    param.build_output_slots.emplace(1);
+    param.probe_output_slots.emplace(0);
+    param.probe_output_slots.emplace(1);
     param.join_keys.emplace_back(JoinKeyDesc{&_tinyint_type, false, nullptr});
     param.search_ht_timer = ADD_TIMER(_runtime_profile, "search_ht");
     param.output_build_column_timer = ADD_TIMER(_runtime_profile, "output_build_column");

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -403,7 +403,6 @@ public class MetadataMgr {
         return statistics.build();
     }
 
-
     public Statistics getTableStatistics(OptimizerContext session,
                                          String catalogName,
                                          Table table,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1239,8 +1239,9 @@ public class PlanFragmentBuilder {
             // set slot
             prepareContextSlots(node, context, tupleDescriptor);
 
+            TupleDescriptor equalityDeleteTupleDesc = context.getDescTbl().createTupleDescriptor();
             IcebergScanNode icebergScanNode =
-                    new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, "IcebergScanNode");
+                    new IcebergScanNode(context.getNextNodeId(), tupleDescriptor, "IcebergScanNode", equalityDeleteTupleDesc);
             icebergScanNode.computeStatistics(optExpression.getStatistics());
             icebergScanNode.setScanOptimzeOption(node.getScanOptimzeOption());
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
@@ -73,13 +73,30 @@ public class TableTestBase {
     protected static final PartitionSpec SPEC_F =
             PartitionSpec.builderFor(SCHEMA_F).day("dt").build();
 
-
     public static final DataFile FILE_A =
             DataFiles.builder(SPEC_A)
                     .withPath("/path/to/data-a.parquet")
                     .withFileSizeInBytes(10)
                     .withPartitionPath("data_bucket=0") // easy way to set partition data for now
                     .withRecordCount(2)
+                    .build();
+
+    public static DeleteFile FILE_A_DELETES =
+            FileMetadata.deleteFileBuilder(SPEC_A)
+                    .ofPositionDeletes()
+                    .withPath("/path/to/data-a-deletes.parquet")
+                    .withFileSizeInBytes(10)
+                    .withPartitionPath("data_bucket=0") // easy way to set partition data for now
+                    .withRecordCount(1)
+                    .build();
+    // Equality delete files.
+    public static DeleteFile FILE_A2_DELETES =
+            FileMetadata.deleteFileBuilder(SPEC_A)
+                    .ofEqualityDeletes(1)
+                    .withPath("/path/to/data-a2-deletes.parquet")
+                    .withFileSizeInBytes(10)
+                    .withPartitionPath("data_bucket=0")
+                    .withRecordCount(1)
                     .build();
 
     public static final DataFile FILE_A_1 =
@@ -181,7 +198,7 @@ public class TableTestBase {
         tableDir.delete(); // created by table create
 
         this.metadataDir = new File(tableDir, "metadata");
-        this.mockedNativeTableA = create(SCHEMA_A, SPEC_A, "ta", 1);
+        this.mockedNativeTableA = create(SCHEMA_A, SPEC_A, "ta", 2);
         this.mockedNativeTableB = create(SCHEMA_B, SPEC_B, "tb", 1);
         this.mockedNativeTableC = create(SCHEMA_B, SPEC_B, "tc", 2);
         this.mockedNativeTableD = create(SCHEMA_D, SPEC_D, "td", 1);

--- a/gensrc/thrift/PlanNodes.thrift
+++ b/gensrc/thrift/PlanNodes.thrift
@@ -358,6 +358,9 @@ struct THdfsScanRange {
     19: optional bool use_odps_jni_reader
 
     20: optional map<string, string> odps_split_infos
+
+    // delete columns slots like iceberg equality delete column slots
+    21: optional list<Types.TSlotId> delete_column_slot_ids;
 }
 
 struct TBinlogScanRange {
@@ -1049,6 +1052,8 @@ struct THdfsScanNode {
     15: optional bool can_use_min_max_count_opt;
 
     16: optional bool use_partition_column_value_only;
+
+    17: optional Types.TTupleId mor_tuple_id;
 }
 
 struct TProjectNode {


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
Using iceberg delete file to filter data file content.  it's the same as left anti join when left child is datafile and right child is delete file. 

Limitation:
Does not support iceberg equality column schema changes such as add eq column or drop eq column

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
