### PR TITLE
[BugFix] Fix memory leak in AlignedBuffer

### DIFF
--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -108,7 +108,7 @@ Status ColumnarSerde::serialize_to_block(SerdeContext& ctx, const ChunkPtr& chun
             }
         }
         size_t content_length = buf - head;
-        auto align_size = ALIGN_UP(content_length + meta_len, 4096);
+        auto align_size = ALIGN_UP(content_length + meta_len, PAGE_SIZE);
         serialize_buffer.resize(align_size);
         // only 8 bytes for serialized size if encoding is disable
         UNALIGNED_STORE64(serialize_buffer.data(), align_size - meta_len);
@@ -138,7 +138,7 @@ Status ColumnarSerde::serialize_to_block(SerdeContext& ctx, const ChunkPtr& chun
         }
         _update_encode_stats(column_stats);
         size_t content_length = buf - head;
-        auto align_size = ALIGN_UP(content_length + meta_len + padding_size, 4096);
+        auto align_size = ALIGN_UP(content_length + meta_len + padding_size, PAGE_SIZE);
         serialize_buffer.resize(align_size);
 
         // fill encoded size

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -552,6 +552,23 @@ TEST_F(SpillTest, partition_process) {
     }
 }
 
+TEST_F(SpillTest, aligned_buffer) {
+    spill::AlignedBuffer buffer;
+    ASSERT_EQ(buffer.data(), nullptr);
+    auto is_aligned = [](void* ptr, std::size_t alignment) {
+        return reinterpret_cast<uintptr_t>(ptr) % alignment == 0;
+    };
+    buffer.resize(1);
+    buffer.data()[0] = '@';
+    ASSERT_TRUE(is_aligned(buffer.data(), 4096));
+    buffer.resize(8192);
+    ASSERT_EQ(buffer.data()[0], '@');
+    ASSERT_TRUE(is_aligned(buffer.data(), 4096));
+    buffer.resize(1);
+    ASSERT_EQ(buffer.data()[0], '@');
+    ASSERT_TRUE(is_aligned(buffer.data(), 4096));
+}
+
 /*
 TEST_F(SpillTest, file_group_test) {
     auto chunk = std::make_unique<Chunk>();


### PR DESCRIPTION
Why I'm doing:
introduced by https://github.com/StarRocks/starrocks/pull/37050

AlignedBuffer will be reused multiple times. You need to free the old buffer when you call resize, otherwise it will lead to memory leaks.


Fixes https://github.com/StarRocks/StarRocksTest/issues/5384

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
