### PR TITLE
[Bugfix] fix short read eos flag error on multi be 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ShortCircuitHybridExecutor.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
@@ -76,6 +77,8 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
         Queue<RowBatch> rowBatchQueue = new LinkedList<>();
         AtomicReference<RuntimeProfile> runtimeProfile = new AtomicReference<>();
         AtomicLong affectedRows = new AtomicLong();
+
+        AtomicInteger i = new AtomicInteger();
         be2ShortCircuitRequests.forEach((beAddress, tRequest) -> {
             PBackendService service = BrpcProxy.getBackendService(beAddress);
             try {
@@ -102,7 +105,7 @@ public class ShortCircuitHybridExecutor extends ShortCircuitExecutor {
 
                 byte[] serialResult = pRequest.getSerializedResult();
                 RowBatch rowBatch = new RowBatch();
-                rowBatch.setEos(true);
+                rowBatch.setEos(i.incrementAndGet() == be2ShortCircuitRequests.keys().size());
                 if (serialResult != null && serialResult.length > 0) {
                     TDeserializer deserializer = new TDeserializer();
                     TResultBatch resultBatch = new TResultBatch();


### PR DESCRIPTION
Fixbug:
eos of RowBatch in FE for short circuit read was not set correctly. The original processing of eos is always true. it will cause query result's records can't be fully return to query client for existing multi be . because that it think data stream already end.

so this pr will set eos based on whether is the last response
What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

