### PR TITLE
[Enhancement] Support avro,rcfile,sequence file split to improve query concurrency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/RemoteFileInputFormat.java
@@ -49,6 +49,9 @@ public enum RemoteFileInputFormat {
                     .put(HUDI_PARQUET_INPUT_FORMAT, true)
                     .put(ORC_INPUT_FORMAT_CLASS, true)
                     .put(TEXT_INPUT_FORMAT_CLASS, true)
+                    .put(AVRO_INPUT_FORMAT_CLASS, true)
+                    .put(RCFILE_INPUT_FORMAT_CLASS, true)
+                    .put(SEQUENCE_INPUT_FORMAT_CLASS, true)
                     .build();
 
     public static RemoteFileInputFormat fromHdfsInputFormatClass(String className) {


### PR DESCRIPTION
Why I'm doing:
Currently, avro, rcfile, and sequence files do not support split, and too few ScanRanges result in very slow queries.

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
