### PR TITLE
[WIP][Enhancement] display resource group and disable create default wg

### DIFF
--- a/be/src/exec/workgroup/work_group.cpp
+++ b/be/src/exec/workgroup/work_group.cpp
@@ -593,7 +593,7 @@ std::vector<TWorkGroup> WorkGroupManager::list_workgroups() {
     std::vector<TWorkGroup> alive_workgroups;
     for (auto& [_, wg] : _workgroups) {
         if (wg->version() != WorkGroup::DEFAULT_VERSION) {
-            alive_workgroups.push_back(wg->to_thrift());
+            alive_workgroups.push_back(wg->to_thrift_verbose());
         }
     }
     return alive_workgroups;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -66,10 +66,8 @@ public class ResourceGroup {
         DEFAULT_MV_WG.setId(DEFAULT_MV_WG_ID);
         DEFAULT_MV_WG.setName(DEFAULT_MV_RESOURCE_GROUP_NAME);
         DEFAULT_MV_WG.setResourceGroupType(TWorkGroupType.WG_MV);
-        DEFAULT_MV_WG.setConcurrencyLimit(0);
         DEFAULT_MV_WG.setCpuCoreLimit(BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
         DEFAULT_MV_WG.setMaxCpuCores(BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
-        DEFAULT_MV_WG.setMemLimit(0.8);
     }
 
     public static final ShowResultSetMetaData META_DATA =
@@ -313,6 +311,22 @@ public class ResourceGroup {
             return true;
         }
         return DEFAULT_MV_RESOURCE_GROUP_NAME.equals(rgName);
+    }
+
+    public static void fillDefaultConfig(TWorkGroup twg) {
+        ResourceGroup defaultRg = null;
+        if (twg.getId() == DEFAULT_MV_WG_ID) {
+            defaultRg = DEFAULT_MV_WG;
+        } else if (twg.getId() == DEFAULT_WG_ID) {
+            defaultRg = DEFAULT_WG;
+        }
+        if (defaultRg != null) {
+            defaultRg.setMemLimit(twg.getMem_limit());
+            defaultRg.setConcurrencyLimit(twg.getConcurrency_limit());
+            defaultRg.setCpuCoreLimit(twg.getCpu_core_limit());
+            defaultRg.setMaxCpuCores(twg.getMax_cpu_cores());
+        }
+
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -67,6 +67,9 @@ public class ResourceGroup {
         DEFAULT_MV_WG.setName(DEFAULT_MV_RESOURCE_GROUP_NAME);
         DEFAULT_MV_WG.setResourceGroupType(TWorkGroupType.WG_MV);
         DEFAULT_MV_WG.setConcurrencyLimit(0);
+        DEFAULT_MV_WG.setCpuCoreLimit(BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
+        DEFAULT_MV_WG.setMaxCpuCores(BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
+        DEFAULT_MV_WG.setMemLimit(0.8);
     }
 
     public static final ShowResultSetMetaData META_DATA =

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -308,7 +308,7 @@ public class ResourceGroup {
         this.classifiers = classifiers;
     }
 
-    public static boolean isDefaultWgOrMvWg(String rgName) {
+    public static boolean isDefault(String rgName) {
         if (DEFAULT_RESOURCE_GROUP_NAME.equals(rgName)) {
             return true;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroup.java
@@ -16,6 +16,7 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.qe.ShowResultSetMetaData;
+import com.starrocks.system.BackendCoreStat;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupType;
 
@@ -56,9 +57,16 @@ public class ResourceGroup {
     static {
         DEFAULT_WG.setId(DEFAULT_WG_ID);
         DEFAULT_WG.setName(DEFAULT_RESOURCE_GROUP_NAME);
+        DEFAULT_WG.setResourceGroupType(TWorkGroupType.WG_DEFAULT);
+        DEFAULT_WG.setConcurrencyLimit(0);
+        DEFAULT_WG.setMemLimit(1.0);
+        DEFAULT_WG.setCpuCoreLimit(BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
+        DEFAULT_WG.setMaxCpuCores(BackendCoreStat.getAvgNumOfHardwareCoresOfBe());
 
         DEFAULT_MV_WG.setId(DEFAULT_MV_WG_ID);
         DEFAULT_MV_WG.setName(DEFAULT_MV_RESOURCE_GROUP_NAME);
+        DEFAULT_MV_WG.setResourceGroupType(TWorkGroupType.WG_MV);
+        DEFAULT_MV_WG.setConcurrencyLimit(0);
     }
 
     public static final ShowResultSetMetaData META_DATA =
@@ -111,37 +119,28 @@ public class ResourceGroup {
     private List<String> showClassifier(ResourceGroupClassifier classifier) {
         List<String> row = new ArrayList<>();
         row.add(this.name);
-        row.add("" + this.id);
-        row.add("" + cpuCoreLimit);
-        row.add("" + (memLimit * 100) + "%");
-        row.add("" + maxCpuCores);
-        if (bigQueryCpuSecondLimit != null) {
-            row.add("" + bigQueryCpuSecondLimit);
-        } else {
-            row.add("" + 0);
-        }
-        if (bigQueryScanRowsLimit != null) {
-            row.add("" + bigQueryScanRowsLimit);
-        } else {
-            row.add("" + 0);
-        }
-        if (bigQueryMemLimit != null) {
-            row.add("" + bigQueryMemLimit);
-        } else {
-            row.add("" + 0);
-        }
-        row.add("" + concurrencyLimit);
+        row.add(String.valueOf(this.id));
+        row.add(String.valueOf(cpuCoreLimit));
+        row.add(memLimit == null ?  null : (memLimit * 100) + "%");
+        row.add(String.valueOf(maxCpuCores));
+        row.add(String.valueOf(Objects.requireNonNullElse(bigQueryCpuSecondLimit, 0)));
+        row.add(String.valueOf(Objects.requireNonNullElse(bigQueryScanRowsLimit, 0)));
+        row.add(String.valueOf(Objects.requireNonNullElse(bigQueryMemLimit, 0)));
+        row.add(String.valueOf(concurrencyLimit));
         if (spillMemLimitThreshold != null) {
-            row.add("" + (spillMemLimitThreshold * 100) + "%");
+            row.add((spillMemLimitThreshold * 100) + "%");
         } else {
-            row.add("" + "100%");
+            row.add("100%");
         }
-        row.add("" + resourceGroupType.name().substring("WG_".length()));
+        row.add(resourceGroupType.name().substring("WG_".length()));
         row.add(classifier.toString());
         return row;
     }
 
     public List<List<String>> showVisible(String user, List<String> activeRoles, String ip) {
+        if (classifiers == null) {
+            return Collections.singletonList(new ArrayList<>());
+        }
         return classifiers.stream().filter(c -> c.isVisible(user, activeRoles, ip))
                 .map(this::showClassifier).collect(Collectors.toList());
     }
@@ -155,7 +154,7 @@ public class ResourceGroup {
     }
 
     public List<List<String>> show() {
-        if (classifiers.isEmpty()) {
+        if (classifiers == null || classifiers.isEmpty()) {
             return Collections.singletonList(showClassifier(new ResourceGroupClassifier()));
         }
         return classifiers.stream().map(this::showClassifier).collect(Collectors.toList());
@@ -304,6 +303,13 @@ public class ResourceGroup {
 
     public void setClassifiers(List<ResourceGroupClassifier> classifiers) {
         this.classifiers = classifiers;
+    }
+
+    public static boolean isDefaultWgOrMvWg(String rgName) {
+        if (DEFAULT_RESOURCE_GROUP_NAME.equals(rgName)) {
+            return true;
+        }
+        return DEFAULT_MV_RESOURCE_GROUP_NAME.equals(rgName);
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -505,8 +505,6 @@ public class ResourceGroupMgr implements Writable {
                         (active && twg.getVersion() > activeResourceGroup.get(twg.getId()).getVersion())) {
                     currentResourceGroupOps.add(op);
                 }
-
-                ResourceGroup.fillDefaultConfig(twg);
             }
             return currentResourceGroupOps;
         } finally {
@@ -524,6 +522,7 @@ public class ResourceGroupMgr implements Writable {
                 if (workgroup.getVersion() < minVersion) {
                     minVersion = workgroup.getVersion();
                 }
+                ResourceGroup.fillDefaultConfig(workgroup);
             }
             activeResourceGroupsPerBe.put(beId, workGroupOnBe);
             minVersionPerBe.put(beId, minVersion == Long.MAX_VALUE ? Long.MIN_VALUE : minVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -105,7 +105,7 @@ public class ResourceGroupMgr implements Writable {
         writeLock();
         try {
             ResourceGroup wg = stmt.getResourceGroup();
-            if (ResourceGroup.isDefaultWgOrMvWg(wg.getName())) {
+            if (ResourceGroup.isDefault(wg.getName())) {
                 throw new DdlException(String.format("Can't create resource group named %s, as it's default.", wg.getName()));
             }
             if (resourceGroupMap.containsKey(wg.getName())) {
@@ -323,7 +323,7 @@ public class ResourceGroupMgr implements Writable {
         writeLock();
         try {
             String name = stmt.getName();
-            if (ResourceGroup.isDefaultWgOrMvWg(name)) {
+            if (ResourceGroup.isDefault(name)) {
                 throw new DdlException(String.format("Default resource group %s does not support change.", name));
             }
             if (!resourceGroupMap.containsKey(name)) {
@@ -421,7 +421,7 @@ public class ResourceGroupMgr implements Writable {
         writeLock();
         try {
             String name = stmt.getName();
-            if (ResourceGroup.isDefaultWgOrMvWg(name)) {
+            if (ResourceGroup.isDefault(name)) {
                 throw new DdlException(String.format("Default resource group %s does not support drop.", name));
             }
             if (!resourceGroupMap.containsKey(name)) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -283,11 +283,7 @@ public class ResourceGroupMgr implements Writable {
     public ResourceGroup getResourceGroup(String name) {
         readLock();
         try {
-            if (resourceGroupMap.containsKey(name)) {
-                return resourceGroupMap.get(name);
-            } else {
-                return null;
-            }
+            return resourceGroupMap.getOrDefault(name, null);
         } finally {
             readUnlock();
         }
@@ -509,6 +505,8 @@ public class ResourceGroupMgr implements Writable {
                         (active && twg.getVersion() > activeResourceGroup.get(twg.getId()).getVersion())) {
                     currentResourceGroupOps.add(op);
                 }
+
+                ResourceGroup.fillDefaultConfig(twg);
             }
             return currentResourceGroupOps;
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ResourceGroupMgr.java
@@ -323,7 +323,7 @@ public class ResourceGroupMgr implements Writable {
         writeLock();
         try {
             String name = stmt.getName();
-            if (ResourceGroup.DEFAULT_RESOURCE_GROUP_NAME.equals(name)) {
+            if (ResourceGroup.isDefaultWgOrMvWg(name)) {
                 throw new DdlException(String.format("Default resource group %s does not support change.", name));
             }
             if (!resourceGroupMap.containsKey(name)) {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -218,7 +218,7 @@ public class ResourceGroupStmtTest {
             starRocksAssert.executeResourceGroupDdlSql("DROP RESOURCE GROUP " + name);
         }
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
-        String defaultWg = "default_mv_wg|1|80.0%|1|0|0|0|0|100%|MV|(weight=0.0)\n" +
+        String defaultWg = "default_mv_wg|1|null|1|0|0|0|null|100%|MV|(weight=0.0)\n" +
                 "default_wg|1|100.0%|1|0|0|0|0|100%|DEFAULT|(weight=0.0)";
         Assert.assertFalse(rows.isEmpty());
         Assert.assertEquals(2, rows.size());
@@ -1274,7 +1274,7 @@ public class ResourceGroupStmtTest {
                 "   'type' = 'normal'" +
                 "   );";
         String showResult =
-                "default_mv_wg|1|80.0%|1|0|0|0|0|100%|MV|(weight=0.0)\n" +
+                "default_mv_wg|1|null|1|0|0|0|null|100%|MV|(weight=0.0)\n" +
                         "default_wg|1|100.0%|1|0|0|0|0|100%|DEFAULT|(weight=0.0)\n" +
                         "rg1|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.0, 2.0), plan_mem_cost_range=[-100.0, 1000.0))\n" +
                         "rg2|32|30.0%|null|0|0|0|31|100%|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
@@ -1373,7 +1373,7 @@ public class ResourceGroupStmtTest {
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
         String actual = rowsToString(rows);
         String expected =
-                "default_mv_wg|1|80.0%|1|0|0|0|0|100%|MV|(weight=0.0)\n" +
+                "default_mv_wg|1|null|1|0|0|0|null|100%|MV|(weight=0.0)\n" +
                         "default_wg|1|100.0%|1|0|0|0|0|100%|DEFAULT|(weight=0.0)\n" +
                         "rg1|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
                         "rg2|16|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_cpu_cost_range=[21.0, 22.0))\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -379,7 +379,7 @@ public class ResourceGroupStmtTest {
         }).distinct().collect(Collectors.toList());
         String ids = String.join(",", classifierIds);
         String alterSql = String.format("ALTER RESOURCE GROUP %s DROP (%s)", rgName, ids);
-        if (ResourceGroup.isDefaultWgOrMvWg(rgName)) {
+        if (ResourceGroup.isDefault(rgName)) {
             Assert.assertThrows("Default resource group does default_mv_wg not support change.",
                     DdlException.class, () -> starRocksAssert.executeResourceGroupDdlSql(alterSql));
         } else {
@@ -418,7 +418,7 @@ public class ResourceGroupStmtTest {
             }
             String alterSql = String.format("ALTER RESOURCE GROUP %s DROP (%s)", rgName, id);
 
-            if (ResourceGroup.isDefaultWgOrMvWg(rgName)) {
+            if (ResourceGroup.isDefault(rgName)) {
                 Assert.assertThrows(String.format("Default resource group does %s not support change.", rgName),
                         DdlException.class, () -> starRocksAssert.executeResourceGroupDdlSql(alterSql));
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ResourceGroupStmtTest.java
@@ -219,7 +219,7 @@ public class ResourceGroupStmtTest {
         }
         List<List<String>> rows = starRocksAssert.executeResourceGroupShowSql("show resource groups all");
         String defaultWg = "default_mv_wg|null|null|null|0|0|0|0|100%|MV|(weight=0.0)\n" +
-                "default_wg|null|100.0%|null|0|0|0|0|100%|DEFAULT|(weight=0.0)";
+                "default_wg|1|100.0%|1|0|0|0|0|100%|DEFAULT|(weight=0.0)";
         Assert.assertFalse(rows.isEmpty());
         Assert.assertEquals(2, rows.size());
         Assert.assertEquals(defaultWg, rowsToString(rows));
@@ -1275,7 +1275,7 @@ public class ResourceGroupStmtTest {
                 "   );";
         String showResult =
                 "default_mv_wg|null|null|null|0|0|0|0|100%|MV|(weight=0.0)\n" +
-                        "default_wg|null|100.0%|null|0|0|0|0|100%|DEFAULT|(weight=0.0)\n" +
+                        "default_wg|1|100.0%|1|0|0|0|0|100%|DEFAULT|(weight=0.0)\n" +
                         "rg1|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=3.0, user=rg1_user, plan_cpu_cost_range=[1.0, 2.0), plan_mem_cost_range=[-100.0, 1000.0))\n" +
                         "rg2|32|30.0%|null|0|0|0|31|100%|NORMAL|(weight=2.0, user=rg1_user, plan_mem_cost_range=[0.0, 2000.0))";
 
@@ -1374,7 +1374,7 @@ public class ResourceGroupStmtTest {
         String actual = rowsToString(rows);
         String expected =
                 "default_mv_wg|null|null|null|0|0|0|0|100%|MV|(weight=0.0)\n" +
-                        "default_wg|null|100.0%|null|0|0|0|0|100%|DEFAULT|(weight=0.0)\n" +
+                        "default_wg|1|100.0%|1|0|0|0|0|100%|DEFAULT|(weight=0.0)\n" +
                         "rg1|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=2.0, plan_cpu_cost_range=[11.0, 12.0), plan_mem_cost_range=[-100.0, 11000.0))\n" +
                         "rg2|16|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_cpu_cost_range=[21.0, 22.0))\n" +
                         "rg3|17|20.0%|null|0|0|0|11|100%|NORMAL|(weight=1.0, plan_mem_cost_range=[-100.0, 31000.0))";


### PR DESCRIPTION
Why I'm doing:

We cannot view the default resource group `default_wg` and `default_mv_wg` by executing the command, which is unreasonable. In StarRocks version 3.1.5, we can even create a resource group with the same name as the default resource group.

What I'm doing:
I added two default resource groups to the system so that we can observe these two resource groups when we view them and do not allow users to delete them.

Fixes https://github.com/StarRocks/starrocks/issues/37297

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5