### PR TITLE
[Enhancement] Querying for non-existing partitions should report an error (backport #36950)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Table.java
@@ -530,6 +530,9 @@ public class Table extends MetaObject implements Writable, GsonPostProcessable {
     public Partition getPartition(String partitionName) {
         return null;
     }
+    public Partition getPartition(String partitionName, boolean isTempPartition) {
+        return null;
+    }
 
     public Partition getPartition(long partitionId) {
         return null;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeSingleTest.java
@@ -69,7 +69,7 @@ public class AnalyzeSingleTest {
         analyzeFail("select error from t0");
         analyzeFail("select v1 from t_error");
 
-        analyzeSuccess("select v1 from t0 temporary partition(t1,t2)");
+        analyzeFail("select v1 from t0 temporary partition(t1,t2)");
         analyzeFail("SELECT v1,v2,v3 FROM t0 INTO OUTFILE \"hdfs://path/to/result_\""
                 + "FORMAT AS PARQUET PROPERTIES" +
                 "(\"broker.name\" = \"my_broker\"," +


### PR DESCRIPTION
Why I'm doing:
Mysql will report an error if you query a non-existent partition.
![image](https://github.com/StarRocks/starrocks/assets/4392280/b4f73a3e-e038-4470-9d65-9af9a077232d)

What I'm doing:
We should behave the same as mysql. It is more reasonable to report an error rather than not reporting an error.

Fixes #36950

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [x] 3.0
  - [x] 2.5

