### PR TITLE
[BugFix] Fix csv writer using incorrect number of columns

### DIFF
--- a/be/src/exec/plain_text_builder.cpp
+++ b/be/src/exec/plain_text_builder.cpp
@@ -46,7 +46,7 @@ Status PlainTextBuilder::add_chunk(Chunk* chunk) {
     RETURN_IF_ERROR(init());
 
     const size_t num_rows = chunk->num_rows();
-    const size_t num_cols = chunk->num_columns();
+    const size_t num_cols = _output_expr_ctxs.size();
     if (num_cols != _converters.size()) {
         auto err = strings::Substitute("Unmatched number of columns expected=$0 real=$1", _converters.size(), num_cols);
         return Status::InternalError(err);


### PR DESCRIPTION
Why I'm doing:

For cases like
```sql
select 1 as a, 1 as b 
into outfile "file:///tmp/test3.csv" 
format as csv;
```
The chunk has only one column. But two slots are required for output.

What I'm doing:

Use the size of `output_exprs` as the number of columns. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
