### PR TITLE
[BugFix] Fix race condition between preloading partial update state and publish

### DIFF
--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -527,7 +527,7 @@ Status DeltaWriterImpl::fill_auto_increment_id(const Chunk& chunk) {
     auto metadata = _tablet_manager->get_latest_cached_tablet_metadata(_tablet_id);
     Status st;
     if (metadata != nullptr) {
-        st = tablet.update_mgr()->get_rowids_from_pkindex(&tablet, metadata->version(), upserts, &rss_rowids);
+        st = tablet.update_mgr()->get_rowids_from_pkindex(&tablet, metadata->version(), upserts, &rss_rowids, true);
     }
 
     std::vector<uint8_t> filter;

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -47,9 +47,9 @@ public:
     int64_t data_version() const { return _data_version; }
     void update_data_version(int64_t version) { _data_version = version; }
 
-    void lock() { _mutex.lock(); }
-
-    void unlock() { _mutex.unlock(); }
+    std::unique_ptr<std::lock_guard<std::mutex>> fetch_guard() {
+        return std::make_unique<std::lock_guard<std::mutex>>(_mutex);
+    }
 
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -51,6 +51,13 @@ public:
         return std::make_unique<std::lock_guard<std::mutex>>(_mutex);
     }
 
+    std::unique_ptr<std::lock_guard<std::mutex>> try_fetch_guard() {
+        if (_mutex.try_lock()) {
+            return std::make_unique<std::lock_guard<std::mutex>>(_mutex, std::adopt_lock);
+        }
+        return nullptr;
+    }
+
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);

--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -47,6 +47,10 @@ public:
     int64_t data_version() const { return _data_version; }
     void update_data_version(int64_t version) { _data_version = version; }
 
+    void lock() { _mutex.lock(); }
+
+    void unlock() { _mutex.unlock(); }
+
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);
@@ -54,6 +58,8 @@ private:
 private:
     // We don't support multi version in PrimaryIndex yet, but we will record latest data version for some checking
     int64_t _data_version = 0;
+    // make sure at most 1 thread is read or write primary index
+    std::mutex _mutex;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -310,12 +310,8 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const Tx
     }
     DCHECK_EQ(_upserts.size(), num_segments);
     // use upserts to get rowids in each segment
-    if (need_lock) {
-        RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
-    } else {
-        RETURN_IF_ERROR(
-                tablet->update_mgr()->get_rowids_from_pkindex_unlock(tablet, _base_version, _upserts, &rss_rowids));
-    }
+    RETURN_IF_ERROR(
+            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids, need_lock));
 
     for (size_t i = 0; i < num_segments; i++) {
         std::vector<uint32_t> rowids;
@@ -423,12 +419,8 @@ Status RowsetUpdateState::_prepare_partial_update_states(const TxnLogPB_OpWrite&
     }
     DCHECK_EQ(_upserts.size(), num_segments);
     // use upserts to get rowids in each segment
-    if (need_lock) {
-        RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
-    } else {
-        RETURN_IF_ERROR(
-                tablet->update_mgr()->get_rowids_from_pkindex_unlock(tablet, _base_version, _upserts, &rss_rowids));
-    }
+    RETURN_IF_ERROR(
+            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids, need_lock));
 
     int64_t t_read_values = MonotonicMillis();
     size_t total_rows = 0;
@@ -563,7 +555,7 @@ Status RowsetUpdateState::_resolve_conflict(const TxnLogPB_OpWrite& op_write, co
         new_rss_rowids_vec[segment_id].resize(_upserts[segment_id]->size());
     }
     RETURN_IF_ERROR(
-            tablet->update_mgr()->get_rowids_from_pkindex_unlock(tablet, _base_version, _upserts, &new_rss_rowids_vec));
+            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &new_rss_rowids_vec, false));
 
     size_t total_conflicts = 0;
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());

