### PR TITLE
[Enhancement] Show Full Tables statement supports table comment field

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShowExecutor.java
@@ -463,6 +463,7 @@ public class ShowExecutor {
 
             Map<String, String> tableMap = Maps.newTreeMap();
             MetaUtils.checkDbNullAndReport(db, statement.getDb());
+            Map<String, String> commentMap = Maps.newHashMap();
 
             Locker locker = new Locker();
             locker.lockDatabase(db, LockType.READ);
@@ -497,6 +498,7 @@ public class ShowExecutor {
                     }
 
                     tableMap.put(tableName, table.getMysqlType());
+                    commentMap.put(tableName, table.getComment());
                 }
             } finally {
                 locker.unLockDatabase(db, LockType.READ);
@@ -504,7 +506,8 @@ public class ShowExecutor {
 
             for (Map.Entry<String, String> entry : tableMap.entrySet()) {
                 if (statement.isVerbose()) {
-                    rows.add(Lists.newArrayList(entry.getKey(), entry.getValue()));
+                    rows.add(Lists.newArrayList(entry.getKey(), entry.getValue(),
+                            commentMap.getOrDefault(entry.getKey(), "")));
                 } else {
                     rows.add(Lists.newArrayList(entry.getKey()));
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ShowTableStmt.java
@@ -33,6 +33,7 @@ import com.starrocks.sql.parser.NodePosition;
 public class ShowTableStmt extends ShowStmt {
     private static final String NAME_COL_PREFIX = "Tables_in_";
     private static final String TYPE_COL = "Table_type";
+    private static final String COMMENT_COL = "Table_comment";
     private static final TableName TABLE_NAME = new TableName(InfoSchemaDb.DATABASE_NAME, "tables");
     private String db;
     private final boolean isVerbose;
@@ -95,6 +96,10 @@ public class ShowTableStmt extends ShowStmt {
             item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_TYPE"), TYPE_COL);
             selectList.addItem(item);
             aliasMap.put(new SlotRef(null, TYPE_COL), item.getExpr().clone(null));
+
+            item = new SelectListItem(new SlotRef(TABLE_NAME, "TABLE_COMMENT"), COMMENT_COL);
+            selectList.addItem(item);
+            aliasMap.put(new SlotRef(null, "Comment"), item.getExpr().clone(null));
         }
         where = where.substitute(aliasMap);
         // where databases_name = currentdb
@@ -118,6 +123,7 @@ public class ShowTableStmt extends ShowStmt {
                 new Column(NAME_COL_PREFIX + db, ScalarType.createVarchar(20)));
         if (isVerbose) {
             builder.addColumn(new Column(TYPE_COL, ScalarType.createVarchar(20)));
+            builder.addColumn(new Column(COMMENT_COL, ScalarType.createVarchar(20)));
         }
         return builder.build();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/ShowTableStmtTest.java
@@ -77,16 +77,18 @@ public class ShowTableStmtTest {
 
         stmt = new ShowTableStmt("abc", true, null);
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
-        Assert.assertEquals(2, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(3, stmt.getMetaData().getColumnCount());
         Assert.assertEquals("Tables_in_abc", stmt.getMetaData().getColumn(0).getName());
         Assert.assertEquals("Table_type", stmt.getMetaData().getColumn(1).getName());
+        Assert.assertEquals("Table_comment", stmt.getMetaData().getColumn(2).getName());
 
         stmt = new ShowTableStmt("abc", true, "bcd");
         com.starrocks.sql.analyzer.Analyzer.analyze(stmt, ctx);
         Assert.assertEquals("bcd", stmt.getPattern());
-        Assert.assertEquals(2, stmt.getMetaData().getColumnCount());
+        Assert.assertEquals(3, stmt.getMetaData().getColumnCount());
         Assert.assertEquals("Tables_in_abc", stmt.getMetaData().getColumn(0).getName());
         Assert.assertEquals("Table_type", stmt.getMetaData().getColumn(1).getName());
+        Assert.assertEquals("Table_comment", stmt.getMetaData().getColumn(2).getName());
         Assert.assertEquals("bcd", stmt.getPattern());
 
         String sql = "show full tables where table_type !='VIEW'";
@@ -95,8 +97,9 @@ public class ShowTableStmtTest {
 
         QueryStatement queryStatement = stmt.toSelectStmt();
         String expect = "SELECT information_schema.tables.TABLE_NAME AS Tables_in_testDb, " +
-                "information_schema.tables.TABLE_TYPE AS Table_type FROM " +
-                "information_schema.tables WHERE (information_schema.tables.TABLE_SCHEMA = 'testDb') AND (information_schema.tables.TABLE_TYPE != 'VIEW')";
+                "information_schema.tables.TABLE_TYPE AS Table_type, " +
+                "information_schema.tables.TABLE_COMMENT AS Table_comment " +
+                "FROM information_schema.tables WHERE (information_schema.tables.TABLE_SCHEMA = 'testDb') AND (information_schema.tables.TABLE_TYPE != 'VIEW')";
         Assert.assertEquals(expect, AstToStringBuilder.toString(queryStatement));
     }
 


### PR DESCRIPTION
Why I'm doing:
Users could not see table comments in a db, however comment is very useful.

What I'm doing:
Print table comments for `show full tables` statement

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
