### PR TITLE
[Refactor] Table function use the chunk size of runtime state (backport #37731)

### DIFF
--- a/be/src/exec/pipeline/table_function_operator.h
+++ b/be/src/exec/pipeline/table_function_operator.h
@@ -46,11 +46,11 @@ public:
 
     Status push_chunk(RuntimeState* state, const ChunkPtr& chunk) override;
 
-    Status reset_state(starrocks::RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
+    Status reset_state(RuntimeState* state, const std::vector<ChunkPtr>& refill_chunks) override;
 
 private:
     ChunkPtr _build_chunk(const std::vector<ColumnPtr>& output_columns);
-    Status _process_table_function();
+    Status _process_table_function(RuntimeState* state);
 
     const TPlanNode& _tnode;
     const TableFunction* _table_function = nullptr;

--- a/be/src/exec/table_function_node.cpp
+++ b/be/src/exec/table_function_node.cpp
@@ -258,7 +258,7 @@ Status TableFunctionNode::build_chunk(ChunkPtr* chunk, const std::vector<ColumnP
 Status TableFunctionNode::get_next_input_chunk(RuntimeState* state, bool* eos) {
     if (_input_chunk_ptr != nullptr && !_table_function_result_eos) {
         SCOPED_TIMER(_table_function_exec_timer);
-        _table_function_result = _table_function->process(_table_function_state, &_table_function_result_eos);
+        _table_function_result = _table_function->process(state, _table_function_state, &_table_function_result_eos);
         return Status::OK();
     }
 
@@ -280,7 +280,7 @@ Status TableFunctionNode::get_next_input_chunk(RuntimeState* state, bool* eos) {
     _table_function_state->set_params(table_function_params);
     {
         SCOPED_TIMER(_table_function_exec_timer);
-        _table_function_result = _table_function->process(_table_function_state, &_table_function_result_eos);
+        _table_function_result = _table_function->process(state, _table_function_state, &_table_function_result_eos);
     }
     return Status::OK();
 }

--- a/be/src/exprs/table_function/java_udtf_function.cpp
+++ b/be/src/exprs/table_function/java_udtf_function.cpp
@@ -123,7 +123,8 @@ Status JavaUDTFFunction::close(RuntimeState* runtime_state, TableFunctionState* 
     return Status::OK();
 }
 
-std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(TableFunctionState* state, bool* eos) const {
+std::pair<Columns, UInt32Column::Ptr> JavaUDTFFunction::process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                                bool* eos) const {
     Columns res;
     const Columns& cols = state->get_columns();
     auto* stateUDTF = down_cast<JavaUDTFState*>(state);

--- a/be/src/exprs/table_function/java_udtf_function.h
+++ b/be/src/exprs/table_function/java_udtf_function.h
@@ -28,7 +28,8 @@ public:
     Status init(const TFunction& fn, TableFunctionState** state) const override;
     Status prepare(TableFunctionState* state) const override;
     Status open(RuntimeState* runtime_state, TableFunctionState* state) const override;
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state, bool* eos) const override;
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                  bool* eos) const override;
     Status close(RuntimeState* _runtime_state, TableFunctionState* state) const override;
 };
 } // namespace starrocks

--- a/be/src/exprs/table_function/json_each.cpp
+++ b/be/src/exprs/table_function/json_each.cpp
@@ -21,7 +21,8 @@
 
 namespace starrocks {
 
-std::pair<Columns, UInt32Column::Ptr> JsonEach::process(TableFunctionState* state, bool* eos) const {
+std::pair<Columns, UInt32Column::Ptr> JsonEach::process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                        bool* eos) const {
     size_t num_input_rows = 0;
     JsonColumn* json_column = nullptr;
     if (!state->get_columns().empty()) {

--- a/be/src/exprs/table_function/json_each.h
+++ b/be/src/exprs/table_function/json_each.h
@@ -27,7 +27,8 @@ namespace starrocks {
 // | b . | 2 .   |
 class JsonEach final : public TableFunction {
 public:
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state, bool* eos) const override;
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                  bool* eos) const override;
 
     Status init(const TFunction& fn, TableFunctionState** state) const override {
         *state = new TableFunctionState();

--- a/be/src/exprs/table_function/multi_unnest.h
+++ b/be/src/exprs/table_function/multi_unnest.h
@@ -29,7 +29,8 @@ namespace starrocks {
  */
 class MultiUnnest final : public TableFunction {
 public:
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state, bool* eos) const override {
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                  bool* eos) const override {
         *eos = true;
         if (state->get_columns().empty()) {
             return {};

--- a/be/src/exprs/table_function/subdivide_bitmap.h
+++ b/be/src/exprs/table_function/subdivide_bitmap.h
@@ -25,14 +25,14 @@
 namespace starrocks {
 template <LogicalType Type>
 class SubdivideBitmap final : public TableFunction {
-    struct UnnestBitmapState final : public TableFunctionState {};
+    struct SubdivideBitmapState final : public TableFunctionState {};
     using SrcSizeCppType = typename RunTimeTypeTraits<Type>::CppType;
 
 public:
     ~SubdivideBitmap() override = default;
 
     Status init(const TFunction& fn, TableFunctionState** state) const override {
-        *state = new UnnestBitmapState();
+        *state = new SubdivideBitmapState();
         return Status::OK();
     }
 
@@ -61,7 +61,8 @@ public:
     }
 
     // TODO: The TableFunction framework should support streaming processing to avoid generating large Column
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state, bool* eos) const override {
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                  bool* eos) const override {
         *eos = true;
         if (state->get_columns().size() != 2) {
             state->set_status(Status::InternalError("The number of parameters of unnest_bitmap is not equal to 2"));

--- a/be/src/exprs/table_function/table_function.h
+++ b/be/src/exprs/table_function/table_function.h
@@ -27,7 +27,7 @@ public:
     TableFunctionState() = default;
     virtual ~TableFunctionState() = default;
 
-    void set_params(starrocks::Columns columns) { this->_columns = std::move(columns); }
+    void set_params(Columns columns) { this->_columns = std::move(columns); }
 
     void set_offset(int offset) { this->_offset = offset; }
 
@@ -41,7 +41,8 @@ public:
 
 private:
     //Params of table function
-    starrocks::Columns _columns;
+    Columns _columns;
+
     /**
      * _offset is used to record the return value offset of the currently processed columns parameter,
      * if the table function needs to return too many results.
@@ -65,7 +66,8 @@ public:
     virtual Status open(RuntimeState* runtime_state, TableFunctionState* state) const = 0;
 
     //Table function processing logic
-    virtual std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state, bool* eos) const = 0;
+    virtual std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                          bool* eos) const = 0;
 
     //Release the resources constructed in init and prepare
     virtual Status close(RuntimeState* runtime_state, TableFunctionState* context) const = 0;

--- a/be/src/exprs/table_function/unnest.h
+++ b/be/src/exprs/table_function/unnest.h
@@ -29,7 +29,8 @@ namespace starrocks {
  */
 class Unnest final : public TableFunction {
 public:
-    std::pair<Columns, UInt32Column::Ptr> process(TableFunctionState* state, bool* eos) const override {
+    std::pair<Columns, UInt32Column::Ptr> process(RuntimeState* runtime_state, TableFunctionState* state,
+                                                  bool* eos) const override {
         *eos = true;
         if (state->get_columns().empty()) {
             return {};

--- a/be/test/exprs/agg/json_each_test.cpp
+++ b/be/test/exprs/agg/json_each_test.cpp
@@ -52,7 +52,7 @@ public:
         // execute
         ASSERT_OK(func->init({}, &func_state));
         func_state->set_params(input_columns);
-        ASSERT_OK(func->open(rt_state, func_state));
+        ASSERT_OK(func->open(rt_state.get(), func_state));
         auto [result_columns, offset_column] = func->process(rt_state.get(), func_state, &eos);
 
         // check


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

