### PR TITLE
[Refactor] Add retry in the broker load when timeout

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -350,7 +350,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                         .build());
                 return;
             }
-            if (retryTime <= 0 || !txnStatusChangeReason.contains("timeout")) {
+            if (retryTime <= 0 || !txnStatusChangeReason.contains("timeout") || !isTimeout()) {
                 // record attachment in load job
                 unprotectUpdateLoadingStatus(txnState);
                 // cancel load job

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -64,11 +64,14 @@ import com.starrocks.metric.TableMetricsRegistry;
 import com.starrocks.persist.AlterLoadJobOperationLog;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
+import com.starrocks.qe.QeProcessorImpl;
+import com.starrocks.qe.scheduler.Coordinator;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.sql.ast.AlterLoadStmt;
 import com.starrocks.sql.ast.LoadStmt;
 import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.task.PriorityLeaderTask;
 import com.starrocks.thrift.TLoadJobType;
 import com.starrocks.thrift.TPartialUpdateMode;
 import com.starrocks.thrift.TReportExecStatusParams;
@@ -328,6 +331,71 @@ public class BrokerLoadJob extends BulkLoadJob {
         // Submit task outside the database lock, cause it may take a while if task queue is full.
         for (LoadTask loadTask : newLoadingTasks) {
             submitTask(GlobalStateMgr.getCurrentState().getLoadingLoadTaskScheduler(), loadTask);
+        }
+    }
+
+    @Override
+    public void afterAborted(TransactionState txnState, boolean txnOperated, String txnStatusChangeReason)
+            throws UserException {
+        if (!txnOperated) {
+            return;
+        }
+        writeLock();
+        try {
+            // check if job has been completed
+            if (isTxnDone()) {
+                LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
+                        .add("state", state)
+                        .add("error_msg", "this task will be ignored when job is: " + state)
+                        .build());
+                return;
+            }
+            if (retryTime <= 0 || !txnStatusChangeReason.contains("timeout")) {
+                // record attachment in load job
+                unprotectUpdateLoadingStatus(txnState);
+                // cancel load job
+                unprotectedExecuteCancel(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, txnStatusChangeReason), true);
+                return;
+            }
+
+            retryTime--;
+            failMsg = new FailMsg(FailMsg.CancelType.TIMEOUT, txnStatusChangeReason);
+            LOG.warn("Retry timeout load jobs. job: {}, retryTime: {}", id, retryTime);
+            unprotectedClearTasksBeforeRetry(failMsg);
+            try {
+                state = JobState.PENDING;
+                unprotectedExecute();
+            } catch (Exception e) {
+                LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
+                        .add("database_id", dbId)
+                        .add("error_msg", "Failed to divide job into loading task.")
+                        .build(), e);
+                cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
+            }
+        } finally {
+            writeUnlock();
+        }
+    }
+
+    protected void unprotectedClearTasksBeforeRetry(FailMsg failMsg) {
+        // get load ids of all loading tasks, we will cancel their coordinator process later
+        List<TUniqueId> loadIds = Lists.newArrayList();
+        for (PriorityLeaderTask loadTask : idToTasks.values()) {
+            if (loadTask instanceof LoadLoadingTask) {
+                loadIds.add(((LoadLoadingTask) loadTask).getLoadId());
+            }
+        }
+        newLoadingTasks.clear();
+        reset();
+
+        // set failMsg
+        this.failMsg = failMsg;
+        // cancel all running coordinators, so that the scheduler's worker thread will be released
+        for (TUniqueId loadId : loadIds) {
+            Coordinator coordinator = QeProcessorImpl.INSTANCE.getCoordinator(loadId);
+            if (coordinator != null) {
+                coordinator.cancel(failMsg.getMsg());
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -366,10 +366,6 @@ public class BrokerLoadJob extends BulkLoadJob {
                 state = JobState.PENDING;
                 unprotectedExecute();
             } catch (Exception e) {
-                LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                        .add("database_id", dbId)
-                        .add("error_msg", "Failed to divide job into loading task.")
-                        .build(), e);
                 cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.ETL_RUN_FAIL, e.getMessage()), true, true);
             }
         } finally {
@@ -465,10 +461,6 @@ public class BrokerLoadJob extends BulkLoadJob {
                 // Sleep and retry.
                 ThreadUtil.sleepAtLeastIgnoreInterrupts(Math.max(e.getAllowCommitTime() - System.currentTimeMillis(), 0));
             } catch (UserException e) {
-                LOG.warn(new LogBuilder(LogKey.LOAD_JOB, id)
-                        .add("database_id", dbId)
-                        .add("error_msg", "Failed to commit txn with error:" + e.getMessage())
-                        .build(), e);
                 cancelJobWithoutCheck(new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL, e.getMessage()), true, true);
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadPendingTask.java
@@ -62,7 +62,6 @@ public class BrokerLoadPendingTask extends LoadTask {
                                  Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToBrokerFileGroups,
                                  BrokerDesc brokerDesc) {
         super(loadTaskCallback, TaskType.PENDING, 0);
-        this.retryTime = 3;
         this.attachment = new BrokerPendingTaskAttachment(signature);
         this.aggKeyToBrokerFileGroups = aggKeyToBrokerFileGroups;
         this.brokerDesc = brokerDesc;

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BulkLoadJob.java
@@ -251,12 +251,10 @@ public abstract class BulkLoadJob extends LoadJob {
                 return;
             }
 
-            if (failMsg.getMsg().contains("timeout")) {
-                return;
+            if (!failMsg.getMsg().contains("timeout")) {
+                unprotectedExecuteCancel(failMsg, true);
+                logFinalOperation();
             }
-
-            unprotectedExecuteCancel(failMsg, true);
-            logFinalOperation();
         } finally {
             writeUnlock();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -285,7 +285,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         loadingStatus.setProgress(0);
     }
 
-    private boolean isTimeout() {
+    public boolean isTimeout() {
         return System.currentTimeMillis() > getDeadlineMs();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -188,6 +188,8 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     // this request id is only used for checking if a load begin request is a duplicate request.
     protected TUniqueId requestId;
 
+    protected int retryTime = 2; // retry time if timeout
+
     // only for persistence param. see readFields() for usage
     private boolean isJobTypeRead = false;
 
@@ -268,6 +270,19 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
 
     protected long getDeadlineMs() {
         return createTimestamp + timeoutSecond * 1000;
+    }
+
+    public void reset() {
+        if (ConnectContext.get() != null) {
+            ConnectContext.get().setStartTime();
+            this.createTimestamp = ConnectContext.get().getStartTime();
+        } else {
+            // only for test used
+            this.createTimestamp = System.currentTimeMillis();
+        }
+        idToTasks.clear();
+        finishedTaskIds.clear();
+        loadingStatus.setProgress(0);
     }
 
     private boolean isTimeout() {
@@ -673,6 +688,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         finishTimestamp = System.currentTimeMillis();
         GlobalStateMgr.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
         state = JobState.FINISHED;
+        failMsg = null;
 
         if (MetricRepo.hasInit) {
             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -152,8 +152,6 @@ public class LoadLoadingTask extends LoadTask {
 
     @Override
     protected void executeTask() throws Exception {
-        LOG.info("begin to execute loading task. load id: {} job: {}. db: {}, tbl: {}.",
-                DebugUtil.printId(loadId), callback.getCallbackId(), db.getOriginName(), table.getName());
         executeOnce();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -125,7 +125,6 @@ public class LoadLoadingTask extends LoadTask {
         this.loadJobType = builder.loadJobType;
         this.originStmt = builder.originStmt;
         this.partialUpdateMode = builder.partialUpdateMode;
-        this.retryTime = 1; // load task retry does not satisfy transaction's atomic
         this.failMsg = new FailMsg(FailMsg.CancelType.LOAD_RUN_FAIL);
         this.loadId = builder.loadId;
         this.fileStatusList = builder.fileStatusList;
@@ -153,9 +152,8 @@ public class LoadLoadingTask extends LoadTask {
 
     @Override
     protected void executeTask() throws Exception {
-        LOG.info("begin to execute loading task. load id: {} job: {}. db: {}, tbl: {}. left retry: {}",
-                DebugUtil.printId(loadId), callback.getCallbackId(), db.getOriginName(), table.getName(), retryTime);
-        retryTime--;
+        LOG.info("begin to execute loading task. load id: {} job: {}. db: {}, tbl: {}.",
+                DebugUtil.printId(loadId), callback.getCallbackId(), db.getOriginName(), table.getName());
         executeOnce();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadLoadingTask.java
@@ -68,7 +68,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class LoadLoadingTask extends LoadTask {
     private static final Logger LOG = LogManager.getLogger(LoadLoadingTask.class);
@@ -267,15 +266,6 @@ public class LoadLoadingTask extends LoadTask {
 
     private long getLeftTimeMs() {
         return jobDeadlineMs - System.currentTimeMillis();
-    }
-
-    @Override
-    public void updateRetryInfo() {
-        super.updateRetryInfo();
-        UUID uuid = UUID.randomUUID();
-        this.loadId = new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
-
-        loadPlanner.updateLoadInfo(this.loadId);
     }
 
     public static class Builder {

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -56,7 +56,6 @@ public abstract class LoadTask extends PriorityLeaderTask {
     protected LoadTaskCallback callback;
     protected TaskAttachment attachment;
     protected FailMsg failMsg = new FailMsg();
-    protected int retryTime = 1;
 
     public LoadTask(LoadTaskCallback callback, TaskType taskType, int priority) {
         super(priority);
@@ -105,13 +104,8 @@ public abstract class LoadTask extends PriorityLeaderTask {
      */
     abstract void executeTask() throws Exception;
 
-    public int getRetryTime() {
-        return retryTime;
-    }
-
     // Derived class may need to override this.
     public void updateRetryInfo() {
-        this.retryTime--;
         this.signature = GlobalStateMgr.getCurrentState().getNextId();
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadTask.java
@@ -104,11 +104,6 @@ public abstract class LoadTask extends PriorityLeaderTask {
      */
     abstract void executeTask() throws Exception;
 
-    // Derived class may need to override this.
-    public void updateRetryInfo() {
-        this.signature = GlobalStateMgr.getCurrentState().getNextId();
-    }
-
     public TaskType getTaskType() {
         return taskType;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/SparkLoadPendingTask.java
@@ -117,7 +117,6 @@ public class SparkLoadPendingTask extends LoadTask {
                                 Map<FileGroupAggKey, List<BrokerFileGroup>> aggKeyToBrokerFileGroups,
                                 SparkResource resource, BrokerDesc brokerDesc) {
         super(loadTaskCallback, TaskType.PENDING, LoadPriority.NORMAL_VALUE);
-        this.retryTime = 3;
         this.attachment = new SparkPendingTaskAttachment(signature);
         this.aggKeyToBrokerFileGroups = aggKeyToBrokerFileGroups;
         this.resource = resource;


### PR DESCRIPTION
We have disable the broker load retry when timeout. If timeout, the retry is very useful. I add a retry in broker load. The retry job keep the same job_id, and a new different transaction_id. The timeout job will be retried two times.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
