### PR TITLE
[BugFix] Fix meta error throw exeception when miss meta block, introduced by #37390

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1550,8 +1550,9 @@ public class GlobalStateMgr {
             loadHeader(dis);
             while (true) {
                 SRMetaBlockReader reader = new SRMetaBlockReader(dis);
+                SRMetaBlockID srMetaBlockID = reader.getHeader().getSrMetaBlockID();
+
                 try {
-                    SRMetaBlockID srMetaBlockID = reader.getHeader().getSrMetaBlockID();
                     SRMetaBlockLoader imageLoader = loadImages.get(srMetaBlockID);
                     if (imageLoader == null) {
                         /*
@@ -1573,6 +1574,7 @@ public class GlobalStateMgr {
                     /*
                      * The number of json expected to be read is more than the number of json actually stored in the image
                      */
+                    metaMgrMustExists.remove(srMetaBlockID);
                     LOG.warn("Got EOF exception, ignore, ", srMetaBlockEOFException);
                 } finally {
                     reader.close();
@@ -1580,8 +1582,9 @@ public class GlobalStateMgr {
             }
         } catch (EOFException exception) {
             if (!metaMgrMustExists.isEmpty()) {
-                throw new IOException("Load meta block failed, miss meta block [" +
-                        Joiner.on(",").join(new ArrayList<>(metaMgrMustExists)) + "]");
+                LOG.warn("Miss meta block [" + Joiner.on(",").join(new ArrayList<>(metaMgrMustExists)) + "], " +
+                        "This may not be a fatal error. It may be because there are new features in the version " +
+                        "you upgraded this time, but there is no relevant metadata.");
             } else {
                 LOG.info("Load meta-image EOF, successful loading all requires meta module");
             }
@@ -1591,8 +1594,7 @@ public class GlobalStateMgr {
         }
 
         if (isUsingNewPrivilege() && needUpgradedToNewPrivilege() && !isLeader() && !isCheckpointThread()) {
-            LOG.warn(
-                    "follower has to wait for leader to upgrade the privileges, set usingNewPrivilege = false for now");
+            LOG.warn("follower has to wait for leader to upgrade the privileges, set usingNewPrivilege = false for now");
             usingNewPrivilege.set(false);
             domainResolver = new DomainResolver(auth);
         }


### PR DESCRIPTION
Why I'm doing:
#37390 introduce a bug, If you upgrade from a lower version to a higher version, the necessary meta block may not exist in the meta images. In this case, an exception cannot be thrown because this is a normal situation.
What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
