### PR TITLE
[BugFix] correct the behavior of base table dropped for MV

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -293,9 +293,9 @@ public class AlterJobMgr {
             try {
                 mvQueryStatement = recreateMVQuery(materializedView, context);
             } catch (SemanticException e) {
-                throw new SemanticException("Can not active materialized view [" + materializedView.getName() +
-                        "] because analyze materialized view define sql: \n\n" + createMvSql +
-                        "\n\nCause an error: " + e.getDetailMsg(), e);
+                throw new SemanticException("Can not active materialized view [%s]" +
+                        " because analyze materialized view define sql: \n\n%s" +
+                        "\n\nCause an error: %s", materializedView.getName(), createMvSql, e.getDetailMsg());
             }
 
             // Skip checks to maintain eventual consistency when replay

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -934,6 +934,9 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                                     Sets.newHashSet(mvId)).build()
                     );
                 }
+            } else {
+                res = false;
+                setInactiveAndReason("base-table dropped: " + baseTableInfo.getTableName());
             }
         }
         analyzePartitionInfo();

--- a/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/InsertOverwriteJobRunner.java
@@ -319,17 +319,19 @@ public class InsertOverwriteJobRunner {
     private void executeInsert() throws Exception {
         long insertStartTimestamp = System.currentTimeMillis();
         // should replan here because prepareInsert has changed the targetPartitionNames of insertStmt
-        ExecPlan newPlan = StatementPlanner.plan(insertStmt, context);
-        // Use `handleDMLStmt` instead of `handleDMLStmtWithProfile` because cannot call `writeProfile` in
-        // InsertOverwriteJobRunner.
-        // InsertOverWriteJob is executed as below:
-        // - StmtExecutor#handleDMLStmtWithProfile
-        //    - StmtExecutor#executeInsert
-        //  - StmtExecutor#handleInsertOverwrite#InsertOverwriteJobMgr#run
-        //  - InsertOverwriteJobRunner#executeInsert
-        //  - StmtExecutor#handleDMLStmt <- no call `handleDMLStmt` again.
-        // `writeProfile` is called in `handleDMLStmt`, and no need call it again later.
-        stmtExecutor.handleDMLStmt(newPlan, insertStmt);
+        try (var guard = context.bindScope()) {
+            ExecPlan newPlan = StatementPlanner.plan(insertStmt, context);
+            // Use `handleDMLStmt` instead of `handleDMLStmtWithProfile` because cannot call `writeProfile` in
+            // InsertOverwriteJobRunner.
+            // InsertOverWriteJob is executed as below:
+            // - StmtExecutor#handleDMLStmtWithProfile
+            //    - StmtExecutor#executeInsert
+            //  - StmtExecutor#handleInsertOverwrite#InsertOverwriteJobMgr#run
+            //  - InsertOverwriteJobRunner#executeInsert
+            //  - StmtExecutor#handleDMLStmt <- no call `handleDMLStmt` again.
+            // `writeProfile` is called in `handleDMLStmt`, and no need call it again later.
+            stmtExecutor.handleDMLStmt(newPlan, insertStmt);
+        }
         insertElapse = System.currentTimeMillis() - insertStartTimestamp;
         if (context.getState().getStateType() == QueryState.MysqlStateType.ERR) {
             LOG.warn("insert overwrite failed. error message:{}", context.getState().getErrorMessage());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -316,6 +316,19 @@ public class ConnectContext {
         threadLocalInfo.set(this);
     }
 
+    /**
+     * Set this connect to thread-local if not exists
+     *
+     * @return set or not
+     */
+    public boolean setThreadLocalInfoIfNotExists() {
+        if (threadLocalInfo.get() == null) {
+            threadLocalInfo.set(this);
+            return true;
+        }
+        return false;
+    }
+
     public void setGlobalStateMgr(GlobalStateMgr globalStateMgr) {
         this.globalStateMgr = globalStateMgr;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ConnectContext.java
@@ -852,6 +852,34 @@ public class ConnectContext {
         return executor;
     }
 
+    public ScopeGuard bindScope() {
+        return ScopeGuard.setIfNotExists(this);
+    }
+
+    /**
+     * Set thread-local context for the scope, and remove it after leaving the scope
+     */
+    public static class ScopeGuard implements AutoCloseable {
+
+        private boolean set = false;
+
+        private ScopeGuard() {
+        }
+
+        public static ScopeGuard setIfNotExists(ConnectContext session) {
+            ScopeGuard res = new ScopeGuard();
+            res.set = session.setThreadLocalInfoIfNotExists();
+            return res;
+        }
+
+        @Override
+        public void close() {
+            if (set) {
+                ConnectContext.remove();
+            }
+        }
+    }
+
     public class ThreadInfo {
         public boolean isRunning() {
             return state.isRunning();

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -608,6 +608,7 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             if (table == null) {
                 LOG.warn("table {} do not exist when refreshing materialized view:{}",
                         baseTableInfo.getTableInfoStr(), materializedView.getName());
+                materializedView.setInactiveAndReason(String.format("base-table dropped: %s", baseTableInfo));
                 throw new DmlException("Materialized view base table: %s not exist.", baseTableInfo.getTableInfoStr());
             }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessor.java
@@ -819,8 +819,8 @@ public class PartitionBasedMvRefreshProcessor extends BaseTaskRunProcessor {
             LOG.info("Activated the MV before refreshing: {}", materializedView.getName());
         }
         if (!materializedView.isActive()) {
-            String errorMsg = String.format("Materialized view: %s, id: %d is not active, " +
-                    "skip sync partition and data with base tables", materializedView.getName(), mvId);
+            String errorMsg = String.format("Materialized view: %s/%d is not active due to %s.",
+                    materializedView.getName(), mvId, materializedView.getInactiveReason());
             LOG.warn(errorMsg);
             throw new DmlException(errorMsg);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskManager.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -317,12 +318,15 @@ public class TaskManager {
         try {
             Constants.TaskRunState taskRunState = taskRun.getFuture().get();
             if (taskRunState != Constants.TaskRunState.SUCCESS) {
-                throw new DmlException("execute task: %s failed. task source:%s, task run state:%s",
-                        task.getName(), task.getSource(), taskRunState);
+                String msg = taskRun.getStatus().getErrorMessage();
+                throw new DmlException("execute task %s failed: %s", task.getName(), msg);
             }
             return submitResult;
+        } catch (InterruptedException | ExecutionException e) {
+            Throwable rootCause = e.getCause();
+            throw new DmlException("execute task %s failed: %s", rootCause, task.getName(), rootCause.getMessage());
         } catch (Exception e) {
-            throw new DmlException("execute task: %s failed.", e, task.getName());
+            throw new DmlException("execute task %s failed: %s", e, task.getName(), e.getMessage());
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskRunExecutor.java
@@ -57,7 +57,7 @@ public class TaskRunExecutor {
                 LOG.warn("failed to execute TaskRun.", ex);
                 status.setState(Constants.TaskRunState.FAILED);
                 status.setErrorCode(-1);
-                status.setErrorMessage(ex.toString());
+                status.setErrorMessage(ex.getMessage());
             } finally {
                 // NOTE: Ensure this thread local is removed after this method to avoid memory leak in JVM.
                 ConnectContext.remove();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -103,9 +103,7 @@ public class StatementPlanner {
 
         // 1. For all queries, we need db lock when analyze phase
         Locker locker = new Locker();
-        boolean setThreadLocal = false;
-        try {
-            setThreadLocal = session.setThreadLocalInfoIfNotExists();
+        try (var guard = session.bindScope()) {
             lock(locker, dbs);
             try (Timer ignored = Tracers.watchScope("Analyzer")) {
                 Analyzer.analyze(stmt, session);
@@ -140,9 +138,6 @@ public class StatementPlanner {
                 unLock(locker, dbs);
             }
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
-            if (setThreadLocal) {
-                ConnectContext.remove();
-            }
         }
 
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/StatementPlanner.java
@@ -103,7 +103,9 @@ public class StatementPlanner {
 
         // 1. For all queries, we need db lock when analyze phase
         Locker locker = new Locker();
+        boolean setThreadLocal = false;
         try {
+            setThreadLocal = session.setThreadLocalInfoIfNotExists();
             lock(locker, dbs);
             try (Timer ignored = Tracers.watchScope("Analyzer")) {
                 Analyzer.analyze(stmt, session);
@@ -138,6 +140,9 @@ public class StatementPlanner {
                 unLock(locker, dbs);
             }
             GlobalStateMgr.getCurrentState().getMetadataMgr().removeQueryMetadata();
+            if (setThreadLocal) {
+                ConnectContext.remove();
+            }
         }
 
         return null;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -658,7 +658,7 @@ public class Optimizer {
 
         if (!sessionVariable.isMVPlanner()) {
             // add join implementRule
-            String joinImplementationMode = ConnectContext.get().getSessionVariable().getJoinImplementationMode();
+            String joinImplementationMode = connectContext.getSessionVariable().getJoinImplementationMode();
             if ("merge".equalsIgnoreCase(joinImplementationMode)) {
                 context.getRuleSet().addMergeJoinImplementationRule();
             } else if ("hash".equalsIgnoreCase(joinImplementationMode)) {

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
@@ -115,3 +115,73 @@ SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${
 2023-12-03	4002
 2023-12-04	4002
 -- !result
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+-- result:
+-- !result
+DROP TABLE mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+use db_${uuid0};
+-- result:
+-- !result
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+ALTER MATERIALIZED VIEW test_mv1 ACTIVE;
+-- result:
+[REGEX].*Unknown table.*
+-- !result
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+-- result:
+-- !result
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+-- result:
+-- !result
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+-- result:
+-- !result
+set catalog default_catalog;
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+-- result:
+true	
+-- !result
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+-- result:
+2023-12-01	4000
+-- !result
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 INACTIVE;
+-- result:
+-- !result
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+-- result:
+false	user use alter materialized view set status to inactive
+-- !result
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 ACTIVE;
+-- result:
+-- !result
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+-- result:
+true	
+-- !result
+  
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+-- result:
+0910c516-a54e-11ee-a82f-5e4f71f202d3
+-- !result
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+-- result:
+2023-12-01	4000
+-- !result

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
@@ -54,3 +54,39 @@ function: check_hit_materialized_view("SELECT dt,sum(col_int) FROM mv_iceberg_${
 
 SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} WHERE dt>='2023-12-03' GROUP BY dt order by dt;
 SELECT dt,sum(col_int) FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} GROUP BY dt order by dt;
+
+-- drop base table
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+DROP TABLE mv_ice_tbl_${uuid0};
+set catalog default_catalog;
+use db_${uuid0};
+-- use default_catalog.db_${uuid0};
+[UC]REFRESH MATERIALIZED VIEW test_mv1 WITH SYNC MODE;
+ALTER MATERIALIZED VIEW test_mv1 ACTIVE;
+
+-- recreate it
+use mv_iceberg_${uuid0}.mv_ice_db_${uuid0};
+create table mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+) partition by(dt);
+insert into mv_ice_tbl_${uuid0} values 
+  ('1d8cf2a2c0e14fa89d8117792be6eb6f', 2000, '2023-12-01'),
+  ('3e82e36e56718dc4abc1168d21ec91ab', 2000, '2023-12-01');
+set catalog default_catalog;
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
+
+-- manually inactive and active
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 INACTIVE;
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+ALTER MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 ACTIVE;
+select is_active, inactive_reason from information_schema.materialized_views
+  where TABLE_NAME = 'test_mv1' and table_schema = 'db_${uuid0}';
+  
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;


### PR DESCRIPTION
Why I'm doing:
- Drop the base table of MV introduce some wired issues
- `refresh materialized view with sync mode` got a useless error message without the root cause
- The MV wouldn't be inactive if the base table is an external table

What I'm doing:
- Correct the error message of `refresh materialized view` when base table dropped
- Fix the NPE issue during `Insert Overwrite`
- Set the MV to inactive if base table got dropped

Behavior Change:
- The error message when dropping base table of MV has been changed
- Drop an external base table of MV would cause the MV to inactive, previously it wouldn't

Fixes #37885 https://github.com/StarRocks/StarRocksTest/issues/5446

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
