### PR TITLE
[Enhancement]make is_null compute auto vectorized

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -78,7 +78,7 @@ public:
         return _rep_level_decoder.decode_batch(n, levels);
     }
 
-    Status decode_values(size_t n, const uint8_t* is_nulls, ColumnContentType content_type, Column* dst) {
+    Status decode_values(size_t n, const uint16_t* is_nulls, ColumnContentType content_type, Column* dst) {
         size_t idx = 0;
         while (idx < n) {
             bool is_null = is_nulls[idx++];

--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -84,7 +84,8 @@ private:
     std::vector<level_t> _def_levels;
     std::vector<level_t> _rep_levels;
 
-    std::vector<uint8_t> _is_nulls;
+    // Use uint16_t instead of uint8_t to make it auto simd by compiler.
+    std::vector<uint16_t> _is_nulls;
 };
 
 class OptionalStoredColumnReader : public StoredColumnReader {
@@ -159,7 +160,8 @@ private:
     size_t _levels_decoded = 0;
     size_t _levels_capacity = 0;
 
-    std::vector<uint8_t> _is_nulls;
+    // Use uint16_t instead of uint8_t to make it auto simd by compiler.
+    std::vector<uint16_t> _is_nulls;
     std::vector<level_t> _def_levels;
 };
 
@@ -246,7 +248,6 @@ Status RepeatedStoredColumnReader::do_read_records(size_t* num_records, ColumnCo
         _delimit_rows(&records_to_read, &num_parsed_levels);
 
         // decode value read from reader
-        // TODO(zc): optimized here
         {
             // ensure enough capacity
             _is_nulls.resize(num_parsed_levels);
@@ -406,7 +407,6 @@ Status OptionalStoredColumnReader::_read_records_and_levels(size_t* num_records,
         }
 
         {
-            // TODO(zc): make it better
             _is_nulls.resize(records_to_read);
             // decode def levels
             for (size_t i = 0; i < records_to_read; ++i) {


### PR DESCRIPTION
Why I'm doing:
<img width="337" alt="截屏2023-12-22 11 28 03" src="https://github.com/StarRocks/starrocks/assets/28446271/a8a3cdce-d3c0-47d7-b8bc-98d78aae1caf">
StoredColumnReadValuesTime4 is computing is_null, that costs even as much time as decode.
What I'm doing:
Make it auto vectorized.
<img width="345" alt="截屏2023-12-22 11 27 18" src="https://github.com/StarRocks/starrocks/assets/28446271/9023b393-c446-4428-9055-54dc908b92cf">

this part from 53ms->3ms

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
