### PR TITLE
[BugFix] fix ScanNode::_mem_limit when query_mem_limit is 0

### DIFF
--- a/be/src/exec/scan_node.cpp
+++ b/be/src/exec/scan_node.cpp
@@ -34,6 +34,7 @@
 
 #include "exec/scan_node.h"
 
+#include "exec/pipeline/query_context.h"
 #include "exec/pipeline/scan/morsel.h"
 
 namespace starrocks {
@@ -59,7 +60,11 @@ Status ScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (options.__isset.scan_use_query_mem_ratio) {
         mem_ratio = options.scan_use_query_mem_ratio;
     }
-    if (runtime_state()->query_mem_tracker_ptr()) {
+    if (runtime_state()->query_ctx()) {
+        // Used in pipeline-engine
+        _mem_limit = state->query_ctx()->get_static_query_mem_limit() * mem_ratio;
+    } else if (runtime_state()->query_mem_tracker_ptr()) {
+        // Fallback in non-pipeline
         _mem_limit = state->query_mem_tracker_ptr()->limit() * mem_ratio;
     }
     return Status::OK();


### PR DESCRIPTION
Why I'm doing:
- Previous PR #34120 ignore the `exec_mem_limit`, which also means `query_mem_limit` will dominate the query
- So when `query_mem_limit` is 0, the `ScanNode::_mem_limit` will also be 0, so the ChunkBuffer would be 1
- The scan performance would be affected if the ChunkBuffer is too small

What I'm doing:
- Use the physical limit of Query to calculate ChunkBuffer
- So the calculated result may be different from `exec_mem_limit`: previous is 2GB, and right now is physical limit

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