--- a/be/src/storage/lake/rowset_update_state.cpp
+++ b/be/src/storage/lake/rowset_update_state.cpp
@@ -42,7 +42,8 @@ RowsetUpdateState::~RowsetUpdateState() {
 }
 
 Status RowsetUpdateState::load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version,
-                               Tablet* tablet, const MetaFileBuilder* builder, bool need_resolve_conflict) {
+                               Tablet* tablet, const MetaFileBuilder* builder, bool need_resolve_conflict,
+                               bool need_lock) {
     if (UNLIKELY(!_status.ok())) {
         return _status;
     }
@@ -51,7 +52,7 @@ Status RowsetUpdateState::load(const TxnLogPB_OpWrite& op_write, const TabletMet
         _base_version = base_version;
         _builder = builder;
         _tablet_id = metadata.id();
-        _status = _do_load(op_write, metadata, tablet);
+        _status = _do_load(op_write, metadata, tablet, need_lock);
         if (!_status.ok()) {
             if (!_status.is_uninitialized()) {
                 LOG(WARNING) << "load RowsetUpdateState error: " << _status << " tablet:" << _tablet_id << " stack:\n"
@@ -68,7 +69,8 @@ Status RowsetUpdateState::load(const TxnLogPB_OpWrite& op_write, const TabletMet
     return _status;
 }
 
-Status RowsetUpdateState::_do_load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet) {
+Status RowsetUpdateState::_do_load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
+                                   bool need_lock) {
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());
     Rowset rowset(tablet->tablet_mgr(), tablet->id(), &op_write.rowset(), -1 /*unused*/, tablet_schema);
 
@@ -78,10 +80,11 @@ Status RowsetUpdateState::_do_load(const TxnLogPB_OpWrite& op_write, const Table
         return Status::OK();
     }
     if (!op_write.txn_meta().partial_update_column_ids().empty()) {
-        RETURN_IF_ERROR(_prepare_partial_update_states(op_write, metadata, tablet, tablet_schema));
+        RETURN_IF_ERROR(_prepare_partial_update_states(op_write, metadata, tablet, tablet_schema, need_lock));
     }
     if (op_write.txn_meta().has_auto_increment_partial_update_column_id()) {
-        RETURN_IF_ERROR(_prepare_auto_increment_partial_update_states(op_write, metadata, tablet, tablet_schema));
+        RETURN_IF_ERROR(
+                _prepare_auto_increment_partial_update_states(op_write, metadata, tablet, tablet_schema, need_lock));
     }
     return Status::OK();
 }
@@ -260,7 +263,8 @@ static std::vector<uint32_t> get_read_columns_ids(const TxnLogPB_OpWrite& op_wri
 
 Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const TxnLogPB_OpWrite& op_write,
                                                                         const TabletMetadata& metadata, Tablet* tablet,
-                                                                        const TabletSchemaCSPtr& tablet_schema) {
+                                                                        const TabletSchemaCSPtr& tablet_schema,
+                                                                        bool need_lock) {
     const auto& txn_meta = op_write.txn_meta();
     size_t num_segments = op_write.rowset().segments_size();
     _auto_increment_partial_update_states.resize(num_segments);
@@ -306,7 +310,12 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const Tx
     }
     DCHECK_EQ(_upserts.size(), num_segments);
     // use upserts to get rowids in each segment
-    RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
+    if (need_lock) {
+        RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
+    } else {
+        RETURN_IF_ERROR(
+                tablet->update_mgr()->get_rowids_from_pkindex_unlock(tablet, _base_version, _upserts, &rss_rowids));
+    }
 
     for (size_t i = 0; i < num_segments; i++) {
         std::vector<uint32_t> rowids;
@@ -384,7 +393,7 @@ Status RowsetUpdateState::_prepare_auto_increment_partial_update_states(const Tx
 
 Status RowsetUpdateState::_prepare_partial_update_states(const TxnLogPB_OpWrite& op_write,
                                                          const TabletMetadata& metadata, Tablet* tablet,
-                                                         const TabletSchemaCSPtr& tablet_schema) {
+                                                         const TabletSchemaCSPtr& tablet_schema, bool need_lock) {
     int64_t t_start = MonotonicMillis();
     std::vector<uint32_t> read_column_ids = get_read_columns_ids(op_write, tablet_schema);
 
@@ -414,7 +423,12 @@ Status RowsetUpdateState::_prepare_partial_update_states(const TxnLogPB_OpWrite&
     }
     DCHECK_EQ(_upserts.size(), num_segments);
     // use upserts to get rowids in each segment
-    RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
+    if (need_lock) {
+        RETURN_IF_ERROR(tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &rss_rowids));
+    } else {
+        RETURN_IF_ERROR(
+                tablet->update_mgr()->get_rowids_from_pkindex_unlock(tablet, _base_version, _upserts, &rss_rowids));
+    }
 
     int64_t t_read_values = MonotonicMillis();
     size_t total_rows = 0;
@@ -549,7 +563,7 @@ Status RowsetUpdateState::_resolve_conflict(const TxnLogPB_OpWrite& op_write, co
         new_rss_rowids_vec[segment_id].resize(_upserts[segment_id]->size());
     }
     RETURN_IF_ERROR(
-            tablet->update_mgr()->get_rowids_from_pkindex(tablet, _base_version, _upserts, &new_rss_rowids_vec));
+            tablet->update_mgr()->get_rowids_from_pkindex_unlock(tablet, _base_version, _upserts, &new_rss_rowids_vec));
 
     size_t total_conflicts = 0;
     std::shared_ptr<TabletSchema> tablet_schema = std::make_shared<TabletSchema>(metadata.schema());

--- a/be/src/storage/lake/rowset_update_state.h
+++ b/be/src/storage/lake/rowset_update_state.h
@@ -59,7 +59,7 @@ public:
     ~RowsetUpdateState();
 
     Status load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version, Tablet* tablet,
-                const MetaFileBuilder* builder, bool need_check_conflict);
+                const MetaFileBuilder* builder, bool need_check_conflict, bool need_lock);
 
     Status rewrite_segment(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet,
                            std::map<int, std::string>* replace_segments, std::vector<std::string>* orphan_files);
@@ -80,13 +80,13 @@ public:
     const std::vector<std::unique_ptr<Column>>& auto_increment_deletes() const;
 
 private:
-    Status _do_load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet);
+    Status _do_load(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, Tablet* tablet, bool need_lock);
 
     Status _do_load_upserts_deletes(const TxnLogPB_OpWrite& op_write, const TabletSchemaCSPtr& tablet_schema,
                                     Tablet* tablet, Rowset* rowset_ptr);
 
     Status _prepare_partial_update_states(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata,
-                                          Tablet* tablet, const TabletSchemaCSPtr& tablet_schema);
+                                          Tablet* tablet, const TabletSchemaCSPtr& tablet_schema, bool need_lock);
 
     Status _resolve_conflict(const TxnLogPB_OpWrite& op_write, const TabletMetadata& metadata, int64_t base_version,
                              Tablet* tablet, const MetaFileBuilder* builder);
