### PR TITLE
[Feature] support prune flat json on plan

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -202,11 +202,13 @@ public class FunctionSet {
     public static final String JSON_OBJECT = "json_object";
     public static final String PARSE_JSON = "parse_json";
     public static final String JSON_QUERY = "json_query";
-    public static final String JSON_EXIST = "json_exists";
+    public static final String JSON_EXISTS = "json_exists";
     public static final String JSON_EACH = "json_each";
     public static final String GET_JSON_DOUBLE = "get_json_double";
     public static final String GET_JSON_INT = "get_json_int";
     public static final String GET_JSON_STRING = "get_json_string";
+    public static final String GET_JSON_OBJECT = "get_json_object";
+    public static final String JSON_LENGTH = "json_length";
 
     // Matching functions:
     public static final String ILIKE = "ilike";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -297,6 +297,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
     public static final String CBO_DEBUG_ALIVE_BACKEND_NUMBER = "cbo_debug_alive_backend_number";
     public static final String CBO_PRUNE_SUBFIELD = "cbo_prune_subfield";
+    public static final String CBO_PRUNE_JSON_SUBFIELD = "cbo_prune_json_subfield";
     public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL =
             "enable_rewrite_groupingsets_to_union_all";
 
@@ -830,6 +831,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = CBO_PRUNE_SUBFIELD, flag = VariableMgr.INVISIBLE)
     private boolean cboPruneSubfield = true;
+
+    @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD, flag = VariableMgr.INVISIBLE)
+    private boolean cboPruneJsonSubfield = false;
 
     @VarAttr(name = ENABLE_SQL_DIGEST, flag = VariableMgr.INVISIBLE)
     private boolean enableSQLDigest = false;
