### PR TITLE
[BugFix] fix compatibility between 2.5 FE and 3.0 BE

### DIFF
--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -70,7 +70,10 @@ Status ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_
             if (chunk == nullptr) {
                 chunk = std::make_shared<Chunk>();
             }
-            if (!_status.ok()) {
+            if (_status.is_eagain()) {
+                _status = Status::OK();
+                continue;
+            } else if (!_status.ok()) {
                 // end of file is normal case, need process chunk
                 if (_status.is_end_of_file()) {
                     chunk->owner_info().set_owner_id(owner_id, true);

--- a/be/src/exec/pipeline/scan/schema_chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.cpp
@@ -18,6 +18,7 @@
 
 #include "exec/schema_scanner.h"
 #include "exec/workgroup/work_group.h"
+#include "runtime/runtime_state.h"
 
 namespace starrocks::pipeline {
 
@@ -50,7 +51,11 @@ Status SchemaChunkSource::prepare(RuntimeState* state) {
     }
 
     RETURN_IF_ERROR(_schema_scanner->init(param, _ctx->object_pool()));
+    RETURN_IF_ERROR(_prepare_slot(state));
+    return _schema_scanner->start(state);
+}
 
+Status SchemaChunkSource::_prepare_slot(RuntimeState* state) {
     const std::vector<SlotDescriptor*>& src_slot_descs = _schema_scanner->get_slot_descs();
     const std::vector<SlotDescriptor*>& dest_slot_descs = _dest_tuple_desc->slots();
     int slot_num = dest_slot_descs.size();
@@ -80,8 +85,7 @@ Status SchemaChunkSource::prepare(RuntimeState* state) {
         _index_map[i] = j;
     }
     _accumulator.set_desired_size(state->chunk_size());
-
-    return _schema_scanner->start(state);
+    return {};
 }
 
 void SchemaChunkSource::close(RuntimeState* state) {}
@@ -127,10 +131,14 @@ Status SchemaChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
     bool scanner_eos = false;
     int32_t row_num = 0;
 
+    _schema_scanner->set_runtime_state(state);
     while (!scanner_eos && chunk_dst->is_empty()) {
         while (row_num < state->chunk_size()) {
-            RETURN_IF_ERROR(_schema_scanner->get_next(&chunk_src, &scanner_eos));
-            if (scanner_eos) {
+            Status st = _schema_scanner->get_next(&chunk_src, &scanner_eos);
+            if (st.is_eagain()) {
+                RETURN_IF_ERROR(_prepare_slot(state));
+                return st;
+            } else if (scanner_eos) {
                 if (row_num == 0) {
                     return Status::EndOfFile("end of file");
                 }

--- a/be/src/exec/pipeline/scan/schema_chunk_source.h
+++ b/be/src/exec/pipeline/scan/schema_chunk_source.h
@@ -39,6 +39,9 @@ public:
 
     void close(RuntimeState* state) override;
 
+protected:
+    Status _prepare_slot(RuntimeState* state);
+
 private:
     Status _read_chunk(RuntimeState* state, ChunkPtr* chunk) override;
 

--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -72,6 +72,10 @@ Status SchemaScanner::start(RuntimeState* state) {
     return Status::OK();
 }
 
+void SchemaScanner::set_runtime_state(RuntimeState* state) {
+    _runtime_state = state;
+}
+
 Status SchemaScanner::get_next(ChunkPtr* chunk, bool* eos) {
     if (!_is_init) {
         return Status::InternalError("used before initialized.");
@@ -199,6 +203,7 @@ Status SchemaScanner::_create_slot_descs(ObjectPool* pool) {
     int null_byte = 0;
     int null_bit = 0;
 
+    _slot_descs.clear();
     for (int i = 0; i < _column_num; ++i) {
         TSlotDescriptor t_slot_desc;
         auto type_desc = TypeDescriptor(_columns[i].type);

--- a/be/src/exec/schema_scanner.h
+++ b/be/src/exec/schema_scanner.h
@@ -95,6 +95,7 @@ public:
     static std::unique_ptr<SchemaScanner> create(TSchemaTableType::type type);
 
     TAuthInfo build_auth_info();
+    void set_runtime_state(RuntimeState* state);
 
     static void set_starrocks_server(StarRocksServer* starrocks_server) { _s_starrocks_server = starrocks_server; }
 

--- a/be/src/exec/schema_scanner/schema_materialized_views_scanner.h
+++ b/be/src/exec/schema_scanner/schema_materialized_views_scanner.h
@@ -17,6 +17,7 @@
 #include "column/datum.h"
 #include "exec/schema_scanner.h"
 #include "gen_cpp/FrontendService_types.h"
+#include "runtime/global_dict/parser.h"
 
 namespace starrocks {
 
@@ -30,13 +31,22 @@ public:
 
 private:
     Status get_materialized_views();
-    Status fill_chunk(ChunkPtr* chunk);
+    Status _fill_chunk_v1(ChunkPtr* chunk);
+    Status _fill_chunk_v2(ChunkPtr* chunk);
+    Status _change_to_v1_schema(RuntimeState* state);
 
     int _db_index{0};
     int _table_index{0};
     TGetDbsResult _db_result;
+
+    // v2 result
     TListMaterializedViewStatusResult _mv_results;
     static SchemaScanner::ColumnDesc _s_tbls_columns[];
+
+    // NOTE v1 result. it's kept for compatibility, and used for 2.5 version
+    static SchemaScanner::ColumnDesc _s_tbls_columns_v1[];
+    TListTableStatusResult _table_result;
+    bool _v1_schema = false;
 };
 
 } // namespace starrocks

--- a/be/src/util/thrift_rpc_helper.cpp
+++ b/be/src/util/thrift_rpc_helper.cpp
@@ -54,6 +54,7 @@ using apache::thrift::transport::TTransport;
 using apache::thrift::transport::TBufferedTransport;
 
 ExecEnv* ThriftRpcHelper::_s_exec_env;
+const char* ThriftRpcHelper::KInvalidMethodName = "Invalid method name";
 
 void ThriftRpcHelper::setup(ExecEnv* exec_env) {
     _s_exec_env = exec_env;

--- a/be/src/util/thrift_rpc_helper.h
+++ b/be/src/util/thrift_rpc_helper.h
@@ -31,6 +31,7 @@ class ClientConnection;
 // this class is a helper for jni call. easy for unit test
 class ThriftRpcHelper {
 public:
+    static const char* KInvalidMethodName;
     static void setup(ExecEnv* exec_env);
 
     // for default timeout

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -364,6 +364,9 @@ struct TTableStatus {
     5: optional i64 last_check_time
     6: optional i64 create_time
     20: optional string ddl_sql
+
+    21: optional string id
+    22: optional string rows
 }
 
 struct TListTableStatusResult {


### PR DESCRIPTION
Why I'm doing:
- `information_schema.materialized_view` is not compatible between 2.5 FE and 3.0 BE, since 3.0 BE uses a new RPC interface of FE

What I'm doing:
- Fallback to old RPC interface if new interface is not available
- Fallback to old SlotDesc
- Use `Status::EAgain` to indicate the recreation of SlotDesc

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/5449

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [x] 3.0
  - [ ] 2.5
