### PR TITLE
[BugFix] fix bad jdbc driver name

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/JDBCTable.java
@@ -60,7 +60,6 @@ public class JDBCTable extends Table {
     private String dbName;
     private List<Column> partitionColumns;
 
-
     public JDBCTable() {
         super(TableType.JDBC);
     }
@@ -176,6 +175,16 @@ public class JDBCTable extends Table {
         }
     }
 
+    private static String buildCatalogDriveName(String uri) {
+        // jdbc:postgresql://172.26.194.237:5432/db_pg_select
+        // -> jdbc_postgresql_172.26.194.237_5432_db_pg_select
+        // requirement: it should be used as local path.
+        // and there is no ':' in it to avoid be parsed into non-local filesystem.
+        return uri.replace("//", "")
+                .replace("/", "_")
+                .replace(":", "_");
+    }
+
     @Override
     public TTableDescriptor toThrift(List<DescriptorTable.ReferencedPartitionInfo> partitions) {
         TJDBCTable tJDBCTable = new TJDBCTable();
@@ -193,7 +202,7 @@ public class JDBCTable extends Table {
             tJDBCTable.setJdbc_passwd(resource.getProperty(JDBCResource.PASSWORD));
         } else {
             String uri = properties.get(JDBCResource.URI);
-            String driverName = uri.replace("//", "").replace("/", "_");
+            String driverName = buildCatalogDriveName(uri);
             tJDBCTable.setJdbc_driver_name(driverName);
             tJDBCTable.setJdbc_driver_url(properties.get(JDBCResource.DRIVER_URL));
             tJDBCTable.setJdbc_driver_checksum(properties.get(JDBCResource.CHECK_SUM));

--- a/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/jdbc/JDBCTableTest.java
@@ -12,14 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.connector.jdbc;
 
+import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.JDBCTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.thrift.TJDBCTable;
+import com.starrocks.thrift.TTableDescriptor;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
-
 
 public class JDBCTableTest {
 
@@ -51,4 +58,31 @@ public class JDBCTableTest {
         }
     }
 
+    @Test
+    public void testJDBCDriverName() {
+        try {
+            Map<String, String> properties = ImmutableMap.of(
+                    "driver_class", "org.postgresql.Driver",
+                    "checksum", "bef0b2e1c6edcd8647c24bed31e1a4ac",
+                    "driver_url",
+                    "http://x.com/postgresql-42.3.3.jar",
+                    "type", "jdbc",
+                    "user", "postgres",
+                    "password", "postgres",
+                    "jdbc_uri", "jdbc:postgresql://172.26.194.237:5432/db_pg_select"
+            );
+            List<Column> schema = new ArrayList<>();
+            schema.add(new Column("id", Type.INT));
+            JDBCTable jdbcTable = new JDBCTable(10, "tbl", schema, "db", "jdbc_catalog", properties);
+            TTableDescriptor tableDescriptor = jdbcTable.toThrift(null);
+            TJDBCTable table = tableDescriptor.getJdbcTable();
+            Assert.assertEquals(table.getJdbc_driver_name(), "jdbc_postgresql_172.26.194.237_5432_db_pg_select");
+            Assert.assertEquals(table.getJdbc_driver_url(), "http://x.com/postgresql-42.3.3.jar");
+            Assert.assertEquals(table.getJdbc_driver_checksum(), "bef0b2e1c6edcd8647c24bed31e1a4ac");
+            Assert.assertEquals(table.getJdbc_driver_class(), "org.postgresql.Driver");
+        } catch (Exception e) {
+            System.out.println(e.getMessage());
+            Assert.fail();
+        }
+    }
 }


### PR DESCRIPTION
> Why I'm doing:

To fix this bug https://github.com/StarRocks/StarRocksTest/issues/5326

**RCA**
- for catalog driver name contains ':'
- in BE side,driver name is used as part of local file path
- However when we parse local file path, ':' could be interpreted as other filesystem


```
inline Status remove(const std::string& path) {
    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(path));
    ASSIGN_OR_RETURN(auto is_dir, fs->is_directory(path));
    return is_dir ? fs->delete_dir(path) : fs->delete_file(path);
}
```

Path like 'jdbc:postgres:111.111.11.111_xxx' could be guessed as hdfs filesystem, and that's why we get error message like

```
HdfsFileSystem::is_directory
```

> What I'm doing:

replace ':' to '_' in driver name.

---

Fixes https://github.com/StarRocks/StarRocksTest/issues/5326

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