@@ -103,7 +103,7 @@ private:
 
     Status _prepare_auto_increment_partial_update_states(const TxnLogPB_OpWrite& op_write,
                                                          const TabletMetadata& metadata, Tablet* tablet,
-                                                         const TabletSchemaCSPtr& tablet_schema);
+                                                         const TabletSchemaCSPtr& tablet_schema, bool need_lock);
 
     std::once_flag _load_once_flag;
     Status _status;

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -49,6 +49,8 @@ public:
     ~PrimaryKeyTxnLogApplier() override {
         // must release primary index before `handle_failure`, otherwise `handle_failure` will fail
         _tablet.update_mgr()->release_primary_index_cache(_index_entry);
+        auto& index = _index_entry->value();
+        index.unlock();
         _index_entry = nullptr;
         // handle failure first, then release lock
         _builder.handle_failure();

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -67,15 +67,9 @@ public:
 
     // get rowids from primary index by each upserts
     Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
-                                   std::vector<std::vector<uint64_t>*>* rss_rowids);
-    Status get_rowids_from_pkindex_unlock(Tablet* tablet, int64_t base_version,
-                                          const std::vector<ColumnUniquePtr>& upserts,
-                                          std::vector<std::vector<uint64_t>*>* rss_rowids);
+                                   std::vector<std::vector<uint64_t>*>* rss_rowids, bool need_lock);
     Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
