### PR TITLE
[Refactor] refactor singleDistinctFunctionPos by column-id

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/physical/PhysicalHashAggregateOperator.java
@@ -53,7 +53,6 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     private final List<ColumnRefOperator> partitionByColumns;
     private final Map<ColumnRefOperator, CallOperator> aggregations;
 
-    // @todo: refactor it, SingleDistinctFunctionPos depend on the map's order, but the order is not fixed
     // When generate plan fragment, we need this info.
     // For select count(distinct id_bigint), sum(id_int) from test_basic;
     // In the distinct local (update serialize) agg stage:
@@ -61,8 +60,8 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     //|   |  output: count(<slot 13>), sum(<slot 16>)                                         |
     //|   |  group by:                                                                        |
     // count function is update function, but sum is merge function
-    // if singleDistinctFunctionPos is -1, means no single distinct function
-    private final int singleDistinctFunctionPos;
+    // if singleDistinctFunctionColumnId is -1, means no single distinct function
+    private final int singleDistinctFunctionColumnId;
 
     // The flag for this aggregate operator has split to
     // two stage aggregate or three stage aggregate
@@ -81,7 +80,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
                                          List<ColumnRefOperator> groupBys,
                                          List<ColumnRefOperator> partitionByColumns,
                                          Map<ColumnRefOperator, CallOperator> aggregations,
-                                         int singleDistinctFunctionPos,
+                                         int singleDistinctFunctionColumnId,
                                          boolean isSplit,
                                          long limit,
                                          ScalarOperator predicate,
@@ -91,7 +90,7 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
         this.groupBys = groupBys;
         this.partitionByColumns = partitionByColumns;
         this.aggregations = aggregations;
-        this.singleDistinctFunctionPos = singleDistinctFunctionPos;
+        this.singleDistinctFunctionColumnId = singleDistinctFunctionColumnId;
         this.isSplit = isSplit;
         this.limit = limit;
         this.predicate = predicate;
@@ -133,11 +132,11 @@ public class PhysicalHashAggregateOperator extends PhysicalOperator {
     }
 
     public boolean hasSingleDistinct() {
-        return singleDistinctFunctionPos > -1;
+        return singleDistinctFunctionColumnId > -1;
     }
 
-    public int getSingleDistinctFunctionPos() {
-        return singleDistinctFunctionPos;
+    public int getSingleDistinctFunctionColumnId() {
+        return singleDistinctFunctionColumnId;
     }
 
     public boolean isSplit() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/implementation/HashAggImplementationRule.java
@@ -39,7 +39,7 @@ public class HashAggImplementationRule extends ImplementationRule {
                 logical.getGroupingKeys(),
                 logical.getPartitionByColumns(),
                 logical.getAggregations(),
-                logical.getSingleDistinctFunctionPos(),
+                logical.getSingleDistinctFunctionColumnId(),
                 logical.isSplit(),
                 logical.getLimit(),
                 logical.getPredicate(),

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVProjectAggProjectScanRewrite.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MVProjectAggProjectScanRewrite.java
@@ -167,7 +167,7 @@ public class MVProjectAggProjectScanRewrite {
                             aggOperator.getPartitionByColumns(),
                             newAggMap,
                             aggOperator.isSplit(),
-                            aggOperator.getSingleDistinctFunctionPos(),
+                            aggOperator.getSingleDistinctFunctionColumnId(),
                             aggOperator.getLimit(),
                             aggOperator.getPredicate()), optExpression.inputAt(0).getInputs()));
                     return new Pair<>(kv.getKey(), aggColumnRef);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/mv/MaterializedViewRewriter.java
@@ -195,7 +195,7 @@ public class MaterializedViewRewriter extends OptExpressionVisitor<OptExpression
                 aggregationOperator.getPartitionByColumns(),
                 newAggMap,
                 aggregationOperator.isSplit(),
-                aggregationOperator.getSingleDistinctFunctionPos(),
+                aggregationOperator.getSingleDistinctFunctionColumnId(),
                 aggregationOperator.getLimit(),
                 aggregationOperator.getPredicate()), optExpression.getInputs());
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/validate/TypeChecker.java
@@ -60,7 +60,8 @@ public class TypeChecker implements PlanValidator.Checker {
 
     private static final TypeChecker INSTANCE = new TypeChecker();
 
-    private TypeChecker() {}
+    private TypeChecker() {
+    }
 
     public static TypeChecker getInstance() {
         return INSTANCE;
@@ -149,7 +150,7 @@ public class TypeChecker implements PlanValidator.Checker {
 
         private void checkAggCall(Map<ColumnRefOperator, CallOperator> aggregations, AggType aggType, boolean isSplit,
                                   int singleDistinctFunctionColumnId) {
-            boolean hasSingleDistinct = singleDistinctFunctionColumnId != - 1;
+            boolean hasSingleDistinct = singleDistinctFunctionColumnId != -1;
             for (Map.Entry<ColumnRefOperator, CallOperator> entry : aggregations.entrySet()) {
                 ColumnRefOperator outputCol = entry.getKey();
                 CallOperator aggCall = entry.getValue();
@@ -159,7 +160,8 @@ public class TypeChecker implements PlanValidator.Checker {
                         isMergeAggFn = isSplit && hasSingleDistinct && (entry.getKey().getId() != singleDistinctFunctionColumnId);
                         break;
                     case GLOBAL:
-                        isMergeAggFn = isSplit && (!hasSingleDistinct || entry.getKey().getId() != singleDistinctFunctionColumnId);
+                        isMergeAggFn =
+                                isSplit && (!hasSingleDistinct || entry.getKey().getId() != singleDistinctFunctionColumnId);
                         break;
                     case DISTINCT_GLOBAL:
                         isMergeAggFn = true;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
SingleDistinctFunctionPos depend on the map's order, but the order is not fixed

so, replace it by column-ref id

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
