### PR TITLE
[Feature][Refactor] Remove the tablet from the tablet writer member variable and use tablet_id instead

### DIFF
--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -487,7 +487,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     }
 
 #if defined(USE_STAROS) && !defined(BE_TEST)
-    _lake_location_provider = new lake::StarletLocationProvider();
+    _lake_location_provider = std::make_shared<lake::StarletLocationProvider>();
     _lake_update_manager =
             new lake::UpdateManager(_lake_location_provider, GlobalEnv::GetInstance()->update_mem_tracker());
     _lake_tablet_manager =
@@ -503,7 +503,7 @@ Status ExecEnv::init(const std::vector<StorePath>& store_paths, bool as_cn) {
     }
 
 #elif defined(BE_TEST)
-    _lake_location_provider = new lake::FixedLocationProvider(_store_paths.front().path);
+    _lake_location_provider = std::make_shared<lake::FixedLocationProvider>(_store_paths.front().path);
     _lake_update_manager =
             new lake::UpdateManager(_lake_location_provider, GlobalEnv::GetInstance()->update_mem_tracker());
     _lake_tablet_manager =
@@ -643,7 +643,6 @@ void ExecEnv::destroy() {
     SAFE_DELETE(_stream_mgr);
     SAFE_DELETE(_external_scan_context_mgr);
     SAFE_DELETE(_lake_tablet_manager);
-    SAFE_DELETE(_lake_location_provider);
     SAFE_DELETE(_lake_update_manager);
     SAFE_DELETE(_lake_replication_txn_manager);
     SAFE_DELETE(_cache_mgr);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -308,7 +308,7 @@ public:
 
     lake::TabletManager* lake_tablet_manager() const { return _lake_tablet_manager; }
 
-    lake::LocationProvider* lake_location_provider() const { return _lake_location_provider; }
+    std::shared_ptr<lake::LocationProvider> lake_location_provider() const { return _lake_location_provider; }
 
     lake::UpdateManager* lake_update_manager() const { return _lake_update_manager; }
 
@@ -379,7 +379,7 @@ private:
     ProfileReportWorker* _profile_report_worker = nullptr;
 
     lake::TabletManager* _lake_tablet_manager = nullptr;
-    lake::LocationProvider* _lake_location_provider = nullptr;
+    std::shared_ptr<lake::LocationProvider> _lake_location_provider;
     lake::UpdateManager* _lake_update_manager = nullptr;
     lake::ReplicationTxnManager* _lake_replication_txn_manager = nullptr;
 

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -220,11 +220,9 @@ Status DeltaWriterImpl::build_schema_and_writer() {
         RETURN_IF_ERROR(init_tablet_schema());
         RETURN_IF_ERROR(init_write_schema());
         if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
-            _tablet_writer =
-                    std::make_unique<HorizontalPkTabletWriter>(_tablet_id, _write_schema, _txn_id);
+            _tablet_writer = std::make_unique<HorizontalPkTabletWriter>(_tablet_id, _write_schema, _txn_id);
         } else {
-            _tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_id, _write_schema,
-                                                                             _txn_id);
+            _tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_id, _write_schema, _txn_id);
         }
         _tablet_writer->set_location_provider(_tablet_manager->location_provider());
         RETURN_IF_ERROR(_tablet_writer->open());

--- a/be/src/storage/lake/delta_writer.cpp
+++ b/be/src/storage/lake/delta_writer.cpp
@@ -221,11 +221,12 @@ Status DeltaWriterImpl::build_schema_and_writer() {
         RETURN_IF_ERROR(init_write_schema());
         if (_tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
             _tablet_writer =
-                    std::make_unique<HorizontalPkTabletWriter>(_tablet_manager, _tablet_id, _write_schema, _txn_id);
+                    std::make_unique<HorizontalPkTabletWriter>(_tablet_id, _write_schema, _txn_id);
         } else {
-            _tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_manager, _tablet_id, _write_schema,
+            _tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_tablet_id, _write_schema,
                                                                              _txn_id);
         }
+        _tablet_writer->set_location_provider(_tablet_manager->location_provider());
         RETURN_IF_ERROR(_tablet_writer->open());
         _mem_table_sink = std::make_unique<TabletWriterSink>(_tablet_writer.get());
         _write_schema_for_mem_table = MemTable::convert_schema(_write_schema, _slots);

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -21,9 +21,9 @@
 #include "fs/fs_util.h"
 #include "serde/column_array_serde.h"
 #include "storage/lake/filenames.h"
