### PR TITLE
[Feature] Support none-pk table replication from another cluster for olap table and cloud-native table (backport #35042) (backport #37880)

### DIFF
--- a/be/src/agent/agent_common.h
+++ b/be/src/agent/agent_common.h
@@ -105,5 +105,7 @@ using ReleaseSnapshotAgentTaskRequest = AgentTaskRequestWithReqBody<TReleaseSnap
 using MoveDirAgentTaskRequest = AgentTaskRequestWithReqBody<TMoveDirReq>;
 using UpdateTabletMetaInfoAgentTaskRequest = AgentTaskRequestWithReqBody<TUpdateTabletMetaInfoReq>;
 using DropAutoIncrementMapAgentTaskRequest = AgentTaskRequestWithReqBody<TDropAutoIncrementMapReq>;
+using RemoteSnapshotAgentTaskRequest = AgentTaskRequestWithReqBody<TRemoteSnapshotRequest>;
+using ReplicateSnapshotAgentTaskRequest = AgentTaskRequestWithReqBody<TReplicateSnapshotRequest>;
 
 } // namespace starrocks

--- a/be/src/agent/agent_server.cpp
+++ b/be/src/agent/agent_server.cpp
@@ -113,6 +113,7 @@ private:
     std::unique_ptr<ThreadPool> _thread_pool_move_dir;
     std::unique_ptr<ThreadPool> _thread_pool_update_tablet_meta_info;
     std::unique_ptr<ThreadPool> _thread_pool_drop_auto_increment_map;
+    std::unique_ptr<ThreadPool> _thread_pool_replication;
 
     std::unique_ptr<PushTaskWorkerPool> _push_workers;
     std::unique_ptr<PublishVersionTaskWorkerPool> _publish_version_workers;
@@ -229,6 +230,9 @@ void AgentServer::Impl::init_or_die() {
                                                 MIN_CLONE_TASK_THREADS_IN_POOL),
                                        DEFAULT_DYNAMIC_THREAD_POOL_QUEUE_SIZE, _thread_pool_clone);
 
+        BUILD_DYNAMIC_TASK_THREAD_POOL("replication", 0, config::replication_threads,
+                                       config::replication_thread_pool_queue_size, _thread_pool_replication);
+
         // It is the same code to create workers of each type, so we use a macro
         // to make code to be more readable.
 #ifndef BE_TEST
@@ -275,6 +279,7 @@ void AgentServer::Impl::stop() {
 
 #ifndef BE_TEST
         _thread_pool_clone->shutdown();
+        _thread_pool_replication->shutdown();
 #define STOP_POOL(type, pool_name) pool_name->stop();
 #else
 #define STOP_POOL(type, pool_name)
@@ -340,6 +345,8 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             HANDLE_TYPE(TTaskType::MOVE, move_dir_req);
             HANDLE_TYPE(TTaskType::UPDATE_TABLET_META_INFO, update_tablet_meta_info_req);
             HANDLE_TYPE(TTaskType::DROP_AUTO_INCREMENT_MAP, drop_auto_increment_map_req);
+            HANDLE_TYPE(TTaskType::REMOTE_SNAPSHOT, remote_snapshot_req);
+            HANDLE_TYPE(TTaskType::REPLICATE_SNAPSHOT, replicate_snapshot_req);
 
         case TTaskType::REALTIME_PUSH:
             if (!task.__isset.push_req) {
@@ -466,6 +473,14 @@ void AgentServer::Impl::submit_tasks(TAgentResult& agent_result, const std::vect
             HANDLE_TASK(TTaskType::DROP_AUTO_INCREMENT_MAP, all_tasks, run_drop_auto_increment_map_task,
                         DropAutoIncrementMapAgentTaskRequest, drop_auto_increment_map_req, _exec_env);
             break;
+        case TTaskType::REMOTE_SNAPSHOT:
+            HANDLE_TASK(TTaskType::REMOTE_SNAPSHOT, all_tasks, run_remote_snapshot_task, RemoteSnapshotAgentTaskRequest,
+                        remote_snapshot_req, _exec_env);
+            break;
+        case TTaskType::REPLICATE_SNAPSHOT:
+            HANDLE_TASK(TTaskType::REPLICATE_SNAPSHOT, all_tasks, run_replicate_snapshot_task,
+                        ReplicateSnapshotAgentTaskRequest, replicate_snapshot_req, _exec_env);
+            break;
         case TTaskType::REALTIME_PUSH:
         case TTaskType::PUSH: {
             // should not run here
@@ -542,6 +557,10 @@ void AgentServer::Impl::update_max_thread_by_type(int type, int new_val) {
     case TTaskType::CLONE:
         st = _thread_pool_clone->update_max_threads(new_val);
         break;
+    case TTaskType::REMOTE_SNAPSHOT:
+    case TTaskType::REPLICATE_SNAPSHOT:
+        st = _thread_pool_replication->update_max_threads(new_val);
+        break;
     default:
         break;
     }
@@ -599,6 +618,10 @@ ThreadPool* AgentServer::Impl::get_thread_pool(int type) const {
         break;
     case TTaskType::DROP_AUTO_INCREMENT_MAP:
         ret = _thread_pool_drop_auto_increment_map.get();
+        break;
+    case TTaskType::REMOTE_SNAPSHOT:
+    case TTaskType::REPLICATE_SNAPSHOT:
+        ret = _thread_pool_replication.get();
         break;
     case TTaskType::PUSH:
     case TTaskType::REALTIME_PUSH:

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -23,8 +23,10 @@
 #include "runtime/current_thread.h"
 #include "runtime/snapshot_loader.h"
 #include "service/backend_options.h"
+#include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/schema_change.h"
 #include "storage/lake/tablet_manager.h"
+#include "storage/replication_txn_manager.h"
 #include "storage/snapshot_manager.h"
 #include "storage/tablet_manager.h"
 #include "storage/task/engine_alter_tablet_task.h"
@@ -285,11 +287,16 @@ void run_clear_transaction_task(const std::shared_ptr<ClearTransactionAgentTaskR
         // transaction_id should be greater than zero.
         // If it is not greater than zero, no need to execute
         // the following clear_transaction_task() function.
-        if (!clear_transaction_task_req.partition_id.empty()) {
-            StorageEngine::instance()->clear_transaction_task(clear_transaction_task_req.transaction_id,
-                                                              clear_transaction_task_req.partition_id);
+        if (clear_transaction_task_req.__isset.txn_type &&
+            clear_transaction_task_req.txn_type == TTxnType::TXN_REPLICATION) {
+            StorageEngine::instance()->replication_txn_manager()->clear_txn(clear_transaction_task_req.transaction_id);
         } else {
-            StorageEngine::instance()->clear_transaction_task(clear_transaction_task_req.transaction_id);
+            if (!clear_transaction_task_req.partition_id.empty()) {
+                StorageEngine::instance()->clear_transaction_task(clear_transaction_task_req.transaction_id,
+                                                                  clear_transaction_task_req.partition_id);
+            } else {
+                StorageEngine::instance()->clear_transaction_task(clear_transaction_task_req.transaction_id);
+            }
         }
         LOG(INFO) << "finish to clear transaction task. signature:" << agent_task_req->signature
                   << ", txn_id: " << clear_transaction_task_req.transaction_id;
@@ -822,6 +829,97 @@ void run_drop_auto_increment_map_task(const std::shared_ptr<DropAutoIncrementMap
     drop_auto_increment_map(drop_auto_increment_map_req.table_id);
     LOG(INFO) << "drop auto increment map task success, tableid=" << drop_auto_increment_map_req.table_id;
     unify_finish_agent_task(status_code, error_msgs, agent_task_req->task_type, agent_task_req->signature);
+}
+
+void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskRequest>& agent_task_req,
+                              ExecEnv* exec_env) {
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
+    DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
+
+    const TRemoteSnapshotRequest& remote_snapshot_req = agent_task_req->task_req;
+
+    // Return result to fe
+    TStatus task_status;
+    TFinishTaskRequest finish_task_request;
+    finish_task_request.__set_backend(BackendOptions::get_localBackend());
+    finish_task_request.__set_task_type(agent_task_req->task_type);
+    finish_task_request.__set_signature(agent_task_req->signature);
+
+    TStatusCode::type status_code = TStatusCode::OK;
+    std::vector<std::string> error_msgs;
+
+    std::string src_snapshot_path;
+    bool incremental_snapshot;
+
+    Status res;
+    if (remote_snapshot_req.tablet_type == TTabletType::TABLET_TYPE_LAKE) {
+        res = exec_env->lake_replication_txn_manager()->remote_snapshot(remote_snapshot_req, &src_snapshot_path,
+                                                                        &incremental_snapshot);
+    } else {
+        res = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+                remote_snapshot_req, &src_snapshot_path, &incremental_snapshot);
+    }
+
+    if (!res.ok()) {
+        status_code = TStatusCode::RUNTIME_ERROR;
+        LOG(WARNING) << "remote snapshot failed. status: " << res << ", signature:" << agent_task_req->signature;
+        error_msgs.emplace_back("replicate snapshot failed, " + res.to_string());
+    } else {
+        finish_task_request.__set_snapshot_path(src_snapshot_path);
+        finish_task_request.__set_incremental_snapshot(incremental_snapshot);
+        LOG(INFO) << "remote snapshot success, signature:" << agent_task_req->signature;
+    }
+
+    task_status.__set_status_code(status_code);
+    task_status.__set_error_msgs(error_msgs);
+    finish_task_request.__set_task_status(task_status);
+
+#ifndef BE_TEST
+    finish_task(finish_task_request);
+#endif
+    remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+}
+
+void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTaskRequest>& agent_task_req,
+                                 ExecEnv* exec_env) {
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
+    DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
+
+    const TReplicateSnapshotRequest& replicate_snapshot_req = agent_task_req->task_req;
+
+    TStatusCode::type status_code = TStatusCode::OK;
+    std::vector<std::string> error_msgs;
+
+    Status res;
+    if (replicate_snapshot_req.tablet_type == TTabletType::TABLET_TYPE_LAKE) {
+        res = exec_env->lake_replication_txn_manager()->replicate_snapshot(replicate_snapshot_req);
+    } else {
+        res = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_req);
+    }
+
+    if (!res.ok()) {
+        status_code = TStatusCode::RUNTIME_ERROR;
+        LOG(WARNING) << "replicate snapshot failed. status: " << res << ", signature:" << agent_task_req->signature;
+        error_msgs.emplace_back("replicate snapshot failed, " + res.to_string());
+    } else {
+        LOG(INFO) << "replicate snapshot success, signature:" << agent_task_req->signature;
+    }
+
+    // Return result to fe
+    TStatus task_status;
+    TFinishTaskRequest finish_task_request;
+    finish_task_request.__set_backend(BackendOptions::get_localBackend());
+    finish_task_request.__set_task_type(agent_task_req->task_type);
+    finish_task_request.__set_signature(agent_task_req->signature);
+
+    task_status.__set_status_code(status_code);
+    task_status.__set_error_msgs(error_msgs);
+    finish_task_request.__set_task_status(task_status);
+
+#ifndef BE_TEST
+    finish_task(finish_task_request);
+#endif
+    remove_task_info(agent_task_req->task_type, agent_task_req->signature);
 }
 
 } // namespace starrocks

--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -833,7 +833,7 @@ void run_drop_auto_increment_map_task(const std::shared_ptr<DropAutoIncrementMap
 
 void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskRequest>& agent_task_req,
                               ExecEnv* exec_env) {
-    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(ExecEnv::GetInstance()->replication_mem_tracker());
     DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     const TRemoteSnapshotRequest& remote_snapshot_req = agent_task_req->task_req;
@@ -882,7 +882,7 @@ void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskReque
 
 void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTaskRequest>& agent_task_req,
                                  ExecEnv* exec_env) {
-    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(GlobalEnv::GetInstance()->replication_mem_tracker());
+    MemTracker* prev_tracker = tls_thread_status.set_mem_tracker(ExecEnv::GetInstance()->replication_mem_tracker());
     DeferOp op([prev_tracker] { tls_thread_status.set_mem_tracker(prev_tracker); });
 
     const TReplicateSnapshotRequest& replicate_snapshot_req = agent_task_req->task_req;

--- a/be/src/agent/agent_task.h
+++ b/be/src/agent/agent_task.h
@@ -41,4 +41,7 @@ void run_update_meta_info_task(const std::shared_ptr<UpdateTabletMetaInfoAgentTa
                                ExecEnv* exec_env);
 void run_drop_auto_increment_map_task(const std::shared_ptr<DropAutoIncrementMapAgentTaskRequest>& agent_task_req,
                                       ExecEnv* exec_env);
+void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskRequest>& agent_task_req, ExecEnv* exec_env);
+void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTaskRequest>& agent_task_req,
+                                 ExecEnv* exec_env);
 } // namespace starrocks

--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -22,6 +22,7 @@
 #include "gen_cpp/AgentService_types.h"
 #include "gutil/strings/join.h"
 #include "storage/data_dir.h"
+#include "storage/replication_txn_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet.h"
 #include "storage/tablet_manager.h"
@@ -61,29 +62,68 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
     auto scoped = trace::Scope(span);
 
     bool enable_sync_publish = publish_version_req.enable_sync_publish;
+    std::vector<TabletPublishVersionTask> tablet_tasks;
     size_t num_partition = publish_version_req.partition_version_infos.size();
     size_t num_active_tablet = 0;
-    std::vector<std::map<TabletInfo, RowsetSharedPtr>> partitions(num_partition);
-    for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
-        StorageEngine::instance()->txn_manager()->get_txn_related_tablets(
-                transaction_id, publish_version_req.partition_version_infos[i].partition_id, &partitions[i]);
-        num_active_tablet += partitions[i].size();
+    bool is_replication_txn =
+            publish_version_req.__isset.txn_type && publish_version_req.txn_type == TTxnType::TXN_REPLICATION;
+    if (is_replication_txn) {
+        std::vector<std::vector<TTabletId>> partitions(num_partition);
+        for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
+            Status st = StorageEngine::instance()->replication_txn_manager()->get_txn_related_tablets(
+                    transaction_id, publish_version_req.partition_version_infos[i].partition_id, &partitions[i]);
+            if (!st.ok()) {
+                LOG(WARNING) << "failed to publish version for replication txn, get_txn_related_tablets failed: " << st
+                             << ", txn_id: " << transaction_id
+                             << ", partition_id: " << publish_version_req.partition_version_infos[i].partition_id;
+                return;
+            }
+            num_active_tablet += partitions[i].size();
+        }
+
+        tablet_tasks.resize(num_active_tablet);
+        size_t tablet_idx = 0;
+
+        for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
+            for (const auto tablet_id : partitions[i]) {
+                auto& task = tablet_tasks[tablet_idx++];
+                task.txn_id = transaction_id;
+                task.partition_id = publish_version_req.partition_version_infos[i].partition_id;
+                task.tablet_id = tablet_id;
+                task.version = publish_version_req.partition_version_infos[i].version;
+            }
+        }
+    } else {
+        std::vector<std::map<TabletInfo, RowsetSharedPtr>> partitions(num_partition);
+        for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
+            StorageEngine::instance()->txn_manager()->get_txn_related_tablets(
+                    transaction_id, publish_version_req.partition_version_infos[i].partition_id, &partitions[i]);
+            num_active_tablet += partitions[i].size();
+        }
+
+        tablet_tasks.resize(num_active_tablet);
+        size_t tablet_idx = 0;
+
+        for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
+            for (const auto& itr : partitions[i]) {
+                auto& task = tablet_tasks[tablet_idx++];
+                task.txn_id = transaction_id;
+                task.partition_id = publish_version_req.partition_version_infos[i].partition_id;
+                task.tablet_id = itr.first.tablet_id;
+                task.version = publish_version_req.partition_version_infos[i].version;
+                task.rowset = std::move(itr.second);
+                if (!task.rowset) {
+                    task.st = Status::NotFound(
+                            fmt::format("rowset not found  of tablet: {}, txn_id: {}", task.tablet_id, task.txn_id));
+                    LOG(WARNING) << task.st;
+                    return;
+                }
+            }
+        }
     }
     span->SetAttribute("num_partition", num_partition);
     span->SetAttribute("num_tablet", num_active_tablet);
-    std::vector<TabletPublishVersionTask> tablet_tasks(num_active_tablet);
-    size_t tablet_idx = 0;
 
