### PR TITLE
[BugFix] Reorder table may lost sort key column

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -714,7 +714,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
             int sortKeyIdx = targetIndexSchema.indexOf(oneCol.get());
             sortKeyIdxes.add(sortKeyIdx);
-            if (useSortKeyUniqueId && oneCol.get().getUniqueId() > 0) {
+            if (useSortKeyUniqueId && oneCol.get().getUniqueId() > Column.COLUMN_UNIQUE_ID_INIT_VALUE) {
                 sortKeyUniqueIds.add(oneCol.get().getUniqueId());
             } else {
                 useSortKeyUniqueId = false;


### PR DESCRIPTION
Why I'm doing:

The initial column on FE has a unique id is `-1`, and we will use this value to do some judgment. When modifying the sort key of the table, the judgment logic for the unique id is wrong. This bug has been fixed in previous pr(https://github.com/StarRocks/starrocks/pull/36563), but reintroduced in this pr(https://github.com/StarRocks/starrocks/pull/34572/), probably not handled well when dealing with conflicts. 

What I'm doing:

Fix the wrong code logic

Fixes https://github.com/StarRocks/StarRocksTest/issues/5420, https://github.com/StarRocks/StarRocksTest/issues/5463

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
