### PR TITLE
[BugFix][Branch-3.0] Fix insert overwrite list partition metadata is incorrect(backport #0)

### DIFF
--- a/test/sql/test_automatic_partition/R/test_insert_overwrite
+++ b/test/sql/test_automatic_partition/R/test_insert_overwrite
@@ -137,3 +137,39 @@ select * from t_recharge_detail;
 -- result:
 3	2	2.00	beijing	2022-04-02
 -- !result
+-- name: test_insert_overwrite_list_duplicate
+CREATE TABLE t_recharge_detail2 (
+            id bigint,
+            city varchar(20) not null,
+            dt varchar(20) not null ) DUPLICATE KEY(id)
+            PARTITION BY (dt,city) DISTRIBUTED BY HASH(id)
+            PROPERTIES("replication_num"="1");
+-- result:
+-- !result
+insert into t_recharge_detail2 values (1, "Menlo Park", "2023-11-01");
+-- result:
+-- !result
+insert into t_recharge_detail2 values (2, "Menlo Park", "2023-11-02");
+-- result:
+-- !result
+select * from t_recharge_detail2;
+-- result:
+1	Menlo Park	2023-11-01
+2	Menlo Park	2023-11-02
+-- !result
+insert overwrite t_recharge_detail2 partition(p20231102_MenloPark) values (3, "Menlo Park", "2023-11-02");
+-- result:
+-- !result
+select * from t_recharge_detail2;
+-- result:
+1	Menlo Park	2023-11-01
+3	Menlo Park	2023-11-02
+-- !result
+insert overwrite t_recharge_detail2 partition(p20231102_MenloPark) values (5, "Menlo Park", "2023-11-02");
+-- result:
+-- !result
+select * from t_recharge_detail2;
+-- result:
+1	Menlo Park	2023-11-01
+5	Menlo Park	2023-11-02
+-- !result

--- a/test/sql/test_automatic_partition/T/test_insert_overwrite
+++ b/test/sql/test_automatic_partition/T/test_insert_overwrite
@@ -80,3 +80,17 @@ select * from t_recharge_detail;
 insert overwrite t_recharge_detail PARTITION(dt='2022-04-02', province='beijing')
 select 3 as id, 2 as user_id, 2 as recharge_money, 'beijing' as province, '2022-04-02' as dt from dual;
 select * from t_recharge_detail;
+-- name: test_insert_overwrite_list_duplicate
+CREATE TABLE t_recharge_detail2 (
+            id bigint,
+            city varchar(20) not null,
+            dt varchar(20) not null ) DUPLICATE KEY(id)
+            PARTITION BY (dt,city) DISTRIBUTED BY HASH(id)
+            PROPERTIES("replication_num"="1");
+insert into t_recharge_detail2 values (1, "Menlo Park", "2023-11-01");
+insert into t_recharge_detail2 values (2, "Menlo Park", "2023-11-02");
+select * from t_recharge_detail2;
+insert overwrite t_recharge_detail2 partition(p20231102_MenloPark) values (3, "Menlo Park", "2023-11-02");
+select * from t_recharge_detail2;
+insert overwrite t_recharge_detail2 partition(p20231102_MenloPark) values (5, "Menlo Park", "2023-11-02");
+select * from t_recharge_detail2;


### PR DESCRIPTION
Why I'm doing:
List partition failed to insert overwrite twice consecutively

What I'm doing:
In version 3.0, this area is not handled properly, so it needs to be fixed.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

