### PR TITLE
[Feature]List partition supports Datacache.partition_duration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -104,6 +104,7 @@ import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TWriteQuorumType;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections4.ListUtils;
 import org.apache.hadoop.util.ThreadUtil;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -3036,7 +3037,11 @@ public class OlapTable extends Table {
         }
 
         PeriodDuration cacheDuration = tableProperty.getDataCachePartitionDuration();
-        if (cacheDuration != null && getPartitionInfo().isRangePartition()) {
+        if (cacheDuration == null) {
+            return true;
+        }
+
+        if (getPartitionInfo().isRangePartition()) {
             RangePartitionInfo rangePartitionInfo = (RangePartitionInfo) getPartitionInfo();
             Range<PartitionKey> partitionRange = rangePartitionInfo.getRange(partition.getId());
             Range<PartitionKey> dataCacheRange;
@@ -3048,16 +3053,52 @@ public class OlapTable extends Table {
                     dataCacheRange = Range.openClosed(PartitionKey.ofDateTime(lower), PartitionKey.ofDateTime(upper));
                     return partitionRange.isConnected(dataCacheRange);
                 } catch (Exception e) {
-                    LOG.warn("Table name: {}, datacache.partiton_duration: {}, Failed to compare with partition range. " +
-                            "Error: {}.", super.name, cacheDuration.toString(), e.getMessage());
+                    LOG.warn("Table name: {}, Partition name: {}, Datacache.partiton_duration: {}, Failed to check the " +
+                            " validaity of range partition. Error: {}.", super.name, partition.getName(),
+                            cacheDuration.toString(), e.getMessage());
                     return false;
                 }
-            } else {
-                // If the table was not partitioned by DATE/DATETIME, ignore the property "datacache.partition_duration" and
-                // enable data cache by default.
+            }
+        } else if (getPartitionInfo().isListPartition()) {
+            ListPartitionInfo listPartitionInfo = (ListPartitionInfo) getPartitionInfo();
+            List<Column> columns = listPartitionInfo.getPartitionColumns();
+            int dateTypeColumnIdx = ListUtils.indexOf(columns, column -> column.getPrimitiveType().isDateType());
+
+            if (dateTypeColumnIdx == -1) {
+                // List partition has no date type column.
                 return true;
             }
+
+            LocalDateTime upper = LocalDateTime.now();
+            LocalDateTime lower = upper.minus(cacheDuration);
+            List<List<String>> multiValues = listPartitionInfo.getIdToMultiValues().get(partition.getId());
+            List<String> values = listPartitionInfo.getIdToValues().get(partition.getId());
+            try {
+                if (multiValues != null) {
+                    for (List<String> multivalue : multiValues) {
+                        LocalDateTime partitionTime = DateUtils.parseDatTimeString(multivalue.get(dateTypeColumnIdx));
+                        if (lower.isBefore(partitionTime) && (partitionTime.isBefore(upper) || partitionTime.isEqual(upper))) {
+                            return true;
+                        }
+                    }
+                }
+                if (values != null) {
+                    for (String value : values) {
+                        LocalDateTime partitionTime = DateUtils.parseDatTimeString(value);
+                        if (lower.isBefore(partitionTime) && (partitionTime.isBefore(upper) || partitionTime.isEqual(upper))) {
+                            return true;
+                        }
+                    }
+                }
+                return false;
+            } catch (Exception e) {
+                LOG.warn("Table name: {}, Partition name: {}, Datacache.partiton_duration: {}, Failed to check the " +
+                        "validaity of list partition. Error: {}.", super.name, partition.getName(),
+                        cacheDuration.toString(), e.getMessage());
+                return false;
+            }
         }
+
         return true;
     }
     // ------ for lake table and lake materialized view end ------

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -113,6 +113,10 @@ public class PartitionInfo implements Cloneable, Writable, GsonPreProcessable, G
         return type == PartitionType.RANGE || type == PartitionType.EXPR_RANGE || type == PartitionType.EXPR_RANGE_V2;
     }
 
