### PR TITLE
[BugFix] fix view with window function ignore null

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/FunctionCallExpr.java
@@ -57,6 +57,8 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import static com.starrocks.catalog.FunctionSet.IGNORE_NULL_WINDOW_FUNCTION;
+
 public class FunctionCallExpr extends Expr {
     private FunctionName fnName;
     // private BuiltinAggregateFunction.Operator aggOp;
@@ -359,10 +361,7 @@ public class FunctionCallExpr extends Expr {
         }
 
         // For BE code simply, handle the following window functions with nullable
-        if (fnName.getFunction().equalsIgnoreCase(FunctionSet.LEAD) ||
-                fnName.getFunction().equalsIgnoreCase(FunctionSet.LAG) ||
-                fnName.getFunction().equalsIgnoreCase(FunctionSet.FIRST_VALUE) ||
-                fnName.getFunction().equalsIgnoreCase(FunctionSet.LAST_VALUE)) {
+        if (IGNORE_NULL_WINDOW_FUNCTION.contains(fnName)) {
             return true;
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -661,6 +661,14 @@ public class FunctionSet {
             .add(FunctionSet.CORR)
             .build();
 
+    public static final Set<String> IGNORE_NULL_WINDOW_FUNCTION =
+            ImmutableSet.<String>builder().add(FunctionSet.FIRST_VALUE)
+                    .add(FunctionSet.LAST_VALUE)
+                    .add(FunctionSet.FIRST_VALUE_REWRITE)
+                    .add(FunctionSet.LEAD)
+                    .add(FunctionSet.LAG)
+                    .build();
+
     public static final List<String> ARRAY_DECIMAL_FUNCTIONS = ImmutableList.<String>builder()
             .add(ARRAY_SUM)
             .add(ARRAY_AVG)

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -112,6 +112,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.starrocks.catalog.FunctionSet.IGNORE_NULL_WINDOW_FUNCTION;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -136,7 +137,6 @@ public class AstToStringBuilder {
         // when you just want to a function name as its alias set it false
         protected boolean addFunctionDbName;
 
-
         public AST2StringBuilderVisitor() {
             this(true);
         }
@@ -144,7 +144,6 @@ public class AstToStringBuilder {
         public AST2StringBuilderVisitor(boolean addFunctionDbName) {
             this.addFunctionDbName = addFunctionDbName;
         }
-
 
         // ------------------------------------------- Privilege Statement -------------------------------------------------
 
@@ -958,6 +957,15 @@ public class AstToStringBuilder {
                     sb.append(visit(node.getChild(end)));
                 }
                 sb.append(")");
+            } else if (IGNORE_NULL_WINDOW_FUNCTION.contains(functionName)) {
+                List<String> p = node.getChildren().stream().map(child -> {
+                    String str = visit(child);
+                    if (child instanceof SlotRef && node.getIgnoreNulls()) {
+                        str += " ignore nulls";
+                    }
+                    return str;
+                }).collect(Collectors.toList());
+                sb.append(Joiner.on(", ").join(p)).append(")");
             } else {
                 List<String> p = node.getChildren().stream().map(this::visit).collect(Collectors.toList());
                 sb.append(Joiner.on(", ").join(p)).append(")");


### PR DESCRIPTION
Why I'm doing:
when create view with window function using ignore null like below:
"create view xxx as  select last_value(col ignore nulls) from table"
ignore null is not kept in view's inlineViewDef. So select * from view will not ignore null

This problem is introduced by https://github.com/StarRocks/starrocks/pull/15437

What I'm doing:
keep "ignore nulls" in view's inlineViewDef, so select from view can handle ignore null

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
