### PR TITLE
[Enhancement] Print compaction task statistics logs for cloud native table

### DIFF
--- a/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
@@ -40,7 +40,15 @@ SchemaScanner::ColumnDesc SchemaBeCloudNativeCompactionsScanner::_s_columns[] = 
         {"START_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"FINISH_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"PROGRESS", TYPE_INT, sizeof(int32_t), false},
-        {"STATUS", TYPE_VARCHAR, sizeof(StringValue), false}};
+        {"STATUS", TYPE_VARCHAR, sizeof(StringValue), false},
+        {"READER_TOTAL_TIME_MS", TYPE_BIGINT, sizeof(int64_t), false},
+        {"READER_IO_MS", TYPE_BIGINT, sizeof(int64_t), false},
+        {"READER_IO_COUNT_REMOTE", TYPE_BIGINT, sizeof(int64_t), false},
+        {"READER_IO_COUNT_LOCAL_DISK", TYPE_BIGINT, sizeof(int64_t), false},
+        {"COMPRESSED_BYTES_READ", TYPE_BIGINT, sizeof(int64_t), false},
+        {"SEGMENT_INIT_MS", TYPE_BIGINT, sizeof(int64_t), false},
+        {"COLUMN_ITERATOR_INIT_MS", TYPE_BIGINT, sizeof(int64_t), false},
+        {"SEGMENT_WRITE_MS", TYPE_BIGINT, sizeof(int64_t), false}};
 
 SchemaBeCloudNativeCompactionsScanner::SchemaBeCloudNativeCompactionsScanner()
         : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
@@ -70,7 +78,7 @@ Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
     for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
-            if (slot_id < 1 || slot_id > 10) {
+            if (slot_id < 1 || slot_id > 18) {
                 return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
             }
             ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
@@ -128,6 +136,38 @@ Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
                 auto s = info.status.message();
                 Slice v(s.data(), s.size());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
+                break;
+            }
+            case 11: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.reader_total_time_ms);
+                break;
+            }
+            case 12: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.reader_io_ms);
+                break;
+            }
+            case 13: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.reader_io_count_remote);
+                break;
+            }
+            case 14: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.reader_io_count_local_disk);
+                break;
+            }
+            case 15: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.compressed_bytes_read);
+                break;
+            }
+            case 16: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.segment_init_ms);
+                break;
+            }
+            case 17: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.column_iterator_init_ms);
+                break;
+            }
+            case 18: {
+                fill_column_with_slot<TYPE_BIGINT>(column.get(), (void*)&info.segment_write_ms);
                 break;
             }
             default:

--- a/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
+++ b/be/src/exec/schema_scanner/schema_be_cloud_native_compactions_scanner.cpp
@@ -38,8 +38,7 @@ SchemaScanner::ColumnDesc SchemaBeCloudNativeCompactionsScanner::_s_columns[] = 
         {"START_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"FINISH_TIME", TYPE_DATETIME, sizeof(DateTimeValue), true},
         {"PROGRESS", TYPE_INT, sizeof(int32_t), false},
-        {"STATUS", TYPE_VARCHAR, sizeof(StringValue), false},
-        {"STATISTICS", TYPE_VARCHAR, sizeof(StringValue), false}};
+        {"STATUS", TYPE_VARCHAR, sizeof(StringValue), false}};
 
 SchemaBeCloudNativeCompactionsScanner::SchemaBeCloudNativeCompactionsScanner()
         : SchemaScanner(_s_columns, sizeof(_s_columns) / sizeof(SchemaScanner::ColumnDesc)) {}
