### PR TITLE
[Enhancement] Support to configure the number of http worker threads on FE

### DIFF
--- a/docs/en/administration/FE_configuration.md
+++ b/docs/en/administration/FE_configuration.md
@@ -1016,6 +1016,12 @@ This section provides an overview of the static parameters that you can configur
 - **Default:** 8030
 - **Description:** The port on which the HTTP server in the FE node listens.
 
+#### http_worker_threads_num
+
+- **Default:** 0
+- **Description:** Number of worker threads for http server to deal with http requests. For a non-positive value, the number of threads will be twice the number of cpu cores.
+- Introduced in: 2.5.18，3.0.10，3.1.7，3.2.2
+
 #### http_backlog_num
 
 - **Default:** 1024

--- a/docs/en/administration/FE_configuration.md
+++ b/docs/en/administration/FE_configuration.md
@@ -1019,7 +1019,7 @@ This section provides an overview of the static parameters that you can configur
 #### http_worker_threads_num
 
 - **Default:** 0
-- **Description:** Number of worker threads for http server to deal with http requests. For a non-positive value, the number of threads will be twice the number of cpu cores.
+- **Description:** Number of worker threads for http server to deal with http requests. For a negative or 0 value, the number of threads will be twice the number of cpu cores.
 - Introduced in: 2.5.18，3.0.10，3.1.7，3.2.2
 
 #### http_backlog_num

--- a/docs/zh/administration/FE_configuration.md
+++ b/docs/zh/administration/FE_configuration.md
@@ -935,6 +935,12 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 - 含义：FE 节点上 HTTP 服务器的端口。
 - 默认值：8030
 
+#### http_worker_threads_num
+
+- 含义：Http Server 用于处理 HTTP 请求的线程数。如果配置为非正数，线程数将设置为 CPU 核数的 2 倍。
+- 默认值：0
+- 引入版本：2.5.18，3.0.10，3.1.7，3.2.2
+
 #### http_backlog_num
 
 - 含义：HTTP 服务器支持的 Backlog 队列长度。

--- a/docs/zh/administration/FE_configuration.md
+++ b/docs/zh/administration/FE_configuration.md
@@ -937,7 +937,7 @@ Compaction Score 代表了一个表分区是否值得进行 Compaction 的评分
 
 #### http_worker_threads_num
 
-- 含义：Http Server 用于处理 HTTP 请求的线程数。如果配置为非正数，线程数将设置为 CPU 核数的 2 倍。
+- 含义：Http Server 用于处理 HTTP 请求的线程数。如果配置为负数或 0 ，线程数将设置为 CPU 核数的 2 倍。
 - 默认值：0
 - 引入版本：2.5.18，3.0.10，3.1.7，3.2.2
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -593,6 +593,17 @@ public class Config extends ConfigBase {
     public static int http_port = 8030;
 
     /**
+     * Number of worker threads for http server to deal with http requests which may do
+     * some I/O operations. If set with a non-positive value, it will use netty's default
+     * value <code>DEFAULT_EVENT_LOOP_THREADS</code> which is availableProcessors * 2. The
+     * default value is 0 which is same as the previous behaviour.
+     * See <a href="https://github.com/netty/netty/blob/netty-4.1.16.Final/transport/src/main/java/io/netty/channel/MultithreadEventLoopGroup.java#L40">DEFAULT_EVENT_LOOP_THREADS</a>
+     * for details.
+     */
+    @ConfField
+    public static int http_worker_threads_num = 0;
+
+    /**
      * The backlog_num for netty http server
      * When you enlarge this backlog_num, you should ensure its value larger than
      * the linux /proc/sys/net/core/somaxconn config

--- a/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/HttpServer.java
@@ -257,7 +257,8 @@ public class HttpServer {
         public void run() {
             // Configure the server.
             EventLoopGroup bossGroup = new NioEventLoopGroup();
-            EventLoopGroup workerGroup = new NioEventLoopGroup();
+            int numWorkerThreads = Math.max(0, Config.http_worker_threads_num);
+            EventLoopGroup workerGroup = new NioEventLoopGroup(numWorkerThreads);
             try {
                 serverBootstrap = new ServerBootstrap();
                 serverBootstrap.option(ChannelOption.SO_BACKLOG, Config.http_backlog_num);


### PR DESCRIPTION
Why I'm doing:
Http worker threads on FE are used to deal with http requests.  Some requests may do heavy operations which will block threads, such as transaction stream load commit, and other operations that need to get lock. As a result, http server can't deal with other requests.  Before optimizing these heavy operations, we first make the number of http worker threads to be configurable, and increase it as a candidate solution if the problem happens.

What I'm doing:
Add a configuration to adjust the number of http worker threads on FE

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5