### PR TITLE
[Feature] support flat json

### DIFF
--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -23,6 +23,7 @@
 #include "common/compiler_util.h"
 #include "glog/logging.h"
 #include "gutil/casts.h"
+#include "simd/simd.h"
 #include "util/hash_util.hpp"
 #include "util/mysql_row_buffer.h"
 
@@ -224,6 +225,13 @@ void JsonColumn::append_default(size_t count) {
         }
     } else {
         SuperClass::append_default(count);
+    }
+}
+
+void JsonColumn::resize(size_t n) {
+    BaseClass::resize(n);
+    for (auto& col : _flat_columns) {
+        col->resize(n);
     }
 }
 

--- a/be/src/column/json_column.cpp
+++ b/be/src/column/json_column.cpp
@@ -14,14 +14,21 @@
 
 #include "column/json_column.h"
 
+#include <sstream>
+
+#include "column/bytes.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/compiler_util.h"
 #include "glog/logging.h"
+#include "gutil/casts.h"
 #include "util/hash_util.hpp"
 #include "util/mysql_row_buffer.h"
 
 namespace starrocks {
 
 void JsonColumn::append_datum(const Datum& datum) {
-    append(datum.get<JsonValue*>());
+    BaseClass::append(datum.get<JsonValue*>());
 }
 
 int JsonColumn::compare_at(size_t left_idx, size_t right_idx, const starrocks::Column& rhs,
@@ -51,7 +58,21 @@ void JsonColumn::put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx
 }
 
 std::string JsonColumn::debug_item(size_t idx) const {
-    return get_object(idx)->to_string_uncheck();
+    if (is_flat_json()) {
+        std::ostringstream ss;
+        ss << "{";
+        size_t i = 0;
+        for (; i < _flat_column_paths.size() - i; i++) {
+            ss << _flat_column_paths[i] << ": ";
+            ss << get_flat_field(i)->debug_item(idx) << ", ";
+        }
+        ss << _flat_column_paths[i] << ": ";
+        ss << get_flat_field(i)->debug_item(idx);
+        ss << "}";
+        return ss.str();
+    } else {
+        return get_object(idx)->to_string_uncheck();
+    }
 }
 
 std::string JsonColumn::get_name() const {
@@ -59,15 +80,38 @@ std::string JsonColumn::get_name() const {
 }
 
 MutableColumnPtr JsonColumn::clone() const {
-    return BaseClass::clone();
+    if (this->is_flat_json()) {
+        auto p = this->create_mutable();
+        p->_flat_column_paths = this->_flat_column_paths;
+        for (auto& f : this->_flat_columns) {
+            p->_flat_columns.emplace_back(f->clone());
+        }
+        return p;
+    } else {
+        return BaseClass::clone();
+    }
 }
 
 MutableColumnPtr JsonColumn::clone_empty() const {
-    return this->create_mutable();
+    auto p = this->create_mutable();
+    p->_flat_column_paths = this->_flat_column_paths;
+    for (auto& f : this->_flat_columns) {
+        p->_flat_columns.emplace_back(f->clone_empty());
+    }
+    return p;
 }
 
 ColumnPtr JsonColumn::clone_shared() const {
-    return BaseClass::clone_shared();
+    if (this->is_flat_json()) {
+        auto p = this->create_mutable();
+        p->_flat_column_paths = this->_flat_column_paths;
+        for (auto& f : this->_flat_columns) {
+            p->_flat_columns.emplace_back(f->clone_shared());
+        }
+        return p;
+    } else {
+        return BaseClass::clone_shared();
+    }
 }
 
 const uint8_t* JsonColumn::deserialize_and_append(const uint8_t* data) {
@@ -92,4 +136,233 @@ void JsonColumn::serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, si
     }
 }
 
+ColumnPtr& JsonColumn::get_flat_field(const std::string& path) {
+    for (size_t i = 0; i < _flat_column_paths.size(); i++) {
+        if (path == _flat_column_paths[i]) {
+            return _flat_columns[i];
+        }
+    }
+    DCHECK(false) << "Json path: " << path << " not found!";
+    return _flat_columns[0];
+}
+
+const ColumnPtr& JsonColumn::get_flat_field(const std::string& path) const {
+    for (size_t i = 0; i < _flat_column_paths.size(); i++) {
+        if (path == _flat_column_paths[i]) {
+            return _flat_columns[i];
+        }
+    }
+    DCHECK(false) << "Json path: " << path << " not found!";
+    return _flat_columns[0];
+}
+
+ColumnPtr& JsonColumn::get_flat_field(int index) {
+    DCHECK(index < _flat_columns.size());
+    return _flat_columns[index];
+}
+
+const ColumnPtr& JsonColumn::get_flat_field(int index) const {
+    DCHECK(index < _flat_columns.size());
+    return _flat_columns[index];
+}
+
+void JsonColumn::init_flat_columns(const std::vector<std::string>& paths) {
+    if (_flat_column_paths.empty()) {
+        _flat_column_paths.insert(_flat_column_paths.cbegin(), paths.cbegin(), paths.cend());
+        for (size_t i = 0; i < _flat_column_paths.size(); i++) {
+            // nullable column
+            _flat_columns.emplace_back(NullableColumn::create(JsonColumn::create(), NullColumn::create()));
+        }
+    } else {
+        DCHECK(_flat_column_paths.size() == paths.size());
+        DCHECK(_flat_columns.size() == paths.size());
+        for (size_t i = 0; i < _flat_column_paths.size(); i++) {
+            DCHECK(_flat_column_paths[i] == paths[i]);
+        }
+    }
+}
+
+// json column & flat column used
+size_t JsonColumn::size() const {
+    if (is_flat_json()) {
+        return _flat_columns[0]->size();
+    } else {
+        return SuperClass::size();
+    }
+}
+
+size_t JsonColumn::capacity() const {
+    size_t s = SuperClass::capacity();
+    for (const auto& col : _flat_columns) {
+        s += col->capacity();
+    }
+    return s;
+}
+
+size_t JsonColumn::byte_size(size_t from, size_t size) const {
+    size_t s = SuperClass::byte_size(from, size);
+    for (const auto& col : _flat_columns) {
+        s += col->byte_size(from, size);
+    }
+    return s;
+}
+
+void JsonColumn::append_value_multiple_times(const void* value, size_t count) {
+    // JSON doesn't support default now
+    DCHECK(!is_flat_json());
+    return SuperClass::append_value_multiple_times(value, count);
+}
+
+void JsonColumn::append_default() {
+    if (is_flat_json()) {
+        for (auto& col : _flat_columns) {
+            col->append_default();
+        }
+    } else {
+        SuperClass::append_default();
+    }
+}
+
+void JsonColumn::append_default(size_t count) {
+    if (is_flat_json()) {
+        for (auto& col : _flat_columns) {
+            col->append_default(count);
+        }
+    } else {
+        SuperClass::append_default(count);
+    }
+}
+
+void JsonColumn::assign(size_t n, size_t idx) {
+    BaseClass::assign(n, idx);
+    for (auto& col : _flat_columns) {
+        col->assign(n, idx);
+    }
+}
+
+void JsonColumn::append(const JsonValue* object) {
+    BaseClass::append(object);
+}
+
+void JsonColumn::append(JsonValue&& object) {
+    BaseClass::append(object);
+}
+
+void JsonColumn::append(const JsonValue& object) {
+    BaseClass::append(object);
+}
+
+void JsonColumn::append(const Column& src, size_t offset, size_t count) {
+    const auto* other_json = down_cast<const JsonColumn*>(&src);
+    if (other_json->is_flat_json() && !is_flat_json()) {
+        // only hit in AggregateIterator (Aggregate mode in storage)
+        DCHECK_EQ(0, this->size());
+        init_flat_columns(other_json->_flat_column_paths);
+    }
+
+    if (is_flat_json()) {
+        DCHECK(src.is_object());
+        DCHECK(_flat_column_paths.size() == other_json->_flat_columns.size());
+        DCHECK(_flat_columns.size() == other_json->_flat_column_paths.size());
+
+        for (size_t i = 0; i < _flat_columns.size(); i++) {
+            DCHECK_EQ(_flat_column_paths[i], other_json->_flat_column_paths[i]);
+            _flat_columns[i]->append(*other_json->get_flat_field(i), offset, count);
+        }
+    } else {
+        SuperClass::append(src, offset, count);
+    }
+}
+
+size_t JsonColumn::filter_range(const Filter& filter, size_t from, size_t to) {
+    if (is_flat_json()) {
+        for (auto& col : _flat_columns) {
+            col->filter_range(filter, from, to);
+        }
+    } else {
+        SuperClass::filter_range(filter, from, to);
+    }
+    return 0;
+}
+
+size_t JsonColumn::container_memory_usage() const {
+    size_t s = SuperClass::container_memory_usage();
+    for (const auto& col : _flat_columns) {
+        s += col->container_memory_usage();
+    }
+    return s;
+}
+
+size_t JsonColumn::reference_memory_usage() const {
+    size_t s = SuperClass::reference_memory_usage();
+    for (const auto& col : _flat_columns) {
+        s += col->reference_memory_usage();
+    }
+    return s;
+}
+
+size_t JsonColumn::reference_memory_usage(size_t from, size_t size) const {
+    size_t s = SuperClass::reference_memory_usage(from, size);
+    for (const auto& col : _flat_columns) {
+        s += col->reference_memory_usage(from, size);
+    }
+    return s;
+}
+
+void JsonColumn::swap_column(Column& rhs) {
+    SuperClass::swap_column(rhs);
+    JsonColumn& json_column = down_cast<JsonColumn&>(rhs);
+    std::swap(_flat_column_paths, json_column._flat_column_paths);
+    std::swap(_flat_columns, json_column._flat_columns);
+}
+
+void JsonColumn::reset_column() {
+    SuperClass::reset_column();
+    _flat_column_paths.clear();
+    _flat_columns.clear();
+}
+
+bool JsonColumn::capacity_limit_reached(std::string* msg) const {
+    if (size() > Column::MAX_CAPACITY_LIMIT) {
+        if (msg != nullptr) {
+            msg->append("row count of object column exceed the limit: " + std::to_string(Column::MAX_CAPACITY_LIMIT));
+        }
+        return true;
+    }
+    return false;
+}
+
+void JsonColumn::check_or_die() const {
+    DCHECK(_flat_column_paths.size() == _flat_columns.size());
+    if (!_flat_columns.empty()) {
+        size_t rows = _flat_columns[0]->size();
+        for (size_t i = 0; i < _flat_columns.size(); i++) {
+            DCHECK(_flat_columns[i]->is_nullable());
+            DCHECK(_flat_columns[i]->size() == rows);
+            _flat_columns[i]->check_or_die();
+        }
+    }
+}
+
+bool JsonColumn::has_flat_column(const std::string& path) const {
+    for (const auto& p : _flat_column_paths) {
+        if (p == path) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::string JsonColumn::debug_flat_paths() const {
+    if (_flat_column_paths.empty()) {
+        return "[]";
+    }
+    std::ostringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < _flat_column_paths.size() - 1; i++) {
+        ss << _flat_column_paths[i] << ", ";
+    }
+    ss << _flat_column_paths.back() << "]";
+    return ss.str();
+}
 } // namespace starrocks

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -62,6 +62,8 @@ public:
     size_t capacity() const override;
     size_t byte_size(size_t from, size_t size) const override;
 
+    void resize(size_t n) override;
+
     void assign(size_t n, size_t idx) override;
 
     void append(const JsonValue* object);

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -35,10 +35,7 @@ public:
 
     JsonColumn() = default;
     explicit JsonColumn(size_t size) : SuperClass(size) {}
-    JsonColumn(const JsonColumn& rhs) : SuperClass(rhs) {
-        _flat_columns = std::move(rhs._flat_columns);
-        _flat_column_paths = std::move(rhs._flat_column_paths);
-    }
+    JsonColumn(const JsonColumn& rhs) : SuperClass(rhs) {}
 
     JsonColumn(JsonColumn&& rhs) noexcept : SuperClass(std::move(rhs)) {
         _flat_columns = std::move(rhs._flat_columns);
@@ -123,6 +120,7 @@ private:
 
     // flat-column paths
     std::vector<std::string> _flat_column_paths;
+    std::unordered_map<std::string, int> _path_to_index;
 };
 
 } // namespace starrocks

--- a/be/src/column/json_column.h
+++ b/be/src/column/json_column.h
@@ -14,6 +14,9 @@
 
 #pragma once
 
+#include <unordered_map>
+#include <utility>
+
 #include "column/column.h"
 #include "column/object_column.h"
 #include "column/vectorized_fwd.h"
@@ -32,17 +35,22 @@ public:
 
     JsonColumn() = default;
     explicit JsonColumn(size_t size) : SuperClass(size) {}
-    JsonColumn(const JsonColumn& rhs) : SuperClass(rhs) {}
+    JsonColumn(const JsonColumn& rhs) : SuperClass(rhs) {
+        _flat_columns = std::move(rhs._flat_columns);
+        _flat_column_paths = std::move(rhs._flat_column_paths);
+    }
+
+    JsonColumn(JsonColumn&& rhs) noexcept : SuperClass(std::move(rhs)) {
+        _flat_columns = std::move(rhs._flat_columns);
+        _flat_column_paths = std::move(rhs._flat_column_paths);
+    }
 
     MutableColumnPtr clone() const override;
     MutableColumnPtr clone_empty() const override;
     ColumnPtr clone_shared() const override;
 
     void append_datum(const Datum& datum) override;
-    int compare_at(size_t left, size_t right, const starrocks::Column& rhs, int nan_direction_hint) const override;
-    void fnv_hash(uint32_t* hash, uint32_t from, uint32_t to) const override;
     void put_mysql_row_buffer(starrocks::MysqlRowBuffer* buf, size_t idx) const override;
-    std::string debug_item(size_t idx) const override;
     std::string get_name() const override;
 
     const uint8_t* deserialize_and_append(const uint8_t* pos) override;
@@ -50,6 +58,71 @@ public:
     uint32_t serialize(size_t idx, uint8_t* pos) override;
     void serialize_batch(uint8_t* dst, Buffer<uint32_t>& slice_sizes, size_t chunk_size,
                          uint32_t max_one_row_size) override;
+
+    // json column & flat column may used
+    std::string debug_item(size_t idx) const override;
+    size_t size() const override;
+    size_t capacity() const override;
+    size_t byte_size(size_t from, size_t size) const override;
+
+    void assign(size_t n, size_t idx) override;
+
+    void append(const JsonValue* object);
+
+    void append(JsonValue&& object);
+
+    void append(const JsonValue& object);
+
+    void append(const Column& src, size_t offset, size_t count) override;
+
+    void append_value_multiple_times(const void* value, size_t count) override;
+
+    void append_default() override;
+
+    void append_default(size_t count) override;
+
+    size_t filter_range(const Filter& filter, size_t from, size_t to) override;
+    int compare_at(size_t left, size_t right, const Column& rhs, int nan_direction_hint) const override;
+
+    void fnv_hash(uint32_t* seed, uint32_t from, uint32_t to) const override;
+
+    size_t container_memory_usage() const override;
+    size_t reference_memory_usage() const override;
+    size_t reference_memory_usage(size_t from, size_t size) const override;
+
+    void swap_column(Column& rhs) override;
+    void reset_column() override;
+
+    bool capacity_limit_reached(std::string* msg = nullptr) const override;
+    void check_or_die() const override;
+
+    // support flat json on storage
+    bool is_flat_json() const { return !_flat_column_paths.empty(); }
+
+    ColumnPtr& get_flat_field(const std::string& path);
+
+    const ColumnPtr& get_flat_field(const std::string& path) const;
+
+    Columns& get_flat_fields() { return _flat_columns; };
+
+    ColumnPtr& get_flat_field(int index);
+
+    const ColumnPtr& get_flat_field(int index) const;
+
+    const std::vector<std::string>& flat_column_paths() const { return _flat_column_paths; }
+
+    bool has_flat_column(const std::string& path) const;
+
+    void init_flat_columns(const std::vector<std::string>& paths);
+
+    std::string debug_flat_paths() const;
+
+private:
+    // flat-columns
+    Columns _flat_columns;
+
+    // flat-column paths
+    std::vector<std::string> _flat_column_paths;
 };
 
 } // namespace starrocks

--- a/be/src/column/object_column.h
+++ b/be/src/column/object_column.h
@@ -26,17 +26,6 @@
 
 namespace starrocks {
 
-//class Object {
-//    Object();
-//
-//    Object(const Slice& s);
-//
-//    void clear();
-//
-//    size_t serialize_size() const;
-//    size_t serialize(uint8_t* dst) const;
-//};
-
 template <typename T>
 class ObjectColumn : public ColumnFactory<Column, ObjectColumn<T>> {
     friend class ColumnFactory<Column, ObjectColumn>;
@@ -238,6 +227,8 @@ public:
 
     bool has_large_column() const override { return false; }
 
+    void check_or_die() const {}
+
 private:
     // add this to avoid warning clang-diagnostic-overloaded-virtual
     using Column::append;
@@ -258,8 +249,6 @@ private:
 
     // Currently, only for data loading
     void _build_slices() const;
-
-    void check_or_die() const override {}
 
 private:
     Buffer<T> _pool;

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1173,4 +1173,16 @@ CONF_mInt64(lake_local_pk_index_unused_threshold_seconds, "86400"); // 1 day
 
 CONF_mBool(lake_enable_vertical_compaction_fill_data_cache, "false");
 
+// json flat flag
+CONF_Bool(enable_json_flat, "true");
+
+// extract flat json column when row_num * null_factor < null_row_num
+CONF_Double(json_flat_null_factor, "0.3");
+
+// only flatten json when the number of sub-field in the JSON exceeds the limit
+CONF_mInt32(json_flat_internal_column_min_limit, "5");
+
+// the maximum number of extracted JSON sub-field
+CONF_mInt32(json_flat_column_max, "20");
+
 } // namespace starrocks::config

--- a/be/src/exec/olap_scan_node.h
+++ b/be/src/exec/olap_scan_node.h
@@ -247,6 +247,7 @@ private:
     RuntimeProfile::Counter* _rowsets_read_count = nullptr;
     RuntimeProfile::Counter* _segments_read_count = nullptr;
     RuntimeProfile::Counter* _total_columns_data_page_count = nullptr;
+    RuntimeProfile::Counter* _pushdown_access_paths_counter = nullptr;
 };
 
 } // namespace starrocks

--- a/be/src/exec/pipeline/scan/olap_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.cpp
@@ -164,6 +164,7 @@ void OlapChunkSource::_init_counter(RuntimeState* state) {
     // IOTime
     _io_timer = ADD_CHILD_TIMER(_runtime_profile, "IOTime", IO_TASK_EXEC_TIMER_NAME);
 
+    _json_flatten_timer = ADD_CHILD_TIMER(_runtime_profile, "JsonFlattern", segment_read_name);
     _access_path_hits_counter = ADD_COUNTER(_runtime_profile, "AccessPathHits", TUnit::UNIT);
     _access_path_unhits_counter = ADD_COUNTER(_runtime_profile, "AccessPathUnhits", TUnit::UNIT);
 }
@@ -575,8 +576,10 @@ void OlapChunkSource::_update_counter() {
             total += v;
             COUNTER_UPDATE(path_counter, v);
         }
-        COUNTER_SET(_access_path_unhits_counter, total);
+        COUNTER_UPDATE(_access_path_unhits_counter, total);
     }
+
+    COUNTER_UPDATE(_json_flatten_timer, _reader->stats().json_flatten_ns);
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -28,6 +28,7 @@
 #include "storage/conjunctive_predicates.h"
 #include "storage/tablet.h"
 #include "storage/tablet_reader.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
@@ -151,6 +152,8 @@ private:
     RuntimeProfile::Counter* _total_columns_data_page_count = nullptr;
     RuntimeProfile::Counter* _read_pk_index_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_access_paths_counter = nullptr;
+    RuntimeProfile::Counter* _access_path_hits_counter = nullptr;
+    RuntimeProfile::Counter* _access_path_unhits_counter = nullptr;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -150,6 +150,7 @@ private:
     RuntimeProfile::Counter* _segments_read_count = nullptr;
     RuntimeProfile::Counter* _total_columns_data_page_count = nullptr;
     RuntimeProfile::Counter* _read_pk_index_timer = nullptr;
+    RuntimeProfile::Counter* _pushdown_access_paths_counter = nullptr;
 };
 } // namespace pipeline
 } // namespace starrocks

--- a/be/src/exec/pipeline/scan/olap_chunk_source.h
+++ b/be/src/exec/pipeline/scan/olap_chunk_source.h
@@ -152,6 +152,7 @@ private:
     RuntimeProfile::Counter* _total_columns_data_page_count = nullptr;
     RuntimeProfile::Counter* _read_pk_index_timer = nullptr;
     RuntimeProfile::Counter* _pushdown_access_paths_counter = nullptr;
