### PR TITLE
[Enhancement] Use the number of hardware threads as default sink dop

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -290,12 +290,12 @@ Status FragmentExecutor::_prepare_runtime_state(ExecEnv* exec_env, const Unified
     return Status::OK();
 }
 
-int32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const {
+uint32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const {
     int32_t degree_of_parallelism = request.pipeline_dop();
     return exec_env->calc_pipeline_dop(degree_of_parallelism);
 }
 
-int32_t FragmentExecutor::_calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const {
+uint32_t FragmentExecutor::_calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const {
     int32_t degree_of_parallelism = request.pipeline_sink_dop();
     return exec_env->calc_pipeline_sink_dop(degree_of_parallelism);
 }

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -297,7 +297,7 @@ int32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFrag
 
 int32_t FragmentExecutor::_calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const {
     int32_t degree_of_parallelism = request.pipeline_sink_dop();
-    return exec_env->calc_pipeline_dop(degree_of_parallelism);
+    return exec_env->calc_pipeline_sink_dop(degree_of_parallelism);
 }
 
 int FragmentExecutor::_calc_delivery_expired_seconds(const UnifiedExecPlanFragmentParams& request) const {

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -295,6 +295,11 @@ int32_t FragmentExecutor::_calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFrag
     return exec_env->calc_pipeline_dop(degree_of_parallelism);
 }
 
+int32_t FragmentExecutor::_calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const {
+    int32_t degree_of_parallelism = request.pipeline_sink_dop();
+    return exec_env->calc_pipeline_dop(degree_of_parallelism);
+}
+
 int FragmentExecutor::_calc_delivery_expired_seconds(const UnifiedExecPlanFragmentParams& request) const {
     const auto& query_options = request.common().query_options;
 
@@ -967,7 +972,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
         auto* source_operator =
                 down_cast<SourceOperatorFactory*>(fragment_ctx->pipelines().back()->source_operator_factory());
 
-        size_t desired_iceberg_sink_dop = request.pipeline_sink_dop();
+        size_t desired_iceberg_sink_dop = _calc_sink_dop(ExecEnv::GetInstance(), request);
         size_t source_operator_dop = source_operator->degree_of_parallelism();
         OpFactoryPtr iceberg_table_sink_op = std::make_shared<IcebergTableSinkOperatorFactory>(
                 context->next_operator_id(), fragment_ctx, iceberg_table_sink->get_output_expr(), iceberg_table_desc,
@@ -996,7 +1001,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
         auto* source_operator =
                 down_cast<SourceOperatorFactory*>(fragment_ctx->pipelines().back()->source_operator_factory());
 
-        size_t desired_hive_sink_dop = request.pipeline_sink_dop();
+        size_t desired_hive_sink_dop = _calc_sink_dop(ExecEnv::GetInstance(), request);
         size_t source_operator_dop = source_operator->degree_of_parallelism();
         OpFactoryPtr hive_table_sink_op = std::make_shared<HiveTableSinkOperatorFactory>(
                 context->next_operator_id(), fragment_ctx, thrift_sink.hive_table_sink,
@@ -1050,7 +1055,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
                 fragment_ctx);
 
         size_t source_dop = fragment_ctx->pipelines().back()->source_operator_factory()->degree_of_parallelism();
-        size_t sink_dop = request.pipeline_sink_dop();
+        size_t sink_dop = _calc_sink_dop(ExecEnv::GetInstance(), request);
 
         if (target_table.write_single_file) {
             sink_dop = 1;

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -100,8 +100,8 @@ public:
 
 private:
     void _fail_cleanup(bool fragment_has_registed);
-    int32_t _calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
-    int32_t _calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
+    uint32_t _calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
+    uint32_t _calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
     int _calc_delivery_expired_seconds(const UnifiedExecPlanFragmentParams& request) const;
     int _calc_query_expired_seconds(const UnifiedExecPlanFragmentParams& request) const;
 

--- a/be/src/exec/pipeline/fragment_executor.h
+++ b/be/src/exec/pipeline/fragment_executor.h
@@ -101,6 +101,7 @@ public:
 private:
     void _fail_cleanup(bool fragment_has_registed);
     int32_t _calc_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
+    int32_t _calc_sink_dop(ExecEnv* exec_env, const UnifiedExecPlanFragmentParams& request) const;
     int _calc_delivery_expired_seconds(const UnifiedExecPlanFragmentParams& request) const;
     int _calc_query_expired_seconds(const UnifiedExecPlanFragmentParams& request) const;
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -656,23 +656,23 @@ void ExecEnv::wait_for_finish() {
     _wait_for_fragments_finish();
 }
 
-int32_t ExecEnv::calc_pipeline_dop(int32_t pipeline_dop) const {
+uint32_t ExecEnv::calc_pipeline_dop(int32_t pipeline_dop) const {
     if (pipeline_dop > 0) {
         return pipeline_dop;
     }
 
     // Default dop is a half of the number of hardware threads.
-    return std::max<int32_t>(1, _max_executor_threads / 2);
+    return std::max<uint32_t>(1, _max_executor_threads / 2);
 }
 
-int32_t ExecEnv::calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const {
+uint32_t ExecEnv::calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const {
     if (pipeline_sink_dop > 0) {
         return pipeline_sink_dop;
     }
 
     // Default sink dop is the number of hardware threads with a cap of 64.
-    auto dop = std::max<int32_t>(1, _max_executor_threads);
-    return std::min<int32_t>(dop, 64);
+    auto dop = std::max<uint32_t>(1, _max_executor_threads);
+    return std::min<uint32_t>(dop, 64);
 }
 
 ThreadPool* ExecEnv::delete_file_thread_pool() {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -670,8 +670,9 @@ int32_t ExecEnv::calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const {
         return pipeline_sink_dop;
     }
 
-    // Default sink dop is the number of hardware threads.
-    return std::max<int32_t>(1, _max_executor_threads);
+    // Default sink dop is the number of hardware threads with a cap of 64.
+    auto dop = std::max<int32_t>(1, _max_executor_threads);
+    return std::min<int32_t>(dop, 64);
 }
 
 ThreadPool* ExecEnv::delete_file_thread_pool() {

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -665,6 +665,15 @@ int32_t ExecEnv::calc_pipeline_dop(int32_t pipeline_dop) const {
     return std::max<int32_t>(1, _max_executor_threads / 2);
 }
 
+int32_t ExecEnv::calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const {
+    if (pipeline_sink_dop > 0) {
+        return pipeline_sink_dop;
+    }
+
+    // Default sink dop is the number of hardware threads.
+    return std::max<int32_t>(1, _max_executor_threads);
+}
+
 ThreadPool* ExecEnv::delete_file_thread_pool() {
     return _agent_server ? _agent_server->get_thread_pool(TTaskType::DROP) : nullptr;
 }

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -296,9 +296,9 @@ public:
 
     int64_t max_executor_threads() const { return _max_executor_threads; }
 
-    int32_t calc_pipeline_dop(int32_t pipeline_dop) const;
+    uint32_t calc_pipeline_dop(int32_t pipeline_dop) const;
 
-    int32_t calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const;
+    uint32_t calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const;
 
     lake::TabletManager* lake_tablet_manager() const { return _lake_tablet_manager; }
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -298,6 +298,8 @@ public:
 
     int32_t calc_pipeline_dop(int32_t pipeline_dop) const;
 
+    int32_t calc_pipeline_sink_dop(int32_t pipeline_sink_dop) const;
+
     lake::TabletManager* lake_tablet_manager() const { return _lake_tablet_manager; }
 
     lake::LocationProvider* lake_location_provider() const { return _lake_location_provider; }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstance.java
@@ -307,11 +307,7 @@ public class FragmentInstance {
                 || dataSink instanceof TableFunctionTableSink)) {
             return dop;
         } else {
-            int sessionVarSinkDop = ConnectContext.get().getSessionVariable().getPipelineSinkDop();
-            if (sessionVarSinkDop > 0) {
-                return sessionVarSinkDop;
-            }
-            return dop;
+            return ConnectContext.get().getSessionVariable().getPipelineSinkDop();
         }
     }
 


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Use the number of hardware threads as default sink dop.

If `pipeline_sink_dop` is set, use it as the sink dop. Otherwise, use the number of hardware and cap it to 64. 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
