### PR TITLE
[Refactor] Table function use the chunk size of runtime state (backport #37731)

### DIFF
--- a/be/src/exec/pipeline/table_function_operator.cpp
+++ b/be/src/exec/pipeline/table_function_operator.cpp
@@ -109,7 +109,7 @@ StatusOr<ChunkPtr> TableFunctionOperator::pull_chunk(RuntimeState* state) {
     std::vector<ColumnPtr> output_columns;
 
     if (_table_function_result.second == nullptr) {
-        RETURN_IF_ERROR(_process_table_function());
+        RETURN_IF_ERROR(_process_table_function(state));
     }
 
     output_columns.reserve(_outer_slots.size());
@@ -124,7 +124,7 @@ StatusOr<ChunkPtr> TableFunctionOperator::pull_chunk(RuntimeState* state) {
         if (!_table_function_result.first.empty() && _next_output_row < _table_function_result.first[0]->size()) {
             _copy_result(output_columns, max_chunk_size);
         } else if (_table_function_state->processed_rows() < _input_chunk->num_rows()) {
-            RETURN_IF_ERROR(_process_table_function());
+            RETURN_IF_ERROR(_process_table_function(state));
         } else {
             DCHECK(!has_output());
             DCHECK(need_input());
@@ -166,18 +166,18 @@ ChunkPtr TableFunctionOperator::_build_chunk(const std::vector<ColumnPtr>& colum
     return chunk;
 }
 
-Status TableFunctionOperator::_process_table_function() {
+Status TableFunctionOperator::_process_table_function(RuntimeState* state) {
     SCOPED_TIMER(_table_function_exec_timer);
     COUNTER_UPDATE(_table_function_exec_counter, 1);
     _input_index_of_first_result = _table_function_state->processed_rows();
     _next_output_row = 0;
     _next_output_row_offset = 0;
 
-    _table_function_result = _table_function->process(_table_function_state);
+    _table_function_result = _table_function->process(state, _table_function_state);
     return _table_function_state->status();
 }
 
-Status TableFunctionOperator::reset_state(starrocks::RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
+Status TableFunctionOperator::reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) {
     _input_chunk.reset();
     _input_index_of_first_result = 0;
     _next_output_row_offset = 0;

--- a/be/src/exec/pipeline/table_function_operator.h
+++ b/be/src/exec/pipeline/table_function_operator.h
@@ -46,11 +46,11 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
-    Status reset_state(starrocks::RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 private:
     ChunkPtr _build_chunk(const std::vector<ColumnPtr>& output_columns);
-    Status _process_table_function();
+    Status _process_table_function(RuntimeState* state);
     void _copy_result(const std::vector<ColumnPtr>& columns, uint32_t max_column_size);
 
     const TPlanNode& _tnode;

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -257,7 +257,7 @@ Status TableFunctionNode::build_chunk(ChunkPtr* chunk, const std::vector<ColumnP
 Status TableFunctionNode::get_next_input_chunk(RuntimeState* state, bool* eos) {
     if (_input_chunk_ptr != nullptr) {
         SCOPED_TIMER(_table_function_exec_timer);
-        _table_function_result = _table_function->process(_table_function_state);
+        _table_function_result = _table_function->process(state, _table_function_state);
         if (_table_function_state->processed_rows() < _input_chunk_ptr->num_rows()) {
             const TFunction& table_fn = _tnode.table_function_node.table_function.nodes[0].fn;
             const std::string& fn_name = table_fn.name.function_name;
@@ -283,7 +283,7 @@ Status TableFunctionNode::get_next_input_chunk(RuntimeState* state, bool* eos) {
     _table_function_state->set_params(table_function_params);
     {
         SCOPED_TIMER(_table_function_exec_timer);
-        _table_function_result = _table_function->process(_table_function_state);
+        _table_function_result = _table_function->process(state, _table_function_state);
         if (_table_function_state->processed_rows() < _input_chunk_ptr->num_rows()) {
             const TFunction& table_fn = _tnode.table_function_node.table_function.nodes[0].fn;
             const std::string& fn_name = table_fn.name.function_name;

--- a/be/src/exprs/table_function/generate_series.h
+++ b/be/src/exprs/table_function/generate_series.h
@@ -49,9 +49,10 @@ public:
         return Status::OK();
     }
 
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* base_state) const override {
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* base_state) const override {
         using NumericType = RunTimeCppType<Type>;
-        auto max_chunk_size = config::vector_chunk_size;
+        auto max_chunk_size = runtime_state->chunk_size();
         auto state = down_cast<MyState*>(base_state);
         auto res = RunTimeColumnType<Type>::create();
         auto offsets = UInt32Column::create();

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -123,7 +123,8 @@ Status JavaUDTFFunction::close(RuntimeState* runtime_state, TableFunctionState* 
     return Status::OK();
 }
 
-std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(TableFunctionState* state) const {
+std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* runtime_state,
+                                                                TableFunctionState* state) const {
     Columns res;
     const Columns& cols = state->get_columns();
     auto* stateUDTF = down_cast<JavaUDTFState*>(state);

--- a/be/src/exprs/table_function/java_udtf_function.h
+++ b/be/src/exprs/table_function/java_udtf_function.h
@@ -28,7 +28,8 @@ public:
     Status init(const TFunction& fn, TableFunctionState** state) const override;
     Status prepare(TableFunctionState* state) const override;
     Status open(RuntimeState* runtime_state, TableFunctionState* state) const override;
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state) const override;
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* state) const override;
     Status close(RuntimeState* _runtime_state, TableFunctionState* state) const override;
 };
 } // namespace starrocks

--- a/be/src/exprs/table_function/json_each.cpp
+++ b/be/src/exprs/table_function/json_each.cpp
@@ -21,7 +21,7 @@
 
 namespace starrocks {
 
-std::pair<Columns, UInt32Column::Ptr> JsonEach::process(TableFunctionState* state) const {
+std::pair<Columns, UInt32Column::Ptr> JsonEach::process(RuntimeState* runtime_state, TableFunctionState* state) const {
     size_t num_input_rows = 0;
     JsonColumn* json_column = nullptr;
     if (!state->get_columns().empty()) {

--- a/be/src/exprs/table_function/json_each.h
+++ b/be/src/exprs/table_function/json_each.h
@@ -27,7 +27,8 @@ namespace starrocks {
 // | b . | 2 .   |
 class JsonEach final : public TableFunction {
 public:
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state) const override;
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* state) const override;
 
     Status init(const TFunction& fn, TableFunctionState** state) const override {
         *state = new TableFunctionState();

--- a/be/src/exprs/table_function/list_rowsets.cpp
+++ b/be/src/exprs/table_function/list_rowsets.cpp
@@ -82,7 +82,8 @@ static void fill_rowset_row(Columns& columns, const RowsetMetadataPB& rowset) {
     }
 }
 
-std::pair<Columns, UInt32Column::Ptr> ListRowsets::process(TableFunctionState* base_state) const {
+std::pair<Columns, UInt32Column::Ptr> ListRowsets::process(RuntimeState* runtime_state,
+                                                           TableFunctionState* base_state) const {
     auto state = down_cast<MyState*>(base_state);
 
     if (UNLIKELY(state->get_columns().size() != 2)) {
@@ -92,7 +93,7 @@ std::pair<Columns, UInt32Column::Ptr> ListRowsets::process(TableFunctionState* b
     }
 
     auto tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
-    auto max_column_size = config::vector_chunk_size;
+    auto max_column_size = runtime_state->chunk_size();
     auto arg_tablet_id = ColumnViewer<TYPE_BIGINT>(state->get_columns()[0]);
     auto arg_tablet_version = ColumnViewer<TYPE_BIGINT>(state->get_columns()[1]);
     auto curr_row = state->processed_rows();

--- a/be/src/exprs/table_function/list_rowsets.h
+++ b/be/src/exprs/table_function/list_rowsets.h
@@ -48,7 +48,8 @@ public:
         return Status::OK();
     }
 
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* base_state) const override;
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* base_state) const override;
 };
 
 } // namespace starrocks

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -29,7 +29,8 @@ namespace starrocks {
  */
 class MultiUnnest final : public TableFunction {
 public:
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state) const override {
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* state) const override {
         if (state->get_columns().empty()) {
             return {};
         }

--- a/be/src/exprs/table_function/subdivide_bitmap.h
+++ b/be/src/exprs/table_function/subdivide_bitmap.h
@@ -25,14 +25,14 @@
 namespace starrocks {
 template <LogicalType Type>
 class SubdivideBitmap final : public TableFunction {
-    struct UnnestBitmapState final : public TableFunctionState {};
+    struct SubdivideBitmapState final : public TableFunctionState {};
     using SrcSizeCppType = typename RunTimeTypeTraits<Type>::CppType;
 
 public:
     ~SubdivideBitmap() override = default;
 
     Status init(const TFunction& fn, TableFunctionState** state) const override {
-        *state = new UnnestBitmapState();
+        *state = new SubdivideBitmapState();
         return Status::OK();
     }
 
@@ -61,7 +61,8 @@ public:
     }
 
     // TODO: The TableFunction framework should support streaming processing to avoid generating large Column
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state) const override {
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* state) const override {
         if (state->get_columns().size() != 2) {
             state->set_status(Status::InternalError("The number of parameters of unnest_bitmap is not equal to 2"));
             return {};

--- a/be/src/exprs/table_function/table_function.h
+++ b/be/src/exprs/table_function/table_function.h
@@ -27,13 +27,13 @@ public:
     TableFunctionState() = default;
     virtual ~TableFunctionState() = default;
 
-    void set_params(starrocks::Columns columns) {
+    void set_params(Columns columns) {
         this->_columns = std::move(columns);
         set_processed_rows(0);
         on_new_params();
     }
 
-    starrocks::Columns& get_columns() { return _columns; }
+    Columns& get_columns() { return _columns; }
 
     void set_offset(int64_t offset) { this->_offset = offset; }
 
@@ -59,7 +59,7 @@ private:
     virtual void on_new_params(){};
 
     //Params of table function
-    starrocks::Columns _columns;
+    Columns _columns;
 
     size_t _processed_rows = 0;
 
@@ -87,7 +87,8 @@ public:
     virtual Status open(RuntimeState* runtime_state, TableFunctionState* state) const = 0;
 
     //Table function processing logic
-    virtual std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state) const = 0;
+    virtual std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                          TableFunctionState* state) const = 0;
 
     //Release the resources constructed in init and prepare
     virtual Status close(RuntimeState* runtime_state, TableFunctionState* context) const = 0;

--- a/be/src/exprs/table_function/unnest.h
+++ b/be/src/exprs/table_function/unnest.h
@@ -29,7 +29,8 @@ namespace starrocks {
  */
 class Unnest final : public TableFunction {
 public:
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state) const override {
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state,
+                                                  TableFunctionState* state) const override {
         if (state->get_columns().empty()) {
             return {};
         }

--- a/be/test/exprs/agg/json_each_test.cpp
+++ b/be/test/exprs/agg/json_each_test.cpp
@@ -30,7 +30,9 @@ public:
         const TableFunction* func =
                 get_table_function("json_each", {TYPE_JSON}, {TYPE_VARCHAR, TYPE_JSON}, TFunctionBinaryType::BUILTIN);
 
-        RuntimeState* rt_state = nullptr;
+        auto rt_state = std::make_unique<RuntimeState>();
+        rt_state->set_chunk_size(4096);
+
         // input
         auto json_column = JsonColumn::create();
         for (auto& input : inputs) {
@@ -49,8 +51,8 @@ public:
         // execute
         ASSERT_OK(func->init({}, &func_state));
         func_state->set_params(input_columns);
-        ASSERT_OK(func->open(rt_state, func_state));
-        auto [result_columns, offset_column] = func->process(func_state);
+        ASSERT_OK(func->open(rt_state.get(), func_state));
+        auto [result_columns, offset_column] = func->process(rt_state.get(), func_state);
 
         // check
         ASSERT_EQ(func_state->input_rows(), func_state->processed_rows());
@@ -66,7 +68,7 @@ public:
         }
 
         // close
-        func->close(rt_state, func_state);
+        func->close(rt_state.get(), func_state);
     }
 };
 


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

