### PR TITLE
[BugFix] Fix loadAlterJob failed when upgrade from version smaller than 3.1.2

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1795,7 +1795,7 @@ public class GlobalStateMgr {
     public long loadAlterJob(DataInputStream dis, long checksum) throws IOException {
         long newChecksum = checksum;
         // Notice: The order in types must be ROLLUP, SCHEMA_CHANGE, DECOMMISSION_BACKEND,
-        // if changed the image read will fail.
+        // if changed, the image read will fail.
         List<AlterJobV2.JobType> types = Lists.newArrayList(AlterJobV2.JobType.ROLLUP,
                 AlterJobV2.JobType.SCHEMA_CHANGE, AlterJobV2.JobType.DECOMMISSION_BACKEND);
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1794,6 +1794,8 @@ public class GlobalStateMgr {
 
     public long loadAlterJob(DataInputStream dis, long checksum) throws IOException {
         long newChecksum = checksum;
+        // Notice: The order in types must be ROLLUP, SCHEMA_CHANGE, DECOMMISSION_BACKEND,
+        // if changed the image read will fail.
         List<AlterJobV2.JobType> types = Lists.newArrayList(AlterJobV2.JobType.ROLLUP,
                 AlterJobV2.JobType.SCHEMA_CHANGE, AlterJobV2.JobType.DECOMMISSION_BACKEND);
 

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1794,7 +1794,10 @@ public class GlobalStateMgr {
 
     public long loadAlterJob(DataInputStream dis, long checksum) throws IOException {
         long newChecksum = checksum;
-        for (AlterJobV2.JobType type : AlterJobV2.JobType.values()) {
+        List<AlterJobV2.JobType> types = Lists.newArrayList(AlterJobV2.JobType.ROLLUP,
+                AlterJobV2.JobType.SCHEMA_CHANGE, AlterJobV2.JobType.DECOMMISSION_BACKEND);
+
+        for (AlterJobV2.JobType type : types) {
             newChecksum = loadAlterJob(dis, newChecksum, type);
         }
         LOG.info("finished replay alterJob from image");


### PR DESCRIPTION
Why I'm doing:
`JobType.OPTIMIZE` is added in version 3.2, it will cause the dislocation of image read.

What I'm doing:
Only read the alter jobs of type: `ROLLUP`, `SCHEMA_CHANGE`, `DECOMMISSION_BACKEND`. The newly added type `JobType.OPTIMIZE` will be saved into new image format, and there is no compatibility issues in this format.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
