### PR TITLE
[BugFix] Fix possible memory leak when using Util#compress (backport #33836)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/Util.java
@@ -64,7 +64,6 @@ import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
 import java.util.zip.Adler32;
-import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 
 public class Util {
@@ -470,8 +469,7 @@ public class Util {
 
     public static byte[] compress(byte[] input) throws IOException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        Deflater deflater = new Deflater();
-        try (DeflaterOutputStream dos = new DeflaterOutputStream(outputStream, deflater)) {
+        try (DeflaterOutputStream dos = new DeflaterOutputStream(outputStream)) {
             dos.write(input);
         }
         return outputStream.toByteArray();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergScanNode.java
@@ -206,9 +206,7 @@ public class IcebergScanNode extends ScanNode {
         return result;
     }
 
-    public static BiMap<Integer, PartitionField> getIdentityPartitions(PartitionSpec partitionSpec)
-    {
-
+    public static BiMap<Integer, PartitionField> getIdentityPartitions(PartitionSpec partitionSpec) {
         // TODO: expose transform information in Iceberg library
         BiMap<Integer, PartitionField> columns = HashBiMap.create();
         if (!ConnectContext.get().getSessionVariable().getEnableIcebergIdentityColumnOptimize()) {


### PR DESCRIPTION
For java.util.zip.DeflaterOutputStream, if the usesDefaultDeflater flag is true, the DeflaterOutputStream close method closes the deflator. However, by default, this flag is false, and it will only become true when you create a DeflaterOutputStream object using one of the following:
java.util.zip.DeflaterOutputStream#DeflaterOutputStream(java.io.OutputStream, boolean) java.util.zip.DeflaterOutputStream#DeflaterOutputStream(java.io.OutputStream)

refs:

https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/util/zip/DeflaterOutputStream.java https://docs.oracle.com/javase/8/docs/api/java/util/zip/Deflater.html#end tests:

Existing tests

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

