### PR TITLE
[Enhancement][Cherry-Pick][Branch-3.0] Avoid high IOPS in orc reader when datacache enabled (backport #38115)

### DIFF
--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -542,34 +542,31 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
     return Status::OK();
 }
 
+static const std::string kORCProfileSectionPrefix = "ORC";
+
 void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
-    const std::string orcProfileSectionPrefix = "ORC";
+    RuntimeProfile::Counter* delete_build_timer = nullptr;
+    RuntimeProfile::Counter* delete_file_per_scan_counter = nullptr;
+    RuntimeProfile::Counter* stripe_sizes_counter = nullptr;
+    RuntimeProfile::Counter* stripe_number_counter = nullptr;
+    RuntimeProfile* root = profile->runtime_profile;
 
-    void HdfsOrcScanner::do_update_counter(HdfsScanProfile * profile) {
-        RuntimeProfile::Counter* delete_build_timer = nullptr;
-        RuntimeProfile::Counter* delete_file_per_scan_counter = nullptr;
-        RuntimeProfile::Counter* stripe_sizes_counter = nullptr;
-        RuntimeProfile::Counter* stripe_number_counter = nullptr;
-        RuntimeProfile* root = profile->runtime_profile;
-        ADD_COUNTER(root, orcProfileSectionPrefix, TUnit::NONE);
+    ADD_COUNTER(root, kORCProfileSectionPrefix, TUnit::UNIT);
 
-        ADD_COUNTER(root, kORCProfileSectionPrefix, TUnit::UNIT);
+    delete_build_timer = ADD_CHILD_TIMER(root, "DeleteBuildTimer", kORCProfileSectionPrefix);
+    delete_file_per_scan_counter = ADD_CHILD_COUNTER(root, "DeleteFilesPerScan", TUnit::UNIT, kORCProfileSectionPrefix);
+    COUNTER_UPDATE(delete_build_timer, _stats.delete_build_ns);
+    COUNTER_UPDATE(delete_file_per_scan_counter, _stats.delete_file_per_scan);
 
-        delete_build_timer = ADD_CHILD_TIMER(root, "DeleteBuildTimer", kORCProfileSectionPrefix);
-        delete_file_per_scan_counter =
-                ADD_CHILD_COUNTER(root, "DeleteFilesPerScan", TUnit::UNIT, kORCProfileSectionPrefix);
-        COUNTER_UPDATE(delete_build_timer, _stats.delete_build_ns);
-        COUNTER_UPDATE(delete_file_per_scan_counter, _stats.delete_file_per_scan);
-
-        // we expect to get average stripe size instead of sum.
-        stripe_sizes_counter = root->add_child_counter(
-                "StripeSizes", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG),
-                kORCProfileSectionPrefix);
-        stripe_number_counter = ADD_CHILD_COUNTER(root, "StripeNumber", TUnit::UNIT, kORCProfileSectionPrefix);
-        for (auto v : _stats.stripe_sizes) {
-            COUNTER_UPDATE(stripe_sizes_counter, v);
-        }
-        COUNTER_UPDATE(stripe_number_counter, _stats.stripe_sizes.size());
+    // we expect to get average stripe size instead of sum.
+    stripe_sizes_counter = root->add_child_counter("StripeSizes", TUnit::BYTES,
+                                                   RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG),
+                                                   kORCProfileSectionPrefix);
+    stripe_number_counter = ADD_CHILD_COUNTER(root, "StripeNumber", TUnit::UNIT, kORCProfileSectionPrefix);
+    for (auto v : _stats.stripe_sizes) {
+        COUNTER_UPDATE(stripe_sizes_counter, v);
     }
+    COUNTER_UPDATE(stripe_number_counter, _stats.stripe_sizes.size());
+}
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -542,7 +542,8 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
     return Status::OK();
 }
 
-static const std::string kORCProfileSectionPrefix = "ORC";
+void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
+    const std::string orcProfileSectionPrefix = "ORC";
 
 void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* delete_build_timer = nullptr;
@@ -550,6 +551,7 @@ void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
     RuntimeProfile::Counter* stripe_sizes_counter = nullptr;
     RuntimeProfile::Counter* stripe_number_counter = nullptr;
     RuntimeProfile* root = profile->runtime_profile;
