### PR TITLE
[BugFix] Fix fe lock failure by correcting the synchronization bug.

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
@@ -22,8 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.thrift.TException;
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Function;
+import java.lang.Thread.State;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -64,16 +63,13 @@ public class SysFeLocksTest {
             assertEquals("[]", item.getWaiter_list());
 
             // add a waiter
-            AtomicInteger state = new AtomicInteger(0);
             Thread waiter = new Thread(() -> {
-                state.set(1);
                 db.writeLock();
                 db.writeUnlock();
-                ;
             }, "waiter");
             waiter.start();
 
-            while (state.get() != 1) {
+            while (waiter.getState() != State.WAITING) {
                 Thread.sleep(1000);
             }
 
@@ -94,19 +90,7 @@ public class SysFeLocksTest {
             assertEquals("[]", item.getWaiter_list());
 
             // add a waiter
-            AtomicInteger state = new AtomicInteger(0);
-            Function<Integer, Void> awaitState = (expected) -> {
-                while (state.get() != expected) {
-                    try {
-                        Thread.sleep(1000);
-                    } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-                return null;
-            };
             Thread waiter = new Thread(() -> {
-                state.set(1);
                 db.writeLock();
                 db.writeUnlock();
             }, "waiter");
@@ -117,7 +101,10 @@ public class SysFeLocksTest {
             // 3. two threads share the lock
             // 4. two threads release the lock
 
-            awaitState.apply(1);
+            while (waiter.getState() != State.WAITING) {
+                Thread.sleep(1000);
+            }
+
             item = SysFeLocks.resolveLockInfo(db);
             assertEquals(String.format("[{\"threadId\":%d,\"threadName\":\"%s\"}]", waiter.getId(), waiter.getName()),
                     item.getWaiter_list());


### PR DESCRIPTION
 SysFeLocksTest occasionally fails due to concurrency issues.
```
AtomicInteger state = new AtomicInteger(0);
Thread waiter = new Thread(() -> {
    // first step
    state.set(1);
    // third step 
    db.writeLock(); 
    db.writeUnlock();
    ;
}, "waiter");
waiter.start();

// pass here
while (state.get() != 1) {
    Thread.sleep(1000);
}

// second step
item = SysFeLocks.resolveLockInfo(db); 
// assert failed cause resolveLockInfo() is called before db.writeLock()
assertEquals(String.format("[{\"threadId\":%d,\"threadName\":\"%s\"}]", waiter.getId(), waiter.getName()),
                    item.getWaiter_list());
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
