### PR TITLE
[Enhancement] Select into outfile support binary type

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -95,7 +95,8 @@ public class OutFileClause implements ParseNode {
         PrimitiveType.VARCHAR,
         PrimitiveType.DECIMAL32,
         PrimitiveType.DECIMAL64,
-        PrimitiveType.DECIMAL128
+        PrimitiveType.DECIMAL128,
+        PrimitiveType.VARBINARY
     );
 
     public static final Set<PrimitiveType> CSV_SUPPORTED_PRIMITIVE_TYPES = ImmutableSet.of(

--- a/test/sql/test_sink/R/test_select_into_outfile
+++ b/test/sql/test_sink/R/test_select_into_outfile
@@ -1,0 +1,28 @@
+-- name: test_select_into_outfile
+create table t1 (c1 int, c2 binary);
+-- result:
+-- !result
+insert into t1 select 1, bitmap_to_binary(bitmap_agg(generate_series)) from TABLE(generate_series(1,10));
+-- result:
+-- !result
+select * from t1 into outfile "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/" format as parquet;
+-- result:
+-- !result
+create table t2 (c1 int, c2 binary);
+-- result:
+-- !result
+insert into t2 select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+-- result:
+-- !result
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t2;
+-- result:
+1	1,2,3,4,5,6,7,8,9,10
+-- !result
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null
+-- result:
+0
+
+-- !result

--- a/test/sql/test_sink/T/test_select_into_outfile
+++ b/test/sql/test_sink/T/test_select_into_outfile
@@ -1,0 +1,20 @@
+-- name: test_select_into_outfile
+
+-- src table
+create table t1 (c1 int, c2 binary);
+insert into t1 select 1, bitmap_to_binary(bitmap_agg(generate_series)) from TABLE(generate_series(1,10));
+
+-- output
+select * from t1 into outfile "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/" format as parquet;
+
+-- insert into binary table
+create table t2 (c1 int, c2 binary);
+
+-- input
+insert into t2 select * from files (
+    "path" = "oss://${oss_bucket}/test_sink/test_files_sink/${uuid0}/*",
+    "format" = "parquet"
+);
+select c1, bitmap_to_string(bitmap_from_binary(c2)) from t2;
+
+shell: ossutil64 rm -rf oss://${oss_bucket}/test_sink/test_files_sink/${uuid0} >/dev/null || echo "exit 0" >/dev/null


### PR DESCRIPTION
Why I'm doing:

We expect to use select into outfile to export bitmap, so we need to support binary type.

What I'm doing:

Select into outfile support binary type

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
