### PR TITLE
[Enhancement] Add debug msg for pk index

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -231,6 +231,7 @@ Status UpdateManager::publish_primary_key_tablet(const TxnLogPB_OpWrite& op_writ
     TRACE_COUNTER_INCREMENT("deletes", state.deletes().size());
     TRACE_COUNTER_INCREMENT("new_del", new_del);
     TRACE_COUNTER_INCREMENT("total_del", total_del);
+    TRACE_COUNTER_INCREMENT("base_version", base_version);
     _print_memory_stats();
     return Status::OK();
 }

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -790,8 +790,15 @@ public:
             const auto value = values[idx];
             uint64_t hash = FixedKeyHash<KeySize>()(key);
             if (auto [it, inserted] = _map.emplace_with_hash(hash, key, value); !inserted) {
-                std::string msg = strings::Substitute("FixedMutableIndex<$0> insert found duplicate key $1", KeySize,
-                                                      hexdump((const char*)key.data, KeySize));
+                auto old = reinterpret_cast<uint64_t*>(&(it->second));
+                auto old_rssid = (uint32_t)((*old) >> 32);
+                auto old_rowid = (uint32_t)((*old) & ROWID_MASK);
+                auto new_value = reinterpret_cast<uint64_t*>(const_cast<IndexValue*>(&value));
+                std::string msg = strings::Substitute(
+                        "FixedMutableIndex<$0> insert found duplicate key $1, new(rssid=$2 rowid=$3), old(rssid=$4 "
+                        "rowid=$5)",
+                        KeySize, hexdump((const char*)key.data, KeySize), (uint32_t)((*new_value) >> 32),
+                        (uint32_t)((*new_value) & ROWID_MASK), old_rssid, old_rowid);
                 LOG(WARNING) << msg;
                 return Status::AlreadyExist(msg);
             }
@@ -1087,11 +1094,19 @@ public:
             composite_key.append(skey.data, skey.size);
             put_fixed64_le(&composite_key, value.get_value());
             uint64_t hash = StringHasher2()(composite_key);
-            if (auto [_, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
+            if (auto [it, inserted] = _set.emplace_with_hash(hash, composite_key); inserted) {
                 _total_kv_pairs_usage += composite_key.size();
             } else {
-                std::string msg = strings::Substitute("SliceMutableIndex key_size=$0 insert found duplicate key $1",
-                                                      skey.size, hexdump((const char*)skey.data, skey.size));
+                auto& old_compose_key = *it;
+                auto old_value = UNALIGNED_LOAD64(old_compose_key.data() + old_compose_key.size() - kIndexValueSize);
+                auto old_rssid = (uint32_t)(old_value >> 32);
+                auto old_rowid = (uint32_t)(old_value & ROWID_MASK);
+                auto new_value = reinterpret_cast<uint64_t*>(const_cast<IndexValue*>(&value));
+                std::string msg = strings::Substitute(
+                        "SliceMutableIndex key_size=$0 insert found duplicate key $1, "
+                        "new(rssid=$2 rowid=$3), old(rssid=$4 rowid=$5)",
+                        skey.size, hexdump((const char*)skey.data, skey.size), (uint32_t)((*new_value) >> 32),
+                        (uint32_t)((*new_value) & ROWID_MASK), old_rssid, old_rowid);
                 LOG(WARNING) << msg;
                 return Status::AlreadyExist(msg);
             }


### PR DESCRIPTION
Why I'm doing:
There is no msg for duplicated key in `PersistentIndex::insert`.
What I'm doing:
Add msg for duplicated key.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
