### PR TITLE
[Feature] Support str2date for partition by expr part 4

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
@@ -232,7 +232,7 @@ public class ExpressionRangePartitionInfoV2 extends RangePartitionInfo
         if (expr instanceof FunctionCallExpr) {
             FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
             String functionName = functionCallExpr.getFnName().getFunction();
-            return FunctionSet.STR_TO_DATE.equals(functionName);
+            return FunctionSet.STR2DATE.equals(functionName);
         }
         return false;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfoV2.java
@@ -225,6 +225,18 @@ public class ExpressionRangePartitionInfoV2 extends RangePartitionInfo
         return false;
     }
 
+    public static boolean supportedDynamicPartition(Expr expr) {
+        if (isTimestampFunction(expr)) {
+            return true;
+        }
+        if (expr instanceof FunctionCallExpr) {
+            FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
+            String functionName = functionCallExpr.getFnName().getFunction();
+            return FunctionSet.STR_TO_DATE.equals(functionName);
+        }
+        return false;
+    }
+
     public List<Expr> getPartitionExprs() {
         return partitionExprs;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -460,7 +460,7 @@ public class DynamicPartitionUtil {
         }
 
         if (!Strings.isNullOrEmpty(properties.get(DynamicPartitionProperty.ENABLE))
-                && ExpressionRangePartitionInfoV2.supportedDynamicPartition(expr)) {
+                && !ExpressionRangePartitionInfoV2.supportedDynamicPartition(expr)) {
             throw new DdlException("Expression partitioning does not support properties of dynamic partitioning");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DynamicPartitionUtil.java
@@ -460,7 +460,7 @@ public class DynamicPartitionUtil {
         }
 
         if (!Strings.isNullOrEmpty(properties.get(DynamicPartitionProperty.ENABLE))
-                && !ExpressionRangePartitionInfoV2.isTimestampFunction(expr)) {
+                && ExpressionRangePartitionInfoV2.supportedDynamicPartition(expr)) {
             throw new DdlException("Expression partitioning does not support properties of dynamic partitioning");
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/PartitionExprAnalyzer.java
@@ -88,9 +88,14 @@ public class PartitionExprAnalyzer {
                     targetColType = Type.VARCHAR;
                 }
             } else if (functionName.equalsIgnoreCase(FunctionSet.STR2DATE)) {
-                Type[] str2DateType = {Type.VARCHAR, Type.VARCHAR};
+                Type[] str2DateType = {partitionSlotRef.getType(), Type.VARCHAR};
                 builtinFunction = Expr.getBuiltinFunction(functionCallExpr.getFnName().getFunction(),
                         str2DateType, Function.CompareMode.IS_IDENTICAL);
+                if (builtinFunction == null) {
+                    String msg = String.format("Unsupported partition expression %s for column %s type %s",
+                            functionName.toLowerCase(), partitionSlotRef.getColumnName(), partitionSlotRef.getType());
+                    throw new SemanticException(msg, expr.getPos());
+                }
                 targetColType = Type.DATE;
             } else if (functionName.equalsIgnoreCase(FunctionSet.FROM_UNIXTIME) || functionName.equalsIgnoreCase(
                     FunctionSet.FROM_UNIXTIME_MS)) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExpressionPartitionDesc.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/ExpressionPartitionDesc.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.ExpressionRangePartitionInfo;
 import com.starrocks.catalog.ExpressionRangePartitionInfoV2;
+import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.RangePartitionInfo;
@@ -104,6 +105,10 @@ public class ExpressionPartitionDesc extends PartitionDesc {
                     partitionType = ((CastExpr) expr).getTargetTypeDef().getType();
                 } else if (expr instanceof FunctionCallExpr) {
                     slotRef = AnalyzerUtils.getSlotRefFromFunctionCall(expr);
+                    String functionName = ((FunctionCallExpr) expr).getFnName().getFunction().toLowerCase();
+                    if (functionName.equals(FunctionSet.STR2DATE)) {
+                        partitionType = Type.DATE;
+                    }
                 } else {
                     throw new AnalysisException("Unsupported expr:" + expr.toSql());
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -483,6 +483,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                     FunctionSet.SUBDATE,
                     FunctionSet.DAYS_SUB);
 
+    private static final List<String> PARTITION_FUNCTIONS =
+            Lists.newArrayList(FunctionSet.SUBSTR, FunctionSet.SUBSTRING,
+                    FunctionSet.FROM_UNIXTIME, FunctionSet.FROM_UNIXTIME_MS,
+                    FunctionSet.STR2DATE);
+
     public AstBuilder(long sqlMode) {
         this(sqlMode, new IdentityHashMap<>());
     }
@@ -781,23 +786,9 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
         List<String> columnList = new ArrayList<>();
         if (expr instanceof FunctionCallExpr) {
             FunctionCallExpr functionCallExpr = (FunctionCallExpr) expr;
-            String functionName = functionCallExpr.getFnName().getFunction();
-            if (FunctionSet.SUBSTR.equals(functionName) || FunctionSet.SUBSTRING.equals(functionName)) {
-                List<Expr> paramsExpr = functionCallExpr.getParams().exprs();
-                Expr firstExpr = paramsExpr.get(0);
-                if (firstExpr instanceof SlotRef) {
-                    columnList.add(((SlotRef) firstExpr).getColumnName());
-                } else {
-                    throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"),
-                            pos);
-                }
-            } else if (FunctionSet.FROM_UNIXTIME.equals(functionName)
-                    || FunctionSet.FROM_UNIXTIME_MS.equals(functionName)) {
-                List<Expr> paramsExpr = functionCallExpr.getParams().exprs();
-                if (hasCast || paramsExpr.size() > 1) {
-                    throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"),
-                            pos);
-                }
+            String functionName = functionCallExpr.getFnName().getFunction().toLowerCase();
+            List<Expr> paramsExpr = functionCallExpr.getParams().exprs();
+            if (PARTITION_FUNCTIONS.contains(functionName)) {
                 Expr firstExpr = paramsExpr.get(0);
                 if (firstExpr instanceof SlotRef) {
                     columnList.add(((SlotRef) firstExpr).getColumnName());
@@ -807,6 +798,11 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 }
             } else {
                 throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"), pos);
+            }
+            if (functionName.equals(FunctionSet.FROM_UNIXTIME) || functionName.equals(FunctionSet.FROM_UNIXTIME_MS)) {
+                if (hasCast || paramsExpr.size() > 1) {
+                    throw new ParsingException(PARSER_ERROR_MSG.unsupportedExprWithInfo(expr.toSql(), "PARTITION BY"), pos);
+                }
             }
         }
         return columnList;

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CreateTableTest.java
@@ -291,6 +291,50 @@ public class CreateTableTest {
     }
 
     @Test
+    public void testPartitionByExprDynamicPartition() {
+        ExceptionChecker
+                .expectThrowsNoException(() -> createTable("CREATE TABLE test.partition_str2date (\n" +
+                        "        create_time varchar(100),\n" +
+                        "        sku_id varchar(100),\n" +
+                        "        total_amount decimal,\n" +
+                        "        id int\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d %H:%i:%s'))(\n" +
+                        "START (\"2021-01-01\") END (\"2021-01-10\") EVERY (INTERVAL 1 DAY)\n" +
+                        ")\n" +
+                        "PROPERTIES(\n" +
+                        "\t\"replication_num\" = \"1\",\n" +
+                        "    \"dynamic_partition.enable\" = \"true\",\n" +
+                        "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                        "    \"dynamic_partition.start\" = \"-3\",\n" +
+                        "    \"dynamic_partition.end\" = \"3\",\n" +
+                        "    \"dynamic_partition.prefix\" = \"p\",\n" +
+                        "    \"dynamic_partition.buckets\" = \"32\",\n" +
+                        "    \"dynamic_partition.history_partition_num\" = \"0\"\n" +
+                        ");"));
+        ExceptionChecker
+                .expectThrowsNoException(() -> createTable("CREATE TABLE test.partition_from_unixtime (\n" +
+                        "        create_time bigint,\n" +
+                        "        sku_id varchar(100),\n" +
+                        "        total_amount decimal,\n" +
+                        "        id int\n" +
+                        ")\n" +
+                        "PARTITION BY RANGE(from_unixtime(create_time))(\n" +
+                        "START (\"2021-01-01\") END (\"2021-01-10\") EVERY (INTERVAL 1 DAY)\n" +
+                        ")\n" +
+                        "PROPERTIES(\n" +
+                        "\t\"replication_num\" = \"1\",\n" +
+                        "    \"dynamic_partition.enable\" = \"true\",\n" +
+                        "    \"dynamic_partition.time_unit\" = \"DAY\",\n" +
+                        "    \"dynamic_partition.start\" = \"-3\",\n" +
+                        "    \"dynamic_partition.end\" = \"3\",\n" +
+                        "    \"dynamic_partition.prefix\" = \"p\",\n" +
+                        "    \"dynamic_partition.buckets\" = \"32\",\n" +
+                        "    \"dynamic_partition.history_partition_num\" = \"0\"\n" +
+                        ");"));
+    }
+
+    @Test
     public void testAbnormal() throws DdlException {
         ExceptionChecker.expectThrowsWithMsg(DdlException.class,
                 "FLOAT column can not be distribution column",

--- a/test/sql/test_partition_by_expr/R/test_expr_str2date
+++ b/test/sql/test_partition_by_expr/R/test_expr_str2date
@@ -1,0 +1,165 @@
+-- name: test_expr_str2date
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d %H:%i:%s'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+-- result:
+-- !result
+insert into partition_str2date values('2021-01-04 23:59:59', '1', 1, 1);
+-- result:
+-- !result
+select * from partition_str2date;
+-- result:
+2021-01-04 23:59:59	1	1	1
+-- !result
+select * from partition_str2date where create_time = '2021-01-04 23:59:59';
+-- result:
+2021-01-04 23:59:59	1	1	1
+-- !result
+drop table partition_str2date;
+-- result:
+-- !result
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+-- result:
+-- !result
+insert into partition_str2date values('2021-01-04', '1', 1, 1);
+-- result:
+-- !result
+select * from partition_str2date;
+-- result:
+2021-01-04	1	1	1
+-- !result
+select * from partition_str2date where create_time = '2021-01-04';
+-- result:
+2021-01-04	1	1	1
+-- !result
+drop table partition_str2date;
+-- result:
+-- !result
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y%m%d%H'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+-- result:
+-- !result
+insert into partition_str2date values('2021010423', '1', 1, 1);
+-- result:
+-- !result
+select * from partition_str2date;
+-- result:
+2021010423	1	1	1
+-- !result
+select * from partition_str2date where create_time = '2021010423';
+-- result:
+2021010423	1	1	1
+-- !result
+drop table partition_str2date;
+-- result:
+-- !result
+-- name: test_expr_str2date_add_partition
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+alter table partition_str2date add partition p20231226 VALUES [("2023-12-26"), ("2023-12-27"));
+-- result:
+-- !result
+show create table partition_str2date;
+-- result:
+partition_str2date	CREATE TABLE `partition_str2date` (
+  `create_time` varchar(100) NULL COMMENT "",
+  `sku_id` varchar(100) NULL COMMENT "",
+  `total_amount` decimal64(10, 0) NULL COMMENT "",
+  `id` int(11) NULL COMMENT ""
+) ENGINE=OLAP 
+DUPLICATE KEY(`create_time`)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))
+(PARTITION p20210101 VALUES [("2021-01-01"), ("2021-01-02")),
+PARTITION p20210102 VALUES [("2021-01-02"), ("2021-01-03")),
+PARTITION p20210103 VALUES [("2021-01-03"), ("2021-01-04")),
+PARTITION p20210104 VALUES [("2021-01-04"), ("2021-01-05")),
+PARTITION p20210105 VALUES [("2021-01-05"), ("2021-01-06")),
+PARTITION p20210106 VALUES [("2021-01-06"), ("2021-01-07")),
+PARTITION p20210107 VALUES [("2021-01-07"), ("2021-01-08")),
+PARTITION p20210108 VALUES [("2021-01-08"), ("2021-01-09")),
+PARTITION p20210109 VALUES [("2021-01-09"), ("2021-01-10")),
+PARTITION p20231226 VALUES [("2023-12-26"), ("2023-12-27")))
+DISTRIBUTED BY RANDOM
+PROPERTIES (
+"replication_num" = "1",
+"bucket_size" = "4294967296",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "true",
+"fast_schema_evolution" = "true",
+"compression" = "LZ4"
+);
+-- !result
+-- name: test_expr_str2date_partition_prune
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+-- result:
+-- !result
+insert into partition_str2date values('2021-01-04','1',1.1,1);
+-- result:
+-- !result
+insert into partition_str2date values('2021-01-05','1',1.1,1);
+-- result:
+-- !result
+insert into partition_str2date values('2021-01-06','1',1.1,1);
+-- result:
+-- !result
+select * from partition_str2date;
+-- result:
+2021-01-04	1	1	1
+2021-01-05	1	1	1
+2021-01-06	1	1	1
+-- !result
+select * from partition_str2date where create_time='2021-01-05';
+-- result:
+2021-01-05	1	1	1
+-- !result
+explain select * from partition_str2date where create_time='2021-01-05';
+select * from partition_str2date where '2021-01-05'=create_time;
+-- result:
+2021-01-05	1	1	1
+-- !result
+select * from partition_str2date where create_time>'2021-01-05';
+-- result:
+2021-01-06	1	1	1
+-- !result

--- a/test/sql/test_partition_by_expr/T/test_expr_str2date
+++ b/test/sql/test_partition_by_expr/T/test_expr_str2date
@@ -1,0 +1,73 @@
+-- name: test_expr_str2date
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d %H:%i:%s'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+insert into partition_str2date values('2021-01-04 23:59:59', '1', 1, 1);
+select * from partition_str2date;
+select * from partition_str2date where create_time = '2021-01-04 23:59:59';
+drop table partition_str2date;
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+insert into partition_str2date values('2021-01-04', '1', 1, 1);
+select * from partition_str2date;
+select * from partition_str2date where create_time = '2021-01-04';
+drop table partition_str2date;
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y%m%d%H'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+insert into partition_str2date values('2021010423', '1', 1, 1);
+select * from partition_str2date;
+select * from partition_str2date where create_time = '2021010423';
+drop table partition_str2date;
+-- name: test_expr_str2date_add_partition
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+)
+PROPERTIES (
+"replication_num" = "1"
+);
+alter table partition_str2date add partition p20231226 VALUES [("2023-12-26"), ("2023-12-27"));
+show create table partition_str2date;
+-- name: test_expr_str2date_partition_prune
+CREATE TABLE partition_str2date (
+        create_time varchar(100),
+        sku_id varchar(100),
+        total_amount decimal,
+        id int
+)
+PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))(
+START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
+);
+insert into partition_str2date values('2021-01-04','1',1.1,1);
+insert into partition_str2date values('2021-01-05','1',1.1,1);
+insert into partition_str2date values('2021-01-06','1',1.1,1);
+select * from partition_str2date;
+select * from partition_str2date where create_time='2021-01-05';
+explain select * from partition_str2date where create_time='2021-01-05';
+select * from partition_str2date where '2021-01-05'=create_time;
+select * from partition_str2date where create_time>='2021-01-05';


### PR DESCRIPTION
Why I'm doing:
For time in a special format of string type, we need a way to convert any format. We chose str2date to convert all possible string formats.

What I'm doing:
The following syntax is supported:
```
CREATE TABLE partition_unixtime (
        create_time varchar(100),
        sku_id varchar(100),
        total_amount decimal,
        id int
)
PARTITION BY RANGE(str2date(create_time, '%Y-%m-%d'))(
START ("2021-01-01") END ("2021-01-10") EVERY (INTERVAL 1 DAY)
);
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
