### PR TITLE
[Feature] from_unixtime partition supports partition pruning part 3

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
@@ -157,10 +157,8 @@ public class ExpressionRangePartitionInfoV2 extends RangePartitionInfo
         }
         List<String> partitionExprDesc = Lists.newArrayList();
         for (Expr partitionExpr : partitionExprs) {
-            if (partitionExpr instanceof CastExpr) {
-                if (isTimestampFunction(partitionExpr)) {
-                    partitionExprDesc.add(partitionExpr.getChild(0).toSql());
-                }
+            if (partitionExpr instanceof CastExpr && isTimestampFunction(partitionExpr)) {
+                partitionExprDesc.add(partitionExpr.getChild(0).toSql());
             } else {
                 partitionExprDesc.add(partitionExpr.toSql());
             }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -108,7 +108,7 @@ public class ColumnFilterConverter {
                     FunctionSet.SUBSTR.equalsIgnoreCase(functionName)) {
                 Expr firstExpr = node.getChild(0);
                 if (firstExpr instanceof SlotRef) {
-                    SlotRef slotRef = (SlotRef) node.getChild(0);
+                    SlotRef slotRef = (SlotRef) firstExpr;
                     if (columnRef.getName().equals(slotRef.getColumnName())) {
                         node.setChild(0, new StringLiteral(constant.getVarchar()));
                         return true;
@@ -118,7 +118,7 @@ public class ColumnFilterConverter {
                     FunctionSet.FROM_UNIXTIME_MS.equalsIgnoreCase(functionName)) {
                 Expr firstExpr = node.getChild(0);
                 if (firstExpr instanceof SlotRef) {
-                    SlotRef slotRef = (SlotRef) node.getChild(0);
+                    SlotRef slotRef = (SlotRef) firstExpr;
                     if (columnRef.getName().equals(slotRef.getColumnName())) {
                         node.setChild(0, new IntLiteral(constant.getBigint()));
                         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -103,13 +103,24 @@ public class ColumnFilterConverter {
 
         @Override
         public Boolean visitFunctionCall(FunctionCallExpr node, Void context) {
-            if (FunctionSet.SUBSTRING.equalsIgnoreCase(node.getFnName().getFunction()) ||
-                    FunctionSet.SUBSTR.equalsIgnoreCase(node.getFnName().getFunction())) {
+            String functionName = node.getFnName().getFunction();
+            if (FunctionSet.SUBSTRING.equalsIgnoreCase(functionName) ||
+                    FunctionSet.SUBSTR.equalsIgnoreCase(functionName)) {
                 Expr firstExpr = node.getChild(0);
                 if (firstExpr instanceof SlotRef) {
                     SlotRef slotRef = (SlotRef) node.getChild(0);
                     if (columnRef.getName().equals(slotRef.getColumnName())) {
                         node.setChild(0, new StringLiteral(constant.getVarchar()));
+                        return true;
+                    }
+                }
+            } else if (FunctionSet.FROM_UNIXTIME.equalsIgnoreCase(functionName) ||
+                    FunctionSet.FROM_UNIXTIME_MS.equalsIgnoreCase(functionName)) {
+                Expr firstExpr = node.getChild(0);
+                if (firstExpr instanceof SlotRef) {
+                    SlotRef slotRef = (SlotRef) node.getChild(0);
+                    if (columnRef.getName().equals(slotRef.getColumnName())) {
+                        node.setChild(0, new IntLiteral(constant.getBigint()));
                         return true;
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -474,7 +474,7 @@ public class ScalarOperatorFunctions {
     public static ConstantOperator fromUnixTimeMs(ConstantOperator unixTime) throws AnalysisException {
         long millisecond = unixTime.getBigint();
 
-        if (millisecond < 0 || millisecond > TimeUtils.MAX_UNIX_TIMESTAMP*1000) {
+        if (millisecond < 0 || millisecond > TimeUtils.MAX_UNIX_TIMESTAMP * 1000) {
             throw new AnalysisException(
                     "unixtime should larger than zero and less than " + TimeUtils.MAX_UNIX_TIMESTAMP);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -472,14 +472,15 @@ public class ScalarOperatorFunctions {
             @ConstantFunction(name = "from_unixtime_ms", argTypes = {BIGINT}, returnType = VARCHAR)
     })
     public static ConstantOperator fromUnixTimeMs(ConstantOperator unixTime) throws AnalysisException {
-        long value = unixTime.getBigint() / 1000;
+        long millisecond = unixTime.getBigint();
 
-        if (value < 0 || value > TimeUtils.MAX_UNIX_TIMESTAMP) {
+        if (millisecond < 0 || millisecond > TimeUtils.MAX_UNIX_TIMESTAMP*1000) {
             throw new AnalysisException(
                     "unixtime should larger than zero and less than " + TimeUtils.MAX_UNIX_TIMESTAMP);
         }
+        long second = millisecond / 1000;
         ConstantOperator dl = ConstantOperator.createDatetime(
-                LocalDateTime.ofInstant(Instant.ofEpochSecond(value), TimeUtils.getTimeZone().toZoneId()));
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(second), TimeUtils.getTimeZone().toZoneId()));
         return ConstantOperator.createVarchar(dl.toString());
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -469,6 +469,21 @@ public class ScalarOperatorFunctions {
     }
 
     @ConstantFunction.List(list = {
+            @ConstantFunction(name = "from_unixtime_ms", argTypes = {BIGINT}, returnType = VARCHAR)
+    })
+    public static ConstantOperator fromUnixTimeMs(ConstantOperator unixTime) throws AnalysisException {
+        long value = unixTime.getBigint() / 1000;
+
+        if (value < 0 || value > TimeUtils.MAX_UNIX_TIMESTAMP) {
+            throw new AnalysisException(
+                    "unixtime should larger than zero and less than " + TimeUtils.MAX_UNIX_TIMESTAMP);
+        }
+        ConstantOperator dl = ConstantOperator.createDatetime(
+                LocalDateTime.ofInstant(Instant.ofEpochSecond(value), TimeUtils.getTimeZone().toZoneId()));
+        return ConstantOperator.createVarchar(dl.toString());
+    }
+
+    @ConstantFunction.List(list = {
             @ConstantFunction(name = "from_unixtime", argTypes = {INT, VARCHAR}, returnType = VARCHAR),
             @ConstantFunction(name = "from_unixtime", argTypes = {BIGINT, VARCHAR}, returnType = VARCHAR)
     })

--- a/test/sql/test_partition_by_expr/R/test_expr_from_unixtime_prune_partition
+++ b/test/sql/test_partition_by_expr/R/test_expr_from_unixtime_prune_partition
@@ -1,0 +1,79 @@
+-- name: test_expr_from_unixtime_prune_partition
+CREATE TABLE partition_unixtime (
+        create_time bigint,
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(from_unixtime(create_time))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+-- result:
+-- !result
+insert into partition_unixtime values(unix_timestamp('2021-01-04'),'1',1.1,1);
+-- result:
+-- !result
+insert into partition_unixtime values(unix_timestamp('2021-01-05'),'1',1.1,1);
+-- result:
+-- !result
+insert into partition_unixtime values(unix_timestamp('2021-01-06'),'1',1.1,1);
+-- result:
+-- !result
+select * from partition_unixtime;
+-- result:
+1609689600	1	1	1
+1609776000	1	1	1
+1609862400	1	1	1
+-- !result
+select * from partition_unixtime where create_time=1609776000;
+-- result:
+1609776000	1	1	1
+-- !result
+explain select * from partition_unixtime where create_time=1609776000;
+select * from partition_unixtime where 1609776000=create_time;
+-- result:
+1609776000	1	1	1
+-- !result
+select * from partition_unixtime where create_time>1609776000;
+-- result:
+1609862400	1	1	1
+-- !result
+CREATE TABLE partition_unixtime_ms (
+        create_time bigint,
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(from_unixtime_ms(create_time))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+-- result:
+-- !result
+insert into partition_unixtime_ms values(unix_timestamp('2021-01-04')*1000,'1',1.1,1);
+-- result:
+-- !result
+insert into partition_unixtime_ms values(unix_timestamp('2021-01-05')*1000,'1',1.1,1);
+-- result:
+-- !result
+insert into partition_unixtime_ms values(unix_timestamp('2021-01-06')*1000,'1',1.1,1);
+-- result:
+-- !result
+select * from partition_unixtime_ms;
+-- result:
+1609862400000	1	1	1
+1609689600000	1	1	1
+1609776000000	1	1	1
+-- !result
+select * from partition_unixtime_ms where create_time=1609776000000;
+-- result:
+1609776000000	1	1	1
+-- !result
+explain select * from partition_unixtime_ms where create_time=1609776000000;
+select * from partition_unixtime_ms where 1609776000000=create_time;
+-- result:
+1609776000000	1	1	1
+-- !result
+select * from partition_unixtime_ms where create_time>1609776000000;
+-- result:
+1609862400000	1	1	1
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_expr_from_unixtime_prune_partition
+++ b/test/sql/test_partition_by_expr/T/test_expr_from_unixtime_prune_partition
@@ -1,0 +1,36 @@
+-- name: test_expr_from_unixtime_prune_partition
+CREATE TABLE partition_unixtime (
+        create_time bigint,
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(from_unixtime(create_time))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+insert into partition_unixtime values(unix_timestamp('2021-01-04'),'1',1.1,1);
+insert into partition_unixtime values(unix_timestamp('2021-01-05'),'1',1.1,1);
+insert into partition_unixtime values(unix_timestamp('2021-01-06'),'1',1.1,1);
+select * from partition_unixtime;
+select * from partition_unixtime where create_time=1609776000;
+explain select * from partition_unixtime where create_time=1609776000;
+select * from partition_unixtime where 1609776000=create_time;
+select * from partition_unixtime where create_time>1609776000;
+
+CREATE TABLE partition_unixtime_ms (
+        create_time bigint,
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(from_unixtime_ms(create_time))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+insert into partition_unixtime_ms values(unix_timestamp('2021-01-04')*1000,'1',1.1,1);
+insert into partition_unixtime_ms values(unix_timestamp('2021-01-05')*1000,'1',1.1,1);
+insert into partition_unixtime_ms values(unix_timestamp('2021-01-06')*1000,'1',1.1,1);
+select * from partition_unixtime_ms;
+select * from partition_unixtime_ms where create_time=1609776000000;
+explain select * from partition_unixtime_ms where create_time=1609776000000;
+select * from partition_unixtime_ms where 1609776000000=create_time;
+select * from partition_unixtime_ms where create_time>1609776000000;


### PR DESCRIPTION
Why I'm doing:
or the from_unix partition, we should handle partition clipping specially, otherwise an error will be reported during query.

What I'm doing:
Add a predicate conversion. When querying the predicate, convert the predicate to the function above the partition to obtain correct tailoring.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
