### PR TITLE
[BugFix] Fix mv refresh with mysql external table bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/MysqlSchemaResolver.java
@@ -220,7 +220,7 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
                 while (rs.next()) {
                     String[] partitionNames = rs.getString("NAME").
                             replace("'", "").split(",");
-                    long createTime = rs.getDate("MODIFIED_TIME").getTime();
+                    long createTime = rs.getTimestamp("MODIFIED_TIME").getTime();
                     for (String partitionName : partitionNames) {
                         list.add(new Partition(partitionName, createTime));
                     }
@@ -234,6 +234,42 @@ public class MysqlSchemaResolver extends JDBCSchemaResolver {
         }
     }
 
+    /**
+     * Fetch jdbc table's partition info from `INFORMATION_SCHEMA.PARTITIONS`.
+     * eg:
+     * mysql> desc INFORMATION_SCHEMA.PARTITIONS;
+     * +-------------------------------+---------------------+------+-----+---------+-------+
+     * | Field                         | Type                | Null | Key | Default | Extra |
+     * +-------------------------------+---------------------+------+-----+---------+-------+
+     * | TABLE_CATALOG                 | varchar(512)        | NO   |     |         |       |
+     * | TABLE_SCHEMA                  | varchar(64)         | NO   |     |         |       |
+     * | TABLE_NAME                    | varchar(64)         | NO   |     |         |       |
+     * | PARTITION_NAME                | varchar(64)         | YES  |     | NULL    |       |
+     * | SUBPARTITION_NAME             | varchar(64)         | YES  |     | NULL    |       |
+     * | PARTITION_ORDINAL_POSITION    | bigint(21) unsigned | YES  |     | NULL    |       |
+     * | SUBPARTITION_ORDINAL_POSITION | bigint(21) unsigned | YES  |     | NULL    |       |
+     * | PARTITION_METHOD              | varchar(18)         | YES  |     | NULL    |       |
+     * | SUBPARTITION_METHOD           | varchar(12)         | YES  |     | NULL    |       |
+     * | PARTITION_EXPRESSION          | longtext            | YES  |     | NULL    |       |
+     * | SUBPARTITION_EXPRESSION       | longtext            | YES  |     | NULL    |       |
+     * | PARTITION_DESCRIPTION         | longtext            | YES  |     | NULL    |       |
+     * | TABLE_ROWS                    | bigint(21) unsigned | NO   |     | 0       |       |
+     * | AVG_ROW_LENGTH                | bigint(21) unsigned | NO   |     | 0       |       |
+     * | DATA_LENGTH                   | bigint(21) unsigned | NO   |     | 0       |       |
+     * | MAX_DATA_LENGTH               | bigint(21) unsigned | YES  |     | NULL    |       |
+     * | INDEX_LENGTH                  | bigint(21) unsigned | NO   |     | 0       |       |
+     * | DATA_FREE                     | bigint(21) unsigned | NO   |     | 0       |       |
+     * | CREATE_TIME                   | datetime            | YES  |     | NULL    |       |
+     * | UPDATE_TIME                   | datetime            | YES  |     | NULL    |       |
+     * | CHECK_TIME                    | datetime            | YES  |     | NULL    |       |
+     * | CHECKSUM                      | bigint(21) unsigned | YES  |     | NULL    |       |
+     * | PARTITION_COMMENT             | varchar(80)         | NO   |     |         |       |
+     * | NODEGROUP                     | varchar(12)         | NO   |     |         |       |
+     * | TABLESPACE_NAME               | varchar(64)         | YES  |     | NULL    |       |
+     * +-------------------------------+---------------------+------+-----+---------+-------+
+     * @param table
+     * @return
+     */
     @NotNull
     private static String getPartitionQuery(Table table) {
         final String partitionsQuery = "SELECT PARTITION_DESCRIPTION AS NAME, " +

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -1628,9 +1628,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
                     }
                 } else if (ConnectorPartitionTraits.isSupported(snapshotTable.getType())) {
                     if (snapshotTable.isUnPartitioned()) {
-                        if (!table.isUnPartitioned()) {
-                            return true;
-                        }
+                        return false;
                     } else {
                         PartitionInfo mvPartitionInfo = materializedView.getPartitionInfo();
                         // TODO: Support list partition later.


### PR DESCRIPTION
Why I'm doing:

Refresh a non-partitioned mysql external table, mv with mysql table cannot detect whether it's changed or not.

Since `INFORMATION_SCHEMA.PARTITIONS`'s CREATE_TIME or `UPDATE_TIME` is datetime type, we should use `getTimestamp` rather than `getDate`.

```
mysql> desc INFORMATION_SCHEMA.PARTITIONS;
+-------------------------------+---------------------+------+-----+---------+-------+
| Field                         | Type                | Null | Key | Default | Extra |
+-------------------------------+---------------------+------+-----+---------+-------+
| TABLE_CATALOG                 | varchar(512)        | NO   |     |         |       |
| TABLE_SCHEMA                  | varchar(64)         | NO   |     |         |       |
| TABLE_NAME                    | varchar(64)         | NO   |     |         |       |
| PARTITION_NAME                | varchar(64)         | YES  |     | NULL    |       |
| SUBPARTITION_NAME             | varchar(64)         | YES  |     | NULL    |       |
| PARTITION_ORDINAL_POSITION    | bigint(21) unsigned | YES  |     | NULL    |       |
| SUBPARTITION_ORDINAL_POSITION | bigint(21) unsigned | YES  |     | NULL    |       |
| PARTITION_METHOD              | varchar(18)         | YES  |     | NULL    |       |
| SUBPARTITION_METHOD           | varchar(12)         | YES  |     | NULL    |       |
| PARTITION_EXPRESSION          | longtext            | YES  |     | NULL    |       |
| SUBPARTITION_EXPRESSION       | longtext            | YES  |     | NULL    |       |
| PARTITION_DESCRIPTION         | longtext            | YES  |     | NULL    |       |
| TABLE_ROWS                    | bigint(21) unsigned | NO   |     | 0       |       |
| AVG_ROW_LENGTH                | bigint(21) unsigned | NO   |     | 0       |       |
| DATA_LENGTH                   | bigint(21) unsigned | NO   |     | 0       |       |
| MAX_DATA_LENGTH               | bigint(21) unsigned | YES  |     | NULL    |       |
| INDEX_LENGTH                  | bigint(21) unsigned | NO   |     | 0       |       |
| DATA_FREE                     | bigint(21) unsigned | NO   |     | 0       |       |
| CREATE_TIME                   | datetime            | YES  |     | NULL    |       |
| UPDATE_TIME                   | datetime            | YES  |     | NULL    |       |
| CHECK_TIME                    | datetime            | YES  |     | NULL    |       |
| CHECKSUM                      | bigint(21) unsigned | YES  |     | NULL    |       |
| PARTITION_COMMENT             | varchar(80)         | NO   |     |         |       |
| NODEGROUP                     | varchar(12)         | NO   |     |         |       |
| TABLESPACE_NAME               | varchar(64)         | YES  |     | NULL    |       |
+-------------------------------+---------------------+------+-----+---------+-------+
25 rows in set (0.00 sec)
```
What I'm doing:
- Fix it.


[Fixes #issue](https://github.com/StarRocks/starrocks/issues/37714)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