+    RuntimeProfile::Counter* _json_flatten_timer = nullptr;
     RuntimeProfile::Counter* _access_path_hits_counter = nullptr;
     RuntimeProfile::Counter* _access_path_unhits_counter = nullptr;
 };

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -22,13 +22,22 @@
 #include "column/column_builder.h"
 #include "column/column_helper.h"
 #include "column/column_viewer.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/compiler_util.h"
 #include "common/status.h"
+#include "common/statusor.h"
 #include "exprs/cast_expr.h"
 #include "exprs/function_context.h"
+#include "exprs/function_helper.h"
 #include "exprs/jsonpath.h"
 #include "glog/logging.h"
+#include "gutil/casts.h"
 #include "gutil/strings/escaping.h"
 #include "gutil/strings/substitute.h"
+#include "storage/chunk_helper.h"
+#include "types/logical_type.h"
 #include "util/json.h"
 #include "velocypack/Builder.h"
 #include "velocypack/Iterator.h"
@@ -518,6 +527,126 @@ static Status _convert_json_slice(const vpack::Slice& slice, ColumnBuilder<Resul
 
 template <LogicalType ResultType>
 StatusOr<ColumnPtr> JsonFunctions::_json_query_impl(FunctionContext* context, const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+    auto* cc = ColumnHelper::get_data_column(columns[0].get());
+    JsonColumn* js = down_cast<JsonColumn*>(cc);
+    if (js->is_flat_json()) {
+        return _flat_json_query_impl<ResultType>(context, columns);
+    }
+    return _full_json_query_impl<ResultType>(context, columns);
+}
+
+static inline StatusOr<std::tuple<ColumnPtr, JsonPath>> _extract_from_flat_json(FunctionContext* context,
+                                                                                const Columns& columns) {
+    // flat json path must be constant
+    std::string path;
+    if (LIKELY(columns[1]->is_constant())) {
+        path = ColumnHelper::get_const_value<TYPE_VARCHAR>(columns[1].get()).to_string();
+    } else {
+        // just for compatible
+        ColumnViewer<TYPE_VARCHAR> viewer(columns[1]);
+        path = viewer.value(0).to_string();
+        for (int row = 1; row < columns[1]->size(); ++row) {
+            if (viewer.is_null(row)) {
+                return Status::JsonFormatError("flat json unsupported null json path");
+            }
+            auto slice = viewer.value(row);
+            if (path != slice.to_string()) {
+                return Status::JsonFormatError("flat json unsupported variables json path");
+            }
+        }
+    }
+
+    if (UNLIKELY(columns[0]->is_constant())) {
+        return Status::JsonFormatError("flat json unsupported constant json");
+    }
+
+    JsonPath required_path;
+    JsonPath* required_path_ptr = &required_path;
+
+    auto ret = get_prepared_or_parse(context, path, required_path_ptr);
+
+    if (UNLIKELY(!ret.ok())) {
+        // invaild path, return null
+        return std::tuple(ColumnHelper::create_const_null_column(columns[0]->size()), JsonPath());
+    }
+
+    required_path_ptr = ret.value();
+    JsonColumn* json_column;
+    if (columns[0]->is_nullable()) {
+        auto* nullable = down_cast<NullableColumn*>(columns[0].get());
+        json_column = down_cast<JsonColumn*>(nullable->data_column().get());
+    } else {
+        json_column = down_cast<JsonColumn*>(columns[0].get());
+    }
+
+    JsonPath real_path;
+    for (const auto& flat_path : json_column->flat_column_paths()) {
+        ASSIGN_OR_RETURN(auto flat_json_path, JsonPath::parse(flat_path));
+        // flat path's depth must less than required_path
+        if (required_path_ptr->starts_with(&flat_json_path)) {
+            RETURN_IF_ERROR(required_path_ptr->relativize(&flat_json_path, &real_path));
+            return std::tuple(json_column->get_flat_field(flat_path), std::move(real_path));
+        }
+    }
+
+    return Status::JsonFormatError(fmt::format("flat json doesn't contains json path: {}", path));
+}
+
+template <LogicalType ResultType>
+StatusOr<ColumnPtr> JsonFunctions::_flat_json_query_impl(FunctionContext* context, const Columns& columns) {
+    auto st = _extract_from_flat_json(context, columns);
+    if (!st.ok()) {
+        return st.status();
+    }
+    auto [json_column, json_path] = st.value();
+    if (!json_path.paths.empty()) {
+        // partial match
+        auto num_rows = json_column->size();
+        auto json_viewer = ColumnViewer<TYPE_JSON>(json_column);
+        ColumnBuilder<ResultType> result(num_rows);
+
+        JsonPath stored_path;
+        vpack::Builder builder;
+        for (int row = 0; row < num_rows; ++row) {
+            if (json_viewer.is_null(row)) {
+                result.append_null();
+                continue;
+            }
+            JsonValue* json_value = json_viewer.value(row);
+            builder.clear();
+            vpack::Slice slice = JsonPath::extract(json_value, json_path, &builder);
+            Status st = _convert_json_slice<ResultType>(slice, result);
+            if (!st.ok()) {
+                result.append_null();
+                continue;
+            }
+        }
+        return result.build(ColumnHelper::is_all_const(columns));
+
+    } else {
+        // full match
+        auto json_viewer = ColumnViewer<TYPE_JSON>(json_column);
+        size_t num_rows = columns[0]->size();
+        ColumnBuilder<ResultType> result(num_rows);
+        for (int row = 0; row < num_rows; ++row) {
+            if (json_viewer.is_null(row)) {
+                result.append_null();
+                continue;
+            }
+            JsonValue* j = json_viewer.value(row);
+            Status st = _convert_json_slice<ResultType>(j->to_vslice(), result);
+            if (!st.ok()) {
+                result.append_null();
+                continue;
+            }
+        }
+        return result.build(ColumnHelper::is_all_const(columns));
+    }
+}
+
+template <LogicalType ResultType>
+StatusOr<ColumnPtr> JsonFunctions::_full_json_query_impl(FunctionContext* context, const Columns& columns) {
     auto num_rows = columns[0]->size();
     auto json_viewer = ColumnViewer<TYPE_JSON>(columns[0]);
     auto path_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
@@ -552,6 +681,56 @@ StatusOr<ColumnPtr> JsonFunctions::_json_query_impl(FunctionContext* context, co
 }
 
 StatusOr<ColumnPtr> JsonFunctions::json_exists(FunctionContext* context, const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+    auto* cc = ColumnHelper::get_data_column(columns[0].get());
+    JsonColumn* js = down_cast<JsonColumn*>(cc);
+    if (js->is_flat_json()) {
+        return _flat_json_exists(context, columns);
+    }
+    return _full_json_exists(context, columns);
+}
+
+StatusOr<ColumnPtr> JsonFunctions::_flat_json_exists(FunctionContext* context, const Columns& columns) {
+    auto st = _extract_from_flat_json(context, columns);
+    if (!st.ok()) {
+        return st.status();
+    }
+
+    size_t rows = columns[0]->size();
+    auto [json_column, json_path] = st.value();
+
+    if (!json_path.paths.empty()) {
+        auto json_viewer = ColumnViewer<TYPE_JSON>(json_column);
+        ColumnBuilder<TYPE_BOOLEAN> result(rows);
+
+        JsonPath stored_path;
+        for (int row = 0; row < rows; row++) {
+            if (json_viewer.is_null(row) || json_viewer.value(row) == nullptr) {
+                result.append_null();
+                continue;
+            }
+            JsonValue* json_value = json_viewer.value(row);
+            vpack::Builder builder;
+            vpack::Slice slice = JsonPath::extract(json_value, json_path, &builder);
+            result.append(!slice.isNone());
+        }
+        return result.build(ColumnHelper::is_all_const(columns));
+    } else {
+        auto json_viewer = ColumnViewer<TYPE_JSON>(json_column);
+
+        ColumnBuilder<TYPE_BOOLEAN> result(rows);
+        for (size_t row = 0; row < rows; ++row) {
+            if (json_viewer.is_null(row)) {
+                result.append_null();
+                continue;
+            }
+            result.append(!json_viewer.value(row)->to_vslice().isNone());
+        }
+        return result.build(ColumnHelper::is_all_const(columns));
+    }
+}
+
+StatusOr<ColumnPtr> JsonFunctions::_full_json_exists(FunctionContext* context, const Columns& columns) {
     auto num_rows = columns[0]->size();
     auto json_viewer = ColumnViewer<TYPE_JSON>(columns[0]);
     auto path_viewer = ColumnViewer<TYPE_VARCHAR>(columns[1]);
@@ -690,6 +869,74 @@ StatusOr<ColumnPtr> JsonFunctions::json_object(FunctionContext* context, const C
 }
 
 StatusOr<ColumnPtr> JsonFunctions::json_length(FunctionContext* context, const Columns& columns) {
+    RETURN_IF_COLUMNS_ONLY_NULL(columns);
+    auto* cc = ColumnHelper::get_data_column(columns[0].get());
+    JsonColumn* js = down_cast<JsonColumn*>(cc);
+    if (js->is_flat_json()) {
+        return _flat_json_length(context, columns);
+    }
+    return _full_json_length(context, columns);
+}
+
+StatusOr<ColumnPtr> JsonFunctions::_flat_json_length(FunctionContext* context, const Columns& columns) {
+    auto st = _extract_from_flat_json(context, columns);
+    if (!st.ok()) {
+        return st.status();
+    }
+
+    size_t rows = columns[0]->size();
+    auto [json_column, json_path] = st.value();
+
+    if (!json_path.paths.empty()) {
+        ColumnBuilder<TYPE_INT> result(rows);
+        ColumnViewer<TYPE_JSON> json_viewer(json_column);
+
+        JsonPath stored_path;
+        for (size_t row = 0; row < rows; row++) {
+            if (json_viewer.is_null(row)) {
+                result.append_null();
+                continue;
+            }
+
+            JsonValue* json = json_viewer.value(row);
+            vpack::Slice target_slice;
+            vpack::Builder builder;
+            target_slice = JsonPath::extract(json, json_path, &builder);
+
+            if (target_slice.isObject() || target_slice.isArray()) {
+                result.append(target_slice.length());
+            } else if (target_slice.isNone()) {
+                result.append(0);
+            } else {
+                result.append(1);
+            }
+        }
+        return result.build(ColumnHelper::is_all_const(columns));
+    } else {
+        // full match
+        ColumnViewer<TYPE_JSON> json_viewer(json_column);
+
+        ColumnBuilder<TYPE_INT> result(rows);
+        for (size_t row = 0; row < rows; ++row) {
+            if (json_viewer.is_null(row)) {
+                result.append_null();
+                continue;
+            }
+
+            vpack::Slice slice = json_viewer.value(row)->to_vslice();
+            if (slice.isObject() || slice.isArray()) {
+                result.append(slice.length());
+            } else if (slice.isNone()) {
+                result.append(0);
+            } else {
+                result.append(1);
+            }
+        }
+        return result.build(ColumnHelper::is_all_const(columns));
+    }
+}
+
+StatusOr<ColumnPtr> JsonFunctions::_full_json_length(FunctionContext* context, const Columns& columns) {
     DCHECK_GT(columns.size(), 0);
     size_t rows = columns[0]->size();
     ColumnBuilder<TYPE_INT> result(rows);

--- a/be/src/exprs/json_functions.cpp
+++ b/be/src/exprs/json_functions.cpp
@@ -548,17 +548,17 @@ static inline StatusOr<std::tuple<ColumnPtr, JsonPath>> _extract_from_flat_json(
         path = viewer.value(0).to_string();
         for (int row = 1; row < columns[1]->size(); ++row) {
             if (viewer.is_null(row)) {
-                return Status::JsonFormatError("flat json unsupported null json path");
+                return Status::JsonFormatError("flat json doesn't support null json path");
             }
             auto slice = viewer.value(row);
             if (path != slice.to_string()) {
-                return Status::JsonFormatError("flat json unsupported variables json path");
+                return Status::JsonFormatError("flat json doesn't support variables json path");
             }
         }
     }
 
     if (UNLIKELY(columns[0]->is_constant())) {
-        return Status::JsonFormatError("flat json unsupported constant json");
+        return Status::JsonFormatError("flat json doesn't support constant json");
     }
 
     JsonPath required_path;
@@ -590,7 +590,7 @@ static inline StatusOr<std::tuple<ColumnPtr, JsonPath>> _extract_from_flat_json(
         }
     }
 
-    return Status::JsonFormatError(fmt::format("flat json doesn't contains json path: {}", path));
+    return Status::JsonFormatError(fmt::format("flat json not found json path: {}", path));
 }
 
 template <LogicalType ResultType>

--- a/be/src/exprs/json_functions.h
+++ b/be/src/exprs/json_functions.h
@@ -21,6 +21,7 @@
 #include <utility>
 
 #include "column/column_builder.h"
+#include "column/vectorized_fwd.h"
 #include "common/compiler_util.h"
 #include "common/status.h"
 #include "exprs/function_context.h"
@@ -236,6 +237,28 @@ public:
 private:
     template <LogicalType ResultType>
     [[nodiscard]] static StatusOr<ColumnPtr> _json_query_impl(FunctionContext* context, const Columns& columns);
+
+    template <LogicalType RresultType>
+    DEFINE_VECTORIZED_FN(_flat_json_query_impl);
+
+    template <LogicalType RresultType>
+    DEFINE_VECTORIZED_FN(_full_json_query_impl);
+
+    /**
+     * @param: [json_object, json_path]
+     * @paramType: [JsonColumn, BinaryColumn]
+     * @return: BooleanColumn
+     */
+    DEFINE_VECTORIZED_FN(_flat_json_exists);
+    DEFINE_VECTORIZED_FN(_full_json_exists);
+
+    /**
+     * Return number of elements in a JSON object/array
+     * @param JSON, JSONPath
+     * @return number of elements if it's object or array, otherwise return 1
+     */
+    DEFINE_VECTORIZED_FN(_flat_json_length);
+    DEFINE_VECTORIZED_FN(_full_json_length);
 
     /**
      * Parse string column as json column

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -80,6 +80,8 @@ add_library(Storage STATIC
     rowset/bitshuffle_page.cpp
     rowset/bitshuffle_wrapper.cpp
     rowset/column_iterator.cpp
+    rowset/json_column_iterator.cpp
+    rowset/json_column_writer.cpp
     rowset/column_reader.cpp
     rowset/column_writer.cpp
     rowset/column_decoder.cpp

--- a/be/src/storage/horizontal_compaction_task.cpp
+++ b/be/src/storage/horizontal_compaction_task.cpp
@@ -129,8 +129,9 @@ StatusOr<size_t> HorizontalCompactionTask::_compact_data(int32_t chunk_size, Tab
     auto status = Status::OK();
     size_t output_rows = 0;
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(schema);
-    auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
     while (LIKELY(!should_stop())) {
+        // don't reuse column, json writer may used the column for an long-term
+        auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
 #ifndef BE_TEST
         status = tls_thread_status.mem_tracker()->check_mem_limit("Compaction");
         if (!status.ok()) {

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -159,13 +159,15 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
                                   config::lake_compaction_stream_buffer_size_bytes};
     RETURN_IF_ERROR(reader.open(reader_params));
 
-    auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
     auto char_field_indexes = ChunkHelper::get_char_field_indexes(schema);
 
     VLOG(3) << "Compact column group. tablet: " << _tablet.id() << ", column group: " << column_group_index
             << ", reader chunk size: " << chunk_size;
 
     while (true) {
+        // don't reuse column, json writer may used the column for an long-term
+        auto chunk = ChunkHelper::new_chunk(schema, chunk_size);
+
         if (UNLIKELY(StorageEngine::instance()->bg_worker_stopped())) {
             return Status::Cancelled("background worker stopped");
         }

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -296,6 +296,7 @@ struct OlapReaderStatistics {
 
     // ------ for json type, to count flat column ------
     // key: json absolute path, value: count
+    int64_t json_flatten_ns = 0;
     std::unordered_map<std::string, int64_t> flat_json_hits;
     std::unordered_map<std::string, int64_t> dynamic_json_hits;
 };

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -36,6 +36,7 @@
 
 #include <netinet/in.h>
 
+#include <cstdint>
 #include <functional>
 #include <list>
 #include <map>
@@ -292,6 +293,11 @@ struct OlapReaderStatistics {
     int64_t prefetch_wait_finish_ns = 0;
     int64_t prefetch_pending_ns = 0;
     // ------ for lake tablet ------
+
+    // ------ for json type, to count flat column ------
+    // key: json absolute path, value: count
+    std::unordered_map<std::string, int64_t> flat_json_hits;
+    std::unordered_map<std::string, int64_t> dynamic_json_hits;
 };
 
 const char* const kBytesReadLocalDisk = "bytes_read_local_disk";

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -39,6 +39,7 @@
 #include "storage/options.h"
 #include "storage/range.h"
 #include "storage/rowset/common.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
@@ -181,7 +182,7 @@ public:
 
     [[nodiscard]] Status fetch_dict_codes_by_rowid(const Column& rowids, Column* values);
 
-    // for complex collection type (Array/Struct/Map)
+    // for Struct type (Struct)
     [[nodiscard]] virtual Status next_batch(size_t* n, Column* dst, ColumnAccessPath* path) {
         return next_batch(n, dst);
     }

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -540,14 +540,14 @@ StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator(ColumnAcces
 
         if (flat_iters.size() != flat_paths.size()) {
             // we must dynamic flat json, because we don't know other segment wasn't the paths
-            return create_json_dynamic_flat_iterater(std::move(json_iter), flat_paths, path);
+            return create_json_dynamic_flat_iterator(std::move(json_iter), flat_paths, path);
         }
 
         std::unique_ptr<ColumnIterator> null_iterator;
         if (is_nullable()) {
             ASSIGN_OR_RETURN(null_iterator, (*_sub_readers)[0]->new_iterator());
         }
-        return create_json_flat_iterater(this, std::move(null_iterator), std::move(flat_iters), flat_paths, path);
+        return create_json_flat_iterator(this, std::move(null_iterator), std::move(flat_iters), flat_paths, path);
     } else if (is_scalar_field_type(delegate_type(_column_type))) {
         return std::make_unique<ScalarColumnIterator>(this);
     } else if (_column_type == LogicalType::TYPE_ARRAY) {

--- a/be/src/storage/rowset/column_reader.cpp
+++ b/be/src/storage/rowset/column_reader.cpp
@@ -43,6 +43,7 @@
 #include "column/column_access_path.h"
 #include "column/column_helper.h"
 #include "column/datum_convert.h"
+#include "common/compiler_util.h"
 #include "common/logging.h"
 #include "storage/column_predicate.h"
 #include "storage/rowset/array_column_iterator.h"
@@ -51,6 +52,7 @@
 #include "storage/rowset/bloom_filter.h"
 #include "storage/rowset/bloom_filter_index_reader.h"
 #include "storage/rowset/encoding_info.h"
+#include "storage/rowset/json_column_iterator.h"
 #include "storage/rowset/map_column_iterator.h"
 #include "storage/rowset/page_handle.h"
 #include "storage/rowset/page_io.h"
@@ -59,6 +61,7 @@
 #include "storage/rowset/struct_column_iterator.h"
 #include "storage/rowset/zone_map_index.h"
 #include "storage/types.h"
+#include "types/logical_type.h"
 #include "util/compression/block_compression.h"
 #include "util/rle_encoding.h"
 
@@ -107,6 +110,7 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
     _column_type = static_cast<LogicalType>(meta->type());
     _dict_page_pointer = PagePointer(meta->dict_page());
     _total_mem_footprint = meta->total_mem_footprint();
+    _name = meta->has_name() ? meta->name() : "None";
 
     if (meta->is_nullable()) _flags |= kIsNullableMask;
     if (meta->has_all_dict_encoded()) _flags |= kHasAllDictEncodedMask;
@@ -175,6 +179,16 @@ Status ColumnReader::_init(ColumnMetaPB* meta) {
         if (_ordinal_index == nullptr) {
             return Status::Corruption(
                     fmt::format("Bad file {}: missing ordinal index for column {}", file_name(), meta->column_id()));
+        }
+
+        if (_column_type == LogicalType::TYPE_JSON) {
+            _sub_readers = std::make_unique<SubReaderList>();
+            for (int i = 0; i < meta->children_columns_size(); ++i) {
+                auto res = ColumnReader::create(meta->mutable_children_columns(i), _segment);
+                RETURN_IF_ERROR(res);
+                _sub_readers->emplace_back(std::move(res).value());
+            }
+            return Status::OK();
         }
         return Status::OK();
     } else if (_column_type == LogicalType::TYPE_ARRAY) {
@@ -489,7 +503,52 @@ bool ColumnReader::segment_zone_map_filter(const std::vector<const ColumnPredica
 }
 
 StatusOr<std::unique_ptr<ColumnIterator>> ColumnReader::new_iterator(ColumnAccessPath* path) {
-    if (is_scalar_field_type(delegate_type(_column_type))) {
+    if (_column_type == LogicalType::TYPE_JSON) {
+        auto json_iter = std::make_unique<ScalarColumnIterator>(this);
+        if (path == nullptr || path->children().empty()) {
+            return json_iter;
+        }
+
+        std::vector<std::unique_ptr<ColumnIterator>> flat_iters;
+        // short name path, e.g. 'a'
+        std::vector<std::string> flat_paths;
+        // full json path, e.g. '$.a'
+        // std::vector<std::string> full_paths;
+        {
+            for (auto& p : path->children()) {
+                if (UNLIKELY(!p->children().empty())) {
+                    // @todo: support later
+                    return Status::InvalidArgument("doesn't support multi-layer json access path: " +
+                                                   p->absolute_path());
+                }
+                flat_paths.emplace_back(p->path());
+                // full_paths.emplace_back("$." + p->path());
+            }
+        }
+
+        int start = is_nullable() ? 1 : 0;
+        for (auto& p : flat_paths) {
+            for (size_t i = start; i < _sub_readers->size(); i++) {
+                const auto& rd = (*_sub_readers)[i];
+                if (rd->name() == p) {
+                    ASSIGN_OR_RETURN(auto iter, rd->new_iterator());
+                    flat_iters.emplace_back(std::move(iter));
+                    break;
+                }
+            }
+        }
+
+        if (flat_iters.size() != flat_paths.size()) {
+            // we must dynamic flat json, because we don't know other segment wasn't the paths
+            return create_json_dynamic_flat_iterater(std::move(json_iter), flat_paths, path);
+        }
+
+        std::unique_ptr<ColumnIterator> null_iterator;
+        if (is_nullable()) {
+            ASSIGN_OR_RETURN(null_iterator, (*_sub_readers)[0]->new_iterator());
+        }
+        return create_json_flat_iterater(this, std::move(null_iterator), std::move(flat_iters), flat_paths, path);
+    } else if (is_scalar_field_type(delegate_type(_column_type))) {
         return std::make_unique<ScalarColumnIterator>(this);
     } else if (_column_type == LogicalType::TYPE_ARRAY) {
         size_t col = 0;

--- a/be/src/storage/rowset/column_reader.h
+++ b/be/src/storage/rowset/column_reader.h
@@ -156,6 +156,8 @@ public:
 
     size_t mem_usage() const;
 
+    const std::string& name() const { return _name; }
+
 private:
     const std::string& file_name() const { return _segment->file_name(); }
 
@@ -214,6 +216,9 @@ private:
     uint8_t _flags = 0;
     // counter to record the reader's mem usage, sub readers excluded.
     std::atomic<size_t> _meta_mem_usage = 0;
+
+    // only for json flat column
+    std::string _name;
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/column_writer.cpp
+++ b/be/src/storage/rowset/column_writer.cpp
@@ -51,6 +51,7 @@
 #include "storage/rowset/bloom_filter.h"
 #include "storage/rowset/bloom_filter_index_writer.h"
 #include "storage/rowset/encoding_info.h"
+#include "storage/rowset/json_column_writer.h"
 #include "storage/rowset/map_column_writer.h"
 #include "storage/rowset/options.h"
 #include "storage/rowset/ordinal_page_index.h"
@@ -263,6 +264,9 @@ StatusOr<std::unique_ptr<ColumnWriter>> ColumnWriter::create(const ColumnWriterO
         str_opts.need_speculate_encoding = true;
         auto column_writer = std::make_unique<ScalarColumnWriter>(str_opts, type_info, wfile);
         return std::make_unique<StringColumnWriter>(str_opts, std::move(type_info), std::move(column_writer));
+    } else if (column->type() == LogicalType::TYPE_JSON) {
+        auto column_writer = std::make_unique<ScalarColumnWriter>(opts, type_info, wfile);
+        return create_json_column_writer(opts, std::move(type_info), wfile, std::move(column_writer));
     } else if (is_scalar_field_type(delegate_type(column->type()))) {
         return std::make_unique<ScalarColumnWriter>(opts, std::move(type_info), wfile);
     } else {

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -76,6 +76,8 @@ struct ColumnWriterOptions {
     // when column data is encoding by dict
     // if global_dict is not nullptr, will checkout whether global_dict can cover all data
     GlobalDictMap* global_dict = nullptr;
+
+    bool need_flat = false;
 };
 
 class BitmapIndexWriter;
@@ -100,6 +102,8 @@ public:
     virtual Status init() = 0;
 
     virtual Status append(const Column& column) = 0;
+
+    virtual Status append(const ColumnPtr& column) { return append(*column); }
 
     virtual Status finish_current_page() = 0;
 

--- a/be/src/storage/rowset/column_writer.h
+++ b/be/src/storage/rowset/column_writer.h
@@ -158,6 +158,8 @@ public:
 
     Status append(const Column& column) override;
 
+    Status append(const ColumnPtr& column) override { return append(*column); }
+
     // Write offset column, it's only used in ArrayColumn
     Status append_array_offsets(const Column& column);
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -279,18 +279,21 @@ Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
 Status JsonDynamicFlatIterator::next_batch(size_t* n, Column* dst) {
     auto proxy = dst->clone_empty();
     RETURN_IF_ERROR(_json_iter->next_batch(n, proxy.get()));
+    dst->set_delete_state(proxy->delete_state());
     return _flat_json(proxy.get(), dst);
 }
 
 Status JsonDynamicFlatIterator::next_batch(const SparseRange<>& range, Column* dst) {
     auto proxy = dst->clone_empty();
     RETURN_IF_ERROR(_json_iter->next_batch(range, proxy.get()));
+    dst->set_delete_state(proxy->delete_state());
     return _flat_json(proxy.get(), dst);
 }
 
 Status JsonDynamicFlatIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
     auto proxy = values->clone_empty();
     RETURN_IF_ERROR(_json_iter->fetch_values_by_rowid(rowids, size, proxy.get()));
+    values->set_delete_state(proxy->delete_state());
     return _flat_json(proxy.get(), values);
 }
 

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -30,6 +30,7 @@
 #include "storage/rowset/column_reader.h"
 #include "storage/rowset/scalar_column_iterator.h"
 #include "util/json_util.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 
@@ -75,6 +76,7 @@ private:
 };
 
 Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
+    RETURN_IF_ERROR(ColumnIterator::init(opts));
     if (_null_iter != nullptr) {
         RETURN_IF_ERROR(_null_iter->init(opts));
     }
@@ -237,6 +239,7 @@ private:
 };
 
 Status JsonDynamicFlatIterator::init(const ColumnIteratorOptions& opts) {
+    RETURN_IF_ERROR(ColumnIterator::init(opts));
     DCHECK(_path != nullptr);
     auto abs_path = _path->absolute_path();
     if (opts.stats->dynamic_json_hits.count(abs_path) == 0) {
@@ -248,6 +251,7 @@ Status JsonDynamicFlatIterator::init(const ColumnIteratorOptions& opts) {
 }
 
 Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
+    SCOPED_RAW_TIMER(&_opts.stats->json_flatten_ns);
     JsonColumn* json_data = nullptr;
 
     // 1. null column handle

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -1,0 +1,323 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/json_column_iterator.h"
+
+#include <algorithm>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "column/column_access_path.h"
+#include "column/const_column.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
+#include "common/status.h"
+#include "gutil/casts.h"
+#include "storage/rowset/column_iterator.h"
+#include "storage/rowset/column_reader.h"
+#include "storage/rowset/scalar_column_iterator.h"
+#include "util/json_util.h"
+
+namespace starrocks {
+
+class JsonFlatColumnIterator final : public ColumnIterator {
+public:
+    JsonFlatColumnIterator(ColumnReader* _reader, std::unique_ptr<ColumnIterator>& null_iter,
+                           std::vector<std::unique_ptr<ColumnIterator>>& field_iters,
+                           std::vector<std::string>& flat_paths, ColumnAccessPath* path)
+            : _reader(_reader),
+              _null_iter(std::move(null_iter)),
+              _flat_iters(std::move(field_iters)),
+              _flat_paths(std::move(flat_paths)),
+              _path(path) {}
+
+    ~JsonFlatColumnIterator() override = default;
+
+    [[nodiscard]] Status init(const ColumnIteratorOptions& opts) override;
+
+    [[nodiscard]] Status next_batch(size_t* n, Column* dst) override;
+
+    [[nodiscard]] Status next_batch(const SparseRange<>& range, Column* dst) override;
+
+    [[nodiscard]] Status seek_to_first() override;
+
+    [[nodiscard]] Status seek_to_ordinal(ordinal_t ord) override;
+
+    ordinal_t get_current_ordinal() const override { return _flat_iters[0]->get_current_ordinal(); }
+
+    /// for vectorized engine
+    [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                                    const ColumnPredicate* del_predicate,
+                                                    SparseRange<>* row_ranges) override;
+
+    [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
+
+private:
+    ColumnReader* _reader;
+
+    std::unique_ptr<ColumnIterator> _null_iter;
+    std::vector<std::unique_ptr<ColumnIterator>> _flat_iters;
+    std::vector<std::string> _flat_paths;
+    ColumnAccessPath* _path;
+};
+
+Status JsonFlatColumnIterator::init(const ColumnIteratorOptions& opts) {
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->init(opts));
+    }
+
+    for (auto& iter : _flat_iters) {
+        RETURN_IF_ERROR(iter->init(opts));
+    }
+
+    //  update stats
+    DCHECK(_path != nullptr);
+    auto abs_path = _path->absolute_path();
+    if (opts.stats->flat_json_hits.count(abs_path) == 0) {
+        opts.stats->flat_json_hits[abs_path] = 1;
+    } else {
+        opts.stats->flat_json_hits[abs_path] = opts.stats->flat_json_hits[abs_path] + 1;
+    }
+    return Status::OK();
+}
+
+Status JsonFlatColumnIterator::next_batch(size_t* n, Column* dst) {
+    JsonColumn* json_column = nullptr;
+    NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+
+        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+    } else {
+        json_column = down_cast<JsonColumn*>(dst);
+    }
+
+    // 1. Read null column
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->next_batch(n, null_column));
+        down_cast<NullableColumn*>(dst)->update_has_null();
+    }
+
+    // 2. Read flat column
+    json_column->init_flat_columns(_flat_paths);
+    for (int i = 0; i < _flat_iters.size(); i++) {
+        Column* flat_column = json_column->get_flat_field(i).get();
+        RETURN_IF_ERROR(_flat_iters[i]->next_batch(n, flat_column));
+    }
+
+    return Status::OK();
+}
+
+Status JsonFlatColumnIterator::next_batch(const SparseRange<>& range, Column* dst) {
+    JsonColumn* json_column = nullptr;
+    NullColumn* null_column = nullptr;
+    if (dst->is_nullable()) {
+        auto* nullable_column = down_cast<NullableColumn*>(dst);
+        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+    } else {
+        json_column = down_cast<JsonColumn*>(dst);
+    }
+
+    CHECK((_null_iter == nullptr && null_column == nullptr) || (_null_iter != nullptr && null_column != nullptr));
+
+    // 1. Read null column
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->next_batch(range, null_column));
+        down_cast<NullableColumn*>(dst)->update_has_null();
+    }
+
+    // 2. Read flat column
+    json_column->init_flat_columns(_flat_paths);
+    for (int i = 0; i < _flat_iters.size(); i++) {
+        Column* flat_column = json_column->get_flat_field(i).get();
+        RETURN_IF_ERROR(_flat_iters[i]->next_batch(range, flat_column));
+    }
+    return Status::OK();
+}
+
+Status JsonFlatColumnIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
+    JsonColumn* json_column = nullptr;
+    NullColumn* null_column = nullptr;
+    // 1. Read null column
+    if (_null_iter != nullptr) {
+        auto* nullable_column = down_cast<NullableColumn*>(values);
+        json_column = down_cast<JsonColumn*>(nullable_column->data_column().get());
+        null_column = down_cast<NullColumn*>(nullable_column->null_column().get());
+        RETURN_IF_ERROR(_null_iter->fetch_values_by_rowid(rowids, size, null_column));
+        nullable_column->update_has_null();
+    } else {
+        json_column = down_cast<JsonColumn*>(values);
+    }
+
+    // 2. Read flat column
+    json_column->init_flat_columns(_flat_paths);
+    for (int i = 0; i < _flat_iters.size(); i++) {
+        Column* flat_column = json_column->get_flat_field(i).get();
+        RETURN_IF_ERROR(_flat_iters[i]->fetch_values_by_rowid(rowids, size, flat_column));
+    }
+    return Status::OK();
+}
+
+Status JsonFlatColumnIterator::seek_to_first() {
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->seek_to_first());
+    }
+    for (int i = 0; i < _flat_iters.size(); i++) {
+        RETURN_IF_ERROR(_flat_iters[i]->seek_to_first());
+    }
+    return Status::OK();
+}
+
+Status JsonFlatColumnIterator::seek_to_ordinal(ordinal_t ord) {
+    if (_null_iter != nullptr) {
+        RETURN_IF_ERROR(_null_iter->seek_to_ordinal(ord));
+    }
+    for (int i = 0; i < _flat_iters.size(); i++) {
+        RETURN_IF_ERROR(_flat_iters[i]->seek_to_ordinal(ord));
+    }
+    return Status::OK();
+}
+
+Status JsonFlatColumnIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                                          const ColumnPredicate* del_predicate,
+                                                          SparseRange<>* row_ranges) {
+    row_ranges->add({0, static_cast<rowid_t>(_reader->num_rows())});
+    return Status::OK();
+}
+
+class JsonDynamicFlatIterator final : public ColumnIterator {
+public:
+    JsonDynamicFlatIterator(std::unique_ptr<ScalarColumnIterator>& json_iter, std::vector<std::string>& flat_paths,
+                            ColumnAccessPath* path)
+            : _json_iter(std::move(json_iter)), _flat_paths(std::move(flat_paths)), _path(path){};
+
+    ~JsonDynamicFlatIterator() override = default;
+
+    [[nodiscard]] Status init(const ColumnIteratorOptions& opts) override;
+
+    [[nodiscard]] Status next_batch(size_t* n, Column* dst) override;
+
+    [[nodiscard]] Status next_batch(const SparseRange<>& range, Column* dst) override;
+
+    [[nodiscard]] Status seek_to_first() override;
+
+    [[nodiscard]] Status seek_to_ordinal(ordinal_t ord) override;
+
+    ordinal_t get_current_ordinal() const override { return _json_iter->get_current_ordinal(); }
+
+    /// for vectorized engine
+    [[nodiscard]] Status get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                                    const ColumnPredicate* del_predicate,
+                                                    SparseRange<>* row_ranges) override;
+
+    [[nodiscard]] Status fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) override;
+
+private:
+    Status _flat_json(Column* input, Column* output);
+
+private:
+    std::unique_ptr<ScalarColumnIterator> _json_iter;
+    std::vector<std::string> _flat_paths;
+    ColumnAccessPath* _path;
+};
+
+Status JsonDynamicFlatIterator::init(const ColumnIteratorOptions& opts) {
+    DCHECK(_path != nullptr);
+    auto abs_path = _path->absolute_path();
+    if (opts.stats->dynamic_json_hits.count(abs_path) == 0) {
+        opts.stats->dynamic_json_hits[abs_path] = 1;
+    } else {
+        opts.stats->dynamic_json_hits[abs_path] = opts.stats->dynamic_json_hits[abs_path] + 1;
+    }
+    return _json_iter->init(opts);
+}
+
+Status JsonDynamicFlatIterator::_flat_json(Column* input, Column* output) {
+    JsonColumn* json_data = nullptr;
+
+    // 1. null column handle
+    if (output->is_nullable()) {
+        // append null column
+        auto* output_nullable = down_cast<NullableColumn*>(output);
+        auto* output_null = down_cast<NullColumn*>(output_nullable->null_column().get());
+
+        auto* input_nullable = down_cast<NullableColumn*>(input);
+        auto* input_null = down_cast<NullColumn*>(input_nullable->null_column().get());
+
+        output_null->append(*input_null, 0, input_null->size());
+        output_nullable->set_has_null(input_nullable->has_null() | output_nullable->has_null());
+
+        // json column
+        json_data = down_cast<JsonColumn*>(output_nullable->data_column().get());
+    } else {
+        json_data = down_cast<JsonColumn*>(output);
+    }
+
+    // 2. flat
+    json_data->init_flat_columns(_flat_paths);
+
+    JsonFlater flater(_flat_paths);
+    flater.flatten(input, &(json_data->get_flat_fields()));
+    return Status::OK();
+}
+
+Status JsonDynamicFlatIterator::next_batch(size_t* n, Column* dst) {
+    auto proxy = dst->clone_empty();
+    RETURN_IF_ERROR(_json_iter->next_batch(n, proxy.get()));
+    return _flat_json(proxy.get(), dst);
+}
+
+Status JsonDynamicFlatIterator::next_batch(const SparseRange<>& range, Column* dst) {
+    auto proxy = dst->clone_empty();
+    RETURN_IF_ERROR(_json_iter->next_batch(range, proxy.get()));
+    return _flat_json(proxy.get(), dst);
+}
+
+Status JsonDynamicFlatIterator::fetch_values_by_rowid(const rowid_t* rowids, size_t size, Column* values) {
+    auto proxy = values->clone_empty();
+    RETURN_IF_ERROR(_json_iter->fetch_values_by_rowid(rowids, size, proxy.get()));
+    return _flat_json(proxy.get(), values);
+}
+
+Status JsonDynamicFlatIterator::seek_to_first() {
+    return _json_iter->seek_to_first();
+}
+
+Status JsonDynamicFlatIterator::seek_to_ordinal(ordinal_t ord) {
+    return _json_iter->seek_to_ordinal(ord);
+}
+
+Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<const ColumnPredicate*>& predicates,
+                                                           const ColumnPredicate* del_predicate,
+                                                           SparseRange<>* row_ranges) {
+    return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges);
+}
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterater(
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& full_paths,
+        ColumnAccessPath* path) {
+    return std::make_unique<JsonFlatColumnIterator>(reader, null_iter, field_iters, full_paths, path);
+}
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterater(
+        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths, ColumnAccessPath* path) {
+    return std::make_unique<JsonDynamicFlatIterator>(json_iter, flat_paths, path);
+}
+
+} // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.cpp
+++ b/be/src/storage/rowset/json_column_iterator.cpp
@@ -308,14 +308,14 @@ Status JsonDynamicFlatIterator::get_row_ranges_by_zone_map(const std::vector<con
     return _json_iter->get_row_ranges_by_zone_map(predicates, del_predicate, row_ranges);
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterater(
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
         ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
         std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& full_paths,
         ColumnAccessPath* path) {
     return std::make_unique<JsonFlatColumnIterator>(reader, null_iter, field_iters, full_paths, path);
 }
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterater(
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
         std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths, ColumnAccessPath* path) {
     return std::make_unique<JsonDynamicFlatIterator>(json_iter, flat_paths, path);
 }

--- a/be/src/storage/rowset/json_column_iterator.h
+++ b/be/src/storage/rowset/json_column_iterator.h
@@ -1,0 +1,32 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include "storage/rowset/column_iterator.h"
+#include "storage/rowset/column_reader.h"
+#include "storage/rowset/scalar_column_iterator.h"
+
+namespace starrocks {
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterater(
+        ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
+        std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& flat_paths,
+        ColumnAccessPath* path);
+
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterater(
+        std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths, ColumnAccessPath* path);
+} // namespace starrocks

--- a/be/src/storage/rowset/json_column_iterator.h
+++ b/be/src/storage/rowset/json_column_iterator.h
@@ -22,11 +22,11 @@
 
 namespace starrocks {
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterater(
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_flat_iterator(
         ColumnReader* reader, std::unique_ptr<ColumnIterator> null_iter,
         std::vector<std::unique_ptr<ColumnIterator>> field_iters, std::vector<std::string>& flat_paths,
         ColumnAccessPath* path);
 
-StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterater(
+StatusOr<std::unique_ptr<ColumnIterator>> create_json_dynamic_flat_iterator(
         std::unique_ptr<ScalarColumnIterator> json_iter, std::vector<std::string>& flat_paths, ColumnAccessPath* path);
 } // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -1,0 +1,342 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/rowset/json_column_writer.h"
+
+#include <sys/types.h>
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "column/column.h"
+#include "column/column_helper.h"
+#include "column/column_viewer.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "common/status.h"
+#include "gen_cpp/segment.pb.h"
+#include "gutil/casts.h"
+#include "storage/rowset/column_writer.h"
+#include "types/logical_type.h"
+#include "util/json_util.h"
+#include "velocypack/vpack.h"
+
+namespace starrocks {
+
+class FlatJsonColumnWriter final : public ColumnWriter {
+public:
+    FlatJsonColumnWriter(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info, WritableFile* wfile,
+                         std::unique_ptr<ScalarColumnWriter> json_writer);
+
+    ~FlatJsonColumnWriter() override = default;
+
+    Status init() override { return _json_column_writer->init(); };
+
+    Status append(const Column& column) override;
+    Status append(const ColumnPtr& column) override;
+
+    Status finish_current_page() override;
+
+    uint64_t estimate_buffer_size() override;
+
+    Status finish() override;
+
+    Status write_data() override;
+    Status write_ordinal_index() override;
+    Status write_zone_map() override;
+    Status write_bitmap_index() override;
+    Status write_bloom_filter_index() override;
+    ordinal_t get_next_rowid() const override { return _json_column_writer->get_next_rowid(); }
+
+    bool is_global_dict_valid() override { return _json_column_writer->is_global_dict_valid(); }
+
+    uint64_t total_mem_footprint() const override { return _json_column_writer->total_mem_footprint(); }
+
+private:
+    void _flat_column(std::vector<ColumnPtr>& json_datas);
+
+private:
+    std::unique_ptr<ScalarColumnWriter> _json_column_writer;
+    ColumnMetaPB* _json_meta;
+    WritableFile* _wfile;
+
+    std::vector<ColumnPtr> _json_datas;
+
+    std::vector<std::unique_ptr<ColumnWriter>> _flat_writers;
+    std::vector<std::string> _flat_paths;
+    std::vector<ColumnPtr> _flat_columns;
+};
+
+FlatJsonColumnWriter::FlatJsonColumnWriter(const ColumnWriterOptions& opts, const TypeInfoPtr& type_info,
+                                           WritableFile* wfile, std::unique_ptr<ScalarColumnWriter> json_writer)
+        : ColumnWriter(std::move(type_info), opts.meta->length(), opts.meta->is_nullable()),
+          _json_column_writer(std::move(json_writer)),
+          _json_meta(opts.meta),
+          _wfile(wfile) {}
+
+Status FlatJsonColumnWriter::append(const Column& column) {
+    return Status::InternalError("json column writer not support append reference interface");
+}
+
+Status FlatJsonColumnWriter::append(const ColumnPtr& column) {
+    _json_datas.emplace_back(column);
+    return Status::OK();
+}
+
+void FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
+    DCHECK(_flat_paths.empty());
+    DCHECK(!json_datas.empty());
+
+    size_t total_rows = 0;
+    size_t null_count = 0;
+
+    for (auto& column : json_datas) {
+        DCHECK(!column->is_constant());
+
+        total_rows += column->size();
+        if (column->only_null() || column->empty()) {
+            null_count += column->size();
+            continue;
+        } else if (column->is_nullable()) {
+            auto* nullable_column = down_cast<NullableColumn*>(column.get());
+            null_count += nullable_column->null_count();
+        }
+    }
+
+    // more than half of null
+    if (null_count > total_rows * config::json_flat_null_factor) {
+        VLOG(8) << "flat json, null_count[" << null_count << "], row[" << total_rows
+                << "], null_factor: " << config::json_flat_null_factor;
+        return;
+    }
+
+    // extract common keys
+    std::unordered_map<std::string, uint64_t> hit_maps;
+    for (size_t k = 0; k < json_datas.size(); k++) {
+        size_t row_count = json_datas[k]->size();
+
+        ColumnViewer<TYPE_JSON> viewer(json_datas[k]);
+        for (size_t i = 0; i < row_count; ++i) {
+            if (viewer.is_null(i)) {
+                continue;
+            }
+
+            JsonValue* json = viewer.value(i);
+            auto vslice = json->to_vslice();
+
+            if (vslice.isNone() || vslice.isNull()) {
+                continue;
+            }
+
+            if (!vslice.isObject()) {
+                VLOG(8) << "flat json, row isn't object, can't be flatten";
+                return;
+            }
+
+            std::vector<std::string> keys = arangodb::velocypack::Collection::keys(json->to_vslice());
+            for (auto& sr : keys) {
+                hit_maps[sr]++;
+            }
+        }
+    }
+
+    if (hit_maps.size() <= config::json_flat_internal_column_min_limit) {
+        VLOG(8) << "flat json, internal column too less: " << hit_maps.size()
+                << ", at least: " << config::json_flat_internal_column_min_limit;
+        return;
+    }
+
+    // sort by hit
+    std::vector<pair<std::string, std::uint64_t>> top_hits(hit_maps.begin(), hit_maps.end());
+    std::sort(top_hits.begin(), top_hits.end(),
+              [](const pair<std::string, std::uint64_t>& a, const pair<std::string, std::uint64_t>& b) {
+                  return a.second > b.second;
+              });
+
+    for (int i = 0; i < top_hits.size() && i < config::json_flat_column_max; i++) {
+        const auto& [name, hit] = top_hits[i];
+        if (hit >= total_rows) {
+            if (name.find('.') != std::string::npos) {
+                // add escape
+                _flat_paths.emplace_back(fmt::format("\"{}\"", name));
+            } else {
+                _flat_paths.emplace_back(name);
+            }
+        }
+        VLOG(8) << "flat json[" << name << "], hit[" << hit << "], row[" << total_rows << "]";
+    }
+
+    if (_flat_paths.empty()) {
+        return;
+    }
+
+    // extract flat column
+    for (size_t i = 0; i < _flat_paths.size(); i++) {
+        _flat_columns.emplace_back(NullableColumn::create(JsonColumn::create(), NullColumn::create()));
+    }
+
+    JsonFlater flater(_flat_paths);
+
+    for (auto& col : json_datas) {
+        flater.flatten(col.get(), &_flat_columns);
+    }
+
+    // recode null column in 1st
+    if (_json_meta->is_nullable()) {
+        auto nulls = NullColumn::create();
+        uint8_t IS_NULL = 1;
+        uint8_t NOT_NULL = 0;
+        for (auto& col : json_datas) {
+            if (col->only_null()) {
+                nulls->append_value_multiple_times(&IS_NULL, col->size());
+            } else if (col->is_nullable()) {
+                auto* nullable_column = down_cast<NullableColumn*>(col.get());
+                auto* nl = down_cast<NullColumn*>(nullable_column->null_column().get());
+                nulls->append(*nl, 0, nl->size());
+            } else {
+                nulls->append_value_multiple_times(&NOT_NULL, col->size());
+            }
+        }
+
+        _flat_columns.insert(_flat_columns.begin(), nulls);
+        _flat_paths.insert(_flat_paths.begin(), "nulls");
+    }
+}
+
+Status FlatJsonColumnWriter::finish() {
+    for (const auto& js : _json_datas) {
+        RETURN_IF_ERROR(_json_column_writer->append(*js));
+    }
+    _flat_column(_json_datas);
+
+    if (!_flat_columns.empty()) {
+        // nulls
+        if (_json_meta->is_nullable()) {
+            ColumnWriterOptions opts;
+            opts.meta = _json_meta->add_children_columns();
+            opts.meta->set_column_id(0);
+            opts.meta->set_unique_id(0);
+            opts.meta->set_type(LogicalType::TYPE_TINYINT);
+            opts.meta->set_length(get_type_info(LogicalType::TYPE_TINYINT)->size());
+            opts.meta->set_is_nullable(false);
+            opts.meta->set_name("nulls");
+            opts.meta->set_encoding(DEFAULT_ENCODING);
+            opts.meta->set_compression(_json_meta->compression());
+
+            TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, LogicalType::TYPE_TINYINT, true);
+            ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));
+            _flat_writers.emplace_back(std::move(fw));
+
+            RETURN_IF_ERROR(_flat_writers[0]->init());
+            RETURN_IF_ERROR(_flat_writers[0]->append(*_flat_columns[0]));
+            RETURN_IF_ERROR(_flat_writers[0]->finish());
+
+            VLOG(8) << "flush flat json nulls";
+        }
+
+        int start = _json_meta->is_nullable() ? 1 : 0;
+        // flat datas
+        for (size_t i = start; i < _flat_columns.size(); i++) {
+            ColumnWriterOptions opts;
+            opts.meta = _json_meta->add_children_columns();
+            opts.meta->set_column_id(i);
+            opts.meta->set_unique_id(i);
+            opts.meta->set_type(LogicalType::TYPE_JSON);
+            opts.meta->set_length(get_type_info(LogicalType::TYPE_JSON)->size());
+            opts.meta->set_is_nullable(true);
+            opts.meta->set_encoding(DEFAULT_ENCODING);
+            opts.meta->set_compression(_json_meta->compression());
+            opts.meta->mutable_json_meta()->set_format_version(kJsonMetaDefaultFormatVersion);
+            opts.meta->set_name(_flat_paths[i]);
+            opts.need_flat = false;
+
+            TabletColumn col(StorageAggregateType::STORAGE_AGGREGATE_NONE, LogicalType::TYPE_JSON, true);
+            ASSIGN_OR_RETURN(auto fw, ColumnWriter::create(opts, &col, _wfile));
+            _flat_writers.emplace_back(std::move(fw));
+
+            RETURN_IF_ERROR(_flat_writers[i]->init());
+            RETURN_IF_ERROR(_flat_writers[i]->append(*_flat_columns[i]));
+            RETURN_IF_ERROR(_flat_writers[i]->finish());
+
+            VLOG(8) << "flush flat json: " << _flat_paths[i];
+        }
+    }
+
+    return _json_column_writer->finish();
+}
+
+uint64_t FlatJsonColumnWriter::estimate_buffer_size() {
+    uint64_t size = _json_column_writer->estimate_buffer_size();
+    for (auto& w : _flat_writers) {
+        size += w->estimate_buffer_size();
+    }
+    return size;
+}
+
+Status FlatJsonColumnWriter::write_data() {
+    for (auto& w : _flat_writers) {
+        RETURN_IF_ERROR(w->write_data());
+    }
+    return _json_column_writer->write_data();
+}
+
+Status FlatJsonColumnWriter::write_ordinal_index() {
+    for (auto& w : _flat_writers) {
+        RETURN_IF_ERROR(w->write_ordinal_index());
+    }
+    return _json_column_writer->write_ordinal_index();
+}
+Status FlatJsonColumnWriter::write_zone_map() {
+    for (auto& w : _flat_writers) {
+        RETURN_IF_ERROR(w->write_zone_map());
+    }
+    return _json_column_writer->write_zone_map();
+}
+
+Status FlatJsonColumnWriter::write_bitmap_index() {
+    for (auto& w : _flat_writers) {
+        RETURN_IF_ERROR(w->write_bitmap_index());
+    }
+    return _json_column_writer->write_bitmap_index();
+}
+
+Status FlatJsonColumnWriter::write_bloom_filter_index() {
+    for (auto& w : _flat_writers) {
+        RETURN_IF_ERROR(w->write_bloom_filter_index());
+    }
+    return _json_column_writer->write_bloom_filter_index();
+}
+
+Status FlatJsonColumnWriter::finish_current_page() {
+    for (auto& w : _flat_writers) {
+        RETURN_IF_ERROR(w->finish_current_page());
+    }
+    return _json_column_writer->finish_current_page();
+}
+
+StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWriterOptions& opts,
+                                                                  const TypeInfoPtr& type_info, WritableFile* wfile,
+                                                                  std::unique_ptr<ScalarColumnWriter> json_writer) {
+    if (!opts.need_flat) {
+        return std::move(json_writer);
+    }
+    return std::make_unique<FlatJsonColumnWriter>(opts, type_info, wfile, std::move(json_writer));
+}
+} // namespace starrocks

--- a/be/src/storage/rowset/json_column_writer.cpp
+++ b/be/src/storage/rowset/json_column_writer.cpp
@@ -96,7 +96,13 @@ Status FlatJsonColumnWriter::append(const Column& column) {
 }
 
 Status FlatJsonColumnWriter::append(const ColumnPtr& column) {
+    size_t ss = column->size();
+    RETURN_IF_ERROR(_json_column_writer->append(column));
+    // keep refs
     _json_datas.emplace_back(column);
+    for (auto& ptr : _json_datas) {
+        DCHECK_EQ(ss, ptr->size());
+    }
     return Status::OK();
 }
 
@@ -222,7 +228,7 @@ void FlatJsonColumnWriter::_flat_column(std::vector<ColumnPtr>& json_datas) {
 
 Status FlatJsonColumnWriter::finish() {
     for (const auto& js : _json_datas) {
-        RETURN_IF_ERROR(_json_column_writer->append(*js));
+        DCHECK_GT(js->size(), 0);
     }
     _flat_column(_json_datas);
 

--- a/be/src/storage/rowset/json_column_writer.h
+++ b/be/src/storage/rowset/json_column_writer.h
@@ -1,0 +1,24 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/rowset/column_writer.h"
+
+namespace starrocks {
+
+StatusOr<std::unique_ptr<ColumnWriter>> create_json_column_writer(const ColumnWriterOptions& opts,
+                                                                  const TypeInfoPtr& type_info, WritableFile* wfile,
+                                                                  std::unique_ptr<ScalarColumnWriter> json_writer);
+}

--- a/be/src/storage/rowset/segment_iterator.cpp
+++ b/be/src/storage/rowset/segment_iterator.cpp
@@ -956,6 +956,7 @@ inline Status SegmentIterator::_read(Chunk* chunk, vector<rowid_t>* rowids, size
         _opts.stats->blocks_load += 1;
         SCOPED_RAW_TIMER(&_opts.stats->block_fetch_ns);
         RETURN_IF_ERROR(_context->read_columns(chunk, range));
+        chunk->check_or_die();
     }
 
     if (rowids != nullptr) {

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -352,7 +352,7 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
     size_t chunk_num_rows = chunk.num_rows();
     size_t chunk_num_columns = chunk.num_columns();
     for (size_t i = 0; i < chunk_num_columns; ++i) {
-        const ColumnPtr col = chunk.get_column_by_index(i);
+        const ColumnPtr& col = chunk.get_column_by_index(i);
         RETURN_IF_ERROR(_column_writers[i]->append(col));
     }
 

--- a/be/src/util/json.cpp
+++ b/be/src/util/json.cpp
@@ -75,6 +75,10 @@ JsonValue JsonValue::from_null() {
     return JsonValue(nullJsonSlice());
 }
 
+JsonValue JsonValue::from_none() {
+    return JsonValue(noneJsonSlice());
+}
+
 JsonValue JsonValue::from_int(int64_t value) {
     vpack::Builder builder;
     builder.add(vpack::Value(value));
@@ -288,8 +292,19 @@ StatusOr<Slice> JsonValue::get_string() const {
     });
 }
 
+StatusOr<JsonValue> JsonValue::get_obj(const std::string& key) const {
+    return callVPack<JsonValue>([this, &key]() {
+        auto ss = to_vslice().get(key);
+        return JsonValue(ss);
+    });
+}
+
 bool JsonValue::is_null() const {
     return to_vslice().isNull();
+}
+
+bool JsonValue::is_none() const {
+    return to_vslice().isNone();
 }
 
 std::ostream& operator<<(std::ostream& os, const JsonValue& json) {

--- a/be/src/util/json.h
+++ b/be/src/util/json.h
@@ -70,6 +70,7 @@ public:
     ////////////////// builder  //////////////////////
 
     // construct a JsonValue from single sql type
+    static JsonValue from_none();
     static JsonValue from_null();
     static JsonValue from_int(int64_t value);
     static JsonValue from_uint(uint64_t value);
@@ -121,7 +122,9 @@ public:
     StatusOr<uint64_t> get_uint() const;
     StatusOr<double> get_double() const;
     StatusOr<Slice> get_string() const;
+    StatusOr<JsonValue> get_obj(const std::string& key) const;
     bool is_null() const;
+    bool is_none() const;
 
     ////////////////// util  //////////////////////
     StatusOr<std::string> to_string() const;

--- a/be/src/util/json_util.h
+++ b/be/src/util/json_util.h
@@ -38,7 +38,9 @@
 #include <rapidjson/rapidjson.h>
 
 #include <string>
+#include <vector>
 
+#include "column/vectorized_fwd.h"
 #include "common/status.h"
 #include "util/pretty_printer.h"
 #include "util/template_util.h"
@@ -80,4 +82,17 @@ std::string to_json(const Status& status);
 std::string to_json(const std::map<std::string, std::map<std::string, std::string>>& value);
 
 Status from_json(const std::string& json_value, std::map<std::string, std::map<std::string, std::string>>* map_result);
+
+class JsonFlater {
+public:
+    JsonFlater(std::vector<std::string> paths) : _flat_paths(paths){};
+
+    ~JsonFlater() = default;
+
+    void flatten(const Column* json_column, std::vector<ColumnPtr>* result);
+
+private:
+    std::vector<std::string> _flat_paths;
+};
+
 } // namespace starrocks

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -376,6 +376,7 @@ set(EXEC_FILES_PART2
         ./storage/rowset/segment_test.cpp
         ./storage/rowset/segment_iterator_test.cpp
         ./storage/rowset/struct_column_rw_test.cpp
+        ./storage/rowset/flat_json_column_rw_test.cpp
         ./storage/rowset/zone_map_index_test.cpp
         ./storage/rowset/unique_rowset_id_generator_test.cpp
         ./storage/rowset/default_value_column_iterator_test.cpp

--- a/be/test/storage/rowset/flat_json_column_rw_test.cpp
+++ b/be/test/storage/rowset/flat_json_column_rw_test.cpp
@@ -1,0 +1,277 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include "column/column_access_path.h"
+#include "column/json_column.h"
+#include "column/nullable_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "common/statusor.h"
+#include "fs/fs_memory.h"
+#include "gen_cpp/PlanNodes_types.h"
+#include "gutil/casts.h"
+#include "storage/chunk_helper.h"
+#include "storage/rowset/column_iterator.h"
+#include "storage/rowset/column_reader.h"
+#include "storage/rowset/column_writer.h"
+#include "storage/rowset/json_column_iterator.h"
+#include "storage/rowset/segment.h"
+#include "storage/tablet_schema_helper.h"
+#include "storage/types.h"
+#include "testutil/assert.h"
+#include "types/logical_type.h"
+#include "util/json.h"
+
+namespace starrocks {
+
+// NOLINTNEXTLINE
+static const std::string TEST_DIR = "/flat_json_column_rw_test";
+
+class FlatJsonColumnRWTest : public testing::Test {
+public:
+    FlatJsonColumnRWTest() = default;
+
+    ~FlatJsonColumnRWTest() override = default;
+
+protected:
+    void SetUp() override {}
+
+    void TearDown() override {}
+
+    std::shared_ptr<Segment> create_dummy_segment(const std::shared_ptr<FileSystem>& fs, const std::string& fname) {
+        return std::make_shared<Segment>(fs, FileInfo{fname}, 1, _dummy_segment_schema, nullptr);
+    }
+
+    void test_json(const std::string& case_file, ColumnPtr& write_col, ColumnPtr& read_col, ColumnAccessPath* path) {
+        auto fs = std::make_shared<MemoryFileSystem>();
+        ASSERT_TRUE(fs->create_dir(TEST_DIR).ok());
+
+        TabletColumn json_tablet_column = create_with_default_value<TYPE_JSON>("");
+        TypeInfoPtr type_info = get_type_info(json_tablet_column);
+        ColumnMetaPB meta;
+
+        const std::string fname = TEST_DIR + case_file;
+        auto segment = create_dummy_segment(fs, fname);
+
+        // write data
+        {
+            ASSIGN_OR_ABORT(auto wfile, fs->new_writable_file(fname));
+
+            ColumnWriterOptions writer_opts;
+            writer_opts.meta = &meta;
+            writer_opts.meta->set_column_id(0);
+            writer_opts.meta->set_unique_id(0);
+            writer_opts.meta->set_type(TYPE_JSON);
+            writer_opts.meta->set_length(0);
+            writer_opts.meta->set_encoding(DEFAULT_ENCODING);
+            writer_opts.meta->set_compression(starrocks::LZ4_FRAME);
+            writer_opts.meta->set_is_nullable(write_col->is_nullable());
+            writer_opts.need_zone_map = false;
+
+            ASSIGN_OR_ABORT(auto writer, ColumnWriter::create(writer_opts, &json_tablet_column, wfile.get()));
+            ASSERT_OK(writer->init());
+
+            ASSERT_TRUE(writer->append(*write_col).ok());
+
+            ASSERT_TRUE(writer->finish().ok());
+            ASSERT_TRUE(writer->write_data().ok());
+            ASSERT_TRUE(writer->write_ordinal_index().ok());
+
+            // close the file
+            ASSERT_TRUE(wfile->close().ok());
+        }
+        LOG(INFO) << "Finish writing";
+
+        auto res = ColumnReader::create(&meta, segment.get());
+        ASSERT_TRUE(res.ok());
+        auto reader = std::move(res).value();
+
+        {
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(path));
+            ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
+
+            ColumnIteratorOptions iter_opts;
+            OlapReaderStatistics stats;
+            iter_opts.stats = &stats;
+            iter_opts.read_file = read_file.get();
+            ASSERT_TRUE(iter->init(iter_opts).ok());
+
+            // sequence read
+            auto st = iter->seek_to_first();
+            ASSERT_TRUE(st.ok()) << st.to_string();
+
+            size_t rows_read = write_col->size();
+            st = iter->next_batch(&rows_read, read_col.get());
+            ASSERT_TRUE(st.ok());
+        }
+    }
+
+private:
+    std::shared_ptr<TabletSchema> _dummy_segment_schema;
+};
+
+TEST_F(FlatJsonColumnRWTest, testNormalFlatJson) {
+    config::json_flat_internal_column_min_limit = 1;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse("{\"a\": 1, \"b\": 21}"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    test_json("/test_flat_json_rw1.data", write_col, read_col, root_path.get());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    ASSERT_EQ(2, read_json->get_flat_fields().size());
+    EXPECT_EQ("{a: 1, b: 21}", read_json->debug_item(0));
+    EXPECT_EQ("{a: 4, b: 24}", read_json->debug_item(3));
+
+    EXPECT_EQ("3", read_json->get_flat_field("a")->debug_item(2));
+}
+
+TEST_F(FlatJsonColumnRWTest, testNullFlatJson) {
+    config::json_flat_internal_column_min_limit = 1;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse("{\"a\": 1, \"b\": 21}"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    auto null_col = NullColumn::create();
+    null_col->append(1);
+    null_col->append(1);
+    null_col->append(1);
+    null_col->append(1);
+    null_col->append(0);
+
+    ColumnPtr write_nl_col = NullableColumn::create(write_col, null_col);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = NullableColumn::create(JsonColumn::create(), NullColumn::create());
+    test_json("/test_flat_json_rw2.data", write_nl_col, read_col, root_path.get());
+
+    auto* read_json = down_cast<JsonColumn*>(down_cast<NullableColumn*>(read_col.get())->data_column().get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_col->size());
+    EXPECT_EQ("NULL", read_col->debug_item(0));
+    EXPECT_EQ("{a: 5, b: 25}", read_col->debug_item(4));
+}
+
+TEST_F(FlatJsonColumnRWTest, testLimitFlatJson) {
+    config::json_flat_internal_column_min_limit = 5;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse("{\"a\": 1, \"b\": 21}"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    test_json("/test_flat_json_rw3.data", write_col, read_col, root_path.get());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    ASSERT_EQ(2, read_json->get_flat_fields().size());
+    EXPECT_EQ("{a: 1, b: 21}", read_json->debug_item(0));
+    EXPECT_EQ("{a: 4, b: 24}", read_json->debug_item(3));
+    EXPECT_EQ("3", read_json->get_flat_field("a")->debug_item(2));
+}
+
+TEST_F(FlatJsonColumnRWTest, tesArrayFlatJson) {
+    config::json_flat_internal_column_min_limit = 5;
+
+    ColumnPtr write_col = JsonColumn::create();
+    auto* json_col = down_cast<JsonColumn*>(write_col.get());
+
+    ASSIGN_OR_ABORT(auto jv1, JsonValue::parse(R"( [{"a": 1}, {"b": 21} ] )"));
+    ASSIGN_OR_ABORT(auto jv2, JsonValue::parse("{\"a\": 2, \"b\": 22}"));
+    ASSIGN_OR_ABORT(auto jv3, JsonValue::parse("{\"a\": 3, \"b\": 23}"));
+    ASSIGN_OR_ABORT(auto jv4, JsonValue::parse("{\"a\": 4, \"b\": 24}"));
+    ASSIGN_OR_ABORT(auto jv5, JsonValue::parse("{\"a\": 5, \"b\": 25}"));
+
+    json_col->append(&jv1);
+    json_col->append(&jv2);
+    json_col->append(&jv3);
+    json_col->append(&jv4);
+    json_col->append(&jv5);
+
+    ASSIGN_OR_ABORT(auto root_path, ColumnAccessPath::create(TAccessPathType::FIELD, "root", 0));
+    ASSIGN_OR_ABORT(auto f1_path, ColumnAccessPath::create(TAccessPathType::FIELD, "a", 0));
+    ASSIGN_OR_ABORT(auto f2_path, ColumnAccessPath::create(TAccessPathType::FIELD, "b", 0));
+    root_path->children().emplace_back(std::move(f1_path));
+    root_path->children().emplace_back(std::move(f2_path));
+
+    ColumnPtr read_col = JsonColumn::create();
+    test_json("/test_flat_json_rw3.data", write_col, read_col, root_path.get());
+
+    auto* read_json = down_cast<JsonColumn*>(read_col.get());
+    EXPECT_TRUE(read_json->is_flat_json());
+    EXPECT_EQ(5, read_json->size());
+    ASSERT_EQ(2, read_json->get_flat_fields().size());
+    EXPECT_EQ("{a: NULL, b: NULL}", read_json->debug_item(0));
+    EXPECT_EQ("{a: 4, b: 24}", read_json->debug_item(3));
+}
+
+} // namespace starrocks

--- a/be/test/storage/rowset/map_column_rw_test.cpp
+++ b/be/test/storage/rowset/map_column_rw_test.cpp
@@ -22,6 +22,7 @@
 #include "column/fixed_length_column.h"
 #include "column/map_column.h"
 #include "column/nullable_column.h"
+#include "common/statusor.h"
 #include "fs/fs_memory.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
@@ -180,14 +181,11 @@ protected:
         }
 
         {
-            auto child_path = std::make_unique<ColumnAccessPath>();
-            child_path->init(TAccessPathType::type::OFFSET, "offsets", 1);
+            ASSIGN_OR_ABORT(auto child_path, ColumnAccessPath::create(TAccessPathType::type::OFFSET, "offsets", 1));
+            ASSIGN_OR_ABORT(auto path, ColumnAccessPath::create(TAccessPathType::type::ROOT, "root", 0));
+            path->children().emplace_back(std::move(child_path));
 
-            ColumnAccessPath path;
-            path.init(TAccessPathType::type::ROOT, "root", 0);
-            path.children().emplace_back(std::move(child_path));
-
-            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(&path));
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(path.get()));
             ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
 
             ColumnIteratorOptions iter_opts;
@@ -221,14 +219,11 @@ protected:
         }
 
         {
-            auto child_path = std::make_unique<ColumnAccessPath>();
-            child_path->init(TAccessPathType::type::KEY, "key", 1);
+            ASSIGN_OR_ABORT(auto child_path, ColumnAccessPath::create(TAccessPathType::type::KEY, "key", 1));
+            ASSIGN_OR_ABORT(auto path, ColumnAccessPath::create(TAccessPathType::type::ROOT, "root", 0));
+            path->children().emplace_back(std::move(child_path));
 
-            ColumnAccessPath path;
-            path.init(TAccessPathType::type::ROOT, "root", 0);
-            path.children().emplace_back(std::move(child_path));
-
-            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(&path));
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(path.get()));
             ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
 
             ColumnIteratorOptions iter_opts;

--- a/be/test/storage/rowset/struct_column_rw_test.cpp
+++ b/be/test/storage/rowset/struct_column_rw_test.cpp
@@ -166,14 +166,11 @@ protected:
         }
 
         {
-            auto child_path = std::make_unique<ColumnAccessPath>();
-            child_path->init(TAccessPathType::type::FIELD, "f1", 0);
+            ASSIGN_OR_ABORT(auto child_path, ColumnAccessPath::create(TAccessPathType::type::FIELD, "f1", 0));
+            ASSIGN_OR_ABORT(auto path, ColumnAccessPath::create(TAccessPathType::type::ROOT, "root", 0));
+            path->children().emplace_back(std::move(child_path));
 
-            ColumnAccessPath path;
-            path.init(TAccessPathType::type::ROOT, "root", 0);
-            path.children().emplace_back(std::move(child_path));
-
-            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(&path));
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(path.get()));
             ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
 
             ColumnIteratorOptions iter_opts;
@@ -205,14 +202,11 @@ protected:
 
         // read and check
         {
-            auto child_path = std::make_unique<ColumnAccessPath>();
-            child_path->init(TAccessPathType::type::FIELD, "f2", 1);
+            ASSIGN_OR_ABORT(auto child_path, ColumnAccessPath::create(TAccessPathType::type::FIELD, "f2", 1));
+            ASSIGN_OR_ABORT(auto path, ColumnAccessPath::create(TAccessPathType::type::ROOT, "root", 0));
+            path->children().emplace_back(std::move(child_path));
 
-            ColumnAccessPath path;
-            path.init(TAccessPathType::type::ROOT, "root", 0);
-            path.children().emplace_back(std::move(child_path));
-
-            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(&path));
+            ASSIGN_OR_ABORT(auto iter, reader->new_iterator(path.get()));
             ASSIGN_OR_ABORT(auto read_file, fs->new_random_access_file(fname));
 
             ColumnIteratorOptions iter_opts;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -213,11 +213,13 @@ public class FunctionSet {
     public static final String JSON_OBJECT = "json_object";
     public static final String PARSE_JSON = "parse_json";
     public static final String JSON_QUERY = "json_query";
-    public static final String JSON_EXIST = "json_exists";
+    public static final String JSON_EXISTS = "json_exists";
     public static final String JSON_EACH = "json_each";
     public static final String GET_JSON_DOUBLE = "get_json_double";
     public static final String GET_JSON_INT = "get_json_int";
     public static final String GET_JSON_STRING = "get_json_string";
+    public static final String GET_JSON_OBJECT = "get_json_object";
+    public static final String JSON_LENGTH = "json_length";
 
     // Matching functions:
     public static final String ILIKE = "ilike";

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -309,6 +309,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CBO_PUSH_DOWN_AGGREGATE = "cbo_push_down_aggregate";
     public static final String CBO_DEBUG_ALIVE_BACKEND_NUMBER = "cbo_debug_alive_backend_number";
     public static final String CBO_PRUNE_SUBFIELD = "cbo_prune_subfield";
+    public static final String CBO_PRUNE_JSON_SUBFIELD = "cbo_prune_json_subfield";
     public static final String ENABLE_OPTIMIZER_REWRITE_GROUPINGSETS_TO_UNION_ALL =
             "enable_rewrite_groupingsets_to_union_all";
 
@@ -875,6 +876,10 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     @VarAttr(name = CBO_PRUNE_SUBFIELD, flag = VariableMgr.INVISIBLE)
     private boolean cboPruneSubfield = true;
 
+    // it's need BE to enable flat json, else will take a poor performance
+    @VarAttr(name = CBO_PRUNE_JSON_SUBFIELD)
+    private boolean cboPruneJsonSubfield = true;
+
     @VarAttr(name = ENABLE_SQL_DIGEST, flag = VariableMgr.INVISIBLE)
     private boolean enableSQLDigest = false;
 
@@ -1258,6 +1263,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
+
+    public boolean isCboPruneJsonSubfield() {
+        return cboPruneJsonSubfield;
+    }
+
+    public void setCboPruneJsonSubfield(boolean cboPruneJsonSubfield) {
+        this.cboPruneJsonSubfield = cboPruneJsonSubfield;
+    }
 
     public void setEnableArrayLowCardinalityOptimize(boolean enableArrayLowCardinalityOptimize) {
         this.enableArrayLowCardinalityOptimize = enableArrayLowCardinalityOptimize;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/ExpressionAnalyzer.java
@@ -840,7 +840,7 @@ public class ExpressionAnalyzer {
 
             List<Expr> queryExpressions = Lists.newArrayList();
             node.collect(arg -> arg instanceof Subquery, queryExpressions);
-            if (queryExpressions.size() > 0 && node.getChildren().size() > 2) {
+            if (!queryExpressions.isEmpty() && node.getChildren().size() > 2) {
                 throw new SemanticException("In Predicate only support literal expression list", node.getPos());
             }
 
@@ -855,7 +855,7 @@ public class ExpressionAnalyzer {
 
             for (Expr child : node.getChildren()) {
                 Type type = child.getType();
-                if (type.isJsonType() && queryExpressions.size() > 0) { // TODO: enable it after support join on JSON
+                if (type.isJsonType() && !queryExpressions.isEmpty()) { // TODO: enable it after support join on JSON
                     throw new SemanticException("In predicate of JSON does not support subquery", child.getPos());
                 }
                 if (!Type.canCastTo(type, compatibleType)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SubfieldExprNoCopyRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/SubfieldExprNoCopyRule.java
@@ -66,7 +66,7 @@ public class SubfieldExprNoCopyRule implements TreeRewriteRule {
                 if (value instanceof SubfieldOperator && value.getChild(0) instanceof ColumnRefOperator) {
                     SubfieldOperator subfield = value.cast();
                     ColumnRefOperator col = value.getChild(0).cast();
-                    SubfieldExpressionCollector collector = new SubfieldExpressionCollector();
+                    SubfieldExpressionCollector collector = new SubfieldExpressionCollector(false);
                     // collect other expr that used the same root slot
                     for (int j = 0; j < projectMapValues.size(); j++) {
                         if (j != i && projectMapValues.get(j).getUsedColumns().contains(col)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/PruneSubfieldRule.java
@@ -34,10 +34,22 @@ import com.starrocks.sql.optimizer.rule.transformation.TransformationRule;
 import java.util.List;
 
 public class PruneSubfieldRule extends TransformationRule {
+    public static final List<String> SUPPORT_JSON_FUNCTIONS = ImmutableList.<String>builder()
+            // arguments: Json, path
+            .add(FunctionSet.GET_JSON_INT)
+            .add(FunctionSet.GET_JSON_DOUBLE)
+            .add(FunctionSet.GET_JSON_STRING)
+            .add(FunctionSet.GET_JSON_OBJECT)
+            .add(FunctionSet.JSON_QUERY)
+            .add(FunctionSet.JSON_EXISTS)
+            .add(FunctionSet.JSON_LENGTH)
+            .build();
+
     public static final List<String> SUPPORT_FUNCTIONS = ImmutableList.<String>builder()
             .add(FunctionSet.MAP_KEYS, FunctionSet.MAP_SIZE)
             .add(FunctionSet.ARRAY_LENGTH)
             .add(FunctionSet.CARDINALITY)
+            .addAll(SUPPORT_JSON_FUNCTIONS)
             .build();
 
     public PruneSubfieldRule() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldAccessPathNormalizer.java
@@ -20,21 +20,32 @@ import com.starrocks.catalog.FunctionSet;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ConstantOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperatorVisitor;
 import com.starrocks.sql.optimizer.operator.scalar.SubfieldOperator;
 import com.starrocks.thrift.TAccessPathType;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.text.StrTokenizer;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /*
  * normalize expression to ColumnAccessPath
  */
 public class SubfieldAccessPathNormalizer {
+    // todo: BE only support one-layer json path, supported more layer in future
+    public static int JSON_FLATTEN_DEPTH = 1;
+    // simple json patten, same as BE's JsonPathPiece, match: abc[1][2], group: (abc)([1][2])
+    private static final Pattern JSON_ARRAY_PATTEN = Pattern.compile("^([\\w#.]*)((?:\\[[\\d:*]+])*)");
+
     private final Deque<AccessPath> allAccessPaths = Lists.newLinkedList();
 
     private static class AccessPath {
@@ -113,7 +124,7 @@ public class SubfieldAccessPathNormalizer {
         @Override
         public Optional<AccessPath> visitVariableReference(ColumnRefOperator variable,
                                                            List<Optional<AccessPath>> childrenAccessPaths) {
-            if (variable.getType().isComplexType()) {
+            if (variable.getType().isComplexType() || variable.getType().isJsonType()) {
                 return Optional.of(new AccessPath(variable));
             }
             return Optional.empty();
@@ -129,7 +140,7 @@ public class SubfieldAccessPathNormalizer {
         public Optional<AccessPath> visitCollectionElement(CollectionElementOperator collectionElementOp,
                                                            List<Optional<AccessPath>> childrenAccessPaths) {
             Optional<AccessPath> parent = childrenAccessPaths.get(0);
-            if (!parent.isPresent()) {
+            if (parent.isEmpty()) {
                 return Optional.empty();
             }
 
@@ -154,9 +165,75 @@ public class SubfieldAccessPathNormalizer {
                     || FunctionSet.ARRAY_LENGTH.equals(call.getFnName())) {
                 return childrenAccessPaths.get(0)
                         .map(p -> p.appendPath(ColumnAccessPath.PATH_PLACEHOLDER, TAccessPathType.OFFSET));
+            } else if (PruneSubfieldRule.SUPPORT_JSON_FUNCTIONS.contains(call.getFnName())
+                    && call.getArguments().size() > 1 && call.getArguments().get(1).isConstantRef()) {
+
+                String path = ((ConstantOperator) call.getArguments().get(1)).getVarchar();
+                // we flatten whole json path, and control the query hierarchy dynamically through BE-self
+                return childrenAccessPaths.get(0).map(p -> p.appendFieldNames(formatJsonPath(path)));
             }
 
             return Optional.empty();
+        }
+
+        // format json path, same as BE's JsonPathPiece, just supported simple path for prune subfield
+        // split char: .
+        // escape char: \
+        // quota char: "
+        //
+        // eg.
+        //  $.a.b -> [a, b]
+        //  $.a[0].b -> [a] -- don't support array index
+        //  $."a.b".c -> ["a.b", c]
+        //  $.a#b.c -> [a#b, c]
+        //  $.a.b.c.d.e.f -> [a, b] -- don't support overflown JSON_FLATTEN_DEPTH
+        //  a.b.c -> [a, b, c]
+        // when meet some unsupported path, return null
+        public static List<String> formatJsonPath(String path) {
+            path = StringUtils.trimToEmpty(path);
+            if (StringUtils.isBlank(path) || StringUtils.contains(path, "..") || StringUtils.equals("$", path)) {
+                // .. is recursive search in json path, not supported
+                return Collections.emptyList();
+            }
+            if (StringUtils.countMatches(path, "\"") % 2 != 0) {
+                // unpaired quota char
+                return Collections.emptyList();
+            }
+            
+            StrTokenizer tokenizer = new StrTokenizer(path, '.', '"');
+            String[] tokens = tokenizer.getTokenArray();
+
+            if (tokens.length < 1) {
+                return Collections.emptyList();
+            }
+            int size = JSON_FLATTEN_DEPTH;
+            List<String> result = Lists.newArrayList();
+
+            int i = 0;
+            if (tokens[0].equals("$")) {
+                size++;
+                i++;
+            }
+            size = Math.min(tokens.length, size);
+            for (; i < size; i++) {
+                if (tokens[i].contains(".")) {
+                    result.add("\"" + tokens[i] + "\"");
+                    continue;
+                }
+                // unsupported path, should stop match
+                Matcher matcher = JSON_ARRAY_PATTEN.matcher(tokens[i]);
+                if (!matcher.matches()) {
+                    break;
+                }
+                // only extract name, don't needed index
+                String name = matcher.group(1);
+                result.add(name);
+                if (tokens[i].replaceFirst(name, "").contains("[")) {
+                    // can't support flatten array index
+                    break;
+                }
+            }
+            return result;
         }
 
         private Optional<AccessPath> process(ScalarOperator scalarOperator, Deque<AccessPath> accessPaths) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
@@ -31,8 +31,18 @@ import java.util.List;
 public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Void> {
     private final List<ScalarOperator> complexExpressions = Lists.newArrayList();
 
+    private final boolean enableJsonCollect;
+
     public List<ScalarOperator> getComplexExpressions() {
         return complexExpressions;
+    }
+
+    public SubfieldExpressionCollector() {
+        this(true);
+    }
+
+    public SubfieldExpressionCollector(boolean enableJsonCollect) {
+        this.enableJsonCollect = enableJsonCollect;
     }
 
     @Override
@@ -80,7 +90,7 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
         }
 
         // Json function has multi-version, support use path version
-        if (PruneSubfieldRule.SUPPORT_JSON_FUNCTIONS.contains(call.getFnName())) {
+        if (enableJsonCollect && PruneSubfieldRule.SUPPORT_JSON_FUNCTIONS.contains(call.getFnName())) {
             Type[] args = call.getFunction().getArgs();
             if (args.length <= 1 || !args[0].isJsonType() || !args[1].isStringType()) {
                 return visit(call, context);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/prunesubfield/SubfieldExpressionCollector.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.optimizer.rule.tree.prunesubfield;
 
 import com.google.common.collect.Lists;
+import com.starrocks.catalog.Type;
 import com.starrocks.sql.optimizer.operator.scalar.CallOperator;
 import com.starrocks.sql.optimizer.operator.scalar.CollectionElementOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
@@ -44,7 +45,7 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
 
     @Override
     public Void visitVariableReference(ColumnRefOperator variable, Void context) {
-        if (variable.getType().isComplexType()) {
+        if (variable.getType().isComplexType() || variable.getType().isJsonType()) {
             complexExpressions.add(variable);
         }
         return null;
@@ -74,10 +75,19 @@ public class SubfieldExpressionCollector extends ScalarOperatorVisitor<Void, Voi
             return null;
         }
 
-        if (PruneSubfieldRule.SUPPORT_FUNCTIONS.contains(call.getFnName())) {
-            complexExpressions.add(call);
-            return null;
+        if (!PruneSubfieldRule.SUPPORT_FUNCTIONS.contains(call.getFnName())) {
+            return visit(call, context);
         }
-        return visit(call, context);
+
+        // Json function has multi-version, support use path version
+        if (PruneSubfieldRule.SUPPORT_JSON_FUNCTIONS.contains(call.getFnName())) {
+            Type[] args = call.getFunction().getArgs();
+            if (args.length <= 1 || !args[0].isJsonType() || !args[1].isStringType()) {
+                return visit(call, context);
+            }
+        }
+
+        complexExpressions.add(call);
+        return null;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -677,7 +677,8 @@ public class PlanFragmentBuilder {
                 return scan.getColumnAccessPaths();
             }
 
-            SubfieldExpressionCollector collector = new SubfieldExpressionCollector();
+            SubfieldExpressionCollector collector = new SubfieldExpressionCollector(
+                    context.getConnectContext().getSessionVariable().isCboPruneJsonSubfield());
             scan.getPredicate().accept(collector, null);
 
             List<ColumnAccessPath> paths = Lists.newArrayList();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -109,6 +109,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     public void setUp() {
         super.setUp();
         connectContext.getSessionVariable().setCboPruneSubfield(true);
+        connectContext.getSessionVariable().setCboPruneJsonSubfield(true);
         connectContext.getSessionVariable().setEnablePruneComplexTypes(false);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
         connectContext.getSessionVariable().setCboCteReuse(true);
@@ -120,6 +121,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     public void tearDown() {
         connectContext.getSessionVariable().setCboCteReuse(false);
         connectContext.getSessionVariable().setCboPruneSubfield(false);
+        connectContext.getSessionVariable().setCboPruneJsonSubfield(false);
         connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
         connectContext.getSessionVariable().setCboCTERuseRatio(1.5);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PruneComplexSubfieldTest.java
@@ -15,6 +15,7 @@
 package com.starrocks.sql.plan;
 
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.optimizer.rule.tree.prunesubfield.SubfieldAccessPathNormalizer;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -87,6 +88,21 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\",\n" +
                 "\"storage_format\" = \"DEFAULT\"\n" +
                 ");");
+
+        starRocksAssert.withTable("CREATE TABLE `js0` (\n" +
+                "  `v1` bigint NULL, \n" +
+                "  `j1` JSON NULL, \n" +
+                "  `st1` struct<j1 Json, j2 Json> NULL, \n" +
+                "  `ar1` Array<Json> NULL, \n" +
+                "  `mp1` map<Int, Json> NULL \n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`v1`)\n" +
+                "DISTRIBUTED BY HASH(`v1`) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\"\n" +
+                ");");
     }
 
     @Before
@@ -97,6 +113,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(-1);
         connectContext.getSessionVariable().setCboCteReuse(true);
         connectContext.getSessionVariable().setCboCTERuseRatio(0);
+        SubfieldAccessPathNormalizer.JSON_FLATTEN_DEPTH = 2;
     }
 
     @After
@@ -106,6 +123,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         connectContext.getSessionVariable().setEnablePruneComplexTypes(true);
         connectContext.getSessionVariable().setOptimizerExecuteTimeout(300000);
         connectContext.getSessionVariable().setCboCTERuseRatio(1.5);
+        SubfieldAccessPathNormalizer.JSON_FLATTEN_DEPTH = 1;
     }
 
     @Test
@@ -366,7 +384,7 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         assertContains(plan, "st5.ss3.s32[false]");
         assertContains(plan, "st3.sa3[false]");
     }
-    
+
     @Test
     public void testCTEInlinePruneColumn() throws Exception {
         String sql =
@@ -726,7 +744,6 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
     }
 
 
-
     @Test
     public void testForceReuseCTE1() throws Exception {
         String sql = "with cte1 as (select array_map((x -> uuid()), t.a1) c1, t.map1 c2 from pc0 t) " +
@@ -834,5 +851,135 @@ public class PruneComplexSubfieldTest extends PlanTestNoneDBBase {
         String sql = "select ass[1].a, ass[1].b from tt;";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "[/ass/INDEX/a, /ass/INDEX/b]");
+    }
+
+    @Test
+    public void testJsonPruneNormal() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$.a.b.c'), " +
+                "get_json_string(j1, '$.\"a.b.c\".e.f.g'), " +
+                "json_query(j1, '$.a1.b1.c1'), " +
+                "json_exists(j1, '$.a2.b2.c2'), " +
+                "json_length(j1, '$.a3.b3[1].c3') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b.c\"/e, /j1/a/b, /j1/a1/b1, /j1/a2/b2, /j1/a3/b3]");
+
+        sql = "select " +
+                "JSON_EXISTS(j1, '$.a.b.c2'), " +
+                "get_json_int(j1, 'asd') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b, /j1/asd]");
+    }
+
+    @Test
+    public void testJsonPathMerge() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$.a.b.c1'), " +
+                "JSON_EXISTS(j1, '$.a.b.c2'), " +
+                "json_length(j1, '$.a.b2.c1'), " +
+                "json_length(j1, '$.a.b2.c3') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b, /j1/a/b2]");
+
+        sql = "select " +
+                "get_json_int(j1, '$.a.b[1].c1'), " +
+                "JSON_EXISTS(j1, '$.a.b[2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[2:2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[*].c2'), " +
+                "JSON_EXISTS(j1, '$.\"a.b[*]\".c2'), " +
+                "JSON_EXISTS(j1, '$.\"a.b[*]\".c2[1]'), " +
+                "JSON_EXISTS(j1, '$.\"a.b[*]\".c2[2].a') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/\"a.b[*]\"/c2, /j1/a/b]");
+    }
+
+    @Test
+    public void testJsonArrayPat() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$.a[2].b[1].c1'), " +
+                "JSON_EXISTS(j1, '$.a[3].b[2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[2:2].c2'), " +
+                "JSON_EXISTS(j1, '$.a.b[*].c2') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a]");
+    }
+
+    @Test
+    public void testJsonErrorPath() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, '$asdfsdf') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "get_json_int(j1, '$.\"a.\"b[*]\"') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "get_json_int(j1, '$.a.b.c1'), " +
+                "json_length(j1, '$.*') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "get_json_int(j1, '$.a.b.c1'), " +
+                "json_length(j1, '$.*') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "json_length(j1, '$.*') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "json_length(j1, '$..abbb[3]') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+
+        sql = "select " +
+                "json_length(j1, '$..abbb[3]') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath:");
+    }
+
+    @Test
+    public void testJsonPathWithoutRoot() throws Exception {
+        String sql = "select " +
+                "get_json_int(j1, 'asd') " +
+                "from js0;";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/asd]");
+
+        sql = "select " +
+                "get_json_int(j1, 'a.b.c.d') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertContains(plan, "ColumnAccessPath: [/j1/a/b]");
+
+        sql = "select " +
+                "get_json_int(j1, '$') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath");
+        
+        sql = "select " +
+                "get_json_int(j1, '$.') " +
+                "from js0;";
+        plan = getVerboseExplain(sql);
+        assertNotContains(plan, "ColumnAccessPath");
     }
 }

