### PR TITLE
[Enhancement] Add iter for BitampValue

### DIFF
--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -59,12 +59,15 @@ namespace starrocks {
 
 namespace detail {
 class Roaring64Map;
+class BitmapValueIter;
 }
 // Represent the in-memory and on-disk structure of StarRocks's BITMAP data type.
 // Optimize for the case where the bitmap contains 0 or 1 element which is common
 // for streaming load scenario.
 class BitmapValue {
 public:
+    friend class BitmapValueIter;
+
     enum BitmapDataType {
         EMPTY = 0,
         SINGLE = 1, // single element
@@ -224,5 +227,29 @@ private:
     std::unique_ptr<phmap::flat_hash_set<uint64_t>> _set;
     uint64_t _sv = 0; // store the single value when _type == SINGLE
     BitmapDataType _type{EMPTY};
+};
+
+class BitmapValueIter {
+public:
+    void reset(const BitmapValue& bitmap) {
+        _bitmap = &bitmap;
+        _offset = 0;
+        _cardinality =  bitmap.cardinality();
+        if (bitmap.type() == BitmapValue::BitmapDataType::BITMAP) {
+            _bitmap_iter = std::make_unique<detail::Roaring64MapSetBitForwardIterator>(*bitmap._bitmap);
+        }
+    }
+
+    uint64_t next_batch(uint64_t* values, uint64_t count);
+    uint64_t offset() { return _offset; }
+    void set_offset(uint64_t offset) { _offset = offset; }
+
+private:
+    uint64_t _remain_rows() const { return _cardinality - _offset; }
+
+    const BitmapValue* _bitmap = nullptr;
+    uint64_t _offset = 0;
+    uint64_t _cardinality = 0;
+    std::unique_ptr<detail::Roaring64MapSetBitForwardIterator> _bitmap_iter;
 };
 } // namespace starrocks

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -237,6 +237,8 @@ public:
         _cardinality =  bitmap.cardinality();
         if (bitmap.type() == BitmapValue::BitmapDataType::BITMAP) {
             _bitmap_iter = std::make_unique<detail::Roaring64MapSetBitForwardIterator>(*bitmap._bitmap);
+        } else {
+            _bitmap_iter.reset();
         }
     }
 

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -60,7 +60,7 @@ namespace starrocks {
 namespace detail {
 class Roaring64Map;
 class BitmapValueIter;
-}
+} // namespace detail
 // Represent the in-memory and on-disk structure of StarRocks's BITMAP data type.
 // Optimize for the case where the bitmap contains 0 or 1 element which is common
 // for streaming load scenario.
@@ -234,7 +234,7 @@ public:
     void reset(const BitmapValue& bitmap) {
         _bitmap = &bitmap;
         _offset = 0;
-        _cardinality =  bitmap.cardinality();
+        _cardinality = bitmap.cardinality();
         if (bitmap.type() == BitmapValue::BitmapDataType::BITMAP) {
             _bitmap_iter = std::make_unique<detail::Roaring64MapSetBitForwardIterator>(*bitmap._bitmap);
         } else {


### PR DESCRIPTION
Why I'm doing:

UnnestBitmap need one iter to batch output the values of bitmap.

What I'm doing:

Add iter for `BitampValue`.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
