### PR TITLE
[Enhancement] thrift_used_clients counter performance  optimization  in thrift client reopen scene

### DIFF
--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -113,7 +113,6 @@ Status ClientCacheHelper::reopen_client(const client_factory& factory_method, vo
 
     Status status = create_client(make_network_address(ipaddress, port), factory_method, client_key, timeout_ms);
     if (!status.ok()) {
-        // When reopen create_client still errs, there is no chance to perform a release operation.
         if (_metrics_enabled) {
             _used_clients->increment(-1);
         }

--- a/be/src/runtime/client_cache.cpp
+++ b/be/src/runtime/client_cache.cpp
@@ -109,13 +109,15 @@ Status ClientCacheHelper::reopen_client(const client_factory& factory_method, vo
 
     if (_metrics_enabled) {
         _opened_clients->increment(-1);
-        _used_clients->increment(-1);
     }
 
-    RETURN_IF_ERROR(create_client(make_network_address(ipaddress, port), factory_method, client_key, timeout_ms));
-
-    if (_metrics_enabled) {
-        _used_clients->increment(1);
+    Status status = create_client(make_network_address(ipaddress, port), factory_method, client_key, timeout_ms);
+    if (!status.ok()) {
+        // When reopen create_client still errs, there is no chance to perform a release operation.
+        if (_metrics_enabled) {
+            _used_clients->increment(-1);
+        }
+        return status;
     }
 
     _client_map[*client_key]->set_send_timeout(timeout_ms);


### PR DESCRIPTION
starrocks_be_thrift_used_clients counter performance optimization in thrift client reopen scene

Why I'm doing:
1 two fewer atomic operations compared to 36906 pr 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
