### PR TITLE
[Enhancement] improve partial update by column when when there is too many segment files

### DIFF
--- a/be/test/storage/rowset_column_partial_update_test.cpp
+++ b/be/test/storage/rowset_column_partial_update_test.cpp
@@ -1054,6 +1054,61 @@ TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_column_batch) {
     ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
 }
 
+TEST_P(RowsetColumnPartialUpdateTest, partial_update_multi_segment_and_column_batch) {
+    const int N = 10;
+    // generate M upt files in each partial rowset
+    const int M = 100;
+    auto tablet = create_tablet(rand(), rand(), true);
+    ASSERT_EQ(1, tablet->updates()->version_history_count());
+
+    std::vector<int64_t> keys(N);
+    std::vector<int64_t> partial_keys1;
+    std::vector<int64_t> partial_keys2;
+    for (int i = 0; i < N; i++) {
+        keys[i] = i;
+        if (i % 2 == 0) {
+            partial_keys1.push_back(i);
+        } else {
+            partial_keys2.push_back(i);
+        }
+    }
+    auto v1_func = [](int64_t k1) { return (int16_t)(k1 % 100 + 3); };
+    auto v2_func = [](int64_t k1) { return (int32_t)(k1 % 1000 + 4); };
+    std::vector<RowsetSharedPtr> rowsets;
+    rowsets.reserve(20);
+    // write full rowset first
+    for (int i = 0; i < 5; i++) {
+        rowsets.emplace_back(create_rowset(tablet, partial_keys1, true));
+    }
+    for (int i = 0; i < 5; i++) {
+        rowsets.emplace_back(create_rowset(tablet, partial_keys2, true));
+    }
+    std::vector<std::shared_ptr<TabletSchema>> partial_schemas;
+    // partial update v1 and v2 at once
+    for (int i = 0; i < 10; i++) {
+        std::vector<int32_t> column_indexes = {0, 1, 2};
+        partial_schemas.push_back(TabletSchema::create(tablet->tablet_schema(), column_indexes));
+        rowsets.emplace_back(
+                create_partial_rowset(tablet, keys, column_indexes, v1_func, v2_func, partial_schemas[i], M));
+        ASSERT_EQ(rowsets.back()->num_update_files(), M);
+    }
+
+    int32_t old_val = config::vertical_compaction_max_columns_per_group;
+    config::vertical_compaction_max_columns_per_group = 1;
+    int64_t version = 1;
+    commit_rowsets(tablet, rowsets, version);
+    // check data
+    ASSERT_TRUE(check_tablet(tablet, version, N, [](int64_t k1, int64_t v1, int32_t v2) {
+        return (int16_t)(k1 % 100 + 3) == v1 && (int32_t)(k1 % 1000 + 4) == v2;
+    }));
+    config::vertical_compaction_max_columns_per_group = old_val;
+    // check refcnt
+    for (const auto& rs_ptr : rowsets) {
+        ASSERT_FALSE(StorageEngine::instance()->update_manager()->TEST_update_state_exist(tablet.get(), rs_ptr.get()));
+    }
+    ASSERT_TRUE(StorageEngine::instance()->update_manager()->TEST_primary_index_refcnt(tablet->tablet_id(), 1));
+}
+
 INSTANTIATE_TEST_SUITE_P(RowsetColumnPartialUpdateTest, RowsetColumnPartialUpdateTest,
                          ::testing::Values(1, 1024, 104857600));
 


### PR DESCRIPTION
Why I'm doing:
There are two bad cases in the previous implementation.

1. SR will read same `upt` file multiple times for each segment's `dcg` generation. This kind of processing will be very inefficient in scenarios with many segment files.
2. There is a tablet, with one large Rowset (data size larger than `config::update_compaction_result_bytes` * 2) with overlapping small segments, and one empty rowset. In this case, SR can't trigger valid compaction because if `info->inputs.size() > 0 && new_bytes > config::update_compaction_result_bytes * 2`, SR can't pick more rowsets.

What I'm doing:
1. Avoid multiple re-reads of `upt` files.
2. improve update compaction strategy to pick more valid rowsets.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
