### PR TITLE
[Enhancement] Convert like predicate to binary predicate when it didn't contains any wildcard

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -31,6 +31,7 @@ import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.InPredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.LambdaFunctionOperator;
+import com.starrocks.sql.optimizer.operator.scalar.LikePredicateOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.SubqueryOperator;
 import com.starrocks.sql.optimizer.rewrite.EliminateNegationsRewriter;
@@ -350,6 +351,35 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return simplifiedDateTrunc(call);
         }
         return call;
+    }
+
+    @Override
+    public ScalarOperator visitLikePredicateOperator(LikePredicateOperator predicate,
+                                                     ScalarOperatorRewriteContext context) {
+        // make sure is like, not regexp
+        if (predicate.getLikeType() != LikePredicateOperator.LikeType.LIKE) {
+            return predicate;
+        }
+
+        ScalarOperator rightOp = predicate.getChild(1);
+
+        // make sure is constant column ref
+        if (!rightOp.isConstantRef()) {
+            return predicate;
+        }
+
+        // make sure is string literal
+        if (rightOp.getType() != Type.VARCHAR && rightOp.getType() != Type.CHAR) {
+            return predicate;
+        }
+
+        // make sure didn't contain '%' and '_' both
+        String likeString =  ((ConstantOperator) predicate.getChild(1)).getVarchar();
+        if (likeString.contains("%") || likeString.contains("_")) {
+            return predicate;
+        }
+
+        return new BinaryPredicateOperator(BinaryType.EQ, predicate.getChild(0), rightOp);
     }
 
     // reduce `date_sub(date_add(x, 1), 2)` -> `date_sub(x, 1)`

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -373,7 +373,7 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
             return predicate;
         }
 
-        // make sure didn't contain '%' and '_' both
+        // make sure it didn't contain '%' and '_' both
         String likeString =  ((ConstantOperator) predicate.getChild(1)).getVarchar();
         if (likeString.contains("%") || likeString.contains("_")) {
             return predicate;

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/MockedHiveMetadata.java
@@ -1092,7 +1092,7 @@ public class MockedHiveMetadata implements ConnectorMetadata {
                         "", false, -1, null, Lists.newArrayList(), Lists.newArrayList(),
                         Maps.newHashMap());
         Table lineItemPar = new Table("single_partition_table", MOCKED_DATACACHE_DB, null, 0, 0, 0, sd,
-                ImmutableList.of(new FieldSchema("l_shipdate", "Date", null)), Maps.newHashMap(),
+                ImmutableList.of(new FieldSchema("l_shipdate", "string", null)), Maps.newHashMap(),
                 null, null, "EXTERNAL_TABLE");
 
         Column partitionColumn1 = new Column("l_shipdate", Type.DATE);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
@@ -173,10 +173,4 @@ public class DataCachePlanTest extends PlanTestBase {
                 "where l_shipdate>='1998-01-03'";
         assertPlanContains(sql, "BLACKHOLE TABLE SINK");
     }
-
-    @Test
-    public void testLikeInPartitionColumn() throws Exception {
-        String sql = "select * from hive0.datacache_db.single_partition_table where l_shipdate LIKE '1998-01-03'";
-        assertPlanContains(sql, "partitions=1/1");
-    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DataCachePlanTest.java
@@ -173,4 +173,10 @@ public class DataCachePlanTest extends PlanTestBase {
                 "where l_shipdate>='1998-01-03'";
         assertPlanContains(sql, "BLACKHOLE TABLE SINK");
     }
+
+    @Test
+    public void testLikeInPartitionColumn() throws Exception {
+        String sql = "select * from hive0.datacache_db.single_partition_table where l_shipdate LIKE '1998-01-03'";
+        assertPlanContains(sql, "partitions=1/1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/HivePartitionPruneTest.java
@@ -173,4 +173,10 @@ public class HivePartitionPruneTest extends ConnectorPlanTestBase {
         Assert.assertFalse(node0.getScanNodePredicates().getSelectedPartitionIds().equals(
                 node1.getScanNodePredicates().getSelectedPartitionIds()));
     }
+
+    @Test
+    public void testLikeInPartitionColumn() throws Exception {
+        String sql = "select * from hive0.datacache_db.single_partition_table where l_shipdate LIKE '1998-01-03'";
+        assertPlanContains(sql, "partitions=1/1");
+    }
 }


### PR DESCRIPTION
Why I'm doing:
Some people will write sql `select * from table where dt like '2019-01-01'`, this will cause our partition prune failed.

What I'm doing:
When like string didn't contains `%` and `_`, just convert it to `=`.

We will convert SQL `select * from table where dt like '2019-01-01'` to `select * from table where dt = '2019-01-01'`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
