### PR TITLE
[BugFix] fix field not be correctly set when deserialization

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedIndexMeta.java
@@ -60,11 +60,11 @@ public class MaterializedIndexMeta implements Writable, GsonPostProcessable {
     @SerializedName(value = "indexId")
     private long indexId;
     @SerializedName(value = "schema")
-    private List<Column> schema = Lists.newArrayList();
+    private List<Column> schema;
     @SerializedName(value = "sortKeyIdxes")
-    public List<Integer> sortKeyIdxes = Lists.newArrayList();
+    public List<Integer> sortKeyIdxes;
     @SerializedName(value = "sortKeyUniqueIds")
-    public List<Integer> sortKeyUniqueIds = Lists.newArrayList();
+    public List<Integer> sortKeyUniqueIds;
     @SerializedName(value = "schemaVersion")
     private int schemaVersion;
     @SerializedName(value = "schemaHash")

--- a/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonSerializationTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/gson/GsonSerializationTest.java
@@ -26,6 +26,8 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Table;
 import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.common.io.FastByteArrayOutputStream;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
@@ -46,6 +48,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+
+import static com.starrocks.catalog.KeysType.PRIMARY_KEYS;
+import static com.starrocks.thrift.TStorageType.COLUMN;
 
 /*
  * This unit test provides examples about how to make a class serializable.
@@ -484,5 +489,24 @@ public class GsonSerializationTest {
 
         Assert.assertEquals(2, newPrePost.a);
         Assert.assertTrue(newPrePost.b.equals("2"));
+    }
+
+    @Test
+    public void testMaterializedIndexMetaGsonProcess() throws Exception {
+        MaterializedIndexMeta indexMeta = new MaterializedIndexMeta(1, Lists.newArrayList(new Column()), 1, 1,
+                (short) 1, COLUMN, PRIMARY_KEYS, null);
+        FastByteArrayOutputStream byteArrayOutputStream = new FastByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(byteArrayOutputStream)) {
+            indexMeta.write(out);
+            out.flush();
+        }
+
+        MaterializedIndexMeta copied = null;
+        try (DataInputStream in = new DataInputStream(byteArrayOutputStream.getInputStream())) {
+            copied = MaterializedIndexMeta.read(in);
+        }
+        byteArrayOutputStream.close();
+        Assert.assertTrue(copied.sortKeyIdxes == null);
+        Assert.assertTrue(copied.sortKeyUniqueIds == null);
     }
 }


### PR DESCRIPTION
Why I'm doing:
To eaisly shallow copy Object, we add a private no-args constructor in `MaterializedIndexMeta` which affected the gson deserialize process. When deserialize it, the old way use `UnsafeAllocator` to build Object making these default value not work. The generated object is same as the original one.  After adding a no-args constructor,  the deserialize process use it  to build Object and the default value worked, then the generated object maybe different from the original one  when `sortKeyIdxes` is null.
```
@SerializedName(value = "schema")
    private List<Column> schema = Lists.newArrayList();
    @SerializedName(value = "sortKeyIdxes")
    public List<Integer> sortKeyIdxes = Lists.newArrayList();
    @SerializedName(value = "sortKeyUniqueIds")
    public List<Integer> sortKeyUniqueIds = Lists.newArrayList();
```

What I'm doing:
All these with-args constructor will set `schema`, `sortKeyIdxes` and `sortKeyUniqueIds`, so the default value is useless. Just delete them.


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