+    ADD_COUNTER(root, orcProfileSectionPrefix, TUnit::NONE);
 
     ADD_COUNTER(root, kORCProfileSectionPrefix, TUnit::UNIT);
 

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -545,30 +545,31 @@ Status HdfsOrcScanner::do_init(RuntimeState* runtime_state, const HdfsScannerPar
 void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
     const std::string orcProfileSectionPrefix = "ORC";
 
-void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
-    RuntimeProfile::Counter* delete_build_timer = nullptr;
-    RuntimeProfile::Counter* delete_file_per_scan_counter = nullptr;
-    RuntimeProfile::Counter* stripe_sizes_counter = nullptr;
-    RuntimeProfile::Counter* stripe_number_counter = nullptr;
-    RuntimeProfile* root = profile->runtime_profile;
-    ADD_COUNTER(root, orcProfileSectionPrefix, TUnit::NONE);
+    void HdfsOrcScanner::do_update_counter(HdfsScanProfile * profile) {
+        RuntimeProfile::Counter* delete_build_timer = nullptr;
+        RuntimeProfile::Counter* delete_file_per_scan_counter = nullptr;
+        RuntimeProfile::Counter* stripe_sizes_counter = nullptr;
+        RuntimeProfile::Counter* stripe_number_counter = nullptr;
+        RuntimeProfile* root = profile->runtime_profile;
+        ADD_COUNTER(root, orcProfileSectionPrefix, TUnit::NONE);
 
-    ADD_COUNTER(root, kORCProfileSectionPrefix, TUnit::UNIT);
+        ADD_COUNTER(root, kORCProfileSectionPrefix, TUnit::UNIT);
 
-    delete_build_timer = ADD_CHILD_TIMER(root, "DeleteBuildTimer", kORCProfileSectionPrefix);
-    delete_file_per_scan_counter = ADD_CHILD_COUNTER(root, "DeleteFilesPerScan", TUnit::UNIT, kORCProfileSectionPrefix);
-    COUNTER_UPDATE(delete_build_timer, _stats.delete_build_ns);
-    COUNTER_UPDATE(delete_file_per_scan_counter, _stats.delete_file_per_scan);
+        delete_build_timer = ADD_CHILD_TIMER(root, "DeleteBuildTimer", kORCProfileSectionPrefix);
+        delete_file_per_scan_counter =
+                ADD_CHILD_COUNTER(root, "DeleteFilesPerScan", TUnit::UNIT, kORCProfileSectionPrefix);
+        COUNTER_UPDATE(delete_build_timer, _stats.delete_build_ns);
+        COUNTER_UPDATE(delete_file_per_scan_counter, _stats.delete_file_per_scan);
 
-    // we expect to get average stripe size instead of sum.
-    stripe_sizes_counter = root->add_child_counter("StripeSizes", TUnit::BYTES,
-                                                   RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG),
-                                                   kORCProfileSectionPrefix);
-    stripe_number_counter = ADD_CHILD_COUNTER(root, "StripeNumber", TUnit::UNIT, kORCProfileSectionPrefix);
-    for (auto v : _stats.stripe_sizes) {
-        COUNTER_UPDATE(stripe_sizes_counter, v);
+        // we expect to get average stripe size instead of sum.
+        stripe_sizes_counter = root->add_child_counter(
+                "StripeSizes", TUnit::BYTES, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG),
+                kORCProfileSectionPrefix);
+        stripe_number_counter = ADD_CHILD_COUNTER(root, "StripeNumber", TUnit::UNIT, kORCProfileSectionPrefix);
+        for (auto v : _stats.stripe_sizes) {
+            COUNTER_UPDATE(stripe_sizes_counter, v);
+        }
+        COUNTER_UPDATE(stripe_number_counter, _stats.stripe_sizes.size());
     }
