### PR TITLE
[BugFix] Fix exhange rewrite join-shuffle col

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -189,6 +189,9 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
                 new PhysicalHashAggregateOperator(aggregate.getType(), groupBys, partitions, aggregations,
                         aggregate.getSingleDistinctFunctionPos(), aggregate.isSplit(), aggregate.getLimit(), predicate,
                         projection);
+        op.setMergedLocalAgg(aggregate.isMergedLocalAgg());
+        op.setUseSortAgg(aggregate.isUseSortAgg());
+        op.setUsePerBucketOptmize(aggregate.isUsePerBucketOptmize());
         return rewriteOptExpression(optExpression, op, info.outputStringColumns);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/tree/lowcardinality/DecodeRewriter.java
@@ -231,6 +231,10 @@ public class DecodeRewriter extends OptExpressionVisitor<OptExpression, ColumnRe
         HashDistributionSpec spec = (HashDistributionSpec) exchange.getDistributionSpec();
         List<DistributionCol> shuffledColumns = Lists.newArrayList();
         for (DistributionCol column : spec.getHashDistributionDesc().getDistributionCols()) {
+            if (!info.outputStringColumns.contains(column.getColId())) {
+                shuffledColumns.add(column);
+                continue;
+            }
             ColumnRefOperator stringRef = factory.getColumnRef(column.getColId());
             ColumnRefOperator dictRef = context.stringRefToDictRefMap.getOrDefault(stringRef, stringRef);
             shuffledColumns.add(new DistributionCol(dictRef.getId(), column.isNullStrict()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/LowCardinalityTest2.java
@@ -2049,4 +2049,22 @@ public class LowCardinalityTest2 extends PlanTestBase {
                 "'2017-02-28 00:00:00', " +
                 "DictExpr(10: S_ADDRESS,[CAST(<place-holder> AS DATETIME)]))");
     }
+
+    @Test
+    public void testJoinShuffle() throws Exception {
+        String sql = "select S_ADDRESS, S_COMMENT from supplier join[shuffle] " +
+                " low_card_t2 on S_ADDRESS = c_new where S_ADDRESS in ('a', 'b')";
+        String plan = getVerboseExplain(sql);
+        assertContains(plan, "  1:Decode\n" +
+                "  |  <dict id 15> : <string id 3>\n" +
+                "  |  cardinality: 1\n" +
+                "  |  probe runtime filters:\n" +
+                "  |  - filter_id = 0, probe_expr = (3)\n" +
+                "  |  \n" +
+                "  0:OlapScanNode");
+        assertContains(plan, "  2:EXCHANGE\n" +
+                "     distribution type: SHUFFLE\n" +
+                "     partition exprs: [3, VARCHAR, false]\n" +
+                "     cardinality: 1");
+    }
 }


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
1. aggregate lose optimize flag
2. shuffle rewrited decode column

![image](https://github.com/StarRocks/starrocks/assets/5609319/d4ec8118-8d6b-4b39-acb4-a23701c2f9a9)

Fixes https://github.com/StarRocks/StarRocksTest/issues/5323

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