--- a/gensrc/proto/segment.proto
+++ b/gensrc/proto/segment.proto
@@ -190,6 +190,8 @@ message ColumnMetaPB {
     optional uint64 total_mem_footprint = 31;
     // for json column only
     optional JsonMetaPB json_meta = 32;
+    // for json flat column only
+    optional bytes name = 33;
 }
 
 message SegmentFooterPB {

--- a/test/sql/test_semi/R/test_flat_json
+++ b/test/sql/test_semi/R/test_flat_json
@@ -1,0 +1,375 @@
+-- name: test_normal_flat_json @system
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT "",
+  `j2` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `ajs1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) SUM NULL COMMENT "",
+  `j1` json REPLACE NULL COMMENT "",
+  `j2` json REPLACE  NULL COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+CREATE TABLE `ujs1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT "",
+  `j2` json NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+INSERT INTO `js1` (`v1`, `v2`, `j1`, `j2`) VALUES
+(1, 28, parse_json('{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16", "key7": "value17", "key8": "value18"}'), parse_json('{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}')),
+(2, 29, parse_json('{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27"}'), parse_json('{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27", "key8": "value28"}')),
+(3, 67, parse_json('{"key1": "value31", "key2": "value32", "key3": "value33", "key4": "value34", "key5": "value35", "key6": "value36"}'), parse_json('{"key1": "value31", "key2": "value32", "key3": "value33", "key4": "value34", "key5": "value35", "key6": "value36"}')),
+(4, 20, parse_json('{"key1": "value41", "key2": "value42", "key3": "value43", "key4": "value44", "key5": "value45"}'), parse_json('{"key1": "value41", "key2": "value42", "key3": "value43", "key4": "value44", "key5": "value45", "key6": "value46", "key7": "value47"}')),
+(5, 86, parse_json('{"key1": "value51", "key2": "value52", "key3": "value53", "key4": "value54", "key5": "value55", "key6": "value56"}'), parse_json('{"key1": "value51", "key2": "value52", "key3": "value53", "key4": "value54", "key5": "value55", "key6": "value56", "key7": "value57", "key8": "value58", "key9": "value59"}')),
+(6, 66, parse_json('{"key1": "value61", "key2": "value62", "key3": "value63", "key4": "value64", "key5": "value65", "key6": "value66", "key7": "value67", "key8": "value68"}'), parse_json('{"key1": "value61", "key2": "value62", "key3": "value63", "key4": "value64", "key5": "value65", "key6": "value66", "key7": "value67"}')),
+(7, 14, parse_json('{"key1": "value71", "key2": "value72", "key3": "value73", "key4": "value74", "key5": "value75", "key6": "value76"}'), parse_json('{"key1": "value71", "key2": "value72", "key3": "value73", "key4": "value74", "key5": "value75", "key6": "value76", "key7": "value77", "key8": "value78", "key9": "value79"}')),
+(8, 54, parse_json('{"key1": "value81", "key2": "value82", "key3": "value83", "key4": "value84", "key5": "value85", "key6": "value86"}'), parse_json('{"key1": "value81", "key2": "value82", "key3": "value83", "key4": "value84", "key5": "value85", "key6": "value86", "key7": "value87", "key8": "value88"}')),
+(9, 67, parse_json('{"key1": "value91", "key2": "value92", "key3": "value93", "key4": "value94", "key5": "value95", "key6": "value96"}'), parse_json('{"key1": "value91", "key2": "value92", "key3": "value93", "key4": "value94", "key5": "value95", "key6": "value96", "key7": "value97", "key8": "value98", "key9": "value99"}')),
+(10, 79, parse_json('{"key1": "value101", "key2": "value102", "key3": "value103", "key4": "value104", "key5": "value105", "key6": "value106", "key7": "value107"}'), parse_json('{"key1": "value101", "key2": "value102", "key3": "value103", "key4": "value104", "key5": "value105", "key6": "value106", "key7": "value107"}')),
+(11, 13, parse_json('{"key1": "value111", "key2": "value112", "key3": "value113", "key4": "value114", "key5": "value115", "key6": "value116", "key7": "value117", "key8": "value118"}'), parse_json('{"key1": "value111", "key2": "value112", "key3": "value113", "key4": "value114", "key5": "value115", "key6": "value116", "key7": "value117"}')),
+(12, 25, parse_json('{"key1": "value121", "key2": "value122", "key3": "value123", "key4": "value124", "key5": "value125"}'), parse_json('{"key1": "value121", "key2": "value122", "key3": "value123", "key4": "value124", "key5": "value125", "key6": "value126", "key7": "value127"}')),
+(13, 2, parse_json('{"key1": "value131", "key2": "value132", "key3": "value133", "key4": "value134", "key5": "value135"}'), parse_json('{"key1": "value131", "key2": "value132", "key3": "value133", "key4": "value134", "key5": "value135"}')),
+(14, 82, parse_json('{"key1": "value141", "key2": "value142", "key3": "value143", "key4": "value144", "key5": "value145", "key6": "value146", "key7": "value147", "key8": "value148"}'), parse_json('{"key1": "value141", "key2": "value142", "key3": "value143", "key4": "value144", "key5": "value145", "key6": "value146"}')),
+(15, 54, parse_json('{"key1": "value151", "key2": "value152", "key3": "value153", "key4": "value154", "key5": "value155", "key6": "value156", "key7": "value157", "key8": "value158", "key9": "value159"}'), parse_json('{"key1": "value151", "key2": "value152", "key3": "value153", "key4": "value154", "key5": "value155", "key6": "value156", "key7": "value157", "key8": "value158", "key9": "value159"}')),
+(16, 3, parse_json('{"key1": "value161", "key2": "value162", "key3": "value163", "key4": "value164", "key5": "value165", "key6": "value166"}'), parse_json('{"key1": "value161", "key2": "value162", "key3": "value163", "key4": "value164", "key5": "value165", "key6": "value166", "key7": "value167"}')),
+(17, 53, parse_json('{"key1": "value171", "key2": "value172", "key3": "value173", "key4": "value174", "key5": "value175", "key6": "value176", "key7": "value177"}'), parse_json('{"key1": "value171", "key2": "value172", "key3": "value173", "key4": "value174", "key5": "value175", "key6": "value176", "key7": "value177"}')),
+(18, 19, parse_json('{"key1": "value181", "key2": "value182", "key3": "value183", "key4": "value184", "key5": "value185", "key6": "value186", "key7": "value187", "key8": "value188"}'), parse_json('{"key1": "value181", "key2": "value182", "key3": "value183", "key4": "value184", "key5": "value185", "key6": "value186", "key7": "value187", "key8": "value188", "key9": "value189"}')),
+(19, 35, parse_json('{"key1": "value191", "key2": "value192", "key3": "value193", "key4": "value194", "key5": "value195", "key6": "value196", "key7": "value197"}'), parse_json('{"key1": "value191", "key2": "value192", "key3": "value193", "key4": "value194", "key5": "value195", "key6": "value196", "key7": "value197", "key8": "value198", "key9": "value199"}')),
+(20, 96, parse_json('{"key1": "value201", "key2": "value202", "key3": "value203", "key4": "value204", "key5": "value205", "key6": "value206", "key7": "value207", "key8": "value208", "key9": "value209"}'), parse_json('{"key1": "value201", "key2": "value202", "key3": "value203", "key4": "value204", "key5": "value205", "key6": "value206", "key7": "value207", "key8": "value208", "key9": "value209"}')),
+(21, 33, parse_json('{"key1": "value211", "key2": "value212", "key3": "value213", "key4": "value214", "key5": "value215", "key6": "value216", "key7": "value217", "key8": "value218", "key9": "value219"}'), parse_json('{"key1": "value211", "key2": "value212", "key3": "value213", "key4": "value214", "key5": "value215", "key6": "value216", "key7": "value217"}')),
+(22, 16, parse_json('{"key1": "value221", "key2": "value222", "key3": "value223", "key4": "value224", "key5": "value225", "key6": "value226", "key7": "value227"}'), parse_json('{"key1": "value221", "key2": "value222", "key3": "value223", "key4": "value224", "key5": "value225", "key6": "value226", "key7": "value227"}')),
+(23, 25, parse_json('{"key1": "value231", "key2": "value232", "key3": "value233", "key4": "value234", "key5": "value235", "key6": "value236", "key7": "value237", "key8": "value238"}'), parse_json('{"key1": "value231", "key2": "value232", "key3": "value233", "key4": "value234", "key5": "value235", "key6": "value236", "key7": "value237", "key8": "value238"}')),
+(24, 53, parse_json('{"key1": "value241", "key2": "value242", "key3": "value243", "key4": "value244", "key5": "value245", "key6": "value246"}'), parse_json('{"key1": "value241", "key2": "value242", "key3": "value243", "key4": "value244", "key5": "value245", "key6": "value246", "key7": "value247", "key8": "value248", "key9": "value249"}')),
+(25, 39, parse_json('{"key1": "value251", "key2": "value252", "key3": "value253", "key4": "value254", "key5": "value255", "key6": "value256", "key7": "value257", "key8": "value258"}'), parse_json('{"key1": "value251", "key2": "value252", "key3": "value253", "key4": "value254", "key5": "value255", "key6": "value256", "key7": "value257"}')),
+(26, 28, parse_json('{"key1": "value261", "key2": "value262", "key3": "value263", "key4": "value264", "key5": "value265", "key6": "value266", "key7": "value267", "key8": "value268", "key9": "value269"}'), parse_json('{"key1": "value261", "key2": "value262", "key3": "value263", "key4": "value264", "key5": "value265", "key6": "value266"}')),
+(27, 45, parse_json('{"key1": "value271", "key2": "value272", "key3": "value273", "key4": "value274", "key5": "value275"}'), parse_json('{"key1": "value271", "key2": "value272", "key3": "value273", "key4": "value274", "key5": "value275", "key6": "value276"}')),
+(28, 20, parse_json('{"key1": "value281", "key2": "value282", "key3": "value283", "key4": "value284", "key5": "value285", "key6": "value286", "key7": "value287", "key8": "value288"}'), parse_json('{"key1": "value281", "key2": "value282", "key3": "value283", "key4": "value284", "key5": "value285", "key6": "value286", "key7": "value287", "key8": "value288", "key9": "value289"}')),
+(29, 3, parse_json('{"key1": "value291", "key2": "value292", "key3": "value293", "key4": "value294", "key5": "value295", "key6": "value296", "key7": "value297"}'), parse_json('{"key1": "value291", "key2": "value292", "key3": "value293", "key4": "value294", "key5": "value295"}')),
+(30, 95, parse_json('{"key1": "value301", "key2": "value302", "key3": "value303", "key4": "value304", "key5": "value305", "key6": "value306", "key7": "value307", "key8": "value308", "key9": "value309"}'), parse_json('{"key1": "value301", "key2": "value302", "key3": "value303", "key4": "value304", "key5": "value305", "key6": "value306"}')),
+(31, 76, parse_json('{"key1": "value311", "key2": "value312", "key3": "value313", "key4": "value314", "key5": "value315", "key6": "value316", "key7": "value317", "key8": "value318", "key9": "value319"}'), parse_json('{"key1": "value311", "key2": "value312", "key3": "value313", "key4": "value314", "key5": "value315"}')),
+(32, 5, parse_json('{"key1": "value321", "key2": "value322", "key3": "value323", "key4": "value324", "key5": "value325", "key6": "value326", "key7": "value327"}'), parse_json('{"key1": "value321", "key2": "value322", "key3": "value323", "key4": "value324", "key5": "value325", "key6": "value326"}')),
+(33, 33, parse_json('{"key1": "value331", "key2": "value332", "key3": "value333", "key4": "value334", "key5": "value335", "key6": "value336", "key7": "value337", "key8": "value338"}'), parse_json('{"key1": "value331", "key2": "value332", "key3": "value333", "key4": "value334", "key5": "value335", "key6": "value336", "key7": "value337"}')),
+(34, 21, parse_json('{"key1": "value341", "key2": "value342", "key3": "value343", "key4": "value344", "key5": "value345", "key6": "value346", "key7": "value347", "key8": "value348"}'), parse_json('{"key1": "value341", "key2": "value342", "key3": "value343", "key4": "value344", "key5": "value345", "key6": "value346", "key7": "value347"}')),
+(35, 6, parse_json('{"key1": "value351", "key2": "value352", "key3": "value353", "key4": "value354", "key5": "value355", "key6": "value356", "key7": "value357"}'), parse_json('{"key1": "value351", "key2": "value352", "key3": "value353", "key4": "value354", "key5": "value355", "key6": "value356", "key7": "value357", "key8": "value358"}')),
+(36, 11, parse_json('{"key1": "value361", "key2": "value362", "key3": "value363", "key4": "value364", "key5": "value365", "key6": "value366", "key7": "value367", "key8": "value368"}'), parse_json('{"key1": "value361", "key2": "value362", "key3": "value363", "key4": "value364", "key5": "value365", "key6": "value366", "key7": "value367", "key8": "value368", "key9": "value369"}')),
+(37, 30, parse_json('{"key1": "value371", "key2": "value372", "key3": "value373", "key4": "value374", "key5": "value375"}'), parse_json('{"key1": "value371", "key2": "value372", "key3": "value373", "key4": "value374", "key5": "value375", "key6": "value376", "key7": "value377", "key8": "value378"}')),
+(38, 78, parse_json('{"key1": "value381", "key2": "value382", "key3": "value383", "key4": "value384", "key5": "value385", "key6": "value386", "key7": "value387", "key8": "value388"}'), parse_json('{"key1": "value381", "key2": "value382", "key3": "value383", "key4": "value384", "key5": "value385", "key6": "value386", "key7": "value387", "key8": "value388", "key9": "value389"}')),
+(39, 9, parse_json('{"key1": "value391", "key2": "value392", "key3": "value393", "key4": "value394", "key5": "value395", "key6": "value396", "key7": "value397"}'), parse_json('{"key1": "value391", "key2": "value392", "key3": "value393", "key4": "value394", "key5": "value395", "key6": "value396", "key7": "value397"}')),
+(40, 65, parse_json('{"key1": "value401", "key2": "value402", "key3": "value403", "key4": "value404", "key5": "value405", "key6": "value406"}'), parse_json('{"key1": "value401", "key2": "value402", "key3": "value403", "key4": "value404", "key5": "value405", "key6": "value406", "key7": "value407", "key8": "value408"}')),
+(41, 85, parse_json('{"key1": "value411", "key2": "value412", "key3": "value413", "key4": "value414", "key5": "value415", "key6": "value416", "key7": "value417", "key8": "value418", "key9": "value419"}'), parse_json('{"key1": "value411", "key2": "value412", "key3": "value413", "key4": "value414", "key5": "value415"}')),
+(42, 59, parse_json('{"key1": "value421", "key2": "value422", "key3": "value423", "key4": "value424", "key5": "value425", "key6": "value426", "key7": "value427", "key8": "value428"}'), parse_json('{"key1": "value421", "key2": "value422", "key3": "value423", "key4": "value424", "key5": "value425", "key6": "value426"}')),
+(43, 66, parse_json('{"key1": "value431", "key2": "value432", "key3": "value433", "key4": "value434", "key5": "value435"}'), parse_json('{"key1": "value431", "key2": "value432", "key3": "value433", "key4": "value434", "key5": "value435"}')),
+(44, 70, parse_json('{"key1": "value441", "key2": "value442", "key3": "value443", "key4": "value444", "key5": "value445", "key6": "value446", "key7": "value447", "key8": "value448", "key9": "value449"}'), parse_json('{"key1": "value441", "key2": "value442", "key3": "value443", "key4": "value444", "key5": "value445", "key6": "value446", "key7": "value447", "key8": "value448", "key9": "value449"}')),
+(45, 26, parse_json('{"key1": "value451", "key2": "value452", "key3": "value453", "key4": "value454", "key5": "value455"}'), parse_json('{"key1": "value451", "key2": "value452", "key3": "value453", "key4": "value454", "key5": "value455", "key6": "value456", "key7": "value457"}')),
+(46, 87, parse_json('{"key1": "value461", "key2": "value462", "key3": "value463", "key4": "value464", "key5": "value465", "key6": "value466", "key7": "value467", "key8": "value468", "key9": "value469"}'), parse_json('{"key1": "value461", "key2": "value462", "key3": "value463", "key4": "value464", "key5": "value465", "key6": "value466", "key7": "value467"}')),
+(47, 23, parse_json('{"key1": "value471", "key2": "value472", "key3": "value473", "key4": "value474", "key5": "value475", "key6": "value476", "key7": "value477", "key8": "value478"}'), parse_json('{"key1": "value471", "key2": "value472", "key3": "value473", "key4": "value474", "key5": "value475", "key6": "value476"}')),
+(48, 44, parse_json('{"key1": "value481", "key2": "value482", "key3": "value483", "key4": "value484", "key5": "value485", "key6": "value486", "key7": "value487", "key8": "value488", "key9": "value489"}'), parse_json('{"key1": "value481", "key2": "value482", "key3": "value483", "key4": "value484", "key5": "value485", "key6": "value486", "key7": "value487"}')),
+(49, 5, parse_json('{"key1": "value491", "key2": "value492", "key3": "value493", "key4": "value494", "key5": "value495", "key6": "value496", "key7": "value497"}'), parse_json('{"key1": "value491", "key2": "value492", "key3": "value493", "key4": "value494", "key5": "value495", "key6": "value496", "key7": "value497"}')),
+(50, 76, parse_json('{"key1": "value501", "key2": "value502", "key3": "value503", "key4": "value504", "key5": "value505", "key6": "value506", "key7": "value507", "key8": "value508"}'), parse_json('{"key1": "value501", "key2": "value502", "key3": "value503", "key4": "value504", "key5": "value505", "key6": "value506", "key7": "value507"}'));
+-- result:
+-- !result
+insert into ajs1 select * from js1;
+-- result:
+-- !result
+insert into ajs1 select * from js1;
+-- result:
+-- !result
+insert into ajs1 select * from js1;
+-- result:
+-- !result
+insert into ajs1 select * from js1;
+-- result:
+-- !result
+insert into ujs1 select * from js1;
+-- result:
+-- !result
+insert into ujs1 select * from js1;
+-- result:
+-- !result
+insert into ujs1 select * from js1;
+-- result:
+-- !result
+insert into ujs1 select * from js1;
+-- result:
+-- !result
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key3"), get_json_string(j2, "$.key4") from js1 order by v1 limit 2;
+-- result:
+None	None	value14
+None	None	value24
+-- !result
+select get_json_int(j1, "$.key8"), get_json_double(j2, "$.key9"), get_json_string(j2, "$.key10") from js1 order by v1 limit 2;
+-- result:
+None	None	None
+None	None	None
+-- !result
+select get_json_int(j1, "$.key12"), get_json_double(j2, "$.key13"), get_json_string(j2, "$") from js1 order by v1 limit 2;
+-- result:
+None	None	{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}
+None	None	{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27", "key8": "value28"}
+-- !result
+select get_json_int(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from js1 order by v1 limit 2;
+-- result:
+None	None	value13
+None	None	value23
+-- !result
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key2.key3") from js1 order by v1 limit 2;
+-- result:
+None	None
+None	None
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from js1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key3"), JSON_EXISTS(j2, "$.key4") from js1 order by v1 limit 2;
+-- result:
+1	1	1
+1	1	1
+-- !result
+select JSON_EXISTS(j1, "$.key8"), JSON_EXISTS(j2, "$.key9"), JSON_EXISTS(j2, "$.key10") from js1 order by v1 limit 2;
+-- result:
+1	0	0
+0	0	0
+-- !result
+select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from js1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j2, "$13"), JSON_EXISTS(j2, "$.key3") from js1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from js1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from js1 order by v1 limit 2;
+-- result:
+1	1	1
+1	1	1
+-- !result
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 order by v1 limit 2;
+-- result:
+1	0	0
+0	0	0
+-- !result
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 order by v1 limit 2;
+-- result:
+0	0	6
+0	0	8
+-- !result
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from js1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key3"), get_json_string(j2, "$.key4") from ujs1 order by v1 limit 2;
+-- result:
+None	None	value14
+None	None	value24
+-- !result
+select get_json_int(j1, "$.key8"), get_json_double(j2, "$.key9"), get_json_string(j2, "$.key10") from ujs1 order by v1 limit 2;
+-- result:
+None	None	None
+None	None	None
+-- !result
+select get_json_int(j1, "$.key12"), get_json_double(j2, "$.key13"), get_json_string(j2, "$") from ujs1 order by v1 limit 2;
+-- result:
+None	None	{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}
+None	None	{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27", "key8": "value28"}
+-- !result
+select get_json_int(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from ujs1 order by v1 limit 2;
+-- result:
+None	None	value13
+None	None	value23
+-- !result
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+-- result:
+None	None
+None	None
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key3"), JSON_EXISTS(j2, "$.key4") from ujs1 order by v1 limit 2;
+-- result:
+1	1	1
+1	1	1
+-- !result
+select JSON_EXISTS(j1, "$.key8"), JSON_EXISTS(j2, "$.key9"), JSON_EXISTS(j2, "$.key10") from ujs1 order by v1 limit 2;
+-- result:
+1	0	0
+0	0	0
+-- !result
+select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from ujs1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j2, "$13"), JSON_EXISTS(j2, "$.key3") from ujs1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from ujs1 order by v1 limit 2;
+-- result:
+1	1	1
+1	1	1
+-- !result
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from ujs1 order by v1 limit 2;
+-- result:
+1	0	0
+0	0	0
+-- !result
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from ujs1 order by v1 limit 2;
+-- result:
+0	0	6
+0	0	8
+-- !result
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from ujs1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key3"), get_json_string(j2, "$.key4") from ajs1 order by v1 limit 2;
+-- result:
+None	None	value14
+None	None	value24
+-- !result
+select get_json_int(j1, "$.key8"), get_json_double(j2, "$.key9"), get_json_string(j2, "$.key10") from ajs1 order by v1 limit 2;
+-- result:
+None	None	None
+None	None	None
+-- !result
+select get_json_int(j1, "$.key12"), get_json_double(j2, "$.key13"), get_json_string(j2, "$") from ajs1 order by v1 limit 2;
+-- result:
+None	None	{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}
+None	None	{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27", "key8": "value28"}
+-- !result
+select get_json_int(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from ajs1 order by v1 limit 2;
+-- result:
+None	None	value13
+None	None	value23
+-- !result
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+-- result:
+None	None
+None	None
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key3"), JSON_EXISTS(j2, "$.key4") from ajs1 order by v1 limit 2;
+-- result:
+1	1	1
+1	1	1
+-- !result
+select JSON_EXISTS(j1, "$.key8"), JSON_EXISTS(j2, "$.key9"), JSON_EXISTS(j2, "$.key10") from ajs1 order by v1 limit 2;
+-- result:
+1	0	0
+0	0	0
+-- !result
+select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from ajs1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j2, "$13"), JSON_EXISTS(j2, "$.key3") from ajs1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+-- result:
+1	0
+1	0
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from ajs1 order by v1 limit 2;
+-- result:
+1	1	1
+1	1	1
+-- !result
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from ajs1 order by v1 limit 2;
+-- result:
+1	0	0
+0	0	0
+-- !result
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from ajs1 order by v1 limit 2;
+-- result:
+0	0	6
+0	0	8
+-- !result
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from ajs1 order by v1 limit 2;
+-- result:
+0	0	1
+0	0	1
+-- !result

--- a/test/sql/test_semi/R/test_flat_json
+++ b/test/sql/test_semi/R/test_flat_json
@@ -373,3 +373,22 @@ select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3"
 0	0	1
 0	0	1
 -- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 where v2 = 2 order by v1 limit 2;
+-- result:
+1	0
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from js1 where v2 > 1 order by v1 limit 2;
+-- result:
+1	1	1
+1	1	1
+-- !result
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 where v1 < 1 order by v1 limit 2;
+-- result:
+-- !result
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 where v1 = -1 order by v1 limit 2;
+-- result:
+-- !result
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from js1 where v1 = 10 order by v1 limit 2;
+-- result:
+0	0	1
+-- !result

--- a/test/sql/test_semi/R/test_flat_json2
+++ b/test/sql/test_semi/R/test_flat_json2
@@ -1,0 +1,58 @@
+-- name: test_flat_not_object_json_load @system
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into js1 values(1,1, parse_json('[{"s1": 4}, {"s2": 5}]'));
+-- result:
+-- !result
+insert into js1 values(2,1, parse_json('"a"'));
+-- result:
+-- !result
+insert into js1 values(3,1, parse_json('1'));
+-- result:
+-- !result
+insert into js1 values(4,1, parse_json('2020-12-12'));
+-- result:
+-- !result
+insert into js1 values(5,1, parse_json('1.000000'));
+-- result:
+-- !result
+insert into js1 values(6,1, parse_json(''));
+-- result:
+-- !result
+insert into js1 values(6,1, parse_json(null));
+-- result:
+-- !result
+insert into js1 values(6,1, parse_json(TRUE));
+-- result:
+-- !result
+select get_json_int(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
+-- result:
+None	None	None
+None	None	None
+-- !result
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order by v1 limit 2;
+-- result:
+None	None
+None	None
+-- !result
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
+-- result:
+None	None	None
+None	None	None
+-- !result

--- a/test/sql/test_semi/T/test_flat_json
+++ b/test/sql/test_semi/T/test_flat_json
@@ -175,3 +175,9 @@ select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.
 select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from ajs1 order by v1 limit 2;
 select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from ajs1 order by v1 limit 2;
 select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from ajs1 order by v1 limit 2;
+
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 where v2 = 2 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from js1 where v2 > 1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 where v1 < 1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 where v1 = -1 order by v1 limit 2;
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from js1 where v1 = 10 order by v1 limit 2;

--- a/test/sql/test_semi/T/test_flat_json
+++ b/test/sql/test_semi/T/test_flat_json
@@ -1,0 +1,177 @@
+-- name: test_normal_flat_json @system
+
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT "",
+  `j2` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+
+CREATE TABLE `ajs1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) SUM NULL COMMENT "",
+  `j1` json REPLACE NULL COMMENT "",
+  `j2` json REPLACE  NULL COMMENT ""
+) ENGINE=OLAP 
+AGGREGATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+
+CREATE TABLE `ujs1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT "",
+  `j2` json NULL COMMENT ""
+) ENGINE=OLAP 
+UNIQUE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+
+INSERT INTO `js1` (`v1`, `v2`, `j1`, `j2`) VALUES
+(1, 28, parse_json('{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16", "key7": "value17", "key8": "value18"}'), parse_json('{"key1": "value11", "key2": "value12", "key3": "value13", "key4": "value14", "key5": "value15", "key6": "value16"}')),
+(2, 29, parse_json('{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27"}'), parse_json('{"key1": "value21", "key2": "value22", "key3": "value23", "key4": "value24", "key5": "value25", "key6": "value26", "key7": "value27", "key8": "value28"}')),
+(3, 67, parse_json('{"key1": "value31", "key2": "value32", "key3": "value33", "key4": "value34", "key5": "value35", "key6": "value36"}'), parse_json('{"key1": "value31", "key2": "value32", "key3": "value33", "key4": "value34", "key5": "value35", "key6": "value36"}')),
+(4, 20, parse_json('{"key1": "value41", "key2": "value42", "key3": "value43", "key4": "value44", "key5": "value45"}'), parse_json('{"key1": "value41", "key2": "value42", "key3": "value43", "key4": "value44", "key5": "value45", "key6": "value46", "key7": "value47"}')),
+(5, 86, parse_json('{"key1": "value51", "key2": "value52", "key3": "value53", "key4": "value54", "key5": "value55", "key6": "value56"}'), parse_json('{"key1": "value51", "key2": "value52", "key3": "value53", "key4": "value54", "key5": "value55", "key6": "value56", "key7": "value57", "key8": "value58", "key9": "value59"}')),
+(6, 66, parse_json('{"key1": "value61", "key2": "value62", "key3": "value63", "key4": "value64", "key5": "value65", "key6": "value66", "key7": "value67", "key8": "value68"}'), parse_json('{"key1": "value61", "key2": "value62", "key3": "value63", "key4": "value64", "key5": "value65", "key6": "value66", "key7": "value67"}')),
+(7, 14, parse_json('{"key1": "value71", "key2": "value72", "key3": "value73", "key4": "value74", "key5": "value75", "key6": "value76"}'), parse_json('{"key1": "value71", "key2": "value72", "key3": "value73", "key4": "value74", "key5": "value75", "key6": "value76", "key7": "value77", "key8": "value78", "key9": "value79"}')),
+(8, 54, parse_json('{"key1": "value81", "key2": "value82", "key3": "value83", "key4": "value84", "key5": "value85", "key6": "value86"}'), parse_json('{"key1": "value81", "key2": "value82", "key3": "value83", "key4": "value84", "key5": "value85", "key6": "value86", "key7": "value87", "key8": "value88"}')),
+(9, 67, parse_json('{"key1": "value91", "key2": "value92", "key3": "value93", "key4": "value94", "key5": "value95", "key6": "value96"}'), parse_json('{"key1": "value91", "key2": "value92", "key3": "value93", "key4": "value94", "key5": "value95", "key6": "value96", "key7": "value97", "key8": "value98", "key9": "value99"}')),
+(10, 79, parse_json('{"key1": "value101", "key2": "value102", "key3": "value103", "key4": "value104", "key5": "value105", "key6": "value106", "key7": "value107"}'), parse_json('{"key1": "value101", "key2": "value102", "key3": "value103", "key4": "value104", "key5": "value105", "key6": "value106", "key7": "value107"}')),
+(11, 13, parse_json('{"key1": "value111", "key2": "value112", "key3": "value113", "key4": "value114", "key5": "value115", "key6": "value116", "key7": "value117", "key8": "value118"}'), parse_json('{"key1": "value111", "key2": "value112", "key3": "value113", "key4": "value114", "key5": "value115", "key6": "value116", "key7": "value117"}')),
+(12, 25, parse_json('{"key1": "value121", "key2": "value122", "key3": "value123", "key4": "value124", "key5": "value125"}'), parse_json('{"key1": "value121", "key2": "value122", "key3": "value123", "key4": "value124", "key5": "value125", "key6": "value126", "key7": "value127"}')),
+(13, 2, parse_json('{"key1": "value131", "key2": "value132", "key3": "value133", "key4": "value134", "key5": "value135"}'), parse_json('{"key1": "value131", "key2": "value132", "key3": "value133", "key4": "value134", "key5": "value135"}')),
+(14, 82, parse_json('{"key1": "value141", "key2": "value142", "key3": "value143", "key4": "value144", "key5": "value145", "key6": "value146", "key7": "value147", "key8": "value148"}'), parse_json('{"key1": "value141", "key2": "value142", "key3": "value143", "key4": "value144", "key5": "value145", "key6": "value146"}')),
+(15, 54, parse_json('{"key1": "value151", "key2": "value152", "key3": "value153", "key4": "value154", "key5": "value155", "key6": "value156", "key7": "value157", "key8": "value158", "key9": "value159"}'), parse_json('{"key1": "value151", "key2": "value152", "key3": "value153", "key4": "value154", "key5": "value155", "key6": "value156", "key7": "value157", "key8": "value158", "key9": "value159"}')),
+(16, 3, parse_json('{"key1": "value161", "key2": "value162", "key3": "value163", "key4": "value164", "key5": "value165", "key6": "value166"}'), parse_json('{"key1": "value161", "key2": "value162", "key3": "value163", "key4": "value164", "key5": "value165", "key6": "value166", "key7": "value167"}')),
+(17, 53, parse_json('{"key1": "value171", "key2": "value172", "key3": "value173", "key4": "value174", "key5": "value175", "key6": "value176", "key7": "value177"}'), parse_json('{"key1": "value171", "key2": "value172", "key3": "value173", "key4": "value174", "key5": "value175", "key6": "value176", "key7": "value177"}')),
+(18, 19, parse_json('{"key1": "value181", "key2": "value182", "key3": "value183", "key4": "value184", "key5": "value185", "key6": "value186", "key7": "value187", "key8": "value188"}'), parse_json('{"key1": "value181", "key2": "value182", "key3": "value183", "key4": "value184", "key5": "value185", "key6": "value186", "key7": "value187", "key8": "value188", "key9": "value189"}')),
+(19, 35, parse_json('{"key1": "value191", "key2": "value192", "key3": "value193", "key4": "value194", "key5": "value195", "key6": "value196", "key7": "value197"}'), parse_json('{"key1": "value191", "key2": "value192", "key3": "value193", "key4": "value194", "key5": "value195", "key6": "value196", "key7": "value197", "key8": "value198", "key9": "value199"}')),
+(20, 96, parse_json('{"key1": "value201", "key2": "value202", "key3": "value203", "key4": "value204", "key5": "value205", "key6": "value206", "key7": "value207", "key8": "value208", "key9": "value209"}'), parse_json('{"key1": "value201", "key2": "value202", "key3": "value203", "key4": "value204", "key5": "value205", "key6": "value206", "key7": "value207", "key8": "value208", "key9": "value209"}')),
+(21, 33, parse_json('{"key1": "value211", "key2": "value212", "key3": "value213", "key4": "value214", "key5": "value215", "key6": "value216", "key7": "value217", "key8": "value218", "key9": "value219"}'), parse_json('{"key1": "value211", "key2": "value212", "key3": "value213", "key4": "value214", "key5": "value215", "key6": "value216", "key7": "value217"}')),
+(22, 16, parse_json('{"key1": "value221", "key2": "value222", "key3": "value223", "key4": "value224", "key5": "value225", "key6": "value226", "key7": "value227"}'), parse_json('{"key1": "value221", "key2": "value222", "key3": "value223", "key4": "value224", "key5": "value225", "key6": "value226", "key7": "value227"}')),
+(23, 25, parse_json('{"key1": "value231", "key2": "value232", "key3": "value233", "key4": "value234", "key5": "value235", "key6": "value236", "key7": "value237", "key8": "value238"}'), parse_json('{"key1": "value231", "key2": "value232", "key3": "value233", "key4": "value234", "key5": "value235", "key6": "value236", "key7": "value237", "key8": "value238"}')),
+(24, 53, parse_json('{"key1": "value241", "key2": "value242", "key3": "value243", "key4": "value244", "key5": "value245", "key6": "value246"}'), parse_json('{"key1": "value241", "key2": "value242", "key3": "value243", "key4": "value244", "key5": "value245", "key6": "value246", "key7": "value247", "key8": "value248", "key9": "value249"}')),
+(25, 39, parse_json('{"key1": "value251", "key2": "value252", "key3": "value253", "key4": "value254", "key5": "value255", "key6": "value256", "key7": "value257", "key8": "value258"}'), parse_json('{"key1": "value251", "key2": "value252", "key3": "value253", "key4": "value254", "key5": "value255", "key6": "value256", "key7": "value257"}')),
+(26, 28, parse_json('{"key1": "value261", "key2": "value262", "key3": "value263", "key4": "value264", "key5": "value265", "key6": "value266", "key7": "value267", "key8": "value268", "key9": "value269"}'), parse_json('{"key1": "value261", "key2": "value262", "key3": "value263", "key4": "value264", "key5": "value265", "key6": "value266"}')),
+(27, 45, parse_json('{"key1": "value271", "key2": "value272", "key3": "value273", "key4": "value274", "key5": "value275"}'), parse_json('{"key1": "value271", "key2": "value272", "key3": "value273", "key4": "value274", "key5": "value275", "key6": "value276"}')),
+(28, 20, parse_json('{"key1": "value281", "key2": "value282", "key3": "value283", "key4": "value284", "key5": "value285", "key6": "value286", "key7": "value287", "key8": "value288"}'), parse_json('{"key1": "value281", "key2": "value282", "key3": "value283", "key4": "value284", "key5": "value285", "key6": "value286", "key7": "value287", "key8": "value288", "key9": "value289"}')),
+(29, 3, parse_json('{"key1": "value291", "key2": "value292", "key3": "value293", "key4": "value294", "key5": "value295", "key6": "value296", "key7": "value297"}'), parse_json('{"key1": "value291", "key2": "value292", "key3": "value293", "key4": "value294", "key5": "value295"}')),
+(30, 95, parse_json('{"key1": "value301", "key2": "value302", "key3": "value303", "key4": "value304", "key5": "value305", "key6": "value306", "key7": "value307", "key8": "value308", "key9": "value309"}'), parse_json('{"key1": "value301", "key2": "value302", "key3": "value303", "key4": "value304", "key5": "value305", "key6": "value306"}')),
+(31, 76, parse_json('{"key1": "value311", "key2": "value312", "key3": "value313", "key4": "value314", "key5": "value315", "key6": "value316", "key7": "value317", "key8": "value318", "key9": "value319"}'), parse_json('{"key1": "value311", "key2": "value312", "key3": "value313", "key4": "value314", "key5": "value315"}')),
+(32, 5, parse_json('{"key1": "value321", "key2": "value322", "key3": "value323", "key4": "value324", "key5": "value325", "key6": "value326", "key7": "value327"}'), parse_json('{"key1": "value321", "key2": "value322", "key3": "value323", "key4": "value324", "key5": "value325", "key6": "value326"}')),
+(33, 33, parse_json('{"key1": "value331", "key2": "value332", "key3": "value333", "key4": "value334", "key5": "value335", "key6": "value336", "key7": "value337", "key8": "value338"}'), parse_json('{"key1": "value331", "key2": "value332", "key3": "value333", "key4": "value334", "key5": "value335", "key6": "value336", "key7": "value337"}')),
+(34, 21, parse_json('{"key1": "value341", "key2": "value342", "key3": "value343", "key4": "value344", "key5": "value345", "key6": "value346", "key7": "value347", "key8": "value348"}'), parse_json('{"key1": "value341", "key2": "value342", "key3": "value343", "key4": "value344", "key5": "value345", "key6": "value346", "key7": "value347"}')),
+(35, 6, parse_json('{"key1": "value351", "key2": "value352", "key3": "value353", "key4": "value354", "key5": "value355", "key6": "value356", "key7": "value357"}'), parse_json('{"key1": "value351", "key2": "value352", "key3": "value353", "key4": "value354", "key5": "value355", "key6": "value356", "key7": "value357", "key8": "value358"}')),
+(36, 11, parse_json('{"key1": "value361", "key2": "value362", "key3": "value363", "key4": "value364", "key5": "value365", "key6": "value366", "key7": "value367", "key8": "value368"}'), parse_json('{"key1": "value361", "key2": "value362", "key3": "value363", "key4": "value364", "key5": "value365", "key6": "value366", "key7": "value367", "key8": "value368", "key9": "value369"}')),
+(37, 30, parse_json('{"key1": "value371", "key2": "value372", "key3": "value373", "key4": "value374", "key5": "value375"}'), parse_json('{"key1": "value371", "key2": "value372", "key3": "value373", "key4": "value374", "key5": "value375", "key6": "value376", "key7": "value377", "key8": "value378"}')),
+(38, 78, parse_json('{"key1": "value381", "key2": "value382", "key3": "value383", "key4": "value384", "key5": "value385", "key6": "value386", "key7": "value387", "key8": "value388"}'), parse_json('{"key1": "value381", "key2": "value382", "key3": "value383", "key4": "value384", "key5": "value385", "key6": "value386", "key7": "value387", "key8": "value388", "key9": "value389"}')),
+(39, 9, parse_json('{"key1": "value391", "key2": "value392", "key3": "value393", "key4": "value394", "key5": "value395", "key6": "value396", "key7": "value397"}'), parse_json('{"key1": "value391", "key2": "value392", "key3": "value393", "key4": "value394", "key5": "value395", "key6": "value396", "key7": "value397"}')),
+(40, 65, parse_json('{"key1": "value401", "key2": "value402", "key3": "value403", "key4": "value404", "key5": "value405", "key6": "value406"}'), parse_json('{"key1": "value401", "key2": "value402", "key3": "value403", "key4": "value404", "key5": "value405", "key6": "value406", "key7": "value407", "key8": "value408"}')),
+(41, 85, parse_json('{"key1": "value411", "key2": "value412", "key3": "value413", "key4": "value414", "key5": "value415", "key6": "value416", "key7": "value417", "key8": "value418", "key9": "value419"}'), parse_json('{"key1": "value411", "key2": "value412", "key3": "value413", "key4": "value414", "key5": "value415"}')),
+(42, 59, parse_json('{"key1": "value421", "key2": "value422", "key3": "value423", "key4": "value424", "key5": "value425", "key6": "value426", "key7": "value427", "key8": "value428"}'), parse_json('{"key1": "value421", "key2": "value422", "key3": "value423", "key4": "value424", "key5": "value425", "key6": "value426"}')),
+(43, 66, parse_json('{"key1": "value431", "key2": "value432", "key3": "value433", "key4": "value434", "key5": "value435"}'), parse_json('{"key1": "value431", "key2": "value432", "key3": "value433", "key4": "value434", "key5": "value435"}')),
+(44, 70, parse_json('{"key1": "value441", "key2": "value442", "key3": "value443", "key4": "value444", "key5": "value445", "key6": "value446", "key7": "value447", "key8": "value448", "key9": "value449"}'), parse_json('{"key1": "value441", "key2": "value442", "key3": "value443", "key4": "value444", "key5": "value445", "key6": "value446", "key7": "value447", "key8": "value448", "key9": "value449"}')),
+(45, 26, parse_json('{"key1": "value451", "key2": "value452", "key3": "value453", "key4": "value454", "key5": "value455"}'), parse_json('{"key1": "value451", "key2": "value452", "key3": "value453", "key4": "value454", "key5": "value455", "key6": "value456", "key7": "value457"}')),
+(46, 87, parse_json('{"key1": "value461", "key2": "value462", "key3": "value463", "key4": "value464", "key5": "value465", "key6": "value466", "key7": "value467", "key8": "value468", "key9": "value469"}'), parse_json('{"key1": "value461", "key2": "value462", "key3": "value463", "key4": "value464", "key5": "value465", "key6": "value466", "key7": "value467"}')),
+(47, 23, parse_json('{"key1": "value471", "key2": "value472", "key3": "value473", "key4": "value474", "key5": "value475", "key6": "value476", "key7": "value477", "key8": "value478"}'), parse_json('{"key1": "value471", "key2": "value472", "key3": "value473", "key4": "value474", "key5": "value475", "key6": "value476"}')),
+(48, 44, parse_json('{"key1": "value481", "key2": "value482", "key3": "value483", "key4": "value484", "key5": "value485", "key6": "value486", "key7": "value487", "key8": "value488", "key9": "value489"}'), parse_json('{"key1": "value481", "key2": "value482", "key3": "value483", "key4": "value484", "key5": "value485", "key6": "value486", "key7": "value487"}')),
+(49, 5, parse_json('{"key1": "value491", "key2": "value492", "key3": "value493", "key4": "value494", "key5": "value495", "key6": "value496", "key7": "value497"}'), parse_json('{"key1": "value491", "key2": "value492", "key3": "value493", "key4": "value494", "key5": "value495", "key6": "value496", "key7": "value497"}')),
+(50, 76, parse_json('{"key1": "value501", "key2": "value502", "key3": "value503", "key4": "value504", "key5": "value505", "key6": "value506", "key7": "value507", "key8": "value508"}'), parse_json('{"key1": "value501", "key2": "value502", "key3": "value503", "key4": "value504", "key5": "value505", "key6": "value506", "key7": "value507"}'));
+
+insert into ajs1 select * from js1;
+insert into ajs1 select * from js1;
+insert into ajs1 select * from js1;
+insert into ajs1 select * from js1;
+
+insert into ujs1 select * from js1;
+insert into ujs1 select * from js1;
+insert into ujs1 select * from js1;
+insert into ujs1 select * from js1;
+
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key3"), get_json_string(j2, "$.key4") from js1 order by v1 limit 2;
+select get_json_int(j1, "$.key8"), get_json_double(j2, "$.key9"), get_json_string(j2, "$.key10") from js1 order by v1 limit 2;
+select get_json_int(j1, "$.key12"), get_json_double(j2, "$.key13"), get_json_string(j2, "$") from js1 order by v1 limit 2;
+select get_json_int(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from js1 order by v1 limit 2;
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key2.key3") from js1 order by v1 limit 2;
+
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from js1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key3"), JSON_EXISTS(j2, "$.key4") from js1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key8"), JSON_EXISTS(j2, "$.key9"), JSON_EXISTS(j2, "$.key10") from js1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from js1 order by v1 limit 2;
+select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j2, "$13"), JSON_EXISTS(j2, "$.key3") from js1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from js1 order by v1 limit 2;
+
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from js1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from js1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from js1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from js1 order by v1 limit 2;
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from js1 order by v1 limit 2;
+
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key3"), get_json_string(j2, "$.key4") from ujs1 order by v1 limit 2;
+select get_json_int(j1, "$.key8"), get_json_double(j2, "$.key9"), get_json_string(j2, "$.key10") from ujs1 order by v1 limit 2;
+select get_json_int(j1, "$.key12"), get_json_double(j2, "$.key13"), get_json_string(j2, "$") from ujs1 order by v1 limit 2;
+select get_json_int(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from ujs1 order by v1 limit 2;
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key3"), JSON_EXISTS(j2, "$.key4") from ujs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key8"), JSON_EXISTS(j2, "$.key9"), JSON_EXISTS(j2, "$.key10") from ujs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from ujs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j2, "$13"), JSON_EXISTS(j2, "$.key3") from ujs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from ujs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from ujs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from ujs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from ujs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from ujs1 order by v1 limit 2;
+
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key3"), get_json_string(j2, "$.key4") from ajs1 order by v1 limit 2;
+select get_json_int(j1, "$.key8"), get_json_double(j2, "$.key9"), get_json_string(j2, "$.key10") from ajs1 order by v1 limit 2;
+select get_json_int(j1, "$.key12"), get_json_double(j2, "$.key13"), get_json_string(j2, "$") from ajs1 order by v1 limit 2;
+select get_json_int(j1, "asdf"), get_json_double(j2, "$13"), get_json_string(j2, "$.key3") from ajs1 order by v1 limit 2;
+select get_json_int(j1, "$.key2"), get_json_double(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key3"), JSON_EXISTS(j2, "$.key4") from ajs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key8"), JSON_EXISTS(j2, "$.key9"), JSON_EXISTS(j2, "$.key10") from ajs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key12"), JSON_EXISTS(j2, "$.key13"), JSON_EXISTS(j2, "$") from ajs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "asdf"), JSON_EXISTS(j2, "$13"), JSON_EXISTS(j2, "$.key3") from ajs1 order by v1 limit 2;
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key2.key3") from ajs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j2, "$.key3"), JSON_LENGTH(j2, "$.key4") from ajs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key8"), JSON_LENGTH(j2, "$.key9"), JSON_LENGTH(j2, "$.key10") from ajs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "$.key12"), JSON_LENGTH(j2, "$.key13"), JSON_LENGTH(j2, "$") from ajs1 order by v1 limit 2;
+select JSON_LENGTH(j1, "asdf"), JSON_LENGTH(j2, "$13"), JSON_LENGTH(j2, "$.key3") from ajs1 order by v1 limit 2;

