### PR TITLE
[Enhancement] Reduce IOPS in HDFS Text Reader when enable datacache

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -787,6 +787,10 @@ CONF_Int64(object_storage_connect_timeout_ms, "-1");
 // When it's 0, low speed limit check will be disabled.
 CONF_Int64(object_storage_request_timeout_ms, "-1");
 
+// text reader
+// Spilt text file's scan range into io ranges of 16mb size
+CONF_Int32(text_io_range_size, "16777216");
+
 // orc reader
 CONF_Bool(enable_orc_late_materialization, "true");
 CONF_Int32(orc_row_index_cache_max_size, "1048576");

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -789,7 +789,7 @@ CONF_Int64(object_storage_request_timeout_ms, "-1");
 
 // text reader
 // Spilt text file's scan range into io ranges of 16mb size
-CONF_Int32(text_io_range_size, "16777216");
+CONF_Int64(text_io_range_size, "16777216");
 
 // orc reader
 CONF_Bool(enable_orc_late_materialization, "true");

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -462,9 +462,8 @@ Status HdfsTextScanner::_setup_io_ranges() const {
     if (_shared_buffered_input_stream != nullptr) {
         std::vector<io::SharedBufferedInputStream::IORange> ranges{};
         for (int64_t offset = 0; offset < _scanner_params.file_size;) {
-            const int64_t remain_length =
-                    std::min(static_cast<int64_t>(config::text_io_range_size), _scanner_params.file_size - offset);
-            ranges.emplace_back((io::SharedBufferedInputStream::IORange{.offset = offset, .size = remain_length}));
+            const int64_t remain_length = std::min(config::text_io_range_size, _scanner_params.file_size - offset);
+            ranges.emplace_back(offset, remain_length);
             offset += remain_length;
         }
         RETURN_IF_ERROR(_shared_buffered_input_stream->set_io_ranges(ranges));

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -462,10 +462,10 @@ Status HdfsTextScanner::_setup_io_ranges() const {
     if (_shared_buffered_input_stream != nullptr) {
         std::vector<io::SharedBufferedInputStream::IORange> ranges{};
         for (int64_t offset = 0; offset < _scanner_params.file_size;) {
-            int64_t length =
+            const int64_t remain_length =
                     std::min(static_cast<int64_t>(config::text_io_range_size), _scanner_params.file_size - offset);
-            ranges.emplace_back(offset, length, true);
-            offset += length;
+            ranges.emplace_back((io::SharedBufferedInputStream::IORange{.offset = offset, .size = remain_length}));
+            offset += remain_length;
         }
         RETURN_IF_ERROR(_shared_buffered_input_stream->set_io_ranges(ranges));
     }

--- a/be/src/exec/hdfs_scanner_text.cpp
+++ b/be/src/exec/hdfs_scanner_text.cpp
@@ -258,6 +258,7 @@ Status HdfsTextScanner::do_open(RuntimeState* runtime_state) {
         }
     }
     RETURN_IF_ERROR(open_random_access_file());
+    RETURN_IF_ERROR(_setup_io_ranges());
     RETURN_IF_ERROR(_create_or_reinit_reader());
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
     RETURN_IF_ERROR(_build_hive_column_name_2_index());
@@ -453,6 +454,20 @@ Status HdfsTextScanner::_create_or_reinit_reader() {
             CSVReader::Record dummy;
             RETURN_IF_ERROR(reader->next_record(&dummy));
         }
+    }
+    return Status::OK();
+}
+
+Status HdfsTextScanner::_setup_io_ranges() const {
+    if (_shared_buffered_input_stream != nullptr) {
+        std::vector<io::SharedBufferedInputStream::IORange> ranges{};
+        for (int64_t offset = 0; offset < _scanner_params.file_size;) {
+            int64_t length =
+                    std::min(static_cast<int64_t>(config::text_io_range_size), _scanner_params.file_size - offset);
+            ranges.emplace_back(offset, length, true);
+            offset += length;
+        }
+        RETURN_IF_ERROR(_shared_buffered_input_stream->set_io_ranges(ranges));
     }
     return Status::OK();
 }

--- a/be/src/exec/hdfs_scanner_text.h
+++ b/be/src/exec/hdfs_scanner_text.h
@@ -34,6 +34,7 @@ public:
     Status parse_csv(int chunk_size, ChunkPtr* chunk);
 
 private:
+    Status _setup_io_ranges() const;
     // create a reader or re init reader
     Status _create_or_reinit_reader();
     Status _build_hive_column_name_2_index();