+    public boolean isListPartition() {
+        return type == PartitionType.LIST;
+    }
+
     public boolean isPartitioned() {
         return type != PartitionType.UNPARTITIONED;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -46,6 +46,7 @@ import com.starrocks.catalog.TableProperty;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.io.FastByteArrayOutputStream;
+import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.common.util.UnitTestUtil;
 import com.starrocks.server.GlobalStateMgr;
@@ -59,7 +60,9 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -234,5 +237,183 @@ public class OlapTableTest {
         olapTable.setTableProperty(new TableProperty(new HashMap<>()));
         Assert.assertNull(olapTable.getTableProperty() == null ? null :
                 olapTable.getTableProperty().getDataCachePartitionDuration());
+    }
+
+    @Test
+    public void testListPartitionSupportPeriodDurationTestDateColumn() throws AnalysisException {
+        Column k1 = new Column("k1", new ScalarType(PrimitiveType.VARCHAR), true, null, "", "");
+        Column k2 = new Column("k2", new ScalarType(PrimitiveType.DATE), true, null, "", "");
+        Column k3 = new Column("k3", new ScalarType(PrimitiveType.DATETIME), true, null, "", "");
+        List<Column> partitionColumns = new LinkedList<Column>();
+        partitionColumns.add(k1);
+        partitionColumns.add(k2);
+        partitionColumns.add(k3);
+
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, partitionColumns);
+        List<String> multiValues1 = new ArrayList<>(Arrays.asList("abcd", "2023-01-01", "2024-01-01"));
+        List<List<String>> multiValuesList1 = new ArrayList<>(Arrays.asList(multiValues1));
+        listPartitionInfo.setMultiValues(1L, multiValuesList1);
+        OlapTable olapTable = new OlapTable(1L, "tb1", partitionColumns, null, (PartitionInfo) listPartitionInfo, null);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        Partition partition1 = new Partition(1L, "p1", null, null);
+
+        // Datacache.partition_duration is not set, cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition1));
+
+        // cache is invalid, because we only take k2 into consideration
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("25 hour"));
+        Assert.assertFalse(olapTable.isEnableFillDataCache(partition1));
+
+        List<String> multiValues2 = new ArrayList<>(Arrays.asList("abcd", LocalDate.now().toString(), "2024-01-01"));
+        List<List<String>> multiValuesList2 = new ArrayList<>(Arrays.asList(multiValues2));
+        listPartitionInfo.setMultiValues(2L, multiValuesList2);
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("28 hour"));
+        Partition partition2 = new Partition(2L, "p2", null, null);
+
+        // cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition2));
+
+        new MockUp<DateUtils>() {
+            @Mock
+            LocalDateTime parseDatTimeString(String text) throws Exception {
+                throw new AnalysisException("Error");
+            }
+        };
+        Assert.assertFalse(olapTable.isEnableFillDataCache(partition1));
+    }
+
+    @Test
+    public void testListPartitionSupportPeriodDurationTestSingleDateColumn() throws AnalysisException {
+        Column k1 = new Column("k1", new ScalarType(PrimitiveType.DATE), true, null, "", "");
+        List<Column> partitionColumns = new LinkedList<Column>();
+        partitionColumns.add(k1);
+
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, partitionColumns);
+        List<String> multiValues1 = new ArrayList<>(Arrays.asList("2023-01-01"));
+        List<List<String>> multiValuesList1 = new ArrayList<>(Arrays.asList(multiValues1));
+        listPartitionInfo.setMultiValues(1L, multiValuesList1);
+        OlapTable olapTable = new OlapTable(1L, "tb1", partitionColumns, null, (PartitionInfo) listPartitionInfo, null);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        Partition partition1 = new Partition(1L, "p1", null, null);
+
+        // Datacache.partition_duration is not set, cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition1));
+
+        // cache is invalid
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("25 hour"));
+        Assert.assertFalse(olapTable.isEnableFillDataCache(partition1));
+
+        List<String> multiValues2 = new ArrayList<>(Arrays.asList(LocalDate.now().toString()));
+        List<List<String>> multiValuesList2 = new ArrayList<>(Arrays.asList(multiValues2));
+        listPartitionInfo.setMultiValues(2L, multiValuesList2);
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("28  hour"));
+        Partition partition2 = new Partition(2L, "p2", null, null);
+
+        // cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition2));
+
+        new MockUp<DateUtils>() {
+            @Mock
+            LocalDateTime parseDatTimeString(String text) throws Exception {
+                throw new AnalysisException("Error");
+            }
+        };
+        Assert.assertFalse(olapTable.isEnableFillDataCache(partition1));
+    }
+
+    @Test
+    public void testListPartitionSupportPeriodDurationTestIdToValues() throws AnalysisException {
+        Column k1 = new Column("k1", new ScalarType(PrimitiveType.DATE), true, null, "", "");
+        List<Column> partitionColumns = new LinkedList<Column>();
+        partitionColumns.add(k1);
+
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, partitionColumns);
+        List<String> values1 = new ArrayList<>(Arrays.asList("2023-01-01", "2023-10-01"));
+        listPartitionInfo.setValues(1L, values1);
+        OlapTable olapTable = new OlapTable(1L, "tb1", partitionColumns, null, (PartitionInfo) listPartitionInfo, null);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        Partition partition1 = new Partition(1L, "p1", null, null);
+
+        // Datacache.partition_duration is not set, cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition1));
+
+        // cache is invalid
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("25 hour"));
+        Assert.assertFalse(olapTable.isEnableFillDataCache(partition1));
+
+        List<String> values2 = new ArrayList<>(Arrays.asList(LocalDate.now().toString()));
+        listPartitionInfo.setValues(2L, values2);
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("28 hour"));
+        Partition partition2 = new Partition(2L, "p2", null, null);
+
+        // cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition2));
+
+        new MockUp<DateUtils>() {
+            @Mock
+            LocalDateTime parseDatTimeString(String text) throws Exception {
+                throw new AnalysisException("Error");
+            }
+        };
+        Assert.assertFalse(olapTable.isEnableFillDataCache(partition1));
+    }
+
+    @Test
+    public void testListPartitionSupportPeriodDurationTestDateTimeColumn() throws AnalysisException {
+        Column k1 = new Column("k1", new ScalarType(PrimitiveType.VARCHAR), true, null, "", "");
+        Column k2 = new Column("k2", new ScalarType(PrimitiveType.DATETIME), true, null, "", "");
+        Column k3 = new Column("k3", new ScalarType(PrimitiveType.DATE), true, null, "", "");
+        List<Column> partitionColumns = new LinkedList<Column>();
+        partitionColumns.add(k1);
+        partitionColumns.add(k2);
+        partitionColumns.add(k3);
+
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, partitionColumns);
+        List<String> multiValues1 = new ArrayList<>(Arrays.asList("abcd", "2023-01-01 10:00:00", "2024-01-01"));
+        List<List<String>> multiValuesList1 = new ArrayList<>(Arrays.asList(multiValues1));
+        listPartitionInfo.setMultiValues(1L, multiValuesList1);
+        OlapTable olapTable = new OlapTable(1L, "tb1", partitionColumns, null, (PartitionInfo) listPartitionInfo, null);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        Partition partition = new Partition(1L, "p1", null, null);
+
+        // Datacache.partition_duration is not set, cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition));
+
+        // cache is invalid, because we only take k2 into consideration
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("25 hour"));
+        Assert.assertFalse(olapTable.isEnableFillDataCache(partition));
+
+        List<String> multiValues2 = new ArrayList<>(Arrays.asList("abcd",
+                DateUtils.formatDateTimeUnix(LocalDateTime.now()), "2024-01-01"));
+        List<List<String>> multiValuesList2 = new ArrayList<>(Arrays.asList(multiValues2));
+        listPartitionInfo.setMultiValues(2L, multiValuesList2);
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("28 hour"));
+        Partition partition2 = new Partition(2L, "p2", null, null);
+
+        // cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition2));
+    }
+
+    @Test
+    public void testListPartitionSupportPeriodDurationTestNoneDateTypeColumn() throws AnalysisException {
+        Column k1 = new Column("k1", new ScalarType(PrimitiveType.VARCHAR), true, null, "", "");
+        Column k2 = new Column("k2", new ScalarType(PrimitiveType.INT), true, null, "", "");
+        Column k3 = new Column("k3", new ScalarType(PrimitiveType.DOUBLE), true, null, "", "");
+        List<Column> partitionColumns = new LinkedList<Column>();
+        partitionColumns.add(k1);
+        partitionColumns.add(k2);
+        partitionColumns.add(k3);
+
+        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST, partitionColumns);
+        List<String> multiValues1 = new ArrayList<>(Arrays.asList("abcd", "1", "1.1"));
+        List<List<String>> multiValuesList1 = new ArrayList<>(Arrays.asList(multiValues1));
+        listPartitionInfo.setMultiValues(1L, multiValuesList1);
+        OlapTable olapTable = new OlapTable(1L, "tb1", partitionColumns, null, (PartitionInfo) listPartitionInfo, null);
+        olapTable.setTableProperty(new TableProperty(new HashMap<>()));
+        Partition partition1 = new Partition(1L, "p1", null, null);
+        olapTable.setDataCachePartitionDuration(TimeUtils.parseHumanReadablePeriodOrDuration("25 hour"));
+
+        // cache is valid
+        Assert.assertTrue(olapTable.isEnableFillDataCache(partition1));
     }
 }


### PR DESCRIPTION
Select the first DATETIME/DATE column in the Partition column to obtain the Partition time. When the Partition column has multiple values, if any one meets the requirements of Datacache.partition_duration, Datacache will be valid.

For example:
```
CREATE TABLE list_partition_test (
       a BIGINT,
       b SMALLINT not null,
       c DATETIME not null,
       d DATE not null
)
ENGINE=olap
DUPLICATE KEY(a)
PARTITION BY LIST (b,c,d) (
      PARTITION p1 VALUES IN (("1", "2023-01-01 10:10:10", "2023-01-02"),("2", "2024-01-01 10:10:10", "2024-01-02")),
      PARTITION p2 VALUES IN (("3", "2023-02-01 10:10:10", "2023-02-02"))
)
DISTRIBUTED BY HASH(a) BUCKETS 10
PROPERTIES (
     "replication_num" = "1",
      "datacache.partition_duration" = "1 hour"
);
```

In the above table definition, c in Partition columns is the first DATETIME/DATE column, so the Partition time will be obtained from the definition of column c. In the p1 partition, since there are multiple values of column c: "2023-01-01 10:10:10" and "2024-01-01 10:10:10", it only needs that any value is later than the "current time" - Datacache.partition_duration", Datacache is valid.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
