### PR TITLE
[Feature] Support more specific error message (backport #34484)

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -225,7 +225,7 @@ void run_create_tablet_task(const std::shared_ptr<CreateTabletAgentTaskRequest>&
                      << ", signature: " << agent_task_req->signature;
         status_code = TStatusCode::RUNTIME_ERROR;
         if (tablet_type == TTabletType::TABLET_TYPE_LAKE) {
-            error_msgs.emplace_back("create tablet failed");
+            error_msgs.emplace_back(create_status.to_string(false));
         } else {
             error_msgs.emplace_back("create tablet " + create_status.get_error_msg());
         }

--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -226,14 +226,20 @@ std::string Status::code_as_string() const {
     return {};
 }
 
-std::string Status::to_string() const {
+std::string Status::to_string(bool with_context_info) const {
     std::string result(code_as_string());
     if (_state == nullptr) {
         return result;
     }
 
     result.append(": ");
-    Slice msg = detailed_message();
+    Slice msg;
+    if (with_context_info) {
+        msg = detailed_message();
+    } else {
+        msg = message();
+    }
+
     result.append(reinterpret_cast<const char*>(msg.data), msg.size);
     return result;
 }

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -207,7 +207,7 @@ public:
 
     /// @return A string representation of this status suitable for printing.
     ///   Returns the string "OK" for success.
-    std::string to_string() const;
+    std::string to_string(bool with_context_info = true) const;
 
     /// @return A string representation of the status code, without the message
     ///   text or sub code information.

--- a/be/test/common/status_test.cpp
+++ b/be/test/common/status_test.cpp
@@ -107,24 +107,32 @@ TEST_F(StatusTest, ErrorWithContext) {
     ASSERT_EQ("123", st.message());
     ASSERT_EQ("123", st.detailed_message());
     ASSERT_EQ("Internal error: 123", st.to_string());
+    ASSERT_EQ("Internal error: 123", st.to_string(true));
+    ASSERT_EQ("Internal error: 123", st.to_string(false));
 
     Status st1 = st.clone_and_append_context("a.cpp", 10, "expr1");
     ASSERT_EQ("123", st1.get_error_msg());
     ASSERT_EQ("123", st1.message());
     ASSERT_EQ("123\na.cpp:10 expr1", st1.detailed_message());
     ASSERT_EQ("Internal error: 123\na.cpp:10 expr1", st1.to_string());
+    ASSERT_EQ("Internal error: 123\na.cpp:10 expr1", st1.to_string(true));
+    ASSERT_EQ("Internal error: 123", st1.to_string(false));
 
     Status st2 = st1.clone_and_append_context("b.cpp", 11, "expr2");
     ASSERT_EQ("123", st2.get_error_msg());
     ASSERT_EQ("123", st2.message());
     ASSERT_EQ("123\na.cpp:10 expr1\nb.cpp:11 expr2", st2.detailed_message());
     ASSERT_EQ("Internal error: 123\na.cpp:10 expr1\nb.cpp:11 expr2", st2.to_string());
+    ASSERT_EQ("Internal error: 123\na.cpp:10 expr1\nb.cpp:11 expr2", st2.to_string(true));
+    ASSERT_EQ("Internal error: 123", st2.to_string(false));
 
     Status st3 = st2.clone_and_append_context("c.cpp", 13, "expr3");
     ASSERT_EQ("123", st3.get_error_msg());
     ASSERT_EQ("123", st3.message());
     ASSERT_EQ("123\na.cpp:10 expr1\nb.cpp:11 expr2\nc.cpp:13 expr3", st3.detailed_message());
     ASSERT_EQ("Internal error: 123\na.cpp:10 expr1\nb.cpp:11 expr2\nc.cpp:13 expr3", st3.to_string());
+    ASSERT_EQ("Internal error: 123\na.cpp:10 expr1\nb.cpp:11 expr2\nc.cpp:13 expr3", st3.to_string(true));
+    ASSERT_EQ("Internal error: 123", st3.to_string(false));
 }
 
 TEST_F(StatusTest, LongContext) {


### PR DESCRIPTION
1. Add a parameter to Starrocks::Status::to_string to control whether the status information it outputs has context.
2. When tablet creation fails, return the error message from be to the user client through Starrocks::Status::to_string.

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
