### PR TITLE
[BugFix] shallow copy indexIdToMeta when copy olapTable

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -1586,7 +1586,9 @@ public class SchemaChangeHandler extends AlterHandler {
             long jobId = GlobalStateMgr.getCurrentState().getNextId();
             long txnId = GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
             long startTime = ConnectContext.get().getStartTime();
-            //for schema change add/drop value column optimize, direct modify table meta.
+            // for schema change add/drop value column optimize, direct modify table meta.
+            // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
+            // try to copy first before modifying, avoiding in-place changes.
             modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, newIndexes, jobId, txnId, startTime,
                                         addColumnsName, false);
             return null;
@@ -2459,7 +2461,8 @@ public class SchemaChangeHandler extends AlterHandler {
             Boolean hasMv = !olapTable.getRelatedMaterializedViews().isEmpty();
             for (long idx : indexIds) {
                 List<Column> indexSchema = indexSchemaMap.get(idx);
-                MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(idx);
+                // modify the copied indexMeta and put the update result in the indexIdToMeta
+                MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(idx).shallowCopy();
                 List<Column> originSchema = currentIndexMeta.getSchema();
                 
                 if (hasMv && indexSchema.size() < originSchema.size()) {
@@ -2467,7 +2470,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     List<Column> differences = originSchema.stream().filter(element ->
                                    !indexSchema.contains(element)).collect(Collectors.toList());
                     // can just drop one column one time, so just one element in differences
-                    Integer dropIdx = new Integer(originSchema.indexOf(differences.get(0)));
+                    int dropIdx = originSchema.indexOf(differences.get(0));
                     modifiedColumns.add(originSchema.get(dropIdx).getName());
                 }
 
@@ -2509,6 +2512,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 int currentSchemaVersion = currentIndexMeta.getSchemaVersion();
                 int newSchemaVersion = currentSchemaVersion + 1;
                 currentIndexMeta.setSchemaVersion(newSchemaVersion);
+                // update the indexIdToMeta
+                olapTable.getIndexIdToMeta().put(idx, currentIndexMeta);
                 schemaChangeJob.addIndexSchema(idx, idx, olapTable.getIndexNameById(idx), newSchemaVersion,
                                                currentIndexMeta.getSchemaHash(), currentIndexMeta.getShortKeyColumnCount(),
                                                indexSchema);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -252,9 +252,9 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     public MaterializedIndexMeta shallowCopy() {
         MaterializedIndexMeta indexMeta = new MaterializedIndexMeta();
         indexMeta.indexId = this.indexId;
-        indexMeta.schema = Lists.newArrayList(schema);
-        indexMeta.sortKeyIdxes = Lists.newArrayList(sortKeyIdxes);
-        indexMeta.sortKeyUniqueIds = Lists.newArrayList(sortKeyUniqueIds);
+        indexMeta.schema = schema == null ? null : Lists.newArrayList(schema);
+        indexMeta.sortKeyIdxes = sortKeyIdxes == null ? null : Lists.newArrayList(sortKeyIdxes);
+        indexMeta.sortKeyUniqueIds = sortKeyUniqueIds == null ? null : Lists.newArrayList(sortKeyUniqueIds);
         indexMeta.schemaVersion = this.schemaVersion;
         indexMeta.schemaHash = this.schemaHash;
         indexMeta.shortKeyColumnCount = this.shortKeyColumnCount;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -86,6 +86,10 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     private Expr whereClause;
 
+    private MaterializedIndexMeta() {
+
+    }
+
     public MaterializedIndexMeta(long indexId, List<Column> schema, int schemaVersion, int schemaHash,
                                  short shortKeyColumnCount, TStorageType storageType, KeysType keysType,
                                  OriginStatement defineStmt, List<Integer> sortKeyIdxes, List<Integer> sortKeyUniqueIds) {
@@ -243,6 +247,25 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
 
     public void setSchemaVersion(int newSchemaVersion) {
         this.schemaVersion = newSchemaVersion;
+    }
+
+    public MaterializedIndexMeta shallowCopy() {
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta();
+        indexMeta.indexId = this.indexId;
+        indexMeta.schema = Lists.newArrayList(schema);
+        indexMeta.sortKeyIdxes = Lists.newArrayList(sortKeyIdxes);
+        indexMeta.sortKeyUniqueIds = Lists.newArrayList(sortKeyUniqueIds);
+        indexMeta.schemaVersion = this.schemaVersion;
+        indexMeta.schemaHash = this.schemaHash;
+        indexMeta.shortKeyColumnCount = this.shortKeyColumnCount;
+        indexMeta.storageType = this.storageType;
+        indexMeta.keysType = this.keysType;
+        indexMeta.defineStmt = this.defineStmt;
+        indexMeta.dbId = this.dbId;
+        indexMeta.viewDefineSql = this.viewDefineSql;
+        indexMeta.isColocateMVIndex = this.isColocateMVIndex;
+        indexMeta.whereClause = this.whereClause;
+        return indexMeta;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -321,6 +321,10 @@ public class OlapTable extends Table {
         olapTable.state = this.state;
         olapTable.indexNameToId = Maps.newHashMap(this.indexNameToId);
         olapTable.indexIdToMeta = Maps.newHashMap(this.indexIdToMeta);
+
+        olapTable.indexes = this.indexes.shallowCopy();
+        olapTable.bfColumns = Sets.newHashSet(bfColumns);
+
         olapTable.keysType = this.keysType;
         if (this.relatedMaterializedViews != null) {
             olapTable.relatedMaterializedViews = Sets.newHashSet(this.relatedMaterializedViews);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -325,8 +325,8 @@ public class OlapTable extends Table {
         for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
             olapTable.indexIdToMeta.put(entry.getKey(), entry.getValue().shallowCopy());
         }
-        olapTable.indexes = this.indexes.shallowCopy();
-        olapTable.bfColumns = Sets.newHashSet(bfColumns);
+        olapTable.indexes = indexes == null ? null : indexes.shallowCopy();
+        olapTable.bfColumns = bfColumns == null ? null : Sets.newHashSet(bfColumns);
 
         olapTable.keysType = this.keysType;
         if (this.relatedMaterializedViews != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -320,11 +320,7 @@ public class OlapTable extends Table {
         olapTable.nameToColumn = Maps.newHashMap(this.nameToColumn);
         olapTable.state = this.state;
         olapTable.indexNameToId = Maps.newHashMap(this.indexNameToId);
-        olapTable.indexIdToMeta = Maps.newHashMap();
-        // fast schema evolution will modify indexIdToMeta in-place, hence we need shallow copy it here.
-        for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
-            olapTable.indexIdToMeta.put(entry.getKey(), entry.getValue().shallowCopy());
-        }
+        olapTable.indexIdToMeta = Maps.newHashMap(this.indexIdToMeta);
         olapTable.indexes = indexes == null ? null : indexes.shallowCopy();
         olapTable.bfColumns = bfColumns == null ? null : Sets.newHashSet(bfColumns);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -320,8 +320,11 @@ public class OlapTable extends Table {
         olapTable.nameToColumn = Maps.newHashMap(this.nameToColumn);
         olapTable.state = this.state;
         olapTable.indexNameToId = Maps.newHashMap(this.indexNameToId);
-        olapTable.indexIdToMeta = Maps.newHashMap(this.indexIdToMeta);
-
+        olapTable.indexIdToMeta = Maps.newHashMap();
+        // fast schema evolution will modify indexIdToMeta in-place, hence we need shallow copy it here.
+        for (Map.Entry<Long, MaterializedIndexMeta> entry : indexIdToMeta.entrySet()) {
+            olapTable.indexIdToMeta.put(entry.getKey(), entry.getValue().shallowCopy());
+        }
         olapTable.indexes = this.indexes.shallowCopy();
         olapTable.bfColumns = Sets.newHashSet(bfColumns);
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableIndexes.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableIndexes.java
@@ -110,6 +110,10 @@ public class TableIndexes implements Writable {
         this.properties = properties;
     }
 
+
+    public TableIndexes shallowCopy() {
+        return new TableIndexes(getCopiedIndexes(), getCopiedProperties());
+    }
     @Override
     public void write(DataOutput out) throws IOException {
         Text.writeString(out, GsonUtils.GSON.toJson(this));

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
@@ -1,0 +1,151 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.google.common.collect.ImmutableSet;
+import com.starrocks.catalog.HiveTable;
+import com.starrocks.common.Config;
+import com.starrocks.common.UserException;
+import com.starrocks.common.profile.Tracers;
+import com.starrocks.common.util.DebugUtil;
+import com.starrocks.connector.ConnectorMetadata;
+import com.starrocks.connector.exception.RemoteFileNotFoundException;
+import com.starrocks.planner.HdfsScanNode;
+import com.starrocks.planner.ScanNode;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.server.CatalogMgr;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.StatementPlanner;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.thrift.TExplainLevel;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class ExecuteExceptionHandler {
+
+    private static final Logger LOG = LogManager.getLogger(ExecuteExceptionHandler.class);
+
+    private static final Set<String> SCHEMA_NOT_MATCH_ERROR = ImmutableSet.of("invalid field name");
+
+    public static void handle(Exception e, RetryContext context) throws Exception {
+        if (e instanceof RemoteFileNotFoundException) {
+            handleRemoteFileNotFound((RemoteFileNotFoundException) e, context);
+        } else if (e instanceof RpcException) {
+            handleRpcException((RpcException) e, context);
+        } else if (e instanceof UserException) {
+            handleUserException((UserException) e, context);
+        } else {
+            throw e;
+        }
+    }
+
+    private static void handleRemoteFileNotFound(RemoteFileNotFoundException e, RetryContext context) {
+        List<ScanNode> scanNodes = context.execPlan.getScanNodes();
+        boolean existExternalCatalog = false;
+        for (ScanNode scanNode : scanNodes) {
+            if (scanNode instanceof HdfsScanNode) {
+                HiveTable hiveTable = ((HdfsScanNode) scanNode).getHiveTable();
+                String catalogName = hiveTable.getCatalogName();
+                if (CatalogMgr.isExternalCatalog(catalogName)) {
+                    existExternalCatalog = true;
+                    ConnectorMetadata metadata = GlobalStateMgr.getCurrentState().getMetadataMgr()
+                            .getOptionalMetadata(hiveTable.getCatalogName()).get();
+                    // refresh catalog level metadata cache
+                    metadata.refreshTable(hiveTable.getDbName(), hiveTable, new ArrayList<>(), true);
+                    // clear query level metadata cache
+                    metadata.clear();
+                }
+            }
+        }
+        if (!existExternalCatalog) {
+            throw e;
+        }
+        Tracers.record(Tracers.Module.EXTERNAL, "HMS.RETRY", String.valueOf(context.retryTime + 1));
+    }
+
+    private static void handleRpcException(RpcException e, RetryContext context) {
+        // When enable_collect_query_detail_info is set to true, the plan will be recorded in the query detail,
+        // and hence there is no need to log it here.
+        ConnectContext connectContext = context.connectContext;
+        if (context.retryTime == 0 && connectContext.getQueryDetail() == null &&
+                Config.log_plan_cancelled_by_crash_be) {
+            LOG.warn(
+                    "Query cancelled by crash of backends or RpcException, [QueryId={}] [SQL={}] [Plan={}]",
+                    DebugUtil.printId(connectContext.getExecutionId()),
+                    context.parsedStmt.getOrigStmt() == null ? "" : context.parsedStmt.getOrigStmt().originStmt,
+                    context.execPlan == null ? "" : context.execPlan.getExplainString(TExplainLevel.COSTS),
+                    e);
+        }
+    }
+
+    private static void handleUserException(UserException e, RetryContext context) throws Exception {
+        String msg = e.getMessage();
+        if (context.parsedStmt instanceof QueryStatement) {
+            for (String errMsg : SCHEMA_NOT_MATCH_ERROR) {
+                if (msg.contains(errMsg)) {
+                    try {
+                        ExecPlan execPlan = StatementPlanner.plan(context.parsedStmt, context.connectContext);
+                        context.execPlan = execPlan;
+                    } catch (Exception e1) {
+                        // encounter exception when re-plan, just log the new error but throw the original cause.
+                        if (LOG.isDebugEnabled()) {
+                            ConnectContext connectContext = context.connectContext;
+                            LOG.debug("encounter exception when retry, [QueryId={}] [SQL={}], ",
+                                    DebugUtil.printId(connectContext.getExecutionId()),
+                                    context.parsedStmt.getOrigStmt() == null ? "" :
+                                            context.parsedStmt.getOrigStmt().originStmt,
+                                    e1);
+                        }
+                        throw e;
+                    }
+                }
+            }
+        } else {
+            throw e;
+        }
+    }
+
+    public static class RetryContext {
+        private int retryTime;
+
+        private ExecPlan execPlan;
+
+        private ConnectContext connectContext;
+
+        private StatementBase parsedStmt;
+
+        public RetryContext(int retryTime, ExecPlan execPlan, ConnectContext connectContext,
+                            StatementBase parsedStmt) {
+            this.retryTime = retryTime;
+            this.execPlan = execPlan;
+            this.connectContext = connectContext;
+            this.parsedStmt = parsedStmt;
+        }
+
+        public ExecPlan getExecPlan() {
+            return execPlan;
+        }
+
+        public void setRetryTime(int retryTime) {
+            this.retryTime = retryTime;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ExecuteExceptionHandler.java
@@ -104,6 +104,7 @@ public class ExecuteExceptionHandler {
                     try {
                         ExecPlan execPlan = StatementPlanner.plan(context.parsedStmt, context.connectContext);
                         context.execPlan = execPlan;
+                        return;
                     } catch (Exception e1) {
                         // encounter exception when re-plan, just log the new error but throw the original cause.
                         if (LOG.isDebugEnabled()) {
@@ -118,9 +119,9 @@ public class ExecuteExceptionHandler {
                     }
                 }
             }
-        } else {
-            throw e;
         }
+
+        throw e;
     }
 
     public static class RetryContext {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -156,14 +156,6 @@ public class StatementPlanner {
             plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType);
         }
         setOutfileSink(queryStmt, plan);
-        int sleep = session.getSessionVariable().getBigQueryProfileSecondThreshold();
-        if (sleep > 0) {
-            try {
-                Thread.sleep(sleep * 1000L);
-            } catch (Exception e) {
-                System.out.println("end");
-            }
-        }
         return plan;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -156,6 +156,14 @@ public class StatementPlanner {
             plan = createQueryPlanWithReTry(queryStmt, session, resultSinkType);
         }
         setOutfileSink(queryStmt, plan);
+        int sleep = session.getSessionVariable().getBigQueryProfileSecondThreshold();
+        if (sleep > 0) {
+            try {
+                Thread.sleep(sleep * 1000L);
+            } catch (Exception e) {
+                System.out.println("end");
+            }
+        }
         return plan;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ExecuteExceptionHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ExecuteExceptionHandlerTest.java
@@ -1,0 +1,98 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.qe;
+
+import com.starrocks.common.UserException;
+import com.starrocks.connector.exception.RemoteFileNotFoundException;
+import com.starrocks.rpc.RpcException;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.sql.plan.ConnectorPlanTestBase;
+import com.starrocks.sql.plan.ExecPlan;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class ExecuteExceptionHandlerTest extends PlanTestBase {
+
+    @Test
+    public void testHandleRemoteFileNotFoundException_1() throws Exception {
+        String sql = "select * from t0";
+        StatementBase statementBase = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        ExecPlan execPlan = getExecPlan(sql);
+        ExecuteExceptionHandler.RetryContext retryContext =
+                new ExecuteExceptionHandler.RetryContext(0, execPlan, connectContext, statementBase);
+        Assert.assertThrows(RemoteFileNotFoundException.class,
+                () -> ExecuteExceptionHandler.handle(new RemoteFileNotFoundException("mock"), retryContext));
+    }
+
+
+    @Test
+    public void testHandleRemoteFileNotFoundException_2() throws Exception {
+        ConnectorPlanTestBase.mockHiveCatalog(connectContext);
+        String sql = "select * from hive0.tpch.customer_view";
+        StatementBase statementBase = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        ExecPlan execPlan = getExecPlan(sql);
+        ExecuteExceptionHandler.RetryContext retryContext =
+                new ExecuteExceptionHandler.RetryContext(0, execPlan, connectContext, statementBase);
+        try {
+            ExecuteExceptionHandler.handle(new RemoteFileNotFoundException("mock"), retryContext);
+        } catch (Exception e) {
+            fail("should not throw any exception");
+        }
+    }
+
+    @Test
+    public void testHandleRpcException() throws Exception {
+        String sql = "select * from t0";
+        StatementBase statementBase = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        ExecPlan execPlan = getExecPlan(sql);
+        ExecuteExceptionHandler.RetryContext retryContext =
+                new ExecuteExceptionHandler.RetryContext(0, execPlan, connectContext, statementBase);
+        try {
+            ExecuteExceptionHandler.handle(new RpcException("mock"), retryContext);
+        } catch (Exception e) {
+            fail("should not throw any exception");
+        }
+    }
+
+    @Test
+    public void testHandleUseException_1() throws Exception {
+        String sql = "select * from t0";
+        StatementBase statementBase = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        ExecPlan execPlan = getExecPlan(sql);
+        ExecuteExceptionHandler.RetryContext retryContext =
+                new ExecuteExceptionHandler.RetryContext(0, execPlan, connectContext, statementBase);
+        try {
+            ExecuteExceptionHandler.handle(new UserException("invalid field name"), retryContext);
+            Assert.assertTrue(retryContext.getExecPlan() != execPlan);
+        } catch (Exception e) {
+            fail("should not throw any exception");
+        }
+    }
+
+    @Test
+    public void testHandleUseException_2() throws Exception {
+        String sql = "select * from t0";
+        StatementBase statementBase = SqlParser.parse(sql, connectContext.getSessionVariable()).get(0);
+        ExecPlan execPlan = getExecPlan(sql);
+        ExecuteExceptionHandler.RetryContext retryContext =
+                new ExecuteExceptionHandler.RetryContext(0, execPlan, connectContext, statementBase);
+        Assert.assertThrows(UserException.class,
+                () -> ExecuteExceptionHandler.handle(new UserException("other exception"), retryContext));
+    }
+}


### PR DESCRIPTION
Why I'm doing:
Fast schema evolution will modify indexIdToMeta in place which may cause diff between plan and table schema.

What I'm doing:
shallow copy indexIdToMeta when copy olapTable
add a retry strategy to re-plan sql when encounters`invalid field name` error.

### Performance benchmark
In ubuntu dev, jmeter test tool,  50 concurrency,  execute `explain select * from test1`
Before, 54153.7 qps
After, 57877 qps.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
