### PR TITLE
[BugFix]sharedbuffer inputstream release with aligned offset may mistake deletion (backport #37535)

### DIFF
--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -133,9 +133,6 @@ void SharedBufferedInputStream::release() {
 }
 
 void SharedBufferedInputStream::release_to_offset(int64_t offset) {
-    if (_align_size != 0) {
-        offset = (offset + _align_size - 1) / _align_size * _align_size;
-    }
     auto it = _map.upper_bound(offset);
     _map.erase(_map.begin(), it);
 }

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -177,6 +177,7 @@ set(EXEC_FILES
         ./io/s3_input_stream_test.cpp
         ./io/fd_input_stream_test.cpp
         ./io/seekable_input_stream_test.cpp
+        ./io/shared_buffered_input_stream_test.cpp
         ./io/spill_test.cpp
         ./storage/decimal12_test.cpp
         ./storage/disjunctive_predicates_test.cpp

--- a/be/test/io/compressed_input_stream_test.cpp
+++ b/be/test/io/compressed_input_stream_test.cpp
@@ -20,10 +20,10 @@
 
 #include "fs/fs_posix.h"
 #include "io/string_input_stream.h"
+#include "io_test_base.h"
 #include "testutil/assert.h"
 #include "util/compression/block_compression.h"
 #include "util/compression/stream_compression.h"
-#include "util/random.h"
 namespace starrocks::io {
 
 class CompressedInputStreamTest : public ::testing::Test {
@@ -33,16 +33,6 @@ protected:
         size_t read_buff_len;
         size_t compressed_buff_len;
     };
-
-    static std::string random_string(int len) {
-        static starrocks::Random rand(20200722);
-        std::string s;
-        s.reserve(len);
-        for (int i = 0; i < len; i++) {
-            s.push_back('a' + (rand.Next() % ('z' - 'a' + 1)));
-        }
-        return s;
-    }
 
     std::shared_ptr<InputStream> LZ4F_compress_to_file(const Slice& content) {
         const BlockCompressionCodec* codec = nullptr;

--- a/be/test/io/io_test_base.h
+++ b/be/test/io/io_test_base.h
@@ -1,0 +1,60 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "io/seekable_input_stream.h"
+#include "util/random.h"
+
+namespace starrocks::io {
+
+class TestInputStream : public io::SeekableInputStream {
+public:
+    explicit TestInputStream(std::string contents, int64_t block_size)
+            : _contents(std::move(contents)), _block_size(block_size) {}
+
+    StatusOr<int64_t> read(void* data, int64_t count) override {
+        count = std::min(count, _block_size);
+        count = std::min(count, (int64_t)_contents.size() - _offset);
+        memcpy(data, &_contents[_offset], count);
+        _offset += count;
+        return count;
+    }
+
+    Status seek(int64_t position) override {
+        _offset = std::min<int64_t>(position, _contents.size());
+        return Status::OK();
+    }
+
+    StatusOr<int64_t> position() override { return _offset; }
+
+    StatusOr<int64_t> get_size() override { return _contents.size(); }
+
+private:
+    std::string _contents;
+    int64_t _block_size;
+    int64_t _offset{0};
+};
+
+static std::string random_string(int len) {
+    static starrocks::Random rand(20200722);
+    std::string s;
+    s.reserve(len);
+    for (int i = 0; i < len; i++) {
+        s.push_back('a' + (rand.Next() % ('z' - 'a' + 1)));
+    }
+    return s;
+}
+
+} // namespace starrocks::io

--- a/be/test/io/shared_buffered_input_stream_test.cpp
+++ b/be/test/io/shared_buffered_input_stream_test.cpp
@@ -1,0 +1,53 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "io/shared_buffered_input_stream.h"
+
+#include <gtest/gtest.h>
+
+#include "io_test_base.h"
+#include "testutil/assert.h"
+#include "testutil/parallel_test.h"
+
+namespace starrocks::io {
+
+PARALLEL_TEST(SharedBufferedInputStreamTest, test_release) {
+    size_t len = 1 * 1024 * 1024; // 1MB
+    const std::string rand_string = random_string(len);
+    auto in = std::make_shared<TestInputStream>(rand_string, len);
+    auto sb_stream = std::make_shared<io::SharedBufferedInputStream>(in, "test", len);
+    sb_stream->set_align_size(256 * 1024); // 1024
+    std::vector<io::SharedBufferedInputStream::IORange> ranges;
+    // set config::io_coalesce_read_max_buffer_size to 300k to avoid merging together.
+    SharedBufferedInputStream::CoalesceOptions opts;
+    opts.max_buffer_size = 300 * 1024;
+    sb_stream->set_coalesce_options(opts);
+
+    // 150k -> 520k
+    auto r_active = io::SharedBufferedInputStream::IORange{.offset = 150 * 1024, .size = 370 * 1024};
+    ranges.push_back(r_active);
+    // 550k -> 650k
+    auto r_lazy = io::SharedBufferedInputStream::IORange{.offset = 550 * 1024, .size = 100 * 1024};
+    ranges.push_back(r_lazy);
+    auto st = sb_stream->set_io_ranges(ranges);
+    ASSERT_OK(st);
+    // for this case, the first range is aligned to 0 -> 768k, the second range is aligned to 512k -> 768k
+    // and now the first range is used and want to release
+    // if release with aligned offset, both two sharedbuffers are released.
+    sb_stream->release_to_offset(520 * 1024);
+    auto sb = sb_stream->find_shared_buffer(550 * 1024, 100 * 1024);
+    ASSERT_OK(sb.status());
+}
+
+} // namespace starrocks::io


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue
cp #37535 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

