### PR TITLE
[Feature] Add REST API For StarMgr Diagnostic

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -408,7 +408,7 @@ if [ ${BUILD_FE} -eq 1 ] || [ ${BUILD_SPARK_DPP} -eq 1 ] || [ ${BUILD_HIVE_UDF} 
         FE_MODULES="fe-common,hive-udf"
     fi
     if [ ${BUILD_FE} -eq 1 ]; then
-        FE_MODULES="hive-udf,fe-common,spark-dpp,fe-core"
+        FE_MODULES="staros/starclient,hive-udf,fe-common,spark-dpp,fe-core"
     fi
 fi
 

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -41,7 +41,7 @@ under the License.
         <iceberg.version>1.4.2</iceberg.version>
         <awsv2.version>2.17.257</awsv2.version>
         <paimon.version>0.6.0-incubating</paimon.version>
-        <staros.version>3.2-rc6-SNAPSHOT</staros.version>
+        <staros.version>3.2-rc7-SNAPSHOT</staros.version>
         <python>python</python>
     </properties>
 
@@ -754,12 +754,12 @@ under the License.
         <dependency>
             <groupId>com.starrocks</groupId>
             <artifactId>starclient</artifactId>
-            <version>3.2-rc6-SNAPSHOT</version>
+            <version>3.2-rc7-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.starrocks</groupId>
             <artifactId>starmanager</artifactId>
-            <version>3.2-rc6-SNAPSHOT</version>
+            <version>3.2-rc7-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-api -->

--- a/fe/fe-core/pom.xml
+++ b/fe/fe-core/pom.xml
@@ -41,7 +41,7 @@ under the License.
         <iceberg.version>1.4.2</iceberg.version>
         <awsv2.version>2.17.257</awsv2.version>
         <paimon.version>0.6.0-incubating</paimon.version>
-        <staros.version>3.2-rc4</staros.version>
+        <staros.version>3.2-rc6-SNAPSHOT</staros.version>
         <python>python</python>
     </properties>
 
@@ -754,12 +754,12 @@ under the License.
         <dependency>
             <groupId>com.starrocks</groupId>
             <artifactId>starclient</artifactId>
-            <version>${staros.version}</version>
+            <version>3.2-rc6-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.starrocks</groupId>
             <artifactId>starmanager</artifactId>
-            <version>${staros.version}</version>
+            <version>3.2-rc6-SNAPSHOT</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/io.opentelemetry/opentelemetry-api -->

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -82,6 +82,7 @@ import com.starrocks.http.rest.ShowDataAction;
 import com.starrocks.http.rest.ShowMetaInfoAction;
 import com.starrocks.http.rest.ShowProcAction;
 import com.starrocks.http.rest.ShowRuntimeInfoAction;
+import com.starrocks.http.rest.StarManagerHttpServiceAction;
 import com.starrocks.http.rest.StopFeAction;
 import com.starrocks.http.rest.StorageTypeCheckAction;
 import com.starrocks.http.rest.SyncCloudTableMetaAction;
@@ -207,6 +208,9 @@ public class HttpServer {
         TableQueryPlanAction.registerAction(controller);
 
         BootstrapFinishAction.registerAction(controller);
+
+        // starmanager usage
+        StarManagerHttpServiceAction.registerAction(controller);
     }
 
     public void start() {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StarManagerHttpServiceAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StarManagerHttpServiceAction.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.http.rest;
 
-import com.staros.exception.StarException;
 import com.starrocks.common.DdlException;
 import com.starrocks.http.ActionController;
 import com.starrocks.http.BaseRequest;
@@ -28,7 +27,6 @@ import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponse;
-import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.util.CharsetUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -77,19 +75,14 @@ public class StarManagerHttpServiceAction extends RestBaseAction {
             throws DdlException, AccessDeniedException {
         UserIdentity currentUser = ConnectContext.get().getCurrentUserIdentity();
         checkUserOwnsAdminRole(currentUser);
-
-        try {
-            HttpResponse httpResponse = StarMgrServer.getCurrentState().getHttpService().starmgrHttpService(request.getRequest());
-            if (httpResponse instanceof FullHttpResponse) {
-                FullHttpResponse fullResponse = (FullHttpResponse) httpResponse;
-                response.getContent().append(fullResponse.content().toString(CharsetUtil.UTF_8));
-                response.setContentType(httpResponse.headers().get(HttpHeaderNames.CONTENT_TYPE));
-                sendResult(request, response);
-            } else {
-                throw new DdlException("Internal Error");
-            }
-        } catch (StarException e) {
-            writeResponse(request, response, HttpResponseStatus.UNAUTHORIZED);
+        HttpResponse httpResponse = StarMgrServer.getCurrentState().getHttpService().starmgrHttpService(request.getRequest());
+        if (httpResponse instanceof FullHttpResponse) {
+            FullHttpResponse fullResponse = (FullHttpResponse) httpResponse;
+            response.getContent().append(fullResponse.content().toString(CharsetUtil.UTF_8));
+            response.setContentType(httpResponse.headers().get(HttpHeaderNames.CONTENT_TYPE));
+            writeResponse(request, response, httpResponse.status());
+        } else {
+            throw new DdlException("Internal Error");
         }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/StarManagerHttpServiceAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/StarManagerHttpServiceAction.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest;
+
+import com.staros.exception.StarException;
+import com.starrocks.common.DdlException;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.IllegalArgException;
+import com.starrocks.privilege.AccessDeniedException;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.staros.StarMgrServer;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.util.CharsetUtil;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/*
+ * The function is used to retrieve the information of a specific shard by its service info and shard id.
+ * eg:
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/shard/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/shardgroup/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/listshardgroup
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/shardgroup/removereplicas
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/worker/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/workergroup/<id>
+ * fe_host:http_port/api/v1/starmgr/service/<serviceid|servicename>/listworkergroup
+ */
+public class StarManagerHttpServiceAction extends RestBaseAction {
+    private static final Logger LOG = LogManager.getLogger(StarManagerHttpServiceAction.class);
+    protected static final String SERVICE = "service";
+    private static final String ID = "id";
+
+    public StarManagerHttpServiceAction(ActionController controller) {
+        super(controller);
+    }
+
+    public static void registerAction(ActionController controller) throws IllegalArgException {
+        StarManagerHttpServiceAction action = new StarManagerHttpServiceAction(controller);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/shard/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/shardgroup/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/listshardgroup", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/worker/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/workergroup/{" + ID + "}", action);
+        controller.registerHandler(HttpMethod.GET,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/listworkergroup", action);
+
+        controller.registerHandler(HttpMethod.POST,
+                "/api/v1/starmgr/service/{" + SERVICE + "}/shardgroup/{" + ID + "}/removereplicas", action);
+    }
+
+    @Override
+    public void executeWithoutPassword(BaseRequest request, BaseResponse response)
+            throws DdlException, AccessDeniedException {
+        UserIdentity currentUser = ConnectContext.get().getCurrentUserIdentity();
+        checkUserOwnsAdminRole(currentUser);
+
+        try {
+            HttpResponse httpResponse = StarMgrServer.getCurrentState().getHttpService().starmgrHttpService(request.getRequest());
+            if (httpResponse instanceof FullHttpResponse) {
+                FullHttpResponse fullResponse = (FullHttpResponse) httpResponse;
+                response.getContent().append(fullResponse.content().toString(CharsetUtil.UTF_8));
+                response.setContentType(httpResponse.headers().get(HttpHeaderNames.CONTENT_TYPE));
+                sendResult(request, response);
+            } else {
+                throw new DdlException("Internal Error");
+            }
+        } catch (StarException e) {
+            writeResponse(request, response, HttpResponseStatus.UNAUTHORIZED);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/StarMgrServer.java
@@ -15,6 +15,7 @@
 
 package com.starrocks.staros;
 
+import com.staros.manager.HttpService;
 import com.staros.manager.StarManager;
 import com.staros.manager.StarManagerServer;
 import com.starrocks.common.Config;
@@ -102,6 +103,10 @@ public class StarMgrServer {
 
     public StarManager getStarMgr() {
         return starMgrServer.getStarManager();
+    }
+
+    public HttpService getHttpService() {
+        return starMgrServer.getHttpService();
     }
 
     public BDBJEJournalSystem getJournalSystem() {

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarManagerHttpServiceActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarManagerHttpServiceActionTest.java
@@ -1,0 +1,139 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http;
+
+import com.staros.exception.ExceptionCode;
+import com.staros.exception.StarException;
+import com.staros.manager.HttpService;
+import com.staros.manager.StarManager;
+import com.starrocks.common.DdlException;
+import com.starrocks.http.ActionController;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.StarManagerHttpServiceAction;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.staros.StarMgrServer;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpHeaderValues;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class StarManagerHttpServiceActionTest {
+    @Test
+    public void testexecuteWithoutPassword() throws Exception {
+        ActionController controller = new ActionController();
+        StarManagerHttpServiceAction starManagerHttpServiceAction = new StarManagerHttpServiceAction(controller);
+        starManagerHttpServiceAction.registerAction(controller);
+
+        BaseRequest request = new BaseRequest(null, null, null);
+        BaseResponse response = new BaseResponse();
+
+        ConnectContext connectContext = new ConnectContext();
+        UserIdentity userIdentity = new UserIdentity();
+        StarMgrServer starMgrServer = new StarMgrServer();
+        StarManager starManager = new StarManager();
+        HttpService httpService = new HttpService(starManager);
+
+        new MockUp<ConnectContext>() {
+            @Mock
+            public ConnectContext get() {
+                return connectContext;
+            }
+            public UserIdentity getCurrentUserIdentity() {
+                return userIdentity;
+            }
+        };
+        new MockUp<StarMgrServer>() {
+            @Mock
+            public StarMgrServer getCurrentState() {
+                return starMgrServer;
+            }
+            @Mock
+            public HttpService getHttpService() {
+                return httpService;
+            }
+        };
+        new MockUp<StarManagerHttpServiceAction>() {
+            @Mock
+            public void sendResult(BaseRequest request, BaseResponse response) {}
+
+            @Mock
+            void checkUserOwnsAdminRole(UserIdentity currentUser) {}
+
+            @Mock
+            void writeResponse(BaseRequest request, BaseResponse response, HttpResponseStatus status) {}
+        };
+
+        { // normal case
+            new MockUp<HttpService>() {
+                @Mock
+                public HttpResponse starmgrHttpService(HttpRequest request) {
+                    String str = "content";
+                    FullHttpResponse response = new DefaultFullHttpResponse(
+                            HttpVersion.HTTP_1_1,
+                            HttpResponseStatus.OK,
+                            Unpooled.copiedBuffer(str.getBytes()));
+
+                    response.headers().set(HttpHeaderNames.CONTENT_TYPE, HttpHeaderValues.TEXT_PLAIN);
+                    response.headers().set(HttpHeaderNames.CONTENT_LENGTH, response.content().readableBytes());
+                    return response;
+                }
+            };
+            starManagerHttpServiceAction.executeWithoutPassword(request, response);
+        }
+        { // Internal error case
+            new MockUp<HttpService>() {
+                @Mock
+                public HttpResponse starmgrHttpService(HttpRequest request) {
+                    String str = "content";
+                    return new DefaultFullHttpResponse(
+                            HttpVersion.HTTP_1_1,
+                            HttpResponseStatus.OK,
+                            Unpooled.wrappedBuffer(str.getBytes()));
+                }
+            };
+            try {
+                starManagerHttpServiceAction.executeWithoutPassword(request, response);
+            } catch (DdlException e) {
+                Assert.assertEquals(e.getMessage(), "Inernal Error");
+            }
+        }
+        { // StarException error case
+            new MockUp<HttpService>() {
+                @Mock
+                public HttpResponse starmgrHttpService(HttpRequest request) throws StarException {
+                    throw new StarException(ExceptionCode.INVALID_ARGUMENT, "invalid argument");
+                }
+                @Mock
+                void writeResponse(BaseRequest request, BaseResponse response, HttpResponseStatus status) {}
+            };
+            try {
+                starManagerHttpServiceAction.executeWithoutPassword(request, response);
+            } catch (DdlException e) {
+                Assert.assertEquals(e.getMessage(), "Inernal Error");
+            }
+        }
+    }
+}

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -34,6 +34,7 @@ under the License.
         <module>spark-dpp</module>
         <module>fe-core</module>
         <module>hive-udf</module>
+        <module>staros</module>
     </modules>
 
     <name>starrocks-fe</name>

--- a/fe/staros
+++ b/fe/staros
@@ -1,0 +1,1 @@
+/home/disk4/chenshi/staros/


### PR DESCRIPTION
Why I'm doing:
Starrocks currently lacks a scripted way to diagnose StarMgr.

What I'm doing:
Use the FE REST API to encapsulate starmgr's rpc interface and provide a
starmgr diagnostic interface to the outside world. Including:
1. Obtain Shard information
2. Get ShardGroup information
3. Get the serviceID and ShardGroupID of all ShardGroups
4. Get worker information
5. Get WorkerGroup information
6. Get the serviceID and WorkerGroupID of all WorkerGroupIds

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