+#include "storage/lake/location_provider.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/vacuum.h"
-#include "storage/lake/location_provider.h"
 #include "storage/rowset/segment_writer.h"
 
 namespace starrocks::lake {

--- a/be/src/storage/lake/general_tablet_writer.cpp
+++ b/be/src/storage/lake/general_tablet_writer.cpp
@@ -23,13 +23,14 @@
 #include "storage/lake/filenames.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/vacuum.h"
+#include "storage/lake/location_provider.h"
 #include "storage/rowset/segment_writer.h"
 
 namespace starrocks::lake {
 
-HorizontalGeneralTabletWriter::HorizontalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
+HorizontalGeneralTabletWriter::HorizontalGeneralTabletWriter(int64_t tablet_id,
                                                              std::shared_ptr<const TabletSchema> schema, int64_t txn_id)
-        : TabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id) {}
+        : TabletWriter(tablet_id, std::move(schema), txn_id) {}
 
 HorizontalGeneralTabletWriter::~HorizontalGeneralTabletWriter() = default;
 
@@ -65,7 +66,7 @@ void HorizontalGeneralTabletWriter::close() {
         std::vector<std::string> full_paths_to_delete;
         full_paths_to_delete.reserve(_files.size());
         for (const auto& f : _files) {
-            full_paths_to_delete.emplace_back(_tablet_mgr->segment_location(_tablet_id, f.path));
+            full_paths_to_delete.emplace_back(location_provider()->segment_location(_tablet_id, f.path));
         }
         delete_files_async(std::move(full_paths_to_delete));
     }
@@ -75,7 +76,7 @@ void HorizontalGeneralTabletWriter::close() {
 Status HorizontalGeneralTabletWriter::reset_segment_writer() {
     DCHECK(_schema != nullptr);
     auto name = gen_segment_filename(_txn_id);
-    ASSIGN_OR_RETURN(auto of, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, name)));
+    ASSIGN_OR_RETURN(auto of, fs::new_writable_file(location_provider()->segment_location(_tablet_id, name)));
     SegmentWriterOptions opts;
     auto w = std::make_unique<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);
     RETURN_IF_ERROR(w->init());
@@ -103,10 +104,9 @@ Status HorizontalGeneralTabletWriter::flush_segment_writer(SegmentPB* segment) {
     return Status::OK();
 }
 
-VerticalGeneralTabletWriter::VerticalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
-                                                         std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-                                                         uint32_t max_rows_per_segment)
-        : TabletWriter(tablet_mgr, tablet_id, std::move(schema), txn_id), _max_rows_per_segment(max_rows_per_segment) {}
+VerticalGeneralTabletWriter::VerticalGeneralTabletWriter(int64_t tablet_id, std::shared_ptr<const TabletSchema> schema,
+                                                         int64_t txn_id, uint32_t max_rows_per_segment)
+        : TabletWriter(tablet_id, std::move(schema), txn_id), _max_rows_per_segment(max_rows_per_segment) {}
 
 VerticalGeneralTabletWriter::~VerticalGeneralTabletWriter() = default;
 
@@ -220,7 +220,7 @@ void VerticalGeneralTabletWriter::close() {
         std::vector<std::string> full_paths_to_delete;
         full_paths_to_delete.reserve(_files.size());
         for (const auto& f : _files) {
-            full_paths_to_delete.emplace_back(_tablet_mgr->segment_location(_tablet_id, f.path));
+            full_paths_to_delete.emplace_back(location_provider()->segment_location(_tablet_id, f.path));
         }
         delete_files_async(std::move(full_paths_to_delete));
     }
@@ -231,7 +231,7 @@ StatusOr<std::unique_ptr<SegmentWriter>> VerticalGeneralTabletWriter::create_seg
         const std::vector<uint32_t>& column_indexes, bool is_key) {
     DCHECK(_schema != nullptr);
     auto name = gen_segment_filename(_txn_id);
-    ASSIGN_OR_RETURN(auto of, fs::new_writable_file(_tablet_mgr->segment_location(_tablet_id, name)));
+    ASSIGN_OR_RETURN(auto of, fs::new_writable_file(location_provider()->segment_location(_tablet_id, name)));
     SegmentWriterOptions opts;
     auto w = std::make_unique<SegmentWriter>(std::move(of), _seg_id++, _schema, opts);
     RETURN_IF_ERROR(w->init(column_indexes, is_key));

--- a/be/src/storage/lake/general_tablet_writer.h
+++ b/be/src/storage/lake/general_tablet_writer.h
@@ -29,8 +29,8 @@ namespace starrocks::lake {
 
 class HorizontalGeneralTabletWriter : public TabletWriter {
 public:
-    explicit HorizontalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
-                                           std::shared_ptr<const TabletSchema> schema, int64_t txn_id);
+    explicit HorizontalGeneralTabletWriter(int64_t tablet_id, std::shared_ptr<const TabletSchema> schema,
+                                           int64_t txn_id);
 
     ~HorizontalGeneralTabletWriter() override;
 
@@ -69,8 +69,7 @@ protected:
 
 class VerticalGeneralTabletWriter : public TabletWriter {
 public:
-    explicit VerticalGeneralTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
-                                         std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
+    explicit VerticalGeneralTabletWriter(int64_t tablet_id, std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
                                          uint32_t max_rows_per_segment);
 
     ~VerticalGeneralTabletWriter() override;

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -56,12 +56,7 @@ private:
 
 class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {
 public:
-<<<<<<< HEAD
-    explicit VerticalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
-                                    std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
-=======
     explicit VerticalPkTabletWriter(int64_t tablet_id, std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
->>>>>>> 9cc0fbaa0b... Remove the tablet from the tablet writer member variable and use tablet_id instead
                                     uint32_t max_rows_per_segment);
 
     ~VerticalPkTabletWriter() override;

--- a/be/src/storage/lake/pk_tablet_writer.h
+++ b/be/src/storage/lake/pk_tablet_writer.h
@@ -29,8 +29,7 @@ namespace starrocks::lake {
 
 class HorizontalPkTabletWriter : public HorizontalGeneralTabletWriter {
 public:
-    explicit HorizontalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
-                                      std::shared_ptr<const TabletSchema> schema, int64_t txn_id);
+    explicit HorizontalPkTabletWriter(int64_t tablet_id, std::shared_ptr<const TabletSchema> schema, int64_t txn_id);
 
     ~HorizontalPkTabletWriter() override;
 
@@ -57,8 +56,12 @@ private:
 
 class VerticalPkTabletWriter : public VerticalGeneralTabletWriter {
 public:
+<<<<<<< HEAD
     explicit VerticalPkTabletWriter(TabletManager* tablet_mgr, int64_t tablet_id,
                                     std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
+=======
+    explicit VerticalPkTabletWriter(int64_t tablet_id, std::shared_ptr<const TabletSchema> schema, int64_t txn_id,
+>>>>>>> 9cc0fbaa0b... Remove the tablet from the tablet writer member variable and use tablet_id instead
                                     uint32_t max_rows_per_segment);
 
     ~VerticalPkTabletWriter() override;

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -72,23 +72,26 @@ StatusOr<TxnLogPtr> Tablet::get_txn_vlog(int64_t version) {
 
 StatusOr<std::unique_ptr<TabletWriter>> Tablet::new_writer(WriterType type, int64_t txn_id,
                                                            uint32_t max_rows_per_segment) {
+    std::unique_ptr<TabletWriter> tablet_writer;
     ASSIGN_OR_RETURN(auto tablet_schema, get_schema());
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalPkTabletWriter>(_mgr, _id, tablet_schema, txn_id);
+            tablet_writer = std::make_unique<HorizontalPkTabletWriter>(_id, tablet_schema, txn_id);
         } else {
             DCHECK(type == kVertical);
-            return std::make_unique<VerticalPkTabletWriter>(_mgr, _id, tablet_schema, txn_id, max_rows_per_segment);
+            tablet_writer = std::make_unique<VerticalPkTabletWriter>(_id, tablet_schema, txn_id, max_rows_per_segment);
         }
     } else {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalGeneralTabletWriter>(_mgr, _id, tablet_schema, txn_id);
+            tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(_id, tablet_schema, txn_id);
         } else {
             DCHECK(type == kVertical);
-            return std::make_unique<VerticalGeneralTabletWriter>(_mgr, _id, tablet_schema, txn_id,
-                                                                 max_rows_per_segment);
+            tablet_writer =
+                    std::make_unique<VerticalGeneralTabletWriter>(_id, tablet_schema, txn_id, max_rows_per_segment);
         }
     }
+    tablet_writer->set_location_provider(_mgr->location_provider());
+    return tablet_writer;
 }
 
 StatusOr<std::shared_ptr<const TabletSchema>> Tablet::get_schema() {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -62,7 +62,7 @@ static bvar::LatencyRecorder g_del_txn_log_latency("lake", "del_txn_log");
 
 TabletManager::TabletManager(std::shared_ptr<LocationProvider> location_provider, UpdateManager* update_mgr,
                              int64_t cache_capacity)
-        : _location_provider(location_provider),
+        : _location_provider(std::move(location_provider)),
           _metacache(std::make_unique<Metacache>(cache_capacity)),
           _compaction_scheduler(std::make_unique<CompactionScheduler>(this)),
           _update_mgr(update_mgr) {

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -60,7 +60,8 @@ static bvar::LatencyRecorder g_get_txn_log_latency("lake", "get_txn_log");
 static bvar::LatencyRecorder g_put_txn_log_latency("lake", "put_txn_log");
 static bvar::LatencyRecorder g_del_txn_log_latency("lake", "del_txn_log");
 
-TabletManager::TabletManager(LocationProvider* location_provider, UpdateManager* update_mgr, int64_t cache_capacity)
+TabletManager::TabletManager(std::shared_ptr<LocationProvider> location_provider, UpdateManager* update_mgr,
+                             int64_t cache_capacity)
         : _location_provider(location_provider),
           _metacache(std::make_unique<Metacache>(cache_capacity)),
           _compaction_scheduler(std::make_unique<CompactionScheduler>(this)),

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -53,7 +53,8 @@ public:
     // this TabletManager.
     // |cache_capacity| is the max number of bytes can be used by the
     // metadata cache.
-    explicit TabletManager(LocationProvider* location_provider, UpdateManager* update_mgr, int64_t cache_capacity);
+    explicit TabletManager(std::shared_ptr<LocationProvider> location_provider, UpdateManager* update_mgr,
+                           int64_t cache_capacity);
 
     ~TabletManager();
 
@@ -110,7 +111,7 @@ public:
     void prune_metacache();
 
     // TODO: remove this method
-    LocationProvider* TEST_set_location_provider(LocationProvider* value) {
+    std::shared_ptr<LocationProvider> TEST_set_location_provider(std::shared_ptr<LocationProvider> value) {
         auto ret = _location_provider;
         _location_provider = value;
         return ret;
@@ -134,7 +135,7 @@ public:
 
     std::string delvec_location(int64_t tablet_id, std::string_view delvec_filename) const;
 
-    const LocationProvider* location_provider() const { return _location_provider; }
+    const std::shared_ptr<LocationProvider>& location_provider() const { return _location_provider; }
 
     UpdateManager* update_mgr();
 
@@ -178,7 +179,7 @@ private:
     StatusOr<TabletMetadataPtr> load_tablet_metadata(const std::string& metadata_location, bool fill_cache);
     StatusOr<TxnLogPtr> load_txn_log(const std::string& txn_log_location, bool fill_cache);
 
-    LocationProvider* _location_provider;
+    std::shared_ptr<LocationProvider> _location_provider;
     std::unique_ptr<Metacache> _metacache;
     std::unique_ptr<CompactionScheduler> _compaction_scheduler;
     UpdateManager* _update_mgr;

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -21,8 +21,8 @@
 #include "fs/fs.h" // FileInfo
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/lake_types.pb.h"
-#include "storage/tablet_schema.h"
 #include "storage/lake/location_provider.h"
+#include "storage/tablet_schema.h"
 
 namespace starrocks {
 class Chunk;
@@ -107,7 +107,9 @@ public:
     // allow to set custom tablet schema for writer, used in partial update
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }
 
-    void set_location_provider(const std::shared_ptr<LocationProvider> provider) { _location_provider = std::move(provider); }
+    void set_location_provider(const std::shared_ptr<LocationProvider> provider) {
+        _location_provider = std::move(provider);
+    }
     const std::shared_ptr<LocationProvider> location_provider() { return _location_provider; }
 
 protected:

--- a/be/src/storage/lake/tablet_writer.h
+++ b/be/src/storage/lake/tablet_writer.h
@@ -22,6 +22,7 @@
 #include "gen_cpp/data.pb.h"
 #include "gen_cpp/lake_types.pb.h"
 #include "storage/tablet_schema.h"
+#include "storage/lake/location_provider.h"
 
 namespace starrocks {
 class Chunk;
@@ -37,13 +38,10 @@ enum WriterType : int { kHorizontal = 0, kVertical = 1 };
 // Basic interface for tablet writers.
 class TabletWriter {
 public:
-    explicit TabletWriter(TabletManager* tablet_mgr, int64_t tablet_id, std::shared_ptr<const TabletSchema> schema,
-                          int64_t txn_id)
-            : _tablet_mgr(tablet_mgr), _tablet_id(tablet_id), _schema(std::move(schema)), _txn_id(txn_id) {}
+    explicit TabletWriter(int64_t tablet_id, std::shared_ptr<const TabletSchema> schema, int64_t txn_id)
+            : _tablet_id(tablet_id), _schema(std::move(schema)), _txn_id(txn_id) {}
 
     virtual ~TabletWriter() = default;
-
-    TabletManager* tablet_manager() const { return _tablet_mgr; }
 
     int64_t tablet_id() const { return _tablet_id; }
 
@@ -109,8 +107,10 @@ public:
     // allow to set custom tablet schema for writer, used in partial update
     void set_tablet_schema(TabletSchemaCSPtr schema) { _schema = std::move(schema); }
 
+    void set_location_provider(const std::shared_ptr<LocationProvider> provider) { _location_provider = std::move(provider); }
+    const std::shared_ptr<LocationProvider> location_provider() { return _location_provider; }
+
 protected:
-    TabletManager* _tablet_mgr;
     int64_t _tablet_id;
     TabletSchemaCSPtr _schema;
     int64_t _txn_id;
@@ -119,6 +119,7 @@ protected:
     int64_t _data_size = 0;
     uint32_t _seg_id = 0;
     bool _finished = false;
+    std::shared_ptr<LocationProvider> _location_provider;
 };
 
 } // namespace lake

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -35,7 +35,7 @@ UpdateManager::UpdateManager(std::shared_ptr<LocationProvider> location_provider
         : _index_cache(std::numeric_limits<size_t>::max()),
           _update_state_cache(std::numeric_limits<size_t>::max()),
           _compaction_cache(std::numeric_limits<size_t>::max()),
-          _location_provider(location_provider),
+          _location_provider(std::move(location_provider)),
           _pk_index_shards(config::pk_index_map_shard_size) {
     _update_mem_tracker = mem_tracker;
     _update_state_mem_tracker = std::make_unique<MemTracker>(-1, "lake_rowset_update_state", mem_tracker);

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -31,7 +31,7 @@
 
 namespace starrocks::lake {
 
-UpdateManager::UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker)
+UpdateManager::UpdateManager(std::shared_ptr<LocationProvider> location_provider, MemTracker* mem_tracker)
         : _index_cache(std::numeric_limits<size_t>::max()),
           _update_state_cache(std::numeric_limits<size_t>::max()),
           _compaction_cache(std::numeric_limits<size_t>::max()),

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -53,8 +53,8 @@ private:
 
 class UpdateManager {
 public:
-    UpdateManager(LocationProvider* location_provider, MemTracker* mem_tracker = nullptr);
-    ~UpdateManager();
+    UpdateManager(std::shared_ptr<LocationProvider> location_provider, MemTracker* mem_tracker = nullptr);
+    ~UpdateManager() {}
     void set_tablet_mgr(TabletManager* tablet_mgr) { _tablet_mgr = tablet_mgr; }
     void set_cache_expire_ms(int64_t expire_ms) { _cache_expire_ms = expire_ms; }
 
@@ -188,7 +188,7 @@ private:
     // compaction cache
     DynamicCache<string, CompactionState> _compaction_cache;
     std::atomic<int64_t> _last_clear_expired_cache_millis = 0;
-    LocationProvider* _location_provider = nullptr;
+    std::shared_ptr<LocationProvider> _location_provider;
     TabletManager* _tablet_mgr = nullptr;
 
     // memory checkers

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -54,7 +54,7 @@ private:
 class UpdateManager {
 public:
     UpdateManager(std::shared_ptr<LocationProvider> location_provider, MemTracker* mem_tracker = nullptr);
-    ~UpdateManager() {}
+    ~UpdateManager();
     void set_tablet_mgr(TabletManager* tablet_mgr) { _tablet_mgr = tablet_mgr; }
     void set_cache_expire_ms(int64_t expire_ms) { _cache_expire_ms = expire_ms; }
 

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -44,21 +44,19 @@ StatusOr<std::unique_ptr<TabletWriter>> VersionedTablet::new_writer(WriterType t
             tablet_writer = std::make_unique<HorizontalPkTabletWriter>(id(), tablet_schema, txn_id);
         } else {
             DCHECK(type == kVertical);
-            tablet_writer = std::make_unique<VerticalPkTabletWriter>(id(), tablet_schema, txn_id,
-                                                            max_rows_per_segment);
+            tablet_writer = std::make_unique<VerticalPkTabletWriter>(id(), tablet_schema, txn_id, max_rows_per_segment);
         }
     } else {
         if (type == kHorizontal) {
             tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(id(), tablet_schema, txn_id);
         } else {
             DCHECK(type == kVertical);
-            tablet_writer = std::make_unique<VerticalGeneralTabletWriter>(id(), tablet_schema, txn_id,
-                                                                 max_rows_per_segment);
+            tablet_writer =
+                    std::make_unique<VerticalGeneralTabletWriter>(id(), tablet_schema, txn_id, max_rows_per_segment);
         }
     }
     tablet_writer->set_location_provider(_tablet_mgr->location_provider());
     return tablet_writer;
-
 }
 
 StatusOr<std::unique_ptr<TabletReader>> VersionedTablet::new_reader(Schema schema) {

--- a/be/src/storage/lake/versioned_tablet.cpp
+++ b/be/src/storage/lake/versioned_tablet.cpp
@@ -37,24 +37,28 @@ int64_t VersionedTablet::version() const {
 
 StatusOr<std::unique_ptr<TabletWriter>> VersionedTablet::new_writer(WriterType type, int64_t txn_id,
                                                                     uint32_t max_rows_per_segment) {
+    std::unique_ptr<TabletWriter> tablet_writer;
     auto tablet_schema = get_schema();
     if (tablet_schema->keys_type() == KeysType::PRIMARY_KEYS) {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id);
+            tablet_writer = std::make_unique<HorizontalPkTabletWriter>(id(), tablet_schema, txn_id);
         } else {
             DCHECK(type == kVertical);
-            return std::make_unique<VerticalPkTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
+            tablet_writer = std::make_unique<VerticalPkTabletWriter>(id(), tablet_schema, txn_id,
                                                             max_rows_per_segment);
         }
     } else {
         if (type == kHorizontal) {
-            return std::make_unique<HorizontalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id);
+            tablet_writer = std::make_unique<HorizontalGeneralTabletWriter>(id(), tablet_schema, txn_id);
         } else {
             DCHECK(type == kVertical);
-            return std::make_unique<VerticalGeneralTabletWriter>(_tablet_mgr, id(), tablet_schema, txn_id,
+            tablet_writer = std::make_unique<VerticalGeneralTabletWriter>(id(), tablet_schema, txn_id,
                                                                  max_rows_per_segment);
         }
     }
+    tablet_writer->set_location_provider(_tablet_mgr->location_provider());
+    return tablet_writer;
+
 }
 
 StatusOr<std::unique_ptr<TabletReader>> VersionedTablet::new_reader(Schema schema) {

--- a/be/test/exec/lake_meta_scanner_test.cpp
+++ b/be/test/exec/lake_meta_scanner_test.cpp
@@ -50,9 +50,9 @@ class LakeMetaScannerTest : public ::testing::Test {
 public:
     LakeMetaScannerTest() : _tablet_id(next_id()) {
         // setup TabletManager
-        _location_provider = std::make_unique<lake::FixedLocationProvider>(kRootLocation);
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(kRootLocation);
         _tablet_mgr = ExecEnv::GetInstance()->lake_tablet_manager();
-        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider.get());
+        _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kSegmentDirectoryName));
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kMetadataDirectoryName));
         FileSystem::Default()->create_dir_recursive(lake::join_path(kRootLocation, lake::kTxnLogDirectoryName));
@@ -115,8 +115,8 @@ public:
 public:
     constexpr static const char* const kRootLocation = "./LakeMetaScannerTest";
     lake::TabletManager* _tablet_mgr;
-    std::unique_ptr<lake::LocationProvider> _location_provider;
-    lake::LocationProvider* _backup_location_provider;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
     int64_t _tablet_id;
 
     ObjectPool _pool;

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -57,8 +57,7 @@ public:
         _mem_tracker = std::make_unique<MemTracker>(-1);
         _location_provider = std::make_shared<lake::FixedLocationProvider>(kTestGroupPath);
         _update_manager = std::make_unique<lake::UpdateManager>(_location_provider);
-        _tablet_manager =
-                std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
 
         _load_channel_mgr = std::make_unique<LoadChannelMgr>();
 

--- a/be/test/runtime/lake_tablets_channel_test.cpp
+++ b/be/test/runtime/lake_tablets_channel_test.cpp
@@ -55,10 +55,10 @@ public:
     LakeTabletsChannelTest() {
         _schema_id = next_id();
         _mem_tracker = std::make_unique<MemTracker>(-1);
-        _location_provider = std::make_unique<lake::FixedLocationProvider>(kTestGroupPath);
-        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get());
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(kTestGroupPath);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider);
         _tablet_manager =
-                std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+                std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
 
         _load_channel_mgr = std::make_unique<LoadChannelMgr>();
 
@@ -243,11 +243,10 @@ protected:
 
     int64_t _schema_id;
     std::unique_ptr<MemTracker> _mem_tracker;
-    std::unique_ptr<lake::FixedLocationProvider> _location_provider;
+    std::shared_ptr<lake::FixedLocationProvider> _location_provider;
     std::unique_ptr<lake::UpdateManager> _update_manager;
     std::unique_ptr<lake::TabletManager> _tablet_manager;
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;
-    lake::LocationProvider* _backup_location_provider;
     std::shared_ptr<TabletSchema> _tablet_schema;
     std::shared_ptr<Schema> _schema;
     std::shared_ptr<OlapTableSchemaParam> _schema_param;

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -54,8 +54,7 @@ public:
         _mem_tracker = std::make_unique<MemTracker>(-1);
         _location_provider = std::make_shared<lake::FixedLocationProvider>(kTestGroupPath);
         _update_manager = std::make_unique<lake::UpdateManager>(_location_provider);
-        _tablet_manager =
-                std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
 
         _load_channel_mgr = std::make_unique<LoadChannelMgr>();
 

--- a/be/test/runtime/load_channel_test.cpp
+++ b/be/test/runtime/load_channel_test.cpp
@@ -52,10 +52,10 @@ public:
     LoadChannelTestForLakeTablet() {
         _schema_id = next_id();
         _mem_tracker = std::make_unique<MemTracker>(-1);
-        _location_provider = std::make_unique<lake::FixedLocationProvider>(kTestGroupPath);
-        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get());
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(kTestGroupPath);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider);
         _tablet_manager =
-                std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+                std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
 
         _load_channel_mgr = std::make_unique<LoadChannelMgr>();
 
@@ -236,7 +236,7 @@ protected:
 
     int64_t _schema_id;
     std::unique_ptr<MemTracker> _mem_tracker;
-    std::unique_ptr<lake::FixedLocationProvider> _location_provider;
+    std::shared_ptr<lake::FixedLocationProvider> _location_provider;
     std::unique_ptr<lake::UpdateManager> _update_manager;
     std::unique_ptr<lake::TabletManager> _tablet_manager;
     std::unique_ptr<LoadChannelMgr> _load_channel_mgr;

--- a/be/test/service/lake_service_test.cpp
+++ b/be/test/service/lake_service_test.cpp
@@ -43,7 +43,7 @@ class LakeServiceTest : public testing::Test {
 public:
     LakeServiceTest()
             : _tablet_id(next_id()),
-              _location_provider(new lake::FixedLocationProvider(kRootLocation)),
+              _location_provider(std::make_shared<lake::FixedLocationProvider>(kRootLocation)),
               _tablet_mgr(ExecEnv::GetInstance()->lake_tablet_manager()),
               _lake_service(ExecEnv::GetInstance(), ExecEnv::GetInstance()->lake_tablet_manager()) {
         _backup_location_provider = _tablet_mgr->TEST_set_location_provider(_location_provider);
@@ -55,7 +55,6 @@ public:
     ~LakeServiceTest() override {
         CHECK_OK(fs::remove_all(kRootLocation));
         (void)_tablet_mgr->TEST_set_location_provider(_backup_location_provider);
-        delete _location_provider;
     }
 
     void create_tablet() {
@@ -127,9 +126,9 @@ protected:
 
     constexpr static const char* const kRootLocation = "./lake_service_test";
     int64_t _tablet_id;
-    lake::LocationProvider* _location_provider;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
     lake::TabletManager* _tablet_mgr;
-    lake::LocationProvider* _backup_location_provider;
+    std::shared_ptr<lake::LocationProvider> _backup_location_provider;
     LakeServiceImpl _lake_service;
 };
 

--- a/be/test/storage/lake/compaction_policy_test.cpp
+++ b/be/test/storage/lake/compaction_policy_test.cpp
@@ -18,7 +18,7 @@
 
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
-#include "storage/lake/fixed_location_provider.h"
+// #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
@@ -107,7 +107,6 @@ protected:
         std::cout << "delete rowset: " << id << std::endl;
     }
 
-    LocationProvider* _backup_location_provider;
     std::shared_ptr<TabletMetadata> _tablet_metadata;
 };
 

--- a/be/test/storage/lake/compaction_policy_test.cpp
+++ b/be/test/storage/lake/compaction_policy_test.cpp
@@ -18,7 +18,6 @@
 
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
-// #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"

--- a/be/test/storage/lake/meta_file_test.cpp
+++ b/be/test/storage/lake/meta_file_test.cpp
@@ -58,17 +58,17 @@ public:
         CHECK_OK(fs::create_directories(join_path(kTestDir, kTxnLogDirectoryName)));
         CHECK_OK(fs::create_directories(join_path(kTestDir, kSegmentDirectoryName)));
 
-        s_location_provider = std::make_unique<FixedLocationProvider>(kTestDir);
-        s_update_manager = std::make_unique<lake::UpdateManager>(s_location_provider.get());
+        s_location_provider = std::make_shared<FixedLocationProvider>(kTestDir);
+        s_update_manager = std::make_unique<lake::UpdateManager>(s_location_provider);
         s_tablet_manager =
-                std::make_unique<lake::TabletManager>(s_location_provider.get(), s_update_manager.get(), 1638400000);
+                std::make_unique<lake::TabletManager>(s_location_provider, s_update_manager.get(), 1638400000);
     }
 
     static void TearDownTestCase() { (void)FileSystem::Default()->delete_dir_recursive(kTestDir); }
 
 protected:
     constexpr static const char* const kTestDir = "./lake_meta_test";
-    inline static std::unique_ptr<lake::LocationProvider> s_location_provider;
+    inline static std::shared_ptr<lake::LocationProvider> s_location_provider;
     inline static std::unique_ptr<TabletManager> s_tablet_manager;
     inline static std::unique_ptr<UpdateManager> s_update_manager;
 };

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -50,12 +50,12 @@ public:
         std::vector<starrocks::StorePath> paths;
         CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
         _test_dir = paths[0].path + "/lake";
-        _location_provider = std::make_unique<lake::FixedLocationProvider>(_test_dir);
+        _location_provider = std::make_shared<lake::FixedLocationProvider>(_test_dir);
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(1)));
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(1)));
         CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->segment_root_location(1)));
-        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get());
-        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 16384);
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider);
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider, _update_manager.get(), 16384);
         _replication_txn_manager = std::make_unique<lake::ReplicationTxnManager>(_tablet_manager.get());
 
         TCreateTabletReq create_tablet_req = get_create_tablet_request(_tablet_id, _schema_hash, _version);
@@ -97,7 +97,7 @@ public:
 protected:
     std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
     std::string _test_dir;
-    std::unique_ptr<lake::LocationProvider> _location_provider;
+    std::shared_ptr<lake::LocationProvider> _location_provider;
     std::unique_ptr<lake::UpdateManager> _update_manager;
     std::unique_ptr<lake::ReplicationTxnManager> _replication_txn_manager;
 

--- a/be/test/storage/lake/schema_change_test.cpp
+++ b/be/test/storage/lake/schema_change_test.cpp
@@ -63,9 +63,9 @@ class SchemaChangeTest : public testing::Test, public testing::WithParamInterfac
 public:
     SchemaChangeTest(const std::string& test_dir) {
         _mem_tracker = std::make_unique<MemTracker>(-1);
-        _location_provider = std::make_unique<FixedLocationProvider>(test_dir);
-        _update_manager = std::make_unique<UpdateManager>(_location_provider.get());
-        _tablet_manager = std::make_unique<TabletManager>(_location_provider.get(), _update_manager.get(), 1024 * 1024);
+        _location_provider = std::make_shared<FixedLocationProvider>(test_dir);
+        _update_manager = std::make_unique<UpdateManager>(_location_provider);
+        _tablet_manager = std::make_unique<TabletManager>(_location_provider, _update_manager.get(), 1024 * 1024);
     }
 
 protected:
@@ -101,7 +101,7 @@ protected:
     }
 
     std::unique_ptr<MemTracker> _mem_tracker;
-    std::unique_ptr<FixedLocationProvider> _location_provider;
+    std::shared_ptr<FixedLocationProvider> _location_provider;
     std::unique_ptr<UpdateManager> _update_manager;
     std::unique_ptr<TabletManager> _tablet_manager;
 

--- a/be/test/storage/lake/test_util.h
+++ b/be/test/storage/lake/test_util.h
@@ -52,9 +52,9 @@ protected:
             : _test_dir(std::move(test_dir)),
               _parent_tracker(std::make_unique<MemTracker>(-1)),
               _mem_tracker(std::make_unique<MemTracker>(-1, "", _parent_tracker.get())),
-              _lp(std::make_unique<FixedLocationProvider>(_test_dir)),
-              _update_mgr(std::make_unique<UpdateManager>(_lp.get(), _mem_tracker.get())),
-              _tablet_mgr(std::make_unique<TabletManager>(_lp.get(), _update_mgr.get(), cache_limit)) {}
+              _lp(std::make_shared<FixedLocationProvider>(_test_dir)),
+              _update_mgr(std::make_unique<UpdateManager>(_lp, _mem_tracker.get())),
+              _tablet_mgr(std::make_unique<TabletManager>(_lp, _update_mgr.get(), cache_limit)) {}
 
     void remove_test_dir_or_die() { ASSERT_OK(fs::remove_all(_test_dir)); }
 
@@ -81,7 +81,7 @@ protected:
     std::string _test_dir;
     std::unique_ptr<MemTracker> _parent_tracker;
     std::unique_ptr<MemTracker> _mem_tracker;
-    std::unique_ptr<LocationProvider> _lp;
+    std::shared_ptr<LocationProvider> _lp;
     std::unique_ptr<UpdateManager> _update_mgr;
     std::unique_ptr<TabletManager> _tablet_mgr;
 };


### PR DESCRIPTION
Why I'm doing:
For the independent TabletWriter sdk, because there is no corresponding TabletManager, the TabletWriter needs to be reconstructed to remove the TabletWriter's dependence on the TabletManager.

What I'm doing:
remove the TabletWriter's member variables TabletManager

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5