### PR TITLE
[Enhancement] Add db lock waiter number metrics

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/consistency/LockChecker.java
@@ -37,6 +37,8 @@ public class LockChecker extends FrontendDaemon {
 
     private static final Logger LOG = LogManager.getLogger(LockChecker.class);
 
+    private static int waiterNumber = 0;
+
     public LockChecker() {
         super("DeadlockChecker", 1000 * Config.lock_checker_interval_second);
     }
@@ -101,6 +103,7 @@ public class LockChecker extends FrontendDaemon {
                     }
                 }
                 ownerInfo.add("lockWaiters", waiterIds);
+                waiterNumber = waiterIds.size();
                 dbLocks.add(ownerInfo);
             }
         }
@@ -122,5 +125,9 @@ public class LockChecker extends FrontendDaemon {
                 }
             }
         }
+    }
+
+    public static int getWaiterNumber() {
+        return waiterNumber;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricCalculator.java
@@ -35,6 +35,7 @@
 package com.starrocks.metric;
 
 import com.starrocks.common.Config;
+import com.starrocks.consistency.LockChecker;
 import com.starrocks.qe.QueryDetail;
 import com.starrocks.qe.QueryDetailQueue;
 import com.starrocks.server.GlobalStateMgr;
@@ -148,5 +149,7 @@ public class MetricCalculator extends TimerTask {
         }
 
         MetricRepo.GAUGE_SAFE_MODE.setValue(GlobalStateMgr.getCurrentState().isSafeMode() ? 1 : 0);
+
+        MetricRepo.GAUGE_DB_LOCK_WAITER.setValue(LockChecker.getWaiterNumber());
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -158,6 +158,8 @@ public final class MetricRepo {
     // Currently, we use gauge for safe mode metrics, since we do not have unTyped metrics till now
     public static GaugeMetricImpl<Integer> GAUGE_SAFE_MODE;
 
+    public static GaugeMetricImpl<Integer> GAUGE_DB_LOCK_WAITER;
+
     private static final ScheduledThreadPoolExecutor METRIC_TIMER =
             ThreadPoolManager.newDaemonScheduledThreadPool(1, "Metric-Timer-Pool", true);
     private static final MetricCalculator METRIC_CALCULATOR = new MetricCalculator();
@@ -358,6 +360,11 @@ public final class MetricRepo {
         GAUGE_SAFE_MODE.addLabel(new MetricLabel("type", "safe_mode"));
         GAUGE_SAFE_MODE.setValue(0);
         STARROCKS_METRIC_REGISTER.addMetric(GAUGE_SAFE_MODE);
+
+        GAUGE_DB_LOCK_WAITER = new GaugeMetricImpl<>("db_lock_waiter", MetricUnit.NOUNIT, "db lock waiter");
+        GAUGE_DB_LOCK_WAITER.addLabel(new MetricLabel("type", "db_lock_waiter"));
+        GAUGE_DB_LOCK_WAITER.setValue(0);
+        STARROCKS_METRIC_REGISTER.addMetric(GAUGE_DB_LOCK_WAITER);
 
         // 2. counter
         COUNTER_REQUEST_ALL = new LongCounterMetric("request_total", MetricUnit.REQUESTS, "total request");


### PR DESCRIPTION
Why I'm doing:
add a lock waiter metrics will help us debug lock problem
What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
