### PR TITLE
[Enhancement] add connnector_sink_compression_codec to control file compression scheme

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/OutFileClause.java
@@ -79,6 +79,7 @@ public class OutFileClause implements ParseNode {
         PARQUET_COMPRESSION_TYPE_MAP.put("lz4", TCompressionType.LZ4);
         PARQUET_COMPRESSION_TYPE_MAP.put("zlib", TCompressionType.ZLIB);
         PARQUET_COMPRESSION_TYPE_MAP.put("uncompressed", TCompressionType.NO_COMPRESSION);
+        PARQUET_COMPRESSION_TYPE_MAP.put("none", TCompressionType.NO_COMPRESSION);
     }
 
     public static final Set<PrimitiveType> PARQUET_SUPPORTED_PRIMITIVE_TYPES = ImmutableSet.of(

--- a/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/IcebergTableSink.java
@@ -23,7 +23,9 @@ import com.starrocks.connector.iceberg.rest.IcebergRESTCatalog;
 import com.starrocks.credential.CloudConfiguration;
 import com.starrocks.credential.CloudConfigurationFactory;
 import com.starrocks.credential.CloudType;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.thrift.TCloudConfiguration;
 import com.starrocks.thrift.TCompressionType;
 import com.starrocks.thrift.TDataSink;
@@ -54,7 +56,7 @@ public class IcebergTableSink extends DataSink {
     private final String tableIdentifier;
     private final CloudConfiguration cloudConfiguration;
 
-    public IcebergTableSink(IcebergTable icebergTable, TupleDescriptor desc, boolean isStaticPartitionSink) {
+    public IcebergTableSink(IcebergTable icebergTable, TupleDescriptor desc, boolean isStaticPartitionSink, SessionVariable sessionVariable) {
         Table nativeTable = icebergTable.getNativeTable();
         this.desc = desc;
         this.location = nativeTable.location();
@@ -63,17 +65,10 @@ public class IcebergTableSink extends DataSink {
         this.isStaticPartitionSink = isStaticPartitionSink;
         this.fileFormat = nativeTable.properties().getOrDefault(DEFAULT_FILE_FORMAT, DEFAULT_FILE_FORMAT_DEFAULT)
                 .toLowerCase();
-        switch (fileFormat) {
-            case "parquet":
-                compressionType = nativeTable.properties().getOrDefault(PARQUET_COMPRESSION, PARQUET_COMPRESSION_DEFAULT)
-                        .toLowerCase(Locale.ROOT);
-                break;
-            case "orc":
-                compressionType = nativeTable.properties().getOrDefault(ORC_COMPRESSION, ORC_COMPRESSION_DEFAULT)
-                        .toLowerCase(Locale.ROOT);
-                break;
-            default:
-                compressionType = "default";
+        this.compressionType = sessionVariable.getConnectorSinkCompressionCodec();
+        if (!PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionType)) {
+            throw new SemanticException("compression type " + compressionType + " is not supported. " +
+                    "Use any of (uncompressed, gzip, brotli, zstd, lz4).");
         }
         String catalogName = icebergTable.getCatalogName();
         CatalogConnector connector = GlobalStateMgr.getCurrentState().getConnectorMgr().getConnector(catalogName);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -408,6 +408,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String CONNECTOR_IO_TASKS_SLOW_IO_LATENCY_MS = "connector_io_tasks_slow_io_latency_ms";
     public static final String SCAN_USE_QUERY_MEM_RATIO = "scan_use_query_mem_ratio";
     public static final String CONNECTOR_SCAN_USE_QUERY_MEM_RATIO = "connector_scan_use_query_mem_ratio";
+    public static final String CONNECTOR_SINK_COMPRESSION_CODEC = "connector_sink_compression_codec";
     public static final String ENABLE_QUERY_CACHE = "enable_query_cache";
     public static final String QUERY_CACHE_FORCE_POPULATE = "query_cache_force_populate";
     public static final String QUERY_CACHE_ENTRY_MAX_BYTES = "query_cache_entry_max_bytes";
@@ -1294,6 +1295,13 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VariableMgr.VarAttr(name = CONNECTOR_SCAN_USE_QUERY_MEM_RATIO)
     private double connectorScanUseQueryMemRatio = 0.3;
+
+    @VariableMgr.VarAttr(name = CONNECTOR_SINK_COMPRESSION_CODEC)
+    private String connectorSinkCompressionCodec = "uncompressed";
+
+    public String getConnectorSinkCompressionCodec() {
+        return connectorSinkCompressionCodec;
+    }
 
     @VariableMgr.VarAttr(name = ENABLE_FILE_METACACHE)
     private boolean enableFileMetaCache = true;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/InsertPlanner.java
@@ -285,7 +285,7 @@ public class InsertPlanner {
             } else if (targetTable instanceof IcebergTable) {
                 descriptorTable.addReferencedTable(targetTable);
                 dataSink = new IcebergTableSink((IcebergTable) targetTable, tupleDesc,
-                        isKeyPartitionStaticInsert(insertStmt, queryRelation));
+                        isKeyPartitionStaticInsert(insertStmt, queryRelation), session.getSessionVariable());
             } else if (targetTable instanceof HiveTable) {
                 dataSink = new HiveTableSink((HiveTable) targetTable, tupleDesc,
                         isKeyPartitionStaticInsert(insertStmt, queryRelation), session.getSessionVariable());

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -308,7 +308,7 @@ public class InsertAnalyzer {
 
     private static Table getTargetTable(InsertStmt insertStmt, ConnectContext session) {
         if (insertStmt.useTableFunctionAsTargetTable()) {
-            return insertStmt.makeTableFunctionTable();
+            return insertStmt.makeTableFunctionTable(session.getSessionVariable());
         } else if (insertStmt.useBlackHoleTableAsTargetTable()) {
             return insertStmt.makeBlackHoleTable();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ast/InsertStmt.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.catalog.Type;
+import com.starrocks.qe.SessionVariable;
 import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.parser.NodePosition;
@@ -308,7 +309,7 @@ public class InsertStmt extends DmlStmt {
         return new BlackHoleTable(collectSelectedFieldsFromQueryStatement());
     }
 
-    public Table makeTableFunctionTable() {
+    public Table makeTableFunctionTable(SessionVariable sessionVariable) {
         checkState(tableFunctionAsTargetTable, "tableFunctionAsTargetTable is false");
         List<Column> columns = collectSelectedFieldsFromQueryStatement();
         List<String> columnNames = columns.stream()
@@ -351,10 +352,9 @@ public class InsertStmt extends DmlStmt {
             throw new SemanticException("use \"path\" = \"parquet\", as only parquet format is supported now");
         }
 
+        // if compression codec is not specified, use compression codec from session
         if (compressionType == null) {
-            throw new SemanticException("compression is a mandatory property. " +
-                    "Use \"compression\" = \"your_chosen_compression_type\". Supported compression types are" +
-                    "(uncompressed, gzip, brotli, zstd, lz4).");
+            compressionType = sessionVariable.getConnectorSinkCompressionCodec();
         }
 
         if (!PARQUET_COMPRESSION_TYPE_MAP.containsKey(compressionType)) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/HiveTableSinkTest.java
@@ -111,7 +111,7 @@ public class HiveTableSinkTest {
         Assert.assertEquals("parquet", tHiveTableSink.getFile_format());
         Assert.assertEquals("c1", tHiveTableSink.getData_column_names().get(0));
         Assert.assertEquals("p1", tHiveTableSink.getPartition_column_names().get(0));
-        Assert.assertEquals(TCompressionType.GZIP, tHiveTableSink.getCompression_type());
+        Assert.assertEquals(TCompressionType.NO_COMPRESSION, tHiveTableSink.getCompression_type());
         Assert.assertTrue(tHiveTableSink.is_static_partition_sink);
         Assert.assertEquals(TCloudType.DEFAULT, tHiveTableSink.getCloud_configuration().cloud_type);
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -271,6 +271,11 @@ public class AnalyzeInsertTest {
                 "\t\"compression\" = \"uncompressed\" ) \n" +
                 "select \"abc\" as k1");
 
+        analyzeSuccess("insert into files ( \n" +
+                "\t\"path\" = \"s3://path/to/directory/\", \n" +
+                "\t\"format\"=\"parquet\" ) \n" +
+                "select \"abc\" as k1");
+
         analyzeFail("insert into files ( \n" +
                 "\t\"format\"=\"parquet\", \n" +
                 "\t\"compression\" = \"uncompressed\" ) \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -293,14 +293,6 @@ public class AnalyzeInsertTest {
 
         analyzeFail("insert into files ( \n" +
                         "\t\"path\" = \"s3://path/to/directory/\", \n" +
-                        "\t\"format\"=\"parquet\" ) \n" +
-                        "select \"abc\" as k1",
-                "compression is a mandatory property. " +
-                "Use \"compression\" = \"your_chosen_compression_type\". Supported compression types are" +
-                "(uncompressed, gzip, brotli, zstd, lz4).");
-
-        analyzeFail("insert into files ( \n" +
-                        "\t\"path\" = \"s3://path/to/directory/\", \n" +
                         "\t\"format\"=\"parquet\", \n" +
                         "\t\"compression\" = \"unknown\" ) \n" +
                         "select \"abc\" as k1",


### PR DESCRIPTION
Why I'm doing:

Give user the ability to change compression codec. 

What I'm doing:

add connnector_sink_compression_codec to control file compression scheme. 

Affecting hive/iceberg/files sink.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
