### PR TITLE
[Enhancement] Ignore ReportExecStatus log for query load

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/QeProcessorImpl.java
@@ -185,8 +185,11 @@ public final class QeProcessorImpl implements QeProcessor {
         final TReportExecStatusResult result = new TReportExecStatusResult();
         final QueryInfo info = coordinatorMap.get(params.query_id);
         if (info == null) {
-            LOG.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
-                    DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id));
+            // ignore log query
+            if (params.getLoad_type() != null) {
+                LOG.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
+                        DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id));
+            }
             result.setStatus(new TStatus(TStatusCode.NOT_FOUND));
             result.status.addToError_msgs("query id " + DebugUtil.printId(params.query_id) + " not found");
             return result;
@@ -257,8 +260,10 @@ public final class QeProcessorImpl implements QeProcessor {
             TReportExecStatusResult result = new TReportExecStatusResult();
             final QueryInfo info = coordinatorMap.get(params.query_id);
             if (info == null) {
-                LOG.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
-                        DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id));
+                if (params.getLoad_type() != null) {
+                    LOG.info("ReportExecStatus() failed, query does not exist, fragment_instance_id={}, query_id={},",
+                            DebugUtil.printId(params.fragment_instance_id), DebugUtil.printId(params.query_id));
+                }
                 result.setStatus(new TStatus(TStatusCode.NOT_FOUND));
                 result.status.addToError_msgs("query id " + DebugUtil.printId(params.query_id) + " not found");
                 resultList.addToStatus_list(result.getStatus());


### PR DESCRIPTION
Why I'm doing:
Ignore  query does not exist log for query,  query  have been deregister
![image](https://github.com/StarRocks/starrocks/assets/8597823/d13136de-2385-4ac1-ac0d-18e78e9d8855)

What I'm doing:
only  print log for  load: broker/spark/insert
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [x] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