@@ -69,7 +68,7 @@ Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
     for (; _cur_idx < end; _cur_idx++) {
         auto& info = _infos[_cur_idx];
         for (const auto& [slot_id, index] : slot_id_to_index_map) {
-            if (slot_id < 1 || slot_id > 11) {
+            if (slot_id < 1 || slot_id > 10) {
                 return Status::InternalError(strings::Substitute("invalid slot id:$0", slot_id));
             }
             ColumnPtr column = (*chunk)->get_column_by_slot_id(slot_id);
@@ -127,11 +126,6 @@ Status SchemaBeCloudNativeCompactionsScanner::fill_chunk(ChunkPtr* chunk) {
                 auto s = info.status.message();
                 Slice v(s.data(), s.size());
                 fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&v);
-                break;
-            }
-            case 11: {
-                Slice statistic = Slice(info.statistic);
-                fill_column_with_slot<TYPE_VARCHAR>(column.get(), (void*)&statistic);
                 break;
             }
             default:

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -185,6 +185,7 @@ add_library(Storage STATIC
     lake/compaction_policy.cpp
     lake/compaction_scheduler.cpp
     lake/compaction_task.cpp
+    lake/compaction_task_context.cpp
     lake/horizontal_compaction_task.cpp
     lake/delta_writer.cpp
     lake/vacuum.cpp

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -140,20 +140,13 @@ void CompactionScheduler::list_tasks(std::vector<CompactionTaskInfo>* infos) {
         info.runs = context->runs.load(std::memory_order_relaxed);
         info.start_time = context->start_time.load(std::memory_order_relaxed);
         info.progress = context->progress.value();
-        info.reader_io_ms = context->io_ns / 1000000;
-        info.segment_init_ms = context->segment_init_ns / 1000000;
-        info.column_iterator_init_ms = context->column_iterator_init_ns / 1000000;
-        info.segment_write_ms = context->segment_write_ns / 1000000;
-        info.reader_total_time_ms = context->reader_time_ns / 1000000;
-        info.compressed_bytes_read = context->compressed_bytes_read;
-        info.reader_io_count_local_disk = context->io_count_local_disk;
-        info.reader_io_count_remote = context->io_count_remote;
         // Load "finish_time" with memory_order_acquire and check its value before reading the "status" to avoid
         // the race condition between this thread and the `CompactionScheduler::thread_task` threads.
         info.finish_time = context->finish_time.load(std::memory_order_acquire);
         if (info.finish_time > 0) {
             info.status = context->status;
         }
+        info.statistic = context->to_json_stats();
     }
 }
 

--- a/be/src/storage/lake/compaction_scheduler.cpp
+++ b/be/src/storage/lake/compaction_scheduler.cpp
@@ -146,7 +146,6 @@ void CompactionScheduler::list_tasks(std::vector<CompactionTaskInfo>* infos) {
         if (info.finish_time > 0) {
             info.status = context->status;
         }
-        info.statistic = context->to_json_stats();
     }
 }
 
@@ -236,7 +235,7 @@ Status CompactionScheduler::do_compaction(std::unique_ptr<CompactionTaskContext>
     context->runs.fetch_add(1, std::memory_order_relaxed);
 
     auto status = Status::OK();
-    auto task_or = _tablet_mgr->compact(tablet_id, version, txn_id, *context);
+    auto task_or = _tablet_mgr->compact(context.get());
     if (task_or.ok()) {
         auto should_cancel = [&]() { return context->callback->has_error() || context->callback->timeout_exceeded(); };
         TEST_SYNC_POINT("CompactionScheduler::do_compaction:before_execute_task");

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -96,15 +96,8 @@ struct CompactionTaskInfo {
     int64_t version;
     int64_t start_time;
     int64_t finish_time;
-    int64_t reader_io_ms;
-    int64_t reader_io_count_local_disk;
-    int64_t reader_io_count_remote;
-    int64_t segment_init_ms;
-    int64_t column_iterator_init_ms;
-    int64_t compressed_bytes_read;
-    int64_t segment_write_ms;
-    int64_t reader_total_time_ms;
     Status status;
+    std::string statistic;
     int runs;     // How many times the compaction task has been executed
     int progress; // 0-100
     bool skipped;

--- a/be/src/storage/lake/compaction_scheduler.h
+++ b/be/src/storage/lake/compaction_scheduler.h
@@ -97,7 +97,6 @@ struct CompactionTaskInfo {
     int64_t start_time;
     int64_t finish_time;
     Status status;
-    std::string statistic;
     int runs;     // How many times the compaction task has been executed
     int progress; // 0-100
     bool skipped;

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -20,12 +20,13 @@
 namespace starrocks::lake {
 
 CompactionTask::CompactionTask(int64_t txn_id, VersionedTablet tablet,
-                               std::vector<std::shared_ptr<Rowset>> input_rowsets)
+                               std::vector<std::shared_ptr<Rowset>> input_rowsets, CompactionTaskContext& context)
         : _txn_id(txn_id),
           _tablet(std::move(tablet)),
           _input_rowsets(std::move(input_rowsets)),
           _mem_tracker(std::make_unique<MemTracker>(MemTracker::COMPACTION, -1,
                                                     "Compaction-" + std::to_string(_tablet.metadata()->id()),
-                                                    GlobalEnv::GetInstance()->compaction_mem_tracker())) {}
+                                                    GlobalEnv::GetInstance()->compaction_mem_tracker())),
+          _context(context) {}
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task.cpp
+++ b/be/src/storage/lake/compaction_task.cpp
@@ -19,9 +19,9 @@
 
 namespace starrocks::lake {
 
-CompactionTask::CompactionTask(int64_t txn_id, VersionedTablet tablet,
-                               std::vector<std::shared_ptr<Rowset>> input_rowsets, CompactionTaskContext& context)
-        : _txn_id(txn_id),
+CompactionTask::CompactionTask(VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets,
+                               CompactionTaskContext* context)
+        : _txn_id(context->txn_id),
           _tablet(std::move(tablet)),
           _input_rowsets(std::move(input_rowsets)),
           _mem_tracker(std::make_unique<MemTracker>(MemTracker::COMPACTION, -1,

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -19,6 +19,7 @@
 #include <ostream>
 
 #include "common/status.h"
+#include "compaction_task_context.h"
 #include "runtime/mem_tracker.h"
 #include "storage/lake/versioned_tablet.h"
 
@@ -28,24 +29,15 @@ class Rowset;
 
 class CompactionTask {
 public:
-    class Progress {
-    public:
-        int value() const { return _value.load(std::memory_order_acquire); }
-
-        void update(int value) { _value.store(value, std::memory_order_release); }
-
-    private:
-        std::atomic<int> _value{0};
-    };
-
     // CancelFunc is a function that used to tell the compaction task whether the task
     // should be cancelled.
     using CancelFunc = std::function<bool()>;
 
-    explicit CompactionTask(int64_t txn_id, VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets);
+    explicit CompactionTask(int64_t txn_id, VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets,
+                            CompactionTaskContext& context);
     virtual ~CompactionTask() = default;
 
-    virtual Status execute(Progress* stats, CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) = 0;
+    virtual Status execute(CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) = 0;
 
     inline static const CancelFunc kNoCancelFn = []() { return false; };
     inline static const CancelFunc kCancelledFn = []() { return true; };
@@ -55,6 +47,7 @@ protected:
     VersionedTablet _tablet;
     std::vector<std::shared_ptr<Rowset>> _input_rowsets;
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
+    CompactionTaskContext& _context;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task.h
+++ b/be/src/storage/lake/compaction_task.h
@@ -33,8 +33,8 @@ public:
     // should be cancelled.
     using CancelFunc = std::function<bool()>;
 
-    explicit CompactionTask(int64_t txn_id, VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets,
-                            CompactionTaskContext& context);
+    explicit CompactionTask(VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets,
+                            CompactionTaskContext* context);
     virtual ~CompactionTask() = default;
 
     virtual Status execute(CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) = 0;
@@ -47,7 +47,7 @@ protected:
     VersionedTablet _tablet;
     std::vector<std::shared_ptr<Rowset>> _input_rowsets;
     std::unique_ptr<MemTracker> _mem_tracker = nullptr;
-    CompactionTaskContext& _context;
+    CompactionTaskContext* _context;
 };
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -22,6 +22,8 @@
 
 namespace starrocks::lake {
 
+static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
+
 void CompactionTaskStats::accumulate(const OlapReaderStatistics& reader_stats) {
     io_ns += reader_stats.io_ns;
     io_ns_remote += reader_stats.io_ns_remote;
@@ -38,16 +40,18 @@ std::string CompactionTaskStats::to_json_stats() {
     root.SetObject();
     auto& allocator = root.GetAllocator();
     // add stats
-    root.AddMember("reader_total_time_ms", rapidjson::Value(reader_time_ns / 1000000), allocator);
-    root.AddMember("reader_io_ms", rapidjson::Value(io_ns / 1000000), allocator);
-    root.AddMember("reader_io_ms_remote", rapidjson::Value(io_ns_remote / 1000000), allocator);
-    root.AddMember("reader_io_ms_local_disk", rapidjson::Value(io_ns_local_disk / 1000000), allocator);
+    root.AddMember("reader_total_time_second", rapidjson::Value(reader_time_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("reader_io_second", rapidjson::Value(io_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("reader_io_second_remote", rapidjson::Value(io_ns_remote / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("reader_io_second_local_disk", rapidjson::Value(io_ns_local_disk / TIME_UNIT_NS_PER_SECOND),
+                   allocator);
     root.AddMember("reader_io_count_remote", rapidjson::Value(io_count_remote), allocator);
     root.AddMember("reader_io_count_local_disk", rapidjson::Value(io_count_local_disk), allocator);
     root.AddMember("compressed_bytes_read", rapidjson::Value(compressed_bytes_read), allocator);
-    root.AddMember("segment_init_ms", rapidjson::Value(segment_init_ns / 1000000), allocator);
-    root.AddMember("column_iterator_init_ms", rapidjson::Value(column_iterator_init_ns / 1000000), allocator);
-    root.AddMember("segment_write_ms", rapidjson::Value(segment_write_ns / 1000000), allocator);
+    root.AddMember("segment_init_second", rapidjson::Value(segment_init_ns / TIME_UNIT_NS_PER_SECOND), allocator);
+    root.AddMember("column_iterator_init_second", rapidjson::Value(column_iterator_init_ns / TIME_UNIT_NS_PER_SECOND),
+                   allocator);
+    root.AddMember("segment_write_second", rapidjson::Value(segment_write_ns / TIME_UNIT_NS_PER_SECOND), allocator);
 
     rapidjson::StringBuffer strbuf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -15,25 +15,39 @@
 #include "storage/lake/compaction_task_context.h"
 
 #include <rapidjson/document.h>
-#include <rapidjson/rapidjson.h>
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include "storage/olap_common.h"
+
 namespace starrocks::lake {
 
-std::string CompactionTaskContext::to_json_stats() {
+void CompactionTaskStats::accumulate(const OlapReaderStatistics& reader_stats) {
+    io_ns += reader_stats.io_ns;
+    io_ns_remote += reader_stats.io_ns_remote;
+    io_ns_local_disk += reader_stats.io_ns_local_disk;
+    segment_init_ns += reader_stats.segment_init_ns;
+    column_iterator_init_ns += reader_stats.column_iterator_init_ns;
+    io_count_local_disk += reader_stats.io_count_local_disk;
+    io_count_remote += reader_stats.io_count_remote;
+    compressed_bytes_read += reader_stats.compressed_bytes_read;
+}
+
+std::string CompactionTaskStats::to_json_stats() {
     rapidjson::Document root;
     root.SetObject();
     auto& allocator = root.GetAllocator();
     // add stats
-    root.AddMember("reader_total_time_ms", rapidjson::Value(stats->reader_time_ns / 1000000), allocator);
-    root.AddMember("reader_io_ms", rapidjson::Value(stats->io_ns / 1000000), allocator);
-    root.AddMember("reader_io_count_remote", rapidjson::Value(stats->io_count_remote), allocator);
-    root.AddMember("reader_io_count_local_disk", rapidjson::Value(stats->io_count_local_disk), allocator);
-    root.AddMember("compressed_bytes_read", rapidjson::Value(stats->compressed_bytes_read), allocator);
-    root.AddMember("segment_init_ms", rapidjson::Value(stats->segment_init_ns / 1000000), allocator);
-    root.AddMember("column_iterator_init_ms", rapidjson::Value(stats->column_iterator_init_ns / 1000000), allocator);
-    root.AddMember("segment_write_ms", rapidjson::Value(stats->segment_write_ns / 1000000), allocator);
+    root.AddMember("reader_total_time_ms", rapidjson::Value(reader_time_ns / 1000000), allocator);
+    root.AddMember("reader_io_ms", rapidjson::Value(io_ns / 1000000), allocator);
+    root.AddMember("reader_io_ms_remote", rapidjson::Value(io_ns_remote / 1000000), allocator);
+    root.AddMember("reader_io_ms_local_disk", rapidjson::Value(io_ns_local_disk / 1000000), allocator);
+    root.AddMember("reader_io_count_remote", rapidjson::Value(io_count_remote), allocator);
+    root.AddMember("reader_io_count_local_disk", rapidjson::Value(io_count_local_disk), allocator);
+    root.AddMember("compressed_bytes_read", rapidjson::Value(compressed_bytes_read), allocator);
+    root.AddMember("segment_init_ms", rapidjson::Value(segment_init_ns / 1000000), allocator);
+    root.AddMember("column_iterator_init_ms", rapidjson::Value(column_iterator_init_ns / 1000000), allocator);
+    root.AddMember("segment_write_ms", rapidjson::Value(segment_write_ns / 1000000), allocator);
 
     rapidjson::StringBuffer strbuf;
     rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);

--- a/be/src/storage/lake/compaction_task_context.cpp
+++ b/be/src/storage/lake/compaction_task_context.cpp
@@ -1,0 +1,43 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/compaction_task_context.h"
+
+#include <rapidjson/document.h>
+#include <rapidjson/rapidjson.h>
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+namespace starrocks::lake {
+
+std::string CompactionTaskContext::to_json_stats() {
+    rapidjson::Document root;
+    root.SetObject();
+    auto& allocator = root.GetAllocator();
+    // add stats
+    root.AddMember("reader_total_time_ms", rapidjson::Value(stats->reader_time_ns / 1000000), allocator);
+    root.AddMember("reader_io_ms", rapidjson::Value(stats->io_ns / 1000000), allocator);
+    root.AddMember("reader_io_count_remote", rapidjson::Value(stats->io_count_remote), allocator);
+    root.AddMember("reader_io_count_local_disk", rapidjson::Value(stats->io_count_local_disk), allocator);
+    root.AddMember("compressed_bytes_read", rapidjson::Value(stats->compressed_bytes_read), allocator);
+    root.AddMember("segment_init_ms", rapidjson::Value(stats->segment_init_ns / 1000000), allocator);
+    root.AddMember("column_iterator_init_ms", rapidjson::Value(stats->column_iterator_init_ns / 1000000), allocator);
+    root.AddMember("segment_write_ms", rapidjson::Value(stats->segment_write_ns / 1000000), allocator);
+
+    rapidjson::StringBuffer strbuf;
+    rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);
+    root.Accept(writer);
+    return {strbuf.GetString()};
+}
+} // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <butil/containers/linked_list.h>
+
+#include <memory>
+
+#include "common/status.h"
+
+namespace starrocks::lake {
+
+class CompactionTaskCallback;
+class Progress {
+public:
+    int value() const { return _value.load(std::memory_order_acquire); }
+
+    void update(int value) { _value.store(value, std::memory_order_release); }
+
+private:
+    std::atomic<int> _value{0};
+};
+
+// Context of a single tablet compaction task.
+struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
+    explicit CompactionTaskContext(int64_t txn_id_, int64_t tablet_id_, int64_t version_,
+                                   std::shared_ptr<CompactionTaskCallback> cb_)
+            : txn_id(txn_id_), tablet_id(tablet_id_), version(version_), callback(std::move(cb_)) {}
+
+#ifndef NDEBUG
+    ~CompactionTaskContext() {
+        CHECK(next() == this && previous() == this) << "Must remove CompactionTaskContext from list before destructor";
+    }
+#endif
+
+    const int64_t txn_id;
+    const int64_t tablet_id;
+    const int64_t version;
+    std::atomic<int64_t> start_time{0};
+    std::atomic<int64_t> finish_time{0};
+    std::atomic<bool> skipped{false};
+    std::atomic<int> runs{0};
+    int64_t io_ns = 0;
+    int64_t segment_init_ns = 0;
+    int64_t column_iterator_init_ns = 0;
+    int64_t io_count_local_disk = 0;
+    int64_t io_count_remote = 0;
+    int64_t compressed_bytes_read = 0;
+    int64_t reader_time_ns = 0;
+    int64_t segment_write_ns = 0;
+    Status status;
+    Progress progress;
+    std::shared_ptr<CompactionTaskCallback> callback;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -22,6 +22,10 @@
 
 #include "common/status.h"
 
+namespace starrocks {
+struct OlapReaderStatistics;
+}
+
 namespace starrocks::lake {
 
 class CompactionTaskCallback;
@@ -37,6 +41,8 @@ private:
 
 struct CompactionTaskStats {
     int64_t io_ns = 0;
+    int64_t io_ns_remote = 0;
+    int64_t io_ns_local_disk = 0;
     int64_t segment_init_ns = 0;
     int64_t column_iterator_init_ns = 0;
     int64_t io_count_local_disk = 0;
@@ -44,6 +50,9 @@ struct CompactionTaskStats {
     int64_t compressed_bytes_read = 0;
     int64_t reader_time_ns = 0;
     int64_t segment_write_ns = 0;
+
+    void accumulate(const OlapReaderStatistics& reader_stats);
+    std::string to_json_stats();
 };
 
 // Context of a single tablet compaction task.
@@ -57,8 +66,6 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
         CHECK(next() == this && previous() == this) << "Must remove CompactionTaskContext from list before destructor";
     }
 #endif
-
-    std::string to_json_stats();
 
     const int64_t txn_id;
     const int64_t tablet_id;

--- a/be/src/storage/lake/compaction_task_context.h
+++ b/be/src/storage/lake/compaction_task_context.h
@@ -15,11 +15,8 @@
 #pragma once
 
 #include <butil/containers/linked_list.h>
-#include <rapidjson/document.h>
-#include <rapidjson/rapidjson.h>
-#include <rapidjson/stringbuffer.h>
-#include <rapidjson/writer.h>
 
+#include <atomic>
 #include <memory>
 #include <string>
 
@@ -61,26 +58,7 @@ struct CompactionTaskContext : public butil::LinkNode<CompactionTaskContext> {
     }
 #endif
 
-    std::string to_json_stats() {
-        rapidjson::Document root;
-        root.SetObject();
-        auto& allocator = root.GetAllocator();
-        // add stats
-        root.AddMember("reader_total_time_ms", rapidjson::Value(stats->reader_time_ns / 1000000), allocator);
-        root.AddMember("reader_io_ms", rapidjson::Value(stats->segment_init_ns / 1000000), allocator);
-        root.AddMember("reader_io_count_remote", rapidjson::Value(stats->io_count_remote), allocator);
-        root.AddMember("reader_io_count_local_disk", rapidjson::Value(stats->io_count_local_disk), allocator);
-        root.AddMember("compressed_bytes_read", rapidjson::Value(stats->compressed_bytes_read), allocator);
-        root.AddMember("segment_init_ms", rapidjson::Value(stats->segment_init_ns / 1000000), allocator);
-        root.AddMember("column_iterator_init_ms", rapidjson::Value(stats->column_iterator_init_ns / 1000000),
-                       allocator);
-        root.AddMember("segment_write_ms", rapidjson::Value(stats->segment_write_ns / 1000000), allocator);
-
-        rapidjson::StringBuffer strbuf;
-        rapidjson::Writer<rapidjson::StringBuffer> writer(strbuf);
-        root.Accept(writer);
-        return std::string(strbuf.GetString());
-    }
+    std::string to_json_stats();
 
     const int64_t txn_id;
     const int64_t tablet_id;

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -43,6 +43,7 @@ Status HorizontalGeneralTabletWriter::open() {
 }
 
 Status HorizontalGeneralTabletWriter::write(const starrocks::Chunk& data, SegmentPB* segment) {
+    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     if (_seg_writer == nullptr || _seg_writer->estimate_segment_size() >= config::max_segment_file_size ||
         _seg_writer->num_rows_written() + data.num_rows() >= INT32_MAX /*TODO: configurable*/) {
         RETURN_IF_ERROR(flush_segment_writer(segment));
@@ -58,6 +59,7 @@ Status HorizontalGeneralTabletWriter::flush(SegmentPB* segment) {
 }
 
 Status HorizontalGeneralTabletWriter::finish(SegmentPB* segment) {
+    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     RETURN_IF_ERROR(flush_segment_writer(segment));
     _finished = true;
     return Status::OK();
@@ -133,6 +135,7 @@ Status VerticalGeneralTabletWriter::open() {
 
 Status VerticalGeneralTabletWriter::write_columns(const Chunk& data, const std::vector<uint32_t>& column_indexes,
                                                   bool is_key) {
+    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     const size_t chunk_num_rows = data.num_rows();
     if (_segment_writers.empty()) {
         DCHECK(is_key);
@@ -204,6 +207,7 @@ Status VerticalGeneralTabletWriter::flush(SegmentPB* segment) {
 }
 
 Status VerticalGeneralTabletWriter::flush_columns() {
+    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     if (_segment_writers.empty()) {
         return Status::OK();
     }
@@ -219,6 +223,7 @@ Status VerticalGeneralTabletWriter::flush_columns() {
 }
 
 Status VerticalGeneralTabletWriter::finish(SegmentPB* segment) {
+    SCOPED_RAW_TIMER(&_stats.segment_write_ns);
     for (auto& segment_writer : _segment_writers) {
         uint64_t segment_size = 0;
         uint64_t footer_position = 0;

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -94,14 +94,8 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     RETURN_IF_ERROR(writer->finish());
 
     // add reader stats
-    auto stats = reader.stats();
     _context->stats->reader_time_ns += reader_time_ns;
-    _context->stats->io_ns += stats.io_ns;
-    _context->stats->segment_init_ns += stats.segment_init_ns;
-    _context->stats->column_iterator_init_ns += stats.column_iterator_init_ns;
-    _context->stats->io_count_local_disk += stats.io_count_local_disk;
-    _context->stats->io_count_remote += stats.io_count_remote;
-    _context->stats->compressed_bytes_read += stats.compressed_bytes_read;
+    _context->stats->accumulate(reader.stats());
 
     // update writer stats
     _context->stats->segment_write_ns += writer->stats().segment_write_ns;
@@ -130,7 +124,7 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     }
 
     LOG(INFO) << "Horizontal compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-              << ", statistics: " << _context->to_json_stats();
+              << ", statistics: " << _context->stats->to_json_stats();
 
     return Status::OK();
 }

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -85,15 +85,6 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
 
         _context->progress.update(100 * reader.stats().raw_rows_read / total_num_rows);
         VLOG_EVERY_N(3, 1000) << "Tablet: " << _tablet.id() << ", compaction progress: " << _context->progress.value();
-        // add reader stats
-        auto stats = reader.stats();
-        _context->stats->reader_time_ns += reader_time_ns;
-        _context->stats->io_ns += stats.io_ns;
-        _context->stats->segment_init_ns += stats.segment_init_ns;
-        _context->stats->column_iterator_init_ns += stats.column_iterator_init_ns;
-        _context->stats->io_count_local_disk += stats.io_count_local_disk;
-        _context->stats->io_count_remote += stats.io_count_remote;
-        _context->stats->compressed_bytes_read += stats.compressed_bytes_read;
     }
 
     // Adjust the progress here for 2 reasons:
@@ -101,6 +92,16 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
     // 2. If the "total_num_rows" is 0, the progress will not be updated above
     _context->progress.update(100);
     RETURN_IF_ERROR(writer->finish());
+
+    // add reader stats
+    auto stats = reader.stats();
+    _context->stats->reader_time_ns += reader_time_ns;
+    _context->stats->io_ns += stats.io_ns;
+    _context->stats->segment_init_ns += stats.segment_init_ns;
+    _context->stats->column_iterator_init_ns += stats.column_iterator_init_ns;
+    _context->stats->io_count_local_disk += stats.io_count_local_disk;
+    _context->stats->io_count_remote += stats.io_count_remote;
+    _context->stats->compressed_bytes_read += stats.compressed_bytes_read;
 
     // update writer stats
     _context->stats->segment_write_ns += writer->stats().segment_write_ns;

--- a/be/src/storage/lake/horizontal_compaction_task.cpp
+++ b/be/src/storage/lake/horizontal_compaction_task.cpp
@@ -83,29 +83,27 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         RETURN_IF_ERROR(writer->write(*chunk));
         chunk->reset();
 
-        _context.progress.update(100 * reader.stats().raw_rows_read / total_num_rows);
-        VLOG_EVERY_N(3, 1000) << "Tablet: " << _tablet.id() << ", compaction progress: " << _context.progress.value();
+        _context->progress.update(100 * reader.stats().raw_rows_read / total_num_rows);
+        VLOG_EVERY_N(3, 1000) << "Tablet: " << _tablet.id() << ", compaction progress: " << _context->progress.value();
         // add reader stats
         auto stats = reader.stats();
-        _context.stats->reader_time_ns += reader_time_ns;
-        _context.stats->io_ns += stats.io_ns;
-        _context.stats->segment_init_ns += stats.segment_init_ns;
-        _context.stats->column_iterator_init_ns += stats.column_iterator_init_ns;
-        _context.stats->io_count_local_disk += stats.io_count_local_disk;
-        _context.stats->io_count_remote += stats.io_count_remote;
-        _context.stats->compressed_bytes_read += stats.compressed_bytes_read;
-        // add writer stats
-        _context.stats->segment_write_ns = writer->stats().segment_write_ns;
+        _context->stats->reader_time_ns += reader_time_ns;
+        _context->stats->io_ns += stats.io_ns;
+        _context->stats->segment_init_ns += stats.segment_init_ns;
+        _context->stats->column_iterator_init_ns += stats.column_iterator_init_ns;
+        _context->stats->io_count_local_disk += stats.io_count_local_disk;
+        _context->stats->io_count_remote += stats.io_count_remote;
+        _context->stats->compressed_bytes_read += stats.compressed_bytes_read;
     }
 
     // Adjust the progress here for 2 reasons:
     // 1. For primary key, due to the existence of the delete vector, the rows read may be less than "total_num_rows"
     // 2. If the "total_num_rows" is 0, the progress will not be updated above
-    _context.progress.update(100);
+    _context->progress.update(100);
     RETURN_IF_ERROR(writer->finish());
 
     // update writer stats
-    _context.stats->segment_write_ns = writer->stats().segment_write_ns;
+    _context->stats->segment_write_ns += writer->stats().segment_write_ns;
 
     auto txn_log = std::make_shared<TxnLog>();
     auto op_compaction = txn_log->mutable_op_compaction();
@@ -130,8 +128,8 @@ Status HorizontalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flu
         _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, tablet_schema);
     }
 
-    VLOG(3) << "Horizontal compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-            << ", statistics: " << _context.to_json_stats();
+    LOG(INFO) << "Horizontal compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
+              << ", statistics: " << _context->to_json_stats();
 
     return Status::OK();
 }

--- a/be/src/storage/lake/horizontal_compaction_task.h
+++ b/be/src/storage/lake/horizontal_compaction_task.h
@@ -31,12 +31,13 @@ class TabletWriter;
 class HorizontalCompactionTask : public CompactionTask {
 public:
     explicit HorizontalCompactionTask(int64_t txn_id, VersionedTablet tablet,
-                                      std::vector<std::shared_ptr<Rowset>> input_rowsets)
-            : CompactionTask(txn_id, std::move(tablet), std::move(input_rowsets)) {}
+                                      std::vector<std::shared_ptr<Rowset>> input_rowsets,
+                                      CompactionTaskContext& context)
+            : CompactionTask(txn_id, std::move(tablet), std::move(input_rowsets), context) {}
 
     ~HorizontalCompactionTask() override = default;
 
-    Status execute(Progress* progress, CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) override;
+    Status execute(CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) override;
 
 private:
     StatusOr<int32_t> calculate_chunk_size();

--- a/be/src/storage/lake/horizontal_compaction_task.h
+++ b/be/src/storage/lake/horizontal_compaction_task.h
@@ -30,10 +30,9 @@ class TabletWriter;
 
 class HorizontalCompactionTask : public CompactionTask {
 public:
-    explicit HorizontalCompactionTask(int64_t txn_id, VersionedTablet tablet,
-                                      std::vector<std::shared_ptr<Rowset>> input_rowsets,
-                                      CompactionTaskContext& context)
-            : CompactionTask(txn_id, std::move(tablet), std::move(input_rowsets), context) {}
+    explicit HorizontalCompactionTask(VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets,
+                                      CompactionTaskContext* context)
+            : CompactionTask(std::move(tablet), std::move(input_rowsets), context) {}
 
     ~HorizontalCompactionTask() override = default;
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -485,17 +485,18 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_index_id(int64_t t
     }
 }
 
-StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t version, int64_t txn_id) {
+StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t version, int64_t txn_id,
+                                                   CompactionTaskContext& context) {
     ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id, version));
     auto tablet_metadata = tablet.metadata();
     ASSIGN_OR_RETURN(auto compaction_policy, CompactionPolicy::create(this, tablet_metadata));
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets());
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));
     if (algorithm == VERTICAL_COMPACTION) {
-        return std::make_shared<VerticalCompactionTask>(txn_id, std::move(tablet), std::move(input_rowsets));
+        return std::make_shared<VerticalCompactionTask>(txn_id, std::move(tablet), std::move(input_rowsets), context);
     } else {
         DCHECK(algorithm == HORIZONTAL_COMPACTION);
-        return std::make_shared<HorizontalCompactionTask>(txn_id, std::move(tablet), std::move(input_rowsets));
+        return std::make_shared<HorizontalCompactionTask>(txn_id, std::move(tablet), std::move(input_rowsets), context);
     }
 }
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -485,18 +485,17 @@ StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema_by_index_id(int64_t t
     }
 }
 
-StatusOr<CompactionTaskPtr> TabletManager::compact(int64_t tablet_id, int64_t version, int64_t txn_id,
-                                                   CompactionTaskContext& context) {
-    ASSIGN_OR_RETURN(auto tablet, get_tablet(tablet_id, version));
+StatusOr<CompactionTaskPtr> TabletManager::compact(CompactionTaskContext* context) {
+    ASSIGN_OR_RETURN(auto tablet, get_tablet(context->tablet_id, context->version));
     auto tablet_metadata = tablet.metadata();
     ASSIGN_OR_RETURN(auto compaction_policy, CompactionPolicy::create(this, tablet_metadata));
     ASSIGN_OR_RETURN(auto input_rowsets, compaction_policy->pick_rowsets());
     ASSIGN_OR_RETURN(auto algorithm, compaction_policy->choose_compaction_algorithm(input_rowsets));
     if (algorithm == VERTICAL_COMPACTION) {
-        return std::make_shared<VerticalCompactionTask>(txn_id, std::move(tablet), std::move(input_rowsets), context);
+        return std::make_shared<VerticalCompactionTask>(std::move(tablet), std::move(input_rowsets), context);
     } else {
         DCHECK(algorithm == HORIZONTAL_COMPACTION);
-        return std::make_shared<HorizontalCompactionTask>(txn_id, std::move(tablet), std::move(input_rowsets), context);
+        return std::make_shared<HorizontalCompactionTask>(std::move(tablet), std::move(input_rowsets), context);
     }
 }
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -20,6 +20,7 @@
 #include <variant>
 
 #include "common/statusor.h"
+#include "compaction_task_context.h"
 #include "gutil/macros.h"
 #include "storage/lake/metadata_iterator.h"
 #include "storage/lake/tablet_metadata.h"
@@ -67,7 +68,8 @@ public:
 
     StatusOr<VersionedTablet> get_tablet(int64_t tablet_id, int64_t version);
 
-    StatusOr<CompactionTaskPtr> compact(int64_t tablet_id, int64_t version, int64_t txn_id);
+    StatusOr<CompactionTaskPtr> compact(int64_t tablet_id, int64_t version, int64_t txn_id,
+                                        CompactionTaskContext& context);
 
     [[nodiscard]] Status put_tablet_metadata(const TabletMetadata& metadata);
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -68,8 +68,7 @@ public:
 
     StatusOr<VersionedTablet> get_tablet(int64_t tablet_id, int64_t version);
 
-    StatusOr<CompactionTaskPtr> compact(int64_t tablet_id, int64_t version, int64_t txn_id,
-                                        CompactionTaskContext& context);
+    StatusOr<CompactionTaskPtr> compact(CompactionTaskContext* context);
 
     [[nodiscard]] Status put_tablet_metadata(const TabletMetadata& metadata);
 

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -29,6 +29,8 @@ class Column;
 class TabletSchema;
 class ThreadPool;
 
+struct OlapWriterStatistics;
+
 namespace lake {
 
 class TabletManager;
@@ -114,6 +116,8 @@ public:
     // allow to set custom tablet schema for writer, used in partial update
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }
 
+    const OlapWriterStatistics& stats() const { return _stats; }
+
 protected:
     TabletManager* _tablet_mgr;
     int64_t _tablet_id;
@@ -125,6 +129,7 @@ protected:
     int64_t _data_size = 0;
     uint32_t _seg_id = 0;
     bool _finished = false;
+    OlapWriterStatistics _stats;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -31,11 +31,7 @@
 
 namespace starrocks::lake {
 
-Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_func, ThreadPool* flush_pool) {
-    if (progress == nullptr) {
-        return Status::InvalidArgument("progress is null");
-    }
-
+Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush_pool) {
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker.get());
 
     _tablet_schema = _tablet.get_schema();
@@ -75,15 +71,18 @@ Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_fun
             RETURN_IF_ERROR(mask_buffer->flip_to_read());
         }
         RETURN_IF_ERROR(compact_column_group(is_key, i, column_group_size, column_groups[i], writer, mask_buffer.get(),
-                                             source_masks.get(), progress, cancel_func));
+                                             source_masks.get(), cancel_func));
     }
     // Adjust the progress here for 2 reasons:
     // 1. For primary key, due to the existence of the delete vector, the number of rows read may be less than the
     //    number of rows counted in the metadata.
     // 2. If the number of rows is 0, the progress will not be updated
-    progress->update(100);
+    _context.progress.update(100);
 
     RETURN_IF_ERROR(writer->finish());
+
+    // update writer stats
+    _context.segment_write_ns += writer->stats().segment_write_ns;
 
     auto txn_log = std::make_shared<TxnLog>();
     auto op_compaction = txn_log->mutable_op_compaction();
@@ -106,6 +105,12 @@ Status VerticalCompactionTask::execute(Progress* progress, CancelFunc cancel_fun
         Tablet t(_tablet.tablet_manager(), _tablet.id());
         _tablet.tablet_manager()->update_mgr()->preload_compaction_state(*txn_log, t, _tablet_schema);
     }
+
+    VLOG(3) << "Vertical compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
+            << ", reader total time cost(ms): " << _context.reader_time_ns / 1000000
+            << ", reader io time cost(ms): " << _context.io_ns / 1000000
+            << ", segment writer total time cost(ms): " << _context.segment_write_ns / 1000000;
+
     return Status::OK();
 }
 
@@ -140,7 +145,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
                                                     const std::vector<uint32_t>& column_group,
                                                     std::unique_ptr<TabletWriter>& writer,
                                                     RowSourceMaskBuffer* mask_buffer,
-                                                    std::vector<RowSourceMask>* source_masks, Progress* progress,
+                                                    std::vector<RowSourceMask>* source_masks,
                                                     const CancelFunc& cancel_func) {
     ASSIGN_OR_RETURN(auto chunk_size, calculate_chunk_size_for_column_group(column_group));
 
@@ -175,10 +180,13 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
 #ifndef BE_TEST
         RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("Compaction"));
 #endif
-        if (auto st = reader.get_next(chunk.get(), source_masks); st.is_end_of_file()) {
-            break;
-        } else if (!st.ok()) {
-            return st;
+        {
+            SCOPED_RAW_TIMER(&_context.reader_time_ns);
+            if (auto st = reader.get_next(chunk.get(), source_masks); st.is_end_of_file()) {
+                break;
+            } else if (!st.ok()) {
+                return st;
+            }
         }
 
         ChunkHelper::padding_char_columns(char_field_indexes, schema, _tablet_schema, chunk.get());
@@ -192,11 +200,22 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
             source_masks->clear();
         }
 
-        progress->update((100 * column_group_index + 100 * reader.stats().raw_rows_read / _total_num_rows) /
-                         column_group_size);
-        VLOG_EVERY_N(3, 1000) << "Tablet: " << _tablet.id() << ", compaction progress: " << progress->value();
+        _context.progress.update((100 * column_group_index + 100 * reader.stats().raw_rows_read / _total_num_rows) /
+                                 column_group_size);
+        VLOG_EVERY_N(3, 1000) << "Tablet: " << _tablet.id() << ", compaction progress: " << _context.progress.value();
     }
     RETURN_IF_ERROR(writer->flush_columns());
+
+    // add reader stats
+    auto stats = reader.stats();
+    _context.io_ns += stats.io_ns;
+    _context.segment_init_ns += stats.segment_init_ns;
+    _context.column_iterator_init_ns += stats.column_iterator_init_ns;
+    _context.io_count_local_disk += stats.io_count_local_disk;
+    _context.io_count_remote += stats.io_count_remote;
+    _context.compressed_bytes_read += stats.compressed_bytes_read;
+    // add writer stats
+    _context.segment_write_ns += writer->stats().segment_write_ns;
 
     if (is_key) {
         RETURN_IF_ERROR(mask_buffer->flush());

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -82,7 +82,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     RETURN_IF_ERROR(writer->finish());
 
     // update writer stats
-    _context.segment_write_ns += writer->stats().segment_write_ns;
+    _context.stats->segment_write_ns = writer->stats().segment_write_ns;
 
     auto txn_log = std::make_shared<TxnLog>();
     auto op_compaction = txn_log->mutable_op_compaction();
@@ -107,9 +107,7 @@ Status VerticalCompactionTask::execute(CancelFunc cancel_func, ThreadPool* flush
     }
 
     VLOG(3) << "Vertical compaction finished. tablet: " << _tablet.id() << ", txn_id: " << _txn_id
-            << ", reader total time cost(ms): " << _context.reader_time_ns / 1000000
-            << ", reader io time cost(ms): " << _context.io_ns / 1000000
-            << ", segment writer total time cost(ms): " << _context.segment_write_ns / 1000000;
+            << ", statistics: " << _context.to_json_stats();
 
     return Status::OK();
 }
@@ -170,6 +168,8 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     VLOG(3) << "Compact column group. tablet: " << _tablet.id() << ", column group: " << column_group_index
             << ", reader chunk size: " << chunk_size;
 
+    int64 reader_time_ns = 0;
+    auto start = MonotonicNanos();
     while (true) {
         if (UNLIKELY(StorageEngine::instance()->bg_worker_stopped())) {
             return Status::Cancelled("background worker stopped");
@@ -181,7 +181,7 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
         RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("Compaction"));
 #endif
         {
-            SCOPED_RAW_TIMER(&_context.reader_time_ns);
+            SCOPED_RAW_TIMER(&reader_time_ns);
             if (auto st = reader.get_next(chunk.get(), source_masks); st.is_end_of_file()) {
                 break;
             } else if (!st.ok()) {
@@ -208,18 +208,24 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
 
     // add reader stats
     auto stats = reader.stats();
-    _context.io_ns += stats.io_ns;
-    _context.segment_init_ns += stats.segment_init_ns;
-    _context.column_iterator_init_ns += stats.column_iterator_init_ns;
-    _context.io_count_local_disk += stats.io_count_local_disk;
-    _context.io_count_remote += stats.io_count_remote;
-    _context.compressed_bytes_read += stats.compressed_bytes_read;
+    _context.stats->reader_time_ns += reader_time_ns;
+    _context.stats->io_ns += stats.io_ns;
+    _context.stats->segment_init_ns += stats.segment_init_ns;
+    _context.stats->column_iterator_init_ns += stats.column_iterator_init_ns;
+    _context.stats->io_count_local_disk += stats.io_count_local_disk;
+    _context.stats->io_count_remote += stats.io_count_remote;
+    _context.stats->compressed_bytes_read += stats.compressed_bytes_read;
     // add writer stats
-    _context.segment_write_ns += writer->stats().segment_write_ns;
+    _context.stats->segment_write_ns = writer->stats().segment_write_ns;
 
     if (is_key) {
         RETURN_IF_ERROR(mask_buffer->flush());
     }
+
+    auto elapsed = MonotonicNanos() - start;
+    VLOG(3) << "End compacting column group. tablet: " << _tablet.id() << ", column group: " << column_group_index
+            << ", time cost(ms): " << elapsed / 1000000.0;
+
     return Status::OK();
 }
 

--- a/be/src/storage/lake/vertical_compaction_task.h
+++ b/be/src/storage/lake/vertical_compaction_task.h
@@ -34,12 +34,12 @@ class TabletWriter;
 class VerticalCompactionTask : public CompactionTask {
 public:
     explicit VerticalCompactionTask(int64_t txn_id, VersionedTablet tablet,
-                                    std::vector<std::shared_ptr<Rowset>> input_rowsets)
-            : CompactionTask(txn_id, std::move(tablet), std::move(input_rowsets)) {}
+                                    std::vector<std::shared_ptr<Rowset>> input_rowsets, CompactionTaskContext& context)
+            : CompactionTask(txn_id, std::move(tablet), std::move(input_rowsets), context) {}
 
     ~VerticalCompactionTask() override = default;
 
-    Status execute(Progress* progress, CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) override;
+    Status execute(CancelFunc cancel_func, ThreadPool* flush_pool = nullptr) override;
 
 private:
     StatusOr<int32_t> calculate_chunk_size_for_column_group(const std::vector<uint32_t>& column_group);
@@ -47,8 +47,7 @@ private:
     Status compact_column_group(bool is_key, int column_group_index, size_t num_column_groups,
                                 const std::vector<uint32_t>& column_group, std::unique_ptr<TabletWriter>& writer,
                                 RowSourceMaskBuffer* mask_buffer, std::vector<RowSourceMask>* source_masks,
-                                Progress* progress, const CancelFunc& cancel_func);
-
+                                const CancelFunc& cancel_func);
     std::shared_ptr<const TabletSchema> _tablet_schema;
     int64_t _total_num_rows = 0;
     int64_t _total_data_size = 0;

--- a/be/src/storage/lake/vertical_compaction_task.h
+++ b/be/src/storage/lake/vertical_compaction_task.h
@@ -33,9 +33,9 @@ class TabletWriter;
 
 class VerticalCompactionTask : public CompactionTask {
 public:
-    explicit VerticalCompactionTask(int64_t txn_id, VersionedTablet tablet,
-                                    std::vector<std::shared_ptr<Rowset>> input_rowsets, CompactionTaskContext& context)
-            : CompactionTask(txn_id, std::move(tablet), std::move(input_rowsets), context) {}
+    explicit VerticalCompactionTask(VersionedTablet tablet, std::vector<std::shared_ptr<Rowset>> input_rowsets,
+                                    CompactionTaskContext* context)
+            : CompactionTask(std::move(tablet), std::move(input_rowsets), context) {}
 
     ~VerticalCompactionTask() override = default;
 

--- a/be/src/storage/olap_common.h
+++ b/be/src/storage/olap_common.h
@@ -304,6 +304,11 @@ struct OlapReaderStatistics {
     std::unordered_map<std::string, int64_t> dynamic_json_hits;
 };
 
+// OlapWriterStatistics used to collect statistics when write data to storage
+struct OlapWriterStatistics {
+    int64_t segment_write_ns = 0;
+};
+
 const char* const kBytesReadLocalDisk = "bytes_read_local_disk";
 const char* const kBytesReadRemote = "bytes_read_remote";
 const char* const kIOCountLocalDisk = "io_count_local_disk";

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -235,6 +235,7 @@ set(EXEC_FILES
         ./storage/lake/meta_file_test.cpp
         ./storage/lake/metacache_test.cpp
         ./storage/lake/compaction_scheduler_test.cpp
+        ./storage/lake/compaction_task_context_test.cpp
         ./storage/rowset_update_state_test.cpp
         ./storage/rowset_column_update_state_test.cpp
         ./storage/rowset_column_partial_update_test.cpp

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -1,0 +1,78 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/compaction_task_context.h"
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+namespace starrocks::lake {
+
+class LakeCompactionTaskProgressTest : public testing::Test {
+protected:
+    Progress progress;
+};
+
+TEST_F(LakeCompactionTaskProgressTest, ValueInitiallyZero) {
+    EXPECT_EQ(0, progress.value());
+}
+
+TEST_F(LakeCompactionTaskProgressTest, UpdateValue) {
+    progress.update(42);
+    EXPECT_EQ(42, progress.value());
+}
+
+class CompactionTaskContextTest : public testing::Test {
+public:
+    CompactionTaskContextTest() = default;
+    ~CompactionTaskContextTest() override = default;
+
+protected:
+    // Implement a mock version of CompactionTaskCallback if needed
+    std::shared_ptr<CompactionTaskCallback> callback;
+    CompactionTaskContext context{123, 456, 789, callback};
+
+    void SetUp() override {
+        // Initialize your context or mock callback here if necessary
+    }
+};
+
+TEST_F(CompactionTaskContextTest, test_constructor) {
+    EXPECT_EQ(123, context.txn_id);
+    EXPECT_EQ(456, context.tablet_id);
+    EXPECT_EQ(789, context.version);
+}
+
+TEST_F(CompactionTaskContextTest, test_to_json_stats) {
+    // Set up some stats to test the JSON output
+    context.stats->reader_time_ns = 1000000;
+    context.stats->io_ns = 2000000;
+    context.stats->segment_init_ns = 2000000;
+    context.stats->io_count_remote = 3;
+    context.stats->io_count_local_disk = 2;
+    context.stats->compressed_bytes_read = 1024;
+    context.stats->segment_init_ns = 3000000;
+    context.stats->column_iterator_init_ns = 4000000;
+    context.stats->segment_write_ns = 5000000;
+
+    // Call the method under test
+    std::string json_stats = context.to_json_stats();
+
+    // Verify the JSON output
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_total_time_ms":1)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_ms":2)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_count_remote":3)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("segment_write_ms":5)"));
+}
+} // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_task_context_test.cpp
+++ b/be/test/storage/lake/compaction_task_context_test.cpp
@@ -82,28 +82,30 @@ TEST_F(CompactionTaskContextTest, test_accumulate) {
 }
 
 TEST_F(CompactionTaskContextTest, test_to_json_stats) {
+    static constexpr long TIME_UNIT_NS_PER_SECOND = 1000000000;
+
     // Set up some stats to test the JSON output
-    context.stats->reader_time_ns = 30000000;
-    context.stats->io_ns = 12000000;
-    context.stats->io_ns_remote = 1100000;
-    context.stats->io_ns_local_disk = 9100000;
-    context.stats->segment_init_ns = 2000000;
+    context.stats->reader_time_ns = 30 * TIME_UNIT_NS_PER_SECOND;
+    context.stats->io_ns = 12 * TIME_UNIT_NS_PER_SECOND;
+    context.stats->io_ns_remote = 1 * TIME_UNIT_NS_PER_SECOND;
+    context.stats->io_ns_local_disk = 9 * TIME_UNIT_NS_PER_SECOND;
+    context.stats->segment_init_ns = 2 * TIME_UNIT_NS_PER_SECOND;
     context.stats->io_count_remote = 3;
     context.stats->io_count_local_disk = 2;
     context.stats->compressed_bytes_read = 1024;
-    context.stats->segment_init_ns = 3000000;
-    context.stats->column_iterator_init_ns = 4000000;
-    context.stats->segment_write_ns = 5000000;
+    context.stats->segment_init_ns = 3 * TIME_UNIT_NS_PER_SECOND;
+    context.stats->column_iterator_init_ns = 4 * TIME_UNIT_NS_PER_SECOND;
+    context.stats->segment_write_ns = 5 * TIME_UNIT_NS_PER_SECOND;
 
     // Call the method under test
     std::string json_stats = context.stats->to_json_stats();
 
     // Verify the JSON output
-    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_total_time_ms":30)"));
-    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_ms":12)"));
-    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_ms_remote":1)"));
-    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_ms_local_disk":9)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_total_time_second":30)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_second":12)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_second_remote":1)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_second_local_disk":9)"));
     EXPECT_THAT(json_stats, testing::HasSubstr(R"("reader_io_count_remote":3)"));