@@ -2772,6 +2776,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setCboPruneSubfield(boolean cboPruneSubfield) {
         this.cboPruneSubfield = cboPruneSubfield;
+    }
+
+    public boolean isCboPruneJsonSubfield() {
+        return cboPruneJsonSubfield;
+    }
+
+    public void setCboPruneJsonSubfield(boolean cboPruneJsonSubfield) {
+        this.cboPruneJsonSubfield = cboPruneJsonSubfield;
     }
 
     public int getScanOrToUnionLimit() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -837,7 +837,7 @@ public class ExpressionAnalyzer {
 
             List<Expr> queryExpressions = Lists.newArrayList();
             node.collect(arg -> arg instanceof Subquery, queryExpressions);
-            if (queryExpressions.size() > 0 && node.getChildren().size() > 2) {
+            if (!queryExpressions.isEmpty() && node.getChildren().size() > 2) {
                 throw new SemanticException("In Predicate only support literal expression list", node.getPos());
             }
 
@@ -852,7 +852,7 @@ public class ExpressionAnalyzer {
 
             for (Expr child : node.getChildren()) {
                 Type type = child.getType();
-                if (type.isJsonType() && queryExpressions.size() > 0) { // TODO: enable it after support join on JSON
+                if (type.isJsonType() && !queryExpressions.isEmpty()) { // TODO: enable it after support join on JSON
                     throw new SemanticException("In predicate of JSON does not support subquery", child.getPos());
                 }
                 if (!Type.canCastTo(type, compatibleType)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -20,21 +20,30 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.thrift.TAccessPathType;
+import org.apache.commons.lang.text.StrTokenizer;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /*
  * normalize expression to ColumnAccessPath
  */
 public class SubfieldAccessPathNormalizer {
+    private static final int JSON_FLATTEN_DEPTH = 3;
+    // simple json patten, same as BE's JsonPathPiece, match: abc[1][2], group: (abc)([1][2])
+    private static final Pattern JSON_ARRAY_PATTEN = Pattern.compile("^([\\w#.]*)((?:\\[[\\d:*]+])*)");
+
     private final Deque<AccessPath> allAccessPaths = Lists.newLinkedList();
 
     private static class AccessPath {
@@ -113,7 +122,7 @@ public class SubfieldAccessPathNormalizer {
         @Override
         public Optional<AccessPath> visitVariableReference(ColumnRefOperator variable,
                                                            List<Optional<AccessPath>> childrenAccessPaths) {
-            if (variable.getType().isComplexType()) {
+            if (variable.getType().isComplexType() || variable.getType().isJsonType()) {
                 return Optional.of(new AccessPath(variable));
             }
             return Optional.empty();
@@ -129,7 +138,7 @@ public class SubfieldAccessPathNormalizer {
         public Optional<AccessPath> visitCollectionElement(CollectionElementOperator collectionElementOp,
                                                            List<Optional<AccessPath>> childrenAccessPaths) {
             Optional<AccessPath> parent = childrenAccessPaths.get(0);
-            if (!parent.isPresent()) {
+            if (parent.isEmpty()) {
                 return Optional.empty();
             }
 
@@ -154,9 +163,61 @@ public class SubfieldAccessPathNormalizer {
                     || FunctionSet.ARRAY_LENGTH.equals(call.getFnName())) {
                 return childrenAccessPaths.get(0)
                         .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.OFFSET));
+            } else if (PruneSubfieldRule.SUPPORT_JSON_FUNCTIONS.contains(call.getFnName())
+                    && call.getArguments().size() > 1 && call.getArguments().get(1).isConstantRef()) {
+
+                String path = ((ConstantOperator) call.getArguments().get(1)).getVarchar();
+                // we flatten whole json path, and control the query hierarchy dynamically through BE-self
+                return childrenAccessPaths.get(0).map(p -> p.appendFieldNames(formatJsonPath(path)));
             }
 
             return Optional.empty();
+        }
+
+        // format json path, same as BE's JsonPathPiece, just supported simple path for prune subfield
+        // split char: .
+        // escape char: \
+        // quota char: "
+        //
+        // eg.
+        //  $.a.b -> [a, b]
+        //  $.a[0].b -> [a, b] -- don't support array index
+        //  $."a.b".c -> ["a.b", c]
+        //  $.a#b.c -> [a#b, c]
+        //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
+        // when meet some unsupported path, return null
+        public static List<String> formatJsonPath(String path) {
+            if (path.contains("..")) {
+                // .. is recursive search in json path, not supported
+                return Collections.emptyList();
+            }
+            StrTokenizer tokenizer = new StrTokenizer(path, '.', '"');
+            String[] tokens = tokenizer.getTokenArray();
+
+            if (tokens.length < 1 || !"$".equals(tokens[0])) {
+                return Collections.emptyList();
+            }
+            int size = Math.min(tokens.length, JSON_FLATTEN_DEPTH);
+            List<String> result = Lists.newArrayList();
+            for (int i = 1; i < size; i++) {
+                if (tokens[i].contains(".")) {
+                    result.add("\"" + tokens[i] + "\"");
+                    continue;
+                }
+                // unsupported path, should stop match
+                Matcher matcher = JSON_ARRAY_PATTEN.matcher(tokens[i]);
+                if (!matcher.matches()) {
+                    break;
+                }
+                // only extract name, don't needed index
+                String name = matcher.group(1);
+                result.add(name);
+                if (tokens[i].replaceFirst(name, "").contains("[")) {
+                    // can't support flatten array index
+                    break;
+                }
+            }
+            return result;
         }
 
         private Optional<AccessPath> process(ScalarOperator scalarOperator, Deque<AccessPath> accessPaths) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -87,12 +87,28 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
+
+        starRocksAssert.withTable("CREATE TABLE `js0` (\n" +
+                "  `v1` bigint NULL, \n" +
+                "  `j1` JSON NULL, \n" +
+                "  `st1` struct<j1 Json, j2 Json> NULL, \n" +
+                "  `ar1` Array<Json> NULL, \n" +
+                "  `mp1` map<Int, Json> NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
     }
 
     @Before
     public void setUp() {
         super.setUp();
         connectContext.getSessionVariable().setCboPruneSubfield(true);
+        connectContext.getSessionVariable().setCboPruneJsonSubfield(true);
         connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
         connectContext.getSessionVariable().setCboCteReuse(true);
@@ -103,6 +119,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     public void tearDown() {
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setCboPruneSubfield(false);
+        connectContext.getSessionVariable().setCboPruneJsonSubfield(false);
         connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
         connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
@@ -366,7 +383,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "st5.ss3.s32[false]");
         assertContains(plan, "st3.sa3[false]");
     }
-    
+
     @Test
     public void testCTEInlinePruneColumn() throws Exception {
         String sql =
@@ -726,7 +743,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     }
 
 
-
     @Test
     public void testForceReuseCTE1() throws Exception {
         String sql = "with cte1 as (select array_map((x -> uuid()), t.a1) c1, t.map1 c2 from pc0 t) " +
@@ -834,5 +850,101 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String sql = "select ass[1].a, ass[1].b from tt;";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "[/ass/INDEX/a, /ass/INDEX/b]");
+    }
+
+    @Test
+    public void testJsonPruneNormal() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$.a.b.c'), " +
+                "get_json_string(j1, '$.\"a.b.c\".e.f.g'), " +
+                "json_query(j1, '$.a1.b1.c1'), " +
+                "json_exists(j1, '$.a2.b2.c2'), " +
+                "json_length(j1, '$.a3.b3[1].c3') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b.c\"/e, /j1/a/b, /j1/a1/b1, /j1/a2/b2, /j1/a3/b3]");
+    }
+
+    @Test
+    public void testJsonPathMerge() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$.a.b.c1'), " +
+                "JSON_EXISTS(j1, '$.a.b.c2'), " +
+                "json_length(j1, '$.a.b2.c1'), " +
+                "json_length(j1, '$.a.b2.c3') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b, /j1/a/b2]");
+
+        sql = "select " +
+                "get_json_int(j1, '$.a.b[1].c1'), " +
+                "JSON_EXISTS(j1, '$.a.b[2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[2:2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[*].c2'), " +
+                "JSON_EXISTS(j1, '$.\"a.b[*]\".c2'), " +
+                "JSON_EXISTS(j1, '$.\"a.b[*]\".c2[1]'), " +
+                "JSON_EXISTS(j1, '$.\"a.b[*]\".c2[2].a') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b[*]\"/c2, /j1/a/b]");
+    }
+
+    @Test
+    public void testJsonArrayPat() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$.a[2].b[1].c1'), " +
+                "JSON_EXISTS(j1, '$.a[3].b[2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[2:2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[*].c2') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a]");
+    }
+
+    @Test
+    public void testJsonErrorPath() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$asdfsdf') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "get_json_int(j1, '$.\"a.\"b[*]\"') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b[*]\"]");
+
+        sql = "select " +
+                "get_json_int(j1, 'asd') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "JSON_EXISTS(j1, '$.a.b.c2'), " +
+                "get_json_int(j1, 'asd') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "get_json_int(j1, '$.a.b.c1'), " +
+                "json_length(j1, '$.*') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "json_length(j1, '$.*') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "json_length(j1, '$..abbb[3]') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
     }
 }

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -190,6 +190,8 @@ message ColumnMetaPB {
     optional uint64 total_mem_footprint = 31;
     // for json column only
     optional JsonMetaPB json_meta = 32;
+    // for json flat column only
+    optional bytes name = 33;
 }
 
 message SegmentFooterPB {

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -190,8 +190,6 @@ message ColumnMetaPB {
     optional uint64 total_mem_footprint = 31;
     // for json column only
     optional JsonMetaPB json_meta = 32;
-    // for json flat column only
-    optional bytes name = 33;
 }
 
 message SegmentFooterPB {


### PR DESCRIPTION
Why I'm doing:
After flatten the JSON on BE's storage,  FE plan is needed to determine which subcolumns to select

What I'm doing:
for special JSON functions with JSON_PATH (e.g. get_json_xx, json_length....), supports using JSON_PATH to prune the flat-sub-column of JSON

This PR only includes changes on the FE Plan; and the flat JSON implementation on the BE is in another PR https://github.com/StarRocks/starrocks/pull/37577

* reuse semi-type's framework
* to compute the ColumnAccessPath base on json functions, BE will use the ColumnAccessPath to select the flat-sub-column of JSON 

```
MySQL x11> explain verbose select get_json_int(j1, '$.c') from js1;
+------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                     |
+------------------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                                         |
|                                                                                                                                    |
| PLAN FRAGMENT 0(F01)                                                                                                               |
|   Output Exprs:5: get_json_int                                                                                                     |
|   Input Partition: UNPARTITIONED                                                                                                   |
|   RESULT SINK                                                                                                                      |
|                                                                                                                                    |
|   2:EXCHANGE                                                                                                                       |
|      cardinality: 1                                                                                                                |
|                                                                                                                                    |
| PLAN FRAGMENT 1(F00)                                                                                                               |
|                                                                                                                                    |
|   Input Partition: RANDOM                                                                                                          |
|   OutPut Partition: UNPARTITIONED                                                                                                  |
|   OutPut Exchange Id: 02                                                                                                           |
|                                                                                                                                    |
|   1:Project                                                                                                                        |
|   |  output columns:                                                                                                               |
|   |  5 <-> get_json_int[([3: j1, JSON, true], '$.c'); args: JSON,VARCHAR; result: INT; args nullable: true; result nullable: true] |
|   |  cardinality: 1                                                                                                                |
|   |                                                                                                                                |
|   0:OlapScanNode                                                                                                                   |
|      table: js1, rollup: js1                                                                                                       |
|      preAggregation: on                                                                                                            |
|      partitionsRatio=1/1, tabletsRatio=10/10                                                                                       |
|      tabletList=7477510,7477512,7477514,7477516,7477518,7477520,7477522,7477524,7477526,7477528                                    |
|      actualRows=1, avgRowSize=1025.0                                                                                               |
|      ColumnAccessPath: [/j1/c]                                                                                                     |
|      cardinality: 1                                                                                                                |
+------------------------------------------------------------------------------------------------------------------------------------+
29 rows in set
Time: 0.014s

```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
