### PR TITLE
[Enhancement]register milliseconds_diff function

### DIFF
--- a/docs/en/sql-reference/sql-functions/date-time-functions/timestampadd.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/timestampadd.md
@@ -10,7 +10,7 @@ Adds an integer expression interval to the date or datetime expression `datetime
 
 The unit for the interval as mentioned must be one of the following:
 
-SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, or YEAR.
+MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, or YEAR.
 
 ## Syntax
 

--- a/docs/en/sql-reference/sql-functions/date-time-functions/timestampdiff.md
+++ b/docs/en/sql-reference/sql-functions/date-time-functions/timestampdiff.md
@@ -10,7 +10,7 @@ Returns the interval from `datetime_expr2` to `datetime_expr1`. `datetime_expr1`
 
 The unit for the integer result and the interval should be one of the following:
 
-SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, or YEAR.
+MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, or YEAR.
 
 ## Syntax
 

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -427,6 +427,7 @@ vectorized_functions = [
     [50231, 'to_days', 'INT', ['DATE'], 'TimeFunctions::to_days'],
     [50241, 'date_format', 'VARCHAR', ['DATETIME', 'VARCHAR'], 'TimeFunctions::datetime_format', 'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
     [50242, 'date_format', 'VARCHAR', ['DATE', 'VARCHAR'], 'TimeFunctions::date_format', 'TimeFunctions::format_prepare', 'TimeFunctions::format_close'],
+    [50245, 'milliseconds_diff', 'BIGINT', ['DATETIME', 'DATETIME'], 'TimeFunctions::milliseconds_diff'],
 
     # From string to DATE/DATETIME
     # the function will call by FE getStrToDateFunction, and is invisible to user

--- a/test/sql/test_time_fn/R/test_time_fn
+++ b/test/sql/test_time_fn/R/test_time_fn
@@ -917,3 +917,15 @@ select to_iso8601(date'2020-01-01'), to_iso8601(datetime'2020-01-01 00:00:00'),t
 -- result:
 2020-01-01	2020-01-01T00:00:00.000000	2020-01-01T00:00:00.100000
 -- !result
+
+-- name: test_timestamp_add
+select timestampadd(MILLISECOND, 1, '2019-01-02 00:00:00');
+-- result:
+2019-01-02 00:00:00.001000
+-- !result
+
+-- name: test_timestamp_diff
+select  timestampdiff(MILLISECOND, '2003-02-01 00:00:00', '2003-05-01 12:05:55');
+-- result:
+7733155000
+-- !result

--- a/test/sql/test_time_fn/T/test_time_fn
+++ b/test/sql/test_time_fn/T/test_time_fn
@@ -297,3 +297,10 @@ VALUES ('2020-01-01','2020-01-01 00:00:00'),
 select to_iso8601(d1),to_iso8601(d2) from to_iso8601_test order by d1;
 
 select to_iso8601(date'2020-01-01'), to_iso8601(datetime'2020-01-01 00:00:00'),to_iso8601(datetime'2020-01-01 00:00:00.1');
+
+-- name: test_timestamp_add
+select timestampadd(MILLISECOND, 1, '2019-01-02 00:00:00');
+
+
+-- name: test_timestamp_diff
+select  timestampdiff(MILLISECOND, '2003-02-01 00:00:00', '2003-05-01 12:05:55');


### PR DESCRIPTION
Why I'm doing:
support milliseconds unit for the buildin function of timestampdiff

What I'm doing:
fe will acess the function named 'milliseconds_diff' in be when using milliseconds unit in timestampdiff function.
So  register the fucntion  'milliseconds_diff' at functions.py

Fixes #issue
#24481
## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5