### PR TITLE
[BugFix] Reset thread local ConnectContext for each materialized view's refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -126,9 +126,10 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
     // 5. update the source table version map if refresh task completes successfully
     @Override
     public void processTaskRun(TaskRunContext context) throws Exception {
+        prepare(context);
+
         ConnectContext connectContext = context.getCtx();
         try {
-            prepare(context);
             doMvRefresh(context);
             connectContext.getState().setOk();
         } catch (Throwable e) {

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -148,6 +148,12 @@ public class TaskRun implements Comparable<TaskRun> {
         runCtx.getState().reset();
         runCtx.setQueryId(UUID.fromString(status.getQueryId()));
 
+        // NOTE: Ensure the thread local connect context is always the same with the newest ConnectContext.
+        // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
+        runCtx.setThreadLocalInfo();
+        LOG.info("start to execute task run, task_id:{}, query_id:{}, thread_local_query_id:{}",
+                taskId, runCtx.getQueryId(), ConnectContext.get() == null ? "" : ConnectContext.get().getQueryId());
+
         Map<String, String> newProperties = refreshTaskProperties(runCtx);
         properties.putAll(newProperties);
         Map<String, String> taskRunContextProperties = Maps.newHashMap();
@@ -169,6 +175,8 @@ public class TaskRun implements Comparable<TaskRun> {
         taskRunContext.setTaskType(type);
         processor.processTaskRun(taskRunContext);
         QueryState queryState = runCtx.getState();
+        LOG.info("finished to execute task run, task_id:{}, query_id:{}, query_state:{}",
+                taskId, runCtx.getQueryId(), queryState);
         if (runCtx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
             status.setErrorMessage(queryState.getErrorMessage());
             int errorCode = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -4,6 +4,7 @@ package com.starrocks.scheduler;
 
 import com.starrocks.common.Config;
 import com.starrocks.common.ThreadPoolManager;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.scheduler.persist.TaskRunStatus;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -45,6 +46,8 @@ public class TaskRunExecutor {
                 status.setErrorCode(-1);
                 status.setErrorMessage(ex.toString());
             } finally {
+                // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
+                ConnectContext.remove();
                 status.setFinishTime(System.currentTimeMillis());
             }
             return status.getState();

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -87,6 +87,8 @@ public class MetadataMgr {
             String queryId = ConnectContext.get() != null && ConnectContext.get().getQueryId() != null ?
                     ConnectContext.get().getQueryId().toString() : null;
             if (queryId != null) {
+                LOG.info("Succeed to register query level connector metadata [catalog:{}, queryId: {}]",
+                        catalogName, queryId);
                 QueryMetadatas queryMetadatas = metadataCacheByQueryId.getUnchecked(queryId);
                 return Optional.ofNullable(queryMetadatas.getConnectorMetadata(catalogName, queryId));
             } else {
@@ -95,6 +97,8 @@ public class MetadataMgr {
                     LOG.error("Failed to get {} catalog", catalogName);
                     return Optional.empty();
                 } else {
+                    LOG.info("Succeed to register query level connector metadata [catalog:{}, queryId: {}]",
+                            catalogName, queryId);
                     return Optional.of(connector.getMetadata());
                 }
             }
@@ -106,6 +110,7 @@ public class MetadataMgr {
                 ConnectContext.get().getQueryId().toString() : null;
         if (queryId != null) {
             metadataCacheByQueryId.invalidate(queryId);
+            LOG.info("Succeed to deregister query level connector metadata on query id: {}", queryId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -9,6 +9,7 @@ import com.starrocks.common.Config;
 import com.starrocks.planner.PlanFragment;
 import com.starrocks.planner.ResultSink;
 import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.analyzer.Analyzer;
 import com.starrocks.sql.analyzer.AnalyzerUtils;
 import com.starrocks.sql.analyzer.PrivilegeChecker;
@@ -86,6 +87,7 @@ public class StatementPlanner {
             if (needWholePhaseLock) {
                 unLock(dbs);
             }
+            GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
         }
         return null;
     }


### PR DESCRIPTION
Why I'm doing:

If Hive table has been updated, but now MV cannot been refreshed automaticlly.

This is because 
1. TaskRun will use the same query id to get Hive's metadata from query level cache because of the same query id.
2. But `PartitionBasedMvRefreshProcessor` only reset the thread local cache after there are new partitions to refresh.

```
2023-12-21 17:00:00,810 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():174] finished to execute task run, task_id:12019, query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35, query_state:OK
2023-12-21 17:01:00,286 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:757f1451-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:02:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:99425a55-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:03:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:bd05a056-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:04:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:e0c8e66f-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:05:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:048c2c70-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:06:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:284f7272-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:07:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:4c12b873-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:08:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:6fd5fe75-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:09:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:93994476-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
```
What I'm doing:
- Reset the thread local ConnectContext after ConnectContext is created.
- Add more logs to track this.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

