### PR TITLE
[BugFix] Fix catalog name not compliant to mysql spec

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -348,7 +348,9 @@ public class InformationSchemaDataSource {
 
                         TTableInfo info = new TTableInfo();
 
-                        info.setTable_catalog(table.getCatalogName());
+                        // refer to https://dev.mysql.com/doc/refman/8.0/en/information-schema-tables-table.html
+                        // the catalog name is always `def`
+                        info.setTable_catalog(DEF);
                         info.setTable_schema(dbName);
                         info.setTable_name(table.getName());
                         info.setTable_type(table.getMysqlType());


### PR DESCRIPTION
Why I'm doing:

https://dev.mysql.com/doc/refman/8.0/en/information-schema-tables-table.html

What I'm doing:

catalog name should always be `def`

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