--- a/test/sql/test_semi/T/test_flat_json2
+++ b/test/sql/test_semi/T/test_flat_json2
@@ -1,0 +1,35 @@
+-- name: test_flat_not_object_json_load @system
+
+CREATE TABLE `js1` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `j1` json NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10 
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into js1 values(1,1, parse_json('[{"s1": 4}, {"s2": 5}]'));
+insert into js1 values(2,1, parse_json('"a"'));
+insert into js1 values(3,1, parse_json('1'));
+insert into js1 values(4,1, parse_json('2020-12-12'));
+insert into js1 values(5,1, parse_json('1.000000'));
+insert into js1 values(6,1, parse_json(''));
+insert into js1 values(6,1, parse_json(null));
+insert into js1 values(6,1, parse_json(TRUE));
+
+select get_json_int(j1, "$.key2"), get_json_double(j1, "$.key3"), get_json_string(j1, "$.key4") from js1 order by v1 limit 2;
+
+select JSON_EXISTS(j1, "$.key2"), JSON_EXISTS(j1, "$.key2.key3") from js1 order by v1 limit 2;
+
+select JSON_LENGTH(j1, "$.key2"), JSON_LENGTH(j1, "$.key3"), JSON_LENGTH(j1, "$.key4") from js1 order by v1 limit 2;
+


