### PR TITLE
[Enhancement] remove garbage delta column files when expired version

### DIFF
--- a/be/src/storage/delta_column_group.cpp
+++ b/be/src/storage/delta_column_group.cpp
@@ -198,8 +198,9 @@ Status DeltaColumnGroupListSerializer::_deserialize_delta_column_group_list(cons
 }
 
 void DeltaColumnGroupListHelper::garbage_collection(DeltaColumnGroupList& dcg_list, const TabletSegmentId& tsid,
-                                                    int64_t min_readable_version,
-                                                    std::vector<std::pair<TabletSegmentId, int64_t>>& garbage_dcgs) {
+                                                    int64_t min_readable_version, const std::string& tablet_path,
+                                                    std::vector<std::pair<TabletSegmentId, int64_t>>* garbage_dcgs,
+                                                    std::vector<std::string>* garbage_files) {
     auto dcg_itr = dcg_list.begin();
     // The delta column group that need to be gc, should satisfy two point:
     // 1. It's version is not larger than min_readable_version
@@ -222,7 +223,9 @@ void DeltaColumnGroupListHelper::garbage_collection(DeltaColumnGroupList& dcg_li
                 }
             }
             if (need_free) {
-                garbage_dcgs.emplace_back(tsid, (*dcg_itr)->version());
+                garbage_dcgs->emplace_back(tsid, (*dcg_itr)->version());
+                std::vector<std::string> dcg_files = (*dcg_itr)->column_files(tablet_path);
+                garbage_files->insert(garbage_files->end(), dcg_files.begin(), dcg_files.end());
                 dcg_itr = dcg_list.erase(dcg_itr);
             } else {
                 for (const auto& cids : all_cids) {

--- a/be/src/storage/delta_column_group.h
+++ b/be/src/storage/delta_column_group.h
@@ -119,8 +119,9 @@ public:
 class DeltaColumnGroupListHelper {
 public:
     static void garbage_collection(DeltaColumnGroupList& dcg_list, const TabletSegmentId& tsid,
-                                   int64_t min_readable_version,
-                                   std::vector<std::pair<TabletSegmentId, int64_t>>& garbage_dcgs);
+                                   int64_t min_readable_version, const std::string& tablet_path,
+                                   std::vector<std::pair<TabletSegmentId, int64_t>>* garbage_dcgs,
+                                   std::vector<std::string>* garbage_files);
 
     // used for non-Primary Key tablet only
     static Status save_snapshot(const std::string& file_path, DeltaColumnGroupSnapshotPB& dcg_snapshot_pb);

--- a/be/src/storage/rowset_column_update_state.cpp
+++ b/be/src/storage/rowset_column_update_state.cpp
@@ -739,7 +739,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             uint64_t index_size = 0;
             uint64_t footer_position = 0;
             padding_char_columns(partial_schema, partial_tschema, source_chunk_ptr.get());
-            ASSIGN_OR_RETURN(auto delta_column_group_writer, build_writer_fn(each.first, partial_tschema, idx++));
+            ASSIGN_OR_RETURN(auto delta_column_group_writer, build_writer_fn(each.first, partial_tschema, idx));
             RETURN_IF_ERROR(delta_column_group_writer->append_chunk(*source_chunk_ptr));
             RETURN_IF_ERROR(delta_column_group_writer->finalize(&segment_file_size, &index_size, &footer_position));
             int64_t t5 = MonotonicMillis();
@@ -752,6 +752,7 @@ Status RowsetColumnUpdateState::finalize(Tablet* tablet, Rowset* rowset, uint32_
             dcg_column_files[each.first].push_back(file_name(delta_column_group_writer->segment_path()));
             handle_cnt++;
         }
+        idx++;
         // 3.7. reclaim update chunk cache
         reclaim_update_cache_fn(false);
     }

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -2306,7 +2306,8 @@ void TabletUpdates::remove_expired_versions(int64_t expire_time) {
         // Remove useless delta column group
         auto update_manager = StorageEngine::instance()->update_manager();
         size_t dcg_deleted = 0;
-        res = update_manager->clear_delta_column_group_before_version(meta_store, tablet_id, min_readable_version);
+        res = update_manager->clear_delta_column_group_before_version(meta_store, _tablet.schema_hash_path(), tablet_id,
+                                                                      min_readable_version);
         if (!res.ok()) {
             LOG(WARNING) << "Fail to clear_delta_column_group_before_version tablet:" << tablet_id
                          << " min_readable_version:" << min_readable_version << " msg:" << res.status();

--- a/be/src/storage/update_manager.h
+++ b/be/src/storage/update_manager.h
@@ -120,8 +120,8 @@ public:
 
     void clear_cached_delta_column_group(const std::vector<TabletSegmentId>& tsids);
 
-    StatusOr<size_t> clear_delta_column_group_before_version(KVStore* meta, int64_t tablet_id,
-                                                             int64_t min_readable_version);
+    StatusOr<size_t> clear_delta_column_group_before_version(KVStore* meta, const std::string& tablet_path,
+                                                             int64_t tablet_id, int64_t min_readable_version);
 
     void expire_cache();
 

--- a/be/test/storage/delta_column_group_test.cpp
+++ b/be/test/storage/delta_column_group_test.cpp
@@ -71,11 +71,17 @@ TEST(TestDeltaColumnGroup, testGC) {
             dcg.init((int64_t)i, {{i, i + 1, i + 2}}, {"abc.cols"});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, garbage_dcgs);
+        const std::string path = "/asd/";
+        std::vector<std::string> clear_files;
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 20);
+        ASSERT_TRUE(clear_files.size() == 0);
         ASSERT_TRUE(garbage_dcgs.size() == 0);
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, garbage_dcgs);
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 20);
+        ASSERT_TRUE(clear_files.size() == 0);
         ASSERT_TRUE(garbage_dcgs.size() == 0);
     };
     // test2
