### PR TITLE
[Refactor] Initialize _max_buffer_row to the maximum value.

### DIFF
--- a/be/src/storage/memtable.h
+++ b/be/src/storage/memtable.h
@@ -111,7 +111,7 @@ private:
 
     int64_t _max_buffer_size = config::write_buffer_size;
     // initial value is max size
-    size_t _max_buffer_row = -1;
+    size_t _max_buffer_row = std::numeric_limits<size_t>::max();
     size_t _total_rows = 0;
     size_t _merged_rows = 0;
 


### PR DESCRIPTION
Why I'm doing:

The initial value of `_max_buffer_row` is max value and we assign -1 to it which is poor readability. 

What I'm doing:

Initialize _max_buffer_row to the maximum value to make it more easy to read.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
