### PR TITLE
[Refactor] Move BitmapValue from package spark-dpp to plugin-common (backport #36533)

### DIFF
--- a/fe/plugin-common/pom.xml
+++ b/fe/plugin-common/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>starrocks-fe</artifactId>
+        <groupId>com.starrocks</groupId>
+        <version>3.4.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>plugin-common</artifactId>
+    <version>1.0.0</version>
+    <packaging>jar</packaging>
+
+    <properties>
+        <starrocks.home>${basedir}/../../</starrocks.home>
+        <fe_ut_parallel>1</fe_ut_parallel>
+    </properties>
+
+    <build>
+        <plugins>
+            <!-- jmockit -->
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <!-->set larger, eg, 3, to reduce the time or running FE unit tests<-->
+                    <forkCount>${fe_ut_parallel}</forkCount>
+                    <!-->not reuse forked jvm, so that each unit test will run in separate jvm. to avoid singleton confict<-->
+                    <reuseForks>false</reuseForks>
+                    <argLine>
+                        -javaagent:${settings.localRepository}/com/github/hazendaz/jmockit/jmockit/1.49.4/jmockit-1.49.4.jar
+                    </argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/fe/plugin-common/src/main/java/com/starrocks/types/BitmapValue.java
+++ b/fe/plugin-common/src/main/java/com/starrocks/types/BitmapValue.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package com.starrocks.load.loadv2.dpp;
+package com.starrocks.types;
 
 import com.google.common.base.Objects;
 import org.roaringbitmap.Util;

--- a/fe/plugin-common/src/main/java/com/starrocks/types/Codec.java
+++ b/fe/plugin-common/src/main/java/com/starrocks/types/Codec.java
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package com.starrocks.common;
+package com.starrocks.types;
 
 import java.io.DataInput;
 import java.io.DataOutput;

--- a/fe/plugin-common/src/main/java/com/starrocks/types/Roaring64Map.java
+++ b/fe/plugin-common/src/main/java/com/starrocks/types/Roaring64Map.java
@@ -15,9 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package com.starrocks.load.loadv2.dpp;
+package com.starrocks.types;
 
-import com.starrocks.common.Codec;
 import org.roaringbitmap.BitmapDataProvider;
 import org.roaringbitmap.BitmapDataProviderSupplier;
 import org.roaringbitmap.IntConsumer;

--- a/fe/plugin-common/src/test/java/com/starrocks/types/BitmapValueTest.java
+++ b/fe/plugin-common/src/test/java/com/starrocks/types/BitmapValueTest.java
@@ -15,9 +15,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package com.starrocks.load.loadv2.dpp;
+package com.starrocks.types;
 
-import com.starrocks.common.Codec;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/fe/pom.xml
+++ b/fe/pom.xml
@@ -29,6 +29,7 @@ under the License.
     <packaging>pom</packaging>
 
     <modules>
+        <module>plugin-common</module>
         <module>fe-common</module>
         <module>spark-dpp</module>
         <module>fe-core</module>
@@ -151,6 +152,12 @@ under the License.
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>com.starrocks</groupId>
+                <artifactId>plugin-common</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+
             <dependency>
                 <groupId>com.starrocks</groupId>
                 <artifactId>fe-common</artifactId>

--- a/fe/spark-dpp/pom.xml
+++ b/fe/spark-dpp/pom.xml
@@ -45,6 +45,11 @@ under the License.
             <artifactId>fe-common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>com.starrocks</groupId>
+            <artifactId>plugin-common</artifactId>
+        </dependency>
+
         <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
         <dependency>
             <groupId>commons-codec</groupId>

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregator.java
@@ -19,6 +19,7 @@ package com.starrocks.load.loadv2.dpp;
 
 import com.starrocks.common.SparkDppException;
 import com.starrocks.load.loadv2.etl.EtlJobConfig;
+import com.starrocks.types.BitmapValue;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.log4j.LogManager;

--- a/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/StarRocksKryoRegistrator.java
+++ b/fe/spark-dpp/src/main/java/com/starrocks/load/loadv2/dpp/StarRocksKryoRegistrator.java
@@ -18,6 +18,8 @@
 package com.starrocks.load.loadv2.dpp;
 
 import com.esotericsoftware.kryo.Kryo;
+import com.starrocks.types.BitmapValue;
+import com.starrocks.types.Roaring64Map;
 import org.apache.spark.serializer.KryoRegistrator;
 
 /**

--- a/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregatorTest.java
+++ b/fe/spark-dpp/src/test/java/com/starrocks/load/loadv2/dpp/SparkRDDAggregatorTest.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.load.loadv2.dpp;
 
+import com.starrocks.types.BitmapValue;
 import org.junit.Assert;
 import org.junit.Test;
 


### PR DESCRIPTION
Why I'm doing:

I want to add a new module (hive_udf). This module will also use `BitmapValue`, so I need to separate `BitmapValue` from `spark-dpp` for reuse, but it cannot be placed in fe-common because fe-common is currently compiled with jdk11. As a result, spark compiled with jdk8 will execute failed, so a new module (plugin-common) is added here.

What I'm doing:

Move BitmapValue from package spark-dpp to plugin-common

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
