### PR TITLE
[BugFix] Fix unavailable external catalog when calculate object_dependencies base table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysObjectDependencies.java
@@ -32,6 +32,8 @@ import com.starrocks.thrift.TObjectDependencyReq;
 import com.starrocks.thrift.TObjectDependencyRes;
 import com.starrocks.thrift.TSchemaTableType;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -39,6 +41,9 @@ import java.util.Optional;
 public class SysObjectDependencies {
 
     public static final String NAME = "object_dependencies";
+
+    private static final Logger LOG = LogManager.getLogger(SysObjectDependencies.class);
+
 
     public static SystemTable create() {
         return new SystemTable(SystemId.OBJECT_DEPENDENCIES, NAME, Table.TableType.SCHEMA,
@@ -75,6 +80,10 @@ public class SysObjectDependencies {
             String catalog = Optional.ofNullable(db.getCatalogName())
                     .orElse(InternalCatalog.DEFAULT_INTERNAL_CATALOG_NAME);
             for (Table table : db.getTables()) {
+                // If it is not a materialized view, we do not need to verify permissions
+                if (!table.isMaterializedView()) {
+                    continue;
+                }
                 // Only show tables with privilege
                 try {
                     Authorizer.checkAnyActionOnTableLikeObject(currentUser, null, db.getFullName(), table);
@@ -82,31 +91,47 @@ public class SysObjectDependencies {
                     continue;
                 }
 
-                if (table.isMaterializedView()) {
-                    MaterializedView mv = (MaterializedView) table;
-                    for (BaseTableInfo refObj : CollectionUtils.emptyIfNull(mv.getBaseTableInfos())) {
-                        TObjectDependencyItem item = new TObjectDependencyItem();
-                        item.setObject_id(mv.getId());
-                        item.setObject_name(mv.getName());
-                        item.setDatabase(db.getFullName());
-                        item.setCatalog(catalog);
-                        item.setObject_type(mv.getType().toString());
+                MaterializedView mv = (MaterializedView) table;
+                for (BaseTableInfo refObj : CollectionUtils.emptyIfNull(mv.getBaseTableInfos())) {
+                    TObjectDependencyItem item = new TObjectDependencyItem();
+                    item.setObject_id(mv.getId());
+                    item.setObject_name(mv.getName());
+                    item.setDatabase(db.getFullName());
+                    item.setCatalog(catalog);
+                    item.setObject_type(mv.getType().toString());
 
-                        item.setRef_object_id(refObj.getTableId());
-                        item.setRef_object_name(refObj.getTableName());
-                        item.setRef_database(refObj.getDbName());
-                        item.setRef_catalog(refObj.getCatalogName());
-                        item.setRef_object_type(Optional.ofNullable(refObj.getTable())
-                                .map(x -> x.getType().toString())
-                                .orElse("UNKNOWN"));
+                    item.setRef_object_id(refObj.getTableId());
+                    item.setRef_object_name(refObj.getTableName());
+                    item.setRef_database(refObj.getDbName());
+                    item.setRef_catalog(refObj.getCatalogName());
+                    item.setRef_object_type(getRefObjectType(refObj, mv.getName()));
 
-                        response.addToItems(item);
-                    }
+                    response.addToItems(item);
                 }
             }
         }
 
         return response;
+    }
+
+    /**
+     * We may not be able to obtain the base table information when external catalog is unavailable
+     *
+     * @param refObj Base tables for materialized views
+     * @param mvName materialized view name
+     * @return base table type
+     */
+    private static String getRefObjectType(BaseTableInfo refObj, String mvName) {
+        String refObjType = "UNKNOWN";
+        try {
+            refObjType = Optional.ofNullable(refObj.getTable())
+                    .map(x -> x.getType().toString())
+                    .orElse("UNKNOWN");
+        } catch (Exception e) {
+            LOG.error("can not get table type error, mv name : {}, error-msg : {}",
+                    mvName, e.getMessage(), e);
+        }
+        return refObjType;
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysObjectDependenciesTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysObjectDependenciesTest.java
@@ -1,0 +1,141 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog.system.sys;
+
+import com.starrocks.common.FeConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.qe.DDLStmtExecutor;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.thrift.TAuthInfo;
+import com.starrocks.thrift.TObjectDependencyReq;
+import com.starrocks.thrift.TObjectDependencyRes;
+import com.starrocks.thrift.TUserIdentity;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class SysObjectDependenciesTest {
+
+    private StarRocksAssert starRocksAssert;
+
+    private ConnectContext connectContext;
+
+    @ClassRule
+    public static TemporaryFolder temp = new TemporaryFolder();
+
+
+    @Before
+    public void setUp() throws Exception {
+        FeConstants.runningUnitTest = true;
+        UtFrameUtils.createMinStarRocksCluster();
+
+        connectContext = UtFrameUtils.createDefaultCtx();
+        starRocksAssert = new StarRocksAssert(connectContext);
+        String createUserSql = "create user if not exists test_mv";
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(createUserSql, connectContext), connectContext);
+    }
+
+    @Test
+    public void testObjectDependencies() throws Exception {
+        starRocksAssert.withDatabase("test")
+                .useDatabase("test")
+                .withTable("CREATE TABLE test.test_mv_base_table\n" +
+                        "(\n" + "    k1 date,\n" + "    k2 int,\n" + "    v1 int sum\n" + ")\n"
+                        + "PARTITION BY RANGE(k1)\n" +
+                        "(\n" + "    PARTITION p1 values [('2022-02-01'),('2022-02-16')),\n"
+                        + "    PARTITION p2 values [('2022-02-16'),('2022-03-01'))\n" + ")\n"
+                        + "DISTRIBUTED BY HASH(k2) BUCKETS 3\n" + "PROPERTIES('replication_num' = '1');")
+                .withMaterializedView("create materialized view test.mv_1\n"
+                        + "PARTITION BY k1\n" + "distributed by hash(k2) buckets 3\n"
+                        + "refresh async\n"
+                        + "as select k1, k2, sum(v1) as total from test_mv_base_table group by k1, k2;")
+                .withMaterializedView("create materialized view test.mv_2\n"
+                        + "PARTITION BY date_trunc('month', k1)\n"
+                        + "distributed by hash(k2) buckets 3\n"
+                        + "refresh async\n"
+                        + "as select k1, k2, sum(v1) as total from test_mv_base_table group by k1, k2;");
+
+
+        String grantSql2 = "GRANT ALL ON TABLE test.test_mv_base_table TO USER `test_mv`@`%`;";
+        String grantSql = "GRANT ALL ON MATERIALIZED VIEW test.mv_1 TO USER `test_mv`@`%`;";
+        String grantSql1 = "GRANT ALL ON MATERIALIZED VIEW test.mv_2 TO USER `test_mv`@`%`;";
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(grantSql2, connectContext), connectContext);
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(grantSql, connectContext), connectContext);
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(grantSql1, connectContext), connectContext);
+
+        TObjectDependencyReq dependencyReq = buildRequest();
+
+        TObjectDependencyRes objectDependencyRes = SysObjectDependencies.listObjectDependencies(dependencyReq);
+        Assert.assertNotNull(objectDependencyRes);
+        Assert.assertEquals(2, objectDependencyRes.getItemsSize());
+        Assert.assertEquals("OLAP", objectDependencyRes.getItems().get(0).getRef_object_type());
+    }
+
+
+    @Test
+    public void testUnknownCatalogObjectDependencies() throws Exception {
+        ConnectorPlanTestBase.mockCatalog(connectContext, temp.newFolder().toURI().toString());
+        starRocksAssert = new StarRocksAssert(connectContext);
+
+
+        String mvName = "test.iceberg_mv";
+
+        starRocksAssert.withDatabase("test")
+                .useDatabase("test")
+                .withMaterializedView("create materialized view " + mvName + " " +
+                        "partition by str2date(d,'%Y-%m-%d') " +
+                        "distributed by hash(a) " +
+                        "REFRESH DEFERRED MANUAL " +
+                        "PROPERTIES (\n" +
+                        "'replication_num' = '1'" +
+                        ") " +
+                        "as select a, b, d, bitmap_union(to_bitmap(t1.c))" +
+                        " from iceberg0.partitioned_db.part_tbl1 as t1 " +
+                        " group by a, b, d;");
+
+        String grantSql1 = "GRANT ALL ON MATERIALIZED VIEW test.iceberg_mv TO USER `test_mv`@`%`;";
+        DDLStmtExecutor.execute(UtFrameUtils.parseStmtWithNewParser(grantSql1, connectContext), connectContext);
+
+
+        TObjectDependencyReq dependencyReq = buildRequest();
+
+
+        TObjectDependencyRes objectDependencyRes = SysObjectDependencies.listObjectDependencies(dependencyReq);
+
+        Assert.assertEquals("ICEBERG", objectDependencyRes.getItems().get(0).getRef_object_type());
+    }
+
+
+    private static TObjectDependencyReq buildRequest() {
+        TObjectDependencyReq dependencyReq = new TObjectDependencyReq();
+        TAuthInfo tAuthInfo = new TAuthInfo();
+
+        TUserIdentity userIdentity = new TUserIdentity();
+        userIdentity.setUsername("test_mv");
+        userIdentity.setHost("%");
+        userIdentity.setIs_domain(false);
+        tAuthInfo.setCurrent_user_ident(userIdentity);
+        tAuthInfo.setUser("root");
+        tAuthInfo.setUser_ip("127.0.0.1");
+        dependencyReq.setAuth_info(tAuthInfo);
+        return dependencyReq;
+    }
+
+
+}


### PR DESCRIPTION
Why I'm doing:



What I'm doing:

I just add try catch when invoke `getTable` method

Fixes https://github.com/StarRocks/starrocks/issues/37722

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
