### PR TITLE
[BugFix] fix mv AggregateType error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -494,7 +494,7 @@ public class MaterializedViewAnalyzer {
                 for (String col : keyCols) {
                     Column column = columnMap.get(col).first;
                     column.setIsKey(true);
-                    //                    column.setAggregationType(null, false);
+                    column.setAggregationType(null, false);
                 }
                 return Streams.mapWithIndex(mvColumns.stream(), (column, idx) -> Pair.create(column, (int) idx))
                         .collect(Collectors.toList());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzerTest.java
@@ -96,9 +96,9 @@ public class MaterializedViewAnalyzerTest {
         ShowExecutor showExecutor = new ShowExecutor(starRocksAssert.getCtx(),
                 (ShowStmt) analyzeSuccess("show full columns from mv1"));
         ShowResultSet showResultSet = showExecutor.execute();
-        Assert.assertEquals("[[a, date, , YES, YES, null, NONE, , a1]," +
-                        " [b, int, , YES, YES, null, NONE, , b2]," +
-                        " [c, int, , YES, YES, null, NONE, , ]]",
+        Assert.assertEquals("[[a, date, , YES, YES, null, , , a1], " +
+                        "[b, int, , YES, YES, null, , , b2], " +
+                        "[c, int, , YES, YES, null, , , ]]",
                 showResultSet.getResultRows().toString());
     }
 


### PR DESCRIPTION
Why I'm doing:
- The key column aggregate type should be set to null if it's a key
- As a result, when trying to activate MV, the schema check would fail since the aggregate type is different

What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