-    for (size_t i = 0; i < publish_version_req.partition_version_infos.size(); i++) {
-        for (auto& itr : partitions[i]) {
-            auto& task = tablet_tasks[tablet_idx++];
-            task.txn_id = transaction_id;
-            task.partition_id = publish_version_req.partition_version_infos[i].partition_id;
-            task.tablet_id = itr.first.tablet_id;
-            task.version = publish_version_req.partition_version_infos[i].version;
-            task.rowset = std::move(itr.second);
-        }
-    }
     std::mutex affected_dirs_lock;
     for (auto& tablet_task : tablet_tasks) {
         uint32_t retry_time = 0;
@@ -96,12 +136,7 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                 tablet_span->SetAttribute("txn_id", transaction_id);
                 tablet_span->SetAttribute("tablet_id", task.tablet_id);
                 tablet_span->SetAttribute("version", task.version);
-                if (!task.rowset) {
-                    task.st = Status::NotFound(
-                            fmt::format("rowset not found  of tablet: {}, txn_id: {}", task.tablet_id, task.txn_id));
-                    LOG(WARNING) << task.st;
-                    return;
-                }
+
                 TabletSharedPtr tablet = StorageEngine::instance()->tablet_manager()->get_tablet(task.tablet_id);
                 if (!tablet) {
                     // tablet may get dropped, it's ok to ignore this situation
@@ -114,18 +149,33 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
                     std::lock_guard lg(affected_dirs_lock);
                     affected_dirs.insert(tablet->data_dir());
                 }
-                task.st = StorageEngine::instance()->txn_manager()->publish_txn(task.partition_id, tablet, task.txn_id,
-                                                                                task.version, task.rowset, wait_time);
-                if (!task.st.ok()) {
-                    LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id() << " version:" << task.version
-                                 << " partition:" << task.partition_id << " txn_id: " << task.txn_id
-                                 << " rowset:" << task.rowset->rowset_id();
-                    tablet_span->SetStatus(trace::StatusCode::kError, task.st.get_error_msg());
+                if (is_replication_txn) {
+                    task.st = StorageEngine::instance()->replication_txn_manager()->publish_txn(
+                            task.txn_id, task.partition_id, tablet, task.version);
+                    if (!task.st.ok()) {
+                        LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id()
+                                     << " version:" << task.version << " partition:" << task.partition_id
+                                     << " txn_id: " << task.txn_id;
+                        tablet_span->SetStatus(trace::StatusCode::kError, task.st.get_error_msg());
+                    } else {
+                        LOG(INFO) << "Publish txn success tablet:" << tablet->tablet_id() << " version:" << task.version
+                                  << " tablet_max_version:" << tablet->max_continuous_version()
+                                  << " partition:" << task.partition_id << " txn_id: " << task.txn_id;
+                    }
                 } else {
-                    LOG(INFO) << "Publish txn success tablet:" << tablet->tablet_id() << " version:" << task.version
-                              << " tablet_max_version:" << tablet->max_continuous_version()
-                              << " partition:" << task.partition_id << " txn_id: " << task.txn_id
-                              << " rowset:" << task.rowset->rowset_id();
+                    task.st = StorageEngine::instance()->txn_manager()->publish_txn(
+                            task.partition_id, tablet, task.txn_id, task.version, task.rowset, wait_time);
+                    if (!task.st.ok()) {
+                        LOG(WARNING) << "Publish txn failed tablet:" << tablet->tablet_id()
+                                     << " version:" << task.version << " partition:" << task.partition_id
+                                     << " txn_id: " << task.txn_id << " rowset:" << task.rowset->rowset_id();
+                        tablet_span->SetStatus(trace::StatusCode::kError, task.st.get_error_msg());
+                    } else {
+                        LOG(INFO) << "Publish txn success tablet:" << tablet->tablet_id() << " version:" << task.version
+                                  << " tablet_max_version:" << tablet->max_continuous_version()
+                                  << " partition:" << task.partition_id << " txn_id: " << task.txn_id
+                                  << " rowset:" << task.rowset->rowset_id();
+                    }
                 }
             });
             if (st.is_service_unavailable()) {

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -170,6 +170,11 @@ CONF_Int32(sleep_five_seconds, "5");
 CONF_mInt32(compact_threads, "4");
 CONF_Int32(compact_thread_pool_queue_size, "100");
 
+// The count of thread to replication
+CONF_Int32(replication_threads, "64");
+CONF_Int32(replication_thread_pool_queue_size, "2048");
+CONF_Int32(clear_expired_replcation_snapshots_interval_seconds, "3600");
+
 // The log dir.
 CONF_String(sys_log_dir, "${STARROCKS_HOME}/log");
 // The user function dir.

--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -77,6 +77,8 @@ void DownloadAction::handle_normal(HttpRequest* req, const std::string& file_par
         if (!status.ok()) {
             std::string error_msg = status.get_error_msg();
             HttpChannel::send_reply(req, error_msg);
+            LOG(WARNING) << "Download method:" << to_method_desc(req->method()) << " " << file_param
+                         << " error:" << status;
             return;
         }
     }
@@ -85,12 +87,15 @@ void DownloadAction::handle_normal(HttpRequest* req, const std::string& file_par
     if (!status.ok()) {
         std::string error_msg = status.get_error_msg();
         HttpChannel::send_reply(req, error_msg);
+        OG(WARNING) << "Download method:" << to_method_desc(req->method()) << " " << file_param << " error:" << status;
         return;
     }
     auto is_dir = fs::is_directory(file_param);
     if (!is_dir.ok()) {
         std::string error_msg = is_dir.status().get_error_msg();
         HttpChannel::send_reply(req, error_msg);
+        LOG(WARNING) << "Download method:" << to_method_desc(req->method()) << " " << file_param
+                     << " error:" << is_dir.status();
         return;
     }
     if (*is_dir) {

--- a/be/src/http/download_action.cpp
+++ b/be/src/http/download_action.cpp
@@ -87,7 +87,7 @@ void DownloadAction::handle_normal(HttpRequest* req, const std::string& file_par
     if (!status.ok()) {
         std::string error_msg = status.get_error_msg();
         HttpChannel::send_reply(req, error_msg);
-        OG(WARNING) << "Download method:" << to_method_desc(req->method()) << " " << file_param << " error:" << status;
+        LOG(WARNING) << "Download method:" << to_method_desc(req->method()) << " " << file_param << " error:" << status;
         return;
     }
     auto is_dir = fs::is_directory(file_param);

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -18,6 +18,7 @@
 #include "http/http_client.h"
 
 #include "common/config.h"
+#include "fs/fs_util.h"
 
 namespace starrocks {
 
@@ -175,7 +176,7 @@ Status HttpClient::execute(const std::function<bool(const void* data, size_t len
     return Status::OK();
 }
 
-Status HttpClient::download(const std::string& local_path) {
+StatusOr<uint64_t> HttpClient::download(const std::string& local_path) {
     // set method to GET
     set_method(GET);
 
@@ -185,24 +186,41 @@ Status HttpClient::download(const std::string& local_path) {
     curl_easy_setopt(_curl, CURLOPT_LOW_SPEED_TIME, config::download_low_speed_time);
     curl_easy_setopt(_curl, CURLOPT_MAX_RECV_SPEED_LARGE, config::max_download_speed_kbps * 1024);
 
-    auto fp_closer = [](FILE* fp) { fclose(fp); };
-    std::unique_ptr<FILE, decltype(fp_closer)> fp(fopen(local_path.c_str(), "w"), fp_closer);
-    if (fp == nullptr) {
-        LOG(WARNING) << "open file failed, file=" << local_path;
-        return Status::InternalError("open file failed");
-    }
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(auto output_file, fs::new_writable_file(opts, local_path));
+
     Status status;
-    auto callback = [&status, &fp, &local_path](const void* data, size_t length) {
-        auto res = fwrite(data, length, 1, fp.get());
-        if (res != 1) {
-            LOG(WARNING) << "fail to write data to file, file=" << local_path << ", error=" << ferror(fp.get());
-            status = Status::InternalError("fail to write data when download");
+    auto callback = [&status, &output_file, &local_path](const void* data, size_t length) {
+        status = output_file->append(Slice((const char*)data, length));
+        if (!status.ok()) {
+            LOG(WARNING) << "fail to write data to file, file=" << local_path << ", error=" << status;
             return false;
         }
         return true;
     };
     RETURN_IF_ERROR(execute(callback));
-    return status;
+    RETURN_IF_ERROR(status);
+    RETURN_IF_ERROR(output_file->close());
+    return output_file->size();
+}
+
+StatusOr<std::string> HttpClient::download() {
+    // set method to GET
+    set_method(GET);
+
+    // TODO(zc) Move this download speed limit outside to limit download speed
+    // at system level
+    curl_easy_setopt(_curl, CURLOPT_LOW_SPEED_LIMIT, config::download_low_speed_limit_kbps * 1024);
+    curl_easy_setopt(_curl, CURLOPT_LOW_SPEED_TIME, config::download_low_speed_time);
+    curl_easy_setopt(_curl, CURLOPT_MAX_RECV_SPEED_LARGE, config::max_download_speed_kbps * 1024);
+
+    std::string result;
+    auto callback = [&result](const void* data, size_t length) {
+        result.append((const char*)data, length);
+        return true;
+    };
+    RETURN_IF_ERROR(execute(callback));
+    return result;
 }
 
 Status HttpClient::execute(std::string* response) {

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "common/status.h"
+#include "common/statusor.h"
 #include "http/http_headers.h"
 #include "http/http_method.h"
 #include "http/http_response.h"
@@ -110,7 +111,9 @@ public:
 
     // helper function to download a file, you can call this function to downlaod
     // a file to local_path
-    Status download(const std::string& local_path);
+    StatusOr<uint64_t> download(const std::string& local_path);
+
+    StatusOr<std::string> download();
 
     Status execute_post_request(const std::string& payload, std::string* response);
 

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -75,6 +75,7 @@
 #include "runtime/stream_load/stream_load_executor.h"
 #include "runtime/stream_load/transaction_mgr.h"
 #include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/starlet_location_provider.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/update_manager.h"
@@ -348,6 +349,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _lake_update_manager = new lake::UpdateManager(_lake_location_provider, update_mem_tracker());
     _lake_tablet_manager =
             new lake::TabletManager(_lake_location_provider, _lake_update_manager, config::lake_metadata_cache_limit);
+    _lake_replication_txn_manager = new lake::ReplicationTxnManager(_lake_tablet_manager);
     if (config::starlet_cache_dir.empty()) {
         std::vector<std::string> starlet_cache_paths;
         std::for_each(store_paths.begin(), store_paths.end(), [&](StorePath root_path) {
@@ -362,6 +364,7 @@ Status ExecEnv::_init(const std::vector<StorePath>& store_paths, bool as_cn) {
     _lake_update_manager = new lake::UpdateManager(_lake_location_provider, update_mem_tracker());
     _lake_tablet_manager =
             new lake::TabletManager(_lake_location_provider, _lake_update_manager, config::lake_metadata_cache_limit);
+    _lake_replication_txn_manager = new lake::ReplicationTxnManager(_lake_tablet_manager);
 #endif
 
     _agent_server = new AgentServer(this, false);
@@ -465,6 +468,7 @@ Status ExecEnv::init_mem_tracker() {
     _clone_mem_tracker = regist_tracker(-1, "clone", process_mem_tracker());
     int64_t consistency_mem_limit = calc_max_consistency_memory(process_mem_tracker()->limit());
     _consistency_mem_tracker = regist_tracker(consistency_mem_limit, "consistency", process_mem_tracker());
+    _replication_mem_tracker = regist_tracker(-1, "replication", _process_mem_tracker.get());
 
     MemChunkAllocator::init_instance(_chunk_allocator_mem_tracker.get(), config::chunk_reserved_bytes_limit);
 
@@ -570,6 +574,7 @@ void ExecEnv::_destroy() {
     SAFE_DELETE(_lake_tablet_manager);
     SAFE_DELETE(_lake_location_provider);
     SAFE_DELETE(_lake_update_manager);
+    SAFE_DELETE(_lake_replication_txn_manager);
     SAFE_DELETE(_cache_mgr);
     _metrics = nullptr;
 

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -98,6 +98,7 @@ namespace lake {
 class LocationProvider;
 class TabletManager;
 class UpdateManager;
+class ReplicationTxnManager;
 } // namespace lake
 namespace spill {
 class DirManager;
@@ -171,6 +172,7 @@ public:
     MemTracker* chunk_allocator_mem_tracker() { return _chunk_allocator_mem_tracker.get(); }
     MemTracker* clone_mem_tracker() { return _clone_mem_tracker.get(); }
     MemTracker* consistency_mem_tracker() { return _consistency_mem_tracker.get(); }
+    MemTracker* replication_mem_tracker() { return _replication_mem_tracker.get(); }
     std::vector<std::shared_ptr<MemTracker>>& mem_trackers() { return _mem_trackers; }
 
     PriorityThreadPool* thread_pool() { return _thread_pool; }
@@ -226,6 +228,8 @@ public:
     lake::LocationProvider* lake_location_provider() const { return _lake_location_provider; }
 
     lake::UpdateManager* lake_update_manager() const { return _lake_update_manager; }
+
+    lake::ReplicationTxnManager* lake_replication_txn_manager() const { return _lake_replication_txn_manager; }
 
     AgentServer* agent_server() const { return _agent_server; }
 
@@ -308,6 +312,8 @@ private:
 
     std::shared_ptr<MemTracker> _consistency_mem_tracker;
 
+    std::shared_ptr<MemTracker> _replication_mem_tracker;
+
     std::vector<std::shared_ptr<MemTracker>> _mem_trackers;
 
     PriorityThreadPool* _thread_pool = nullptr;
@@ -354,6 +360,7 @@ private:
     lake::TabletManager* _lake_tablet_manager = nullptr;
     lake::LocationProvider* _lake_location_provider = nullptr;
     lake::UpdateManager* _lake_update_manager = nullptr;
+    lake::ReplicationTxnManager* _lake_replication_txn_manager = nullptr;
 
     AgentServer* _agent_server = nullptr;
     query_cache::CacheManagerRawPtr _cache_mgr;

--- a/be/src/service/service_be/lake_service.cpp
+++ b/be/src/service/service_be/lake_service.cpp
@@ -343,9 +343,10 @@ void LakeServiceImpl::abort_txn(::google::protobuf::RpcController* controller,
     auto task = [&]() {
         DeferOp defer([&] { latch.count_down(); });
         auto txn_ids = request->txn_ids().data();
-        auto txn_ids_size = request->txn_ids_size();
+        auto txn_types = request->txn_types_size() > 0 ? request->txn_types().data() : nullptr;
+        auto txn_size = request->txn_ids_size();
         for (auto tablet_id : request->tablet_ids()) {
-            lake::abort_txn(_tablet_mgr, tablet_id, txn_ids, txn_ids_size);
+            lake::abort_txn(_tablet_mgr, tablet_id, txn_ids, txn_types, txn_size);
         }
     };
     auto st = thread_pool->submit_func(task);

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -43,6 +43,8 @@ add_library(Storage STATIC
     primary_index.cpp
     primary_key_encoder.cpp
     protobuf_file.cpp
+    replication_txn_manager.cpp
+    replication_utils.cpp
     rowset_update_state.cpp
     rowset_column_update_state.cpp
     update_compaction_state.cpp
@@ -173,6 +175,7 @@ add_library(Storage STATIC
     lake/vacuum.cpp
     lake/general_tablet_writer.cpp
     lake/pk_tablet_writer.cpp
+    lake/replication_txn_manager.cpp
     lake/rowset.cpp
     lake/schema_change.cpp
     lake/starlet_location_provider.cpp

--- a/be/src/storage/data_dir.h
+++ b/be/src/storage/data_dir.h
@@ -145,6 +145,8 @@ public:
     std::string get_persistent_index_path() { return _path + PERSISTENT_INDEX_PREFIX; }
     Status init_persistent_index_dir();
 
+    std::string get_replication_path() { return _path + REPLICATION_PREFIX; }
+
     // for test
     size_t get_all_check_dcg_files_cnt() const { return _all_check_dcg_files.size(); }
 

--- a/be/src/storage/lake/filenames.h
+++ b/be/src/storage/lake/filenames.h
@@ -47,6 +47,10 @@ inline bool is_txn_log(std::string_view file_name) {
     return HasSuffixString(file_name, ".log");
 }
 
+inline bool is_txn_slog(std::string_view file_name) {
+    return HasSuffixString(file_name, ".slog");
+}
+
 inline bool is_txn_vlog(std::string_view file_name) {
     return HasSuffixString(file_name, ".vlog");
 }
@@ -69,6 +73,10 @@ inline std::string gen_delvec_filename(int64_t txn_id) {
 
 inline std::string txn_log_filename(int64_t tablet_id, int64_t txn_id) {
     return fmt::format("{:016X}_{:016X}.log", tablet_id, txn_id);
+}
+
+inline std::string txn_slog_filename(int64_t tablet_id, int64_t txn_id) {
+    return fmt::format("{:016X}_{:016X}.slog", tablet_id, txn_id);
 }
 
 inline std::string txn_vlog_filename(int64_t tablet_id, int64_t version) {
@@ -120,6 +128,16 @@ inline std::pair<int64_t, int64_t> parse_tablet_metadata_filename(std::string_vi
 inline std::pair<int64_t, int64_t> parse_txn_log_filename(std::string_view file_name) {
     constexpr static int kBase = 16;
     CHECK_EQ(kTxnLogFilenameLength, file_name.size()) << file_name;
+    StringParser::ParseResult res;
+    auto tablet_id = StringParser::string_to_int<int64_t>(file_name.data(), 16, kBase, &res);
+    CHECK_EQ(StringParser::PARSE_SUCCESS, res) << file_name;
+    auto txn_id = StringParser::string_to_int<int64_t>(file_name.data() + 17, 16, kBase, &res);
+    CHECK_EQ(StringParser::PARSE_SUCCESS, res) << file_name;
+    return {tablet_id, txn_id};
+}
+
+inline std::pair<int64_t, int64_t> parse_txn_slog_filename(std::string_view file_name) {
+    constexpr static int kBase = 16;
     StringParser::ParseResult res;
     auto tablet_id = StringParser::string_to_int<int64_t>(file_name.data(), 16, kBase, &res);
     CHECK_EQ(StringParser::PARSE_SUCCESS, res) << file_name;

--- a/be/src/storage/lake/location_provider.h
+++ b/be/src/storage/lake/location_provider.h
@@ -56,6 +56,10 @@ public:
         return join_path(txn_log_root_location(tablet_id), txn_log_filename(tablet_id, txn_id));
     }
 
+    std::string txn_slog_location(int64_t tablet_id, int64_t txn_id) const {
+        return join_path(txn_log_root_location(tablet_id), txn_slog_filename(tablet_id, txn_id));
+    }
+
     std::string txn_vlog_location(int64_t tablet_id, int64_t version) const {
         return join_path(txn_log_root_location(tablet_id), txn_vlog_filename(tablet_id, version));
     }

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -1,0 +1,288 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/replication_txn_manager.h"
+
+#include <fmt/format.h>
+#include <sys/stat.h>
+
+#include <filesystem>
+#include <set>
+
+#include "agent/agent_server.h"
+#include "agent/master_info.h"
+#include "agent/task_signatures_manager.h"
+#include "fs/fs.h"
+#include "gen_cpp/BackendService.h"
+#include "gen_cpp/Types_constants.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/stringpiece.h"
+#include "gutil/strings/substitute.h"
+#include "http/http_client.h"
+#include "runtime/client_cache.h"
+#include "runtime/current_thread.h"
+#include "runtime/exec_env.h"
+#include "service/backend_options.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/protobuf_file.h"
+#include "storage/replication_utils.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/snapshot_manager.h"
+#include "storage/tablet_updates.h"
+#include "util/defer_op.h"
+#include "util/string_parser.hpp"
+#include "util/thrift_rpc_helper.h"
+
+namespace starrocks::lake {
+
+Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
+                                              bool* incremental_snapshot) {
+    ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(request.tablet_id));
+
+    auto status_or_txn_log = tablet.get_txn_slog(request.transaction_id);
+    if (status_or_txn_log.ok()) {
+        const ReplicationTxnMetaPB& txn_meta = status_or_txn_log.value()->op_replication().txn_meta();
+        if (txn_meta.txn_state() == ReplicationTxnStatePB::TXN_SNAPSHOTED &&
+            txn_meta.snapshot_version() == request.src_visible_version) {
+            LOG(INFO) << "Tablet " << request.tablet_id << " already made remote snapshot"
+                      << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                      << ", src_tablet_id: " << request.src_tablet_id
+                      << ", visible_version: " << request.visible_version
+                      << ", snapshot_version: " << request.src_visible_version;
+            return Status::OK();
+        }
+    }
+
+    std::vector<Version> missed_versions;
+    for (auto v = request.visible_version + 1; v <= request.src_visible_version; ++v) {
+        missed_versions.emplace_back(Version(v, v));
+    }
+    if (missed_versions.empty()) {
+        LOG(WARNING) << "Remote snapshot tablet skipped, no missing version"
+                     << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                     << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
+                     << ", snapshot_version: " << request.src_visible_version;
+        return Status::Corruption("No missing version");
+    }
+
+    LOG(INFO) << "Start make remote snapshot tablet"
+              << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+              << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
+              << ", snapshot_version: " << request.src_visible_version << ", missed_versions: ["
+              << (request.visible_version + 1) << " ... " << request.src_visible_version << "]";
+
+    TBackend src_backend;
+    *incremental_snapshot = true;
+    Status status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
+    if (!status.ok()) {
+        LOG(INFO) << "Fail to make incremental snapshot: " << status << ". switch to fully snapshot"
+                  << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                  << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
+                  << ", snapshot_version: " << request.src_visible_version;
+        *incremental_snapshot = false;
+        status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+    }
+
+    if (!status.ok()) {
+        LOG(WARNING) << "Fail to make remote snapshot: " << status << ", txn_id: " << request.transaction_id
+                     << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+                     << ", visible_version: " << request.visible_version
+                     << ", snapshot_version: " << request.src_visible_version;
+        return status;
+    }
+
+    LOG(INFO) << "Made snapshot from " << src_backend.host << ":" << src_backend.be_port << ":" << *src_snapshot_path
+              << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+              << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
+              << ", snapshot_version: " << request.src_visible_version;
+
+    auto txn_log = std::make_shared<TxnLog>();
+    txn_log->set_tablet_id(request.tablet_id);
+    txn_log->set_txn_id(request.transaction_id);
+
+    auto* txn_meta = txn_log->mutable_op_replication()->mutable_txn_meta();
+    txn_meta->set_txn_id(request.transaction_id);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_SNAPSHOTED);
+    txn_meta->set_tablet_id(request.tablet_id);
+    txn_meta->set_visible_version(request.visible_version);
+    txn_meta->set_src_backend_host(src_backend.host);
+    txn_meta->set_src_backend_port(src_backend.be_port);
+    txn_meta->set_src_snapshot_path(*src_snapshot_path);
+    txn_meta->set_snapshot_version(request.src_visible_version);
+    txn_meta->set_incremental_snapshot(*incremental_snapshot);
+
+    return tablet.put_txn_slog(std::move(txn_log));
+}
+
+Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest& request) {
+    ASSIGN_OR_RETURN(auto tablet, _tablet_manager->get_tablet(request.tablet_id));
+
+    auto status_or_txn_log = tablet.get_txn_log(request.transaction_id);
+    if (status_or_txn_log.ok()) {
+        const ReplicationTxnMetaPB& txn_meta = status_or_txn_log.value()->op_replication().txn_meta();
+        if (txn_meta.txn_state() >= ReplicationTxnStatePB::TXN_REPLICATED &&
+            txn_meta.snapshot_version() == request.src_visible_version) {
+            LOG(INFO) << "Tablet " << request.tablet_id << " already replicated remote snapshot"
+                      << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                      << ", src_tablet_id: " << request.src_tablet_id
+                      << ", visible_version: " << request.visible_version
+                      << ", snapshot_version: " << request.src_visible_version;
+            return Status::OK();
+        }
+    }
+
+    Status status;
+    for (const auto& src_snapshot_info : request.src_snapshot_infos) {
+        auto status_or = replicate_remote_snapshot(request, src_snapshot_info);
+
+        if (!status_or.ok()) {
+            status = status_or.status();
+            LOG(WARNING) << "Fail to download snapshot from " << src_snapshot_info.backend.host << ":"
+                         << src_snapshot_info.backend.http_port << ":" << src_snapshot_info.snapshot_path << ", "
+                         << status << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                         << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            continue;
+        }
+
+        LOG(INFO) << "Replicated snapshot from " << src_snapshot_info.backend.host << ":"
+                  << src_snapshot_info.backend.http_port << ":" << src_snapshot_info.snapshot_path << " to "
+                  << _tablet_manager->location_provider()->segment_root_location(request.tablet_id)
+                  << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                  << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
+                  << ", snapshot_version: " << request.src_visible_version;
+
+        return tablet.put_txn_log(std::move(status_or.value()));
+    }
+
+    return status;
+}
+
+Status ReplicationTxnManager::clear_snapshots(const TxnLogPtr& txn_slog) {
+    const auto& txn_meta = txn_slog->op_replication().txn_meta();
+    return ReplicationUtils::release_remote_snapshot(txn_meta.src_backend_host(), txn_meta.src_backend_port(),
+                                                     txn_meta.src_snapshot_path());
+}
+
+Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest& request,
+                                                   const std::vector<Version>* missed_versions,
+                                                   const std::vector<int64_t>* missing_version_ranges,
+                                                   TBackend* src_backend, std::string* src_snapshot_path) {
+    int timeout_s = 0;
+    if (request.__isset.timeout_sec) {
+        timeout_s = request.timeout_sec;
+    }
+
+    Status status;
+    for (const auto& src_be : request.src_backends) {
+        // Make snapshot in remote olap engine
+        status = ReplicationUtils::make_remote_snapshot(src_be.host, src_be.be_port, request.src_tablet_id,
+                                                        request.src_schema_hash, request.src_visible_version, timeout_s,
+                                                        missed_versions, missing_version_ranges, src_snapshot_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to make snapshot from " << src_be.host << ":" << src_be.be_port << ", " << status
+                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                         << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            continue;
+        }
+
+        *src_backend = src_be;
+        break;
+    }
+
+    return status;
+}
+
+StatusOr<TxnLogPtr> ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
+                                                                     const TRemoteSnapshotInfo& src_snapshot_info) {
+    std::string remote_header_file_name = std::to_string(request.src_tablet_id) + ".hdr";
+    ASSIGN_OR_RETURN(auto header_file_content,
+                     ReplicationUtils::download_remote_snapshot_file(
+                             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+                             src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
+                             remote_header_file_name, config::download_low_speed_time));
+    TabletMeta tablet_meta;
+    RETURN_IF_ERROR(tablet_meta.create_from_memory(header_file_content));
+
+    auto txn_log = std::make_shared<TxnLog>();
+    std::unordered_map<std::string, std::string> segment_filename_map;
+    const auto& rowset_metas =
+            tablet_meta.all_rs_metas().empty() ? tablet_meta.all_inc_rs_metas() : tablet_meta.all_rs_metas();
+    for (const auto& rowset_meta : rowset_metas) {
+        auto* rowset_metadata = txn_log->mutable_op_replication()->add_op_writes()->mutable_rowset();
+        RETURN_IF_ERROR(
+                convert_rowset_meta(*rowset_meta, request.transaction_id, rowset_metadata, &segment_filename_map));
+    }
+
+    RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
+            src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+            src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash, nullptr,
+            _tablet_manager->location_provider()->segment_root_location(request.tablet_id) + '/',
+            [segment_filename_map = std::move(segment_filename_map)](const std::string& filename) {
+                auto iter = segment_filename_map.find(filename);
+                if (iter == segment_filename_map.end()) {
+                    return std::string();
+                }
+                return iter->second;
+            }));
+
+    txn_log->set_tablet_id(request.tablet_id);
+    txn_log->set_txn_id(request.transaction_id);
+
+    auto* txn_meta = txn_log->mutable_op_replication()->mutable_txn_meta();
+    txn_meta->set_txn_id(request.transaction_id);
+    txn_meta->set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+    txn_meta->set_tablet_id(request.tablet_id);
+    txn_meta->set_visible_version(request.visible_version);
+    txn_meta->set_src_backend_host(src_snapshot_info.backend.host);
+    txn_meta->set_src_backend_port(src_snapshot_info.backend.be_port);
+    txn_meta->set_src_snapshot_path(src_snapshot_info.snapshot_path);
+    txn_meta->set_snapshot_version(request.src_visible_version);
+    txn_meta->set_incremental_snapshot(src_snapshot_info.incremental_snapshot);
+
+    return txn_log;
+}
+
+Status ReplicationTxnManager::convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,
+                                                  RowsetMetadata* rowset_metadata,
+                                                  std::unordered_map<std::string, std::string>* segment_filename_map) {
+    rowset_metadata->set_overlapped(rowset_meta.is_segments_overlapping());
+    rowset_metadata->set_num_rows(rowset_meta.num_rows());
+    rowset_metadata->set_data_size(rowset_meta.data_disk_size());
+    if (rowset_meta.has_delete_predicate()) {
+        rowset_metadata->mutable_delete_predicate()->CopyFrom(rowset_meta.delete_predicate());
+    }
+
+    std::string rowset_id = rowset_meta.rowset_id().to_string();
+    for (int64_t segment_id = 0; segment_id < rowset_meta.num_segments(); ++segment_id) {
+        std::string old_segment_filename = rowset_id + '_' + std::to_string(segment_id) + ".dat";
+        std::string new_segment_filename = gen_segment_filename(transaction_id);
+
+        rowset_metadata->add_segments(new_segment_filename);
+        auto pair = segment_filename_map->emplace(std::move(old_segment_filename), std::move(new_segment_filename));
+        if (!pair.second) {
+            return Status::Corruption("Duplicated segment file: " + pair.first->first);
+        }
+    }
+
+    return Status::OK();
+}
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/status.h"
+#include "gen_cpp/AgentService_types.h"
+#include "storage/lake/txn_log.h"
+#include "storage/lake/types_fwd.h"
+#include "storage/olap_common.h"
+#include "storage/olap_define.h"
+#include "storage/rowset/rowset_meta.h"
+
+namespace starrocks::lake {
+
+class TabletManager;
+
+class ReplicationTxnManager {
+public:
+    explicit ReplicationTxnManager(lake::TabletManager* tablet_manager) : _tablet_manager(tablet_manager) {}
+
+    Status remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
+                           bool* incremental_snapshot);
+
+    Status replicate_snapshot(const TReplicateSnapshotRequest& request);
+
+    Status clear_snapshots(const TxnLogPtr& txn_slog);
+
+    DISALLOW_COPY_AND_MOVE(ReplicationTxnManager);
+
+private:
+    Status make_remote_snapshot(const TRemoteSnapshotRequest& request, const std::vector<Version>* missed_versions,
+                                const std::vector<int64_t>* missing_version_ranges, TBackend* src_backend,
+                                std::string* src_snapshot_path);
+
+    StatusOr<TxnLogPtr> replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
+                                                  const TRemoteSnapshotInfo& src_snapshot_info);
+
+    Status convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,
+                               RowsetMetadata* rowset_metadata,
+                               std::unordered_map<std::string, std::string>* segment_filename_map);
+
+private:
+    lake::TabletManager* _tablet_manager;
+};
+
+} // namespace starrocks::lake

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -16,6 +16,7 @@
 
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
+#include "gutil/macros.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"

--- a/be/src/storage/lake/tablet.cpp
+++ b/be/src/storage/lake/tablet.cpp
@@ -74,8 +74,16 @@ Status Tablet::put_txn_log(const TxnLogPtr& log) {
     return _mgr->put_txn_log(log);
 }
 
+Status Tablet::put_txn_slog(const TxnLogPtr& log) {
+    return _mgr->put_txn_slog(log);
+}
+
 StatusOr<TxnLogPtr> Tablet::get_txn_log(int64_t txn_id) {
     return _mgr->get_txn_log(_id, txn_id);
+}
+
+StatusOr<TxnLogPtr> Tablet::get_txn_slog(int64_t txn_id) {
+    return _mgr->get_txn_slog(_id, txn_id);
 }
 
 StatusOr<TxnLogPtr> Tablet::get_txn_vlog(int64_t version) {
@@ -176,6 +184,10 @@ std::string Tablet::metadata_root_location() const {
 
 std::string Tablet::txn_log_location(int64_t txn_id) const {
     return _mgr->txn_log_location(_id, txn_id);
+}
+
+std::string Tablet::txn_slog_location(int64_t txn_id) const {
+    return _mgr->txn_slog_location(_id, txn_id);
 }
 
 std::string Tablet::txn_vlog_location(int64_t version) const {

--- a/be/src/storage/lake/tablet.h
+++ b/be/src/storage/lake/tablet.h
@@ -80,7 +80,11 @@ public:
 
     [[nodiscard]] Status put_txn_log(const TxnLogPtr& log);
 
+    [[nodiscard]] Status put_txn_slog(const TxnLogPtr& log);
+
     StatusOr<TxnLogPtr> get_txn_log(int64_t txn_id);
+
+    StatusOr<TxnLogPtr> get_txn_slog(int64_t txn_id);
 
     StatusOr<TxnLogPtr> get_txn_vlog(int64_t version);
 
@@ -114,6 +118,8 @@ public:
     [[nodiscard]] std::string metadata_root_location() const;
 
     [[nodiscard]] std::string txn_log_location(int64_t txn_id) const;
+
+    [[nodiscard]] std::string txn_slog_location(int64_t txn_id) const;
 
     [[nodiscard]] std::string txn_vlog_location(int64_t version) const;
 

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -87,6 +87,10 @@ std::string TabletManager::txn_log_location(int64_t tablet_id, int64_t txn_id) c
     return _location_provider->txn_log_location(tablet_id, txn_id);
 }
 
+std::string TabletManager::txn_slog_location(int64_t tablet_id, int64_t txn_id) const {
+    return _location_provider->txn_slog_location(tablet_id, txn_id);
+}
+
 std::string TabletManager::txn_vlog_location(int64_t tablet_id, int64_t version) const {
     return _location_provider->txn_vlog_location(tablet_id, version);
 }
@@ -317,6 +321,11 @@ StatusOr<TxnLogPtr> TabletManager::get_txn_vlog(const std::string& path, bool fi
     return get_txn_log(path, fill_cache);
 }
 
+StatusOr<TxnLogPtr> TabletManager::get_txn_slog(const std::string& path, bool fill_cache) {
+    TEST_ERROR_POINT("TabletManager::get_txn_slog");
+    return get_txn_log(path, fill_cache);
+}
+
 StatusOr<TxnLogPtr> TabletManager::get_txn_log(const std::string& path, bool fill_cache) {
     if (auto ptr = _metacache->lookup_txn_log(path); ptr != nullptr) {
         TRACE("got cached txn log");
@@ -334,11 +343,15 @@ StatusOr<TxnLogPtr> TabletManager::get_txn_log(int64_t tablet_id, int64_t txn_id
     return get_txn_log(txn_log_location(tablet_id, txn_id));
 }
 
+StatusOr<TxnLogPtr> TabletManager::get_txn_slog(int64_t tablet_id, int64_t txn_id) {
+    return get_txn_log(txn_slog_location(tablet_id, txn_id));
+}
+
 StatusOr<TxnLogPtr> TabletManager::get_txn_vlog(int64_t tablet_id, int64_t version) {
     return get_txn_log(txn_vlog_location(tablet_id, version), false);
 }
 
-Status TabletManager::put_txn_log(const TxnLogPtr& log) {
+Status TabletManager::put_txn_log(const TxnLogPtr& log, const std::string& path) {
     if (UNLIKELY(!log->has_tablet_id())) {
         return Status::InvalidArgument("txn log does not have tablet id");
     }
@@ -346,16 +359,19 @@ Status TabletManager::put_txn_log(const TxnLogPtr& log) {
         return Status::InvalidArgument("txn log does not have txn id");
     }
     auto t0 = butil::gettimeofday_us();
-    auto txn_log_path = txn_log_location(log->tablet_id(), log->txn_id());
 
-    ProtobufFile file(txn_log_path);
+    ProtobufFile file(path);
     RETURN_IF_ERROR(file.save(*log));
 
-    _metacache->cache_txn_log(txn_log_path, log);
+    _metacache->cache_txn_log(path, log);
 
     auto t1 = butil::gettimeofday_us();
     g_put_txn_log_latency << (t1 - t0);
     return Status::OK();
+}
+
+Status TabletManager::put_txn_log(const TxnLogPtr& log) {
+    return put_txn_log(log, txn_log_location(log->tablet_id(), log->txn_id()));
 }
 
 Status TabletManager::put_txn_log(const TxnLog& log) {
@@ -420,6 +436,14 @@ bool TabletManager::is_tablet_in_worker(int64_t tablet_id) {
     return in_worker;
 }
 #endif // USE_STAROS
+
+Status TabletManager::put_txn_slog(const TxnLogPtr& log) {
+    return put_txn_log(log, txn_slog_location(log->tablet_id(), log->txn_id()));
+}
+
+Status TabletManager::put_txn_slog(const TxnLogPtr& log, const std::string& path) {
+    return put_txn_log(log, path);
+}
 
 StatusOr<TabletSchemaPtr> TabletManager::get_tablet_schema(int64_t tablet_id, int64_t* version_hint) {
     // 1. direct lookup in cache, if there is schema info for the tablet

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -84,9 +84,19 @@ public:
 
     [[nodiscard]] Status put_txn_log(const TxnLogPtr& log);
 
+    [[nodiscard]] Status put_txn_log(const TxnLogPtr& log, const std::string& path);
+
+    [[nodiscard]] Status put_txn_slog(const TxnLogPtr& log);
+
+    [[nodiscard]] Status put_txn_slog(const TxnLogPtr& log, const std::string& path);
+
     StatusOr<TxnLogPtr> get_txn_log(int64_t tablet_id, int64_t txn_id);
 
     StatusOr<TxnLogPtr> get_txn_log(const std::string& path, bool fill_cache = true);
+
+    StatusOr<TxnLogPtr> get_txn_slog(int64_t tablet_id, int64_t txn_id);
+
+    StatusOr<TxnLogPtr> get_txn_slog(const std::string& path, bool fill_cache = true);
 
     StatusOr<TxnLogPtr> get_txn_vlog(int64_t tablet_id, int64_t version);
 
@@ -121,6 +131,8 @@ public:
     std::string tablet_metadata_location(int64_t tablet_id, int64_t version) const;
 
     std::string txn_log_location(int64_t tablet_id, int64_t txn_id) const;
+
+    std::string txn_slog_location(int64_t tablet_id, int64_t txn_id) const;
 
     std::string txn_vlog_location(int64_t tablet_id, int64_t version) const;
 

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -16,7 +16,9 @@
 
 #include "fs/fs_util.h"
 #include "gutil/strings/join.h"
+#include "runtime/exec_env.h"
 #include "storage/lake/metacache.h"
+#include "storage/lake/replication_txn_manager.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/lake/txn_log.h"
@@ -25,6 +27,30 @@
 #include "util/lru_cache.h"
 
 namespace starrocks::lake {
+
+static void clear_remote_snapshot_async(TabletManager* tablet_mgr, int64_t tablet_id, int64_t txn_id,
+                                        std::vector<std::string>* files_to_delete) {
+    auto slog_path = tablet_mgr->txn_slog_location(tablet_id, txn_id);
+    auto txn_slog_or = tablet_mgr->get_txn_log(slog_path, false);
+
+    if (!txn_slog_or.ok()) {
+        // Not found is ok
+        if (!txn_slog_or.status().is_not_found()) {
+            LOG(WARNING) << "Fail to get txn slog " << slog_path << ": " << txn_slog_or.status();
+
+            tablet_mgr->metacache()->erase(slog_path);
+            files_to_delete->emplace_back(std::move(slog_path));
+        }
+        return;
+    }
+
+    run_clear_task_async([txn_slog = std::move(txn_slog_or.value())]() {
+        (void)ExecEnv::GetInstance()->lake_replication_txn_manager()->clear_snapshots(txn_slog);
+    });
+
+    tablet_mgr->metacache()->erase(slog_path);
+    files_to_delete->emplace_back(std::move(slog_path));
+}
 
 StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t base_version,
                                             int64_t new_version, const int64_t* txn_ids, size_t txn_ids_size,
@@ -119,6 +145,11 @@ StatusOr<TabletMetadataPtr> publish_version(TabletManager* tablet_mgr, int64_t t
         files_to_delete.emplace_back(log_path);
 
         tablet_mgr->metacache()->erase(log_path);
+
+        // Clear remote snapshot and slog for replication txn
+        if (txn_log->has_op_replication()) {
+            clear_remote_snapshot_async(tablet_mgr, tablet_id, txn_id, &files_to_delete);
+        }
     }
 
     // Apply vtxn logs for schema change
@@ -188,10 +219,16 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t
     }
 }
 
-void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_ids, size_t txn_ids_size) {
+void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int32_t* txn_types, size_t txn_size) {
     std::vector<std::string> files_to_delete;
-    for (size_t i = 0; i < txn_ids_size; i++) {
+    for (size_t i = 0; i < txn_size; ++i) {
         auto txn_id = txn_ids[i];
+
+        // Clear remote snapshot and slog for replication txn
+        if (txn_types != nullptr && txn_types[i] == TxnTypePB::TXN_REPLICATION) {
+            clear_remote_snapshot_async(tablet_mgr, tablet_id, txn_id, &files_to_delete);
+        }
+
         auto log_path = tablet_mgr->txn_log_location(tablet_id, txn_id);
         auto txn_log_or = tablet_mgr->get_txn_log(log_path, false);
         if (!txn_log_or.ok()) {
@@ -218,6 +255,16 @@ void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_
             for (const auto& rowset : txn_log->op_schema_change().rowsets()) {
                 for (const auto& segment : rowset.segments()) {
                     files_to_delete.emplace_back(tablet_mgr->segment_location(tablet_id, segment));
+                }
+            }
+        }
+        if (txn_log->has_op_replication()) {
+            for (const auto& op_write : txn_log->op_replication().op_writes()) {
+                for (const auto& segment : op_write.rowset().segments()) {
+                    files_to_delete.emplace_back(tablet_mgr->segment_location(tablet_id, segment));
+                }
+                for (const auto& del_file : op_write.dels()) {
+                    files_to_delete.emplace_back(tablet_mgr->del_location(tablet_id, del_file));
                 }
             }
         }

--- a/be/src/storage/lake/transactions.cpp
+++ b/be/src/storage/lake/transactions.cpp
@@ -219,7 +219,8 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t
     }
 }
 
-void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int32_t* txn_types, size_t txn_size) {
+void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_ids, const int32_t* txn_types,
+               size_t txn_size) {
     std::vector<std::string> files_to_delete;
     for (size_t i = 0; i < txn_size; ++i) {
         auto txn_id = txn_ids[i];

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -74,6 +74,7 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t
 // - tablet_id The ID of the tablet where the transaction will be aborted.
 // - txn_types transaction types
 //
-void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_ids, const int32_t* txn_types, size_t txn_size);
+void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_ids, const int32_t* txn_types,
+               size_t txn_size);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/transactions.h
+++ b/be/src/storage/lake/transactions.h
@@ -72,8 +72,8 @@ Status publish_log_version(TabletManager* tablet_mgr, int64_t tablet_id, int64_t
 // Parameters:
 // - tablet_mgr A pointer to the TabletManager object managing the tablet, cannot be nullptr
 // - tablet_id The ID of the tablet where the transaction will be aborted.
-// - txn_ids transaction IDs to be aborted.
+// - txn_types transaction types
 //
-void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_ids, size_t txn_ids_size);
+void abort_txn(TabletManager* tablet_mgr, int64_t tablet_id, const int64_t* txn_ids, const int32_t* txn_types, size_t txn_size);
 
 } // namespace starrocks::lake

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -256,6 +256,9 @@ public:
         if (log.has_op_schema_change()) {
             RETURN_IF_ERROR(apply_schema_change_log(log.op_schema_change()));
         }
+        if (log.has_op_replication()) {
+            RETURN_IF_ERROR(apply_replication_log(log.op_replication()));
+        }
         return Status::OK();
     }
 
@@ -378,6 +381,29 @@ private:
             _metadata->set_next_rowset_id(new_rowset->id() + std::max(1, new_rowset->segments_size()));
         }
         DCHECK(!op_schema_change.has_delvec_meta());
+        return Status::OK();
+    }
+
+    Status apply_replication_log(const TxnLogPB_OpReplication& op_replication) {
+        if (op_replication.txn_meta().txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
+            LOG(WARNING) << "Fail to apply replication log, invalid txn meta state: "
+                         << ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state());
+            return Status::Corruption("Invalid txn meta state: " +
+                                      ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state()));
+        }
+        if (op_replication.txn_meta().snapshot_version() != _new_version) {
+            LOG(WARNING) << "Fail to apply replication log, mismatched snapshot version and new version"
+                         << ", snapshot version: " << op_replication.txn_meta().snapshot_version()
+                         << ", new version: " << _new_version;
+            return Status::Corruption("mismatched snapshot version and new version");
+        }
+
+        if (!op_replication.txn_meta().incremental_snapshot()) {
+            _metadata->clear_rowsets();
+        }
+        for (const auto& op_write : op_replication.op_writes()) {
+            RETURN_IF_ERROR(apply_write_log(op_write));
+        }
         return Status::OK();
     }
 

--- a/be/src/storage/lake/vacuum.cpp
+++ b/be/src/storage/lake/vacuum.cpp
@@ -233,6 +233,12 @@ std::future<Status> delete_files_callable(std::vector<std::string> files_to_dele
     return task->get_future();
 }
 
+void run_clear_task_async(std::function<void()> task) {
+    auto tp = ExecEnv::GetInstance()->delete_file_thread_pool();
+    auto st = tp->submit_func(std::move(task));
+    LOG_IF(ERROR, !st.ok()) << st;
+}
+
 static Status collect_garbage_files(const TabletMetadataPB& metadata, const std::string& base_dir,
                                     AsyncFileDeleter* deleter, int64_t* garbage_data_size) {
     for (const auto& rowset : metadata.compaction_inputs()) {
@@ -373,11 +379,17 @@ static Status vacuum_txn_log(std::string_view root_location, int64_t min_active_
     auto ret = Status::OK();
     auto log_dir = join_path(root_location, kTxnLogDirectoryName);
     auto iter_st = ignore_not_found(fs->iterate_dir2(log_dir, [&](DirEntry entry) {
-        if (!is_txn_log(entry.name)) {
-            return true;
-        }
-        auto [tablet_id, txn_id] = parse_txn_log_filename(entry.name);
-        if (txn_id >= min_active_txn_id) {
+        if (is_txn_log(entry.name)) {
+            auto [tablet_id, txn_id] = parse_txn_log_filename(entry.name);
+            if (txn_id >= min_active_txn_id) {
+                return true;
+            }
+        } else if (is_txn_slog(entry.name)) {
+            auto [tablet_id, txn_id] = parse_txn_slog_filename(entry.name);
+            if (txn_id >= min_active_txn_id) {
+                return true;
+            }
+        } else {
             return true;
         }
 
@@ -465,6 +477,11 @@ Status delete_tablets_impl(TabletManager* tablet_mgr, const std::string& root_di
     RETURN_IF_ERROR(ignore_not_found(fs->iterate_dir(log_dir, [&](std::string_view name) {
         if (is_txn_log(name)) {
             auto [tablet_id, txn_id] = parse_txn_log_filename(name);
+            if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), tablet_id)) {
+                return true;
+            }
+        } else if (is_txn_slog(name)) {
+            auto [tablet_id, txn_id] = parse_txn_slog_filename(name);
             if (!std::binary_search(tablet_ids.begin(), tablet_ids.end(), tablet_id)) {
                 return true;
             }

--- a/be/src/storage/lake/vacuum.h
+++ b/be/src/storage/lake/vacuum.h
@@ -49,4 +49,7 @@ void delete_files_async(std::vector<std::string> files_to_delete);
 // it can be executed in parallel to other requests
 std::future<Status> delete_files_callable(std::vector<std::string> files_to_delete);
 
+// Run a clear task async
+void run_clear_task_async(std::function<void()> task);
+
 } // namespace starrocks::lake

--- a/be/src/storage/olap_define.h
+++ b/be/src/storage/olap_define.h
@@ -74,6 +74,7 @@ static const std::string REJECTED_RECORD_PREFIX = "/rejected_record"; // NOLINT
 static const std::string CLONE_PREFIX = "/clone";                     // NOLINT
 static const std::string TMP_PREFIX = "/tmp";                         // NOLINT
 static const std::string PERSISTENT_INDEX_PREFIX = "/persistent";     // NOLINT
+static const std::string REPLICATION_PREFIX = "/replication";         // NOLINT
 
 static const int32_t OLAP_DATA_VERSION_APPLIED = STARROCKS_V1;
 

--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -53,6 +53,7 @@
 #include "storage/olap_define.h"
 #include "storage/persistent_index_compaction_manager.h"
 #include "storage/publish_version_manager.h"
+#include "storage/replication_txn_manager.h"
 #include "storage/storage_engine.h"
 #include "storage/tablet_manager.h"
 #include "storage/update_manager.h"
@@ -240,6 +241,10 @@ Status StorageEngine::start_bg_threads() {
             Thread::set_thread_name(_path_gc_threads.back(), "path_gc");
         }
     }
+
+    _clear_expired_replcation_snapshots_thread =
+            std::thread([this]() { _clear_expired_replication_snapshots_callback(nullptr); });
+    Thread::set_thread_name(_clear_expired_replcation_snapshots_thread, "clear_expiired_replication_snapshots");
 
     if (!config::disable_storage_page_cache) {
         _adjust_cache_thread = std::thread([this] { _adjust_pagecache_callback(nullptr); });
@@ -829,6 +834,27 @@ void* StorageEngine::_path_scan_thread_callback(void* arg) {
             LOG(WARNING) << "path gc thread check interval config is illegal:" << interval
                          << "will be forced set to one day";
             interval = 24 * 3600; // one day
+        }
+        SLEEP_IN_BG_WORKER(interval);
+    }
+
+    return nullptr;
+}
+
+void* StorageEngine::_clear_expired_replication_snapshots_callback(void* arg) {
+#ifdef GOOGLE_PROFILER
+    ProfilerRegisterThread();
+#endif
+
+    while (!_bg_worker_stopped.load(std::memory_order_consume)) {
+        LOG(INFO) << "try to clear expired replication snapshots!";
+        replication_txn_manager()->clear_expired_snapshots();
+
+        int32_t interval = config::clear_expired_replcation_snapshots_interval_seconds;
+        if (interval <= 0) {
+            LOG(WARNING) << "clear expired replcation snapshots interval seconds config is illegal:" << interval
+                         << "will be forced set to one hour";
+            interval = 3600; // 1 hour
         }
         SLEEP_IN_BG_WORKER(interval);
     }

--- a/be/src/storage/protobuf_file.h
+++ b/be/src/storage/protobuf_file.h
@@ -51,6 +51,8 @@ public:
 
     Status load(::google::protobuf::Message* message, bool fill_cache = true);
 
+    static Status load(::google::protobuf::Message* message, std::string_view data);
+
 private:
     std::string _path;
 };

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -1,0 +1,790 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/replication_txn_manager.h"
+
+#include <fmt/format.h>
+#include <sys/stat.h>
+
+#include <filesystem>
+#include <set>
+
+#include "agent/agent_server.h"
+#include "agent/master_info.h"
+#include "agent/task_signatures_manager.h"
+#include "fs/fs.h"
+#include "gen_cpp/BackendService.h"
+#include "gen_cpp/Types_constants.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/stringpiece.h"
+#include "gutil/strings/substitute.h"
+#include "http/http_client.h"
+#include "runtime/client_cache.h"
+#include "runtime/current_thread.h"
+#include "runtime/exec_env.h"
+#include "service/backend_options.h"
+#include "storage/protobuf_file.h"
+#include "storage/replication_utils.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/snapshot_manager.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_updates.h"
+#include "util/defer_op.h"
+#include "util/string_parser.hpp"
+#include "util/thrift_rpc_helper.h"
+
+namespace starrocks {
+
+static string version_list_to_string(const std::vector<Version>& versions) {
+    std::ostringstream str;
+    size_t last = 0;
+    for (size_t i = last + 1; i <= versions.size(); i++) {
+        if (i == versions.size() || versions[last].second + 1 != versions[i].first) {
+            if (versions[last].first == versions[i - 1].second) {
+                str << versions[last].first << ",";
+            } else {
+                str << versions[last].first << "-" << versions[i - 1].second << ",";
+            }
+            last = i;
+        }
+    }
+    return str.str();
+}
+
+static std::string get_txn_dir_path(DataDir* data_dir, TTransactionId transaction_id) {
+    return fmt::format("{}/{}/", data_dir->get_replication_path(), transaction_id);
+}
+
+static std::string get_tablet_txn_dir_path(DataDir* data_dir, TTransactionId transaction_id, TPartitionId partition_id,
+                                           TTabletId tablet_id) {
+    return fmt::format("{}/{}/{}/{}/", data_dir->get_replication_path(), transaction_id, partition_id, tablet_id);
+}
+
+static std::string get_tablet_snapshot_dir_path(DataDir* data_dir, TTransactionId transaction_id,
+                                                TPartitionId partition_id, TTabletId tablet_id) {
+    return fmt::format("{}/{}/{}/{}/snapshot/", data_dir->get_replication_path(), transaction_id, partition_id,
+                       tablet_id);
+}
+
+static std::string get_tablet_txn_meta_file_path(DataDir* data_dir, TTransactionId transaction_id,
+                                                 TPartitionId partition_id, TTabletId tablet_id) {
+    return fmt::format("{}/{}/{}/{}/txn_meta", data_dir->get_replication_path(), transaction_id, partition_id,
+                       tablet_id);
+}
+
+static std::string get_tablet_txn_meta_file_path(const std::string& tablet_txn_dir_path) {
+    return tablet_txn_dir_path + "txn_meta";
+}
+
+Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
+                                              bool* incremental_snapshot) {
+    ASSIGN_OR_RETURN(auto tablet, get_tablet(request.tablet_id));
+
+    ReplicationTxnMetaPB txn_meta_pb;
+    Status status = load_tablet_txn_meta(tablet->data_dir(), request.transaction_id, request.partition_id,
+                                         request.tablet_id, txn_meta_pb);
+    if (status.ok()) {
+        if (txn_meta_pb.txn_state() >= ReplicationTxnStatePB::TXN_SNAPSHOTED &&
+            txn_meta_pb.snapshot_version() == request.src_visible_version) {
+            LOG(INFO) << "Tablet " << request.tablet_id << " already made remote snapshot"
+                      << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                      << ", src_tablet_id: " << request.src_tablet_id
+                      << ", visible_version: " << request.visible_version
+                      << ", snapshot_version: " << request.src_visible_version;
+            return Status::OK();
+        }
+    }
+
+    // TODO: Primary key
+    std::vector<Version> missed_versions;
+    tablet->calc_missed_versions(request.src_visible_version, &missed_versions);
+    if (missed_versions.empty()) {
+        LOG(WARNING) << "Remote snapshot tablet skipped, no missing version"
+                     << ", type: " << KeysType_Name(tablet->keys_type()) << ", txn_id: " << request.transaction_id
+                     << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                     << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
+                     << ", snapshot_version: " << request.src_visible_version;
+        return Status::Corruption("No missing version");
+    }
+
+    LOG(INFO) << "Remote snapshot tablet. "
+              << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+              << ", type: " << KeysType_Name(tablet->keys_type()) << ", src_tablet_id: " << request.src_tablet_id
+              << ", visible version: " << request.visible_version
+              << ", snapshot version: " << request.src_visible_version
+              << ", missed_versions=" << version_list_to_string(missed_versions);
+
+    TBackend src_backend;
+    *incremental_snapshot = true;
+    status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
+    if (!status.ok()) {
+        LOG(INFO) << "Fail to make incremental snapshot: " << status << ", txn_id: " << request.transaction_id
+                  << ", switch to fully snapshot. tablet_id: " << request.tablet_id
+                  << ", src_tablet_id: " << request.src_tablet_id << ", visible version: " << request.visible_version
+                  << ", snapshot version: " << request.src_visible_version;
+        *incremental_snapshot = false;
+        status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+    }
+
+    if (!status.ok()) {
+        LOG(WARNING) << "Fail to make remote snapshot: " << status << ", txn_id: " << request.transaction_id
+                     << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+                     << ", visible_version: " << request.visible_version
+                     << ", snapshot_version: " << request.src_visible_version;
+        return status;
+    }
+
+    txn_meta_pb.set_txn_id(request.transaction_id);
+    txn_meta_pb.set_txn_state(ReplicationTxnStatePB::TXN_SNAPSHOTED);
+    txn_meta_pb.set_tablet_id(request.tablet_id);
+    txn_meta_pb.set_visible_version(request.visible_version);
+    txn_meta_pb.set_src_backend_host(src_backend.host);
+    txn_meta_pb.set_src_backend_port(src_backend.be_port);
+    txn_meta_pb.set_src_snapshot_path(*src_snapshot_path);
+    txn_meta_pb.set_snapshot_version(request.src_visible_version);
+    txn_meta_pb.set_incremental_snapshot(*incremental_snapshot);
+
+    return save_tablet_txn_meta(tablet->data_dir(), request.transaction_id, request.partition_id, request.tablet_id,
+                                txn_meta_pb);
+}
+
+Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest& request) {
+    ASSIGN_OR_RETURN(auto tablet, get_tablet(request.tablet_id));
+
+    ReplicationTxnMetaPB txn_meta_pb;
+    Status status = load_tablet_txn_meta(tablet->data_dir(), request.transaction_id, request.partition_id,
+                                         request.tablet_id, txn_meta_pb);
+    if (status.ok()) {
+        if (txn_meta_pb.txn_state() >= ReplicationTxnStatePB::TXN_REPLICATED &&
+            txn_meta_pb.snapshot_version() == request.src_visible_version) {
+            LOG(INFO) << "Tablet " << request.tablet_id << " already replicated remote snapshot"
+                      << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                      << ", src_tablet_id: " << request.src_tablet_id
+                      << ", visible_version: " << request.visible_version
+                      << ", snapshot_version: " << request.src_visible_version;
+            return Status::OK();
+        }
+    }
+
+    std::string tablet_snapshot_dir_path = get_tablet_snapshot_dir_path(tablet->data_dir(), request.transaction_id,
+                                                                        request.partition_id, request.tablet_id);
+    for (const auto& src_snapshot_info : request.src_snapshot_infos) {
+        // Check local path exist, if exist, remove it, then create the dir
+        RETURN_IF_ERROR(fs::remove_all(tablet_snapshot_dir_path));
+        RETURN_IF_ERROR(fs::create_directories(tablet_snapshot_dir_path));
+
+        const TBackend& src_be = src_snapshot_info.backend;
+        const std::string& src_snapshot_path = src_snapshot_info.snapshot_path;
+
+        status = ReplicationUtils::download_remote_snapshot(
+                src_be.host, src_be.http_port, request.src_token, src_snapshot_path, request.src_tablet_id,
+                request.src_schema_hash, tablet->data_dir(), tablet_snapshot_dir_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to download snapshot from " << src_be.host << ":" << src_be.http_port << ":"
+                         << src_snapshot_path << ", " << status << ", txn_id: " << request.transaction_id
+                         << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            continue;
+        }
+
+        status = convert_tablet_meta_file(tablet_snapshot_dir_path, request);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to convert tablet meta file: " << status << ", txn_id: " << request.transaction_id
+                         << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            continue;
+        }
+
+        status = SnapshotManager::instance()->convert_rowset_ids(tablet_snapshot_dir_path, request.tablet_id,
+                                                                 request.schema_hash);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to convert rowset ids: " << status << ", txn_id: " << request.transaction_id
+                         << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            continue;
+        }
+
+        txn_meta_pb.set_txn_id(request.transaction_id);
+        txn_meta_pb.set_txn_state(ReplicationTxnStatePB::TXN_REPLICATED);
+        txn_meta_pb.set_tablet_id(request.tablet_id);
+        txn_meta_pb.set_visible_version(request.visible_version);
+        txn_meta_pb.set_snapshot_version(request.src_visible_version);
+        txn_meta_pb.set_incremental_snapshot(src_snapshot_info.incremental_snapshot);
+        status = save_tablet_txn_meta(tablet->data_dir(), request.transaction_id, request.partition_id,
+                                      request.tablet_id, txn_meta_pb);
+        RETURN_IF_ERROR(status);
+
+        LOG(INFO) << "Replicated snapshot from " << src_be.host << ":" << src_be.http_port << ":" << src_snapshot_path
+                  << " to " << tablet_snapshot_dir_path << ", txn_id: " << request.transaction_id
+                  << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+                  << ", visible_version: " << request.visible_version
+                  << ", snapshot_version: " << request.src_visible_version;
+        break;
+    }
+
+    return status;
+}
+
+Status ReplicationTxnManager::get_txn_related_tablets(const TTransactionId transaction_id, TPartitionId partition_id,
+                                                      std::vector<TTabletId>* tablet_ids) {
+    for (DataDir* data_dir : StorageEngine::instance()->get_stores()) {
+        std::string txn_dir_path = get_txn_dir_path(data_dir, transaction_id);
+        std::string partition_dir_path = txn_dir_path + std::to_string(partition_id) + '/';
+        if (!fs::path_exist(partition_dir_path)) {
+            continue;
+        }
+
+        std::set<std::string> tablet_dirs;
+        Status status = fs::list_dirs_files(partition_dir_path, &tablet_dirs, nullptr);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to list partition dir: " << partition_dir_path << ", " << status
+                         << ", txn_id: " << transaction_id;
+            return status;
+        }
+
+        for (const std::string& tablet_dir : tablet_dirs) {
+            TTabletId tablet_id = ::atoll(tablet_dir.c_str());
+            if (tablet_id == 0) {
+                LOG(WARNING) << "Invalid tablet dir name: " << tablet_dir << " in partition dir: " << partition_dir_path
+                             << ", txn_id: " << transaction_id;
+                return Status::InternalError("Invalid tablet dir name: " + tablet_dir);
+            }
+            tablet_ids->push_back(tablet_id);
+        }
+    }
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::publish_txn(TTransactionId transaction_id, TPartitionId partition_id,
+                                          const TabletSharedPtr& tablet, int64_t version) {
+    ReplicationTxnMetaPB txn_meta_pb;
+    RETURN_IF_ERROR(
+            load_tablet_txn_meta(tablet->data_dir(), transaction_id, partition_id, tablet->tablet_id(), txn_meta_pb));
+    if (txn_meta_pb.txn_state() == ReplicationTxnStatePB::TXN_PUBLISHED) {
+        return Status::OK();
+    }
+
+    if (txn_meta_pb.txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
+        LOG(WARNING) << "Fail to publish snapshot, invalid txn meta state, tablet_id: " << tablet->tablet_id()
+                     << ", partition_id: " << partition_id << ", txn_id: " << transaction_id
+                     << ", txn state: " << ReplicationTxnStatePB_Name(txn_meta_pb.txn_state());
+        return Status::Corruption("Invalid txn meta state: " + ReplicationTxnStatePB_Name(txn_meta_pb.txn_state()));
+    }
+
+    if (txn_meta_pb.snapshot_version() != version) {
+        LOG(WARNING) << "Fail to publish snapshot, missmatched version, tablet_id: " << tablet->tablet_id()
+                     << ", partition_id: " << partition_id << ", txn_id: " << transaction_id << ", version: " << version
+                     << ", snapshot version: " << txn_meta_pb.snapshot_version();
+        return Status::Corruption("Missmatched version");
+    }
+
+    std::string snapshot_dir_path =
+            get_tablet_snapshot_dir_path(tablet->data_dir(), transaction_id, partition_id, tablet->tablet_id());
+
+    return publish_snapshot(tablet.get(), snapshot_dir_path, version, txn_meta_pb.incremental_snapshot());
+}
+
+void ReplicationTxnManager::clear_expired_snapshots() {
+    int64_t min_active_txn_id = get_master_info().min_active_txn_id;
+
+    for (DataDir* data_dir : StorageEngine::instance()->get_stores()) {
+        std::string replication_path = data_dir->get_replication_path();
+        std::set<std::string> txn_dirs;
+        Status status = fs::list_dirs_files(replication_path, &txn_dirs, nullptr);
+        if (!status.ok()) {
+            continue;
+        }
+
+        for (const std::string& txn_dir : txn_dirs) {
+            int64_t txn_id = ::atoll(txn_dir.c_str());
+            if (txn_id != 0 && txn_id < min_active_txn_id) {
+                clear_txn_snapshots(txn_id);
+            }
+        }
+    }
+}
+
+Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest& request,
+                                                   const std::vector<Version>* missed_versions,
+                                                   const std::vector<int64_t>* missing_version_ranges,
+                                                   TBackend* src_backend, std::string* src_snapshot_path) {
+    int timeout_s = 0;
+    if (request.__isset.timeout_sec) {
+        timeout_s = request.timeout_sec;
+    }
+
+    Status status;
+    for (const auto& src_be : request.src_backends) {
+        // Make snapshot in remote olap engine
+        status = ReplicationUtils::make_remote_snapshot(src_be.host, src_be.be_port, request.src_tablet_id,
+                                                        request.src_schema_hash, request.src_visible_version, timeout_s,
+                                                        missed_versions, missing_version_ranges, src_snapshot_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to make snapshot from " << src_be.host << ", " << status
+                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                         << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            continue;
+        }
+
+        *src_backend = src_be;
+        LOG(INFO) << "Made snapshot from " << src_be.host << ", txn_id: " << request.transaction_id
+                  << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+                  << ", visible_version: " << request.visible_version
+                  << ", snapshot_version: " << request.src_visible_version;
+        break;
+    }
+
+    return status;
+}
+
+Status ReplicationTxnManager::convert_tablet_meta_file(const std::string& tablet_snapshot_path,
+                                                       const TReplicateSnapshotRequest& request) {
+    std::string src_header_file_path = tablet_snapshot_path + std::to_string(request.src_tablet_id) + ".hdr";
+    if (fs::path_exist(src_header_file_path)) {
+        TabletMeta tablet_meta;
+        Status status = tablet_meta.create_from_file(src_header_file_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to load tablet meta from " << src_header_file_path << ", " << status
+                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                         << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            return status;
+        }
+
+        TabletMetaPB tablet_meta_pb;
+        tablet_meta.to_meta_pb(&tablet_meta_pb);
+        tablet_meta_pb.set_table_id(request.table_id);
+        tablet_meta_pb.set_partition_id(request.partition_id);
+        tablet_meta_pb.set_tablet_id(request.tablet_id);
+
+        std::string header_file_path = tablet_snapshot_path + std::to_string(request.tablet_id) + ".hdr";
+        status = TabletMeta::save(header_file_path, tablet_meta_pb);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to save tablet meta pb to " << header_file_path << ", " << status
+                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                         << ", src_tablet_id: " << request.src_tablet_id
+                         << ", visible_version: " << request.visible_version
+                         << ", snapshot_version: " << request.src_visible_version;
+            return status;
+        }
+
+        if (request.tablet_id != request.src_tablet_id) {
+            status = fs::remove(src_header_file_path);
+            if (!status.ok()) {
+                LOG(WARNING) << "Fail to remove tablet meta " << src_header_file_path << ", " << status
+                             << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                             << ", src_tablet_id: " << request.src_tablet_id
+                             << ", visible_version: " << request.visible_version
+                             << ", snapshot_version: " << request.src_visible_version;
+            }
+        }
+
+        return status;
+    }
+
+    // TODO: convert meta file and dcgs_snapshot file
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,
+                                               bool incremental_snapshot) {
+    if (tablet->updates() != nullptr) {
+        return Status::NotSupported("Pk table not supported");
+    }
+
+    Status res;
+    std::vector<std::string> linked_success_files;
+
+    // clone and compaction operation should be performed sequentially
+    tablet->obtain_base_compaction_lock();
+    DeferOp base_compaction_lock_release_guard([&tablet]() { tablet->release_base_compaction_lock(); });
+
+    tablet->obtain_cumulative_lock();
+    DeferOp cumulative_lock_release_guard([&tablet]() { tablet->release_cumulative_lock(); });
+
+    tablet->obtain_push_lock();
+    DeferOp push_lock_release_guard([&tablet]() { tablet->release_push_lock(); });
+
+    tablet->obtain_header_wrlock();
+    DeferOp header_wrlock_release_guard([&tablet]() { tablet->release_header_lock(); });
+
+    do {
+        // load src header
+        std::string header_file = strings::Substitute("$0/$1.hdr", snapshot_dir, tablet->tablet_id());
+        std::string dcgs_snapshot_file = strings::Substitute("$0/$1.dcgs_snapshot", snapshot_dir, tablet->tablet_id());
+        TabletMeta cloned_tablet_meta;
+        res = cloned_tablet_meta.create_from_file(header_file);
+        if (!res.ok()) {
+            LOG(WARNING) << "Fail to load load tablet meta from " << header_file;
+            break;
+        }
+
+        DeltaColumnGroupSnapshotPB dcg_snapshot_pb;
+        bool has_dcgs_snapshot_file = fs::path_exist(dcgs_snapshot_file);
+        if (has_dcgs_snapshot_file) {
+            res = DeltaColumnGroupListHelper::parse_snapshot(dcgs_snapshot_file, dcg_snapshot_pb);
+            if (!res.ok()) {
+                LOG(WARNING) << "Fail to load load dcg snapshot from " << dcgs_snapshot_file;
+                break;
+            }
+        }
+
+        std::set<std::string> clone_files;
+        res = fs::list_dirs_files(snapshot_dir, nullptr, &clone_files);
+        if (!res.ok()) {
+            LOG(WARNING) << "Fail to list directory " << snapshot_dir << ": " << res;
+            break;
+        }
+
+        clone_files.erase(strings::Substitute("$0.hdr", tablet->tablet_id()));
+        if (has_dcgs_snapshot_file) {
+            clone_files.erase(strings::Substitute("$0.dcgs_snapshot", tablet->tablet_id()));
+        }
+
+        std::set<string> local_files;
+        std::string tablet_dir = tablet->schema_hash_path();
+        res = fs::list_dirs_files(tablet_dir, nullptr, &local_files);
+        if (!res.ok()) {
+            LOG(WARNING) << "Fail to list tablet directory " << tablet_dir << ": " << res;
+            break;
+        }
+
+        // link files from clone dir, if file exists, skip it
+        for (const string& clone_file : clone_files) {
+            if (local_files.find(clone_file) != local_files.end()) {
+                VLOG(3) << "find same file when clone, skip it. "
+                        << "tablet=" << tablet->full_name() << ", clone_file=" << clone_file;
+                continue;
+            }
+
+            std::string from = strings::Substitute("$0/$1", snapshot_dir, clone_file);
+            std::string to = strings::Substitute("$0/$1", tablet_dir, clone_file);
+            res = FileSystem::Default()->link_file(from, to);
+            if (!res.ok()) {
+                LOG(WARNING) << "Fail to link " << from << " to " << to << ": " << res;
+                break;
+            }
+            linked_success_files.emplace_back(std::move(to));
+        }
+        if (!res.ok()) {
+            break;
+        }
+        LOG(INFO) << "Linked " << clone_files.size() << " files from " << snapshot_dir << " to " << tablet_dir;
+
+        std::vector<RowsetMetaSharedPtr> rs_to_clone;
+        if (incremental_snapshot) {
+            res = publish_incremental_meta(tablet, cloned_tablet_meta, snapshot_version);
+        } else {
+            res = publish_full_meta(tablet, &cloned_tablet_meta, rs_to_clone);
+        }
+
+        // if full clone success, need to update cumulative layer point
+        if (!incremental_snapshot && res.ok()) {
+            tablet->set_cumulative_layer_point(-1);
+        }
+
+        // recover dcg meta
+        if (has_dcgs_snapshot_file && rs_to_clone.size() != 0) {
+            auto data_dir = tablet->data_dir();
+            rocksdb::WriteBatch wb;
+            for (const auto& rs_meta : rs_to_clone) {
+                int idx = 0;
+                for (const auto& rowset_id : dcg_snapshot_pb.rowset_id()) {
+                    if (rowset_id != rs_meta->rowset_id().to_string()) {
+                        ++idx;
+                        continue;
+                    }
+                    // dcgs for each segment
+                    auto& dcg_list_pb = dcg_snapshot_pb.dcg_lists(idx);
+                    DeltaColumnGroupList dcgs;
+                    RETURN_IF_ERROR(
+                            DeltaColumnGroupListSerializer::deserialize_delta_column_group_list(dcg_list_pb, &dcgs));
+
+                    if (dcgs.size() == 0) {
+                        continue;
+                    }
+
+                    RETURN_IF_ERROR(TabletMetaManager::put_delta_column_group(
+                            data_dir, &wb, dcg_snapshot_pb.tablet_id(idx), dcg_snapshot_pb.rowset_id(idx),
+                            dcg_snapshot_pb.segment_id(idx), dcgs));
+                    ++idx;
+                }
+            }
+            res = data_dir->get_meta()->write_batch(&wb);
+            if (!res.ok()) {
+                std::stringstream ss;
+                ss << "save dcgs meta failed, tablet id: " << tablet->tablet_id();
+                LOG(WARNING) << ss.str();
+                return Status::InternalError(ss.str());
+            }
+        }
+    } while (false);
+
+    // clear linked files if errors happen
+    if (!res.ok()) {
+        (void)fs::remove(linked_success_files);
+    }
+
+    return res;
+}
+
+Status ReplicationTxnManager::publish_incremental_meta(Tablet* tablet, const TabletMeta& cloned_tablet_meta,
+                                                       int64_t snapshot_version) {
+    LOG(INFO) << "begin to publish incremental meta. tablet=" << tablet->full_name()
+              << ", snapshot_version=" << snapshot_version;
+
+    std::vector<Version> missed_versions;
+    tablet->calc_missed_versions_unlocked(snapshot_version, &missed_versions);
+
+    std::vector<Version> versions_to_delete;
+    std::vector<RowsetMetaSharedPtr> rowsets_to_clone;
+
+    VLOG(3) << "get missed versions again when publish incremental meta. "
+            << "tablet=" << tablet->full_name() << ", snapshot_version=" << snapshot_version
+            << ", missed_versions_size=" << missed_versions.size();
+
+    // check missing versions exist in clone src
+    for (Version version : missed_versions) {
+        RowsetMetaSharedPtr inc_rs_meta = cloned_tablet_meta.acquire_inc_rs_meta_by_version(version);
+        if (inc_rs_meta == nullptr) {
+            LOG(WARNING) << "missed version is not found in cloned tablet meta."
+                         << ", missed_version=" << version.first << "-" << version.second;
+            return Status::NotFound(strings::Substitute("version not found"));
+        }
+
+        rowsets_to_clone.push_back(inc_rs_meta);
+    }
+
+    // clone_data to tablet
+    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
+    LOG(INFO) << "finish to publish incremental meta. [tablet=" << tablet->full_name() << ", status=" << st << "]";
+    return st;
+}
+
+Status ReplicationTxnManager::publish_full_meta(Tablet* tablet, TabletMeta* cloned_tablet_meta,
+                                                std::vector<RowsetMetaSharedPtr>& rs_to_clone) {
+    Version cloned_max_version = cloned_tablet_meta->max_version();
+    LOG(INFO) << "begin to publish full meta. tablet=" << tablet->full_name()
+              << ", cloned_max_version=" << cloned_max_version.first << "-" << cloned_max_version.second;
+    std::vector<Version> versions_to_delete;
+    std::vector<RowsetMetaSharedPtr> rs_metas_found_in_src;
+    // check local versions
+    for (auto& rs_meta : tablet->tablet_meta()->all_rs_metas()) {
+        Version local_version(rs_meta->start_version(), rs_meta->end_version());
+        LOG(INFO) << "check local delta when publish full snapshot."
+                  << "tablet=" << tablet->full_name() << ", local_version=" << local_version.first << "-"
+                  << local_version.second;
+
+        // if local version cross src latest, clone failed
+        // if local version is : 0-0, 1-1, 2-10, 12-14, 15-15,16-16
+        // cloned max version is 13-13, this clone is failed, because could not
+        // fill local data by using cloned data.
+        // It should not happen because if there is a hole, the following delta will not
+        // do compaction.
+        if (local_version.first <= cloned_max_version.second && local_version.second > cloned_max_version.second) {
+            LOG(WARNING) << "stop to publish full snapshot, version cross src latest."
+                         << "tablet=" << tablet->full_name() << ", local_version=" << local_version.first << "-"
+                         << local_version.second;
+            return Status::InternalError("clone version conflict with local version");
+
+        } else if (local_version.second <= cloned_max_version.second) {
+            // if local version smaller than src, check if existed in src, will not clone it
+            bool existed_in_src = false;
+
+            // if delta labeled with local_version is same with the specified version in clone header,
+            // there is no necessity to clone it.
+            for (auto& rs_meta : cloned_tablet_meta->all_rs_metas()) {
+                if (rs_meta->version().first == local_version.first &&
+                    rs_meta->version().second == local_version.second) {
+                    existed_in_src = true;
+                    break;
+                }
+            }
+
+            if (existed_in_src) {
+                cloned_tablet_meta->delete_rs_meta_by_version(local_version, &rs_metas_found_in_src);
+                LOG(INFO) << "Delta has already existed in local header, no need to clone."
+                          << "tablet=" << tablet->full_name() << ", version='" << local_version.first << "-"
+                          << local_version.second;
+            } else {
+                // Delta labeled in local_version is not existed in clone header,
+                // some overlapping delta will be cloned to replace it.
+                // And also, the specified delta should deleted from local header.
+                versions_to_delete.push_back(local_version);
+                LOG(INFO) << "Delete delta not included by the clone header, should delete it from "
+                             "local header."
+                          << "tablet=" << tablet->full_name() << ","
+                          << ", version=" << local_version.first << "-" << local_version.second;
+            }
+        }
+    }
+
+    std::vector<RowsetMetaSharedPtr> rowsets_to_clone;
+    for (auto& rs_meta : cloned_tablet_meta->all_rs_metas()) {
+        rowsets_to_clone.push_back(rs_meta);
+        LOG(INFO) << "Delta to clone."
+                  << "tablet=" << tablet->full_name() << ", version=" << rs_meta->version().first << "-"
+                  << rs_meta->version().second;
+    }
+    rs_to_clone = rowsets_to_clone;
+
+    // clone_data to tablet
+    Status st = tablet->revise_tablet_meta(rowsets_to_clone, versions_to_delete);
+    LOG(INFO) << "finish to full clone. tablet=" << tablet->full_name() << ", res=" << st;
+    // in previous step, copy all files from CLONE_DIR to tablet dir
+    // but some rowset is useless, so that remove them here
+    for (auto& rs_meta_ptr : rs_metas_found_in_src) {
+        RowsetSharedPtr rowset_to_remove;
+        if (auto s = RowsetFactory::create_rowset(cloned_tablet_meta->tablet_schema_ptr(), tablet->schema_hash_path(),
+                                                  rs_meta_ptr, &rowset_to_remove);
+            !s.ok()) {
+            LOG(WARNING) << "failed to init rowset to remove: " << rs_meta_ptr->rowset_id().to_string();
+            continue;
+        }
+        if (auto ost = rowset_to_remove->remove(); !ost.ok()) {
+            LOG(WARNING) << "failed to remove rowset " << rs_meta_ptr->rowset_id().to_string() << ", res=" << ost;
+        }
+    }
+    return st;
+}
+
+void ReplicationTxnManager::clear_txn_snapshots(TTransactionId transaction_id) {
+    for (DataDir* data_dir : StorageEngine::instance()->get_stores()) {
+        std::string txn_dir_path = get_txn_dir_path(data_dir, transaction_id);
+        if (!fs::path_exist(txn_dir_path)) {
+            continue;
+        }
+
+        std::set<std::string> partition_dirs;
+        Status status = fs::list_dirs_files(txn_dir_path, &partition_dirs, nullptr);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to list txn dir: " << txn_dir_path << ", " << status
+                         << ", txn_id: " << transaction_id;
+            continue;
+        }
+
+        for (const std::string& partition_dir : partition_dirs) {
+            std::string partition_dir_path = txn_dir_path + partition_dir + '/';
+            std::set<std::string> tablet_dirs;
+            status = fs::list_dirs_files(partition_dir_path, &tablet_dirs, nullptr);
+            if (!status.ok()) {
+                LOG(WARNING) << "Fail to list partition dir: " << partition_dir_path << ", " << status
+                             << ", txn_id: " << transaction_id;
+                continue;
+            }
+
+            for (const std::string& tablet_dir : tablet_dirs) {
+                std::string tablet_dir_path = partition_dir_path + tablet_dir + '/';
+                ReplicationTxnMetaPB txn_meta_pb;
+                status = load_tablet_txn_meta(tablet_dir_path, txn_meta_pb);
+                if (!status.ok()) {
+                    continue;
+                }
+
+                const std::string& src_backend_host = txn_meta_pb.src_backend_host();
+                int32_t src_backend_port = txn_meta_pb.src_backend_port();
+                const std::string& src_snapshot_path = txn_meta_pb.src_snapshot_path();
+                if (src_backend_host.empty() || src_backend_port == 0 || src_snapshot_path.empty()) {
+                    continue;
+                }
+
+                (void)ReplicationUtils::release_remote_snapshot(src_backend_host, src_backend_port, src_snapshot_path);
+            }
+        }
+
+        status = fs::remove_all(txn_dir_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to remove txn dir: " << txn_dir_path << ", " << status
+                         << ", txn_id: " << transaction_id;
+        } else {
+            LOG(INFO) << "Removed txn dir: " << txn_dir_path << ", txn_id: " << transaction_id;
+        }
+    }
+}
+
+Status ReplicationTxnManager::save_tablet_txn_meta(DataDir* data_dir, TTransactionId transaction_id,
+                                                   TPartitionId partition_id, TTabletId tablet_id,
+                                                   const ReplicationTxnMetaPB& txn_meta) {
+    std::string tablet_txn_dir_path = get_tablet_txn_dir_path(data_dir, transaction_id, partition_id, tablet_id);
+    if (!fs::path_exist(tablet_txn_dir_path)) {
+        Status status = fs::create_directories(tablet_txn_dir_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to create directory " << tablet_txn_dir_path << ", " << status
+                         << ", txn_id: " << transaction_id;
+            return status;
+        }
+    }
+
+    return save_tablet_txn_meta(tablet_txn_dir_path, txn_meta);
+}
+
+Status ReplicationTxnManager::save_tablet_txn_meta(const std::string& tablet_txn_dir_path,
+                                                   const ReplicationTxnMetaPB& txn_meta) {
+    std::string tablet_txn_meta_file_path = get_tablet_txn_meta_file_path(tablet_txn_dir_path);
+    std::string tmp_tablet_txn_meta_file_path = tablet_txn_meta_file_path + ".temp";
+    ProtobufFileWithHeader file(tmp_tablet_txn_meta_file_path);
+    Status status = file.save(txn_meta, true);
+    if (!status.ok()) {
+        LOG(WARNING) << "Fail to save txn meta to " << tmp_tablet_txn_meta_file_path << ", " << status;
+        return status;
+    }
+
+    if (0 != rename(tmp_tablet_txn_meta_file_path.c_str(), tablet_txn_meta_file_path.c_str())) {
+        LOG(WARNING) << "Fail to rename txn meta file from " << tmp_tablet_txn_meta_file_path << " to "
+                     << tablet_txn_meta_file_path << ", " << strerror(errno);
+        return Status::IOError(strerror(errno));
+    }
+
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::load_tablet_txn_meta(DataDir* data_dir, TTransactionId transaction_id,
+                                                   TPartitionId partition_id, TTabletId tablet_id,
+                                                   ReplicationTxnMetaPB& txn_meta) {
+    std::string tablet_txn_meta_file_path =
+            get_tablet_txn_meta_file_path(data_dir, transaction_id, partition_id, tablet_id);
+    ProtobufFileWithHeader file(tablet_txn_meta_file_path);
+    return file.load(&txn_meta);
+}
+
+Status ReplicationTxnManager::load_tablet_txn_meta(const std::string& tablet_txn_dir_path,
+                                                   ReplicationTxnMetaPB& txn_meta) {
+    std::string tablet_txn_meta_file_path = get_tablet_txn_meta_file_path(tablet_txn_dir_path);
+    ProtobufFileWithHeader file(tablet_txn_meta_file_path);
+    Status status = file.load(&txn_meta);
+    if (!status.ok()) {
+        LOG(WARNING) << "Fail to load txn meta from " << tablet_txn_meta_file_path << ", " << status;
+    }
+    return status;
+}
+
+StatusOr<TabletSharedPtr> ReplicationTxnManager::get_tablet(TTabletId tablet_id) {
+    auto tablet_manager = StorageEngine::instance()->tablet_manager();
+    std::string error_msg;
+    auto tablet = tablet_manager->get_tablet(tablet_id, false, &error_msg);
+    if (tablet == nullptr) {
+        LOG(WARNING) << "Cannot get tablet " << tablet_id << ", " << error_msg;
+        return Status::NotFound(error_msg);
+    }
+    return tablet;
+}
+
+} // namespace starrocks

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -653,8 +653,8 @@ Status ReplicationTxnManager::publish_full_meta(Tablet* tablet, TabletMeta* clon
     // but some rowset is useless, so that remove them here
     for (auto& rs_meta_ptr : rs_metas_found_in_src) {
         RowsetSharedPtr rowset_to_remove;
-        if (auto s = RowsetFactory::create_rowset(cloned_tablet_meta->tablet_schema_ptr(), tablet->schema_hash_path(),
-                                                  rs_meta_ptr, &rowset_to_remove);
+        if (auto s = RowsetFactory::create_rowset(cloned_tablet_meta->tablet_schema_ptr().get(),
+                                                  tablet->schema_hash_path(), rs_meta_ptr, &rowset_to_remove);
             !s.ok()) {
             LOG(WARNING) << "failed to init rowset to remove: " << rs_meta_ptr->rowset_id().to_string();
             continue;

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "storage/storage_engine.h"
+
+namespace starrocks {
+
+class ReplicationTxnManager {
+public:
+    explicit ReplicationTxnManager() {}
+
+    Status remote_snapshot(const TRemoteSnapshotRequest& request, std::string* src_snapshot_path,
+                           bool* incremental_snapshot);
+
+    Status replicate_snapshot(const TReplicateSnapshotRequest& request);
+
+    Status get_txn_related_tablets(const TTransactionId transaction_id, TPartitionId partition_id,
+                                   std::vector<TTabletId>* tablet_ids);
+
+    Status publish_txn(TTransactionId transaction_id, TPartitionId partition_id, const TabletSharedPtr& tablet,
+                       int64_t version);
+
+    void clear_txn(TTransactionId transaction_id) { clear_txn_snapshots(transaction_id); }
+
+    void clear_expired_snapshots();
+
+    DISALLOW_COPY_AND_MOVE(ReplicationTxnManager);
+
+private:
+    Status make_remote_snapshot(const TRemoteSnapshotRequest& request, const std::vector<Version>* missed_versions,
+                                const std::vector<int64_t>* missing_version_ranges, TBackend* src_backend,
+                                std::string* src_snapshot_path);
+
+    Status convert_tablet_meta_file(const std::string& tablet_snapshot_path, const TReplicateSnapshotRequest& request);
+
+    Status publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,
+                            bool incremental_snapshot);
+
+    Status publish_incremental_meta(Tablet* tablet, const TabletMeta& cloned_tablet_meta, int64_t snapshot_version);
+
+    Status publish_full_meta(Tablet* tablet, TabletMeta* cloned_tablet_meta,
+                             std::vector<RowsetMetaSharedPtr>& rs_to_clone);
+
+    Status publish_snapshot_primary(Tablet* tablet, const std::string& snapshot_dir);
+
+    void clear_txn_snapshots(TTransactionId transaction_id);
+
+    Status save_tablet_txn_meta(DataDir* data_dir, TTransactionId transaction_id, TPartitionId partition_id,
+                                TTabletId tablet_id, const ReplicationTxnMetaPB& txn_meta);
+
+    Status save_tablet_txn_meta(const std::string& tablet_txn_dir_path, const ReplicationTxnMetaPB& txn_meta);
+
+    Status load_tablet_txn_meta(DataDir* data_dir, TTransactionId transaction_id, TPartitionId partition_id,
+                                TTabletId tablet_id, ReplicationTxnMetaPB& txn_meta);
+
+    Status load_tablet_txn_meta(const std::string& tablet_txn_dir_path, ReplicationTxnMetaPB& txn_meta);
+
+    StatusOr<TabletSharedPtr> get_tablet(TTabletId tablet_id);
+};
+
+} // namespace starrocks

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "gutil/macros.h"
 #include "storage/storage_engine.h"
 
 namespace starrocks {

--- a/be/src/storage/replication_utils.cpp
+++ b/be/src/storage/replication_utils.cpp
@@ -1,0 +1,320 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/replication_utils.h"
+
+#include <sys/stat.h>
+
+#ifdef BE_TEST
+#include "agent/agent_server.h"
+#endif
+
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/BackendService.h"
+#include "gen_cpp/Types_constants.h"
+#include "gutil/strings/split.h"
+#include "gutil/strings/stringpiece.h"
+#include "gutil/strings/substitute.h"
+#include "http/http_client.h"
+#include "runtime/client_cache.h"
+#include "service/backend_options.h"
+#include "util/string_parser.hpp"
+#include "util/thrift_rpc_helper.h"
+
+namespace starrocks {
+
+const std::string HTTP_REQUEST_PREFIX = "/api/_tablet/_download";
+const uint32_t DOWNLOAD_FILE_MAX_RETRY = 3;
+const uint32_t LIST_REMOTE_FILE_TIMEOUT = 15;
+const uint32_t GET_LENGTH_TIMEOUT = 10;
+
+#ifndef BE_TEST
+static Status list_remote_files(const std::string& remote_url_prefix, std::vector<string>* file_name_list,
+                                std::vector<int64_t>* file_size_list) {
+    // Get remote dir file list
+    string file_list_str;
+    auto list_files_cb = [&remote_url_prefix, &file_list_str](HttpClient* client) {
+        RETURN_IF_ERROR(client->init(remote_url_prefix));
+        client->set_timeout_ms(LIST_REMOTE_FILE_TIMEOUT * 1000);
+        RETURN_IF_ERROR(client->execute(&file_list_str));
+        return Status::OK();
+    };
+    RETURN_IF_ERROR(HttpClient::execute_with_retry(DOWNLOAD_FILE_MAX_RETRY, 1, list_files_cb));
+
+    // Parse file name and size
+    const char* const FILE_DELIMETER_IN_DIR_RESPONSE = "\n";
+    const char* const FILE_NAME_SIZE_DELIMETER = "|";
+
+    bool use_file_name_and_size_format = file_list_str.find(FILE_NAME_SIZE_DELIMETER) != string::npos;
+    if (use_file_name_and_size_format) {
+        for (auto file_str : strings::Split(file_list_str, FILE_DELIMETER_IN_DIR_RESPONSE, strings::SkipWhitespace())) {
+            std::vector<string> list = strings::Split(file_str, FILE_NAME_SIZE_DELIMETER);
+            if (list.size() != 2) {
+                return Status::InternalError(fmt::format("invalid directory entry {}", file_str.as_string()));
+            }
+
+            StringParser::ParseResult result;
+            std::string& file_size_str = list[1];
+            auto file_size = StringParser::string_to_int<int64_t>(file_size_str.data(), file_size_str.size(), &result);
+            if (result != StringParser::PARSE_SUCCESS || file_size < 0) {
+                return Status::InternalError("wrong file size.");
+            }
+
+            file_name_list->emplace_back(std::move(list[0]));
+            file_size_list->emplace_back(file_size);
+        }
+    } else {
+        *file_name_list = strings::Split(file_list_str, FILE_DELIMETER_IN_DIR_RESPONSE, strings::SkipWhitespace());
+    }
+    return Status::OK();
+}
+
+static StatusOr<uint64_t> get_remote_file_size(const std::string& remote_file_url) {
+    uint64_t file_size = 0;
+    auto get_file_size_cb = [&remote_file_url, &file_size](HttpClient* client) {
+        RETURN_IF_ERROR(client->init(remote_file_url));
+        client->set_timeout_ms(GET_LENGTH_TIMEOUT * 1000);
+        RETURN_IF_ERROR(client->head());
+        file_size = client->get_content_length();
+        return Status::OK();
+    };
+    RETURN_IF_ERROR(HttpClient::execute_with_retry(DOWNLOAD_FILE_MAX_RETRY, 1, get_file_size_cb));
+    return file_size;
+}
+
+static StatusOr<uint64_t> download_remote_file(const std::string& remote_file_url, const std::string& local_file_path,
+                                               uint64_t timeout_sec) {
+    uint64_t file_size = 0;
+    auto download_cb = [&remote_file_url, timeout_sec, &local_file_path, &file_size](HttpClient* client) {
+        RETURN_IF_ERROR(client->init(remote_file_url));
+        client->set_timeout_ms(timeout_sec * 1000);
+        ASSIGN_OR_RETURN(file_size, client->download(local_file_path));
+        return Status::OK();
+    };
+    RETURN_IF_ERROR(HttpClient::execute_with_retry(DOWNLOAD_FILE_MAX_RETRY, 1, download_cb));
+    return file_size;
+}
+#endif
+
+Status ReplicationUtils::make_remote_snapshot(const std::string& host, int32_t be_port, TTabletId tablet_id,
+                                              TSchemaHash schema_hash, TVersion version, int32_t timeout_s,
+                                              const std::vector<Version>* missed_versions,
+                                              const std::vector<int64_t>* missing_version_ranges,
+                                              std::string* remote_snapshot_path) {
+    TSnapshotRequest request;
+    request.__set_tablet_id(tablet_id);
+    request.__set_schema_hash(schema_hash);
+    request.__set_preferred_snapshot_format(g_Types_constants.TPREFER_SNAPSHOT_REQ_VERSION);
+    if (missed_versions != nullptr) {
+        DCHECK(!missed_versions->empty());
+        request.__isset.missing_version = true;
+        for (auto& version : *missed_versions) {
+            // NOTE: assume missing version composed of singleton delta.
+            DCHECK_EQ(version.first, version.second);
+            request.missing_version.push_back(version.first);
+        }
+    }
+    if (missing_version_ranges != nullptr) {
+        DCHECK(!missing_version_ranges->empty());
+        request.__isset.missing_version_ranges = true;
+        for (auto v : *missing_version_ranges) {
+            request.missing_version_ranges.push_back(v);
+        }
+    }
+    if (version > 0) {
+        request.__set_version(version);
+    }
+    if (timeout_s > 0) {
+        request.__set_timeout(timeout_s);
+    }
+
+    TAgentResult result;
+
+#ifdef BE_TEST
+    ExecEnv::GetInstance()->agent_server()->make_snapshot(result, request);
+#else
+    // snapshot will hard link all required rowsets' segment files, the number of files may be very large(>1000),
+    // so it may take some time to process this rpc, so we increase rpc timeout from 5s to 20s to reduce the chance
+    // of timeout for now, we may need a smart way to estimate the time of make_snapshot in future
+    RETURN_IF_ERROR(ThriftRpcHelper::rpc<BackendServiceClient>(
+            host, be_port,
+            [&request, &result](BackendServiceConnection& client) { client->make_snapshot(result, request); },
+            config::make_snapshot_rpc_timeout_ms));
+#endif
+
+    if (result.status.status_code != TStatusCode::OK) {
+        return {result.status};
+    }
+
+    if (result.__isset.snapshot_path) {
+        *remote_snapshot_path = result.snapshot_path;
+        if (remote_snapshot_path->at(remote_snapshot_path->length() - 1) != '/') {
+            remote_snapshot_path->append("/");
+        }
+    } else {
+        return Status::InternalError("success snapshot without snapshot path");
+    }
+
+    if (result.snapshot_format != g_Types_constants.TSNAPSHOT_REQ_VERSION2) {
+        LOG(WARNING) << "Unsupported snapshot format version: " << result.snapshot_format << ", from: " << host
+                     << ", tablet: " << tablet_id;
+        return Status::NotSupported("Unsupported snapshot format version");
+    }
+
+    return Status::OK();
+}
+
+Status ReplicationUtils::release_remote_snapshot(const std::string& ip, int32_t port,
+                                                 const std::string& src_snapshot_path) {
+    TAgentResult result;
+
+#ifdef BE_TEST
+    ExecEnv::GetInstance()->agent_server()->release_snapshot(result, src_snapshot_path);
+#else
+    RETURN_IF_ERROR(ThriftRpcHelper::rpc<BackendServiceClient>(
+            ip, port, [&src_snapshot_path, &result](BackendServiceConnection& client) {
+                client->release_snapshot(result, src_snapshot_path);
+            }));
+#endif
+    return {result.status};
+}
+
+Status ReplicationUtils::download_remote_snapshot(
+        const std::string& host, int32_t http_port, const std::string& remote_token,
+        const std::string& remote_snapshot_path, TTabletId remote_tablet_id, TSchemaHash remote_schema_hash,
+        DataDir* data_dir, const std::string& local_path_prefix,
+        const std::function<std::string(const std::string&)>& name_converter) {
+#ifdef BE_TEST
+    std::error_code error_code;
+    std::filesystem::copy(strings::Substitute("$0/$1/$2/", remote_snapshot_path, remote_tablet_id, remote_schema_hash),
+                          local_path_prefix, error_code);
+    if (error_code) {
+        return Status::InternalError(error_code.message());
+    }
+    return Status::OK();
+#else
+
+    std::string remote_url_prefix =
+            strings::Substitute("http://$0:$1$2?token=$3&type=V2&file=$4/$5/$6/", host, http_port, HTTP_REQUEST_PREFIX,
+                                remote_token, remote_snapshot_path, remote_tablet_id, remote_schema_hash);
+
+    std::vector<string> file_name_list;
+    std::vector<int64_t> file_size_list;
+    RETURN_IF_ERROR(list_remote_files(remote_url_prefix, &file_name_list, &file_size_list));
+
+    // If the header file is not exist, the table could't loaded by olap engine.
+    // Avoid of data is not complete, we copy the header file at last.
+    // The header file's name is end of .hdr.
+    for (int i = 0; i < file_name_list.size() - 1; ++i) {
+        StringPiece sp(file_name_list[i]);
+        if (sp.ends_with(".hdr")) {
+            std::swap(file_name_list[i], file_name_list[file_name_list.size() - 1]);
+            if (!file_size_list.empty()) {
+                std::swap(file_size_list[i], file_size_list[file_size_list.size() - 1]);
+            }
+            break;
+        }
+    }
+
+    // Get copy from remote
+    uint64_t total_file_size = 0;
+    uint64_t skipped_file_count = 0;
+    MonotonicStopWatch watch;
+    watch.start();
+    for (int i = 0; i < file_name_list.size(); ++i) {
+        const std::string& remote_file_name = file_name_list[i];
+        auto remote_file_url = remote_url_prefix + remote_file_name;
+
+        uint64_t file_size = 0;
+        if (!file_size_list.empty()) {
+            file_size = file_size_list[i];
+        } else {
+            ASSIGN_OR_RETURN(file_size, get_remote_file_size(remote_file_url));
+        }
+
+        // check disk capacity
+        if (data_dir != nullptr && data_dir->capacity_limit_reached(file_size)) {
+            return Status::InternalError("Disk reach capacity limit");
+        }
+
+        total_file_size += file_size;
+        uint64_t estimate_timeout = file_size / config::download_low_speed_limit_kbps / 1024;
+        if (estimate_timeout < config::download_low_speed_time) {
+            estimate_timeout = config::download_low_speed_time;
+        }
+
+        std::string local_file_name = name_converter ? name_converter(remote_file_name) : remote_file_name;
+        if (local_file_name.empty()) {
+            ++skipped_file_count;
+            LOG(INFO) << "Skipped download remote file: " << remote_file_url << ", file_size: " << file_size;
+            continue;
+        }
+
+        std::string local_file_path = local_path_prefix + local_file_name;
+
+        VLOG(1) << "Downloading " << remote_file_url << " to " << local_file_path << ", bytes: " << file_size
+                << ", timeout: " << estimate_timeout;
+
+        ASSIGN_OR_RETURN(uint64_t local_file_size,
+                         download_remote_file(remote_file_url, local_file_path, estimate_timeout));
+        // Check file length
+        if (local_file_size != file_size) {
+            LOG(WARNING) << "Fail to download " << remote_file_url << ", file_size: " << local_file_size << "/"
+                         << file_size;
+            return Status::InternalError("mismatched file size");
+        }
+    } // Clone files from remote backend
+
+    uint64_t total_time_ms = watch.elapsed_time() / 1000 / 1000;
+    total_time_ms = total_time_ms > 0 ? total_time_ms : 0;
+    double copy_rate = 0.0;
+    if (total_time_ms > 0) {
+        copy_rate = total_file_size / ((double)total_time_ms) / 1000;
+    }
+    LOG(INFO) << "Copied tablet file count: " << (file_name_list.size() - skipped_file_count)
+              << ", skipped: " << skipped_file_count << ", bytes: " << total_file_size << ", cost: " << total_time_ms
+              << " ms, rate: " << copy_rate << " MB/s";
+    return Status::OK();
+#endif
+}
+
+StatusOr<std::string> ReplicationUtils::download_remote_snapshot_file(
+        const std::string& host, int32_t http_port, const std::string& remote_token,
+        const std::string& remote_snapshot_path, TTabletId remote_tablet_id, TSchemaHash remote_schema_hash,
+        const std::string& file_name, uint64_t timeout_sec) {
+#ifdef BE_TEST
+    std::string path =
+            strings::Substitute("$0/$1/$2/$3", remote_snapshot_path, remote_tablet_id, remote_schema_hash, file_name);
+    ASSIGN_OR_RETURN(auto file, fs::new_random_access_file(path));
+    return file->read_all();
+#else
+
+    std::string remote_file_url = strings::Substitute(
+            "http://$0:$1$2?token=$3&type=V2&file=$4/$5/$6/$7", host, http_port, HTTP_REQUEST_PREFIX, remote_token,
+            remote_snapshot_path, remote_tablet_id, remote_schema_hash, file_name);
+
+    std::string file_content;
+    auto download_cb = [&remote_file_url, timeout_sec, &file_content](HttpClient* client) {
+        RETURN_IF_ERROR(client->init(remote_file_url));
+        client->set_timeout_ms(timeout_sec * 1000);
+        ASSIGN_OR_RETURN(file_content, client->download());
+        return Status::OK();
+    };
+    RETURN_IF_ERROR(HttpClient::execute_with_retry(DOWNLOAD_FILE_MAX_RETRY, 1, download_cb));
+    return file_content;
+#endif
+}
+
+} // namespace starrocks

--- a/be/src/storage/replication_utils.h
+++ b/be/src/storage/replication_utils.h
@@ -1,0 +1,50 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "common/status.h"
+#include "storage/olap_common.h"
+#include "storage/olap_define.h"
+#include "storage/storage_engine.h"
+
+namespace starrocks {
+
+class ReplicationUtils {
+public:
+    static Status make_remote_snapshot(const std::string& host, int32_t be_port, TTabletId tablet_id,
+                                       TSchemaHash schema_hash, TVersion version, int32_t timeout_s,
+                                       const std::vector<Version>* missed_versions,
+                                       const std::vector<int64_t>* missing_version_ranges,
+                                       std::string* remote_snapshot_path);
+
+    static Status release_remote_snapshot(const std::string& host, int32_t be_port,
+                                          const std::string& remote_snapshot_path);
+
+    static Status download_remote_snapshot(const std::string& host, int32_t http_port, const std::string& remote_token,
+                                           const std::string& remote_snapshot_path, TTabletId remote_tablet_id,
+                                           TSchemaHash remote_schema_hash, DataDir* data_dir,
+                                           const std::string& local_path_prefix,
+                                           const std::function<std::string(const std::string&)>& name_converter =
+                                                   std::function<std::string(const std::string&)>());
+
+    static StatusOr<std::string> download_remote_snapshot_file(const std::string& host, int32_t http_port,
+                                                               const std::string& remote_token,
+                                                               const std::string& remote_snapshot_path,
+                                                               TTabletId remote_tablet_id,
+                                                               TSchemaHash remote_schema_hash,
+                                                               const std::string& file_name, uint64_t timeout_sec);
+};
+
+} // namespace starrocks

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -60,6 +60,7 @@
 #include "storage/data_dir.h"
 #include "storage/memtable_flush_executor.h"
 #include "storage/publish_version_manager.h"
+#include "storage/replication_txn_manager.h"
 #include "storage/rowset/rowset_meta.h"
 #include "storage/rowset/rowset_meta_manager.h"
 #include "storage/rowset/unique_rowset_id_generator.h"
@@ -110,6 +111,7 @@ StorageEngine::StorageEngine(const EngineOptions& options)
           _is_all_cluster_id_exist(true),
           _tablet_manager(new TabletManager(config::tablet_map_shard_size)),
           _txn_manager(new TxnManager(config::txn_map_shard_size, config::txn_shard_size, options.store_paths.size())),
+          _replication_txn_manager(new ReplicationTxnManager()),
           _rowset_id_generator(new UniqueRowsetIdGenerator(options.backend_uid)),
           _memtable_flush_executor(nullptr),
           _update_manager(new UpdateManager(options.update_mem_tracker)),

--- a/be/src/storage/storage_engine.cpp
+++ b/be/src/storage/storage_engine.cpp
@@ -627,6 +627,7 @@ void StorageEngine::stop() {
         JOIN_THREADS(_path_gc_threads);
     }
 
+    JOIN_THREAD(_clear_expired_replcation_snapshots_thread)
 #undef JOIN_THREADS
 #undef JOIN_THREAD
 

--- a/be/src/storage/storage_engine.h
+++ b/be/src/storage/storage_engine.h
@@ -73,6 +73,7 @@ class DataDir;
 class EngineTask;
 class MemTableFlushExecutor;
 class Tablet;
+class ReplicationTxnManager;
 class UpdateManager;
 class CompactionManager;
 class PublishVersionManager;
@@ -213,6 +214,8 @@ public:
     TabletManager* tablet_manager() { return _tablet_manager.get(); }
 
     TxnManager* txn_manager() { return _txn_manager.get(); }
+
+    ReplicationTxnManager* replication_txn_manager() { return _replication_txn_manager.get(); }
 
     CompactionManager* compaction_manager() { return _compaction_manager.get(); }
 
@@ -362,6 +365,8 @@ private:
 
     void* _path_scan_thread_callback(void* arg);
 
+    void* _clear_expired_replication_snapshots_callback(void* arg);
+
     void* _tablet_checkpoint_callback(void* arg);
 
     void* _adjust_pagecache_callback(void* arg);
@@ -423,6 +428,8 @@ private:
     // threads to run tablet checkpoint
     std::vector<std::thread> _tablet_checkpoint_threads;
 
+    std::thread _clear_expired_replcation_snapshots_thread;
+
     std::thread _compaction_checker_thread;
     std::mutex _checker_mutex;
     std::condition_variable _checker_cv;
@@ -443,6 +450,8 @@ private:
 
     std::unique_ptr<TabletManager> _tablet_manager;
     std::unique_ptr<TxnManager> _txn_manager;
+
+    std::unique_ptr<ReplicationTxnManager> _replication_txn_manager;
 
     std::unique_ptr<RowsetIdGenerator> _rowset_id_generator;
 

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -122,6 +122,17 @@ Status TabletMeta::create_from_file(const string& file_path) {
     return Status::OK();
 }
 
+Status TabletMeta::create_from_memory(std::string_view data) {
+    TabletMetaPB tablet_meta_pb;
+    Status st = ProtobufFileWithHeader::load(&tablet_meta_pb, data);
+    if (!st.ok()) {
+        LOG(WARNING) << "Fail to load tablet meta from memory: " << st;
+        return st;
+    }
+    init_from_pb(&tablet_meta_pb);
+    return Status::OK();
+}
+
 Status TabletMeta::reset_tablet_uid(const string& file_path) {
     Status res;
     TabletMeta tmp_tablet_meta;

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -110,6 +110,7 @@ public:
     // Function create_from_file is used to be compatible with previous tablet_meta.
     // Previous tablet_meta is a physical file in tablet dir, which is not stored in rocksdb.
     [[nodiscard]] Status create_from_file(const std::string& file_path);
+    [[nodiscard]] Status create_from_memory(std::string_view data);
     [[nodiscard]] Status save(const std::string& file_path);
     [[nodiscard]] static Status save(const std::string& file_path, const TabletMetaPB& tablet_meta_pb);
     [[nodiscard]] static Status reset_tablet_uid(const std::string& file_path);

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 set(EXEC_FILES
+        ./agent/agent_task_test.cpp
         ./agent/master_info_test.cpp
         ./column/array_column_test.cpp
         ./column/binary_column_test.cpp
@@ -217,6 +218,7 @@ set(EXEC_FILES
         ./storage/lake/primary_key_publish_test.cpp
         ./storage/lake/meta_file_test.cpp
         ./storage/lake/metacache_test.cpp
+        ./storage/lake/replication_txn_manager_test.cpp
         ./storage/rowset_update_state_test.cpp
         ./storage/rowset_column_update_state_test.cpp
         ./storage/rowset_column_partial_update_test.cpp
@@ -270,6 +272,7 @@ set(EXEC_FILES
         ./storage/projection_iterator_test.cpp
         ./storage/push_handler_test.cpp
         ./storage/range_test.cpp
+        ./storage/replication_txn_manager_test.cpp
         ./storage/row_source_mask_test.cpp
         ./storage/union_iterator_test.cpp
         ./storage/unique_iterator_test.cpp

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -1,0 +1,180 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "agent/agent_task.h"
+
+#include <gtest/gtest.h>
+
+#include "agent/agent_server.h"
+#include "agent/publish_version.h"
+#include "agent/task_worker_pool.h"
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/AgentService_types.h"
+#include "runtime/exec_env.h"
+#include "storage/olap_define.h"
+#include "storage/replication_txn_manager.h"
+#include "storage/tablet_manager.h"
+#include "testutil/assert.h"
+#include "util/uuid_generator.h"
+
+namespace starrocks {
+
+class AgentTaskTest : public testing::Test {
+public:
+    AgentTaskTest() = default;
+    ~AgentTaskTest() override = default;
+    void SetUp() override {
+        _transaction_id = 100;
+        _table_id = 10001;
+        _partition_id = 10002;
+        _tablet_id = 10003;
+        _src_tablet_id = 10004;
+        _schema_hash = 368169781;
+        _version = 2;
+        _src_version = 10;
+
+        TCreateTabletReq create_tablet_req = get_create_tablet_request(_tablet_id, _schema_hash, _version);
+        Status create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
+                create_tablet_req, StorageEngine::instance()->get_stores());
+        ASSERT_TRUE(create_st.ok());
+
+        TCreateTabletReq src_create_tablet_req = get_create_tablet_request(_src_tablet_id, _schema_hash, _src_version);
+        Status src_create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
+                src_create_tablet_req, StorageEngine::instance()->get_stores());
+        ASSERT_TRUE(src_create_st.ok());
+    }
+
+    void TearDown() override {}
+
+    TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int schema_hash, int64_t version) {
+        TColumnType col_type;
+        col_type.__set_type(TPrimitiveType::SMALLINT);
+        TColumn col1;
+        col1.__set_column_name("col1");
+        col1.__set_column_type(col_type);
+        col1.__set_is_key(true);
+        std::vector<TColumn> cols;
+        cols.push_back(col1);
+        TTabletSchema tablet_schema;
+        tablet_schema.__set_short_key_column_count(1);
+        tablet_schema.__set_schema_hash(schema_hash);
+        tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
+        tablet_schema.__set_storage_type(TStorageType::COLUMN);
+        tablet_schema.__set_columns(cols);
+        TCreateTabletReq create_tablet_req;
+        create_tablet_req.__set_tablet_schema(tablet_schema);
+        create_tablet_req.__set_tablet_id(tablet_id);
+        create_tablet_req.__set_version(version);
+        create_tablet_req.__set_version_hash(0);
+        return create_tablet_req;
+    }
+
+protected:
+    int64_t _transaction_id;
+    int64_t _table_id;
+    int64_t _partition_id;
+    int64_t _tablet_id;
+    int64_t _src_tablet_id;
+    int32_t _schema_hash;
+    int64_t _version;
+    int64_t _src_version;
+};
+
+TEST_F(AgentTaskTest, test_replication_txn) {
+    TAgentTaskRequest agent_task_request;
+    agent_task_request.__set_task_type(TTaskType::REMOTE_SNAPSHOT);
+    agent_task_request.__set_signature(100);
+
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    agent_task_request.__set_remote_snapshot_req(remote_snapshot_request);
+
+    auto remote_snapshot_agent_task = std::make_shared<RemoteSnapshotAgentTaskRequest>(
+            agent_task_request, agent_task_request.remote_snapshot_req, time(nullptr));
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    run_remote_snapshot_task(remote_snapshot_agent_task, nullptr);
+
+    agent_task_request.__set_task_type(TTaskType::REPLICATE_SNAPSHOT);
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    TRemoteSnapshotInfo remote_snapshot_info;
+    remote_snapshot_info.__set_backend(TBackend());
+    remote_snapshot_info.__set_snapshot_path(snapshot_path);
+    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+    agent_task_request.__set_replicate_snapshot_req(replicate_snapshot_request);
+
+    auto replicate_snapshot_agent_task = std::make_shared<ReplicateSnapshotAgentTaskRequest>(
+            agent_task_request, agent_task_request.replicate_snapshot_req, time(nullptr));
+
+    run_replicate_snapshot_task(replicate_snapshot_agent_task, nullptr);
+
+    TPublishVersionRequest publish_version_request;
+    publish_version_request.__set_transaction_id(_transaction_id);
+    TPartitionVersionInfo partition_version_info;
+    partition_version_info.__set_partition_id(_partition_id);
+    partition_version_info.__set_version(_src_version);
+    publish_version_request.partition_version_infos.push_back(partition_version_info);
+    publish_version_request.__set_txn_type(TTxnType::TXN_REPLICATION);
+
+    auto token = ExecEnv::GetInstance()
+                         ->agent_server()
+                         ->get_thread_pool(TTaskType::PUBLISH_VERSION)
+                         ->new_token(ThreadPool::ExecutionMode::CONCURRENT);
+    TFinishTaskRequest finish_task_request;
+    std::unordered_set<DataDir*> affected_dirs;
+
+    run_publish_version_task(token.get(), publish_version_request, finish_task_request, affected_dirs, 0);
+
+    agent_task_request.__set_task_type(TTaskType::CLEAR_TRANSACTION_TASK);
+    TClearTransactionTaskRequest clear_transaction_task_request;
+    clear_transaction_task_request.__set_transaction_id(_transaction_id);
+    clear_transaction_task_request.__set_txn_type(TTxnType::TXN_REPLICATION);
+    agent_task_request.__set_clear_transaction_task_req(clear_transaction_task_request);
+
+    auto clear_transaction_agent_task = std::make_shared<ClearTransactionAgentTaskRequest>(
+            agent_task_request, agent_task_request.clear_transaction_task_req, time(nullptr));
+
+    run_clear_transaction_task(clear_transaction_agent_task, nullptr);
+}
+
+} // namespace starrocks

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -123,14 +123,24 @@ TEST_F(HttpClientTest, download) {
     ASSERT_TRUE(st.ok());
     client.set_basic_auth("test1", "");
     std::string local_file = ".http_client_test.dat";
-    st = client.download(local_file);
-    ASSERT_TRUE(st.ok());
+    auto st_or = client.download(local_file);
+    ASSERT_TRUE(st_or.ok());
     char buf[50];
     auto fp = fopen(local_file.c_str(), "r");
     auto size = fread(buf, 1, 50, fp);
     buf[size] = 0;
     ASSERT_STREQ("test1", buf);
     unlink(local_file.c_str());
+}
+
+TEST_F(HttpClientTest, download_to_memory) {
+    HttpClient client;
+    auto st = client.init(hostname + "/simple_get");
+    ASSERT_TRUE(st.ok());
+    client.set_basic_auth("test1", "");
+    auto st_or = client.download();
+    ASSERT_TRUE(st_or.ok());
+    ASSERT_EQ("test1", st_or.value());
 }
 
 TEST_F(HttpClientTest, get_failed) {

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -1,0 +1,301 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/lake/replication_txn_manager.h"
+
+#include <fmt/format.h>
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <fstream>
+
+#include "common/config.h"
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "runtime/exec_env.h"
+#include "storage/lake/fixed_location_provider.h"
+#include "storage/lake/join_path.h"
+#include "storage/lake/location_provider.h"
+#include "storage/lake/tablet_manager.h"
+#include "storage/lake/transactions.h"
+#include "storage/lake/update_manager.h"
+#include "storage/olap_define.h"
+#include "storage/options.h"
+#include "storage/tablet_manager.h"
+#include "storage/tablet_schema.h"
+#include "testutil/assert.h"
+#include "testutil/id_generator.h"
+#include "util/filesystem_util.h"
+
+namespace starrocks {
+
+class LakeReplicationTxnManagerTest : public testing::Test {
+public:
+    LakeReplicationTxnManagerTest() : _test_dir(){};
+
+    ~LakeReplicationTxnManagerTest() override = default;
+
+    void SetUp() override {
+        std::vector<starrocks::StorePath> paths;
+        CHECK_OK(starrocks::parse_conf_store_paths(starrocks::config::storage_root_path, &paths));
+        _test_dir = paths[0].path + "/lake";
+        _location_provider = std::make_unique<lake::FixedLocationProvider>(_test_dir);
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->metadata_root_location(1)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->txn_log_root_location(1)));
+        CHECK_OK(FileSystem::Default()->create_dir_recursive(_location_provider->segment_root_location(1)));
+        _update_manager = std::make_unique<lake::UpdateManager>(_location_provider.get());
+        _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 16384);
+        _replication_txn_manager = std::make_unique<lake::ReplicationTxnManager>(_tablet_manager.get());
+
+        TCreateTabletReq create_tablet_req = get_create_tablet_request(_tablet_id, _schema_hash, _version);
+        Status create_st = _tablet_manager->create_tablet(create_tablet_req);
+        ASSERT_TRUE(create_st.ok());
+
+        TCreateTabletReq src_create_tablet_req = get_create_tablet_request(_src_tablet_id, _schema_hash, _src_version);
+        Status src_create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
+                src_create_tablet_req, StorageEngine::instance()->get_stores());
+        ASSERT_TRUE(src_create_st.ok());
+    }
+
+    void TearDown() override { (void)FileSystem::Default()->delete_dir_recursive(_test_dir); }
+
+    TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int schema_hash, int64_t version) {
+        TColumnType col_type;
+        col_type.__set_type(TPrimitiveType::SMALLINT);
+        TColumn col1;
+        col1.__set_column_name("col1");
+        col1.__set_column_type(col_type);
+        col1.__set_is_key(true);
+        std::vector<TColumn> cols;
+        cols.push_back(col1);
+        TTabletSchema tablet_schema;
+        tablet_schema.__set_id(1);
+        tablet_schema.__set_short_key_column_count(1);
+        tablet_schema.__set_schema_hash(schema_hash);
+        tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
+        tablet_schema.__set_storage_type(TStorageType::COLUMN);
+        tablet_schema.__set_columns(cols);
+        TCreateTabletReq create_tablet_req;
+        create_tablet_req.__set_tablet_schema(tablet_schema);
+        create_tablet_req.__set_tablet_id(tablet_id);
+        create_tablet_req.__set_version(version);
+        create_tablet_req.__set_version_hash(0);
+        return create_tablet_req;
+    }
+
+protected:
+    std::unique_ptr<starrocks::lake::TabletManager> _tablet_manager;
+    std::string _test_dir;
+    std::unique_ptr<lake::LocationProvider> _location_provider;
+    std::unique_ptr<lake::UpdateManager> _update_manager;
+    std::unique_ptr<lake::ReplicationTxnManager> _replication_txn_manager;
+
+    int64_t _transaction_id = 100;
+    int64_t _table_id = 10001;
+    int64_t _partition_id = 10002;
+    int64_t _tablet_id = 10003;
+    int64_t _src_tablet_id = 10004;
+    int32_t _schema_hash = 368169781;
+    int64_t _version = 1;
+    int64_t _src_version = 10;
+};
+
+TEST_F(LakeReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status =
+            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_F(LakeReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version + 1);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status =
+            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_FALSE(status.ok());
+}
+
+TEST_F(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status =
+            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash + 1);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    TRemoteSnapshotInfo remote_snapshot_info;
+    remote_snapshot_info.__set_backend(TBackend());
+    remote_snapshot_info.__set_snapshot_path(snapshot_path);
+    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_FALSE(status.ok());
+
+    auto slog_path = _tablet_manager->txn_slog_location(_tablet_id, _transaction_id);
+    auto txn_slog_or = _tablet_manager->get_txn_log(slog_path, false);
+    EXPECT_TRUE(txn_slog_or.ok());
+
+    _replication_txn_manager->clear_snapshots(txn_slog_or.value());
+}
+
+TEST_F(LakeReplicationTxnManagerTest, test_publish_failed) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status =
+            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    const int64_t txn_ids[] = {_transaction_id};
+    auto txn_id_span = std::span<const int64_t>(txn_ids, 1);
+    auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_id_span, 0);
+    EXPECT_TRUE(!status_or.ok());
+
+    const int32_t txn_types[] = {TxnTypePB::TXN_REPLICATION};
+    auto txn_type_span = std::span<const int32_t>(txn_types, 1);
+    lake::abort_txn(_tablet_manager.get(), _tablet_id, txn_id_span, txn_type_span);
+}
+
+TEST_F(LakeReplicationTxnManagerTest, test_run_normal) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status =
+            _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_LAKE);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    TRemoteSnapshotInfo remote_snapshot_info;
+    remote_snapshot_info.__set_backend(TBackend());
+    remote_snapshot_info.__set_snapshot_path(snapshot_path);
+    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok());
+
+    status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok());
+
+    const int64_t txn_ids[] = {_transaction_id};
+    auto txn_id_span = std::span<const int64_t>(txn_ids, 1);
+    auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_id_span, 0);
+    EXPECT_TRUE(status_or.ok()) << status_or.status();
+
+    EXPECT_EQ(_src_version, status_or.value()->version());
+}
+
+} // namespace starrocks

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -234,13 +234,11 @@ TEST_F(LakeReplicationTxnManagerTest, test_publish_failed) {
     EXPECT_TRUE(status.ok());
 
     const int64_t txn_ids[] = {_transaction_id};
-    auto txn_id_span = std::span<const int64_t>(txn_ids, 1);
-    auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_id_span, 0);
+    auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_ids, 1, 0);
     EXPECT_TRUE(!status_or.ok());
 
     const int32_t txn_types[] = {TxnTypePB::TXN_REPLICATION};
-    auto txn_type_span = std::span<const int32_t>(txn_types, 1);
-    lake::abort_txn(_tablet_manager.get(), _tablet_id, txn_id_span, txn_type_span);
+    lake::abort_txn(_tablet_manager.get(), _tablet_id, txn_ids, txn_types, 1);
 }
 
 TEST_F(LakeReplicationTxnManagerTest, test_run_normal) {
@@ -291,8 +289,7 @@ TEST_F(LakeReplicationTxnManagerTest, test_run_normal) {
     EXPECT_TRUE(status.ok());
 
     const int64_t txn_ids[] = {_transaction_id};
-    auto txn_id_span = std::span<const int64_t>(txn_ids, 1);
-    auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_id_span, 0);
+    auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_ids, 1, 0);
     EXPECT_TRUE(status_or.ok()) << status_or.status();
 
     EXPECT_EQ(_src_version, status_or.value()->version());

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -1,0 +1,288 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/replication_txn_manager.h"
+
+#include <gtest/gtest.h>
+
+#include "fs/fs.h"
+#include "fs/fs_util.h"
+#include "gen_cpp/AgentService_types.h"
+#include "runtime/exec_env.h"
+#include "storage/olap_define.h"
+#include "storage/tablet_manager.h"
+#include "testutil/assert.h"
+#include "util/uuid_generator.h"
+
+namespace starrocks {
+
+class ReplicationTxnManagerTest : public testing::Test {
+public:
+    ReplicationTxnManagerTest() = default;
+    ~ReplicationTxnManagerTest() override = default;
+    void SetUp() override {
+        TCreateTabletReq create_tablet_req = get_create_tablet_request(_tablet_id, _schema_hash, _version);
+        Status create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
+                create_tablet_req, StorageEngine::instance()->get_stores());
+        ASSERT_TRUE(create_st.ok());
+
+        TCreateTabletReq src_create_tablet_req = get_create_tablet_request(_src_tablet_id, _schema_hash, _src_version);
+        Status src_create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
+                src_create_tablet_req, StorageEngine::instance()->get_stores());
+        ASSERT_TRUE(src_create_st.ok());
+    }
+
+    void TearDown() override {}
+
+    TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int schema_hash, int64_t version) {
+        TColumnType col_type;
+        col_type.__set_type(TPrimitiveType::SMALLINT);
+        TColumn col1;
+        col1.__set_column_name("col1");
+        col1.__set_column_type(col_type);
+        col1.__set_is_key(true);
+        std::vector<TColumn> cols;
+        cols.push_back(col1);
+        TTabletSchema tablet_schema;
+        tablet_schema.__set_short_key_column_count(1);
+        tablet_schema.__set_schema_hash(schema_hash);
+        tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
+        tablet_schema.__set_storage_type(TStorageType::COLUMN);
+        tablet_schema.__set_columns(cols);
+        TCreateTabletReq create_tablet_req;
+        create_tablet_req.__set_tablet_schema(tablet_schema);
+        create_tablet_req.__set_tablet_id(tablet_id);
+        create_tablet_req.__set_version(version);
+        create_tablet_req.__set_version_hash(0);
+        return create_tablet_req;
+    }
+
+protected:
+    int64_t _transaction_id = 100;
+    int64_t _table_id = 10001;
+    int64_t _partition_id = 10002;
+    int64_t _tablet_id = 10003;
+    int64_t _src_tablet_id = 10004;
+    int32_t _schema_hash = 368169781;
+    int64_t _version = 2;
+    int64_t _src_version = 10;
+};
+
+TEST_F(ReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_FALSE(status.ok());
+
+    StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
+
+    StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
+}
+
+TEST_F(ReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version + 1);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_FALSE(status.ok());
+
+    StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
+
+    StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
+}
+
+TEST_F(ReplicationTxnManagerTest, test_replicate_snapshot_failed) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash + 1);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    TRemoteSnapshotInfo remote_snapshot_info;
+    remote_snapshot_info.__set_backend(TBackend());
+    remote_snapshot_info.__set_snapshot_path(snapshot_path);
+    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_FALSE(status.ok());
+
+    StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
+
+    StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
+}
+
+TEST_F(ReplicationTxnManagerTest, test_publish_failed) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    TabletSharedPtr tablet_ptr = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
+    EXPECT_TRUE(tablet_ptr != nullptr);
+
+    status = StorageEngine::instance()->replication_txn_manager()->publish_txn(_transaction_id, _partition_id,
+                                                                               tablet_ptr, _src_version);
+    EXPECT_TRUE(!status.ok());
+
+    StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
+
+    StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
+}
+
+TEST_F(ReplicationTxnManagerTest, test_run_normal) {
+    TRemoteSnapshotRequest remote_snapshot_request;
+    remote_snapshot_request.__set_transaction_id(_transaction_id);
+    remote_snapshot_request.__set_table_id(_table_id);
+    remote_snapshot_request.__set_partition_id(_partition_id);
+    remote_snapshot_request.__set_tablet_id(_tablet_id);
+    remote_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_visible_version(_version);
+    remote_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    remote_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    remote_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    remote_snapshot_request.__set_src_schema_hash(_schema_hash);
+    remote_snapshot_request.__set_src_visible_version(_src_version);
+    remote_snapshot_request.__set_src_backends({TBackend()});
+
+    std::string snapshot_path;
+    bool incremental_snapshot = false;
+    Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
+            remote_snapshot_request, &snapshot_path, &incremental_snapshot);
+    EXPECT_TRUE(status.ok());
+
+    TReplicateSnapshotRequest replicate_snapshot_request;
+    replicate_snapshot_request.__set_transaction_id(_transaction_id);
+    replicate_snapshot_request.__set_table_id(_table_id);
+    replicate_snapshot_request.__set_partition_id(_partition_id);
+    replicate_snapshot_request.__set_tablet_id(_tablet_id);
+    replicate_snapshot_request.__set_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_visible_version(_version);
+    replicate_snapshot_request.__set_src_token(ExecEnv::GetInstance()->token());
+    replicate_snapshot_request.__set_src_tablet_id(_src_tablet_id);
+    replicate_snapshot_request.__set_src_tablet_type(TTabletType::TABLET_TYPE_DISK);
+    replicate_snapshot_request.__set_src_schema_hash(_schema_hash);
+    replicate_snapshot_request.__set_src_visible_version(_src_version);
+    TRemoteSnapshotInfo remote_snapshot_info;
+    remote_snapshot_info.__set_backend(TBackend());
+    remote_snapshot_info.__set_snapshot_path(snapshot_path);
+    remote_snapshot_info.__set_incremental_snapshot(incremental_snapshot);
+    replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
+
+    status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok());
+
+    status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);
+    EXPECT_TRUE(status.ok());
+
+    TabletSharedPtr tablet_ptr = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
+    EXPECT_TRUE(tablet_ptr != nullptr);
+
+    status = StorageEngine::instance()->replication_txn_manager()->publish_txn(_transaction_id, _partition_id,
+                                                                               tablet_ptr, _src_version);
+    EXPECT_TRUE(status.ok());
+
+    status = StorageEngine::instance()->replication_txn_manager()->publish_txn(_transaction_id, _partition_id,
+                                                                               tablet_ptr, _src_version);
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(_src_version, tablet_ptr->max_version().second);
+
+    StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
+
+    StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
+}
+
+} // namespace starrocks

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -69,11 +69,11 @@ public:
     }
 
 protected:
