### PR TITLE
[Enhancement] Make audit report for insert into statement asynchronous

### DIFF
--- a/be/src/exec/pipeline/audit_statistics_reporter.cpp
+++ b/be/src/exec/pipeline/audit_statistics_reporter.cpp
@@ -28,7 +28,7 @@ using apache::thrift::TProcessor;
 using apache::thrift::transport::TTransportException;
 
 AuditStatisticsReporter::AuditStatisticsReporter() {
-    auto status = ThreadPoolBuilder("audit_report") // exec state reporter
+    auto status = ThreadPoolBuilder("audit_report")
                           .set_min_threads(1)
                           .set_max_threads(2)
                           .set_max_queue_size(1000)

--- a/be/src/exec/pipeline/audit_statistics_reporter.cpp
+++ b/be/src/exec/pipeline/audit_statistics_reporter.cpp
@@ -17,17 +17,27 @@
 #include <thrift/Thrift.h>
 #include <thrift/protocol/TDebugProtocol.h>
 
-#include "agent/master_info.h"
 #include "gen_cpp/FrontendService_types.h"
 #include "runtime/client_cache.h"
 #include "runtime/exec_env.h"
-#include "service/backend_options.h"
 
 namespace starrocks::pipeline {
 
 using apache::thrift::TException;
 using apache::thrift::TProcessor;
 using apache::thrift::transport::TTransportException;
+
+AuditStatisticsReporter::AuditStatisticsReporter() {
+    auto status = ThreadPoolBuilder("audit_report") // exec state reporter
+                          .set_min_threads(1)
+                          .set_max_threads(2)
+                          .set_max_queue_size(1000)
+                          .set_idle_timeout(MonoDelta::FromMilliseconds(2000))
+                          .build(&_thread_pool);
+    if (!status.ok()) {
+        LOG(FATAL) << "Cannot create thread pool for ExecStateReport: error=" << status.to_string();
+    }
+}
 
 // including the final status when execution finishes.
 Status AuditStatisticsReporter::report_audit_statistics(const TReportAuditStatisticsParams& params, ExecEnv* exec_env,
@@ -73,5 +83,9 @@ Status AuditStatisticsReporter::report_audit_statistics(const TReportAuditStatis
         return rpc_status;
     }
     return rpc_status;
+}
+
+Status AuditStatisticsReporter::submit(std::function<void()>&& report_task) {
+    return _thread_pool->submit_func(std::move(report_task));
 }
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/audit_statistics_reporter.h
+++ b/be/src/exec/pipeline/audit_statistics_reporter.h
@@ -16,14 +16,9 @@
 
 #include <memory>
 
-#include "exec/pipeline/fragment_context.h"
-#include "exec/pipeline/pipeline_fwd.h"
-#include "gen_cpp/FrontendService.h"
-#include "gen_cpp/InternalService_types.h"
 #include "gen_cpp/Types_types.h"
 #include "runtime/exec_env.h"
 #include "runtime/runtime_state.h"
-#include "service/backend_options.h"
 #include "util/threadpool.h"
 
 namespace starrocks::pipeline {
@@ -33,5 +28,10 @@ public:
 
     static Status report_audit_statistics(const TReportAuditStatisticsParams& params, ExecEnv* exec_env,
                                           const TNetworkAddress& fe_addr);
+
+    [[nodiscard]] Status submit(std::function<void()>&& report_task);
+
+private:
+    std::unique_ptr<ThreadPool> _thread_pool;
 };
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/olap_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/olap_table_sink_operator.cpp
@@ -54,6 +54,11 @@ bool OlapTableSinkOperator::is_finished() const {
 }
 
 bool OlapTableSinkOperator::pending_finish() const {
+    // audit report not finish, we need check until finish
+    if (!_is_audit_report_done) {
+        return true;
+    }
+
     // sink's open not finish, we need check util finish
     if (!_is_open_done) {
         if (!_sink->is_open_done()) {
@@ -108,7 +113,9 @@ Status OlapTableSinkOperator::set_finishing(RuntimeState* state) {
     _is_finished = true;
 
     if (_num_sinkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx());
+        _is_audit_report_done = false;
+        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx(),
+                                                                         &_is_audit_report_done);
     }
     if (_is_open_done && !_automatic_partition_chunk) {
         // sink's open already finish, we can try_close

--- a/be/src/exec/pipeline/olap_table_sink_operator.h
+++ b/be/src/exec/pipeline/olap_table_sink_operator.h
@@ -69,6 +69,7 @@ private:
     mutable bool _is_open_done = false;
     int32_t _sender_id;
     bool _is_cancelled = false;
+    bool _is_audit_report_done = true;
 
     // temporarily save chunk during automatic partition creation
     mutable ChunkPtr _automatic_partition_chunk;

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -35,7 +35,8 @@ GlobalDriverExecutor::GlobalDriverExecutor(const std::string& name, std::unique_
                                               : std::make_unique<QuerySharedDriverQueue>()),
           _thread_pool(std::move(thread_pool)),
           _blocked_driver_poller(new PipelineDriverPoller(_driver_queue.get())),
-          _exec_state_reporter(new ExecStateReporter()) {
+          _exec_state_reporter(new ExecStateReporter()),
+          _audit_statistics_reporter(new AuditStatisticsReporter()) {
     REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_schedule_count, [this]() { return _schedule_count.load(); });
     REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_execution_time, [this]() { return _driver_execution_ns.load(); });
     REGISTER_GAUGE_STARROCKS_METRIC(pipe_driver_queue_len, [this]() { return _driver_queue->size(); });
@@ -336,7 +337,13 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
     this->_exec_state_reporter->submit(std::move(report_task));
 }
 
-void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) {
+void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) {
+    bool submit_success = false;
+    DeferOp defer([&]() {
+        if (!submit_success) {
+            *done = true;
+        }
+    });
     auto query_statistics = query_ctx->final_query_statistic();
 
     TReportAuditStatisticsParams params;
@@ -355,17 +362,24 @@ void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, Frag
     auto exec_env = fragment_ctx->runtime_state()->exec_env();
     auto fragment_id = fragment_ctx->fragment_instance_id();
 
-    auto status = AuditStatisticsReporter::report_audit_statistics(params, exec_env, fe_addr);
-    if (!status.ok()) {
-        if (status.is_not_found()) {
-            LOG(INFO) << "[Driver] Fail to report audit statistics due to query not found: fragment_instance_id="
-                      << print_id(fragment_id);
+    auto report_task = [=]() {
+        *done = true;
+        auto status = AuditStatisticsReporter::report_audit_statistics(params, exec_env, fe_addr);
+        if (!status.ok()) {
+            if (status.is_not_found()) {
+                LOG(INFO) << "[Driver] Fail to report audit statistics due to query not found: fragment_instance_id="
+                          << print_id(fragment_id);
+            } else {
+                LOG(WARNING) << "[Driver] Fail to report audit statistics fragment_instance_id="
+                             << print_id(fragment_id) << ", status: " << status.to_string();
+            }
         } else {
-            LOG(WARNING) << "[Driver] Fail to report audit statistics fragment_instance_id=" << print_id(fragment_id)
-                         << ", status: " << status.to_string();
+            LOG(INFO) << "[Driver] Succeed to report audit statistics: fragment_instance_id=" << print_id(fragment_id);
         }
-    } else {
-        LOG(INFO) << "[Driver] Succeed to report audit statistics: fragment_instance_id=" << print_id(fragment_id);
+    };
+    auto st = this->_audit_statistics_reporter->submit(std::move(report_task));
+    if (st.ok()) {
+        submit_success = true;
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -338,6 +338,9 @@ void GlobalDriverExecutor::report_exec_state(QueryContext* query_ctx, FragmentCo
 }
 
 void GlobalDriverExecutor::report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) {
+    // It should be guaranteed that the done flag must be set to true in any cases.
+    // If the async task is submitted successfully, the done flag will be set to true in the lambda function.
+    // Otherwise, the done flag will be set to true in the defer object.
     bool submit_success = false;
     DeferOp defer([&]() {
         if (!submit_success) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.h
+++ b/be/src/exec/pipeline/pipeline_driver_executor.h
@@ -52,7 +52,7 @@ public:
     virtual void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status,
                                    bool done, bool attach_profile) = 0;
 
-    virtual void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) = 0;
+    virtual void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) = 0;
 
     virtual void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const = 0;
 
@@ -78,7 +78,7 @@ public:
     void close() override;
     void report_exec_state(QueryContext* query_ctx, FragmentContext* fragment_ctx, const Status& status, bool done,
                            bool attach_profile) override;
-    void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx) override;
+    void report_audit_statistics(QueryContext* query_ctx, FragmentContext* fragment_ctx, bool* done) override;
 
     void iterate_immutable_blocking_driver(const IterateImmutableDriverFunc& call) const override;
 
@@ -107,6 +107,7 @@ private:
     std::unique_ptr<ThreadPool> _thread_pool;
     PipelineDriverPollerPtr _blocked_driver_poller;
     std::unique_ptr<ExecStateReporter> _exec_state_reporter;
+    std::unique_ptr<AuditStatisticsReporter> _audit_statistics_reporter;
 
     std::atomic<int> _next_id = 0;
     std::atomic_int64_t _schedule_count = 0;

--- a/be/src/exec/pipeline/sink/export_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/export_sink_operator.cpp
@@ -193,12 +193,18 @@ bool ExportSinkOperator::is_finished() const {
 
 Status ExportSinkOperator::set_finishing(RuntimeState* state) {
     if (_num_sinkers.fetch_sub(1, std::memory_order_acq_rel) == 1) {
-        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx());
+        _is_audit_report_done = false;
+        state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx(),
+                                                                         &_is_audit_report_done);
     }
     return _export_sink_buffer->set_finishing();
 }
 
 bool ExportSinkOperator::pending_finish() const {
+    // audit report not finish, we need check until finish
+    if (!_is_audit_report_done) {
+        return true;
+    }
     return !_export_sink_buffer->is_finished();
 }
 

--- a/be/src/exec/pipeline/sink/export_sink_operator.h
+++ b/be/src/exec/pipeline/sink/export_sink_operator.h
@@ -64,6 +64,7 @@ public:
 private:
     std::shared_ptr<ExportSinkIOBuffer> _export_sink_buffer;
     std::atomic<int32_t>& _num_sinkers;
+    bool _is_audit_report_done = true;
 };
 
 class ExportSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/iceberg_table_sink_operator.h
@@ -93,6 +93,8 @@ private:
     std::atomic<bool> _is_finished = false;
     bool _is_static_partition_insert = false;
     std::atomic<int32_t>& _num_sinkers;
+
+    bool _is_audit_report_done = true;
 };
 
 class IcebergTableSinkOperatorFactory final : public OperatorFactory {

--- a/be/src/exec/pipeline/sink/memory_scratch_sink_operator.h
+++ b/be/src/exec/pipeline/sink/memory_scratch_sink_operator.h
@@ -76,6 +76,8 @@ private:
     mutable std::shared_ptr<arrow::RecordBatch> _pending_result;
     bool _is_finished = false;
     bool _has_put_sentinel = false;
+
+    bool _is_audit_report_done = true;
 };
 
 class MemoryScratchSinkOperatorFactory final : public OperatorFactory {


### PR DESCRIPTION
## Why I'm doing:

For insert into statement, audit statistics will be reported to fe through a sync rpc call at the finishing stage of final sink, like `olap_table_sink_operator`

```cpp
state->exec_env()->wg_driver_executor()->report_audit_statistics(state->query_ctx(), state->fragment_ctx());
```

It should be guarantee that the rpc invocation must be done before the execution is finished. So I choose to use the synchronous manner in the previous version.

But here's another problem, if the fe is of high load, the thrift thread pool is too busy to answer the rpc invocation, then the be's thread will be blocked and further blocked all the workloads, because the worker number is limited (equal to the core's size)

## What I'm doing:

Make the rpc all asynchronous, and wait it to be finished in the operator's `pending_finish` method.


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
