### PR TITLE
[BugFix] Fix wrong profile of retry queries

### DIFF
--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -137,7 +137,7 @@ void GlobalDriverExecutor::_worker_thread() {
                 _finalize_driver(driver, runtime_state, driver->driver_state());
                 continue;
             } else if (!driver->is_ready()) {
-                // Enabling blocked driver a change to trigger exec state report.
+                // Offer blocked driver a chance to trigger profile report.
                 driver->report_exec_state_if_necessary();
                 _blocked_driver_poller->add_blocked_driver(driver);
                 continue;

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -67,6 +67,7 @@ public class ProfileManager {
     public static final String START_TIME = "Start Time";
     public static final String END_TIME = "End Time";
     public static final String TOTAL_TIME = "Total";
+    public static final String RETRY_TIMES = "Retry Times";
     public static final String QUERY_TYPE = "Query Type";
     public static final String QUERY_STATE = "Query State";
     public static final String SQL_STATEMENT = "Sql Statement";
@@ -219,6 +220,17 @@ public class ProfileManager {
             readLock.unlock();
         }
         return result;
+    }
+
+    public void removeProfile(String queryId) {
+        ProfileElement element = new ProfileElement();
+        writeLock.lock();
+        try {
+            loadProfileMap.remove(queryId);
+            profileMap.remove(queryId);
+        } finally {
+            writeLock.unlock();
+        }
     }
 
     public String getProfile(String queryId) {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/ProfileManager.java
@@ -223,7 +223,6 @@ public class ProfileManager {
     }
 
     public void removeProfile(String queryId) {
-        ProfileElement element = new ProfileElement();
         writeLock.lock();
         try {
             loadProfileMap.remove(queryId);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -887,12 +887,16 @@ public class StmtExecutor {
     }
 
     private boolean tryProcessProfileAsync(ExecPlan plan, int retryIndex) {
-        if (coord == null || coord.getQueryProfile() == null) {
+        if (coord == null) {
             return false;
         }
 
         // Disable runtime profile processing after the query is finished.
         coord.setTopProfileSupplier(null);
+
+        if (coord.getQueryProfile() == null) {
+            return false;
+        }
 
         // This process will get information from the context, so it must be executed synchronously.
         // Otherwise, the context may be changed, for example, containing the wrong query id.

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -266,7 +266,8 @@ public class QueryRuntimeProfile {
         long now = System.currentTimeMillis();
         long lastTime = lastRuntimeProfileUpdateTime.get();
         Supplier<RuntimeProfile> topProfileSupplier = this.topProfileSupplier;
-        if (topProfileSupplier != null && execPlan != null && connectContext != null &&
+        ExecPlan plan = execPlan;
+        if (topProfileSupplier != null && plan != null && connectContext != null &&
                 connectContext.isProfileEnabled() &&
                 // If it's the last done report, avoiding duplicate trigger
                 (!execState.isFinished() || profileDoneSignal.getLeftMarks().size() > 1) &&
@@ -274,9 +275,8 @@ public class QueryRuntimeProfile {
                 now - lastTime > (connectContext.getSessionVariable().getRuntimeProfileReportInterval() * 950L) &&
                 lastRuntimeProfileUpdateTime.compareAndSet(lastTime, now)) {
             RuntimeProfile profile = topProfileSupplier.get();
-            ExecPlan plan = execPlan;
             profile.addChild(buildQueryProfile(connectContext.needMergeProfile()));
-            ProfilingExecPlan profilingPlan = plan == null ? null : plan.getProfilingPlan();
+            ProfilingExecPlan profilingPlan = plan.getProfilingPlan();
             saveRunningProfile(profilingPlan, profile);
         }
     }


### PR DESCRIPTION
## Why I'm doing:

The following long running query(20+s) is easily to be failed and will undergo the retry process. And each of the execution will have a unique QueryId, so there many be multiply profile records if the runtime profile is enabled.

```sh
select sum(length(o)) from (select group_concat(l_orderkey, l_linenumber) as o from lineitem group by l_returnflag)A
```

## What I'm doing:

Clean up profile recoreds if current execution is failed and need retried.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
