### PR TITLE
[Enhancement] persist refresh mv error msg

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -354,16 +354,12 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             }
         }
         if (lastException != null) {
-            String errorMsg;
+            String errorMsg = lastException.getMessage();
             if (lastException instanceof NullPointerException) {
                 errorMsg = ExceptionUtils.getStackTrace(lastException);
-            } else {
-                errorMsg = lastException.getMessage();
             }
             // field ERROR_MESSAGE in information_schema.task_runs length is 65535
-            if (errorMsg.length() > MAX_FIELD_VARCHAR_LENGTH) {
-                errorMsg = errorMsg.substring(0, MAX_FIELD_VARCHAR_LENGTH);
-            }
+            errorMsg = errorMsg.length() > MAX_FIELD_VARCHAR_LENGTH ? errorMsg.substring(0, MAX_FIELD_VARCHAR_LENGTH) : errorMsg;
             throw new DmlException("Refresh materialized view %s failed after retrying %s times, error-msg : %s",
                     lastException, this.materializedView.getName(), maxRefreshMaterializedViewRetryNum, errorMsg);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -129,6 +129,8 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import static com.starrocks.catalog.system.SystemTable.MAX_FIELD_VARCHAR_LENGTH;
+
 /**
  * Core logic of materialized view refresh task run
  * PartitionBasedMvRefreshProcessor is not thread safe for concurrent runs of the same materialized view
@@ -359,7 +361,9 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                 errorMsg = lastException.getMessage();
             }
             // field ERROR_MESSAGE in information_schema.task_runs length is 65535
-            errorMsg = errorMsg.substring(0, 65535);
+            if (errorMsg.length() > MAX_FIELD_VARCHAR_LENGTH) {
+                errorMsg = errorMsg.substring(0, MAX_FIELD_VARCHAR_LENGTH);
+            }
             throw new DmlException("Refresh materialized view %s failed after retrying %s times, error-msg : %s",
                     lastException, this.materializedView.getName(), maxRefreshMaterializedViewRetryNum, errorMsg);
         }


### PR DESCRIPTION
Why I'm doing:

We always expect to get the reason for mv refresh failure from the `information_schema.task_runs` table, but now we can only see how many times it failed.

Currently, mv refresh error msg is 
```log
com.starrocks.sql.common.DmlException: Refresh materialized view view_name failed after retrying 1 times	
```

we expect to get detail error just like this
```log
com.starrocks.sql.common.DmlException: Refresh materialized view view_name failed after retrying 1 times, error-msg : xxx	
```

What I'm doing:

I put the abnormal message in formatString

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