### PR DESCRIPTION
Why I'm doing:
support flat JSON, only read partial columns when the query only need some sub-field，to optimize json query's IO/CPU cost

What I'm doing:
support single layer json flat, only support on `Object` json, don't support on `Array`/`Literal` json, save subfiled data in segment file, and support different schema in different segment.
only read json's sub-field when use speical json function and with json path, supported functions: `get_json_xxx...`/`json_query
`/`json_exists`/`json_length`


* add JsonFlatter, to extract subfield column by special json subfield name (must be name, not path)
* add JsonColumnWriter, save origin json data (not the final solution) and extract subfield when load data, the extrace strategy: check nulls, check same name, check column numbers. it's work on segment file.
    * ColumnPBMeta: add name to recorde subfield name
* add JsonFlatIterator, read flat json's subfield by ColumnAccessPath
* add JsonDynamicIterator, to extract json's subfield when the segment file doesn't support flat json 
* modify json columns, to support flat mode
* modify json functions, to use sub-field
* support duplicate/aggregate/unique table mode
* FE plan support compute Json subfield path by ColumnAccessPath framework
* add `AccessPathHits` in profile, to count flat json subfield stats in query

Write:
![image](https://github.com/StarRocks/starrocks/assets/5609319/10962861-f2e0-4c75-bd37-7dc0a378350b)

Read:
![image](https://github.com/StarRocks/starrocks/assets/5609319/9c45a415-fe34-4195-910c-a6fd5b4889ff)


### Performance
I test 100g(600037902 rows) ssb-flat data, will flatten 35 sub-field, 8c16g * 3

```
CREATE TABLE `lineorder_flat_js` ( 
  `lo_orderdate` date NOT NULL COMMENT "", 
  `lo_orderkey` int(11) NOT NULL COMMENT "", 
  `js`  JSON NOT NULL COMMENT "" 
) ENGINE=OLAP  
DUPLICATE KEY(`lo_orderdate`, `lo_orderkey`) 
COMMENT "olap" 
PARTITION BY RANGE(`lo_orderdate`) 
(PARTITION p1 VALUES [("0000-01-01"), ("1993-01-01")), 
PARTITION p2 VALUES [("1993-01-01"), ("1994-01-01")), 
PARTITION p3 VALUES [("1994-01-01"), ("1995-01-01")), 
PARTITION p4 VALUES [("1995-01-01"), ("1996-01-01")), 
PARTITION p5 VALUES [("1996-01-01"), ("1997-01-01")), 
PARTITION p6 VALUES [("1997-01-01"), ("1998-01-01")), 
PARTITION p7 VALUES [("1998-01-01"), ("1999-01-01"))) 
DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 48  
PROPERTIES ( 
"replication_num" = "1", 
"colocate_with" = "groupxx1", 
"in_memory" = "false", 
"enable_persistent_index" = "false", 
"replicated_storage" = "true", 
"fast_schema_evolution" = "true", 
"compression" = "LZ4" 
); 

