### PR TITLE
[BugFix] Fix query plan when table or partition is empty

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -71,30 +71,31 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
                 .addHeader("Authorization", rootAuth)
                 .url(URI + PATH_URI)
                 .build();
-        Response response = networkClient.newCall(request).execute();
-        String respStr = Objects.requireNonNull(response.body()).string();
-        JSONObject jsonObject = new JSONObject(respStr);
-        System.out.println(respStr);
-        Assert.assertEquals(200, jsonObject.getInt("status"));
+        try (Response response = networkClient.newCall(request).execute()) {
+            String respStr = Objects.requireNonNull(response.body()).string();
+            JSONObject jsonObject = new JSONObject(respStr);
+            System.out.println(respStr);
+            Assert.assertEquals(200, jsonObject.getInt("status"));
 
-        JSONObject partitionsObject = jsonObject.getJSONObject("partitions");
-        Assert.assertNotNull(partitionsObject);
-        for (String tabletKey : partitionsObject.keySet()) {
-            JSONObject tabletObject = partitionsObject.getJSONObject(tabletKey);
-            Assert.assertNotNull(tabletObject.getJSONArray("routings"));
-            Assert.assertEquals(3, tabletObject.getJSONArray("routings").length());
-            Assert.assertEquals(testStartVersion, tabletObject.getLong("version"));
-            Assert.assertEquals(testSchemaHash, tabletObject.getLong("schemaHash"));
+            JSONObject partitionsObject = jsonObject.getJSONObject("partitions");
+            Assert.assertNotNull(partitionsObject);
+            for (String tabletKey : partitionsObject.keySet()) {
+                JSONObject tabletObject = partitionsObject.getJSONObject(tabletKey);
+                Assert.assertNotNull(tabletObject.getJSONArray("routings"));
+                Assert.assertEquals(3, tabletObject.getJSONArray("routings").length());
+                Assert.assertEquals(testStartVersion, tabletObject.getLong("version"));
+                Assert.assertEquals(testSchemaHash, tabletObject.getLong("schemaHash"));
 
+            }
+            String queryPlan = jsonObject.getString("opaqued_query_plan");
+            Assert.assertNotNull(queryPlan);
+            byte[] binaryPlanInfo = Base64.getDecoder().decode(queryPlan);
+            TDeserializer deserializer = new TDeserializer();
+            TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
+            deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo);
+            expectThrowsNoException(() -> deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo));
+            System.out.println(tQueryPlanInfo);
         }
-        String queryPlan = jsonObject.getString("opaqued_query_plan");
-        Assert.assertNotNull(queryPlan);
-        byte[] binaryPlanInfo = Base64.getDecoder().decode(queryPlan);
-        TDeserializer deserializer = new TDeserializer();
-        TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
-        deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo);
-        expectThrowsNoException(() -> deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo));
-        System.out.println(tQueryPlanInfo);
     }
 
     @Test
@@ -106,16 +107,17 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
                 .addHeader("Authorization", rootAuth)
                 .url(URI + PATH_URI)
                 .build();
-        Response response = networkClient.newCall(request).execute();
-        String respStr = Objects.requireNonNull(response.body()).string();
-        System.out.println(respStr);
-        Assert.assertNotNull(respStr);
-        expectThrowsNoException(() -> new JSONObject(respStr));
-        JSONObject jsonObject = new JSONObject(respStr);
-        Assert.assertEquals(400, jsonObject.getInt("status"));
-        String exception = jsonObject.getString("exception");
-        Assert.assertNotNull(exception);
-        Assert.assertEquals("POST body must contains [sql] root object", exception);
+        try (Response response = networkClient.newCall(request).execute()) {
+            String respStr = Objects.requireNonNull(response.body()).string();
+            System.out.println(respStr);
+            Assert.assertNotNull(respStr);
+            expectThrowsNoException(() -> new JSONObject(respStr));
+            JSONObject jsonObject = new JSONObject(respStr);
+            Assert.assertEquals(400, jsonObject.getInt("status"));
+            String exception = jsonObject.getString("exception");
+            Assert.assertNotNull(exception);
+            Assert.assertEquals("POST body must contains [sql] root object", exception);
+        }
     }
 
     @Test