-    int64_t _transaction_id = 100;
-    int64_t _table_id = 10001;
-    int64_t _partition_id = 10002;
-    int64_t _tablet_id = 10003;
-    int64_t _src_tablet_id = 10004;
+    int64_t _transaction_id = 200;
+    int64_t _table_id = 20001;
+    int64_t _partition_id = 20002;
+    int64_t _tablet_id = 20003;
+    int64_t _src_tablet_id = 20004;
     int32_t _schema_hash = 368169781;
     int64_t _version = 2;
     int64_t _src_version = 10;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Database.java
@@ -605,10 +605,7 @@ public class Database extends MetaObject implements Writable {
     }
 
     public Table getTable(String tableName) {
-        if (nameToTable.containsKey(tableName)) {
-            return nameToTable.get(tableName);
-        }
-        return null;
+        return nameToTable.get(tableName);
     }
 
     public Pair<Table, MaterializedIndexMeta> getMaterializedViewIndex(String mvName) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/LocalTablet.java
@@ -190,6 +190,11 @@ public class LocalTablet extends Tablet implements GsonPostProcessable {
         return num;
     }
 
+    @Override
+    public List<Replica> getAllReplicas() {
+        return replicas;
+    }
+
     /**
      * @return Immutable list of replicas
      * notice: the list is immutable, not replica

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/Tablet.java
@@ -44,6 +44,8 @@ public abstract class Tablet extends MetaObject implements Writable {
 
     public abstract Set<Long> getBackendIds();
 
+    public abstract List<Replica> getAllReplicas();
+
     public abstract void getQueryableReplicas(List<Replica> allQuerableReplicas, List<Replica> localReplicas,
                                               long visibleVersion, long localBeId, int schemaHash);
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2580,4 +2580,18 @@ public class Config extends ConfigBase {
 
     @ConfField(mutable = true)
     public static long routine_load_unstable_threshold_second = 3600;
+    
+    /*
+     * replication transaction config
+     */
+    @ConfField(mutable = true)
+    public static int replication_transaction_max_parallel_job_count = 100; // 100
+    @ConfField(mutable = true)
+    public static int replication_transaction_max_parallel_replication_data_size_mb = 10240; // 10g
+    @ConfField(mutable = true)
+    public static int replication_transaction_timeout_sec = 1 * 60 * 60; // 1hour
+    @ConfField(mutable = true)
+    public static int replication_transaction_remote_snapshot_timeout_sec = 30 * 60; // 30minute
+    @ConfField(mutable = true)
+    public static int replication_transaction_replicate_snapshot_timeout_sec = 30 * 60; // 30minute
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -110,6 +110,7 @@ import com.starrocks.persist.RemoveAlterJobV2OperationLog;
 import com.starrocks.persist.RenameMaterializedViewLog;
 import com.starrocks.persist.ReplacePartitionOperationLog;
 import com.starrocks.persist.ReplicaPersistInfo;
