### PR TITLE
[BugFix] Reset thread local ConnectContext for each materialized view's refresh

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRun.java
@@ -180,6 +180,12 @@ public class TaskRun implements Comparable<TaskRun> {
         runCtx.getState().reset();
         runCtx.setQueryId(UUID.fromString(status.getQueryId()));
 
+        // NOTE: Ensure the thread local connect context is always the same with the newest ConnectContext.
+        // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
+        runCtx.setThreadLocalInfo();
+        LOG.info("[QueryId:{}] [ThreadLocal QueryId: {}] start to execute task run, task_id:{}",
+                runCtx.getQueryId(), ConnectContext.get() == null ? "" : ConnectContext.get().getQueryId(), taskId);
+
         Map<String, String> newProperties = refreshTaskProperties(runCtx);
         properties.putAll(newProperties);
 
@@ -205,6 +211,8 @@ public class TaskRun implements Comparable<TaskRun> {
 
         processor.processTaskRun(taskRunContext);
         QueryState queryState = runCtx.getState();
+        LOG.info("[QueryId:{}] finished to execute task run, task_id:{}, query_state:{}",
+                runCtx.getQueryId(), taskId, queryState);
         if (runCtx.getState().getStateType() == QueryState.MysqlStateType.ERR) {
             status.setErrorMessage(queryState.getErrorMessage());
             int errorCode = -1;

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -59,6 +59,7 @@ public class TaskRunExecutor {
                 status.setErrorCode(-1);
                 status.setErrorMessage(ex.toString());
             } finally {
+                // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
                 ConnectContext.remove();
                 status.setFinishTime(System.currentTimeMillis());
             }


### PR DESCRIPTION
Why I'm doing:

If Hive table has been updated, but now MV cannot been refreshed automaticlly.

This is because 
1. TaskRun will use the same query id to get Hive's metadata from query level cache because of the same query id.
2. But `PartitionBasedMvRefreshProcessor` only reset the thread local cache after there are new partitions to refresh.

```
2023-12-21 17:00:00,810 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():174] finished to execute task run, task_id:12019, query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35, query_state:OK
2023-12-21 17:01:00,286 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:757f1451-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:02:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:99425a55-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:03:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:bd05a056-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:04:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:e0c8e66f-9fdf-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:05:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:048c2c70-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:06:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:284f7272-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:07:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:4c12b873-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:08:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:6fd5fe75-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
2023-12-21 17:09:00,285 INFO (starrocks-taskrun-pool-1|323) [TaskRun.executeTaskRun():151] start to execute task run, task_id:12019, query_id:93994476-9fe0-11ee-b918-c20e6cc03e35, thread_local_query_id:51bbcf4c-9fdf-11ee-b918-c20e6cc03e35
```
What I'm doing:
- Reset the thread local ConnectContext after ConnectContext is created.
- Add more logs to track this.


Backport from https://github.com/StarRocks/starrocks/pull/37551

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