-    EXPECT_THAT(json_stats, testing::HasSubstr(R"("segment_write_ms":5)"));
+    EXPECT_THAT(json_stats, testing::HasSubstr(R"("segment_write_second":5)"));
 }
 } // namespace starrocks::lake

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -150,11 +150,11 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
     ASSERT_EQ(kChunkSize * 3, read(version));
 
     auto txn_id = next_id();
-    CompactionTaskContext task_context;
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, task_context.progress.value());
+    EXPECT_EQ(100, task_context->progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -174,10 +174,10 @@ TEST_F(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
     ASSERT_EQ(0, read(version));
 
     auto txn_id = next_id();
-    CompactionTaskContext task_context;
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, task_context.progress.value());
+    EXPECT_EQ(100, task_context->progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(0, read(version));
@@ -283,21 +283,21 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     // Cancelled compaction task
     {
         auto txn_id = next_id();
-        CompactionTaskContext task_context;
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
         check_task(task);
-        auto st = task->execute(CompactionTask::kCancelledFn);
-        EXPECT_EQ(0, task_context.progress.value());
+        ASSERT_OK(task->execute(CompactionTask::kCancelledFn));
+        EXPECT_EQ(0, task_context->progress.value());
         EXPECT_TRUE(st.is_cancelled()) << st;
     }
     // Completed compaction task without error
     {
         auto txn_id = next_id();
-        CompactionTaskContext task_context;
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
         check_task(task);
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
-        EXPECT_EQ(100, task_context.progress.value());
+        EXPECT_EQ(100, task_context->progress.value());
         ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
         version++;
         ASSERT_EQ(kChunkSize * 6, read(version));
@@ -428,11 +428,11 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
     ASSERT_EQ(kChunkSize, read(version));
 
     auto txn_id = next_id();
-    CompactionTaskContext task_context;
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, task_context.progress.value());
+    EXPECT_EQ(100, task_context->progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
@@ -566,11 +566,11 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
     }
 
     auto txn_id = next_id();
-    CompactionTaskContext task_context;
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, task_context.progress.value());
+    EXPECT_EQ(100, task_context->progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize - 4, read(version));

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -150,11 +150,11 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
     ASSERT_EQ(kChunkSize * 3, read(version));
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    CompactionTaskContext task_context;
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context.progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize * 3, read(version));
@@ -174,10 +174,10 @@ TEST_F(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
     ASSERT_EQ(0, read(version));
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    CompactionTaskContext task_context;
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context.progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(0, read(version));
@@ -283,21 +283,21 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     // Cancelled compaction task
     {
         auto txn_id = next_id();
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+        CompactionTaskContext task_context;
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
         check_task(task);
-        CompactionTask::Progress progress;
-        auto st = task->execute(&progress, CompactionTask::kCancelledFn);
-        EXPECT_EQ(0, progress.value());
+        auto st = task->execute(CompactionTask::kCancelledFn);
+        EXPECT_EQ(0, task_context.progress.value());
         EXPECT_TRUE(st.is_cancelled()) << st;
     }
     // Completed compaction task without error
     {
         auto txn_id = next_id();
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+        CompactionTaskContext task_context;
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
         check_task(task);
-        CompactionTask::Progress progress;
-        ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-        EXPECT_EQ(100, progress.value());
+        ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+        EXPECT_EQ(100, task_context.progress.value());
         ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
         version++;
         ASSERT_EQ(kChunkSize * 6, read(version));
@@ -428,11 +428,11 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
     ASSERT_EQ(kChunkSize, read(version));
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    CompactionTaskContext task_context;
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context.progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize, read(version));
@@ -566,11 +566,11 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
     }
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    CompactionTaskContext task_context;
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, &task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context.progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     version++;
     ASSERT_EQ(kChunkSize - 4, read(version));

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -151,7 +151,7 @@ TEST_P(LakeDuplicateKeyCompactionTest, test1) {
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -176,7 +176,7 @@ TEST_F(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
     auto txn_id = next_id();
     auto tablet_id = _tablet_metadata->id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
@@ -285,7 +285,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     {
         auto txn_id = next_id();
         auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         check_task(task);
         auto st = task->execute(CompactionTask::kCancelledFn);
         EXPECT_EQ(0, task_context->progress.value());
@@ -295,7 +295,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
     {
         auto txn_id = next_id();
         auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         check_task(task);
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());
@@ -430,7 +430,7 @@ TEST_P(LakeUniqueKeyCompactionTest, test1) {
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -568,7 +568,7 @@ TEST_P(LakeUniqueKeyCompactionWithDeleteTest, test_base_compaction_with_delete) 
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());

--- a/be/test/storage/lake/compaction_task_test.cpp
+++ b/be/test/storage/lake/compaction_task_test.cpp
@@ -174,6 +174,7 @@ TEST_F(LakeDuplicateKeyCompactionTest, test_empty_tablet) {
     ASSERT_EQ(0, read(version));
 
     auto txn_id = next_id();
+    auto tablet_id = _tablet_metadata->id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
     ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
@@ -286,7 +287,7 @@ TEST_P(LakeDuplicateKeyOverlapSegmentsCompactionTest, test) {
         auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
         ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
         check_task(task);
-        ASSERT_OK(task->execute(CompactionTask::kCancelledFn));
+        auto st = task->execute(CompactionTask::kCancelledFn);
         EXPECT_EQ(0, task_context->progress.value());
         EXPECT_TRUE(st.is_cancelled()) << st;
     }

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -212,11 +212,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
     }
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context->progress.value());
     EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
@@ -268,11 +268,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
     ASSERT_EQ(kChunkSize * 3, read(version));
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context->progress.value());
     EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
@@ -333,11 +333,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
     ASSERT_EQ(kChunkSize * 2, read(version));
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context->progress.value());
     EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
