### PR TITLE
[BugFix] disable bottom outer join projection contains  not always null function

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinLeftAsscomRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/JoinLeftAsscomRule.java
@@ -84,7 +84,7 @@ public class JoinLeftAsscomRule extends JoinAssociateBaseRule {
             return false;
         }
 
-        return JoinReorderHelper.isLeftAsscom(input.inputAt(0), input);
+        return JoinReorderHelper.isLeftAsscom(input.inputAt(0), input, isInnerMode);
     }
 
     @Override

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1567,7 +1567,12 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
         String sql = "select * from (select c.*, ifnull(p_name, 0) from customer c left join part n on C_ADDRESS = P_NAME) " +
                 "t join nation on C_CUSTKEY = n_nationkey;";
         String plan = getFragmentPlan(sql);
-        System.out.println(plan);
+        assertContains(plan, "|  <slot 20> : ifnull(11: P_NAME, '0')\n" +
+                "  |  \n" +
+                "  4:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (PARTITIONED)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 3: C_ADDRESS = 11: P_NAME");
 
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1561,4 +1561,13 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "4: v4 + 6: v6 >= CAST('test_min_v2' AS BIGINT)\n" +
                 "     partitions=1/1");
     }
+
+    @Test
+    public void testNotAlwaysNullProjection() throws Exception {
+        String sql = "select * from (select c.*, ifnull(p_name, 0) from customer c left join part n on C_ADDRESS = P_NAME) " +
+                "t join nation on C_CUSTKEY = n_nationkey;";
+        String plan = getFragmentPlan(sql);
+        System.out.println(plan);
+
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OuterJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OuterJoinReorderTest.java
@@ -141,7 +141,16 @@ public class OuterJoinReorderTest extends PlanTestBase {
                 "  |----13:EXCHANGE");
         sqlList.add("select * from (select t0.*, concat(abs(abs(v7)), ifnull(v8, 1), null) from colocate_t0 t0 left join" +
                 " t2 on v2 = v7) t left join colocate_t1 on v1 = v4");
-        planList.add("xxx");
+        planList.add("4:Project\n" +
+                "  |  <slot 1> : 1: v1\n" +
+                "  |  <slot 2> : 2: v2\n" +
+                "  |  <slot 3> : 3: v3\n" +
+                "  |  <slot 7> : concat(CAST(abs(abs(4: v7)) AS VARCHAR), CAST(ifnull(5: v8, 1) AS VARCHAR), NULL)\n" +
+                "  |  \n" +
+                "  3:HASH JOIN\n" +
+                "  |  join op: LEFT OUTER JOIN (BROADCAST)\n" +
+                "  |  colocate: false, reason: \n" +
+                "  |  equal join conjunct: 2: v2 = 4: v7");
         List<Arguments> zips = zipSqlAndPlan(sqlList, planList);
         return zips.stream();
     }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OuterJoinReorderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OuterJoinReorderTest.java
@@ -16,7 +16,6 @@ package com.starrocks.sql.plan;
 
 import com.google.common.collect.Lists;
 import com.starrocks.common.FeConstants;
-import com.starrocks.common.Pair;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -37,9 +36,9 @@ public class OuterJoinReorderTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("joinAssocRuleSqls")
-    void joinAssociativityRuleSql(Pair<String, String> pair) throws Exception {
-        String plan = getFragmentPlan(pair.first);
-        assertContains(plan, pair.second);
+    void joinAssociativityRuleSql(String sql, String expectedPlan) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, expectedPlan);
     }
 
 
@@ -140,7 +139,10 @@ public class OuterJoinReorderTest extends PlanTestBase {
                 "  |  other predicates: 8: v8 <=> 2: v2\n" +
                 "  |  \n" +
                 "  |----13:EXCHANGE");
-        List<Pair<String, String>> zips = zipSqlAndPlan(sqlList, planList);
-        return zips.stream().map(e -> Arguments.of(e));
+        sqlList.add("select * from (select t0.*, concat(abs(abs(v7)), ifnull(v8, 1), null) from colocate_t0 t0 left join" +
+                " t2 on v2 = v7) t left join colocate_t1 on v1 = v4");
+        planList.add("xxx");
+        List<Arguments> zips = zipSqlAndPlan(sqlList, planList);
+        return zips.stream();
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestNoneDBBase.java
@@ -47,6 +47,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Rule;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.rules.ErrorCollector;
 import org.junit.rules.ExpectedException;
 
@@ -734,13 +735,13 @@ public class PlanTestNoneDBBase {
         return (OlapTable) getTable(t);
     }
 
-    public static List<Pair<String, String>> zipSqlAndPlan(List<String> sqls, List<String> plans) {
+    public static List<Arguments> zipSqlAndPlan(List<String> sqls, List<String> plans) {
         Preconditions.checkState(sqls.size() == plans.size(), "sqls and plans should have same size");
-        List<Pair<String, String>> zips = Lists.newArrayList();
+        List<Arguments> arguments = Lists.newArrayList();
         for (int i = 0; i < sqls.size(); i++) {
-            zips.add(Pair.create(sqls.get(i), plans.get(i)));
+            arguments.add(Arguments.of(sqls.get(i), plans.get(i)));
         }
-        return zips;
+        return arguments;
     }
 
     protected static void createTables(String dirName, List<String> fileNames) {


### PR DESCRIPTION
Why I'm doing:
The outer join reorder rule reorder sql like `select * from (select c.*, ifnull(n_name, 0) from customer c left join nation n on c_nationkey = n_nationkey) t left join part on c_custkey = p_partkey;` and push `ifnull(n_name, 0)` to table nation.
`
Function like `ifnull` not always return null when its args is 

What I'm doing:
Function like `ifnull` not always return null when its args are null values. If we want to correctly process this scene we need pull up this projection to the top join and rewrite the scalarOperator may ref its output in the bottom join. 
We temporarily disable reorder this scene.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
