### PR TITLE
[BugFix] fix wrong order by scope for distinct query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -434,6 +434,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_PLAN_SERIALIZE_CONCURRENTLY = "enable_plan_serialize_concurrently";
 
+    public static final String ENABLE_STRICT_ORDER_BY = "enable_strict_order_by";
+
     // Flag to control whether to proxy follower's query statement to leader/follower.
     public enum FollowerQueryForwardMode {
         DEFAULT,    // proxy queries by the follower's replay progress (default)
@@ -1596,6 +1598,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = FOLLOWER_QUERY_FORWARD_MODE, flag = VariableMgr.INVISIBLE | VariableMgr.DISABLE_FORWARD_TO_LEADER)
     private String followerForwardMode = "";
+
+    @VarAttr(name = ENABLE_STRICT_ORDER_BY)
+    private boolean enableStrictOrderBy = true;
 
     public void setFollowerQueryForwardMode(String mode) {
         this.followerForwardMode = mode;
@@ -3004,6 +3009,14 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public void setSkewJoinRandRange(int skewJoinRandRange) {
         this.skewJoinRandRange = skewJoinRandRange;
+    }
+
+    public boolean isEnableStrictOrderBy() {
+        return enableStrictOrderBy;
+    }
+
+    public void setEnableStrictOrderBy(boolean enableStrictOrderBy) {
+        this.enableStrictOrderBy = enableStrictOrderBy;
     }
 
     // Serialize to thrift object

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AggregationAnalyzer.java
@@ -48,6 +48,7 @@ import com.starrocks.qe.SqlModeHelper;
 import com.starrocks.sql.ast.ArrayExpr;
 import com.starrocks.sql.ast.AstVisitor;
 import com.starrocks.sql.ast.DictionaryGetExpr;
+import com.starrocks.sql.ast.FieldReference;
 import com.starrocks.sql.ast.LambdaFunctionExpr;
 import com.starrocks.sql.ast.QueryStatement;
 
@@ -118,8 +119,15 @@ public class AggregationAnalyzer {
         }
 
         @Override
+        public Boolean visitFieldReference(FieldReference node, Void context) {
+            String colInfo = node.getTblName() == null ? "column" : "column of " + node.getTblName().toString();
+            throw new SemanticException(colInfo + " must appear in the GROUP BY clause or be used in an aggregate function",
+                    node.getPos());
+        }
+
+        @Override
         public Boolean visitExpression(Expr node, Void context) {
-            throw new SemanticException(PARSER_ERROR_MSG.unsupportedExprWithInfo(node.toSql(), "GROUP BY"),
+            throw new SemanticException(node.toSql() + " must appear in the GROUP BY clause or be used in an aggregate function",
                     node.getPos());
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.sql.analyzer;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -86,10 +87,11 @@ public class SelectAnalyzer {
         analyzeHaving(havingClause, analyzeState, sourceScope, outputScope, outputExpressions);
 
         // Construct sourceAndOutputScope with sourceScope and outputScope
-        Scope sourceAndOutputScope = computeAndAssignOrderScope(analyzeState, sourceScope, outputScope);
+        Scope sourceAndOutputScope = computeAndAssignOrderScope(analyzeState, sourceScope, outputScope,
+                selectList.isDistinct());
 
         List<OrderByElement> orderByElements =
-                analyzeOrderBy(sortClause, analyzeState, sourceAndOutputScope, outputExpressions);
+                analyzeOrderBy(sortClause, analyzeState, sourceAndOutputScope, outputExpressions, selectList.isDistinct());
         List<Expr> orderByExpressions =
                 orderByElements.stream().map(OrderByElement::getExpr).collect(Collectors.toList());
 
@@ -183,7 +185,7 @@ public class SelectAnalyzer {
                     .collect(Collectors.toList());
 
             Scope sourceScopeForOrder = new Scope(RelationId.anonymous(), new RelationFields(sourceForOrderFields));
-            computeAndAssignOrderScope(analyzeState, sourceScopeForOrder, outputScope);
+            computeAndAssignOrderScope(analyzeState, sourceScopeForOrder, outputScope, selectList.isDistinct());
             analyzeState.setOrderSourceExpressions(orderSourceExpressions);
         }
 
@@ -311,7 +313,8 @@ public class SelectAnalyzer {
 
     private List<OrderByElement> analyzeOrderBy(List<OrderByElement> orderByElements, AnalyzeState analyzeState,
                                                 Scope orderByScope,
-                                                List<Expr> outputExpressions) {
+                                                List<Expr> outputExpressions,
+                                                boolean isDistinct) {
         if (orderByElements == null) {
             analyzeState.setOrderBy(Collections.emptyList());
             return Collections.emptyList();
@@ -327,20 +330,33 @@ public class SelectAnalyzer {
                 if (ordinal < 1 || ordinal > outputExpressions.size()) {
                     throw new SemanticException("ORDER BY position %s is not in select list", ordinal);
                 }
+                // index can ensure no ambiguous, we don't need to re-analyze this output expression
                 expression = outputExpressions.get((int) ordinal - 1);
-            }
-
-            if (expression instanceof FieldReference) {
-                // If the expression of order by is a FieldReference, it means that the type of sql is
+            } else if (expression instanceof FieldReference) {
+                // If the expression of order by is a FieldReference, and it's not a distinct select,
+                // it means that the type of sql is
                 // "select * from t order by 1", then this FieldReference cannot be parsed in OrderByScope,
                 // but should be parsed in sourceScope
-                analyzeExpression(expression, analyzeState, orderByScope.getParent());
+                if (isDistinct) {
+                    analyzeExpression(expression, analyzeState, orderByScope);
+                } else {
+                    analyzeExpression(expression, analyzeState, orderByScope.getParent());
+                }
             } else {
                 ExpressionAnalyzer expressionAnalyzer = new ExpressionAnalyzer(session);
                 expressionAnalyzer.analyzeWithoutUpdateState(expression, analyzeState, orderByScope);
                 List<Expr> aggregations = Lists.newArrayList();
                 expression.collectAll(e -> e.isAggregate(), aggregations);
-                aggregations.forEach(e -> analyzeExpression(e, analyzeState, orderByScope.getParent()));
+                if (isDistinct && !aggregations.isEmpty()) {
+                    throw new SemanticException("for SELECT DISTINCT, ORDER BY expressions must appear in select list",
+                            expression.getPos());
+                }
+
+                if (!aggregations.isEmpty()) {
+                    // use parent scope to analyze agg func firstly
+                    Preconditions.checkState(orderByScope.getParent() != null, "parent scope not be set");
+                    aggregations.forEach(e -> analyzeExpression(e, analyzeState, orderByScope.getParent()));
+                }
                 analyzeExpression(expression, analyzeState, orderByScope);
             }
 
@@ -655,23 +671,24 @@ public class SelectAnalyzer {
         }
     }
 
-    private Scope computeAndAssignOrderScope(AnalyzeState analyzeState, Scope sourceScope, Scope outputScope) {
-        // The Scope used by order by allows parsing of the same column,
-        // such as 'select v1 as v, v1 as v from t0 order by v'
-        // but normal parsing does not allow it. So add a de-duplication operation here.
+    private Scope computeAndAssignOrderScope(AnalyzeState analyzeState, Scope sourceScope, Scope outputScope,
+                                             boolean isDistinct) {
 
-        List<Field> allFields = new ArrayList<>();
+        List<Field> allFields = Lists.newArrayList();
+        // order by can only "see" fields from distinct output
+        if (isDistinct) {
+            allFields = removeDuplicateField(outputScope.getRelationFields().getAllFields());
+            Scope orderScope = new Scope(outputScope.getRelationId(), new RelationFields(allFields));
+            analyzeState.setOrderScope(orderScope);
+            return orderScope;
+        }
+
         for (int i = 0; i < analyzeState.getOutputExprInOrderByScope().size(); ++i) {
             Field field = outputScope.getRelationFields()
                     .getFieldByIndex(analyzeState.getOutputExprInOrderByScope().get(i));
-            if (field.getName() != null && field.getOriginExpression() != null &&
-                    allFields.stream().anyMatch(f -> f.getOriginExpression() != null
-                            && f.getName() != null && field.getName().equals(f.getName())
-                            && field.getOriginExpression().equals(f.getOriginExpression()))) {
-                continue;
-            }
             allFields.add(field);
         }
+        allFields = removeDuplicateField(allFields);
 
         Scope orderScope = new Scope(outputScope.getRelationId(), new RelationFields(allFields));
 
@@ -687,5 +704,30 @@ public class SelectAnalyzer {
 
     private void analyzeExpression(Expr expr, AnalyzeState analyzeState, Scope scope) {
         ExpressionAnalyzer.analyzeExpression(expr, analyzeState, scope, session);
+    }
+
+
+    // The Scope used by order by allows parsing of the same column,
+    // such as 'select v1 as v, v1 as v from t0 order by v'
+    // but normal parsing does not allow it. So add a de-duplication operation here.
+    private List<Field> removeDuplicateField(List<Field> originalFields) {
+        List<Field> allFields = Lists.newArrayList();
+        for (Field field : originalFields) {
+            if (session.getSessionVariable().isEnableStrictOrderBy()) {
+                if (field.getName() != null && field.getOriginExpression() != null &&
+                        allFields.stream().anyMatch(f -> f.getOriginExpression() != null
+                                && f.getName() != null && field.getName().equals(f.getName())
+                                && field.getOriginExpression().equals(f.getOriginExpression()))) {
+                    continue;
+                }
+            } else {
+                if (field.getName() != null &&
+                        allFields.stream().anyMatch(f -> f.getName() != null && field.getName().equals(f.getName()))) {
+                    continue;
+                }
+            }
+            allFields.add(field);
+        }
+        return allFields;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/FieldReference.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/FieldReference.java
@@ -48,6 +48,10 @@ public class FieldReference extends Expr {
         return fieldIndex;
     }
 
+    public TableName getTblName() {
+        return tblName;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -131,9 +131,11 @@ public class AnalyzeAggregateTest {
         analyzeSuccess("select distinct v1, v2 as v from t0 order by v");
         analyzeSuccess("select distinct abs(v1) as v from t0 order by v");
         analyzeFail("select distinct v1 from t0 order by v2",
-                "must be an aggregate expression or appear in GROUP BY clause");
+                "Column 'v2' cannot be resolved");
         analyzeFail("select distinct v1 as v from t0 order by v2",
-                "must be an aggregate expression or appear in GROUP BY clause");
+                "Column 'v2' cannot be resolved");
+        analyzeFail("select * from t0 order by max(v2)",
+                "column must appear in the GROUP BY clause or be used in an aggregate function.");
 
         analyzeSuccess("select distinct v1 as v from t0 having v = 1");
         analyzeFail("select distinct v1 as v from t0 having v2 = 2",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/parser/ParserTest.java
@@ -403,7 +403,7 @@ class ParserTest {
         assertContains(res, "{'pipeline_dop', 'pipeline_sink_dop', 'pipeline_profile_level'}");
 
         res = VariableMgr.findSimilarVarNames("disable_joinreorder");
-        assertContains(res, "{'disable_join_reorder', 'disable_colocate_join', 'enable_predicate_reorder'}");
+        assertContains(res, "{'disable_join_reorder', 'disable_colocate_join'");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -649,6 +649,8 @@ class OrderByTest extends PlanTestBase {
         list.add(Arguments.of("select distinct * from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select * from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select t0.* from t0 order by t0.v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct t0.* from t0 order by t0.v1", "order by: <slot 1> 1: v1 ASC"));
+
 
         list.add(Arguments.of("select *, v1 from t0  order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select *, v1 from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -648,6 +648,8 @@ class OrderByTest extends PlanTestBase {
         list.add(Arguments.of("select abs(v1) v1, * from t0  order by 1", "order by: <slot 4> 4: abs ASC"));
         list.add(Arguments.of("select distinct * from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select * from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select t0.* from t0 order by t0.v1", "order by: <slot 1> 1: v1 ASC"));
+
         list.add(Arguments.of("select *, v1 from t0  order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select *, v1 from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));
         list.add(Arguments.of("select v1, * from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -616,6 +616,25 @@ class OrderByTest extends PlanTestBase {
                 "  |  - filter_id = 0, build_expr = (<slot 1> 1: t1a), remote = false");
     }
 
+    @Test
+    public void testTopNRuntimeFilterWithFilter() throws Exception {
+        String sql = "select * from t0 where v1 > 1 order by v1 limit 10";
+        String plan = getVerboseExplain(sql);
+
+        assertContains(plan, "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (<slot 1> 1: v1)");
+
+        String sql1 = "select * from t0 where v1 is not null order by v1 limit 10";
+        String plan1 = getVerboseExplain(sql1);
+
+        assertContains(plan1, "     probe runtime filters:\n" +
+                "     - filter_id = 0, probe_expr = (<slot 1> 1: v1)");
+
+        String sql2 = "select * from t0 where v1 is null order by v1 limit 10";
+        String plan2 = getVerboseExplain(sql2);
+        assertNotContains(plan2, " runtime filters");
+    }
+
     @ParameterizedTest
     @MethodSource("failToStrictSql")
     void testFailToStrictOrderByExpression(String sql) {

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -12,16 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+
 package com.starrocks.sql.plan;
 
+import com.google.common.collect.Lists;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.sql.analyzer.SemanticException;
 import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
-public class OrderByTest extends PlanTestBase {
+import java.util.List;
+import java.util.stream.Stream;
+
+class OrderByTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+    }
 
     @Test
-    public void testExistOrderBy() throws Exception {
+    void testExistOrderBy() throws Exception {
         String sql = "SELECT * \n" +
                 "FROM   emp \n" +
                 "WHERE  EXISTS (SELECT dept.dept_id \n" +
@@ -34,7 +49,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testSort() throws Exception {
+    void testSort() throws Exception {
         String sql = "select count(*) from (select L_QUANTITY, L_PARTKEY, L_ORDERKEY from lineitem " +
                 "order by L_QUANTITY, L_PARTKEY, L_ORDERKEY limit 5000, 10000) as a;";
         String plan = getFragmentPlan(sql);
@@ -42,7 +57,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testPruneSortColumns() throws Exception {
+    void testPruneSortColumns() throws Exception {
         String sql = "select count(v1) from (select v1 from t0 order by v2 limit 10) t";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("  3:Project\n" +
@@ -50,7 +65,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testSortProject() throws Exception {
+    void testSortProject() throws Exception {
         String sql = "select avg(null) over (order by ref_0.v1) as c2 "
                 + "from t0 as ref_0 left join t1 as ref_1 on (ref_0.v1 = ref_1.v4 );";
         String plan = getThriftPlan(sql);
@@ -62,7 +77,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testTopNOffsetError() throws Exception {
+    void testTopNOffsetError() throws Exception {
         long limit = connectContext.getSessionVariable().getSqlSelectLimit();
         connectContext.getSessionVariable().setSqlSelectLimit(200);
         String sql = "select * from (select * from t0 order by v1 limit 5) as a left join t1 on a.v1 = t1.v4";
@@ -75,7 +90,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testOrderBySameColumnDiffOrder() throws Exception {
+    void testOrderBySameColumnDiffOrder() throws Exception {
         String sql = "select v1 from t0 order by v1 desc, v1 asc";
         String plan = getFragmentPlan(sql);
         Assert.assertTrue(plan.contains("1:SORT\n" +
@@ -83,14 +98,14 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testUnionOrderByDuplicateColumn() throws Exception {
+    void testUnionOrderByDuplicateColumn() throws Exception {
         String sql = "select * from t0 union all select * from t1 order by v1, v2, v1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 7> 7: v1 ASC, <slot 8> 8: v2 ASC");
     }
 
     @Test
-    public void testSqlSelectLimit() throws Exception {
+    void testSqlSelectLimit() throws Exception {
         connectContext.getSessionVariable().setSqlSelectLimit(200);
         // test order by with project
         String sql;
@@ -113,7 +128,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testOrderByWithSubquery() throws Exception {
+    void testOrderByWithSubquery() throws Exception {
         String sql = "select t0.*, " +
                 "(select sum(v5) from t1) as x1, " +
                 "(select sum(v7) from t2) as x2 from t0 order by t0.v3";
@@ -133,7 +148,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void tstOrderByNullLiteral() throws Exception {
+    void tstOrderByNullLiteral() throws Exception {
         String sql;
         String plan;
 
@@ -171,7 +186,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testOrderByGroupByWithSubquery() throws Exception {
+    void testOrderByGroupByWithSubquery() throws Exception {
         String sql = "select t0.v2, sum(v3) as x3, " +
                 "(select sum(v5) from t1) as x1, " +
                 "(select sum(v7) from t2) as x2 from t0 group by v2 order by x3";
@@ -190,7 +205,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testOrderByTransform() throws Exception {
+    void testOrderByTransform() throws Exception {
         String sql = "select v1, * from test.t0 order by v2";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 2> 2: v2 ASC");
@@ -256,6 +271,7 @@ public class OrderByTest extends PlanTestBase {
                 "  |  output: sum(1: v1)\n" +
                 "  |  group by: 2: v2, 3: v3");
 
+
         sql = "select abs(t0.v1), abs(t1.v1) from t0, t0_not_null t1 order by t1.v2";
         plan = getFragmentPlan(sql);
         assertContains(plan, "5:SORT\n" +
@@ -280,14 +296,14 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testUDTFWithOrderBy() throws Exception {
+    void testUDTFWithOrderBy() throws Exception {
         String sql = "select t.* from t0, unnest([1,2,3]) as t order by `unnest`";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 4> 4: unnest ASC");
     }
 
     @Test
-    public void testOrderByWithSameColumnName() throws Exception {
+    void testOrderByWithSameColumnName() throws Exception {
         String sql = "select t0_not_null.*, t0.* from t0, t0_not_null order by t0_not_null.v1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 4> 4: v1 ASC");
@@ -310,7 +326,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testOrderByWithFieldReference() throws Exception {
+    void testOrderByWithFieldReference() throws Exception {
         String sql = "select * from t0 order by 1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 1> 1: v1 ASC");
@@ -357,7 +373,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testOrderByWithWindow() throws Exception {
+    void testOrderByWithWindow() throws Exception {
         String sql = "select sum(v1) over(partition by v1 + 1) from t0 order by v1";
         String plan = getFragmentPlan(sql);
         assertContains(plan, "order by: <slot 4> 4: v1 ASC");
@@ -385,8 +401,7 @@ public class OrderByTest extends PlanTestBase {
                 "  |  functions: [, sum(4: v1), ]\n" +
                 "  |  partition by: 7: expr");
 
-        sql =
-                "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by avg(v1) over(partition by v1 + 1)";
+        sql = "select v1, v2, sum(v1) over(partition by v1 + 1) as v from t0 order by avg(v1) over(partition by v1 + 1)";
         plan = getFragmentPlan(sql);
         assertContains(plan, "5:SORT\n" +
                 "  |  order by: <slot 9> 9: avg(4: v1) ASC\n" +
@@ -495,7 +510,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testTopNFilter() throws Exception {
+    void testTopNFilter() throws Exception {
         String sql = "select * from test_all_type_not_null order by t1a limit 10";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "  1:TOP-N\n" +
@@ -542,7 +557,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testGroupByOrderBy() throws Exception {
+    void testGroupByOrderBy() throws Exception {
         String sql = "select v2,v3,v2 from t0 group by 1,2,3 order by 1,2,3";
         String plan = getFragmentPlan(sql);
 
@@ -551,7 +566,7 @@ public class OrderByTest extends PlanTestBase {
     }
 
     @Test
-    public void testTopNFilterWithProject() throws Exception {
+    void testTopNFilterWithProject() throws Exception {
         String sql;
         String plan;
 
@@ -601,22 +616,61 @@ public class OrderByTest extends PlanTestBase {
                 "  |  - filter_id = 0, build_expr = (<slot 1> 1: t1a), remote = false");
     }
 
-    @Test
-    public void testTopNRuntimeFilterWithFilter() throws Exception {
-        String sql = "select * from t0 where v1 > 1 order by v1 limit 10";
-        String plan = getVerboseExplain(sql);
+    @ParameterizedTest
+    @MethodSource("failToStrictSql")
+    void testFailToStrictOrderByExpression(String sql) {
+        Assert.assertThrows(SemanticException.class, () -> getFragmentPlan(sql));
+    }
 
-        assertContains(plan, "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (<slot 1> 1: v1)");
+    @ParameterizedTest
+    @MethodSource("successToStrictSql")
+    void testSuccessToStrictOrderByExpression(String sql, String expectedPlan) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, expectedPlan);
+    }
 
-        String sql1 = "select * from t0 where v1 is not null order by v1 limit 10";
-        String plan1 = getVerboseExplain(sql1);
+    @ParameterizedTest
+    @MethodSource("allOrderBySql")
+    void testNotStrictOrderByExpression(String sql, String expectedPlan) throws Exception {
+        String hint = "select /*+ set_var(enable_strict_order_by = false) */ ";
+        sql = hint + sql.substring(7);
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, expectedPlan);
+    }
 
-        assertContains(plan1, "     probe runtime filters:\n" +
-                "     - filter_id = 0, probe_expr = (<slot 1> 1: v1)");
+    private static Stream<Arguments> allOrderBySql() {
+        return Stream.concat(successToStrictSql(), failToStrictSql());
+    }
 
-        String sql2 = "select * from t0 where v1 is null order by v1 limit 10";
-        String plan2 = getVerboseExplain(sql2);
-        assertNotContains(plan2, " runtime filters");
+    private static Stream<Arguments> successToStrictSql() {
+        List<Arguments> list = Lists.newArrayList();
+        list.add(Arguments.of("select * from t0 order by 1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select abs(v1) v1, * from t0  order by 1", "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select distinct * from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select * from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select *, v1 from t0  order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select *, v1 from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select v1, * from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select distinct * from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct *, v1 from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));
+        return list.stream();
+    }
+
+    private static Stream<Arguments> failToStrictSql() {
+        List<Arguments> list = Lists.newArrayList();
+        list.add(Arguments.of("select *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct *, v1, abs(v1) v1 from t0  order by 1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct abs(v1) v1, * from t0  order by 1", "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select distinct *, v1, abs(v1) v1 from t0  order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select v1, max(v2) v1 from t0 group by v1  order by abs(v1)", "order by: <slot 5> 5: abs ASC"));
+        list.add(Arguments.of("select max(v2) v1, v1 from t0 group by v1  order by abs(v1)", "order by: <slot 5> 5: abs ASC"));
+        list.add(Arguments.of("select v2, max(v2) v2 from t0 group by v2  order by max(v2)", "order by: <slot 4> 4: max ASC"));
+        list.add(Arguments.of("select max(v2) v2, v2 from t0 group by v2  order by max(v2)", "order by: <slot 4> 4: max ASC"));
+        list.add(Arguments.of("select upper(v1) v1, *, v1 from t0 order by v1", "order by: <slot 4> 4: upper ASC"));
+        list.add(Arguments.of("select *, v1, upper(v1) v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct upper(v1) v1, *, v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct *, v1, upper(v1) v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+
+        return list.stream();
     }
 }


### PR DESCRIPTION
Why I'm doing:
Fail to execute `select distinct * from tbl order by col`.
**Root Casue:**
The scope for order by is like `scope([], parentScope(tbl.col1, tbl.col2, ...)), so the analyze result of col is a field from parent scope filed. When check whether the col is a valid expr for aggregation expr, the col should be in the original order by scope instead of its parent scope. If not, error happens.
Actually, the scope for order should be the output of the distinct and cannot 'see' its parent scope.

What I'm doing:
- combine output scope and parent scope when distinct and set partent scope to null.
- add a `enable_strict_order_by` session variable default value is true to keep same behavior in 2.3 version.
- add a more loose de-duplicate operatiton (only save the first unique col name field) when `set enable_strict_order_by = false` to execute sql like `select distinct *, abs(v1) v1 from tbl order by v1` which is a valid sql in MySQL.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
