### PR TITLE
[Enhancement] Dump metrics with bvar (backport #27064)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -1001,4 +1001,5 @@ CONF_mBool(enable_stream_load_verbose_log, "false");
 
 CONF_mInt32(get_txn_status_internal_sec, "30");
 
+CONF_mBool(dump_metrics_with_bvar, "true");
 } // namespace starrocks::config

--- a/be/test/http/metrics_action_test.cpp
+++ b/be/test/http/metrics_action_test.cpp
@@ -41,7 +41,10 @@ class MetricsActionTest : public testing::Test {
 public:
     MetricsActionTest() = default;
     ~MetricsActionTest() override = default;
-    void SetUp() override { _evhttp_req = evhttp_request_new(nullptr, nullptr); }
+    void SetUp() override {
+        config::dump_metrics_with_bvar = false;
+        _evhttp_req = evhttp_request_new(nullptr, nullptr);
+    }
     void TearDown() override {
         if (_evhttp_req != nullptr) {
             evhttp_request_free(_evhttp_req);


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
backport https://github.com/StarRocks/starrocks/pull/27064

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

