### PR TITLE
[Feature][JDBC Catalog][Partitions] Add the partition scan configuration

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCResource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCResource.java
@@ -55,6 +55,13 @@ public class JDBCResource extends Resource {
     public static final String CHECK_SUM = "checksum";
     public static final String DRIVER_CLASS = "driver_class";
 
+    public static final String JDBC_META_CACHE_ENABLE = "jdbc_meta_cache_enable";
+    public static final String JDBC_META_CACHE_EXPIRESEC = "jdbc_meta_cache_expire_sec";
+
+    public static final String JDBC_SUPPORT_PARTITION_SCAN = "jdbc_support_partition_scan";
+
+
+
     // @TODO is this necessary?
     // private static final String JDBC_TYPE = "jdbc_type";
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2781,4 +2781,7 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static long jdbc_meta_default_cache_expire_sec = 600L;
+
+    @ConfField(mutable = true)
+    public static boolean jdbc_meta_default_support_partition_scan = true;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetaCache.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCMetaCache.java
@@ -17,6 +17,7 @@ package com.starrocks.connector.jdbc;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.starrocks.catalog.JDBCResource;
 import com.starrocks.common.Config;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -30,9 +31,6 @@ public class JDBCMetaCache<K, V> {
     private boolean enableCache = false;
     private Cache<K, V> metaCache;
     private long currentExpireSec;
-
-    private final String jdbcMetaCacheEnable = "jdbc_meta_cache_enable";
-    private final String jdbcMetaCacheExpireSec = "jdbc_meta_cache_expire_sec";
 
 
     public JDBCMetaCache(Map<String, String> properties, Boolean permanent) {
@@ -49,7 +47,7 @@ public class JDBCMetaCache<K, V> {
 
     private boolean checkEnableCache(Map<String, String> properties) {
         // The priority of jdbc_meta_cache_enable from properties is higher than that from Config
-        String enableFromProperties = properties.get(jdbcMetaCacheEnable);
+        String enableFromProperties = properties.get(JDBCResource.JDBC_META_CACHE_ENABLE);
         if (enableFromProperties != null) {
             return this.enableCache = Boolean.parseBoolean(enableFromProperties);
         } else {
@@ -58,7 +56,7 @@ public class JDBCMetaCache<K, V> {
     }
 
     private void initializeExpireSec(Map<String, String> properties) {
-        String expireSec = properties.get(jdbcMetaCacheExpireSec);
+        String expireSec = properties.get(JDBCResource.JDBC_META_CACHE_EXPIRESEC);
         if (expireSec != null) {
             this.currentExpireSec = Long.parseLong(expireSec);
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/jdbc/JDBCSchemaResolver.java
@@ -104,6 +104,10 @@ public abstract class JDBCSchemaResolver {
 
     }
 
+    public void setSupportPartitionInformation(boolean supportPartitionInformation) {
+        this.supportPartitionInformation = supportPartitionInformation;
+    }
+
     public boolean isSupportPartitionInformation() {
         return supportPartitionInformation;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCMetaCacheTest.java
@@ -174,8 +174,7 @@ public class JDBCMetaCacheTest {
             Table table2 = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertTrue(table2 instanceof JDBCTable);
             JDBCCacheTestUtil.closeCacheEnable(connectContext);
-            Map<String, String> properties = new HashMap<>();
-            jdbcMetadata.refreshCache(properties);
+            jdbcMetadata.refreshCache();
             Table table3 = jdbcMetadata.getTable("test", "tbl1");
             Assert.assertFalse(table3 instanceof JDBCTable);
         } catch (Exception e) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCSupportPartitionScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCSupportPartitionScanTest.java
@@ -1,0 +1,148 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+package com.starrocks.connector.jdbc;
+
+import com.mockrunner.mock.jdbc.MockResultSet;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.JDBCResource;
+import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.connector.PartitionInfo;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Expectations;
+import mockit.Mocked;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.starrocks.catalog.JDBCResource.DRIVER_CLASS;
+
+public class JDBCSupportPartitionScanTest {
+
+    private static ConnectContext connectContext;
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Mocked
+    DriverManager driverManager;
+
+    @Mocked
+    Connection connection;
+
+    @Mocked
+    PreparedStatement preparedStatement;
+
+    private Map<String, String> properties;
+    private MockResultSet dbResult;
+    private MockResultSet tableResult;
+    private MockResultSet partitionsResult;
+    private Map<JDBCTableName, Integer> tableIdCache;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+
+        // create connect context
+        connectContext = UtFrameUtils.createDefaultCtx();
+    }
+
+    @Before
+    public void setUp() throws SQLException {
+        partitionsResult = new MockResultSet("partitions");
+        partitionsResult.addColumn("NAME", Arrays.asList("'20230810'"));
+        partitionsResult.addColumn("PARTITION_EXPRESSION", Arrays.asList("`d`"));
+        partitionsResult.addColumn("MODIFIED_TIME", Arrays.asList("2023-08-01"));
+        properties = new HashMap<>();
+        properties.put(DRIVER_CLASS, "com.mysql.cj.jdbc.Driver");
+        properties.put(JDBCResource.URI, "jdbc:mysql://127.0.0.1:3306");
+        properties.put(JDBCResource.USER, "root");
+        properties.put(JDBCResource.PASSWORD, "123456");
+        properties.put(JDBCResource.CHECK_SUM, "xxxx");
+        properties.put(JDBCResource.DRIVER_URL, "xxxx");
+        properties.put(JDBCResource.JDBC_SUPPORT_PARTITION_SCAN, "false");
+        tableIdCache = new ConcurrentHashMap<>();
+        tableIdCache.put(JDBCTableName.of("catalog", "test", "tbl1"), 100000);
+
+        new Expectations() {
+            {
+                driverManager.getConnection(anyString, anyString, anyString);
+                result = connection;
+                minTimes = 0;
+
+                preparedStatement.executeQuery();
+                result = partitionsResult;
+                minTimes = 0;
+            }
+        };
+    }
+
+    @Test
+    public void testListPartitionNames() {
+        try {
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            List<String> partitionNames = jdbcMetadata.listPartitionNames("test", "tbl1");
+            Assert.assertTrue(partitionNames.isEmpty());
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
+    }
+
+    @Test
+    public void testListPartitionColumns() {
+        try {
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            List<Column> partitionColumns = jdbcMetadata.listPartitionColumns("test", "tbl1",
+                    Arrays.asList(new Column("d", Type.VARCHAR)));
+            Assert.assertTrue(partitionColumns.isEmpty());
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
+    }
+
+
+    @Test
+    public void testGetPartitions() {
+        try {
+            JDBCMetadata jdbcMetadata = new JDBCMetadata(properties, "catalog");
+            JDBCTable jdbcTable = new JDBCTable(100000, "tbl1", Arrays.asList(new Column("d", Type.VARCHAR)),
+                    Arrays.asList(new Column("d", Type.VARCHAR)), "test", "catalog", properties);
+            List<PartitionInfo> partitions = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810"));
+            Assert.assertEquals(1, partitions.size());
+            Assert.assertEquals("tbl1", ((Partition) partitions.get(0)).getPartitionName());
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
+    }
+
+}

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/MysqlSchemaResolverTest.java
@@ -169,8 +169,7 @@ public class MysqlSchemaResolverTest {
             List<String> partitionNamesWithCache = jdbcMetadata.listPartitionNames("test", "tbl1");
             Assert.assertFalse(partitionNamesWithCache.isEmpty());
             JDBCCacheTestUtil.closeCacheEnable(connectContext);
-            Map<String, String> properties = new HashMap<>();
-            jdbcMetadata.refreshCache(properties);
+            jdbcMetadata.refreshCache();
             List<String> partitionNamesWithOutCache = jdbcMetadata.listPartitionNames("test", "tbl1");
             Assert.assertTrue(partitionNamesWithOutCache.isEmpty());
         } catch (Exception e) {
@@ -257,8 +256,7 @@ public class MysqlSchemaResolverTest {
             int sizeWithCache = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
             Assert.assertTrue(sizeWithCache > 0);
             JDBCCacheTestUtil.closeCacheEnable(connectContext);
-            Map<String, String> properties = new HashMap<>();
-            jdbcMetadata.refreshCache(properties);
+            jdbcMetadata.refreshCache();
             int sizeWithOutCache = jdbcMetadata.getPartitions(jdbcTable, Arrays.asList("20230810")).size();
             Assert.assertEquals(0, sizeWithOutCache);
         } catch (Exception e) {


### PR DESCRIPTION
Why I'm doing:
When using jdbc catalog, there are some cases that do not need to scan the metadata table to obtain the partition information, and SR needs to provide parameter control whether to open the partition information scan.
What I'm doing:
Provide parameter control whether to open the partition information scan

Fixes #38512

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [X] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