@@ -635,12 +635,12 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
     ASSERT_EQ(kChunkSize * 3, read(version));
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
-    EXPECT_EQ(100, progress.value());
+    EXPECT_EQ(100, task_context->progress.value());
     // check compaction state
     ASSIGN_OR_ABORT(auto txn_log, _tablet_mgr->get_txn_log(tablet_id, txn_id));
     Rowset output_rowset(_tablet_mgr.get(), _tablet_metadata->id(), &txn_log->op_compaction().output_rowset(), -1,
@@ -721,11 +721,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test_remove_compaction_state) {
     }
 
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context->progress.value());
     // remove compaction state
     _update_mgr->TEST_remove_compaction_cache(tablet_id, txn_id);
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
@@ -802,11 +802,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test_abort_txn) {
 
     auto txn_id = next_id();
     std::thread t1([&]() {
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+        auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
         check_task(task);
-        CompactionTask::Progress progress;
-        ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-        EXPECT_EQ(100, progress.value());
+        ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+        EXPECT_EQ(100, task_context->progress.value());
     });
 
     std::thread t2([&]() {
@@ -863,11 +863,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test_multi_output_seg) {
     // make sure compact can generate more than one segment in output rowset
     config::max_segment_file_size = 50;
     config::vector_chunk_size = 10;
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context->progress.value());
     EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
@@ -928,11 +928,11 @@ TEST_P(LakePrimaryKeyCompactionTest, test_pk_recover_rowset_order_after_compact)
 
     config::lake_pk_compaction_max_input_rowsets = 2;
     auto txn_id = next_id();
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
     check_task(task);
-    CompactionTask::Progress progress;
-    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
-    EXPECT_EQ(100, progress.value());
+    ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, task_context->progress.value());
     EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
     ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
     EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -213,7 +213,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test1) {
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -269,7 +269,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test2) {
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -334,7 +334,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test3) {
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -636,7 +636,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_compaction_sorted) {
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
@@ -722,7 +722,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_remove_compaction_state) {
 
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -803,7 +803,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_abort_txn) {
     auto txn_id = next_id();
     std::thread t1([&]() {
         auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+        ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
         check_task(task);
         ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
         EXPECT_EQ(100, task_context->progress.value());
@@ -864,7 +864,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_multi_output_seg) {
     config::max_segment_file_size = 50;
     config::vector_chunk_size = 10;
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());
@@ -929,7 +929,7 @@ TEST_P(LakePrimaryKeyCompactionTest, test_pk_recover_rowset_order_after_compact)
     config::lake_pk_compaction_max_input_rowsets = 2;
     auto txn_id = next_id();
     auto task_context = std::make_unique<CompactionTaskContext>(txn_id, tablet_id, version, nullptr);
-    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id, *task_context));
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(task_context.get()));
     check_task(task);
     ASSERT_OK(task->execute(CompactionTask::kNoCancelFn));
     EXPECT_EQ(100, task_context->progress.value());

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
@@ -38,14 +38,7 @@ public class BeCloudNativeCompactionsSystemTable {
                         .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("PROGRESS", ScalarType.createType(PrimitiveType.INT))
                         .column("STATUS", ScalarType.createType(PrimitiveType.VARCHAR))
-                        .column("READER_TOTAL_TIME_MS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("READER_IO_MS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("READER_IO_COUNT_REMOTE", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("READER_IO_COUNT_LOCAL_DISK", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("COMPRESSED_BYTES_READ", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SEGMENT_INIT_MS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("COLUMN_ITERATOR_INIT_MS", ScalarType.createType(PrimitiveType.BIGINT))
-                        .column("SEGMENT_WRITE_MS", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("STATISTICS", ScalarType.createType(PrimitiveType.VARCHAR))
                         .build(), TSchemaTableType.SCH_BE_CLOUD_NATIVE_COMPACTIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
@@ -38,6 +38,14 @@ public class BeCloudNativeCompactionsSystemTable {
                         .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("PROGRESS", ScalarType.createType(PrimitiveType.INT))
                         .column("STATUS", ScalarType.createType(PrimitiveType.VARCHAR))
+                        .column("READER_TOTAL_TIME_MS", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("READER_IO_MS", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("READER_IO_COUNT_REMOTE", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("READER_IO_COUNT_LOCAL_DISK", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("COMPRESSED_BYTES_READ", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("SEGMENT_INIT_MS", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("COLUMN_ITERATOR_INIT_MS", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("SEGMENT_WRITE_MS", ScalarType.createType(PrimitiveType.BIGINT))
                         .build(), TSchemaTableType.SCH_BE_CLOUD_NATIVE_COMPACTIONS);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/information/BeCloudNativeCompactionsSystemTable.java
@@ -38,7 +38,6 @@ public class BeCloudNativeCompactionsSystemTable {
                         .column("FINISH_TIME", ScalarType.createType(PrimitiveType.DATETIME))
                         .column("PROGRESS", ScalarType.createType(PrimitiveType.INT))
                         .column("STATUS", ScalarType.createType(PrimitiveType.VARCHAR))
-                        .column("STATISTICS", ScalarType.createType(PrimitiveType.VARCHAR))
                         .build(), TSchemaTableType.SCH_BE_CLOUD_NATIVE_COMPACTIONS);
     }
 }


### PR DESCRIPTION
Why I'm doing:
What I'm doing:

Record lake compaction process metrics, after this pr we can see compaction metrics in be/cn's log

```sh
I0226 15:05:07.353010 307673 vertical_compaction_task.cpp:109] Vertical compaction finished. tablet: 10089, txn_id: 10089, statistics: {"reader_total_time_ms":342033,"reader_io_ms":7424,"reader_io_count_remote":0,"reader_io_count_local_disk":1217774,"compressed_bytes_read":19553793796,"segment_init_ms":277,"column_iterator_init_ms":191,"segment_write_ms":586577}
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
