### PR TITLE
[BugFix] Fix refresh bugs for non-partition auto refresh with partition_fresh_number is one

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/SyncPartitionUtils.java
@@ -549,7 +549,8 @@ public class SyncPartitionUtils {
                                                              Map<String, Map<Table, Set<String>>> mvToBaseNameRef,
                                                              Set<String> mvPotentialRefreshPartitionNames) {
         int curNameCount = needRefreshMvPartitionNames.size();
-        for (String needRefreshMvPartitionName : needRefreshMvPartitionNames) {
+        Set<String> copiedNeedRefreshMvPartitionNames = Sets.newHashSet(needRefreshMvPartitionNames);
+        for (String needRefreshMvPartitionName : copiedNeedRefreshMvPartitionNames) {
             // baseTable with its partitions by mv's partition
             Map<Table, Set<String>> baseNames = mvToBaseNameRef.get(needRefreshMvPartitionName);
             Set<String> mvNeedRefreshPartitions = Sets.newHashSet();

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -160,7 +160,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                     "alter table sc_dup3 drop column op_id");
             jobSize++;
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail();
         }
     }
@@ -210,7 +209,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "where type > 10",
                     "alter table sc_dup3 modify column type BIGINT");
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column type, because the column is used " +
                     "in the related rollup mv1 with the where expr:`test`.`sc_dup3`.`type` > 10, " +
                     "please drop the rollup index first."));
@@ -226,7 +224,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 drop column op_id");
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
                     "is used in the related rollup mv1, please drop the rollup index first."));
         }
@@ -240,7 +237,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 drop column timestamp");
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
                     "is used in the related rollup mv1, please drop the rollup index first."));
         }
@@ -255,7 +251,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 drop column error_code");
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column mv_count_error_code, because the column " +
                     "is used in the related rollup mv1 with the define expr:" +
                     "CASE WHEN `test`.`sc_dup3`.`error_code` IS NULL THEN 0 ELSE 1 END, please drop the rollup index first."));
@@ -271,7 +266,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 modify column error_code BIGINT");
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column mv_count_error_code, because " +
                     "the column is used in the related rollup mv1 with the define expr:" +
                     "CASE WHEN `test`.`sc_dup3`.`error_code` IS NULL THEN 0 ELSE 1 END, please drop the rollup index first."));
@@ -286,7 +280,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "where type > 10 group by timestamp",
                     "alter table sc_dup3 modify column type BIGINT");
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column type, because the column is " +
                     "used in the related rollup mv1 with the where expr:`test`.`sc_dup3`.`type` > 10, " +
                     "please drop the rollup index first."));
@@ -302,7 +295,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "where type > 10 group by timestamp",
                     "alter table sc_dup3 drop column type");
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column type, because the column is " +
                     "used in the related rollup mv1 with the where expr:`test`.`sc_dup3`.`type` > 10, " +
                     "please drop the rollup index first."));
