### PR TITLE
[Enhancement]Support binary type for paimon table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ColumnTypeConverter.java
@@ -50,6 +50,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
 
 import java.util.ArrayList;
@@ -494,6 +495,10 @@ public class ColumnTypeConverter {
         private static final PaimonToHiveTypeVisitor INSTANCE = new PaimonToHiveTypeVisitor();
 
         public Type visit(BinaryType binaryType) {
+            return ScalarType.createType(PrimitiveType.VARBINARY);
+        }
+
+        public Type visit(VarBinaryType varBinaryType) {
             return ScalarType.createType(PrimitiveType.VARBINARY);
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/paimon/PaimonColumnConverterTest.java
@@ -34,6 +34,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
 import org.junit.Assert;
 import org.junit.Test;
@@ -46,6 +47,13 @@ public class PaimonColumnConverterTest {
     @Test
     public void testConvertBinary() {
         BinaryType paimonType = new BinaryType();
+        Type result = ColumnTypeConverter.fromPaimonType(paimonType);
+        Assert.assertEquals(result, Type.VARBINARY);
+    }
+
+    @Test
+    public void testConvertVarBinary() {
+        VarBinaryType paimonType = new VarBinaryType();
         Type result = ColumnTypeConverter.fromPaimonType(paimonType);
         Assert.assertEquals(result, Type.VARBINARY);
     }

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonTypeUtils.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonTypeUtils.java
@@ -31,6 +31,7 @@ import org.apache.paimon.types.RowType;
 import org.apache.paimon.types.SmallIntType;
 import org.apache.paimon.types.TimestampType;
 import org.apache.paimon.types.TinyIntType;
+import org.apache.paimon.types.VarBinaryType;
 import org.apache.paimon.types.VarCharType;
 
 import java.util.stream.Collectors;
@@ -60,6 +61,10 @@ public class PaimonTypeUtils {
         }
 
         public String visit(BinaryType binaryType) {
+            return "binary";
+        }
+
+        public String visit(VarBinaryType varBinaryType) {
             return "binary";
         }
 


### PR DESCRIPTION
Why I'm doing:
Paimon catalog not support varbinary type
What I'm doing:
Support varbinary type for paimon table
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
