### PR TITLE
[Enhancement] Adjust calculation method for page cache mem usage metrics

### DIFF
--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -39,6 +39,7 @@
 #include "runtime/current_thread.h"
 #include "runtime/mem_tracker.h"
 #include "util/defer_op.h"
+#include "util/lru_cache.h"
 #include "util/metrics.h"
 #include "util/starrocks_metrics.h"
 
@@ -85,7 +86,7 @@ static void init_metrics() {
 }
 
 StoragePageCache::StoragePageCache(MemTracker* mem_tracker, size_t capacity)
-        : _mem_tracker(mem_tracker), _cache(new_lru_cache(capacity)) {
+        : _mem_tracker(mem_tracker), _cache(new_lru_cache(capacity, ChargeMode::MEMSIZE)) {
     init_metrics();
 }
 
@@ -127,21 +128,24 @@ bool StoragePageCache::lookup(const CacheKey& key, PageCacheHandle* handle) {
 }
 
 void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheHandle* handle, bool in_memory) {
+    // mem size should equals to data size when running UT
+    int64_t mem_size = data.size;
 #ifndef BE_TEST
-    int64_t mem_size = malloc_usable_size(data.data);
+    mem_size = malloc_usable_size(data.data);
     tls_thread_status.mem_release(mem_size);
     SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_mem_tracker);
     tls_thread_status.mem_consume(mem_size);
 #endif
 
-    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[](uint8_t*) value; };
+    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[] (uint8_t*)value; };
 
     CachePriority priority = CachePriority::NORMAL;
     if (in_memory) {
         priority = CachePriority::DURABLE;
     }
-
-    auto* lru_handle = _cache->insert(key.encode(), data.data, data.size, deleter, priority);
+    // Use mem size managed by memory allocator as this record charge size. At the same time, we should record this record size
+    // for data fetching when lookup.
+    auto* lru_handle = _cache->insert(key.encode(), data.data, mem_size, deleter, priority, data.size);
     *handle = PageCacheHandle(_cache.get(), lru_handle);
 }
 

--- a/be/src/storage/page_cache.cpp
+++ b/be/src/storage/page_cache.cpp
@@ -137,7 +137,7 @@ void StoragePageCache::insert(const CacheKey& key, const Slice& data, PageCacheH
     tls_thread_status.mem_consume(mem_size);
 #endif
 
-    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[] (uint8_t*)value; };
+    auto deleter = [](const starrocks::CacheKey& key, void* value) { delete[](uint8_t*) value; };
 
     CachePriority priority = CachePriority::NORMAL;
     if (in_memory) {

--- a/be/src/util/lru_cache.cpp
+++ b/be/src/util/lru_cache.cpp
@@ -193,6 +193,10 @@ void LRUCache::set_capacity(size_t capacity) {
     }
 }
 
