### PR TITLE
[Feature] modify some cloud star cache configs

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -894,10 +894,14 @@ CONF_mDouble(starlet_cache_evict_low_water, "0.1");
 CONF_mDouble(starlet_cache_evict_high_water, "0.2");
 // type:Integer. cache directory allocation policy. (0:default, 1:random, 2:round-robin)
 CONF_Int32(starlet_cache_dir_allocate_policy, "0");
+// Cache will evict file cache at this percent if star cache is turned on
+CONF_mDouble(starlet_cache_evict_percent, "0.1");
+// Cache will evict file cache at this speed if star cache is turned on
+CONF_mInt32(starlet_cache_evict_throughput_mb, "200");
 // Buffer size in starlet fs buffer stream, size <= 0 means not use buffer stream.
 // Only support in S3/HDFS currently.
 CONF_mInt32(starlet_fs_stream_buffer_size_bytes, "131072");
-CONF_mBool(starlet_use_star_cache, "false");
+CONF_mBool(starlet_use_star_cache, "true");
 // TODO: support runtime change
 CONF_Int32(starlet_star_cache_mem_size_percent, "0");
 CONF_Int32(starlet_star_cache_disk_size_percent, "80");

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -210,6 +210,16 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
                 LOG(WARNING) << "Failed to update cachemgr_evict_low_water";
             }
         });
+        _config_callback.emplace("starlet_cache_evict_percent", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_percent", value).empty()) {
+                LOG(WARNING) << "Failed to update cachemgr_evict_percent";
+            }
+        });
+        _config_callback.emplace("starlet_cache_evict_throughput_mb", [&]() {
+            if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_throughput_mb", value).empty()) {
+                LOG(WARNING) << "Failed to update cachemgr_evict_throughput_mb";
+            }
+        });
         _config_callback.emplace("starlet_cache_evict_high_water", [&]() {
             if (staros::starlet::common::GFlagsUtils::UpdateFlagValue("cachemgr_evict_high_water", value).empty()) {
                 LOG(WARNING) << "Failed to update cachemgr_evict_high_water";

--- a/be/src/service/staros_worker.cpp
+++ b/be/src/service/staros_worker.cpp
@@ -43,6 +43,10 @@ DECLARE_int32(cachemgr_evict_interval);
 DECLARE_double(cachemgr_evict_low_water);
 // cache will stop evict cache files if free space is above this value(percentage)
 DECLARE_double(cachemgr_evict_high_water);
+// cache will evict file cache at this percent if star cache is turned on
+DECLARE_double(cachemgr_evict_percent);
+// cache will evict file cache at this speed if star cache is turned on
+DECLARE_int32(cachemgr_evict_throughput_mb);
 // type:Integer. CacheManager cache directory allocation policy. (0:default, 1:random, 2:round-robin)
 DECLARE_int32(cachemgr_dir_allocate_policy);
 // buffer size in starlet fs buffer stream, size <= 0 means not use buffer stream.


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
1. change starlet_use_star_cache default to true;
2. add starlet_cache_evict_throughput_mb to control speed when transferring file cache;
3. add starlet_cache_evict_percent to control speed when transferring file cache;

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