-    COUNTER_UPDATE(stripe_number_counter, _stats.stripe_sizes.size());
-}
 
 } // namespace starrocks

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -1016,7 +1016,8 @@ void RowReaderImpl::buildIORanges(std::vector<InputStream::IORange>* io_ranges) 
     for (const proto::Stream& stream : currentStripeFooter.streams()) {
         uint32_t columnId = stream.column();
         uint64_t length = stream.length();
-        if (selectedColumns[columnId] || lazyLoadColumns[columnId]) {
+        // ColumnId = 0 is root column, we always need it
+        if (columnId == 0 || selectedColumns[columnId] || lazyLoadColumns[columnId]) {
             io_ranges->emplace_back(InputStream::IORange{.offset = offset, .size = length});
         }
         offset += length;

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -72,7 +72,7 @@ Status OrcChunkReader::init(std::unique_ptr<orc::InputStream> input_stream) {
     try {
         _reader_options.setMemoryPool(*getOrcMemoryPool());
         auto reader = orc::createReader(std::move(input_stream), _reader_options);
-        return init(std::move(reader));
+        RETURN_IF_ERROR(init(std::move(reader)));
     } catch (std::exception& e) {
         auto s = strings::Substitute("OrcChunkReader::init failed. reason = $0, file = $1", e.what(),
                                      _current_file_name);

--- a/be/src/formats/orc/orc_chunk_reader.h
+++ b/be/src/formats/orc/orc_chunk_reader.h
@@ -166,7 +166,7 @@ private:
     // We make the same behavior as Trino & Presto.
     // https://trino.io/docs/current/connector/hive.html?highlight=hive#orc-format-configuration-properties
     bool _use_orc_column_names = false;
-    OrcMappingOptions _orc_mapping_options;
+    OrcMappingOptions _orc_mapping_options{};
     std::unique_ptr<OrcMapping> _root_selected_mapping;
     std::vector<TypeDescriptor> _src_types;
     // slot id to position in orc.

--- a/be/src/formats/orc/orc_input_stream.cpp
+++ b/be/src/formats/orc/orc_input_stream.cpp
@@ -30,25 +30,34 @@ ORCHdfsFileStream::ORCHdfsFileStream(RandomAccessFile* file, uint64_t length, io
         : _file(file), _length(length), _cache_buffer(0), _cache_offset(0), _sb_stream(sb_stream) {}
 
 void ORCHdfsFileStream::prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length) {
-    size_t cache_max_size = config::orc_file_cache_max_size;
-    if (scope == PrepareCacheScope::READ_FULL_ROW_INDEX) {
+    size_t cache_max_size = 0;
+    if (scope == PrepareCacheScope::READ_FULL_FILE) {
+        cache_max_size = config::orc_file_cache_max_size;
+    } else if (scope == PrepareCacheScope::READ_FULL_ROW_INDEX) {
         cache_max_size = config::orc_row_index_cache_max_size;
-    }
-    if (scope == PrepareCacheScope::READ_FULL_STRIPE) {
+    } else if (scope == PrepareCacheScope::READ_FULL_STRIPE) {
         cache_max_size = config::orc_stripe_cache_max_size;
     }
 
     if (length > cache_max_size) return;
-    if (canUseCacheBuffer(offset, length)) return;
+    if (isAlreadyCachedInBuffer(offset, length)) return;
     if (scope == PrepareCacheScope::READ_FULL_STRIPE && _tiny_stripe_read) {
         length = computeCacheFullStripeSize(offset, length);
     }
     _cache_buffer.resize(length);
     _cache_offset = offset;
+
+    // We need to set io range manually, otherwise one io request will be split into multiple requests
+    std::vector<IORange> io_ranges{};
+    io_ranges.emplace_back(InputStream::IORange{.offset = offset, .size = length});
+    setIORanges(io_ranges);
+
     doRead(_cache_buffer.data(), length, offset);
+
+    clearIORanges();
 }
 
-bool ORCHdfsFileStream::canUseCacheBuffer(uint64_t offset, uint64_t length) {
+bool ORCHdfsFileStream::isAlreadyCachedInBuffer(uint64_t offset, uint64_t length) {
     if ((_cache_buffer.size() != 0) && (offset >= _cache_offset) &&
         ((offset + length) <= (_cache_offset + _cache_buffer.size()))) {
         return true;
@@ -57,7 +66,7 @@ bool ORCHdfsFileStream::canUseCacheBuffer(uint64_t offset, uint64_t length) {
 }
 
 void ORCHdfsFileStream::read(void* buf, uint64_t length, uint64_t offset) {
-    if (canUseCacheBuffer(offset, length)) {
+    if (isAlreadyCachedInBuffer(offset, length)) {
         size_t idx = offset - _cache_offset;
         memcpy(buf, _cache_buffer.data() + idx, length);
     } else {

--- a/be/src/formats/orc/orc_input_stream.h
+++ b/be/src/formats/orc/orc_input_stream.h
@@ -75,7 +75,7 @@ public:
 
 private:
     void doRead(void* buf, uint64_t length, uint64_t offset);
-    bool canUseCacheBuffer(uint64_t offset, uint64_t length);
+    bool isAlreadyCachedInBuffer(uint64_t offset, uint64_t length);
     uint64_t computeCacheFullStripeSize(uint64_t offset, uint64_t length);
 
     RandomAccessFile* _file;


### PR DESCRIPTION
cp from https://github.com/StarRocks/starrocks/pull/38115

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

