### PR TITLE
[Enhancement] Support topn runtime filter for nullable columns that have filter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -50,9 +50,12 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.TreeNode;
 import com.starrocks.common.UserException;
 import com.starrocks.sql.common.PermutationGenerator;
+import com.starrocks.sql.optimizer.Utils;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
+import com.starrocks.sql.optimizer.transformer.SqlToScalarOperatorTranslator;
 import com.starrocks.thrift.TExplainLevel;
 import com.starrocks.thrift.TNormalPlanNode;
 import com.starrocks.thrift.TPlan;
@@ -71,7 +74,6 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 
 /**
  * Each PlanNode represents a single relational operator
@@ -832,8 +834,9 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         }
         return false;
     }
+
     protected Function<Expr, Boolean> couldBound(RuntimeFilterDescription rfDesc, DescriptorTable descTbl) {
-        return (Expr expr) -> couldBound(expr ,rfDesc, descTbl);
+        return (Expr expr) -> couldBound(expr, rfDesc, descTbl);
     }
 
     protected Function<Expr, Boolean> couldBoundForPartitionExpr() {
@@ -858,8 +861,13 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             SlotRef slotRef = (SlotRef) probeExpr;
             for (TupleId tupleId : getTupleIds()) {
                 for (SlotDescriptor slot : descTbl.getTupleDesc(tupleId).getSlots()) {
-                    // TopN Filter only works in no-nullable column
-                    if (slot.getId().equals(slotRef.getSlotId()) && (!slotRef.isNullable() || rfDesc.isNullLast())) {
+                    if (!slot.getId().equals(slotRef.getSlotId())) {
+                        return false;
+                    }
+                    if (!slotRef.isNullable() || rfDesc.isNullLast()) {
+                        return true;
+                    }
+                    if (slotRef.isNullable() && canEliminateNull(slot)) {
                         return true;
                     }
                 }
@@ -868,6 +876,20 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
         } else {
             return getSlotIds(descTbl).contains(probeExpr.getUsedSlotIds());
         }
+    }
+
+    private boolean canEliminateNull(SlotDescriptor slot) {
+        for (Expr expr : conjuncts) {
+            if (expr.isBound(slot.getId())) {
+                ScalarOperator operator = SqlToScalarOperatorTranslator.translate(expr);
+                ColumnRefOperator column = new ColumnRefOperator(slot.getId().asInt(), slot.getType(),
+                        "any", true);
+                if (Utils.canEliminateNull(Sets.newHashSet(column), operator)) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private boolean tryPushdownRuntimeFilterToChild(DescriptorTable descTbl, RuntimeFilterDescription description,
@@ -915,7 +937,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
                 optPartitionByExprsCandidates, childIdx);
         RoaringBitmap slotIds = getSlotIds(descTbl);
         boolean isBound = slotIds.contains(probeExpr.getUsedSlotIds()) &&
-                partitionByExprs.stream().allMatch(expr->slotIds.contains(expr.getUsedSlotIds()));
+                partitionByExprs.stream().allMatch(expr -> slotIds.contains(expr.getUsedSlotIds()));
         if (isBound) {
             checkRuntimeFilterOnNullValue(description, probeExpr);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanNode.java
@@ -862,7 +862,7 @@ abstract public class PlanNode extends TreeNode<PlanNode> {
             for (TupleId tupleId : getTupleIds()) {
                 for (SlotDescriptor slot : descTbl.getTupleDesc(tupleId).getSlots()) {
                     if (!slot.getId().equals(slotRef.getSlotId())) {
-                        return false;
+                        continue;
                     }
                     if (!slotRef.isNullable() || rfDesc.isNullLast()) {
                         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/transformer/SqlToScalarOperatorTranslator.java
@@ -291,6 +291,7 @@ public final class SqlToScalarOperatorTranslator {
             return super.visit(node, context);
 
         }
+
         @Override
         public ScalarOperator visitParameterExpr(Parameter node, Context context) {
             if (node.getExpr() == null) {
@@ -848,9 +849,9 @@ public final class SqlToScalarOperatorTranslator {
                     .stream()
                     .map(child -> visit(child, context.clone(node)))
                     .collect(Collectors.toList());
-            
+
             DictionaryGetOperator op = new DictionaryGetOperator(arguments, node.getType(), node.getDictionaryId(),
-                                                                 node.getDictionaryTxnId(), node.getKeySize());
+                    node.getDictionaryTxnId(), node.getKeySize());
             return op;
         }
     }
@@ -872,8 +873,9 @@ public final class SqlToScalarOperatorTranslator {
                 LOG.warn("Can't use IgnoreSlotVisitor with not analyzed slot ref: " + node.toSql());
                 throw unsupportedException("Can't use IgnoreSlotVisitor with not analyzed slot ref");
             }
+            String columnName = node.getColumnName() == null ? node.getLabel() : node.getColumnName();
             return new ColumnRefOperator(node.getSlotId().asInt(),
-                    node.getType(), node.getColumnName(), node.isNullable());
+                    node.getType(), columnName, node.isNullable());
         }
     }
 }


### PR DESCRIPTION
Why I'm doing:
For the sql:

```
select * from t0 where v1 > 1 order by v1 limit 10
```

if  v1 column is a nullable column, we won't generate the topn runtime filter. but because the v1 > 1 predicate could filter the null value, so we could safely push down the topn runtime filter to scan node.

What I'm doing:
 
Change the topn runtime filter push down condition: if topn column is nullable but have a filter could eliminate null value.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