@@ -320,10 +312,8 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                     false);
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
-            System.out.println(mv.getInactiveReason());
             Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: op_id"));
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail();
         } finally {
             try {
@@ -345,10 +335,8 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                     false);
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
-            System.out.println(mv.getInactiveReason());
             Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: error_code"));
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail();
         } finally {
             try {
@@ -370,10 +358,8 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                     false);
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
-            System.out.println(mv.getInactiveReason());
             Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: error_code"));
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail();
         } finally {
             try {
@@ -395,10 +381,8 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                     false);
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertFalse(mv.isActive());
-            System.out.println(mv.getInactiveReason());
             Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: op_id"));
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail();
         } finally {
             try {
@@ -421,7 +405,6 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
             MaterializedView mv = (MaterializedView) starRocksAssert.getTable("test", "mv1");
             Assert.assertTrue(mv.isActive());
         } catch (Exception e) {
-            e.printStackTrace();
             Assert.fail();
         } finally {
             try {

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -286,7 +286,7 @@ public class AlterMaterializedViewTest {
         starRocksAssert.dropTable(baseTableName);
         starRocksAssert.withTable(createTableSql);
         Assert.assertFalse(mv.isActive());
-        Thread.sleep(1000);
+        checker.runForTest(true);
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mv.getName() + " with sync mode");
         Assert.assertTrue(mv.isActive());
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/AlterMaterializedViewTest.java
@@ -286,7 +286,7 @@ public class AlterMaterializedViewTest {
         starRocksAssert.dropTable(baseTableName);
         starRocksAssert.withTable(createTableSql);
         Assert.assertFalse(mv.isActive());
-        checker.runForTest(true);
+        Thread.sleep(1000);
         starRocksAssert.getCtx().executeSql("refresh materialized view " + mv.getName() + " with sync mode");
         Assert.assertTrue(mv.isActive());
 

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -3403,9 +3403,12 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                                     String tt1Partition = tt1Partitions.get(i);
                                     taskRun.initStatus(UUIDUtil.genUUID().toString(), System.currentTimeMillis());
                                     taskRun.executeTaskRun();
-                                    MvTaskRunContext mvContext = ((PartitionBasedMvRefreshProcessor) taskRun.getProcessor()).getMvContext();
-                                    Assert.assertTrue(isEnd ? !mvContext.hasNextBatchPartition() : mvContext.hasNextBatchPartition());
-                                    PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
+                                    MvTaskRunContext mvContext =
+                                            ((PartitionBasedMvRefreshProcessor) taskRun.getProcessor()).getMvContext();
+                                    Assert.assertTrue(isEnd ? !mvContext.hasNextBatchPartition()
+                                            : mvContext.hasNextBatchPartition());
+                                    PartitionBasedMvRefreshProcessor processor =
+                                            (PartitionBasedMvRefreshProcessor) taskRun.getProcessor();
                                     System.out.println(processor.getMVTaskRunExtraMessage());
                                     Assert.assertEquals(Sets.newHashSet(tt1Partition),
                                             processor.getMVTaskRunExtraMessage().getMvPartitionsToRefresh());

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTestBase.java
@@ -145,7 +145,11 @@ public class MvRewriteTestBase {
 
     @AfterClass
     public static void tearDown() throws Exception {
-        PseudoCluster.getInstance().shutdown(true);
+        try {
+            PseudoCluster.getInstance().shutdown(true);
+        } catch (Exception e) {
+            // ignore exception
+        }
     }
 
     private static void setPartitionVersion(Partition partition, long version) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ReplayWithMVFromDumpTest.java
@@ -17,7 +17,6 @@ package com.starrocks.sql.plan;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.Pair;
-import com.starrocks.common.profile.Tracers;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.optimizer.dump.QueryDumpInfo;
 import com.starrocks.thrift.TExplainLevel;
@@ -87,13 +86,9 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
     public void testMV_JoinAgg2() throws Exception {
         FeConstants.isReplayFromQueryDump = true;
         String jsonStr = getDumpInfoFromFile("query_dump/materialized-view/join_agg2");
-        Tracers.register(connectContext);
-        Tracers.init(connectContext, Tracers.Mode.LOGS, "MV");
         connectContext.getSessionVariable()
                 .setMaterializedViewRewriteMode(SessionVariable.MaterializedViewRewriteMode.FORCE.toString());
         Pair<QueryDumpInfo, String> replayPair = getCostPlanFragment(jsonStr, connectContext.getSessionVariable());
-        String pr = Tracers.printLogs();
-        Tracers.close();
         Assert.assertTrue(replayPair.second.contains("table: mv1, rollup: mv1"));
         FeConstants.isReplayFromQueryDump = false;
     }
@@ -147,6 +142,7 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/mv_on_mv2"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
+        connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         Assert.assertTrue(replayPair.second.contains("test_mv2"));
     }
 
@@ -186,14 +182,10 @@ public class ReplayWithMVFromDumpTest extends ReplayFromDumpTestBase {
     public void testMock_MV_CostBug() throws Exception {
         FeConstants.isReplayFromQueryDump = true;
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("force");
-        Tracers.register(connectContext);
-        Tracers.init(connectContext, Tracers.Mode.LOGS, "ALL");
         Pair<QueryDumpInfo, String> replayPair =
                 getPlanFragment(getDumpInfoFromFile("query_dump/materialized-view/mv_with_cost_bug1"),
                         connectContext.getSessionVariable(), TExplainLevel.NORMAL);
         Assert.assertTrue(replayPair.second, replayPair.second.contains("mv_35"));
-        String pr = Tracers.printLogs();
-        System.out.println(pr);
         connectContext.getSessionVariable().setMaterializedViewRewriteMode("default");
         FeConstants.isReplayFromQueryDump = false;
     }


### PR DESCRIPTION


Why I'm doing:
After https://github.com/StarRocks/starrocks/pull/36560, refresh partitioned tables one partition by one partition.

When there is a mv which is a partitioned table joined with a non-partitioned table, once the non-partitioned table has updated, should refresh all partitions for the partitioned table.

But now only consider start/end, it will ignore the triggered refresh when the start/end is not null and the partitioned table has not been updated.
```
      if (start == null && end == null) {
                    // if non partition table changed, should refresh all partitions of materialized view
                    return mvRangePartitionNames;
                } else {
                        // If the user specifies the start and end ranges, and the non-partitioned table still changes,
                        // it should be refreshed according to the user-specified range, not all partitions.
                        return getMVPartitionNamesToRefreshByRangePartitionNamesAndForce(refBaseTable,
                                mvRangePartitionNames, true);
                }
```


What I'm doing:
- Trigger partitioned  table refresh whatever it has changed or not.
- Fix stupid bugs in `gatherPotentialRefreshPartitionNames `
```
If this refresh comes from PERIODIC/EVENT_TRIGGER, it should not respect the config to do the
 refresh rather than only checking the ref table's update.
 eg:
  MV: SELECT t2.k1 as k1, t2.k2 as k2, t1.k1 as k3, t1.k2 as k4 FROM t1 join t2 on t1.k1=t2.k1;
  RefTable    : t1, Partition: p0,p1,p2
  NonRefTable : t2, Partition: p0,p1,p2
 when t2 is updated, it will trigger refresh of ref-table's all partitions.
 if `partition_refresh_number` is 1, then:
 - The 1th TaskRun: start=null,end=null,  ref-table refresh partition: p0
 - The 2th TaskRun: start=p1,end=p2,      ref-table refresh partition: p1
 - The 3th TaskRun: start=p2,end=p2,      ref-table refresh partition: p2
 if use method below, it will break in the 2th TaskRun because ref-table has not updated in the
 specific start and end ranges
```


Fixes https://github.com/StarRocks/StarRocksTest/issues/5407
Fixes https://github.com/StarRocks/StarRocksTest/issues/5406

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
