### PR TITLE
[BugFix] Fix multi local shuffle aggregations on single BE (backport #37645)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/PlanFragment.java
@@ -130,6 +130,7 @@ public class PlanFragment extends TreeNode<PlanFragment> {
     // Whether to assign scan ranges to each driver sequence of pipeline,
     // for the normal backend assignment (not colocate, bucket, and replicated join).
     protected boolean assignScanRangesPerDriverSeq = false;
+    protected boolean withLocalShuffle = false;
 
     protected final Map<Integer, RuntimeFilterDescription> buildRuntimeFilters = Maps.newTreeMap();
     protected final Map<Integer, RuntimeFilterDescription> probeRuntimeFilters = Maps.newTreeMap();
@@ -237,6 +238,14 @@ public class PlanFragment extends TreeNode<PlanFragment> {
 
     public void setForceSetTableSinkDop() {
         this.forceSetTableSinkDop = true;
+    }
+
+    public boolean isWithLocalShuffle() {
+        return withLocalShuffle;
+    }
+
+    public void setWithLocalShuffleIfTrue(boolean withLocalShuffle) {
+        this.withLocalShuffle |= withLocalShuffle;
     }
 
     public boolean isAssignScanRangesPerDriverSeq() {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1417,7 +1417,7 @@ public class PlanFragmentBuilder {
             PlanFragment originalInputFragment = visit(optExpr.inputAt(0), context);
 
             PlanFragment inputFragment = removeExchangeNodeForLocalShuffleAgg(originalInputFragment, context);
-            boolean withLocalShuffle = inputFragment != originalInputFragment;
+            boolean withLocalShuffle = inputFragment != originalInputFragment || inputFragment.isWithLocalShuffle();
 
             /*
              * Create aggregate TupleDescriptor
@@ -1615,6 +1615,7 @@ public class PlanFragmentBuilder {
             if (node.isOnePhaseAgg() || node.isMergedLocalAgg() || node.getType().isDistinctGlobal()) {
                 // For ScanNode->LocalShuffle->AggNode, we needn't assign scan ranges per driver sequence.
                 inputFragment.setAssignScanRangesPerDriverSeq(!withLocalShuffle);
+                inputFragment.setWithLocalShuffleIfTrue(withLocalShuffle);
                 aggregationNode.setWithLocalShuffle(withLocalShuffle);
             }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1555,7 +1555,55 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  0:OlapScanNode");
 
-            // case 2: use one-phase local aggregation without local shuffle for high-cardinality agg and single BE.
+            // case 2: use multiple one-phase local aggregation with local shuffle for high-cardinality agg and single BE.
+            isSingleBackendAndComputeNode.setRef(true);
+            cardinality.setRef(avgHighCardinality);
+            sql = "with w1 as (select v2, count(v2) as cnt from colocate_t0 group by v2) " +
+                    "select v2, sum(cnt) from w1 group by v2, cnt";
+            execPlan = getExecPlan(sql);
+            olapScanNode = (OlapScanNode) execPlan.getScanNodes().get(0);
+            Assert.assertEquals(0, olapScanNode.getBucketExprs().size());
+            Assert.assertFalse(containAnyColocateNode(execPlan.getFragments().get(1).getPlanRoot()));
+            Assert.assertFalse(execPlan.getFragments().get(1).isAssignScanRangesPerDriverSeq());
+            plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+            assertContains(plan, "  3:AGGREGATE (update finalize)\n" +
+                    "  |  output: sum(4: count)\n" +
+                    "  |  group by: 2: v2, 4: count\n" +
+                    "  |  withLocalShuffle: true\n" +
+                    "  |  \n" +
+                    "  2:AGGREGATE (update finalize)\n" +
+                    "  |  output: count(2: v2)\n" +
+                    "  |  group by: 2: v2\n" +
+                    "  |  withLocalShuffle: true\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+
+            // case 3: use one-phase local aggregation without local shuffle for high-cardinality agg and single BE.
+            isSingleBackendAndComputeNode.setRef(true);
+            cardinality.setRef(avgHighCardinality);
+            sql = "with w1 as (select v1, count(v1) as cnt from colocate_t0 group by v1) " +
+                    "select sum(cnt) from w1 group by cnt";
+            execPlan = getExecPlan(sql);
+            olapScanNode = (OlapScanNode) execPlan.getScanNodes().get(0);
+            Assert.assertEquals(0, olapScanNode.getBucketExprs().size());
+            Assert.assertTrue(containAnyColocateNode(execPlan.getFragments().get(1).getPlanRoot()));
+            Assert.assertTrue(execPlan.getFragments().get(2).isAssignScanRangesPerDriverSeq());
+            plan = execPlan.getExplainString(TExplainLevel.NORMAL);
+            assertContains(plan, "  3:AGGREGATE (update serialize)\n" +
+                    "  |  STREAMING\n" +
+                    "  |  output: sum(4: count)\n" +
+                    "  |  group by: 4: count\n" +
+                    "  |  \n" +
+                    "  2:Project\n" +
+                    "  |  <slot 4> : 4: count\n" +
+                    "  |  \n" +
+                    "  1:AGGREGATE (update finalize)\n" +
+                    "  |  output: count(1: v1)\n" +
+                    "  |  group by: 1: v1\n" +
+                    "  |  \n" +
+                    "  0:OlapScanNode");
+
+            // case 4: use one-phase local aggregation without local shuffle when grouping key contains all the bucket keys.
             isSingleBackendAndComputeNode.setRef(true);
             cardinality.setRef(avgHighCardinality);
             sql = "select sum(v1) from colocate_t0 group by v1";
@@ -1570,7 +1618,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  0:OlapScanNode");
 
-            // case 3: use two-phase aggregation for non-grouping agg.
+            // case 5: use two-phase aggregation for non-grouping agg.
             isSingleBackendAndComputeNode.setRef(true);
             cardinality.setRef(avgHighCardinality);
             sql = "select sum(v2) from t0";
@@ -1589,7 +1637,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  2:EXCHANGE");
 
-            // case 4: use two-phase aggregation for multiple BEs.
+            // case 6: use two-phase aggregation for multiple BEs.
             isSingleBackendAndComputeNode.setRef(false);
             cardinality.setRef(avgHighCardinality);
             sql = "select sum(v2) from t0 group by v2";
@@ -1608,7 +1656,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  1:EXCHANGE");
 
-            // case 5: use two-phase aggregation for low-cardinality agg.
+            // case 7: use two-phase aggregation for low-cardinality agg.
             isSingleBackendAndComputeNode.setRef(true);
             cardinality.setRef(avgLowCardinality);
             sql = "select sum(v2) from t0 group by v2";
@@ -1628,7 +1676,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  2:EXCHANGE");
 
-            // case 6: insert into cannot use one-phase local aggregation with local shuffle.
+            // case 8: insert into cannot use one-phase local aggregation with local shuffle.
             isSingleBackendAndComputeNode.setRef(true);
             cardinality.setRef(avgHighCardinality);
             sql = "insert into colocate_t0 select v2, v2, sum(v2) from t0 group by v2";
@@ -1643,7 +1691,7 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                     "  |  \n" +
                     "  1:EXCHANGE");
 
-            // case 7: Plan with join cannot use one-phase local aggregation with local shuffle.
+            // case 9: Plan with join cannot use one-phase local aggregation with local shuffle.
             isSingleBackendAndComputeNode.setRef(true);
             cardinality.setRef(avgHighCardinality);
             sql = "select count(1) from " +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -1567,13 +1567,13 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             Assert.assertFalse(execPlan.getFragments().get(1).isAssignScanRangesPerDriverSeq());
             plan = execPlan.getExplainString(TExplainLevel.NORMAL);
             assertContains(plan, "  3:AGGREGATE (update finalize)\n" +
-                    "  |  output: sum(4: count)\n" +
-                    "  |  group by: 2: v2, 4: count\n" +
+                    "  |  output: sum(8: count)\n" +
+                    "  |  group by: 6: v2, 8: count\n" +
                     "  |  withLocalShuffle: true\n" +
                     "  |  \n" +
                     "  2:AGGREGATE (update finalize)\n" +
-                    "  |  output: count(2: v2)\n" +
-                    "  |  group by: 2: v2\n" +
+                    "  |  output: count(6: v2)\n" +
+                    "  |  group by: 6: v2\n" +
                     "  |  withLocalShuffle: true\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
@@ -1589,17 +1589,12 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
             Assert.assertTrue(containAnyColocateNode(execPlan.getFragments().get(1).getPlanRoot()));
             Assert.assertTrue(execPlan.getFragments().get(2).isAssignScanRangesPerDriverSeq());
             plan = execPlan.getExplainString(TExplainLevel.NORMAL);
-            assertContains(plan, "  3:AGGREGATE (update serialize)\n" +
-                    "  |  STREAMING\n" +
-                    "  |  output: sum(4: count)\n" +
-                    "  |  group by: 4: count\n" +
-                    "  |  \n" +
-                    "  2:Project\n" +
-                    "  |  <slot 4> : 4: count\n" +
+            assertContains(plan, "  2:Project\n" +
+                    "  |  <slot 8> : 8: count\n" +
                     "  |  \n" +
                     "  1:AGGREGATE (update finalize)\n" +
-                    "  |  output: count(1: v1)\n" +
-                    "  |  group by: 1: v1\n" +
+                    "  |  output: count(5: v1)\n" +
+                    "  |  group by: 5: v1\n" +
                     "  |  \n" +
                     "  0:OlapScanNode");
 


### PR DESCRIPTION
This is an automatic backport of pull request #37645 done by [Mergify](https://mergify.com).


---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://docs.mergify.com/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR on its base branch
- `@Mergifyio update` will merge the base branch into this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.com) you can:

- look at your merge queues
- generate the Mergify configuration with the config editor.

Finally, you can contact us on https://mergify.com
</details>
### Why I'm doing:
When executing on the single BE, two original fragments `(ScanNode->ExchangeSink) (ExchangeSource->BlockingAgg)` will be simplified to  one fragment `ScanNode->**LocalShuffle**->BlockingAgg`. 
In order to insert this `LocalShuffle` between `ScanNode` and `BlockingAgg`, the fragment is marked as `assignScanRangesPerDriverSeq=false` when building the node `BlockingAgg`.

However, if the original fragments contains two `BlockingAgg`, that is `(ScanNode->ExchangeSink) (ExchangeSource->BlockingAgg#1->BlockingAgg#2)`, the second agg `BlockingAgg#2` will overwrite `assignScanRangesPerDriverSeq` to true.

**The root cause is that the fragment doesn't store the `withLocalShuffle` state, so `BlockingAgg#2` the fragment isn't with local shuffle.**

```
|   3:AGGREGATE (update finalize)                                                           |
|   |  output: sum(3: count)                                                                |
|   |  group by: 2: c1, 3: count                                                            |
|   |                                                                                       |
|   2:AGGREGATE (update finalize)                                                           |
|   |  output: count(1)                                                                     |
|   |  group by: 2: c1                                                                      |
|   |  withLocalShuffle: true                                                               |
|   |                                                                                       |
|   0:OlapScanNode
```


### What I'm doing:
Fixed it. Store the `withLocalShuffle` state in the fragment when simplifying `(ScanNode->ExchangeSink) (ExchangeSource->BlockingAgg)` to `ScanNode->**LocalShuffle**->BlockingAgg`.

Fixes #37646.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr


