### PR TITLE
[Enhancement] Add iter for BitampValue (backport #37773)

### DIFF
--- a/be/src/types/bitmap_value.cpp
+++ b/be/src/types/bitmap_value.cpp
@@ -1048,4 +1048,36 @@ void BitmapValue::add_many(size_t n_args, const uint32_t* vals) {
     }
 }
 
+uint64_t BitmapValueIter::next_batch(uint64_t* values, uint64_t count) {
+    uint64_t remain_rows = _remain_rows();
+    uint64_t read_count = std::min(count, remain_rows);
+    if (read_count <= 0) {
+        return 0;
+    }
+
+    switch (_bitmap->type()) {
+    case BitmapValue::EMPTY:
+        break;
+    case BitmapValue::SINGLE:
+        values[0] = _bitmap->_sv;
+        break;
+    case BitmapValue::SET: {
+        std::vector tmp_array(_bitmap->_set->begin(), _bitmap->_set->end());
+        std::sort(tmp_array.begin(), tmp_array.end());
+        for (uint64_t i = 0; i < read_count; i++) {
+            values[i] = tmp_array[_offset + i];
+        }
+        break;
+    }
+    case BitmapValue::BITMAP: {
+        for (uint64_t i = 0; i < read_count; i++) {
+            values[i] = *((*_bitmap_iter)++);
+        }
+        break;
+    }
+    }
+    _offset += read_count;
+    return read_count;
+}
+
 } // namespace starrocks

--- a/be/src/types/bitmap_value.h
+++ b/be/src/types/bitmap_value.h
@@ -59,12 +59,15 @@ namespace starrocks {
 
 namespace detail {
 class Roaring64Map;
-}
+class BitmapValueIter;
+} // namespace detail
 // Represent the in-memory and on-disk structure of StarRocks's BITMAP data type.
 // Optimize for the case where the bitmap contains 0 or 1 element which is common
 // for streaming load scenario.
 class BitmapValue {
 public:
+    friend class BitmapValueIter;
+
     enum BitmapDataType {
         EMPTY = 0,
         SINGLE = 1, // single element
@@ -218,5 +221,31 @@ private:
     std::unique_ptr<phmap::flat_hash_set<uint64_t>> _set;
     uint64_t _sv = 0; // store the single value when _type == SINGLE
     BitmapDataType _type{EMPTY};
+};
+
+class BitmapValueIter {
+public:
+    void reset(const BitmapValue& bitmap) {
+        _bitmap = &bitmap;
+        _offset = 0;
+        _cardinality = bitmap.cardinality();
+        if (bitmap.type() == BitmapValue::BitmapDataType::BITMAP) {
+            _bitmap_iter = std::make_unique<detail::Roaring64MapSetBitForwardIterator>(*bitmap._bitmap);
+        } else {
+            _bitmap_iter.reset();
+        }
+    }
+
+    uint64_t next_batch(uint64_t* values, uint64_t count);
+    uint64_t offset() { return _offset; }
+    void set_offset(uint64_t offset) { _offset = offset; }
+
+private:
+    uint64_t _remain_rows() const { return _cardinality - _offset; }
+
+    const BitmapValue* _bitmap = nullptr;
+    uint64_t _offset = 0;
+    uint64_t _cardinality = 0;
+    std::unique_ptr<detail::Roaring64MapSetBitForwardIterator> _bitmap_iter;
 };
 } // namespace starrocks

--- a/be/test/types/bitmap_value_test.cpp
+++ b/be/test/types/bitmap_value_test.cpp
@@ -851,4 +851,73 @@ TEST_F(BitmapValueTest, split_bitmap) {
     ASSERT_EQ(result.size(), 1);
     ASSERT_EQ(result[0].to_string(), "0,1,2,3,4,5,6,7,8,9,10,11,12,13");
 }
+
+TEST_F(BitmapValueTest, next_batch) {
+    BitmapValueIter iter;
+    std::vector<uint64_t> values;
+
+    // empty
+    values.resize(5);
+    iter.reset(_empty_bitmap);
+    uint64_t ret_size = iter.next_batch(values.data(), 5);
+    ASSERT_EQ(ret_size, 0);
+
+    // single
+    values.resize(5);
+    iter.reset(_single_bitmap);
+    ret_size = iter.next_batch(values.data(), 5);
+    ASSERT_EQ(ret_size, 1);
+    ASSERT_EQ(values[0], 0);
+
+    // set
+    values.resize(5);
+    iter.reset(_medium_bitmap);
+    ret_size = iter.next_batch(values.data(), 5);
+    ASSERT_EQ(ret_size, 5);
+    for (size_t i = 0; i < 5; i++) {
+        ASSERT_EQ(values[i], i);
+    }
+    ret_size = iter.next_batch(values.data(), 5);
+    ASSERT_EQ(ret_size, 5);
+    for (size_t i = 0; i < 5; i++) {
+        ASSERT_EQ(values[i], i + 5);
+    }
+    ret_size = iter.next_batch(values.data(), 5);
+    ASSERT_EQ(ret_size, 4);
+    for (size_t i = 0; i < 4; i++) {
+        ASSERT_EQ(values[i], i + 10);
+    }
+
+    // bitmap
+    values.resize(30);
+    iter.reset(_large_bitmap);
+    ret_size = iter.next_batch(values.data(), 30);
+    ASSERT_EQ(ret_size, 30);
+    for (size_t i = 0; i < 30; i++) {
+        ASSERT_EQ(values[i], i);
+    }
+    ret_size = iter.next_batch(values.data(), 30);
+    ASSERT_EQ(ret_size, 30);
+    for (size_t i = 0; i < 30; i++) {
+        ASSERT_EQ(values[i], i + 30);
+    }
+    ret_size = iter.next_batch(values.data(), 30);
+    ASSERT_EQ(ret_size, 4);
+    for (size_t i = 0; i < 4; i++) {
+        ASSERT_EQ(values[i], i + 60);
+    }
+
+    // read more then bitmap size
+    values.resize(100);
+    iter.reset(_large_bitmap);
+    ret_size = iter.next_batch(values.data(), 100);
+    ASSERT_EQ(ret_size, 64);
+    for (size_t i = 0; i < 64; i++) {
+        ASSERT_EQ(values[i], i);
+    }
+
+    // read 0
+    ret_size = iter.next_batch(values.data(), 0);
+    ASSERT_EQ(ret_size, 0);
+}
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Add iter for BitampValue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

