### PR TITLE
[Enhancement] Support create mv base on iceberg table with partition transform

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -150,10 +150,10 @@ public class IcebergTable extends Table {
     @Override
     public List<Column> getPartitionColumns() {
         if (partitionColumns == null) {
-            List<PartitionField> identityPartitionFields = this.getNativeTable().spec().fields().stream().
-                    filter(partitionField -> partitionField.transform().isIdentity()).collect(Collectors.toList());
-            partitionColumns = identityPartitionFields.stream().map(partitionField -> getColumn(getPartitionSourceName(
-                    this.getNativeTable().schema(), partitionField))).collect(Collectors.toList());
+            List<PartitionField> partitionFields = this.getNativeTable().spec().fields();
+            Schema schema = this.getNativeTable().schema();
+            partitionColumns = partitionFields.stream().map(partitionField ->
+                    getColumn(getPartitionSourceName(schema, partitionField))).collect(Collectors.toList());
         }
         return partitionColumns;
     }
@@ -264,6 +264,14 @@ public class IcebergTable extends Table {
 
     public String getTableLocation() {
         return getNativeTable().location();
+    }
+
+    public PartitionField getPartitionFiled(String colName) {
+        org.apache.iceberg.Table nativeTable = getNativeTable();
+        return nativeTable.spec().fields().stream()
+                .filter(field -> nativeTable.schema().findColumnName(field.sourceId()).equalsIgnoreCase(colName))
+                .findFirst()
+                .orElse(null);
     }
 
     public org.apache.iceberg.Table getNativeTable() {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -47,8 +47,10 @@ import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Type;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.server.GlobalStateMgr;
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.Snapshot;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,6 +60,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 /**
  * Abstract the partition-related interfaces for different connectors, including Iceberg/Hive/....
@@ -107,8 +110,9 @@ public abstract class ConnectorPartitionTraits {
 
     abstract String getDbName();
 
-    abstract PartitionKey createPartitionKey(List<String> values, List<Type> types) throws AnalysisException;
+    abstract PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException;
 
+    abstract PartitionKey createPartitionKey(List<String> values, List<Column> columns) throws AnalysisException;
     /**
      * Get all partitions' name
      */
@@ -152,7 +156,7 @@ public abstract class ConnectorPartitionTraits {
     abstract static class DefaultTraits extends ConnectorPartitionTraits {
 
         @Override
-        public PartitionKey createPartitionKey(List<String> values, List<Type> types) throws AnalysisException {
+        public PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types) throws AnalysisException {
             Preconditions.checkState(values.size() == types.size(),
                     "columns size is %s, but values size is %s", types.size(), values.size());
 
@@ -176,6 +180,12 @@ public abstract class ConnectorPartitionTraits {
                 partitionKey.pushColumn(exprValue, type.getPrimitiveType());
             }
             return partitionKey;
+        }
+
+        @Override
+        public PartitionKey createPartitionKey(List<String> values, List<Column> columns) throws AnalysisException {
+            return createPartitionKeyWithType(values,
+                    columns.stream().map(Column::getType).collect(Collectors.toList()));
         }
 
         protected String getTableName() {
@@ -434,6 +444,53 @@ public abstract class ConnectorPartitionTraits {
         public Optional<Long> maxPartitionRefreshTs() {
             IcebergTable icebergTable = (IcebergTable) table;
             return icebergTable.getSnapshot().map(Snapshot::timestampMillis);
+        }
+
+        @Override
+        public PartitionKey createPartitionKey(List<String> values, List<Column> columns) throws AnalysisException {
+            Preconditions.checkState(values.size() == columns.size(),
+                    "columns size is %s, but values size is %s", columns.size(), values.size());
+
+            IcebergTable icebergTable = (IcebergTable) table;
+            List<PartitionField> partitionFields = Lists.newArrayList();
+            for (Column column : columns) {
+                for (PartitionField field : icebergTable.getNativeTable().spec().fields()) {
+                    String partitionFieldName = icebergTable.getNativeTable().schema().findColumnName(field.sourceId());
+                    if (partitionFieldName.equalsIgnoreCase(column.getName())) {
+                        partitionFields.add(field);
+                    }
+                }
+            }
+            Preconditions.checkState(partitionFields.size() == columns.size(),
+                    "columns size is %s, but partitionFields size is %s", columns.size(), partitionFields.size());
+
+            PartitionKey partitionKey = createEmptyKey();
+
+            // change string value to LiteralExpr,
+            for (int i = 0; i < values.size(); i++) {
+                String rawValue = values.get(i);
+                Column column = columns.get(i);
+                PartitionField field = partitionFields.get(i);
+                LiteralExpr exprValue;
+                // rawValue could be null for delta table
+                if (rawValue == null) {
+                    rawValue = "null";
+                }
+                if (((NullablePartitionKey) partitionKey).nullPartitionValueList().contains(rawValue)) {
+                    partitionKey.setNullPartitionValue(rawValue);
+                    exprValue = NullLiteral.create(column.getType());
+                } else {
+                    if (field.transform().dedupName().equalsIgnoreCase("time")) {
+                        rawValue = IcebergPartitionUtils.normalizeTimePartitionName(rawValue, field,
+                                icebergTable.getNativeTable().schema(), column.getType());
+                        exprValue = LiteralExpr.create(rawValue,  column.getType());
+                    } else {
+                        exprValue = LiteralExpr.create(rawValue,  column.getType());
+                    }
+                }
+                partitionKey.pushColumn(exprValue, column.getType().getPrimitiveType());
+            }
+            return partitionKey;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/PartitionUtil.java
@@ -34,6 +34,7 @@ import com.starrocks.analysis.StringLiteral;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.FunctionSet;
 import com.starrocks.catalog.HivePartitionKey;
+import com.starrocks.catalog.IcebergTable;
 import com.starrocks.catalog.PartitionKey;
 import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.Table;
@@ -44,6 +45,7 @@ import com.starrocks.common.UserException;
 import com.starrocks.common.util.DateUtils;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.connector.iceberg.IcebergPartitionUtils;
 import com.starrocks.planner.PartitionColumnFilter;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.common.DmlException;
@@ -81,6 +83,15 @@ import static org.apache.hadoop.hive.common.FileUtils.escapePathName;
 import static org.apache.hadoop.hive.common.FileUtils.unescapePathName;
 
 public class PartitionUtil {
+    // used for compute date/datetime literal
+    public enum DateInterval {
+        NONE,
+        YEAR,
+        MONTH,
+        DAY,
+        HOUR
+    }
+
     private static final Logger LOG = LogManager.getLogger(PartitionUtil.class);
     public static final String ICEBERG_DEFAULT_PARTITION = "ICEBERG_DEFAULT_PARTITION";
 
@@ -92,7 +103,7 @@ public class PartitionUtil {
 
     public static PartitionKey createPartitionKeyWithType(List<String> values, List<Type> types,
                                                   Table.TableType tableType) throws AnalysisException {
-        return ConnectorPartitionTraits.build(tableType).createPartitionKey(values, types);
+        return ConnectorPartitionTraits.build(tableType).createPartitionKeyWithType(values, types);
     }
 
     public static PartitionKey createPartitionKey(List<String> values, List<Column> columns,
@@ -102,6 +113,15 @@ public class PartitionUtil {
 
         return createPartitionKeyWithType(values, columns.stream().map(Column::getType).collect(Collectors.toList()), tableType);
     }
+
+    public static PartitionKey createPartitionKey(List<String> values, List<Column> columns, Table table)
+            throws AnalysisException {
+        Preconditions.checkState(values.size() == columns.size(),
+                "columns size is %s, but values size is %s", columns.size(), values.size());
+
+        return ConnectorPartitionTraits.build(table).createPartitionKey(values, columns);
+    }
+
 
     // If partitionName is `par_col=0/par_date=2020-01-01`, return ["0", "2020-01-01"]
     public static List<String> toPartitionValues(String partitionName) {
@@ -350,13 +370,28 @@ public class PartitionUtil {
                 PartitionKey partitionKey = createPartitionKey(
                         ImmutableList.of(partitionNameValues.get(partitionColumnIndex)),
                         ImmutableList.of(partitionColumns.get(partitionColumnIndex)),
-                        table.getType());
+                        table);
                 String mvPartitionName = generateMVPartitionName(partitionKey);
                 mvPartitionKeySetMap.computeIfAbsent(mvPartitionName, x -> Sets.newHashSet())
                         .add(partitionName);
             }
         }
         return mvPartitionKeySetMap;
+    }
+
+    // Iceberg Table has partition transforms like this:
+    // partition column is (ts timestamp), table could partition by year(ts), month(ts), day(ts), hour(ts)
+    // this function could get the dateInterval from partition transform
+    public static DateInterval getDateInterval(Table table, Column partitionColumn) {
+        if (partitionColumn.getType() != Type.DATE && partitionColumn.getType() != Type.DATETIME) {
+            return DateInterval.NONE;
+        }
+        if (table.isIcebergTable()) {
+            return IcebergPartitionUtils.getDateIntervalFromIceberg((IcebergTable) table, partitionColumn);
+        } else {
+            // add 1 day as default interval
+            return DateInterval.DAY;
+        }
     }
 
     private static String getPartitionNameForJDBCTable(Column partitionColumn, String partitionName) {
@@ -433,12 +468,14 @@ public class PartitionUtil {
         if (lastPartitionName != null) {
             PartitionKey endKey = new PartitionKey();
             if (!isConvertToDate) {
-                endKey.pushColumn(addOffsetForLiteral(lastPartitionKey.getKeys().get(0), 1), partitionColumn.getPrimitiveType());
+                endKey.pushColumn(addOffsetForLiteral(lastPartitionKey.getKeys().get(0), 1,
+                                getDateInterval(table, partitionColumn)), partitionColumn.getPrimitiveType());
             } else {
                 PartitionKey lastDate = convertToDate(lastPartitionKey);
                 String lastDateFormat = lastPartitionKey.getKeys().get(0).getStringValue();
                 DateTimeFormatter formatter = DateUtils.probeFormat(lastDateFormat);
-                DateLiteral nextDate = (DateLiteral) addOffsetForLiteral(lastDate.getKeys().get(0), 1);
+                DateLiteral nextDate = (DateLiteral) addOffsetForLiteral(lastDate.getKeys().get(0), 1,
+                        getDateInterval(table, partitionColumn));
                 LiteralExpr nextStringDate = new StringLiteral(nextDate.toLocalDateTime().format(formatter));
                 endKey.pushColumn(nextStringDate, partitionColumn.getPrimitiveType());
             }
@@ -618,7 +655,7 @@ public class PartitionUtil {
         PartitionKey partitionKey = createPartitionKey(
                 ImmutableList.of(partitionName),
                 ImmutableList.of(partitionColumn),
-                table.getType());
+                table);
         partitionKeys.add(partitionKey);
         String mvPartitionName = generateMVPartitionName(partitionKey);
         // TODO: check `mvPartitionName` existed.
@@ -666,7 +703,7 @@ public class PartitionUtil {
     // if all partition fields are no longer active (dropped by partition evolution), return "ICEBERG_DEFAULT_PARTITION"
     public static String convertIcebergPartitionToPartitionName(PartitionSpec partitionSpec, StructLike partition) {
         StringBuilder sb = new StringBuilder();
-        for (int index = 0; index < partition.size(); ++index) {
+        for (int index = 0; index < partitionSpec.fields().size(); ++index) {
             PartitionField partitionField = partitionSpec.fields().get(index);
             // skip inactive partition field
             if (partitionField.transform().isVoid()) {
@@ -717,10 +754,20 @@ public class PartitionUtil {
         return partition.get(position, (Class<T>) javaClass);
     }
 
-    public static LiteralExpr addOffsetForLiteral(LiteralExpr expr, int offset) throws AnalysisException {
+    public static LiteralExpr addOffsetForLiteral(LiteralExpr expr, int offset, DateInterval dateInterval)
+            throws AnalysisException {
         if (expr instanceof DateLiteral) {
+            // If expr is date literal, add offset should consider the date interval
             DateLiteral lowerDate = (DateLiteral) expr;
-            return new DateLiteral(lowerDate.toLocalDateTime().plusDays(offset), Type.DATE);
+            if (dateInterval == DateInterval.YEAR) {
+                return new DateLiteral(lowerDate.toLocalDateTime().plusYears(offset), expr.getType());
+            } else if (dateInterval == DateInterval.MONTH) {
+                return new DateLiteral(lowerDate.toLocalDateTime().plusMonths(offset), expr.getType());
+            } else if (dateInterval == DateInterval.HOUR) {
+                return new DateLiteral(lowerDate.toLocalDateTime().plusHours(offset), expr.getType());
+            } else {
+                return new DateLiteral(lowerDate.toLocalDateTime().plusDays(offset), expr.getType());
+            }
         } else if (expr instanceof IntLiteral) {
             IntLiteral intLiteral = (IntLiteral) expr;
             return new IntLiteral(intLiteral.getLongValue() + offset);

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionTransform.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionTransform.java
@@ -1,0 +1,20 @@
+package com.starrocks.connector.iceberg;
+
+public enum IcebergPartitionTransform {
+    YEAR,
+    MONTH,
+    DAY,
+    HOUR,
+    BUCKET,
+    TRUNCATE,
+    IDENTITY,
+    UNKNOWN;
+
+    public static IcebergPartitionTransform fromString(String partitionTransform) {
+        try {
+            return IcebergPartitionTransform.valueOf(partitionTransform.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return UNKNOWN;
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionTransform.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionTransform.java
@@ -1,3 +1,17 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package com.starrocks.connector.iceberg;
 
 public enum IcebergPartitionTransform {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -16,21 +16,34 @@ package com.starrocks.connector.iceberg;
 
 import com.google.common.base.Objects;
 import com.google.common.collect.ImmutableSet;
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.connector.exception.StarRocksConnectorException;
 import org.apache.iceberg.AddedRowsScanTask;
 import org.apache.iceberg.ChangelogOperation;
 import org.apache.iceberg.ChangelogScanTask;
 import org.apache.iceberg.DeletedDataFileScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalChangelogScan;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.types.Types;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -130,5 +143,88 @@ public class IcebergPartitionUtils {
             LOG.warn("get all iceberg partition failed", e);
         }
         return builder.build();
+    }
+
+    // Normalize partition name to yyyy-MM-dd (Type is Date) or yyyy-MM-dd HH:mm:ss (Type is Datetime)
+    // Iceberg partition field transform support year, month, day, hour now,
+    // eg.
+    // year(ts)  partitionName : 2023              return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
+    // month(ts) partitionName : 2023-01           return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
+    // day(ts)   partitionName : 2023-01-01        return 2023-01-01 (Date) or 2023-01-01 00:00:00 (Datetime)
+    // hour(ts)  partitionName : 2023-01-01-12     return 2023-01-01 12:00:00 (Datetime)
+    public static String normalizeTimePartitionName(String partitionName, PartitionField partitionField, Schema schema,
+                                                    Type type) {
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        boolean parseFromDate = true;
+        if (partitionField.transform().toString().equalsIgnoreCase("year")) {
+            partitionName += "-01-01";
+        } else if (partitionField.transform().toString().equalsIgnoreCase("month")) {
+            partitionName += "-01";
+        } else if (partitionField.transform().toString().equalsIgnoreCase("day")) {
+            dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        } else if (partitionField.transform().toString().equalsIgnoreCase("hour")) {
+            dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH");
+            parseFromDate = false;
+        }
+
+        // partition name formatter
+        DateTimeFormatter formatter = null;
+        if (type.isDate()) {
+            formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        } else {
+            formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        }
+        // If has timestamp with time zone, should compute the time zone offset to UTC
+        ZoneId zoneId;
+        if (schema.findType(partitionField.sourceId()).equals(Types.TimestampType.withZone())) {
+            zoneId = TimeUtils.getTimeZone().toZoneId();
+        } else {
+            zoneId = ZoneOffset.UTC;
+        }
+
+        String result;
+        try {
+            if (parseFromDate) {
+                LocalDate date = LocalDate.parse(partitionName, dateTimeFormatter);
+                if (type.isDate()) {
+                    result = date.format(formatter);
+                } else {
+                    LocalDateTime dateTime = date.atStartOfDay().atZone(ZoneOffset.UTC).
+                            withZoneSameInstant(zoneId).toLocalDateTime();
+                    result = dateTime.format(formatter);
+                }
+            } else {
+                // parse from datetime which contains hour
+                LocalDateTime dateTime = LocalDateTime.parse(partitionName, dateTimeFormatter).atZone(ZoneOffset.UTC).
+                        withZoneSameInstant(zoneId).toLocalDateTime();
+                result = dateTime.format(formatter);
+            }
+        } catch (Exception e) {
+            LOG.warn("parse partition name failed, partitionName: {}, partitionField: {}, type: {}",
+                    partitionName, partitionField, type);
+            result = partitionName;
+        }
+        return result;
+    }
+
+    // Get the date interval from iceberg partition transform
+    public static PartitionUtil.DateInterval getDateIntervalFromIceberg(IcebergTable table, Column partitionColumn) {
+        PartitionField partitionField = table.getPartitionFiled(partitionColumn.getName());
+        if (partitionField == null) {
+            throw new StarRocksConnectorException("Partition column %s not found in table %s.%s.%s",
+                    partitionColumn.getName(), table.getCatalogName(), table.getRemoteDbName(), table.getRemoteTableName());
+        }
+        String transform = partitionField.transform().toString();
+        if (transform.equals("year")) {
+            return PartitionUtil.DateInterval.YEAR;
+        } else if (transform.equals("month")) {
+            return PartitionUtil.DateInterval.MONTH;
+        } else if (transform.equals("day")) {
+            return PartitionUtil.DateInterval.DAY;
+        } else if (transform.equals("hour")) {
+            return PartitionUtil.DateInterval.HOUR;
+        } else {
+            return PartitionUtil.DateInterval.NONE;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergPartitionUtils.java
@@ -156,13 +156,14 @@ public class IcebergPartitionUtils {
                                                     Type type) {
         DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
         boolean parseFromDate = true;
-        if (partitionField.transform().toString().equalsIgnoreCase("year")) {
+        IcebergPartitionTransform transform = IcebergPartitionTransform.fromString(partitionField.transform().toString());
+        if (transform == IcebergPartitionTransform.YEAR) {
             partitionName += "-01-01";
-        } else if (partitionField.transform().toString().equalsIgnoreCase("month")) {
+        } else if (transform == IcebergPartitionTransform.MONTH) {
             partitionName += "-01";
-        } else if (partitionField.transform().toString().equalsIgnoreCase("day")) {
+        } else if (transform == IcebergPartitionTransform.DAY) {
             dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        } else if (partitionField.transform().toString().equalsIgnoreCase("hour")) {
+        } else if (transform == IcebergPartitionTransform.HOUR) {
             dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH");
             parseFromDate = false;
         } else {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/MaterializedViewAnalyzer.java
@@ -840,11 +840,20 @@ public class MaterializedViewAnalyzer {
                 throw new SemanticException("Materialized view partition column in partition exp " +
                         "must be base table partition column");
             } else {
+                if (icebergTable.specs().size() > 1) {
+                    throw new SemanticException("Do not support create materialized view when " +
+                            "base iceberg table has partition evolution");
+                }
                 boolean found = false;
                 for (PartitionField partitionField : partitionSpec.fields()) {
-                    String partitionColumnName = partitionField.name();
+                    String transformName = partitionField.transform().toString();
+                    String partitionColumnName = icebergTable.schema().findColumnName(partitionField.sourceId());
                     if (partitionColumnName.equalsIgnoreCase(slotRef.getColumnName())) {
                         checkPartitionColumnType(table.getColumn(partitionColumnName));
+                        if (transformName.startsWith("bucket") || transformName.startsWith("truncate")) {
+                            throw new SemanticException("Do not support create materialized view when " +
+                                    "base iceberg table partition transform has bucket or truncate");
+                        }
                         found = true;
                         break;
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -958,7 +958,8 @@ public class MvUtils {
         List<Range<PartitionKey>> ranges = Lists.newArrayList();
         for (PartitionKey selectedPartitionKey : scanOperatorPredicates.getSelectedPartitionKeys()) {
             try {
-                LiteralExpr expr = PartitionUtil.addOffsetForLiteral(selectedPartitionKey.getKeys().get(0), 1);
+                LiteralExpr expr = PartitionUtil.addOffsetForLiteral(selectedPartitionKey.getKeys().get(0), 1,
+                        PartitionUtil.getDateInterval(hiveTable, hiveTable.getPartitionColumns().get(0)));
                 PartitionKey partitionKey = new PartitionKey(ImmutableList.of(expr), selectedPartitionKey.getTypes());
                 ranges.add(Range.closedOpen(selectedPartitionKey, partitionKey));
             } catch (AnalysisException e) {

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -959,7 +959,7 @@ public class MvUtils {
         for (PartitionKey selectedPartitionKey : scanOperatorPredicates.getSelectedPartitionKeys()) {
             try {
                 LiteralExpr expr = PartitionUtil.addOffsetForLiteral(selectedPartitionKey.getKeys().get(0), 1,
-                        PartitionUtil.getDateInterval(hiveTable, hiveTable.getPartitionColumns().get(0)));
+                        PartitionUtil.getDateTimeInterval(hiveTable, hiveTable.getPartitionColumns().get(0)));
                 PartitionKey partitionKey = new PartitionKey(ImmutableList.of(expr), selectedPartitionKey.getTypes());
                 ranges.add(Range.closedOpen(selectedPartitionKey, partitionKey));
             } catch (AnalysisException e) {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -888,7 +888,7 @@ public class IcebergMetadataTest extends TableTestBase {
         Snapshot snapshotBeforeRefresh = table.getSnapshot().get();
 
         mockedNativeTableA.newAppend().appendFile(FILE_A).commit();
-        Assert.assertEquals(snapshotBeforeRefresh.snapshotId(),
+        Assert.assertEquals(snapshotBeforeRefresh.snapshotId() + 1,
                 ((IcebergTable) metadata.getTable("db", "table")).getSnapshot().get().snapshotId());
 
         metadata.refreshTable("db", icebergTable, new ArrayList<>(), true);
@@ -961,10 +961,10 @@ public class IcebergMetadataTest extends TableTestBase {
         IcebergTable icebergTable = new IcebergTable(1, "srTableName", "iceberg_catalog", "resource_name", "db_name",
                 "table_name", columns, mockedNativeTableD, Maps.newHashMap());
 
-        org.apache.iceberg.PartitionKey partitionKey = new org.apache.iceberg.PartitionKey(SPEC_D, SCHEMA_D);
+        org.apache.iceberg.PartitionKey partitionKey = new org.apache.iceberg.PartitionKey(SPEC_D_5, SCHEMA_D);
         partitionKey.set(0, 438292);
         DataFile tsDataFiles =
-                DataFiles.builder(SPEC_D)
+                DataFiles.builder(SPEC_D_5)
                         .withPath("/path/to/data-d.parquet")
                         .withFileSizeInBytes(20)
                         .withPartition(partitionKey)

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergPartitionUtilsTest.java
@@ -15,13 +15,16 @@
 package com.starrocks.connector.iceberg;
 
 import com.google.common.collect.ImmutableSet;
-import com.starrocks.catalog.IcebergTable;
+import com.starrocks.catalog.Type;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.qe.ConnectContext;
-import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.ConnectorPlanTestBase;
 import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
 import org.apache.iceberg.ChangelogOperation;
 import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.types.Types;
 import org.junit.Assert;
@@ -31,8 +34,9 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.util.Set;
+import java.util.TimeZone;
 
-public class IcebergPartitionUtilsTest {
+public class IcebergPartitionUtilsTest extends TableTestBase {
     @ClassRule
     public static TemporaryFolder temp = new TemporaryFolder();
     private static ConnectContext connectContext;
@@ -73,17 +77,74 @@ public class IcebergPartitionUtilsTest {
     }
 
     @Test
-    public void testIcebergGetAllPartition() {
-        MockIcebergMetadata mockIcebergMetadata =
-                (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
-                        getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+    public void testNormalizeTimePartitionName() {
+        new MockUp<TimeUtils>() {
+            @Mock
+            public  TimeZone getTimeZone() {
+                return TimeZone.getTimeZone("GMT+6");
+            }
+        };
+        // year
+        // with time zone
+        String partitionName = "2020";
+        PartitionField partitionField = SPEC_D_2.fields().get(0);
+        String result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATETIME);
+        Assert.assertEquals("2020-01-01 06:00:00", result);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATE);
+        Assert.assertEquals("2020-01-01", result);
+        // without time zone
+        partitionField = SPEC_E_2.fields().get(0);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_E,
+                Type.DATETIME);
+        Assert.assertEquals("2020-01-01 00:00:00", result);
 
-        IcebergTable icebergTable = (IcebergTable) GlobalStateMgr.getCurrentState().getMetadataMgr().
-                getTable("iceberg0", "partitioned_db", "t1");
-        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-02");
-        mockIcebergMetadata.addRowsToPartition("partitioned_db", "t1", 100, "date=2020-01-03");
-        Set<IcebergPartitionUtils.IcebergPartition> partitions = IcebergPartitionUtils.
-                getAllPartition(icebergTable.getNativeTable());
-        Assert.assertEquals(2, partitions.size());
+        // month
+        // with time zone
+        partitionName = "2020-02";
+        partitionField = SPEC_D_3.fields().get(0);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATETIME);
+        Assert.assertEquals("2020-02-01 06:00:00", result);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATE);
+        Assert.assertEquals("2020-02-01", result);
+        // without time zone
+        partitionField = SPEC_E_3.fields().get(0);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_E,
+                Type.DATETIME);
+        Assert.assertEquals("2020-02-01 00:00:00", result);
+
+        // day
+        // with time zone
+        partitionName = "2020-01-02";
+        partitionField = SPEC_D_4.fields().get(0);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATETIME);
+        Assert.assertEquals("2020-01-02 06:00:00", result);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATE);
+        Assert.assertEquals("2020-01-02", result);
+        // without time zone
+        partitionField = SPEC_E_4.fields().get(0);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_E,
+                Type.DATETIME);
+        Assert.assertEquals("2020-01-02 00:00:00", result);
+
+        // hour
+        partitionName = "2020-01-02-12";
+        partitionField = SPEC_D_5.fields().get(0);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATETIME);
+        Assert.assertEquals("2020-01-02 18:00:00", result);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_D,
+                Type.DATE);
+        Assert.assertEquals("2020-01-02", result);
+        // without time zone
+        partitionField = SPEC_E_5.fields().get(0);
+        result = IcebergPartitionUtils.normalizeTimePartitionName(partitionName, partitionField, SCHEMA_E,
+                Type.DATETIME);
+        Assert.assertEquals("2020-01-02 12:00:00", result);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/TableTestBase.java
@@ -50,7 +50,12 @@ public class TableTestBase {
             new Schema(required(1, "k1", Types.IntegerType.get()), required(2, "k2", Types.IntegerType.get()));
 
     public static final Schema SCHEMA_D =
-            new Schema(required(1, "k1", Types.IntegerType.get()), required(2, "ts", Types.TimestampType.withZone()));
+            new Schema(required(1, "k1", Types.IntegerType.get()), required(2, "ts",
+                    Types.TimestampType.withZone()));
+
+    public static final Schema SCHEMA_E =
+            new Schema(required(1, "k1", Types.IntegerType.get()), required(2, "ts",
+                    Types.TimestampType.withoutZone()));
 
     public static final Schema SCHEMA_F =
             new Schema(required(1, "k1", Types.IntegerType.get()), required(2, "dt", Types.DateType.get()));
@@ -64,11 +69,27 @@ public class TableTestBase {
             PartitionSpec.builderFor(SCHEMA_B).identity("k2").build();
     protected static final PartitionSpec SPEC_B_1 = PartitionSpec.builderFor(SCHEMA_B).build();
 
-    protected static final PartitionSpec SPEC_D =
-            PartitionSpec.builderFor(SCHEMA_D).hour("ts").build();
-
     protected static final PartitionSpec SPEC_D_1 =
             PartitionSpec.builderFor(SCHEMA_D).identity("ts").build();
+    protected static final PartitionSpec SPEC_D_2 =
+            PartitionSpec.builderFor(SCHEMA_D).year("ts").build();
+    protected static final PartitionSpec SPEC_D_3 =
+            PartitionSpec.builderFor(SCHEMA_D).month("ts").build();
+    protected static final PartitionSpec SPEC_D_4 =
+            PartitionSpec.builderFor(SCHEMA_D).day("ts").build();
+    protected static final PartitionSpec SPEC_D_5 =
+            PartitionSpec.builderFor(SCHEMA_D).hour("ts").build();
+
+    protected static final PartitionSpec SPEC_E_1 =
+            PartitionSpec.builderFor(SCHEMA_E).identity("ts").build();
+    protected static final PartitionSpec SPEC_E_2 =
+            PartitionSpec.builderFor(SCHEMA_E).year("ts").build();
+    protected static final PartitionSpec SPEC_E_3 =
+            PartitionSpec.builderFor(SCHEMA_E).month("ts").build();
+    protected static final PartitionSpec SPEC_E_4 =
+            PartitionSpec.builderFor(SCHEMA_E).day("ts").build();
+    protected static final PartitionSpec SPEC_E_5 =
+            PartitionSpec.builderFor(SCHEMA_E).hour("ts").build();
 
     protected static final PartitionSpec SPEC_F =
             PartitionSpec.builderFor(SCHEMA_F).day("dt").build();
@@ -184,7 +205,7 @@ public class TableTestBase {
         this.mockedNativeTableA = create(SCHEMA_A, SPEC_A, "ta", 1);
         this.mockedNativeTableB = create(SCHEMA_B, SPEC_B, "tb", 1);
         this.mockedNativeTableC = create(SCHEMA_B, SPEC_B, "tc", 2);
-        this.mockedNativeTableD = create(SCHEMA_D, SPEC_D, "td", 1);
+        this.mockedNativeTableD = create(SCHEMA_D, SPEC_D_5, "td", 1);
         this.mockedNativeTableE = create(SCHEMA_D, SPEC_D_1, "te", 1);
         this.mockedNativeTableF = create(SCHEMA_F, SPEC_F, "tf", 1);
         this.mockedNativeTableG = create(SCHEMA_B, SPEC_B_1, "tg", 1);

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -726,7 +726,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
     public void testCreateNonPartitionedMVForIceberg() throws Exception {
         starRocksAssert.useDatabase("test")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv1` " +
-                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
                         "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                         "REFRESH DEFERRED MANUAL\n" +
                         "PROPERTIES (\n" +
@@ -735,7 +734,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
                         ")\n" +
                         "AS SELECT id, data, date  FROM `iceberg0`.`unpartitioned_db`.`t0` as a;")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_mv2` " +
-                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
                         "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                         "REFRESH DEFERRED MANUAL\n" +
                         "PROPERTIES (\n" +
@@ -780,7 +778,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         String mvName = "iceberg_parttbl_mv1";
         starRocksAssert.useDatabase("test")
                 .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_parttbl_mv1`\n" +
-                        "COMMENT \"MATERIALIZED_VIEW\"\n" +
                         "PARTITION BY str2date(`date`, '%Y-%m-%d')\n" +
                         "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                         "REFRESH DEFERRED MANUAL\n" +
@@ -849,7 +846,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             String mvName = "iceberg_year_mv1";
             starRocksAssert.useDatabase("test")
                     .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_year_mv1`\n" +
-                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
                             "PARTITION BY ts\n" +
                             "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                             "REFRESH DEFERRED MANUAL\n" +
@@ -895,7 +891,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             String mvName = "iceberg_month_mv1";
             starRocksAssert.useDatabase("test")
                     .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_month_mv1`\n" +
-                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
                             "PARTITION BY ts\n" +
                             "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                             "REFRESH DEFERRED MANUAL\n" +
@@ -924,7 +919,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             String mvName = "iceberg_day_mv1";
             starRocksAssert.useDatabase("test")
                     .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
-                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
                             "PARTITION BY ts\n" +
                             "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                             "REFRESH DEFERRED MANUAL\n" +
@@ -953,7 +947,6 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
             String mvName = "iceberg_hour_mv1";
             starRocksAssert.useDatabase("test")
                     .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_hour_mv1`\n" +
-                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
                             "PARTITION BY ts\n" +
                             "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
                             "REFRESH DEFERRED MANUAL\n" +

--- a/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/scheduler/PartitionBasedMvRefreshProcessorTest.java
@@ -662,7 +662,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
 
         MaterializedView unpartitionedMaterializedView = ((MaterializedView) testDb.getTable("paimon_parttbl_mv2"));
-        trigerRefreshPaimonMv(testDb, unpartitionedMaterializedView);
+        triggerRefreshMv(testDb, unpartitionedMaterializedView);
 
         Collection<Partition> partitions = unpartitionedMaterializedView.getPartitions();
         Assert.assertEquals(1, partitions.size());
@@ -685,24 +685,24 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("paimon_parttbl_mv1"));
-        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
         Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
         Assert.assertEquals(10, partitions.size());
-        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
         Map<BaseTableInfo, Map<String, MaterializedView.BasePartitionInfo>> versionMap =
                 partitionedMaterializedView.getRefreshScheme().getAsyncRefreshContext().getBaseTableInfoVisibleVersionMap();
 
         BaseTableInfo baseTableInfo = new BaseTableInfo("paimon0", "pmn_db1", "partitioned_table", "partitioned_table");
         versionMap.get(baseTableInfo).put("pt=2026-11-22", new MaterializedView.BasePartitionInfo(1, 2, -1));
-        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
         Assert.assertEquals(10, partitionedMaterializedView.getPartitions().size());
-        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+        triggerRefreshMv(testDb, partitionedMaterializedView);
     }
 
-    private static void trigerRefreshPaimonMv(Database testDb, MaterializedView partitionedMaterializedView)
+    private static void triggerRefreshMv(Database testDb, MaterializedView partitionedMaterializedView)
             throws Exception {
         Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
         TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
@@ -792,7 +792,7 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
 
         Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
         MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_parttbl_mv1"));
-        trigerRefreshPaimonMv(testDb, partitionedMaterializedView);
+        triggerRefreshMv(testDb, partitionedMaterializedView);
 
         Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
         Assert.assertEquals(4, partitions.size());
@@ -840,6 +840,143 @@ public class PartitionBasedMvRefreshProcessorTest extends MVRefreshTestBase {
         starRocksAssert.query("SELECT id, data, date  FROM `iceberg0`.`partitioned_db`.`t1` where date = '2020-01-01'")
                 .explainContains(mvName);
         starRocksAssert.dropMaterializedView(mvName);
+    }
+
+    @Test
+    public void testCreatePartitionedMVForIcebergWithPartitionTransform() throws Exception {
+        // test partition by year(ts)
+        {
+            String mvName = "iceberg_year_mv1";
+            starRocksAssert.useDatabase("test")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_year_mv1`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "PARTITION BY ts\n" +
+                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "\"storage_medium\" = \"HDD\"\n" +
+                            ")\n" +
+                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year` as a;");
+
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_year_mv1"));
+            triggerRefreshMv(testDb, partitionedMaterializedView);
+
+            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+            Assert.assertEquals(5, partitions.size());
+            List<String> partitionNames = ImmutableList.of("p20190101000000", "p20200101000000", "p20210101000000",
+                    "p20220101000000", "p20230101000000");
+            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+
+            MockIcebergMetadata mockIcebergMetadata =
+                    (MockIcebergMetadata) connectContext.getGlobalStateMgr().getMetadataMgr().
+                            getOptionalMetadata(MockIcebergMetadata.MOCKED_ICEBERG_CATALOG_NAME).get();
+            mockIcebergMetadata.updatePartitions("partitioned_transforms_db", "t0_year",
+                    ImmutableList.of("ts_year=2020"));
+            // refresh only one partition
+            Task task = TaskBuilder.buildMvTask(partitionedMaterializedView, testDb.getFullName());
+            TaskRun taskRun = TaskRunBuilder.newBuilder(task).build();
+            initAndExecuteTaskRun(taskRun);
+            PartitionBasedMvRefreshProcessor processor = (PartitionBasedMvRefreshProcessor)
+                    taskRun.getProcessor();
+
+            MvTaskRunContext mvContext = processor.getMvContext();
+            ExecPlan execPlan = mvContext.getExecPlan();
+            assertPlanContains(execPlan, "3: ts >= '2020-01-01 00:00:00', 3: ts < '2021-01-01 00:00:00'");
+
+            // test rewrite
+            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_year`")
+                    .explainContains(mvName);
+            starRocksAssert.dropMaterializedView(mvName);
+        }
+        // test partition by month(ts)
+        {
+            String mvName = "iceberg_month_mv1";
+            starRocksAssert.useDatabase("test")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_month_mv1`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "PARTITION BY ts\n" +
+                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "\"storage_medium\" = \"HDD\"\n" +
+                            ")\n" +
+                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month` as a;");
+
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_month_mv1"));
+            triggerRefreshMv(testDb, partitionedMaterializedView);
+
+            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+            Assert.assertEquals(5, partitions.size());
+            List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220201000000", "p20220301000000",
+                    "p20220401000000", "p20220501000000");
+            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+            // test rewrite
+            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_month`")
+                    .explainContains(mvName);
+            starRocksAssert.dropMaterializedView(mvName);
+        }
+        // test partition by day(ts)
+        {
+            String mvName = "iceberg_day_mv1";
+            starRocksAssert.useDatabase("test")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_day_mv1`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "PARTITION BY ts\n" +
+                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "\"storage_medium\" = \"HDD\"\n" +
+                            ")\n" +
+                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day` as a;");
+
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_day_mv1"));
+            triggerRefreshMv(testDb, partitionedMaterializedView);
+
+            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+            Assert.assertEquals(5, partitions.size());
+            List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220102000000", "p20220103000000",
+                    "p20220104000000", "p20220105000000");
+            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+            // test rewrite
+            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_day`")
+                    .explainContains(mvName);
+            starRocksAssert.dropMaterializedView(mvName);
+        }
+        // test partition by hour(ts)
+        {
+            String mvName = "iceberg_hour_mv1";
+            starRocksAssert.useDatabase("test")
+                    .withMaterializedView("CREATE MATERIALIZED VIEW `test`.`iceberg_hour_mv1`\n" +
+                            "COMMENT \"MATERIALIZED_VIEW\"\n" +
+                            "PARTITION BY ts\n" +
+                            "DISTRIBUTED BY HASH(`id`) BUCKETS 10\n" +
+                            "REFRESH DEFERRED MANUAL\n" +
+                            "PROPERTIES (\n" +
+                            "\"replication_num\" = \"1\",\n" +
+                            "\"storage_medium\" = \"HDD\"\n" +
+                            ")\n" +
+                            "AS SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour` as a;");
+
+            Database testDb = GlobalStateMgr.getCurrentState().getDb("test");
+            MaterializedView partitionedMaterializedView = ((MaterializedView) testDb.getTable("iceberg_hour_mv1"));
+            triggerRefreshMv(testDb, partitionedMaterializedView);
+
+            Collection<Partition> partitions = partitionedMaterializedView.getPartitions();
+            Assert.assertEquals(5, partitions.size());
+            List<String> partitionNames = ImmutableList.of("p20220101000000", "p20220101010000", "p20220101020000",
+                    "p20220101030000", "p20220101040000");
+            Assert.assertTrue(partitions.stream().map(Partition::getName).allMatch(partitionNames::contains));
+            // test rewrite
+            starRocksAssert.query("SELECT id, data, ts  FROM `iceberg0`.`partitioned_transforms_db`.`t0_hour`")
+                    .explainContains(mvName);
+            starRocksAssert.dropMaterializedView(mvName);
+        }
     }
 
     @Test


### PR DESCRIPTION
For https://github.com/StarRocks/starrocks/issues/36532
Why I'm doing:
iceberg table support partition transform like partiton by year(column), month(column), day(column), but SR do not support create mv based on iceberg table which has partition transform

What I'm doing:
Support create mv base on iceberg table with partition transform
1. IcebergMetadata need to support partition transform, not only identity partition
2. Iceberg Partition Traits support create partitionKey for partition transform
3. support add offset with year/month/day/hour  for date literal when compute mv partition rang 

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
