### PR TITLE
[BugFix]Fix query wrong result for paimon table binay type

### DIFF
--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonColumnValue.java
@@ -94,7 +94,7 @@ public class PaimonColumnValue implements ColumnValue {
 
     @Override
     public byte[] getBytes() {
-        return new byte[0];
+        return (byte[]) fieldData;
     }
 
     @Override


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #37945

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
