### PR TITLE
[Feature] support max concurrency control in pipeline

### DIFF
--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -149,6 +149,9 @@ Status FragmentExecutor::_prepare_query_ctx(ExecEnv* exec_env, const UnifiedExec
     if (query_options.__isset.runtime_profile_report_interval) {
         _query_ctx->set_runtime_profile_report_interval(std::max(1L, query_options.runtime_profile_report_interval));
     }
+    if (query_options.__isset.driver_max_concurrency && query_options.driver_max_concurrency > 0) {
+        _query_ctx->set_max_concurrency(query_options.driver_max_concurrency);
+    }
 
     bool enable_query_trace = false;
     if (query_options.__isset.enable_query_debug_trace && query_options.enable_query_debug_trace) {

--- a/be/src/exec/pipeline/pipeline_driver_executor.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_executor.cpp
@@ -142,6 +142,12 @@ void GlobalDriverExecutor::_worker_thread() {
                 _blocked_driver_poller->add_blocked_driver(driver);
                 continue;
             }
+            auto concurrency_token = driver->query_ctx()->acquire_exec_concurrency();
+            if (!concurrency_token) {
+                // reach max concurrency add to poller
+                _blocked_driver_poller->add_blocked_driver(driver);
+                continue;
+            }
 
             StatusOr<DriverState> maybe_state;
             int64_t start_time = driver->get_active_time();

--- a/be/src/exec/pipeline/pipeline_driver_poller.cpp
+++ b/be/src/exec/pipeline/pipeline_driver_poller.cpp
@@ -127,6 +127,8 @@ void PipelineDriverPoller::run_internal() {
                 } else if (driver->is_finished()) {
                     remove_blocked_driver(_local_blocked_drivers, driver_it);
                     ready_drivers.emplace_back(driver);
+                } else if (driver->query_ctx()->exceed_max_concurrency()) {
+                    ++driver_it;
                 } else {
                     auto status_or_is_not_blocked = driver->is_not_blocked();
                     if (!status_or_is_not_blocked.ok()) {

--- a/be/src/util/atomic_token.h
+++ b/be/src/util/atomic_token.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <atomic>
+
+#include "gutil/macros.h"
+
+namespace starrocks {
+template <class Counter>
+class AtomicToken {
+public:
+    AtomicToken() : _counter(nullptr) {}
+    AtomicToken(Counter* counter) : _counter(counter) {}
+    AtomicToken(AtomicToken&& other) noexcept : _counter(other._counter) { other._counter = nullptr; }
+    ~AtomicToken() {
+        if (_counter) {
+            (*_counter)--;
+        }
+        _counter = nullptr;
+    }
+    void operator=(AtomicToken&&) = delete;
+    DISALLOW_COPY(AtomicToken);
+    operator bool() const { return _counter != nullptr; }
+
+private:
+    Counter* _counter;
+};
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -600,6 +600,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     public static final String ENABLE_HYPERSCAN_VEC = "enable_hyperscan_vec";
 
+    // pipeline driver max concurrency. 0 means unlimited
+    public static final String DRIVER_MAX_CONCURRENCY = "driver_max_concurrency";
+
     public static final List<String> DEPRECATED_VARIABLES = ImmutableList.<String>builder()
             .add(CODEGEN_LEVEL)
             .add(MAX_EXECUTION_TIME)
@@ -1226,6 +1229,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
 
     @VarAttr(name = ENABLE_HYPERSCAN_VEC)
     private boolean enableHyperscanVec = true;
+
+    @VarAttr(name = DRIVER_MAX_CONCURRENCY)
+    private int driverMaxConcurrency = 0;
 
     public long getCboPushDownTopNLimit() {
         return cboPushDownTopNLimit;
@@ -3104,6 +3110,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
         tResult.setEnable_collect_table_level_scan_stats(enableCollectTableLevelScanStats);
         tResult.setEnable_pipeline_level_shuffle(enablePipelineLevelShuffle);
         tResult.setEnable_hyperscan_vec(enableHyperscanVec);
+        tResult.setDriver_max_concurrency(driverMaxConcurrency);
         return tResult;
     }
 

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -247,6 +247,7 @@ struct TQueryOptions {
 
   112: optional bool enable_pipeline_level_shuffle;
   113: optional bool enable_hyperscan_vec;
+  114: optional i32 driver_max_concurrency;
 }
 
 


### PR DESCRIPTION
Why I'm doing:
Currently there is no good control parameter for complex queries to control the maximum concurrency (cpu usage). So we introduce a parameter to control the maximum cpu usage of a single query

What I'm doing:

add a new session variable `driver_max_concurrency` to control max concurrency.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