+void LRUCache::set_charge_mode(ChargeMode charge_mode) {
+    _charge_mode = charge_mode;
+}
+
 uint64_t LRUCache::get_lookup_count() const {
     std::lock_guard l(_mutex);
     return _lookup_count;
@@ -295,7 +299,8 @@ void LRUCache::_evict_one_entry(LRUHandle* e) {
 }
 
 Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value, size_t charge,
-                                void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+                                void (*deleter)(const CacheKey& key, void* value), CachePriority priority,
+                                size_t value_size) {
     auto* e = reinterpret_cast<LRUHandle*>(malloc(sizeof(LRUHandle) - 1 + key.size()));
     e->value = value;
     e->deleter = deleter;
@@ -306,6 +311,7 @@ Cache::Handle* LRUCache::insert(const CacheKey& key, uint32_t hash, void* value,
     e->next = e->prev = nullptr;
     e->in_cache = true;
     e->priority = priority;
+    e->value_size = value_size;
     memcpy(e->key_data, key.data(), key.size());
     std::vector<LRUHandle*> last_ref_list;
     {
@@ -395,10 +401,12 @@ uint32_t ShardedLRUCache::_shard(uint32_t hash) {
     return hash >> (32 - kNumShardBits);
 }
 
-ShardedLRUCache::ShardedLRUCache(size_t capacity) : _last_id(0), _capacity(capacity) {
+ShardedLRUCache::ShardedLRUCache(size_t capacity, ChargeMode charge_mode)
+        : _last_id(0), _capacity(capacity), _charge_mode(charge_mode) {
     const size_t per_shard = (_capacity + (kNumShards - 1)) / kNumShards;
     for (auto& _shard : _shards) {
         _shard.set_capacity(per_shard);
+        _shard.set_charge_mode(_charge_mode);
     }
 }
 
@@ -427,9 +435,10 @@ bool ShardedLRUCache::adjust_capacity(int64_t delta, size_t min_capacity) {
 }
 
 Cache::Handle* ShardedLRUCache::insert(const CacheKey& key, void* value, size_t charge,
-                                       void (*deleter)(const CacheKey& key, void* value), CachePriority priority) {
+                                       void (*deleter)(const CacheKey& key, void* value), CachePriority priority,
+                                       size_t value_size) {
     const uint32_t hash = _hash_slice(key);
-    return _shards[_shard(hash)].insert(key, hash, value, charge, deleter, priority);
+    return _shards[_shard(hash)].insert(key, hash, value, charge, deleter, priority, value_size);
 }
 
 Cache::Handle* ShardedLRUCache::lookup(const CacheKey& key) {
@@ -453,7 +462,8 @@ void* ShardedLRUCache::value(Handle* handle) {
 
 Slice ShardedLRUCache::value_slice(Handle* handle) {
     auto lru_handle = reinterpret_cast<LRUHandle*>(handle);
-    return {(char*)lru_handle->value, lru_handle->charge};
+    size_t record_size = _charge_mode == ChargeMode::VALUESIZE ? lru_handle->charge : lru_handle->value_size;
+    return {(char*)lru_handle->value, record_size};
 }
 
 uint64_t ShardedLRUCache::new_id() {
@@ -526,8 +536,8 @@ void ShardedLRUCache::get_cache_status(rapidjson::Document* document) {
     }
 }
 
-Cache* new_lru_cache(size_t capacity) {
-    return new ShardedLRUCache(capacity);
+Cache* new_lru_cache(size_t capacity, ChargeMode charge_mode) {
+    return new ShardedLRUCache(capacity, charge_mode);
 }
 
 } // namespace starrocks

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -43,7 +43,6 @@
 #include "gutil/strings/split.h" // for string split
 #include "gutil/strtoint.h"      //  for atoi64
 #include "jemalloc/jemalloc.h"
-#include "storage/page_cache.h"
 
 namespace starrocks {
 
@@ -321,13 +320,7 @@ void SystemMetrics::_update_memory_metrics() {
     SET_MEM_METRIC_VALUE(short_key_index_mem_tracker, short_key_index_mem_bytes)
     SET_MEM_METRIC_VALUE(compaction_mem_tracker, compaction_mem_bytes)
     SET_MEM_METRIC_VALUE(schema_change_mem_tracker, schema_change_mem_bytes)
-    // The memory usage of the page cache tracked by MemTracker may exceed the maximum available
-    // memory of the page cache. This could be problematic for users. Therefore, in this case,
-    // we use the memory usage size maintained by the page cache itself as the metric value.
-    auto cache = StoragePageCache::instance();
-    if (cache != nullptr) {
-        _memory_metrics->storage_page_cache_mem_bytes.set_value(cache->memory_usage());
-    }
+    SET_MEM_METRIC_VALUE(page_cache_mem_tracker, storage_page_cache_mem_bytes)
     SET_MEM_METRIC_VALUE(update_mem_tracker, update_mem_bytes)
     SET_MEM_METRIC_VALUE(chunk_allocator_mem_tracker, chunk_allocator_mem_bytes)
     SET_MEM_METRIC_VALUE(clone_mem_tracker, clone_mem_bytes)

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -43,6 +43,7 @@
 #include "gutil/strings/split.h" // for string split
 #include "gutil/strtoint.h"      //  for atoi64
 #include "jemalloc/jemalloc.h"
+#include "storage/page_cache.h"
 
 namespace starrocks {
 
@@ -320,7 +321,11 @@ void SystemMetrics::_update_memory_metrics() {
     SET_MEM_METRIC_VALUE(short_key_index_mem_tracker, short_key_index_mem_bytes)
     SET_MEM_METRIC_VALUE(compaction_mem_tracker, compaction_mem_bytes)
     SET_MEM_METRIC_VALUE(schema_change_mem_tracker, schema_change_mem_bytes)
-    SET_MEM_METRIC_VALUE(page_cache_mem_tracker, storage_page_cache_mem_bytes)
+    // The memory usage of the page cache tracked by MemTracker may exceed the maximum available
+    // memory of the page cache. This could be problematic for users. Therefore, in this case,
+    // we use the memory usage size maintained by the page cache itself as the metric value.
+    auto cache = StoragePageCache::instance();
+    _memory_metrics->storage_page_cache_mem_bytes.set_value(cache->memory_usage());
     SET_MEM_METRIC_VALUE(update_mem_tracker, update_mem_bytes)
     SET_MEM_METRIC_VALUE(chunk_allocator_mem_tracker, chunk_allocator_mem_bytes)
     SET_MEM_METRIC_VALUE(clone_mem_tracker, clone_mem_bytes)

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -325,7 +325,9 @@ void SystemMetrics::_update_memory_metrics() {
     // memory of the page cache. This could be problematic for users. Therefore, in this case,
     // we use the memory usage size maintained by the page cache itself as the metric value.
     auto cache = StoragePageCache::instance();
-    _memory_metrics->storage_page_cache_mem_bytes.set_value(cache->memory_usage());
+    if (cache != nullptr) {
+        _memory_metrics->storage_page_cache_mem_bytes.set_value(cache->memory_usage());
+    }
     SET_MEM_METRIC_VALUE(update_mem_tracker, update_mem_bytes)
     SET_MEM_METRIC_VALUE(chunk_allocator_mem_tracker, chunk_allocator_mem_bytes)
     SET_MEM_METRIC_VALUE(clone_mem_tracker, clone_mem_bytes)


### PR DESCRIPTION
Why I'm doing:
The memory usage of the page cache tracked by MemTracker may exceed the maximum available memory of the page cache. This could be problematic for users.
![image](https://github.com/StarRocks/starrocks/assets/45813655/b378ce53-c4b2-4b88-937f-cf77c115215b)

What I'm doing:
Make the size tracked by the memory allocator as the size occupied in the page cache. The new strategy results in starrocks_be_storage_page_cache_mem_bytes being slightly larger than starrocks_be_page_cache_capacity, as starrocks_be_page_cache_capacity does not include the metadata of the page cache itself.
![image](https://github.com/StarRocks/starrocks/assets/45813655/887a7e79-a7fc-4c9c-aed7-aefc71f08446)

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