insert into lineorder_flat_js
select LO_ORDERDATE, LO_ORDERKEY, to_json(named_struct("LO_LINENUMBER" , LO_LINENUMBER,"LO_CUSTKEY" , LO_CUSTKEY,"LO_PARTKEY" , LO_PARTKEY,"LO_SUPPKEY" , LO_SUPPKEY,"LO_ORDERPRIORITY" , LO_ORDERPRIORITY,"LO_SHIPPRIORITY" , LO_SHIPPRIORITY,"LO_QUANTITY" , LO_QUANTITY,"LO_EXTENDEDPRICE" , LO_EXTENDEDPRICE,"LO_ORDTOTALPRICE" , LO_ORDTOTALPRICE,"LO_DISCOUNT" , LO_DISCOUNT,"LO_REVENUE" , LO_REVENUE,"LO_SUPPLYCOST" , LO_SUPPLYCOST,"LO_TAX" , LO_TAX,"LO_COMMITDATE" , LO_COMMITDATE,"LO_SHIPMODE" , LO_SHIPMODE,"C_NAME" , C_NAME,"C_ADDRESS" , C_ADDRESS,"C_CITY" , C_CITY,"C_NATION" , C_NATION,"C_REGION" , C_REGION,"C_PHONE" , C_PHONE,"C_MKTSEGMENT" , C_MKTSEGMENT,"S_NAME" , S_NAME,"S_ADDRESS" , S_ADDRESS,"S_CITY" , S_CITY,"S_NATION" , S_NATION,"S_REGION" , S_REGION,"S_PHONE" , S_PHONE,"P_NAME" , P_NAME,"P_MFGR" , P_MFGR,"P_CATEGORY" , P_CATEGORY,"P_BRAND" , P_BRAND,"P_COLOR" , P_COLOR,"P_TYPE" , P_TYPE,"P_SIZE" , P_SIZE,"P_CONTAINER" , P_CONTAINER)) 
from lineorder_flat ;
```

#### Load
Load with Json Flatten Time cost: 1640.965s
Load without Json Flatten Time cost: 790.653s

![image](https://github.com/StarRocks/starrocks/assets/5609319/c8e2f0fa-7ce2-4c5d-966e-25e31e9cd115)

![20240116-154745x](https://github.com/StarRocks/starrocks/assets/5609319/124fccd5-939a-43bf-9e5c-acf5728e8709)

![image](https://github.com/StarRocks/starrocks/assets/5609319/40c7059a-c02e-4320-8372-cb86a01b3a81)

#### Read

| SSB | origin | Json | FlatJson | DynamicFlatJson | Struct |
| ---- | ---- | ---- | ---- | ---- | ----- |
|  Q01   |  84  |  18895  |  5589   | 37437 | 374 |
|  Q03   |  64  |  9553  |  4465   | 29678 |  180 |
|  Q04   |  933  | 319234   |  109882 | 362446 |  3959 |
|  Q05   |  668  | 319833   |  55168  |  -(362446+)  |  3956  |
|  Q06   |  503  | 319020   |  44419  |  -(362446+)  |   2822 |
|  Q07   |  790  | 319020   |  129003 |  -(362446+)  |  3862 |

* IO is the bottleneck
* Dynamic Flat Json need read full json and do flat logical in runtime, it's bad performance, we should avoid this case

#### data useage
```
-- lineorder is origin data
-- lineorder_flat_js is flat json
-- lineorder_flat_js1 is json
MySQL ssb> show data
+--------------------+----------------+---------------------+
| TableName          | Size           | ReplicaCount        |
+--------------------+----------------+---------------------+
| lineorder_flat     | 58.827 GB      | 336                 | 
| lineorder_flat_js  | 292.569 GB     | 336                 |
| lineorder_flat_js1 | 141.805 GB     | 336                 |
+--------------------+----------------+---------------------+
```

Other TODO：
* how to support multi-layer json flat,  recursion Multi-Json iterator or flat to one layer?
* how to recorde the flat stats in load process?
* how to controll flat setting by user?
* don't save origin Json data, always storage flat data?
* compaction will cost a significant amount of memory, it's risk
* optimize JSON Flattern performance

### Split
this PR is too large, split to different PR to review and merge:
- [x] FE Plan: https://github.com/StarRocks/starrocks/pull/39729
- [x] JsonColumn & JsonFunction: https://github.com/StarRocks/starrocks/pull/39738
- [x] FlatJson read process: https://github.com/StarRocks/starrocks/pull/39798
- [x] FlatJson write process: https://github.com/StarRocks/starrocks/pull/40010
- [ ] Doc: https://github.com/StarRocks/starrocks/pull/39321

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
