### PR TITLE
[Tool] Add merged label when backport pr merged

### DIFF
--- a/.github/workflows/ci-merged.yml
+++ b/.github/workflows/ci-merged.yml
@@ -166,3 +166,27 @@ jobs:
           fi
           
           gh run list --workflow ${yaml} -R ${REPO} -b ${GITHUB_HEAD_REF} --json databaseId -q '.[].databaseId' | xargs gh run cancel -R ${REPO} || true
+
+  update_backport_merged_msg:
+    runs-on: ubuntu-latest
+    if: >
+      github.base_ref != 'main' && github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.title, '(backport #' &&
+      !contains(github.event.pull_request.labels.*.name, 'sync')
+    env:
+      LABEL: ${{ github.base_ref }}-merged
+    steps:
+      - name: prepare label
+        env:
+          GH_TOKEN: ${{ secrets.PAT }}
+        run: |
+          gh label create ${LABEL} -R ${GITHUB_REPOSITORY} -c 98C1D7 -f
+
+      - name: commit_sha
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ORI_PR=$(echo "${{ github.event.pull_request.title }}" | grep -oP '\(backport #\K\d+' | tail -n 1)
+          gh pr edit ${ORI_PR} -R ${GITHUB_REPOSITORY} --add-label "${BRANCH}-merged"
+          

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -55,7 +55,7 @@ jobs:
           ORI_PR=$(echo "${{ github.event.pull_request.title }}" | grep -oP '\(backport #\K\d+' | tail -n 1)
           author=$(gh pr view ${ORI_PR} -R ${REPO} --json author -q '.author.login')
           if [[ ! "${author}" =~ "mergify" ]]; then
-            gh pr edit ${PR_NUMBER} -R ${REPO} --add-assignee ${author}
+            gh pr edit ${PR_NUMBER} -R ${REPO} --add-assignee ${author} || true
             echo "ORI_PR=${ORI_PR}" >> $GITHUB_OUTPUT
           fi
 
@@ -103,6 +103,17 @@ jobs:
             echo "::error::Backport PR title is not valid. It should end with '(backport #[0-9]+)'"
             exit 1
           fi
+
+      - name: update body
+        if: >
+          github.base_ref != 'main' && github.event.action != 'opened' &&
+          !contains(github.event.pull_request.title, 'Revert') &&
+          !contains(toJson(github.event.pull_request.body), '[x] This is a backport pr') &&
+          !contains(toJson(github.event.pull_request.body), '[ ] This is a backport pr')
+
+        run: |
+          echo "::error::Branch PR does not contain the backport option!"
+          exit 1
 
   backport-check:
     needs: title-check


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