+import com.starrocks.persist.ReplicationJobLog;
 import com.starrocks.persist.ResourceGroupOpEntry;
 import com.starrocks.persist.RolePrivilegeCollectionInfo;
 import com.starrocks.persist.RoutineLoadOperation;
@@ -1035,6 +1036,10 @@ public class JournalEntity implements Writable {
             case OperationType.OP_CREATE_STORAGE_VOLUME:
             case OperationType.OP_UPDATE_STORAGE_VOLUME:
                 data = StorageVolume.read(in);
+                isRead = true;
+                break;
+            case OperationType.OP_REPLICATION_JOB:
+                data = ReplicationJobLog.read(in);
                 isRead = true;
                 break;
             default: {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -14,6 +14,7 @@
 
 package com.starrocks.lake;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.gson.annotations.SerializedName;
 import com.staros.client.StarClientException;
@@ -123,6 +124,13 @@ public class LakeTablet extends Tablet {
             LOG.warn("Failed to get backends by shard. tablet id: {}", getId(), e);
             return Sets.newHashSet();
         }
+    }
+
+    @Override
+    public List<Replica> getAllReplicas() {
+        List<Replica> replicas = Lists.newArrayList();
+        getQueryableReplicas(replicas, null, 0, -1, 0);
+        return replicas;
     }
 
     // visibleVersion and schemaHash is not used

--- a/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/LeaderImpl.java
@@ -96,6 +96,8 @@ import com.starrocks.task.DownloadTask;
 import com.starrocks.task.DropAutoIncrementMapTask;
 import com.starrocks.task.PublishVersionTask;
 import com.starrocks.task.PushTask;
+import com.starrocks.task.RemoteSnapshotTask;
+import com.starrocks.task.ReplicateSnapshotTask;
 import com.starrocks.task.SnapshotTask;
 import com.starrocks.task.UpdateTabletMetaInfoTask;
 import com.starrocks.task.UploadTask;
@@ -132,6 +134,8 @@ import com.starrocks.thrift.TSinglePartitionDesc;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTableMeta;
+import com.starrocks.thrift.TTableReplicationRequest;
+import com.starrocks.thrift.TTableReplicationResponse;
 import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletMeta;
 import com.starrocks.thrift.TTaskType;
@@ -239,7 +243,8 @@ public class LeaderImpl {
                         && taskType != TTaskType.CLONE && taskType != TTaskType.PUBLISH_VERSION
                         && taskType != TTaskType.CREATE && taskType != TTaskType.UPDATE_TABLET_META_INFO
                         && taskType != TTaskType.DROP_AUTO_INCREMENT_MAP
-                        && taskType != TTaskType.STORAGE_MEDIUM_MIGRATE) {
+                        && taskType != TTaskType.STORAGE_MEDIUM_MIGRATE
+                        && taskType != TTaskType.REMOTE_SNAPSHOT && taskType != TTaskType.REPLICATE_SNAPSHOT) {
                     if (taskType == TTaskType.REALTIME_PUSH) {
                         PushTask pushTask = (PushTask) task;
                         if (pushTask.getPushType() == TPushType.DELETE) {
@@ -316,6 +321,12 @@ public class LeaderImpl {
                     break;
                 case COMPACTION:
                     finishCompactionTask(task, request);
+                    break;
+                case REMOTE_SNAPSHOT:
+                    finishRemoteSnapshotTask(task, request);
+                    break;
+                case REPLICATE_SNAPSHOT:
+                    finishReplicateSnapshotTask(task, request);
                     break;
                 default:
                     break;
@@ -418,6 +429,24 @@ public class LeaderImpl {
 
     private void finishCompactionTask(AgentTask task, TFinishTaskRequest request) {
         AgentTaskQueue.removeTask(task.getBackendId(), task.getTaskType(), task.getSignature());
+    }
+
+    private void finishRemoteSnapshotTask(AgentTask task, TFinishTaskRequest request) throws MetaNotFoundException {
+        try {
+            GlobalStateMgr.getCurrentState().getReplicationMgr().finishRemoteSnapshotTask(
+                    (RemoteSnapshotTask) task, request);
+        } finally {
+            AgentTaskQueue.removeTask(task.getBackendId(), task.getTaskType(), task.getSignature());
+        }
+    }
+
+    private void finishReplicateSnapshotTask(AgentTask task, TFinishTaskRequest request) throws MetaNotFoundException {
+        try {
+            GlobalStateMgr.getCurrentState().getReplicationMgr().finishReplicateSnapshotTask(
+                    (ReplicateSnapshotTask) task, request);
+        } finally {
+            AgentTaskQueue.removeTask(task.getBackendId(), task.getTaskType(), task.getSignature());
+        }
     }
 
     private void finishRealtimePush(AgentTask task, TFinishTaskRequest request) {
@@ -1276,5 +1305,43 @@ public class LeaderImpl {
         TStatus status = new TStatus(TStatusCode.OK);
         response.setStatus(status);
         return response;
+    }
+
+    public TTableReplicationResponse startTableReplication(TTableReplicationRequest request)
+            throws TException {
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        // if current node is follower, forward it to leader
+        if (!globalStateMgr.isLeader()) {
+            TNetworkAddress addr = masterAddr();
+            try {
+                LOG.info("startTableReplication as follower, forward it to master. master: {}", addr.toString());
+                return FrontendServiceProxy.call(addr,
+                        Config.thrift_rpc_timeout_ms,
+                        Config.thrift_rpc_retry_times,
+                        client -> client.startTableReplication(request));
+            } catch (Exception e) {
+                LOG.warn("create thrift client failed during startTableReplication, exception: ", e);
+                TTableReplicationResponse response = new TTableReplicationResponse();
+                TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+                status.setError_msgs(Lists.newArrayList("forward request to fe master failed"));
+                response.setStatus(status);
+                return response;
+            }
+        }
+
+        try {
+            globalStateMgr.getReplicationMgr().addReplicationJob(request);
+            TTableReplicationResponse response = new TTableReplicationResponse();
+            TStatus status = new TStatus(TStatusCode.OK);
+            response.setStatus(status);
+            return response;
+        } catch (Exception e) {
+            LOG.warn("Start table replication failed ", e);
+            TTableReplicationResponse response = new TTableReplicationResponse();
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.setError_msgs(Lists.newArrayList(e.getMessage()));
+            response.setStatus(status);
+            return response;
+        }
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/ReportHandler.java
@@ -104,6 +104,7 @@ import com.starrocks.thrift.TTablet;
 import com.starrocks.thrift.TTabletInfo;
 import com.starrocks.thrift.TTabletMetaType;
 import com.starrocks.thrift.TTaskType;
+import com.starrocks.thrift.TTxnType;
 import com.starrocks.thrift.TWorkGroup;
 import com.starrocks.thrift.TWorkGroupOp;
 import org.apache.commons.lang.StringUtils;
@@ -1097,7 +1098,7 @@ public class ReportHandler extends Daemon {
                         new PublishVersionTask(backendId, txnId, dbId, commitTime,
                                 map.get(txnId).values().stream().collect(Collectors.toList()), null, null,
                                 createPublishVersionTaskTime, null,
-                                Config.enable_sync_publish);
+                                Config.enable_sync_publish, TTxnType.TXN_NORMAL);
                 batchTask.addTask(task);
                 // add to AgentTaskQueue for handling finish report.
                 AgentTaskQueue.addTask(task);
@@ -1378,7 +1379,7 @@ public class ReportHandler extends Daemon {
         AgentBatchTask batchTask = new AgentBatchTask();
         for (Long transactionId : transactionsToClear.keySet()) {
             ClearTransactionTask clearTransactionTask = new ClearTransactionTask(backendId,
-                    transactionId, transactionsToClear.get(transactionId));
+                    transactionId, transactionsToClear.get(transactionId), TTxnType.TXN_NORMAL);
             batchTask.addTask(clearTransactionTask);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -83,6 +83,7 @@ import com.starrocks.plugin.PluginInfo;
 import com.starrocks.privilege.RolePrivilegeCollectionV2;
 import com.starrocks.privilege.UserPrivilegeCollectionV2;
 import com.starrocks.qe.SessionVariable;
+import com.starrocks.replication.ReplicationJob;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.mv.MVEpoch;
 import com.starrocks.scheduler.mv.MVMaintenanceJob;
@@ -1084,6 +1085,11 @@ public class EditLog {
                     globalStateMgr.getStorageVolumeMgr().replayDropStorageVolume(log);
                     break;
                 }
+                case OperationType.OP_REPLICATION_JOB: {
+                    ReplicationJobLog replicationJobLog = (ReplicationJobLog) journal.getData();
+                    globalStateMgr.getReplicationMgr().replayReplicationJob(replicationJobLog.getReplicationJob());
+                    break;
+                }
                 default: {
                     if (Config.ignore_unknown_log_id) {
                         LOG.warn("UNKNOWN Operation Type {}", opCode);
@@ -2060,5 +2066,10 @@ public class EditLog {
 
     public void logDropStorageVolume(DropStorageVolumeLog log) {
         logEdit(OperationType.OP_DROP_STORAGE_VOLUME, log);
+    }
+
+    public void logReplicationJob(ReplicationJob replicationJob) {
+        ReplicationJobLog replicationJobLog = new ReplicationJobLog(replicationJob);
+        logEdit(OperationType.OP_REPLICATION_JOB, replicationJobLog);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -487,6 +487,9 @@ public class OperationType {
     // alter catalog
     public static final short OP_ALTER_CATALOG = 13300;
 
+    // Replication job
+    public static final short OP_REPLICATION_JOB = 13500;
+
     /**
      * NOTICE: OperationType cannot use a value exceeding 20000, and an error will be reported if it exceeds
      */

--- a/fe/fe-core/src/main/java/com/starrocks/persist/ReplicationJobLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/ReplicationJobLog.java
@@ -1,0 +1,48 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.replication.ReplicationJob;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class ReplicationJobLog implements Writable {
+    @SerializedName(value = "replicationJob")
+    private final ReplicationJob replicationJob;
+
+    public ReplicationJobLog(ReplicationJob replicationJob) {
+        this.replicationJob = replicationJob;
+    }
+
+    public ReplicationJob getReplicationJob() {
+        return replicationJob;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static ReplicationJobLog read(DataInput in) throws IOException {
+        String json = Text.readString(in);
+        return GsonUtils.GSON.fromJson(json, ReplicationJobLog.class);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/gson/GsonUtils.java
@@ -156,6 +156,7 @@ import com.starrocks.privilege.TablePEntryObject;
 import com.starrocks.privilege.UserPEntryObject;
 import com.starrocks.privilege.ViewPEntryObject;
 import com.starrocks.privilege.WarehouseFCPEntryObject;
+import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.server.SharedDataStorageVolumeMgr;
 import com.starrocks.server.SharedNothingStorageVolumeMgr;
 import com.starrocks.server.StorageVolumeMgr;
@@ -335,7 +336,8 @@ public class GsonUtils {
                     .registerSubtype(ManualLoadTxnCommitAttachment.class, "ManualLoadTxnCommitAttachment")
                     .registerSubtype(MiniLoadTxnCommitAttachment.class, "MiniLoadTxnCommitAttachment")
                     .registerSubtype(RLTaskTxnCommitAttachment.class, "RLTaskTxnCommitAttachment")
-                    .registerSubtype(StreamLoadTxnCommitAttachment.class, "StreamLoadTxnCommitAttachment");
+                    .registerSubtype(StreamLoadTxnCommitAttachment.class, "StreamLoadTxnCommitAttachment")
+                    .registerSubtype(ReplicationTxnCommitAttachment.class, "ReplicationTxnCommitAttachment");
 
     public static final RuntimeTypeAdapterFactory<RoutineLoadProgress> ROUTINE_LOAD_PROGRESS_TYPE_RUNTIME_ADAPTER_FACTORY =
             RuntimeTypeAdapterFactory.of(RoutineLoadProgress.class, "clazz")

--- a/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockID.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/metablock/SRMetaBlockID.java
@@ -90,6 +90,8 @@ public class SRMetaBlockID {
 
     public static final SRMetaBlockID STORAGE_VOLUME_MGR = new SRMetaBlockID(28);
 
+    public static final SRMetaBlockID REPLICATION_MGR = new SRMetaBlockID(30);
+
     @Override
     public String toString() {
         return String.valueOf(id);

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -1,0 +1,789 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Replica;
+import com.starrocks.catalog.Table;
+import com.starrocks.catalog.Table.TableType;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.AnalysisException;
+import com.starrocks.common.Config;
+import com.starrocks.common.DuplicatedRequestException;
+import com.starrocks.common.LabelAlreadyUsedException;
+import com.starrocks.common.MetaNotFoundException;
+import com.starrocks.common.UserException;
+import com.starrocks.persist.gson.GsonPostProcessable;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.system.Backend;
+import com.starrocks.system.SystemInfoService;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.AgentTaskExecutor;
+import com.starrocks.task.AgentTaskQueue;
+import com.starrocks.task.RemoteSnapshotTask;
+import com.starrocks.task.ReplicateSnapshotTask;
+import com.starrocks.thrift.TBackend;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TIndexReplicationInfo;
+import com.starrocks.thrift.TPartitionReplicationInfo;
+import com.starrocks.thrift.TRemoteSnapshotInfo;
+import com.starrocks.thrift.TReplicaReplicationInfo;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTableReplicationRequest;
+import com.starrocks.thrift.TTableType;
+import com.starrocks.thrift.TTabletReplicationInfo;
+import com.starrocks.thrift.TTabletType;
+import com.starrocks.transaction.BeginTransactionException;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class ReplicationJob implements GsonPostProcessable {
+    private static final Logger LOG = LogManager.getLogger(ReplicationJob.class);
+
+    private static class TableInfo {
+        private Table.TableType tableType;
+        private long tableDataSize;
+        private final Map<Long, PartitionInfo> partitionInfos;
+
+        public TableInfo(TableType tableType, long tableDataSize, Map<Long, PartitionInfo> partitionInfos) {
+            this.tableType = tableType;
+            this.tableDataSize = tableDataSize;
+            this.partitionInfos = partitionInfos;
+        }
+
+        public Table.TableType getTableType() {
+            return tableType;
+        }
+
+        public long getTableDataSize() {
+            return tableDataSize;
+        }
+
+        public Map<Long, PartitionInfo> getPartitionInfos() {
+            return partitionInfos;
+        }
+    }
+
+    private static class PartitionInfo {
+        @SerializedName(value = "partitionId")
+        private final long partitionId;
+
+        @SerializedName(value = "version")
+        private final long version;
+
+        @SerializedName(value = "srcVersion")
+        private final long srcVersion;
+
+        @SerializedName(value = "indexInfos")
+        private final Map<Long, IndexInfo> indexInfos;
+
+        public PartitionInfo(long partitionId, long version, long srcVersion, Map<Long, IndexInfo> indexInfos) {
+            this.partitionId = partitionId;
+            this.version = version;
+            this.srcVersion = srcVersion;
+            this.indexInfos = indexInfos;
+        }
+
+        public long getPartitionId() {
+            return partitionId;
+        }
+
+        public long getVersion() {
+            return version;
+        }
+
+        public long getSrcVersion() {
+            return srcVersion;
+        }
+
+        public Map<Long, IndexInfo> getIndexInfos() {
+            return indexInfos;
+        }
+    }
+
+    private static class IndexInfo {
+        @SerializedName(value = "indexId")
+        private final long indexId;
+
+        @SerializedName(value = "schemaHash")
+        private final int schemaHash;
+
+        @SerializedName(value = "srcSchemaHash")
+        private final int srcSchemaHash;
+
+        @SerializedName(value = "tabletInfos")
+        private final Map<Long, TabletInfo> tabletInfos;
+
+        public IndexInfo(long indexId, int schemaHash, int srcSchemaHash, Map<Long, TabletInfo> tabletInfos) {
+            this.indexId = indexId;
+            this.schemaHash = schemaHash;
+            this.srcSchemaHash = srcSchemaHash;
+            this.tabletInfos = tabletInfos;
+        }
+
+        public long getIndexId() {
+            return indexId;
+        }
+
+        public int getSchemaHash() {
+            return schemaHash;
+        }
+
+        public int getSrcSchemaHash() {
+            return srcSchemaHash;
+        }
+
+        public Map<Long, TabletInfo> getTabletInfos() {
+            return tabletInfos;
+        }
+    }
+
+    private static class TabletInfo {
+        @SerializedName(value = "tabletId")
+        private final long tabletId;
+
+        @SerializedName(value = "srcTabletId")
+        private final long srcTabletId;
+
+        @SerializedName(value = "replicaInfos")
+        private final Map<Long, ReplicaInfo> replicaInfos;
+
+        public TabletInfo(long tabletId, long srcTabletId, Map<Long, ReplicaInfo> replicaInfos) {
+            this.tabletId = tabletId;
+            this.srcTabletId = srcTabletId;
+            this.replicaInfos = replicaInfos;
+        }
+
+        public long getTabletId() {
+            return tabletId;
+        }
+
+        public long getSrcTabletId() {
+            return srcTabletId;
+        }
+
+        public Map<Long, ReplicaInfo> getReplicaInfos() {
+            return replicaInfos;
+        }
+    }
+
+    private static class ReplicaInfo {
+        @SerializedName(value = "backendId")
+        private final long backendId;
+
+        @SerializedName(value = "backendHost")
+        private final String backendHost;
+        @SerializedName(value = "backendBePort")
+        private final int backendBePort;
+        @SerializedName(value = "backendHttpPort")
+        private final int backendHttpPort;
+
+        @SerializedName(value = "srcSnapshotPath")
+        private volatile String srcSnapshotPath;
+
+        @SerializedName(value = "srcIncrementalSnapshot")
+        private volatile boolean srcIncrementalSnapshot;
+
+        public ReplicaInfo(long backendId, Backend srcBackend) {
+            this.backendId = backendId;
+            this.backendHost = srcBackend.getHost();
+            this.backendBePort = srcBackend.getBePort();
+            this.backendHttpPort = srcBackend.getHttpPort();
+        }
+
+        public ReplicaInfo(long backendId, String backendHost, int backendBePort, int backendHttpPort) {
+            this.backendId = backendId;
+            this.backendHost = backendHost;
+            this.backendBePort = backendBePort;
+            this.backendHttpPort = backendHttpPort;
+        }
+
+        public long getBackendId() {
+            return backendId;
+        }
+
+        public TBackend getSrcBackend() {
+            return new TBackend(backendHost, backendBePort, backendHttpPort);
+        }
+
+        public String getSrcSnapshotPath() {
+            return srcSnapshotPath;
+        }
+
+        public void setSrcSnapshotPath(String srcSnapshotPath) {
+            this.srcSnapshotPath = srcSnapshotPath;
+        }
+
+        public boolean getSrcIncrementalSnapshot() {
+            return srcIncrementalSnapshot;
+        }
+
+        public void setSrcIncrementalSnapshot(boolean srcIncrementalSnapshot) {
+            this.srcIncrementalSnapshot = srcIncrementalSnapshot;
+        }
+    }
+
+    @SerializedName(value = "srcToken")
+    private final String srcToken;
+
+    @SerializedName(value = "databaseId")
+    private final long databaseId;
+
+    @SerializedName(value = "tableId")
+    private final long tableId;
+
+    @SerializedName(value = "tableType")
+    private final Table.TableType tableType;
+
+    @SerializedName(value = "srcTableType")
+    private final Table.TableType srcTableType;
+
+    @SerializedName(value = "replicationDataSize")
+    private final long replicationDataSize;
+
+    @SerializedName(value = "partitionInfos")
+    private final Map<Long, PartitionInfo> partitionInfos;
+
+    @SerializedName(value = "transactionId")
+    private volatile long transactionId;
+
+    @SerializedName(value = "state")
+    private volatile ReplicationJobState state;
+
+    @SerializedName(value = "stateStartTime")
+    private volatile long stateStartTime;
+
+    private Map<AgentTask, AgentTask> runningTasks = Maps.newConcurrentMap();
+    private volatile int taskNum = 0;
+    private Map<AgentTask, AgentTask> finishedTasks = Maps.newConcurrentMap();
+
+    public long getTableId() {
+        return tableId;
+    }
+
+    public long getReplicationDataSize() {
+        return replicationDataSize;
+    }
+
+    public ReplicationJobState getState() {
+        return state;
+    }
+
+    private void setState(ReplicationJobState state) {
+        this.state = state;
+        this.stateStartTime = System.currentTimeMillis();
+    }
+
+    public Map<AgentTask, AgentTask> getRunningTasks() {
+        return runningTasks;
+    }
+
+    public ReplicationJob(TTableReplicationRequest request) throws MetaNotFoundException {
+        Preconditions.checkState(request.src_table_type == TTableType.OLAP_TABLE);
+
+        this.srcToken = request.src_token;
+        this.databaseId = request.database_id;
+        this.tableId = request.table_id;
+        TableInfo tableInfo = initTableInfo(request);
+        this.tableType = tableInfo.getTableType();
+        this.srcTableType = Table.TableType.OLAP;
+        this.replicationDataSize = request.src_table_data_size - tableInfo.getTableDataSize();
+        this.partitionInfos = tableInfo.getPartitionInfos();
+        this.transactionId = 0;
+        this.setState(ReplicationJobState.INITIALIZING);
+
+        if (partitionInfos.isEmpty()) {
+            throw new RuntimeException("No data need to replicate");
+        }
+    }
+
+    public ReplicationJob(String srcToken, long databaseId, OlapTable table, OlapTable srcTable,
+            SystemInfoService srcSystemInfoService) {
+        this.srcToken = srcToken;
+        this.databaseId = databaseId;
+        this.tableId = table.getId();
+        this.tableType = table.getType();
+        this.srcTableType = srcTable.getType();
+        this.replicationDataSize = srcTable.getDataSize() - table.getDataSize();
+        this.partitionInfos = initPartitionInfos(table, srcTable, srcSystemInfoService);
+        this.transactionId = 0;
+        this.setState(ReplicationJobState.INITIALIZING);
+
+        if (partitionInfos.isEmpty()) {
+            throw new RuntimeException("No data need to replicate");
+        }
+    }
+
+    public void cancel() {
+        if (state.equals(ReplicationJobState.COMMITTED) || state.equals(ReplicationJobState.ABORTED)) {
+            return;
+        }
+
+        if (transactionId != 0) {
+            abortTransaction("Replication job cancelled");
+        }
+
+        setState(ReplicationJobState.ABORTED);
+
+        GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+        LOG.warn("Replication job cancelled, abort, database id: {}, table id: {}, transaction id: {}",
+                databaseId, tableId, transactionId);
+    }
+
+    public void run() {
+        try {
+            if (state.equals(ReplicationJobState.INITIALIZING)) {
+                beginTransaction();
+                sendRemoteSnapshotTasks();
+                setState(ReplicationJobState.SNAPSHOTING);
+                GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+                LOG.info("Replication job state: {}, database id: {}, table id: {}, transaction id: {}", state,
+                        databaseId, tableId, transactionId);
+            } else if (state.equals(ReplicationJobState.SNAPSHOTING)) {
+                if (isTransactionAborted()) {
+                    setState(ReplicationJobState.ABORTED);
+                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+                    LOG.warn("Replication job snapshot timeout, database id: {}, table id: {}, transaction id: {}, ",
+                            databaseId, tableId, transactionId);
+                } else if (isCrashRecovery()) {
+                    sendRemoteSnapshotTasks();
+                    LOG.info("Replication job recovered, state: {}, database id: {}, table id: {}, transaction id: {}",
+                            state, databaseId, tableId, transactionId);
+                } else if (isAllTaskFinished()) {
+                    sendReplicateSnapshotTasks();
+                    setState(ReplicationJobState.REPLICATING);
+                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+                    LOG.info("Replication job state: {}, database id: {}, table id: {}, transaction id: {}", state,
+                            databaseId, tableId, transactionId);
+                }
+            } else if (state.equals(ReplicationJobState.REPLICATING)) {
+                if (isTransactionAborted()) {
+                    setState(ReplicationJobState.ABORTED);
+                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+                    LOG.warn("Replication job replicate timeout, database id: {}, table id: {}, transaction id: {}, ",
+                            databaseId, tableId, transactionId);
+                } else if (isCrashRecovery()) {
+                    sendReplicateSnapshotTasks();
+                    LOG.info("Replication job recovered, state: {}, database id: {}, table id: {}, transaction id: {}",
+                            state, databaseId, tableId, transactionId);
+                } else if (isAllTaskFinished()) {
+                    commitTransaction();
+                    setState(ReplicationJobState.COMMITTED);
+                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+                    LOG.info("Replication job state: {}, database id: {}, table id: {}, transaction id: {}", state,
+                            databaseId, tableId, transactionId);
+                }
+            }
+        } catch (Exception e) {
+            abortTransaction(e.getMessage());
+            setState(ReplicationJobState.ABORTED);
+            GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+            LOG.warn("Replication job run failed, abort, database id: {}, table id: {}, transaction id: {}, ",
+                    databaseId, tableId, transactionId, e);
+        }
+    }
+
+    public void finishRemoteSnapshotTask(RemoteSnapshotTask task, TFinishTaskRequest request) {
+        if (!runningTasks.remove(task, task)) {
+            LOG.warn("Remote snapshot task {} is finished, but cannot find it in running tasks", task);
+            return;
+        }
+
+        if (request.getTask_status().getStatus_code() == TStatusCode.OK) {
+            if (request.isSetSnapshot_path() && request.isSetIncremental_snapshot()) {
+                PartitionInfo partitionInfo = partitionInfos.get(task.getPartitionId());
+                Preconditions.checkNotNull(partitionInfo);
+                IndexInfo indexInfo = partitionInfo.getIndexInfos().get(task.getIndexId());
+                Preconditions.checkNotNull(indexInfo);
+                TabletInfo tabletInfo = indexInfo.getTabletInfos().get(task.getTabletId());
+                Preconditions.checkNotNull(tabletInfo);
+                ReplicaInfo replicaInfo = tabletInfo.getReplicaInfos().get(task.getBackendId());
+                Preconditions.checkNotNull(replicaInfo);
+
+                replicaInfo.setSrcSnapshotPath(request.snapshot_path);
+                replicaInfo.setSrcIncrementalSnapshot(request.incremental_snapshot);
+            } else {
+                task.setFailed(true);
+                task.setErrorMsg("No snapshot path or incremental snapshot");
+                LOG.warn("Remote snapshot task failed, task: {}, error: {}", task, task.getErrorMsg());
+            }
+        } else {
+            task.setFailed(true);
+            task.setErrorMsg(request.getTask_status().getError_msgs().get(0));
+            LOG.warn("Remote snapshot task failed, task: {}, error: {}", task, task.getErrorMsg());
+        }
+
+        finishedTasks.put(task, task);
+    }
+
+    public void finishReplicateSnapshotTask(ReplicateSnapshotTask task, TFinishTaskRequest request) {
+        if (!runningTasks.remove(task, task)) {
+            LOG.warn("Replicate snapshot task {} is finished, but cannot find it in running tasks", task);
+            return;
+        }
+
+        if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
+            task.setFailed(true);
+            task.setErrorMsg(request.getTask_status().getError_msgs().get(0));
+            LOG.warn("Replicate snapshot task failed, task: {}, error: {}", task, task.getErrorMsg());
+        }
+
+        finishedTasks.put(task, task);
+    }
+
+    private TableInfo initTableInfo(TTableReplicationRequest request) throws MetaNotFoundException {
+        Table.TableType tableType;
+        long tableDataSize;
+        Map<Long, PartitionInfo> partitionInfos = Maps.newHashMap();
+
+        Database db = GlobalStateMgr.getCurrentState().getDb(request.database_id);
+        if (db == null) {
+            throw new MetaNotFoundException("Database " + request.database_id + " not found");
+        }
+
+        db.readLock();
+        try {
+            Table table = db.getTable(request.table_id);
+            if (table == null) {
+                throw new MetaNotFoundException(
+                        "Table " + request.table_id + " in database " + db.getFullName() + " not found");
+            }
+            if (!(table instanceof OlapTable)) {
+                throw new MetaNotFoundException(
+                        "Table " + request.table_id + " in database " + db.getFullName() + " is not olap table");
+            }
+            OlapTable olapTable = (OlapTable) table;
+            tableType = olapTable.getType();
+            tableDataSize = olapTable.getDataSize();
+
+            for (TPartitionReplicationInfo tPartitionInfo : request.partition_replication_infos.values()) {
+                Partition partition = olapTable.getPartition(tPartitionInfo.partition_id);
+                if (partition == null) {
+                    throw new MetaNotFoundException("Partition " + tPartitionInfo.partition_id + " in table "
+                            + table.getName() + " in database " + db.getFullName() + " not found");
+                }
+                PartitionInfo partitionInfo = initPartitionInfo(olapTable, tPartitionInfo, partition);
+                partitionInfos.put(partitionInfo.getPartitionId(), partitionInfo);
+            }
+        } finally {
+            db.readUnlock();
+        }
+        return new TableInfo(tableType, tableDataSize, partitionInfos);
+    }
+
+    private PartitionInfo initPartitionInfo(OlapTable olapTable, TPartitionReplicationInfo tPartitionInfo,
+            Partition partition) throws MetaNotFoundException {
+        Map<Long, IndexInfo> indexInfos = Maps.newHashMap();
+        for (TIndexReplicationInfo tIndexInfo : tPartitionInfo.index_replication_infos.values()) {
+            MaterializedIndex index = partition.getIndex(tIndexInfo.index_id);
+            if (index == null) {
+                throw new MetaNotFoundException("Index " + tIndexInfo.index_id + " in partition " + partition.getName()
+                        + " in table " + olapTable.getName() + " not found");
+            }
+            IndexInfo indexInfo = initIndexInfo(olapTable, tIndexInfo, index);
+            indexInfos.put(indexInfo.getIndexId(), indexInfo);
+        }
+        return new PartitionInfo(tPartitionInfo.partition_id, partition.getVisibleVersion(),
+                tPartitionInfo.src_version, indexInfos);
+    }
+
+    private IndexInfo initIndexInfo(OlapTable olapTable, TIndexReplicationInfo tIndexInfo, MaterializedIndex index)
+            throws MetaNotFoundException {
+        Map<Long, TabletInfo> tabletInfos = Maps.newHashMap();
+        for (TTabletReplicationInfo tTabletInfo : tIndexInfo.tablet_replication_infos.values()) {
+            Tablet tablet = index.getTablet(tTabletInfo.tablet_id);
+            if (tablet == null) {
+                throw new MetaNotFoundException("Tablet " + tTabletInfo.tablet_id + " in index " + tIndexInfo.index_id
+                        + " in table " + olapTable.getName() + " not found");
+            }
+            TabletInfo tabletInfo = initTabletInfo(tTabletInfo, tablet);
+            tabletInfos.put(tabletInfo.getTabletId(), tabletInfo);
+        }
+        int schemaHash = olapTable.getSchemaHashByIndexId(tIndexInfo.index_id);
+        // If src schema hash is 0, use target schema hash
+        int srcSchemaHash = tIndexInfo.src_schema_hash != 0 ? tIndexInfo.src_schema_hash : schemaHash;
+        return new IndexInfo(tIndexInfo.index_id, schemaHash, srcSchemaHash, tabletInfos);
+    }
+
+    private TabletInfo initTabletInfo(TTabletReplicationInfo tTabletInfo, Tablet tablet)
+            throws MetaNotFoundException {
+        Map<Long, ReplicaInfo> replicaInfos = Maps.newHashMap();
+        List<Replica> replicas = tablet.getAllReplicas();
+        List<TReplicaReplicationInfo> tReplicaInfos = tTabletInfo.replica_replication_infos;
+        Preconditions.checkState(replicas.size() <= tReplicaInfos.size(),
+                "Source replica number must not less than target replica number");
+        for (int i = 0; i < replicas.size(); ++i) {
+            Replica replica = replicas.get(i);
+            TReplicaReplicationInfo tReplicaInfo = tReplicaInfos.get(i);
+            ReplicaInfo replicaInfo = new ReplicaInfo(replica.getBackendId(),
+                    tReplicaInfo.src_backend.host, tReplicaInfo.src_backend.be_port,
+                    tReplicaInfo.src_backend.http_port);
+            replicaInfos.put(replicaInfo.getBackendId(), replicaInfo);
+        }
+        return new TabletInfo(tTabletInfo.tablet_id, tTabletInfo.src_tablet_id, replicaInfos);
+    }
+
+    private Map<Long, PartitionInfo> initPartitionInfos(OlapTable table, OlapTable srcTable,
+            SystemInfoService srcSystemInfoService) {
+        Map<Long, PartitionInfo> partitionInfos = Maps.newHashMap();
+        for (Partition partition : table.getPartitions()) {
+            Partition srcPartition = srcTable.getPartition(partition.getName());
+            if (partition.getCommittedVersion() >= srcPartition.getVisibleVersion()) {
+                continue;
+            }
+            PartitionInfo partitionInfo = initPartitionInfo(table, srcTable, partition, srcPartition,
+                    srcSystemInfoService);
+            partitionInfos.put(partitionInfo.getPartitionId(), partitionInfo);
+        }
+        return partitionInfos;
+    }
+
+    private PartitionInfo initPartitionInfo(OlapTable table, OlapTable srcTable, Partition partition,
+            Partition srcPartition, SystemInfoService srcSystemInfoService) {
+        Map<Long, IndexInfo> indexInfos = Maps.newHashMap();
+        for (Map.Entry<String, Long> indexNameToId : table.getIndexNameToId().entrySet()) {
+            long indexId = indexNameToId.getValue();
+            long srcIndexId = srcTable.getIndexIdByName(indexNameToId.getKey());
+            MaterializedIndex index = partition.getIndex(indexId);
+            MaterializedIndex srcIndex = srcPartition.getIndex(srcIndexId);
+            IndexInfo indexInfo = initIndexInfo(table, srcTable, index, srcIndex, srcSystemInfoService);
+            indexInfos.put(indexInfo.getIndexId(), indexInfo);
+        }
+        return new PartitionInfo(partition.getId(), partition.getVisibleVersion(), srcPartition.getVisibleVersion(),
+                indexInfos);
+    }
+
+    private IndexInfo initIndexInfo(OlapTable table, OlapTable srcTable, MaterializedIndex index,
+            MaterializedIndex srcIndex,
+            SystemInfoService srcSystemInfoService) {
+        int schemaHash = table.getSchemaHashByIndexId(index.getId());
+        int srcSchemaHash = srcTable.getSchemaHashByIndexId(srcIndex.getId());
+
+        Map<Long, TabletInfo> tabletInfos = Maps.newHashMap();
+        List<Tablet> tablets = index.getTablets();
+        List<Tablet> srcTablets = srcIndex.getTablets();
+        Preconditions.checkState(tablets.size() == srcTablets.size());
+        for (int i = 0; i < tablets.size(); ++i) {
+            Tablet tablet = tablets.get(i);
+            Tablet srcTablet = srcTablets.get(i);
+            TabletInfo tabletInfo = initTabletInfo(tablet, srcTablet, srcSystemInfoService);
+            tabletInfos.put(tabletInfo.getTabletId(), tabletInfo);
+        }
+        return new IndexInfo(index.getId(), schemaHash, srcSchemaHash, tabletInfos);
+    }
+
+    private TabletInfo initTabletInfo(Tablet tablet, Tablet srcTablet,
+            SystemInfoService srcSystemInfoService) {
+        Map<Long, ReplicaInfo> replicaInfos = Maps.newHashMap();
+        List<Replica> replicas = tablet.getAllReplicas();
+        List<Replica> srcReplicas = srcTablet.getAllReplicas();
+        Preconditions.checkState(replicas.size() <= srcReplicas.size());
+        for (int i = 0; i < replicas.size(); ++i) {
+            Replica replica = replicas.get(i);
+            Replica srcReplica = srcReplicas.get(i); // TODO: replicas.size() > srcReplicas.size()
+            ReplicaInfo replicaInfo = initReplicaInfo(replica, srcReplica, srcSystemInfoService);
+            replicaInfos.put(replicaInfo.getBackendId(), replicaInfo);
+        }
+        return new TabletInfo(tablet.getId(), srcTablet.getId(), replicaInfos);
+    }
+
+    private ReplicaInfo initReplicaInfo(Replica replica, Replica srcReplica, SystemInfoService srcSystemInfoService) {
+        Backend srcBackend = srcSystemInfoService.getBackend(srcReplica.getBackendId());
+        return new ReplicaInfo(replica.getBackendId(), srcBackend);
+    }
+
+    private TTabletType getTabletType(Table.TableType tableType) {
+        return tableType == Table.TableType.CLOUD_NATIVE ? TTabletType.TABLET_TYPE_LAKE
+                : TTabletType.TABLET_TYPE_DISK;
+    }
+
+    private void beginTransaction()
+            throws LabelAlreadyUsedException, DuplicatedRequestException, AnalysisException, BeginTransactionException {
+        TransactionState.LoadJobSourceType loadJobSourceType = TransactionState.LoadJobSourceType.REPLICATION;
+        TransactionState.TxnCoordinator coordinator = TransactionState.TxnCoordinator.fromThisFE();
+        String label = String.format("REPLICATION_%d-%d-%d", databaseId, tableId, System.currentTimeMillis());
+        transactionId = GlobalStateMgr.getServingState().getGlobalTransactionMgr().beginTransaction(databaseId,
+                Lists.newArrayList(tableId), label, coordinator, loadJobSourceType,
+                Config.replication_transaction_timeout_sec);
+    }
+
+    private void commitTransaction() throws UserException {
+        List<TabletCommitInfo> tabletCommitInfos = Lists.newArrayList();
+        List<TabletFailInfo> tabletFailInfos = Lists.newArrayList();
+        for (AgentTask task : finishedTasks.values()) {
+            if (task.isFailed()) {
+                tabletFailInfos.add(new TabletFailInfo(task.getTabletId(), task.getBackendId()));
+            } else {
+                tabletCommitInfos.add(new TabletCommitInfo(task.getTabletId(), task.getBackendId()));
+            }
+        }
+
+        Map<Long, Long> partitionVersions = Maps.newHashMap();
+        for (PartitionInfo partitionInfo : partitionInfos.values()) {
+            partitionVersions.put(partitionInfo.getPartitionId(), partitionInfo.getSrcVersion());
+        }
+        ReplicationTxnCommitAttachment attachment = new ReplicationTxnCommitAttachment(partitionVersions);
+
+        GlobalStateMgr.getServingState().getGlobalTransactionMgr().commitTransaction(databaseId,
+                transactionId, tabletCommitInfos, tabletFailInfos, attachment);
+    }
+
+    private void abortTransaction(String reason) {
+        try {
+            GlobalStateMgr.getServingState().getGlobalTransactionMgr().abortTransaction(databaseId, transactionId,
+                    reason);
+        } catch (Exception e) {
+            LOG.warn("Replication job abort transaction failed, ignore, database id: {}, table id: {}, ",
+                    databaseId, tableId, e);
+        }
+    }
+
+    private boolean isTransactionAborted() {
+        TransactionState txnState = GlobalStateMgr.getServingState().getGlobalTransactionMgr()
+                .getTransactionState(databaseId, transactionId);
+        if (txnState == null) {
+            return true;
+        }
+        return txnState.getTransactionStatus() == TransactionStatus.ABORTED;
+    }
+
+    private void sendRemoteSnapshotTasks() {
+        runningTasks.clear();
+        for (PartitionInfo partitionInfo : partitionInfos.values()) {
+            for (IndexInfo indexInfo : partitionInfo.getIndexInfos().values()) {
+                for (TabletInfo tabletInfo : indexInfo.getTabletInfos().values()) {
+                    for (ReplicaInfo replicaInfo : tabletInfo.getReplicaInfos().values()) {
+                        RemoteSnapshotTask task = new RemoteSnapshotTask(replicaInfo.getBackendId(), databaseId,
+                                tableId, partitionInfo.getPartitionId(), indexInfo.getIndexId(),
+                                tabletInfo.getTabletId(), getTabletType(tableType), transactionId,
+                                indexInfo.getSchemaHash(), partitionInfo.getVersion(),
+                                srcToken, tabletInfo.getSrcTabletId(), getTabletType(srcTableType),
+                                indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(),
+                                Lists.newArrayList(replicaInfo.getSrcBackend()),
+                                Config.replication_transaction_remote_snapshot_timeout_sec);
+                        runningTasks.put(task, task);
+                    }
+                }
+            }
+        }
+
+        taskNum = runningTasks.size();
+
+        sendRunningTasks();
+    }
+
+    private void sendReplicateSnapshotTasks() {
+        runningTasks.clear();
+        for (PartitionInfo partitionInfo : partitionInfos.values()) {
+            for (IndexInfo indexInfo : partitionInfo.getIndexInfos().values()) {
+                for (TabletInfo tabletInfo : indexInfo.getTabletInfos().values()) {
+                    for (ReplicaInfo replicaInfo : tabletInfo.getReplicaInfos().values()) {
+                        TRemoteSnapshotInfo srcSnapshotInfo = new TRemoteSnapshotInfo();
+                        srcSnapshotInfo.setBackend(replicaInfo.getSrcBackend());
+                        srcSnapshotInfo.setSnapshot_path(replicaInfo.getSrcSnapshotPath());
+                        srcSnapshotInfo.setIncremental_snapshot(replicaInfo.getSrcIncrementalSnapshot());
+                        ReplicateSnapshotTask task = new ReplicateSnapshotTask(replicaInfo.getBackendId(), databaseId,
+                                tableId, partitionInfo.getPartitionId(), indexInfo.getIndexId(),
+                                tabletInfo.getTabletId(), getTabletType(tableType), transactionId,
+                                indexInfo.getSchemaHash(), partitionInfo.getVersion(),
+                                srcToken, tabletInfo.getSrcTabletId(), getTabletType(srcTableType),
+                                indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(),
+                                Lists.newArrayList(srcSnapshotInfo));
+                        runningTasks.put(task, task);
+                    }
+                }
+            }
+        }
+
+        taskNum = runningTasks.size();
+
+        sendRunningTasks();
+    }
+
+    private void sendRunningTasks() {
+        if (runningTasks.isEmpty()) {
+            throw new RuntimeException("Running tasks is empty");
+        }
+
+        finishedTasks.clear();
+
+        AgentBatchTask batchTask = new AgentBatchTask();
+        for (AgentTask task : runningTasks.values()) {
+            batchTask.addTask(task);
+            AgentTaskQueue.addTask(task);
+        }
+
+        AgentTaskExecutor.submit(batchTask);
+    }
+
+    private void setAllTaskTimeout() {
+        List<AgentTask> tasks = Lists.newArrayList(runningTasks.values());
+        for (AgentTask task : tasks) {
+            if (runningTasks.remove(task, task)) {
+                task.setFailed(true);
+                task.setErrorMsg("Task timeout");
+                finishedTasks.put(task, task);
+                LOG.warn("Task timeout, task: {}, error: {}", task, task.getErrorMsg());
+            }
+        }
+    }
+
+    private boolean isAllTaskFinished() {
+        if (runningTasks.isEmpty() && finishedTasks.size() == taskNum) {
+            return true;
+        }
+
+        long timeoutMs = 0;
+        if (state.equals(ReplicationJobState.SNAPSHOTING)) {
+            timeoutMs = Config.replication_transaction_remote_snapshot_timeout_sec * 1000;
+        } else if (state.equals(ReplicationJobState.REPLICATING)) {
+            timeoutMs = Config.replication_transaction_replicate_snapshot_timeout_sec * 1000;
+        } else {
+            throw new RuntimeException("Invalid replication job state: " + state);
+        }
+
+        if (System.currentTimeMillis() > stateStartTime + timeoutMs) {
+            setAllTaskTimeout();
+        }
+
+        return runningTasks.isEmpty() && finishedTasks.size() == taskNum;
+    }
+
+    private boolean isCrashRecovery() {
+        return runningTasks.isEmpty() && finishedTasks.isEmpty();
+    }
+
+    @Override
+    public void gsonPostProcess() throws IOException {
+        runningTasks = Maps.newConcurrentMap();
+        finishedTasks = Maps.newConcurrentMap();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJobState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJobState.java
@@ -1,0 +1,94 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.Map;
+import java.util.Objects;
+
+public class ReplicationJobState {
+    @SerializedName("id")
+    protected final int id;
+
+    protected ReplicationJobState(int id) {
+        this.id = id;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public String name() {
+        String name = ID_TO_NAME.get(id);
+        if (name != null) {
+            return name;
+        }
+        return "UNKNOWN";
+    }
+
+    public static final ReplicationJobState INITIALIZING = new ReplicationJobState(1);
+    public static final ReplicationJobState SNAPSHOTING = new ReplicationJobState(2);
+    public static final ReplicationJobState REPLICATING = new ReplicationJobState(3);
+    public static final ReplicationJobState COMMITTED = new ReplicationJobState(4);
+    public static final ReplicationJobState ABORTED = new ReplicationJobState(5);
+
+    public static final Map<String, ReplicationJobState> NAME_TO_STATE = new ImmutableMap.Builder<String, ReplicationJobState>()
+            .put("INITIALIZING", INITIALIZING)
+            .put("SNAPSHOTING", SNAPSHOTING)
+            .put("REPLICATING", REPLICATING)
+            .put("COMMITTED", COMMITTED)
+            .put("ABORTED", ABORTED)
+            .build();
+
+    public static final Map<Integer, String> ID_TO_NAME = new ImmutableMap.Builder<Integer, String>()
+            .put(INITIALIZING.getId(), "INITIALIZING")
+            .put(SNAPSHOTING.getId(), "SNAPSHOTING")
+            .put(REPLICATING.getId(), "REPLICATING")
+            .put(COMMITTED.getId(), "COMMITTED")
+            .put(ABORTED.getId(), "ABORTED")
+            .build();
+
+    public static final Map<Integer, ReplicationJobState> ID_TO_STATE = new ImmutableMap.Builder<Integer, ReplicationJobState>()
+            .put(INITIALIZING.getId(), INITIALIZING)
+            .put(SNAPSHOTING.getId(), SNAPSHOTING)
+            .put(REPLICATING.getId(), REPLICATING)
+            .put(COMMITTED.getId(), COMMITTED)
+            .put(ABORTED.getId(), ABORTED)
+            .build();
+
+    @Override
+    public String toString() {
+        return name();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (this == other) {
+            return true;
+        }
+        if (!(other instanceof ReplicationJobState)) {
+            return false;
+        }
+        ReplicationJobState that = (ReplicationJobState) other;
+        return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationMgr.java
@@ -1,0 +1,196 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.AlreadyExistsException;
+import com.starrocks.common.Config;
+import com.starrocks.common.UserException;
+import com.starrocks.common.util.FrontendDaemon;
+import com.starrocks.persist.metablock.SRMetaBlockEOFException;
+import com.starrocks.persist.metablock.SRMetaBlockException;
+import com.starrocks.persist.metablock.SRMetaBlockID;
+import com.starrocks.persist.metablock.SRMetaBlockReader;
+import com.starrocks.persist.metablock.SRMetaBlockWriter;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.task.RemoteSnapshotTask;
+import com.starrocks.task.ReplicateSnapshotTask;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TTableReplicationRequest;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class ReplicationMgr extends FrontendDaemon {
+    private static final Logger LOG = LogManager.getLogger(ReplicationMgr.class);
+
+    @SerializedName(value = "runningJobs")
+    private final Map<Long, ReplicationJob> runningJobs = Maps.newConcurrentMap(); // Running jobs
+
+    @SerializedName(value = "committedJobs")
+    private final Map<Long, ReplicationJob> committedJobs = Maps.newConcurrentMap(); // Committed jobs
+
+    @SerializedName(value = "abortedJobs")
+    private final Map<Long, ReplicationJob> abortedJobs = Maps.newConcurrentMap(); // Aborted jobs, will retry later
+
+    public ReplicationMgr() {
+        super("ReplicationMgr", 1000L);
+    }
+
+    @Override
+    protected void runAfterCatalogReady() {
+        List<ReplicationJob> toRemovedJobs = Lists.newArrayList();
+        for (ReplicationJob job : runningJobs.values()) {
+            job.run();
+
+            ReplicationJobState state = job.getState();
+            if (state.equals(ReplicationJobState.COMMITTED)) {
+                toRemovedJobs.add(job);
+                committedJobs.put(job.getTableId(), job);
+            } else if (state.equals(ReplicationJobState.ABORTED)) {
+                toRemovedJobs.add(job);
+                abortedJobs.put(job.getTableId(), job);
+            }
+        }
+
+        for (ReplicationJob job : toRemovedJobs) {
+            runningJobs.remove(job.getTableId(), job);
+        }
+    }
+
+    public void addReplicationJob(TTableReplicationRequest request) throws UserException {
+        ReplicationJob job = new ReplicationJob(request);
+        addReplicationJob(job);
+    }
+
+    public void addReplicationJob(ReplicationJob job) throws AlreadyExistsException {
+        // Limit replication job size
+        if (runningJobs.size() >= Config.replication_transaction_max_parallel_job_count) {
+            throw new RuntimeException(
+                    "The replication jobs exceeds the replication_transaction_max_parallel_job_count: "
+                            + Config.replication_transaction_max_parallel_job_count);
+        }
+
+        // Limit replication data size
+        long totalReplicationDataSize = getTotalReplicationDataSize();
+        if (totalReplicationDataSize >= Config.replication_transaction_max_parallel_replication_data_size_mb) {
+            throw new RuntimeException("The total replication data size in replication jobs exceeds "
+                    + "replication_transaction_max_parallel_replication_data_size_mb: "
+                    + Config.replication_transaction_max_parallel_replication_data_size_mb);
+        }
+
+        if (runningJobs.putIfAbsent(job.getTableId(), job) != null) {
+            throw new AlreadyExistsException("Replication job of table " + job.getTableId() + " is already running");
+        }
+
+        committedJobs.remove(job.getTableId()); // If the job is committed before, remove it from committed jobs
+        abortedJobs.remove(job.getTableId()); // If the job is aborted before, remove it from aborted jobs
+    }
+
+    public boolean hasRunningJobs() {
+        return !runningJobs.isEmpty();
+    }
+
+    public boolean hasFailedJobs() {
+        return !abortedJobs.isEmpty();
+    }
+
+    public void clearFinishedJobs() {
+        committedJobs.clear();
+        abortedJobs.clear();
+        GlobalStateMgr.getServingState().getEditLog().logReplicationJob(null);
+    }
+
+    public void cancelRunningJobs() {
+        List<ReplicationJob> toRemovedJobs = Lists.newArrayList();
+        for (ReplicationJob job : runningJobs.values()) {
+            job.cancel();
+
+            if (job.getState().equals(ReplicationJobState.ABORTED)) {
+                toRemovedJobs.add(job);
+                abortedJobs.put(job.getTableId(), job);
+            }
+        }
+
+        for (ReplicationJob job : toRemovedJobs) {
+            runningJobs.remove(job.getTableId(), job);
+        }
+    }
+
+    public void finishRemoteSnapshotTask(RemoteSnapshotTask task, TFinishTaskRequest request) {
+        ReplicationJob job = runningJobs.get(task.getTableId());
+        if (job == null) {
+            LOG.warn("Remote snapshot task {} is finished, but cannot find it in replication jobs", task);
+            return;
+        }
+
+        job.finishRemoteSnapshotTask(task, request);
+    }
+
+    public void finishReplicateSnapshotTask(ReplicateSnapshotTask task, TFinishTaskRequest request) {
+        ReplicationJob job = runningJobs.get(task.getTableId());
+        if (job == null) {
+            LOG.warn("Replicate snapshot task {} is finished, but cannot find it in replication jobs", task);
+            return;
+        }
+
+        job.finishReplicateSnapshotTask(task, request);
+    }
+
+    public void replayReplicationJob(ReplicationJob replicationJob) {
+        if (replicationJob == null) {
+            committedJobs.clear();
+            abortedJobs.clear();
+            return;
+        }
+
+        if (replicationJob.getState().equals(ReplicationJobState.COMMITTED)) {
+            committedJobs.put(replicationJob.getTableId(), replicationJob);
+            runningJobs.remove(replicationJob.getTableId());
+        } else if (replicationJob.getState().equals(ReplicationJobState.ABORTED)) {
+            abortedJobs.put(replicationJob.getTableId(), replicationJob);
+            runningJobs.remove(replicationJob.getTableId());
+        } else {
+            runningJobs.put(replicationJob.getTableId(), replicationJob);
+        }
+    }
+
+    private long getTotalReplicationDataSize() {
+        long totalReplicationDataSize = 0;
+        for (ReplicationJob job : runningJobs.values()) {
+            totalReplicationDataSize += job.getReplicationDataSize();
+        }
+        return totalReplicationDataSize;
+    }
+
+    public void save(DataOutputStream dos) throws IOException, SRMetaBlockException {
+        SRMetaBlockWriter writer = new SRMetaBlockWriter(dos, SRMetaBlockID.REPLICATION_MGR, 1);
+        writer.writeJson(this);
+        writer.close();
+    }
+
+    public void load(SRMetaBlockReader reader) throws SRMetaBlockEOFException, IOException, SRMetaBlockException {
+        ReplicationMgr replicationMgr = reader.readJson(ReplicationMgr.class);
+        runningJobs.putAll(replicationMgr.runningJobs);
+        committedJobs.putAll(replicationMgr.committedJobs);
+        abortedJobs.putAll(replicationMgr.abortedJobs);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationTxnCommitAttachment.java
@@ -1,0 +1,63 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.common.io.Text;
+import com.starrocks.persist.gson.GsonUtils;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TxnCommitAttachment;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.Map;
+
+/*
+ * The new versions in a replication transaction depend on the versions in source cluster
+ * So we use this class to save the version in source cluster when committing a replication transaction
+ */
+public class ReplicationTxnCommitAttachment extends TxnCommitAttachment {
+    @SerializedName("partitionVersions")
+    private Map<Long, Long> partitionVersions; // The version of partitions
+
+    public ReplicationTxnCommitAttachment() {
+        super(TransactionState.LoadJobSourceType.REPLICATION);
+    }
+
+    public ReplicationTxnCommitAttachment(Map<Long, Long> partitionVersions) {
+        super(TransactionState.LoadJobSourceType.REPLICATION);
+        this.partitionVersions = partitionVersions;
+    }
+
+    public Map<Long, Long> getPartitionVersions() {
+        return partitionVersions;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        super.write(out);
+        String s = GsonUtils.GSON.toJson(this);
+        Text.writeString(out, s);
+    }
+
+    public void readFields(DataInput in) throws IOException {
+        super.readFields(in);
+        String s = Text.readString(in);
+        ReplicationTxnCommitAttachment insertTxnCommitAttachment = GsonUtils.GSON.fromJson(s,
+                ReplicationTxnCommitAttachment.class);
+        this.partitionVersions = insertTxnCommitAttachment.getPartitionVersions();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -230,6 +230,7 @@ import com.starrocks.qe.VariableMgr;
 import com.starrocks.qe.scheduler.slot.ResourceUsageMonitor;
 import com.starrocks.qe.scheduler.slot.SlotManager;
 import com.starrocks.qe.scheduler.slot.SlotProvider;
+import com.starrocks.replication.ReplicationMgr;
 import com.starrocks.rpc.FrontendServiceProxy;
 import com.starrocks.scheduler.MVActiveChecker;
 import com.starrocks.scheduler.TaskManager;
@@ -545,6 +546,8 @@ public class GlobalStateMgr {
 
     private MVActiveChecker mvActiveChecker;
 
+    private ReplicationMgr replicationMgr;
+
     private final ResourceUsageMonitor resourceUsageMonitor = new ResourceUsageMonitor();
     private final SlotManager slotManager = new SlotManager(resourceUsageMonitor);
     private final SlotProvider slotProvider = new SlotProvider();
@@ -796,6 +799,7 @@ public class GlobalStateMgr {
             }
         });
 
+        this.replicationMgr = new ReplicationMgr();
         nodeMgr.registerLeaderChangeListener(slotProvider::leaderChangeListener);
     }
 
@@ -1034,7 +1038,11 @@ public class GlobalStateMgr {
         return connectorTableMetadataProcessor;
     }
 
-    // Use tryLock to avoid potential dead lock
+    public ReplicationMgr getReplicationMgr() {
+        return replicationMgr;
+    }
+
+    // Use tryLock to avoid potential deadlock
     public boolean tryLock(boolean mustLock) {
         while (true) {
             try {
@@ -1414,6 +1422,8 @@ public class GlobalStateMgr {
             LOG.info("Start safe mode checker!");
             safeModeChecker.start();
         }
+
+        replicationMgr.start();
     }
 
     // start threads that should run on all FE
@@ -1539,6 +1549,7 @@ public class GlobalStateMgr {
                         .put(SRMetaBlockID.MATERIALIZED_VIEW_MGR, MaterializedViewMgr.getInstance()::load)
                         .put(SRMetaBlockID.GLOBAL_FUNCTION_MGR, globalFunctionMgr::load)
                         .put(SRMetaBlockID.STORAGE_VOLUME_MGR, storageVolumeMgr::load)
+                        .put(SRMetaBlockID.REPLICATION_MGR, replicationMgr::load)
                         .build();
                 try {
                     loadHeaderV2(dis);
@@ -1955,6 +1966,7 @@ public class GlobalStateMgr {
                     MaterializedViewMgr.getInstance().save(dos);
                     globalFunctionMgr.save(dos);
                     storageVolumeMgr.save(dos);
+                    replicationMgr.save(dos);
                 } catch (SRMetaBlockException e) {
                     LOG.error("Save meta block failed ", e);
                     throw new IOException("Save meta block failed ", e);

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -237,6 +237,8 @@ import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TStreamLoadPutRequest;
 import com.starrocks.thrift.TStreamLoadPutResult;
 import com.starrocks.thrift.TTablePrivDesc;
+import com.starrocks.thrift.TTableReplicationRequest;
+import com.starrocks.thrift.TTableReplicationResponse;
 import com.starrocks.thrift.TTableStatus;
 import com.starrocks.thrift.TTableType;
 import com.starrocks.thrift.TTabletLocation;
@@ -2179,5 +2181,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
         res.setStatus(tstatus);
 
         return res;
+    }
+
+    @Override
+    public TTableReplicationResponse startTableReplication(TTableReplicationRequest request) throws TException {
+        return leaderImpl.startTableReplication(request);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/system/HeartbeatMgr.java
@@ -98,6 +98,7 @@ public class HeartbeatMgr extends FrontendDaemon {
         tMasterInfo.setHttp_port(Config.http_port);
         long flags = HeartbeatFlags.getHeartbeatFlags();
         tMasterInfo.setHeartbeat_flags(flags);
+        tMasterInfo.setMin_active_txn_id(GlobalStateMgr.getCurrentGlobalTransactionMgr().getMinActiveTxnId());
         MASTER_INFO.set(tMasterInfo);
     }
 
@@ -277,6 +278,7 @@ public class HeartbeatMgr extends FrontendDaemon {
                 long flags = HeartbeatFlags.getHeartbeatFlags();
                 copiedMasterInfo.setHeartbeat_flags(flags);
                 copiedMasterInfo.setBackend_id(computeNodeId);
+                copiedMasterInfo.setMin_active_txn_id(GlobalStateMgr.getCurrentGlobalTransactionMgr().getMinActiveTxnId());
                 copiedMasterInfo.setRun_mode(RunMode.toTRunMode(RunMode.getCurrentRunMode()));
                 THeartbeatResult result = client.heartbeat(copiedMasterInfo);
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/AgentBatchTask.java
@@ -57,6 +57,8 @@ import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TPublishVersionRequest;
 import com.starrocks.thrift.TPushReq;
 import com.starrocks.thrift.TReleaseSnapshotRequest;
+import com.starrocks.thrift.TRemoteSnapshotRequest;
+import com.starrocks.thrift.TReplicateSnapshotRequest;
 import com.starrocks.thrift.TSnapshotRequest;
 import com.starrocks.thrift.TStorageMediumMigrateReq;
 import com.starrocks.thrift.TTaskType;
@@ -384,6 +386,18 @@ public class AgentBatchTask implements Runnable {
                 CompactionTask compactionTask = (CompactionTask) task;
                 TCompactionReq req = compactionTask.toThrift();
                 tAgentTaskRequest.setCompaction_req(req);
+                return tAgentTaskRequest;
+            }
+            case REMOTE_SNAPSHOT: {
+                RemoteSnapshotTask remoteSnapshotTask = (RemoteSnapshotTask) task;
+                TRemoteSnapshotRequest req = remoteSnapshotTask.toThrift();
+                tAgentTaskRequest.setRemote_snapshot_req(req);
+                return tAgentTaskRequest;
+            }
+            case REPLICATE_SNAPSHOT: {
+                ReplicateSnapshotTask replicateSnapshotTask = (ReplicateSnapshotTask) task;
+                TReplicateSnapshotRequest req = replicateSnapshotTask.toThrift();
+                tAgentTaskRequest.setReplicate_snapshot_req(req);
                 return tAgentTaskRequest;
             }
             default:

--- a/fe/fe-core/src/main/java/com/starrocks/task/ClearTransactionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ClearTransactionTask.java
@@ -19,6 +19,7 @@ package com.starrocks.task;
 
 import com.starrocks.thrift.TClearTransactionTaskRequest;
 import com.starrocks.thrift.TTaskType;
+import com.starrocks.thrift.TTxnType;
 
 import java.util.List;
 
@@ -26,17 +27,20 @@ public class ClearTransactionTask extends AgentTask {
 
     private long transactionId;
     private List<Long> partitionIds;
+    private TTxnType txnType;
 
-    public ClearTransactionTask(long backendId, long transactionId, List<Long> partitionIds) {
+    public ClearTransactionTask(long backendId, long transactionId, List<Long> partitionIds, TTxnType txnType) {
         super(null, backendId, TTaskType.CLEAR_TRANSACTION_TASK, -1L, -1L, -1L, -1L, -1L, transactionId);
         this.transactionId = transactionId;
         this.partitionIds = partitionIds;
+        this.txnType = txnType;
         this.isFinished = false;
     }
 
     public TClearTransactionTaskRequest toThrift() {
         TClearTransactionTaskRequest clearTransactionTaskRequest = new TClearTransactionTaskRequest(
                 transactionId, partitionIds);
+        clearTransactionTaskRequest.setTxn_type(txnType);
         return clearTransactionTaskRequest;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/PublishVersionTask.java
@@ -44,6 +44,7 @@ import com.starrocks.thrift.TPartitionVersionInfo;
 import com.starrocks.thrift.TPublishVersionRequest;
 import com.starrocks.thrift.TTabletVersionPair;
 import com.starrocks.thrift.TTaskType;
+import com.starrocks.thrift.TTxnType;
 import com.starrocks.transaction.TransactionState;
 import io.opentelemetry.api.trace.Span;
 import org.apache.logging.log4j.LogManager;
@@ -65,10 +66,11 @@ public class PublishVersionTask extends AgentTask {
     private final TransactionState txnState;
     private Span span;
     private boolean enableSyncPublish;
+    private TTxnType txnType;
 
     public PublishVersionTask(long backendId, long transactionId, long dbId, long commitTimestamp,
                               List<TPartitionVersionInfo> partitionVersionInfos, String traceParent, Span txnSpan,
-                              long createTime, TransactionState state, boolean enableSyncPublish) {
+                              long createTime, TransactionState state, boolean enableSyncPublish, TTxnType txnType) {
         super(null, backendId, TTaskType.PUBLISH_VERSION, dbId, -1L, -1L, -1L, -1L, transactionId, createTime, traceParent);
         this.transactionId = transactionId;
         this.partitionVersionInfos = partitionVersionInfos;
@@ -77,6 +79,7 @@ public class PublishVersionTask extends AgentTask {
         this.commitTimestamp = commitTimestamp;
         this.txnState = state;
         this.enableSyncPublish = enableSyncPublish;
+        this.txnType = txnType;
         if (txnSpan != null) {
             span = TraceManager.startSpan("publish_version_task", txnSpan);
             span.setAttribute("backend_id", backendId);
@@ -92,6 +95,7 @@ public class PublishVersionTask extends AgentTask {
         publishVersionRequest.setCommit_timestamp(commitTimestamp);
         publishVersionRequest.setTxn_trace_parent(traceParent);
         publishVersionRequest.setEnable_sync_publish(enableSyncPublish);
+        publishVersionRequest.setTxn_type(txnType);
         return publishVersionRequest;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/task/RemoteSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/RemoteSnapshotTask.java
@@ -1,0 +1,95 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.task;
+
+import com.starrocks.task.AgentTask;
+import com.starrocks.thrift.TBackend;
+import com.starrocks.thrift.TRemoteSnapshotRequest;
+import com.starrocks.thrift.TTabletType;
+import com.starrocks.thrift.TTaskType;
+
+import java.util.List;
+
+public class RemoteSnapshotTask extends AgentTask {
+    private final long transactionId;
+
+    private final TTabletType tabletType;
+    private final int schemaHash;
+    private final long visibleVersion;
+
+    private final String srcToken;
+    private final long srcTabletId;
+    private final TTabletType srcTabletType;
+    private final int srcSchemaHash;
+    private final long srcVisibleVersion;
+    private final List<TBackend> srcBackends;
+
+    private final int timeoutSec;
+
+    public RemoteSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
+            TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion,
+            String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
+            long srcVisibleVersion, List<TBackend> srcBackends, int timeoutSec) {
+        super(null, backendId, TTaskType.REMOTE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId);
+        this.transactionId = transactionId;
+        this.tabletType = tabletType;
+        this.schemaHash = schemaHash;
+        this.visibleVersion = visibleVersion;
+        this.srcToken = srcToken;
+        this.srcTabletId = srcTabletId;
+        this.srcTabletType = srcTabletType;
+        this.srcSchemaHash = srcSchemaHash;
+        this.srcVisibleVersion = srcVisibleVersion;
+        this.srcBackends = srcBackends;
+        this.timeoutSec = timeoutSec;
+    }
+
+    public TRemoteSnapshotRequest toThrift() {
+        TRemoteSnapshotRequest request = new TRemoteSnapshotRequest();
+        request.setTransaction_id(transactionId);
+
+        request.setTable_id(tableId);
+        request.setPartition_id(partitionId);
+        request.setTablet_id(tabletId);
+        request.setTablet_type(tabletType);
+        request.setSchema_hash(schemaHash);
+        request.setVisible_version(visibleVersion);
+
+        request.setSrc_token(srcToken);
+        request.setSrc_tablet_id(srcTabletId);
+        request.setSrc_tablet_type(srcTabletType);
+        request.setSrc_schema_hash(srcSchemaHash);
+        request.setSrc_visible_version(srcVisibleVersion);
+        request.setSrc_backends(srcBackends);
+
+        request.setTimeout_sec(timeoutSec);
+        return request;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("transaction id: ").append(transactionId);
+        sb.append(", tablet id: ").append(tabletId).append(", tablet type: ").append(tabletType);
+        sb.append(", schema hash: ").append(schemaHash);
+        sb.append(", visible version: ").append(visibleVersion);
+        sb.append(", src token:").append(srcToken).append(", src tablet id:").append(srcTabletId);
+        sb.append(", src tablet type:").append(srcTabletType).append(", src schema hash: ").append(srcSchemaHash);
+        sb.append(", src visible version: ").append(srcVisibleVersion);
+        sb.append(", src backends: ").append(srcBackends);
+        sb.append(", dest backend: ").append(backendId).append(", timeout sec: ").append(timeoutSec);
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
@@ -1,0 +1,91 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.task;
+
+import com.starrocks.task.AgentTask;
+import com.starrocks.thrift.TRemoteSnapshotInfo;
+import com.starrocks.thrift.TReplicateSnapshotRequest;
+import com.starrocks.thrift.TTabletType;
+import com.starrocks.thrift.TTaskType;
+
+import java.util.List;
+
+public class ReplicateSnapshotTask extends AgentTask {
+    private final long transactionId;
+
+    private final TTabletType tabletType;
+    private final int schemaHash;
+    private final long visibleVersion;
+
+    private final String srcToken;
+    private final long srcTabletId;
+    private final TTabletType srcTabletType;
+    private final int srcSchemaHash;
+    private final long srcVisibleVersion;
+    private final List<TRemoteSnapshotInfo> srcSnapshotInfos;
+
+    public ReplicateSnapshotTask(long backendId, long dbId, long tableId, long partitionId, long indexId, long tabletId,
+            TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion,
+            String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
+            long srcVisibleVersion, List<TRemoteSnapshotInfo> srcSnapshotInfos) {
+        super(null, backendId, TTaskType.REPLICATE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId);
+        this.transactionId = transactionId;
+        this.tabletType = tabletType;
+        this.schemaHash = schemaHash;
+        this.visibleVersion = visibleVersion;
+        this.srcToken = srcToken;
+        this.srcTabletId = srcTabletId;
+        this.srcTabletType = srcTabletType;
+        this.srcSchemaHash = srcSchemaHash;
+        this.srcVisibleVersion = srcVisibleVersion;
+        this.srcSnapshotInfos = srcSnapshotInfos;
+    }
+
+    public TReplicateSnapshotRequest toThrift() {
+        TReplicateSnapshotRequest request = new TReplicateSnapshotRequest();
+        request.setTransaction_id(transactionId);
+
+        request.setTable_id(tableId);
+        request.setPartition_id(partitionId);
+        request.setTablet_id(tabletId);
+        request.setTablet_type(tabletType);
+        request.setSchema_hash(schemaHash);
+        request.setVisible_version(visibleVersion);
+
+        request.setSrc_token(srcToken);
+        request.setSrc_tablet_id(srcTabletId);
+        request.setSrc_tablet_type(srcTabletType);
+        request.setSrc_schema_hash(srcSchemaHash);
+        request.setSrc_visible_version(srcVisibleVersion);
+        request.setSrc_snapshot_infos(srcSnapshotInfos);
+
+        return request;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("transaction id: ").append(transactionId);
+        sb.append(", tablet id: ").append(tabletId).append(", tablet type: ").append(tabletType);
+        sb.append(", schema hash: ").append(schemaHash);
+        sb.append(", visible version: ").append(visibleVersion);
+        sb.append(", src token:").append(srcToken).append(", src tablet id:").append(srcTabletId);
+        sb.append(", src tablet type:").append(srcTabletType).append(", src schema hash: ").append(srcSchemaHash);
+        sb.append(", src visible version: ").append(srcVisibleVersion);
+        sb.append(", src snapshot infos: ").append(srcSnapshotInfos);
+        sb.append(", dest backend: ").append(backendId);
+        return sb.toString();
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -747,7 +747,9 @@ public class DatabaseTransactionMgr {
                         continue;
                     }
 
-                    if (partition.getVisibleVersion() != partitionCommitInfo.getVersion() - 1) {
+                    // The version of a replication transaction may not continuously
+                    if (txn.getSourceType() != TransactionState.LoadJobSourceType.REPLICATION &&
+                            partition.getVisibleVersion() != partitionCommitInfo.getVersion() - 1) {
                         return false;
                     }
 
@@ -865,7 +867,9 @@ public class DatabaseTransactionMgr {
                                 transactionState);
                         continue;
                     }
-                    if (partition.getVisibleVersion() != partitionCommitInfo.getVersion() - 1) {
+                    // The version of a replication transaction may not continuously
+                    if (transactionState.getSourceType() != TransactionState.LoadJobSourceType.REPLICATION &&
+                            partition.getVisibleVersion() != partitionCommitInfo.getVersion() - 1) {
                         // prevent excessive logging
                         if (transactionState.getLastErrTimeMs() + 3000 < System.nanoTime() / 1000000) {
                             LOG.debug("transactionId {} partition commitInfo version {} is not equal with " +

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnLogApplier.java
@@ -47,7 +47,13 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
                 LOG.warn("ignored dropped partition {} when applying commit log", partitionId);
                 continue;
             }
-            partition.setNextVersion(partition.getNextVersion() + 1);
+
+            // The version of a replication transaction may not continuously
+            if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
+                partition.setNextVersion(partitionCommitInfo.getVersion() + 1);
+            } else {
+                partition.setNextVersion(partition.getNextVersion() + 1);
+            }
         }
     }
 
@@ -68,7 +74,10 @@ public class LakeTableTxnLogApplier implements TransactionLogApplier {
             long version = partitionCommitInfo.getVersion();
             long versionTime = partitionCommitInfo.getVersionTime();
             Quantiles compactionScore = partitionCommitInfo.getCompactionScore();
-            Preconditions.checkState(version == partition.getVisibleVersion() + 1);
+            // The version of a replication transaction may not continuously
+            Preconditions.checkState(txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
+                    || version == partition.getVisibleVersion() + 1);
+
             partition.updateVisibleVersion(version, versionTime);
 
             PartitionIdentifier partitionIdentifier =

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/LakeTableTxnStateListener.java
@@ -26,6 +26,8 @@ import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
 import com.starrocks.proto.AbortTxnRequest;
+import com.starrocks.proto.TxnTypePB;
+import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.rpc.BrpcProxy;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
@@ -178,6 +180,17 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
             tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
             isFirstPartition = false;
         }
+
+        // The new versions in a replication transaction depend on the versions in ReplicationTxnCommitAttachment
+        if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
+            ReplicationTxnCommitAttachment attachment = (ReplicationTxnCommitAttachment) txnState
+                    .getTxnCommitAttachment();
+            Map<Long, Long> partitionVersions = attachment.getPartitionVersions();
+            for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
+                partitionCommitInfo.setVersion(partitionVersions.get(partitionCommitInfo.getPartitionId()));
+            }
+        }
+
         txnState.putIdToTableCommitInfo(table.getId(), tableCommitInfo);
     }
 
@@ -197,10 +210,15 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
 
     private void abortTxnSkipCleanup(TransactionState txnState) {
         List<Long> txnIds = Collections.singletonList(txnState.getTransactionId());
+        List<TxnTypePB> txnTypes = Collections.singletonList(
+                txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
+                        ? TxnTypePB.TXN_REPLICATION
+                        : TxnTypePB.TXN_NORMAL);
         List<ComputeNode> nodes = getAllAliveNodes();
         for (ComputeNode node : nodes) { // Send abortTxn() request to all nodes
             AbortTxnRequest request = new AbortTxnRequest();
             request.txnIds = txnIds;
+            request.txnTypes = txnTypes;
             request.skipCleanup = true;
             request.tabletIds = null; // unused when skipCleanup is true
 
@@ -210,6 +228,10 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
 
     private void abortTxnWithCleanup(TransactionState txnState) {
         List<Long> txnIds = Collections.singletonList(txnState.getTransactionId());
+        List<TxnTypePB> txnTypes = Collections.singletonList(
+                txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION
+                        ? TxnTypePB.TXN_REPLICATION
+                        : TxnTypePB.TXN_NORMAL);
         Map<Long, List<Long>> tabletGroup = new HashMap<>();
         for (TabletCommitInfo info : txnState.getTabletCommitInfos()) {
             tabletGroup.computeIfAbsent(info.getBackendId(), k -> Lists.newArrayList()).add(info.getTabletId());
@@ -221,6 +243,7 @@ public class LakeTableTxnStateListener implements TransactionStateListener {
             }
             AbortTxnRequest request = new AbortTxnRequest();
             request.txnIds = txnIds;
+            request.txnTypes = txnTypes;
             request.tabletIds = entry.getValue();
             request.skipCleanup = false;
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnLogApplier.java
@@ -58,7 +58,12 @@ public class OlapTableTxnLogApplier implements TransactionLogApplier {
                     }
                 }
             }
-            partition.setNextVersion(partition.getNextVersion() + 1);
+            // The version of a replication transaction may not continuously
+            if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
+                partition.setNextVersion(partitionCommitInfo.getVersion() + 1);
+            } else {
+                partition.setNextVersion(partition.getNextVersion() + 1);
+            }
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/OlapTableTxnStateListener.java
@@ -26,6 +26,7 @@ import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.catalog.TabletInvertedIndex;
 import com.starrocks.catalog.TabletMeta;
+import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
 import com.starrocks.task.AgentBatchTask;
@@ -275,6 +276,16 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
             tableCommitInfo.addPartitionCommitInfo(partitionCommitInfo);
             isFirstPartition = false;
         }
+
+        if (txnState.getSourceType() == TransactionState.LoadJobSourceType.REPLICATION) {
+            ReplicationTxnCommitAttachment attachment = (ReplicationTxnCommitAttachment) txnState
+                    .getTxnCommitAttachment();
+            Map<Long, Long> partitionVersions = attachment.getPartitionVersions();
+            for (PartitionCommitInfo partitionCommitInfo : tableCommitInfo.getIdToPartitionCommitInfo().values()) {
+                partitionCommitInfo.setVersion(partitionVersions.get(partitionCommitInfo.getPartitionId()));
+            }
+        }
+
         txnState.putIdToTableCommitInfo(table.getId(), tableCommitInfo);
     }
 
@@ -327,8 +338,8 @@ public class OlapTableTxnStateListener implements TransactionStateListener {
         AgentBatchTask batchTask = null;
         synchronized (CLEAR_TRANSACTION_TASKS) {
             for (Long beId : allBeIds) {
-                ClearTransactionTask task =
-                        new ClearTransactionTask(beId, txnState.getTransactionId(), Lists.newArrayList());
+                ClearTransactionTask task = new ClearTransactionTask(beId, txnState.getTransactionId(),
+                        Lists.newArrayList(), txnState.getTxnType());
                 CLEAR_TRANSACTION_TASKS.add(task);
             }
             // try to group send tasks, not sending every time a txn is aborted. to avoid too many task rpc.

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/PublishVersionDaemon.java
@@ -449,6 +449,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
                                      @NotNull PartitionCommitInfo partitionCommitInfo,
                                      @NotNull TransactionState txnState) {
         long tableId = tableCommitInfo.getTableId();
+        long baseVersion = 0;
         long txnVersion = partitionCommitInfo.getVersion();
         long txnId = txnState.getTransactionId();
         long commitTime = txnState.getCommitTime();
@@ -470,9 +471,11 @@ public class PublishVersionDaemon extends FrontendDaemon {
                 LOG.info("Ignore non-exist partition {} of table {} in txn {}", partitionId, table.getName(), txnLabel);
                 return true;
             }
-            if (partition.getVisibleVersion() + 1 != txnVersion) {
+            if (txnState.getSourceType() != TransactionState.LoadJobSourceType.REPLICATION &&
+                    partition.getVisibleVersion() + 1 != txnVersion) {
                 return false;
             }
+            baseVersion = partition.getVisibleVersion();
             List<MaterializedIndex> indexes = txnState.getPartitionLoadedTblIndexes(table.getId(), partition);
             for (MaterializedIndex index : indexes) {
                 if (!index.visibleForTransaction(txnId)) {
@@ -497,7 +500,7 @@ public class PublishVersionDaemon extends FrontendDaemon {
             }
             if (CollectionUtils.isNotEmpty(normalTablets)) {
                 Map<Long, Double> compactionScores = new HashMap<>();
-                Utils.publishVersion(normalTablets, txnId, txnVersion - 1, txnVersion, commitTime / 1000,
+                Utils.publishVersion(normalTablets, txnId, baseVersion, txnVersion, commitTime / 1000,
                         compactionScores);
 
                 Quantiles quantiles = Quantiles.compute(compactionScores.values());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -58,6 +58,7 @@ import com.starrocks.service.FrontendOptions;
 import com.starrocks.system.Backend;
 import com.starrocks.task.PublishVersionTask;
 import com.starrocks.thrift.TPartitionVersionInfo;
+import com.starrocks.thrift.TTxnType;
 import com.starrocks.thrift.TUniqueId;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
@@ -101,7 +102,8 @@ public class TransactionState implements Writable {
         DELETE(6),                     // synchronization delete job use this type
         LAKE_COMPACTION(7),            // compaction of LakeTable
         FRONTEND_STREAMING(8),          // FE streaming load use this type
-        MV_REFRESH(9);                  // Refresh MV
+        MV_REFRESH(9),                  // Refresh MV
+        REPLICATION(10);                // Replication
 
         private final int flag;
 
@@ -133,6 +135,8 @@ public class TransactionState implements Writable {
                     return FRONTEND_STREAMING;
                 case 9:
                     return MV_REFRESH;
+                case 10:
+                    return REPLICATION;
                 default:
                     return null;
             }
@@ -747,6 +751,10 @@ public class TransactionState implements Writable {
         return sourceType;
     }
 
+    public TTxnType getTxnType() {
+        return sourceType == LoadJobSourceType.REPLICATION ? TTxnType.TXN_REPLICATION : TTxnType.TXN_NORMAL;
+    }
+
     public Map<Long, PublishVersionTask> getPublishVersionTasks() {
         return publishVersionTasks;
     }
@@ -956,7 +964,8 @@ public class TransactionState implements Writable {
                     txnSpan,
                     createTime,
                     this,
-                    Config.enable_sync_publish);
+                    Config.enable_sync_publish,
+                    this.getTxnType());
             this.addPublishVersionTask(backendId, task);
             tasks.add(task);
         }

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TxnCommitAttachment.java
@@ -42,6 +42,7 @@ import com.starrocks.load.loadv2.ManualLoadTxnCommitAttachment;
 import com.starrocks.load.loadv2.MiniLoadTxnCommitAttachment;
 import com.starrocks.load.routineload.RLTaskTxnCommitAttachment;
 import com.starrocks.load.streamload.StreamLoadTxnCommitAttachment;
+import com.starrocks.replication.ReplicationTxnCommitAttachment;
 import com.starrocks.thrift.TTxnCommitAttachment;
 import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 
@@ -100,6 +101,8 @@ public abstract class TxnCommitAttachment implements Writable {
             attachment = new InsertTxnCommitAttachment();
         } else if (type == LoadJobSourceType.FRONTEND_STREAMING) {
             attachment = StreamLoadTxnCommitAttachment.loadStreamLoadTxnCommitAttachment(in);
+        } else if (type == LoadJobSourceType.REPLICATION) {
+            attachment = new ReplicationTxnCommitAttachment();
         } else {
             throw new IOException("Unknown load job source type: " + type.name());
         }

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -1,0 +1,345 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.io.DeepCopy;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.leader.LeaderImpl;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.system.Backend;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.AgentTaskExecutor;
+import com.starrocks.task.RemoteSnapshotTask;
+import com.starrocks.task.ReplicateSnapshotTask;
+import com.starrocks.thrift.TBackend;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TIndexReplicationInfo;
+import com.starrocks.thrift.TPartitionReplicationInfo;
+import com.starrocks.thrift.TReplicaReplicationInfo;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTableReplicationRequest;
+import com.starrocks.thrift.TTableType;
+import com.starrocks.thrift.TTabletReplicationInfo;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class ReplicationJobTest {
+    private static StarRocksAssert starRocksAssert;
+
+    private static Database db;
+    private static OlapTable table;
+    private static OlapTable srcTable;
+    private ReplicationJob job;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
+        starRocksAssert.withDatabase("test").useDatabase("test");
+
+        db = GlobalStateMgr.getCurrentState().getDb("test");
+
+        String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1'); ";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
+                AnalyzeTestUtil.getConnectContext());
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        table = (OlapTable) db.getTable("single_partition_duplicate_key");
+
+        srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
+
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+
+            }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        srcTable.getPartitions().iterator().next()
+                .updateVisibleVersion(table.getPartitions().iterator().next().getCommittedVersion() + 100);
+
+        job = new ReplicationJob("test_token", db.getId(), table, srcTable, GlobalStateMgr.getCurrentSystemInfo());
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        Assert.assertFalse(ReplicationJobState.INITIALIZING.equals(job));
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+        Assert.assertEquals(ReplicationJobState.INITIALIZING.name(), job.getState().name());
+        Assert.assertEquals(ReplicationJobState.INITIALIZING.toString(), job.getState().toString());
+        Assert.assertEquals(ReplicationJobState.INITIALIZING.hashCode(), job.getState().hashCode());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+
+            Deencapsulation.invoke(new LeaderImpl(), "finishRemoteSnapshotTask",
+                    (RemoteSnapshotTask) task, request);
+            ((RemoteSnapshotTask) task).toThrift();
+            task.toString();
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+
+            Deencapsulation.invoke(new LeaderImpl(), "finishReplicateSnapshotTask",
+                    (ReplicateSnapshotTask) task, request);
+            ((ReplicateSnapshotTask) task).toThrift();
+            task.toString();
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+    }
+
+    @Test
+    public void testInitializingCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.cancel();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testSnapshotingCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        job.cancel();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testReplicatingCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        job.cancel();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testCommittedCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+
+        job.cancel();
+        Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+    }
+
+    @Test
+    public void testSnapshotingFailed() throws Exception {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            TStatus status = new TStatus(TStatusCode.OK);
+            request.setTask_status(status);
+            job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("failed");
+            request.setTask_status(status);
+            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testReplicatingFailed() throws Exception {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            job.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("failed");
+            request.setTask_status(status);
+            job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        job.run();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testInitializedByThrift() {
+        TTableReplicationRequest request = new TTableReplicationRequest();
+        request.username = "test_usename";
+        request.password = "test_password";
+        request.database_id = db.getId();
+        request.table_id = table.getId();
+        request.src_token = "test_token";
+        request.src_table_type = TTableType.OLAP_TABLE;
+        request.src_table_data_size = 100;
+
+        request.partition_replication_infos = new HashMap<Long, TPartitionReplicationInfo>();
+        TPartitionReplicationInfo partitionInfo = new TPartitionReplicationInfo();
+        Partition partition = table.getPartitions().iterator().next();
+        Partition srcPartition = srcTable.getPartitions().iterator().next();
+        partitionInfo.partition_id = partition.getId();
+        partitionInfo.src_version = srcPartition.getVisibleVersion();
+        request.partition_replication_infos.put(partitionInfo.partition_id, partitionInfo);
+
+        partitionInfo.index_replication_infos = new HashMap<Long, TIndexReplicationInfo>();
+        TIndexReplicationInfo indexInfo = new TIndexReplicationInfo();
+        MaterializedIndex index = partition.getBaseIndex();
+        MaterializedIndex srcIndex = srcPartition.getBaseIndex();
+        indexInfo.index_id = index.getId();
+        indexInfo.src_schema_hash = srcTable.getSchemaHashByIndexId(srcIndex.getId());
+        partitionInfo.index_replication_infos.put(indexInfo.index_id, indexInfo);
+
+        indexInfo.tablet_replication_infos = new HashMap<Long, TTabletReplicationInfo>();
+        List<Tablet> tablets = index.getTablets();
+        List<Tablet> srcTablets = srcIndex.getTablets();
+        for (int i = 0; i < tablets.size(); ++i) {
+            Tablet tablet = tablets.get(i);
+            Tablet srcTablet = srcTablets.get(i);
+            TTabletReplicationInfo tabletInfo = new TTabletReplicationInfo();
+            tabletInfo.tablet_id = tablet.getId();
+            tabletInfo.src_tablet_id = srcTablet.getId();
+            indexInfo.tablet_replication_infos.put(tabletInfo.tablet_id, tabletInfo);
+
+            tabletInfo.replica_replication_infos = new ArrayList<TReplicaReplicationInfo>();
+            TReplicaReplicationInfo replicaInfo = new TReplicaReplicationInfo();
+            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackends().iterator().next();
+            replicaInfo.src_backend = new TBackend(backend.getHost(), backend.getBePort(), backend.getHttpPort());
+            tabletInfo.replica_replication_infos.add(replicaInfo);
+        }
+
+        try {
+            new LeaderImpl().startTableReplication(request);
+        } catch (Exception e) {
+            Assert.assertNull(e);
+        }
+    }
+}

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -1,0 +1,360 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.replication;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedIndex;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Partition;
+import com.starrocks.catalog.Tablet;
+import com.starrocks.common.io.DeepCopy;
+import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.leader.LeaderImpl;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.AnalyzeTestUtil;
+import com.starrocks.sql.ast.CreateTableStmt;
+import com.starrocks.system.Backend;
+import com.starrocks.task.AgentBatchTask;
+import com.starrocks.task.AgentTask;
+import com.starrocks.task.AgentTaskExecutor;
+import com.starrocks.task.RemoteSnapshotTask;
+import com.starrocks.task.ReplicateSnapshotTask;
+import com.starrocks.thrift.TBackend;
+import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.TIndexReplicationInfo;
+import com.starrocks.thrift.TPartitionReplicationInfo;
+import com.starrocks.thrift.TReplicaReplicationInfo;
+import com.starrocks.thrift.TStatus;
+import com.starrocks.thrift.TStatusCode;
+import com.starrocks.thrift.TTableReplicationRequest;
+import com.starrocks.thrift.TTableType;
+import com.starrocks.thrift.TTabletReplicationInfo;
+import com.starrocks.utframe.StarRocksAssert;
+import com.starrocks.utframe.UtFrameUtils;
+import mockit.Mock;
+import mockit.MockUp;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class ReplicationMgrTest {
+    private static StarRocksAssert starRocksAssert;
+
+    private static Database db;
+    private static OlapTable table;
+    private static OlapTable srcTable;
+    private ReplicationJob job;
+    private ReplicationMgr replicationMgr;
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        UtFrameUtils.createMinStarRocksCluster();
+        AnalyzeTestUtil.init();
+        starRocksAssert = new StarRocksAssert(AnalyzeTestUtil.getConnectContext());
+        starRocksAssert.withDatabase("test").useDatabase("test");
+
+        db = GlobalStateMgr.getCurrentState().getDb("test");
+
+        String sql = "create table single_partition_duplicate_key (key1 int, key2 varchar(10))\n" +
+                "distributed by hash(key1) buckets 1\n" +
+                "properties('replication_num' = '1'); ";
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(sql,
+                AnalyzeTestUtil.getConnectContext());
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        table = (OlapTable) db.getTable("single_partition_duplicate_key");
+
+        srcTable = DeepCopy.copyWithGson(table, OlapTable.class);
+
+        new MockUp<AgentTaskExecutor>() {
+            @Mock
+            public void submit(AgentBatchTask task) {
+
+            }
+        };
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        srcTable.getPartitions().iterator().next()
+                .updateVisibleVersion(table.getPartitions().iterator().next().getCommittedVersion() + 100);
+
+        job = new ReplicationJob("test_token", db.getId(), table, srcTable, GlobalStateMgr.getCurrentSystemInfo());
+        replicationMgr = new ReplicationMgr();
+        replicationMgr.addReplicationJob(job);
+    }
+
+    @Test
+    public void testNormal() throws Exception {
+        Assert.assertFalse(ReplicationJobState.INITIALIZING.equals(job));
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+        Assert.assertEquals(ReplicationJobState.INITIALIZING.name(), job.getState().name());
+        Assert.assertEquals(ReplicationJobState.INITIALIZING.toString(), job.getState().toString());
+        Assert.assertEquals(ReplicationJobState.INITIALIZING.hashCode(), job.getState().hashCode());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        replicationMgr.replayReplicationJob(job);
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+
+            Deencapsulation.invoke(new LeaderImpl(), "finishRemoteSnapshotTask",
+                    (RemoteSnapshotTask) task, request);
+            ((RemoteSnapshotTask) task).toThrift();
+            task.toString();
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        replicationMgr.replayReplicationJob(job);
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+
+            Deencapsulation.invoke(new LeaderImpl(), "finishReplicateSnapshotTask",
+                    (ReplicateSnapshotTask) task, request);
+            ((ReplicateSnapshotTask) task).toThrift();
+            task.toString();
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+
+        replicationMgr.replayReplicationJob(job);
+    }
+
+    @Test
+    public void testInitializingCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        replicationMgr.cancelRunningJobs();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        Assert.assertFalse(replicationMgr.hasRunningJobs());
+        Assert.assertTrue(replicationMgr.hasFailedJobs());
+
+        replicationMgr.clearFinishedJobs();
+        replicationMgr.replayReplicationJob(null);
+    }
+
+    @Test
+    public void testSnapshotingCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        replicationMgr.cancelRunningJobs();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testReplicatingCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        replicationMgr.cancelRunningJobs();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testCommittedCancel() {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+
+        replicationMgr.cancelRunningJobs();
+        Assert.assertEquals(ReplicationJobState.COMMITTED, job.getState());
+    }
+
+    @Test
+    public void testSnapshotingFailed() throws Exception {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            TStatus status = new TStatus(TStatusCode.OK);
+            request.setTask_status(status);
+            replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("failed");
+            request.setTask_status(status);
+            replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testReplicatingFailed() throws Exception {
+        Assert.assertEquals(ReplicationJobState.INITIALIZING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            request.setTask_status(new TStatus(TStatusCode.OK));
+            request.setSnapshot_path("test_snapshot_path");
+            request.setIncremental_snapshot(true);
+            replicationMgr.finishRemoteSnapshotTask((RemoteSnapshotTask) task, request);
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
+
+        for (AgentTask task : job.getRunningTasks().values()) {
+            TFinishTaskRequest request = new TFinishTaskRequest();
+            TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
+            status.addToError_msgs("failed");
+            request.setTask_status(status);
+            replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
+        }
+
+        replicationMgr.runAfterCatalogReady();
+        Assert.assertEquals(ReplicationJobState.ABORTED, job.getState());
+    }
+
+    @Test
+    public void testInitializedByThrift() {
+        TTableReplicationRequest request = new TTableReplicationRequest();
+        request.username = "test_usename";
+        request.password = "test_password";
+        request.database_id = db.getId();
+        request.table_id = table.getId();
+        request.src_token = "test_token";
+        request.src_table_type = TTableType.OLAP_TABLE;
+        request.src_table_data_size = 100;
+
+        request.partition_replication_infos = new HashMap<Long, TPartitionReplicationInfo>();
+        TPartitionReplicationInfo partitionInfo = new TPartitionReplicationInfo();
+        Partition partition = table.getPartitions().iterator().next();
+        Partition srcPartition = srcTable.getPartitions().iterator().next();
+        partitionInfo.partition_id = partition.getId();
+        partitionInfo.src_version = srcPartition.getVisibleVersion();
+        request.partition_replication_infos.put(partitionInfo.partition_id, partitionInfo);
+
+        partitionInfo.index_replication_infos = new HashMap<Long, TIndexReplicationInfo>();
+        TIndexReplicationInfo indexInfo = new TIndexReplicationInfo();
+        MaterializedIndex index = partition.getBaseIndex();
+        MaterializedIndex srcIndex = srcPartition.getBaseIndex();
+        indexInfo.index_id = index.getId();
+        indexInfo.src_schema_hash = srcTable.getSchemaHashByIndexId(srcIndex.getId());
+        partitionInfo.index_replication_infos.put(indexInfo.index_id, indexInfo);
+
+        indexInfo.tablet_replication_infos = new HashMap<Long, TTabletReplicationInfo>();
+        List<Tablet> tablets = index.getTablets();
+        List<Tablet> srcTablets = srcIndex.getTablets();
+        for (int i = 0; i < tablets.size(); ++i) {
+            Tablet tablet = tablets.get(i);
+            Tablet srcTablet = srcTablets.get(i);
+            TTabletReplicationInfo tabletInfo = new TTabletReplicationInfo();
+            tabletInfo.tablet_id = tablet.getId();
+            tabletInfo.src_tablet_id = srcTablet.getId();
+            indexInfo.tablet_replication_infos.put(tabletInfo.tablet_id, tabletInfo);
+
+            tabletInfo.replica_replication_infos = new ArrayList<TReplicaReplicationInfo>();
+            TReplicaReplicationInfo replicaInfo = new TReplicaReplicationInfo();
+            Backend backend = GlobalStateMgr.getCurrentSystemInfo().getBackends().iterator().next();
+            replicaInfo.src_backend = new TBackend(backend.getHost(), backend.getBePort(), backend.getHttpPort());
+            tabletInfo.replica_replication_infos.add(replicaInfo);
+        }
+
+        try {
+            new LeaderImpl().startTableReplication(request);
+        } catch (Exception e) {
+            Assert.assertNull(e);
+        }
+    }
+}

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -45,9 +45,11 @@ message PublishVersionResponse {
 
 message AbortTxnRequest {
     repeated int64 tablet_ids = 1;
-    repeated int64 txn_ids = 2;    
+    repeated int64 txn_ids = 2;
     // Whether need to clean up the txn logs
     optional bool skip_cleanup = 3;
+    // Should have the save size with txn_ids or 0
+    repeated TxnTypePB txn_types = 4;
 }
 
 message AbortTxnResponse {

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -129,12 +129,18 @@ message TxnLogPB {
         repeated MetadataUpdateInfoPB metadata_update_infos = 1;
     }
 
+    message OpReplication {
+        optional ReplicationTxnMetaPB txn_meta = 1;
+        repeated OpWrite op_writes = 2;
+    }
+
     optional int64 tablet_id = 1;
     optional int64 txn_id = 2;
     optional OpWrite op_write = 3;
     optional OpCompaction op_compaction = 4;
     optional OpSchemaChange op_schema_change = 5;
     optional OpAlterMetadata op_alter_metadata = 6;
+    optional OpReplication op_replication = 7;
 }
 
 message TabletMetadataLockPB {}

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -103,6 +103,30 @@ enum WriteQuorumTypePB {
     ALL = 2;
 }
 
+enum TxnTypePB {
+     TXN_NORMAL = 0;
+     TXN_REPLICATION = 1;
+ }
+
+ enum ReplicationTxnStatePB {
+     TXN_INVALID = 0;
+     TXN_SNAPSHOTED = 1;
+     TXN_REPLICATED = 2;
+     TXN_PUBLISHED = 3;
+ }
+
+ message ReplicationTxnMetaPB {
+     optional int64 txn_id = 1;
+     optional ReplicationTxnStatePB txn_state = 2;
+     optional int64 tablet_id = 3;
+     optional int64 visible_version = 4;
+     optional string src_backend_host = 5;
+     optional int32 src_backend_port = 6;
+     optional string src_snapshot_path = 7;
+     optional int64 snapshot_version = 8;
+     optional bool incremental_snapshot = 9;
+ } 
+
 // Used to store additional information about a txn when it is finished/visible
 // It will be serialized with TransactionState
 message TxnFinishStatePB {

--- a/gensrc/thrift/AgentService.thrift
+++ b/gensrc/thrift/AgentService.thrift
@@ -70,6 +70,11 @@ enum TTabletType {
     TABLET_TYPE_LAKE = 2
 }
 
+enum TTxnType {
+    TXN_NORMAL = 0,
+    TXN_REPLICATION = 1
+}
+
 struct TBinlogConfig {
     // Version of the configuration, and FE should deliver it to
     // the BE when executing 'ALTER TABLE'. The configuration with
@@ -316,6 +321,7 @@ struct TPublishVersionRequest {
     4: optional i64 commit_timestamp
     5: optional string txn_trace_parent
     6: optional bool enable_sync_publish = false
+    7: optional TTxnType txn_type = TTxnType.TXN_NORMAL
 }
 
 struct TClearAlterTaskRequest {
@@ -326,6 +332,7 @@ struct TClearAlterTaskRequest {
 struct TClearTransactionTaskRequest {
     1: required Types.TTransactionId transaction_id
     2: required list<Types.TPartitionId> partition_id
+    3: optional TTxnType txn_type = TTxnType.TXN_NORMAL
 }
 
 struct TRecoverTabletReq {
@@ -334,6 +341,45 @@ struct TRecoverTabletReq {
     3: optional Types.TVersion version
     4: optional Types.TVersionHash version_hash // Deprecated
 }
+
+struct TRemoteSnapshotRequest {
+     1: optional Types.TTransactionId transaction_id
+     2: optional Types.TTableId table_id
+     3: optional Types.TPartitionId partition_id
+     4: optional Types.TTabletId tablet_id
+     5: optional TTabletType tablet_type
+     6: optional Types.TSchemaHash schema_hash
+     7: optional Types.TVersion visible_version
+     8: optional string src_token
+     9: optional Types.TTabletId src_tablet_id
+     10: optional TTabletType src_tablet_type
+     11: optional Types.TSchemaHash src_schema_hash
+     12: optional Types.TVersion src_visible_version
+     13: optional list<Types.TBackend> src_backends
+     14: optional i32 timeout_sec
+ }
+
+ struct TRemoteSnapshotInfo {
+     1: optional Types.TBackend backend
+     2: optional string snapshot_path
+     3: optional bool incremental_snapshot
+ }
+
+ struct TReplicateSnapshotRequest {
+     1: optional Types.TTransactionId transaction_id
+     2: optional Types.TTableId table_id
+     3: optional Types.TPartitionId partition_id
+     4: optional Types.TTabletId tablet_id
+     5: optional TTabletType tablet_type
+     6: optional Types.TSchemaHash schema_hash
+     7: optional Types.TVersion visible_version
+     8: optional string src_token
+     9: optional Types.TTabletId src_tablet_id
+     10: optional TTabletType src_tablet_type
+     11: optional Types.TSchemaHash src_schema_hash
+     12: optional Types.TVersion src_visible_version
+     13: optional list<TRemoteSnapshotInfo> src_snapshot_infos
+ }
 
 enum TTabletMetaType {
     PARTITIONID,
@@ -399,6 +445,8 @@ struct TAgentTaskRequest {
     26: optional TUpdateTabletMetaInfoReq update_tablet_meta_info_req
     27: optional TDropAutoIncrementMapReq drop_auto_increment_map_req
     28: optional TCompactionReq compaction_req
+    29: optional TRemoteSnapshotRequest remote_snapshot_req
+    30: optional TReplicateSnapshotRequest replicate_snapshot_req
 }
 
 struct TAgentResult {

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1418,6 +1418,43 @@ struct TGetProfileResponse {
     2: optional list<string> query_result
 }
 
+struct TReplicaReplicationInfo {
+    1: optional Types.TBackend src_backend
+}
+
+struct TTabletReplicationInfo {
+    1: optional i64 tablet_id
+    2: optional i64 src_tablet_id
+    3: optional list<TReplicaReplicationInfo> replica_replication_infos
+}
+
+struct TIndexReplicationInfo {
+    1: optional i64 index_id
+    2: optional i32 src_schema_hash
+    3: optional map<i64, TTabletReplicationInfo> tablet_replication_infos
+}
+
+struct TPartitionReplicationInfo {
+    1: optional i64 partition_id
+    2: optional i64 src_version
+    3: optional map<i64, TIndexReplicationInfo> index_replication_infos
+}
+
+struct TTableReplicationRequest {
+    1: optional string username
+    2: optional string password
+    3: optional i64 database_id
+    4: optional i64 table_id
+    5: optional string src_token
+    6: optional Types.TTableType src_table_type
+    7: optional i64 src_table_data_size
+    8: optional map<i64, TPartitionReplicationInfo> partition_replication_infos
+}
+
+struct TTableReplicationResponse {
+    1: optional Status.TStatus status
+}
+
 service FrontendService {
     TGetDbsResult getDbNames(1:TGetDbsParams params)
     TGetTablesResult getTableNames(1:TGetTablesParams params)
@@ -1501,5 +1538,7 @@ service FrontendService {
     TRequireSlotResponse requireSlotAsync(1: TRequireSlotRequest request)
     TFinishSlotRequirementResponse finishSlotRequirement(1: TFinishSlotRequirementRequest request)
     TReleaseSlotResponse releaseSlot(1: TReleaseSlotRequest request)
+
+    TTableReplicationResponse startTableReplication(1: TTableReplicationRequest request)
 }
 

--- a/gensrc/thrift/HeartbeatService.thrift
+++ b/gensrc/thrift/HeartbeatService.thrift
@@ -29,7 +29,7 @@ struct TMasterInfo {
     6: optional Types.TPort http_port
     7: optional i64 heartbeat_flags
     8: optional i64 backend_id
-    // 9: optional i64 min_active_txn_id = 0
+    9: optional i64 min_active_txn_id = 0
     10: optional Types.TRunMode run_mode
 }
 

--- a/gensrc/thrift/MasterService.thrift
+++ b/gensrc/thrift/MasterService.thrift
@@ -88,6 +88,7 @@ struct TFinishTaskRequest {
     16: optional i64 copy_time_ms
     17: optional list<TTabletVersionPair> tablet_versions;
     18: optional list<TTabletVersionPair> tablet_publish_versions;
+    19: optional bool incremental_snapshot
 }
 
 struct TTablet {

--- a/gensrc/thrift/Types.thrift
+++ b/gensrc/thrift/Types.thrift
@@ -203,6 +203,8 @@ enum TTaskType {
     // this use for calculate enum count
     DROP_AUTO_INCREMENT_MAP,
     COMPACTION,
+    REMOTE_SNAPSHOT,
+    REPLICATE_SNAPSHOT,
     NUM_TASK_TYPE
 }
 


### PR DESCRIPTION
Why I'm doing:
To support starrocks cluster migration, from shared-nothing cluster to shared-nothing cluster or shared-data cluster.

What I'm doing:
Implement a replication job to support none-pk table replication from another source starrocks cluster

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