@@ -127,15 +129,16 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
                 .addHeader("Authorization", rootAuth)
                 .url(ES_TABLE_URL + PATH_URI)
                 .build();
-        Response response = networkClient.newCall(request).execute();
-        String respStr = Objects.requireNonNull(response.body()).string();
-        Assert.assertNotNull(respStr);
-        expectThrowsNoException(() -> new JSONObject(respStr));
-        JSONObject jsonObject = new JSONObject(respStr);
-        Assert.assertEquals(400, jsonObject.getInt("status"));
-        String exception = jsonObject.getString("exception");
-        Assert.assertNotNull(exception);
-        Assert.assertTrue(exception.startsWith("malformed json"));
+        try (Response response = networkClient.newCall(request).execute()) {
+            String respStr = Objects.requireNonNull(response.body()).string();
+            Assert.assertNotNull(respStr);
+            expectThrowsNoException(() -> new JSONObject(respStr));
+            JSONObject jsonObject = new JSONObject(respStr);
+            Assert.assertEquals(400, jsonObject.getInt("status"));
+            String exception = jsonObject.getString("exception");
+            Assert.assertNotNull(exception);
+            Assert.assertTrue(exception.startsWith("malformed json"));
+        }
     }
 
     @Test
@@ -147,15 +150,39 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
                 .addHeader("Authorization", rootAuth)
                 .url(ES_TABLE_URL + PATH_URI)
                 .build();
-        Response response = networkClient.newCall(request).execute();
-        String respStr = Objects.requireNonNull(response.body()).string();
-        Assert.assertNotNull(respStr);
-        expectThrowsNoException(() -> new JSONObject(respStr));
-        JSONObject jsonObject = new JSONObject(respStr);
-        Assert.assertEquals(403, jsonObject.getInt("status"));
-        String exception = jsonObject.getString("exception");
-        Assert.assertNotNull(exception);
-        Assert.assertTrue(
-                exception.startsWith("Only support OlapTable, CloudNativeTable and MaterializedView currently"));
+        try (Response response = networkClient.newCall(request).execute()) {
+            String respStr = Objects.requireNonNull(response.body()).string();
+            Assert.assertNotNull(respStr);
+            expectThrowsNoException(() -> new JSONObject(respStr));
+            JSONObject jsonObject = new JSONObject(respStr);
+            Assert.assertEquals(403, jsonObject.getInt("status"));
+            String exception = jsonObject.getString("exception");
+            Assert.assertNotNull(exception);
+            Assert.assertTrue(
+                    exception.startsWith("Only support OlapTable, CloudNativeTable and MaterializedView currently"));
+        }
+    }
+
+    @Test
+    public void testQueryPlanActionPruneEmpty() throws IOException {
+        super.setUpWithCatalog();
+
+
+        String tableName = "test_empty_table";
+
+        RequestBody body =
+                RequestBody.create(JSON, "{ \"sql\" :  \" select k1,k2,k3 from " + DB_NAME + "." + tableName +
+                        " where k3  > '2023-10-01 11:11:11' and k3 < '2023-10-02 11:11:11'" + " \" }");
+        String uri = "http://localhost:" + HTTP_PORT + "/api/" + DB_NAME + "/test_empty_table";
+
+        Request request = new Request.Builder()
+                .post(body)
+                .addHeader("Authorization", rootAuth)
+                .url(uri + PATH_URI)
+                .build();
+        try (Response response = networkClient.newCall(request).execute()) {
+            String respStr = Objects.requireNonNull(response.body()).string();
+            Assert.assertEquals("{\"partitions\":{},\"opaqued_query_plan\":\"\",\"status\":200}", respStr);
+        }
     }
 }


### PR DESCRIPTION
Why I'm doing:
#31301 introduces a new feature enablePruneEmptyOutputScan. In this new feature, empty partition or empty table information will be automatically filtered out, but this will affect our ability to obtain query_plan.

What I'm doing:

Fixes https://github.com/StarRocks/starrocks/issues/38080

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