-                                   std::vector<std::vector<uint64_t>>* rss_rowids);
-    Status get_rowids_from_pkindex_unlock(Tablet* tablet, int64_t base_version,
-                                          const std::vector<ColumnUniquePtr>& upserts,
-                                          std::vector<std::vector<uint64_t>>* rss_rowids);
+                                   std::vector<std::vector<uint64_t>>* rss_rowids, bool need_lock);
 
     // get column data by rssid and rowids
     Status get_column_values(Tablet* tablet, const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,
@@ -169,7 +163,8 @@ private:
 
     int32_t _get_condition_column(const TxnLogPB_OpWrite& op_write, const TabletSchema& tablet_schema);
 
-    Status _handle_index_op(Tablet* tablet, int64_t base_version, const std::function<void(LakePrimaryIndex&)>& op);
+    Status _handle_index_op(Tablet* tablet, int64_t base_version, bool need_lock,
+                            const std::function<void(LakePrimaryIndex&)>& op);
 
     std::shared_mutex& _get_pk_index_shard_lock(int64_t tabletId) { return _get_pk_index_shard(tabletId).lock; }
 

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -68,8 +68,14 @@ public:
     // get rowids from primary index by each upserts
     Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
                                    std::vector<std::vector<uint64_t>*>* rss_rowids);
+    Status get_rowids_from_pkindex_unlock(Tablet* tablet, int64_t base_version,
+                                          const std::vector<ColumnUniquePtr>& upserts,
+                                          std::vector<std::vector<uint64_t>*>* rss_rowids);
     Status get_rowids_from_pkindex(Tablet* tablet, int64_t base_version, const std::vector<ColumnUniquePtr>& upserts,
                                    std::vector<std::vector<uint64_t>>* rss_rowids);
+    Status get_rowids_from_pkindex_unlock(Tablet* tablet, int64_t base_version,
+                                          const std::vector<ColumnUniquePtr>& upserts,
+                                          std::vector<std::vector<uint64_t>>* rss_rowids);
 
     // get column data by rssid and rowids
     Status get_column_values(Tablet* tablet, const TabletMetadata& metadata, const TxnLogPB_OpWrite& op_write,

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -137,7 +137,8 @@ public:
 
     // get or create primary index, and prepare primary index state
     StatusOr<IndexEntry*> prepare_primary_index(const TabletMetadataPtr& metadata, MetaFileBuilder* builder,
-                                                int64_t base_version, int64_t new_version);
+                                                int64_t base_version, int64_t new_version,
+                                                std::unique_ptr<std::lock_guard<std::mutex>>& lock);
 
     // commit primary index, only take affect when it is local persistent index
     Status commit_primary_index(IndexEntry* index_entry, Tablet* tablet);

--- a/be/test/storage/lake/partial_update_test.cpp
+++ b/be/test/storage/lake/partial_update_test.cpp
@@ -82,7 +82,7 @@ public:
             c2->set_is_key(false);
             c2->set_is_nullable(false);
             c2->set_aggregation("REPLACE");
-            //c2->set_default_value("10");
+            c2->set_default_value("10");
         }
 
         _slots.emplace_back(0, "c0", TypeDescriptor{LogicalType::TYPE_INT});
