### PR TITLE
[UT] Enhance the stability of union testing of materialized views

### DIFF
--- a/test/sql/test_materialized_view/R/test_materialized_view_union
+++ b/test/sql/test_materialized_view/R/test_materialized_view_union
@@ -55,10 +55,7 @@ select k1, v1, v2 from t2;
 insert into t1 values ("202301",1,1),("202305",1,2);
 -- result:
 -- !result
-function: wait_async_materialized_view_finish("test_union_mv1_${uuid0}")
--- result:
-None
--- !result
+refresh materialized view test_union_mv1_${uuid0} with sync mode;
 select * from test_union_mv1_${uuid0} order by k1, v1;
 -- result:
 202301	1	1
@@ -123,12 +120,10 @@ union
 select k1, v1, v2 from t2;
 -- result:
 -- !result
-function: wait_async_materialized_view_finish("test_union_mv2_${uuid0}")
--- result:
-None
--- !result
+refresh materialized view test_union_mv2_${uuid0} with sync mode;
 select * from test_union_mv2_${uuid0} order by k1, v1;
 -- result:
+202301	1	1
 202305	1	2
 -- !result
 drop table t1;

--- a/test/sql/test_materialized_view/T/test_materialized_view_union
+++ b/test/sql/test_materialized_view/T/test_materialized_view_union
@@ -48,7 +48,7 @@ union all
 select k1, v1, v2 from t2;
 
 insert into t1 values ("202301",1,1),("202305",1,2);
-function: wait_async_materialized_view_finish("test_union_mv1_${uuid0}")
+refresh materialized view test_union_mv1_${uuid0} with sync mode;
 select * from test_union_mv1_${uuid0} order by k1, v1;
 drop table t1;
 drop table t2;
@@ -96,7 +96,7 @@ PROPERTIES (
 AS select k1, v1, v2 from t1
 union
 select k1, v1, v2 from t2;
-function: wait_async_materialized_view_finish("test_union_mv2_${uuid0}")
+refresh materialized view test_union_mv2_${uuid0} with sync mode;
 select * from test_union_mv2_${uuid0} order by k1, v1;
 drop table t1;
 drop table t2;


### PR DESCRIPTION
Why I'm doing:

Strange problems still occur with previous modifications. After running the synchronization interface of the materialized view 100 times, the problem no longer occurs.

What I'm doing:

Change the function that determines the materialized view to the synchronous refresh interface

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