@@ -91,11 +97,17 @@ TEST(TestDeltaColumnGroup, testGC) {
             dcg.init((int64_t)i, {{1, 2, 3}}, {"abc.cols"});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, garbage_dcgs);
+        const std::string path = "/asd/";
+        std::vector<std::string> clear_files;
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 11);
+        ASSERT_TRUE(clear_files.size() == 9);
         ASSERT_TRUE(garbage_dcgs.size() == 9);
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, garbage_dcgs);
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 1);
+        ASSERT_TRUE(clear_files.size() == 19);
         ASSERT_TRUE(garbage_dcgs.size() == 19);
     };
     // test3
@@ -112,12 +124,18 @@ TEST(TestDeltaColumnGroup, testGC) {
             dcg.init((int64_t)i, {{1 + shift, 2 + shift, 3 + shift}}, {"abc.cols"});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, garbage_dcgs);
+        const std::string path = "/asd/";
+        std::vector<std::string> clear_files;
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 12);
         ASSERT_TRUE(garbage_dcgs.size() == 8);
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, garbage_dcgs);
+        ASSERT_TRUE(clear_files.size() == 8);
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 2);
         ASSERT_TRUE(garbage_dcgs.size() == 18);
+        ASSERT_TRUE(clear_files.size() == 18);
     };
     // test4
     {
@@ -134,12 +152,18 @@ TEST(TestDeltaColumnGroup, testGC) {
             dcg.init((int64_t)i, {{1 + shift, 2 + shift, 3 + shift}}, {"abc.cols"});
             dcgs.push_back(std::make_shared<DeltaColumnGroup>(dcg));
         }
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, garbage_dcgs);
+        const std::string path = "/asd/";
+        std::vector<std::string> clear_files;
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 10, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 13);
         ASSERT_TRUE(garbage_dcgs.size() == 7);
-        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, garbage_dcgs);
+        ASSERT_TRUE(clear_files.size() == 7);
+        DeltaColumnGroupListHelper::garbage_collection(dcgs, TabletSegmentId(100, 100), 20, path, &garbage_dcgs,
+                                                       &clear_files);
         ASSERT_TRUE(dcgs.size() == 3);
         ASSERT_TRUE(garbage_dcgs.size() == 17);
+        ASSERT_TRUE(clear_files.size() == 17);
     };
 };
 


### PR DESCRIPTION
Why I'm doing:
In current implementation, garbage delta column files removed when data dir gc, which will be slow. 

What I'm doing:
garbage delta column files removed when version expired.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