--- a/be/src/formats/orc/orc_input_stream.cpp
+++ b/be/src/formats/orc/orc_input_stream.cpp
@@ -90,8 +90,7 @@ void ORCHdfsFileStream::setIORanges(std::vector<IORange>& io_ranges) {
     std::vector<io::SharedBufferedInputStream::IORange> bs_io_ranges;
     bs_io_ranges.reserve(io_ranges.size());
     for (const auto& r : io_ranges) {
-        bs_io_ranges.emplace_back(io::SharedBufferedInputStream::IORange{.offset = static_cast<int64_t>(r.offset),
-                                                                         .size = static_cast<int64_t>(r.size)});
+        bs_io_ranges.emplace_back(static_cast<int64_t>(r.offset), static_cast<int64_t>(r.size));
     }
     Status st = _sb_stream->set_io_ranges(bs_io_ranges);
     if (!st.ok()) {

--- a/be/src/formats/parquet/group_reader.cpp
+++ b/be/src/formats/parquet/group_reader.cpp
@@ -522,8 +522,7 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
             offset = column.data_page_offset;
         }
         int64_t size = column.total_compressed_size;
-        auto r = io::SharedBufferedInputStream::IORange{.offset = offset, .size = size, .active = active};
-        ranges->emplace_back(r);
+        ranges->emplace_back(offset, size, active);
         *end_offset = std::max(*end_offset, offset + size);
     }
 }
@@ -565,8 +564,7 @@ void GroupReader::_collect_field_io_range(const ParquetField& field, const TypeD
             offset = column.data_page_offset;
         }
         int64_t size = column.total_compressed_size;
-        auto r = io::SharedBufferedInputStream::IORange{.offset = offset, .size = size, .active = active};
-        ranges->emplace_back(r);
+        ranges->emplace_back(offset, size, active);
         *end_offset = std::max(*end_offset, offset + size);
     }
 }

--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -94,8 +94,10 @@ Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bo
             sb = ret.value();
             if (sb->buffer.capacity() > 0) {
                 strings::memcpy_inlined(out, sb->buffer.data() + offset - sb->offset, size);
-                _populate_cache_from_zero_copy_buffer((const char*)sb->buffer.data() + block_offset - sb->offset,
-                                                      block_offset, load_size);
+                if (_enable_populate_cache) {
+                    _populate_cache_from_zero_copy_buffer((const char*)sb->buffer.data() + block_offset - sb->offset,
+                                                          block_offset, load_size);
+                }
                 return Status::OK();
             }
         }

--- a/be/src/io/shared_buffered_input_stream.cpp
+++ b/be/src/io/shared_buffered_input_stream.cpp
@@ -131,7 +131,7 @@ Status SharedBufferedInputStream::_set_io_ranges_separately(const std::vector<IO
             sb.align(_align_size, _file_size);
             _map.insert(std::make_pair(sb.raw_offset + sb.raw_size, sb));
         } else {
-            if (r.active) {
+            if (r.is_active) {
                 small_active_ranges.emplace_back(r);
             } else {
                 small_lazy_flag[index] = true;

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -26,10 +26,11 @@ namespace starrocks::io {
 class SharedBufferedInputStream : public SeekableInputStream {
 public:
     struct IORange {
-        IORange(const int64_t offset, const int64_t size) : offset(offset), size(size) {}
+        IORange(const int64_t offset, const int64_t size, const bool is_active = true)
+                : offset(offset), size(size), is_active(is_active) {}
         int64_t offset;
         int64_t size;
-        bool active = true;
+        bool is_active = true;
         bool operator<(const IORange& x) const { return offset < x.offset; }
     };
     struct CoalesceOptions {

--- a/be/src/io/shared_buffered_input_stream.h
+++ b/be/src/io/shared_buffered_input_stream.h
@@ -26,6 +26,7 @@ namespace starrocks::io {
 class SharedBufferedInputStream : public SeekableInputStream {
 public:
     struct IORange {
+        IORange(const int64_t offset, const int64_t size) : offset(offset), size(size) {}
         int64_t offset;
         int64_t size;
         bool active = true;


### PR DESCRIPTION
Why I'm doing:
After DataCache is enabled, remote files will be read with a block size of 256kb each time, bringing a lot of IOPS.
So we need to setup the io ranges in the shared buffer to optimize this situation

What I'm doing:
Divide the scan range into multiple 16mb io ranges.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
