### PR TITLE
[UT] fix persistent index unstable ut

### DIFF
--- a/be/test/storage/persistent_index_test.cpp
+++ b/be/test/storage/persistent_index_test.cpp
@@ -2918,7 +2918,7 @@ TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_update) {
         // 1. upsert
         for (int i = 0; i < K; i++) {
             incre_key(i);
-            std::vector<IndexValue> old_values(M);
+            std::vector<IndexValue> old_values(M, IndexValue(NullIndexValue));
             ASSERT_OK(index.load(index_meta));
             ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
             ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));
@@ -2929,7 +2929,7 @@ TEST_P(PersistentIndexTest, test_multi_l2_not_tmp_l1_update) {
         // 2. update half key
         for (int i = 0; i < K - 2; i++) {
             update_key(i);
-            std::vector<IndexValue> old_values(M);
+            std::vector<IndexValue> old_values(M, IndexValue(NullIndexValue));
             ASSERT_OK(index.load(index_meta));
             ASSERT_OK(index.prepare(EditVersion(cur_version++, 0), M));
             ASSERT_OK(index.upsert(M, key_slices.data(), values.data(), old_values.data()));


### PR DESCRIPTION
Why I'm doing:
BE ut `PersistentIndexTest.test_multi_l2_not_tmp_l1_update` is unstable, because old values when `upsert` not init, it will lead to internal check fail.

What I'm doing:
Init old values to `NullIndexValue`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