@@ -663,6 +663,89 @@ TEST_P(LakePartialUpdateTest, test_partial_update_publish_retry) {
     ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
     _tablet_mgr->prune_metacache();
     ASSERT_EQ(kChunkSize, check(version, [](int c0, int c1, int c2) { return (c0 * 3 == c1) && (c0 * 4 == c2); }));
+}
+
+TEST_P(LakePartialUpdateTest, test_concurrent_write_publish) {
+    auto chunk0 = generate_data(kChunkSize, 0, false, 3);
+    auto chunk1 = generate_data(kChunkSize, 0, true, 5);
+    auto chunk2 = generate_data(kChunkSize, 0, true, 6);
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    // normal write
+    {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_index_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunk0, indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        ++version;
+    }
+    // partial update
+    std::thread t1([&]() {
+        for (int i = 0; i < 100; ++i) {
+            auto txn_id1 = next_id();
+            ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(tablet_id)
+                                                       .set_txn_id(txn_id1)
+                                                       .set_partition_id(_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_index_id(_tablet_schema->id())
+                                                       .set_slot_descriptors(&_slot_pointers)
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->finish());
+            add_trash_files(tablet_id, txn_id1);
+            delta_writer->close();
+            ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id1).status());
+            version++;
+        }
+    });
+
+    // partial update
+    std::thread t2([&]() {
+        for (int i = 0; i < 100; ++i) {
+            const int64_t old_size = config::write_buffer_size;
+            config::write_buffer_size = 1;
+            const int64_t old_mem_usage = config::l0_max_mem_usage;
+            config::l0_max_mem_usage = 1;
+            auto txn_id2 = next_id() + 1000;
+            ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                       .set_tablet_manager(_tablet_mgr.get())
+                                                       .set_tablet_id(tablet_id)
+                                                       .set_txn_id(txn_id2)
+                                                       .set_partition_id(_partition_id)
+                                                       .set_mem_tracker(_mem_tracker.get())
+                                                       .set_index_id(_tablet_schema->id())
+                                                       .set_slot_descriptors(&_slot_pointers)
+                                                       .build());
+            ASSERT_OK(delta_writer->open());
+            ASSERT_OK(delta_writer->write(chunk1, indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->write(chunk2, indexes.data(), indexes.size()));
+            ASSERT_OK(delta_writer->finish());
+            delta_writer->close();
+            config::write_buffer_size = old_size;
+            config::l0_max_mem_usage = old_mem_usage;
+        }
+    });
+    t1.join();
+    t2.join();
 }
 
 INSTANTIATE_TEST_SUITE_P(LakePartialUpdateTest, LakePartialUpdateTest,

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -306,8 +306,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_fail_retry) {
         new_metadata->set_version(version + 1);
         std::unique_ptr<MetaFileBuilder> builder = std::make_unique<MetaFileBuilder>(tablet, new_metadata);
         // update primary table state, such as primary index
-        ASSIGN_OR_ABORT(auto index_entry,
-                        tablet.update_mgr()->prepare_primary_index(new_metadata, builder.get(), version, version + 1));
+        std::unique_ptr<std::lock_guard<std::mutex>> lock = nullptr;
+        ASSIGN_OR_ABORT(auto index_entry, tablet.update_mgr()->prepare_primary_index(new_metadata, builder.get(),
+                                                                                     version, version + 1, lock));
         ASSERT_OK(tablet.update_mgr()->publish_primary_key_tablet(txn_log->op_write(), txn_log->txn_id(), *new_metadata,
                                                                   &tablet, index_entry, builder.get(), version));
         // if builder.finalize fail, remove primary index cache and retry


### PR DESCRIPTION
Why I'm doing:
For partial update, preloading partial update will read pk index while publishing will update pk index. if there is no lock is used, memory problem will occur.

What I'm doing:
Use lock in `get_rowids_from_pkindex` and publishing.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
