### PR TITLE
[Enhancement] Print hint message for waiting globalStateMgr to be ready

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1221,15 +1221,15 @@ public class GlobalStateMgr {
 
             if (System.currentTimeMillis() - waitStartTime > printHintTimeInterval * printHintCnt) {
                 printHintCnt++;
-                LOG.warn("It took too much time to get ready, there are some reasons: \n" +
-                        "1. There are too many BDB logs to replay, because the failure of checkpoint. \n" +
-                        "2. More than half of the followers in the cluster are not started. \n" +
-                        "3. There are multiple IPs on the machine, " +
+                LOG.warn("It took too much time to get ready, there are some reasons: " +
+                        "1. There are too many BDB logs to replay, because the failure of checkpoint. " +
+                        "2. More than half of the followers in the cluster are not started. " +
+                        "3. There are multiple IPs on the machine, or ip has changed, " +
                         "you should specify the priority_networks to use the IP from image/ROLE, " +
-                        "ignore this reason if you are using FQDN. \n" +
+                        "ignore this reason if you are using FQDN. " +
                         "4. The time deviation between machines is greater than 5s, " +
-                        "please use ntp or other tools to synchronize clock. \n" +
-                        "5. The configuration of edit_log_port is changed, please reset to the original value. \n" +
+                        "please use ntp or other tools to synchronize clock. " +
+                        "5. The configuration of edit_log_port is changed, please reset to the original value. " +
                         "6. The thread of replayer is blocked, please use jstack to find the details");
             }
         }

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1221,7 +1221,7 @@ public class GlobalStateMgr {
 
             if (System.currentTimeMillis() - waitStartTime > printHintTimeInterval * printHintCnt) {
                 printHintCnt++;
-                LOG.warn("It took too much time to get ready, there are some reasons: \n " +
+                LOG.warn("It took too much time to get ready, there are some reasons: \n" +
                         "1. There are too many BDB logs to replay, because the failure of checkpoint. \n" +
                         "2. More than half of the followers in the cluster are not started. \n" +
                         "3. There are multiple IPs on the machine, " +


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
Print hint message for waiting globalStateMgr to be ready.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
