### PR TITLE
[BugFix] fixed-35898 : mv refresh with postgres table in jdbc catalog 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/PostgresSchemaResolver.java
@@ -23,6 +23,7 @@ import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
+import com.starrocks.common.util.TimeUtils;
 
 import java.sql.Connection;
 import java.sql.ResultSet;
@@ -138,6 +139,10 @@ public class PostgresSchemaResolver extends JDBCSchemaResolver {
             }
             return ScalarType.createUnifiedDecimalType(precision, max(digits, 0));
         }
+    }
+
+    public List<Partition> getPartitions(Connection connection, Table table) {
+        return Lists.newArrayList(new Partition(table.getName(), TimeUtils.getEpochSeconds()));
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/PostgresSchemaResolverTest.java
@@ -182,4 +182,13 @@ public class PostgresSchemaResolverTest {
             Assert.fail();
         }
     }
+
+    @Test
+    public void testGetPartitions() {
+        PostgresSchemaResolver postgresSchemaResolver = new PostgresSchemaResolver();
+        List<Partition> partitions = postgresSchemaResolver.getPartitions(null, new Table(1L, "tbl1",
+                Table.TableType.JDBC, Lists.newArrayList()));
+        Assert.assertEquals(partitions.size(), 1);
+        Assert.assertEquals(partitions.get(0).getPartitionName(), "tbl1");
+    }
 }


### PR DESCRIPTION
Why I'm doing:
fixed: https://github.com/StarRocks/starrocks/issues/35898
What I'm doing:
Provide a default list of length 0 for Method getPartitions
Fixes #35898

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
