### PR TITLE
[BugFix] fix jni decimal parsing (backport #33789)

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1582,7 +1582,7 @@ public class ExpressionTest extends PlanTestBase {
 
     @Test
     public void testDoubleCastToString() throws Exception {
-        String sql = "select concat(substr(DATE_SUB(CURDATE(), INTERVAL 1 DAY), 1, 4) -1, '-');";
+        String sql = "select concat(substr(DATE_SUB('2023-12-23', INTERVAL 1 DAY), 1, 4) -1, '-');";
         String plan = getVerboseExplain(sql);
         assertContains(plan, "2022-");
 

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -168,9 +168,20 @@ public class ColumnType {
     }
 
     private void parse(StringScanner scanner) {
-        int p = scanner.indexOf('<', ',', '>');
+        int p = scanner.indexOf('<', ',', '>', '(', ')');
+        int end = scanner.indexOf(')') + 1;
         String t = scanner.substr(p);
-        scanner.moveTo(p);
+        if (t.startsWith("decimal")) {
+            t = scanner.substr(end);
+            scanner.moveTo(end);
+        } else if (t.startsWith("char") || t.startsWith("varchar")) {
+            // right now this only used in hive scanner
+            // for char(xx) and varchar(xx), we only need t to be char or varchar and skip (xx)
+            // otherwise struct<c_char:char(30),c_varchar:varchar(200)> will get wrong result
+            scanner.moveTo(end);
+        } else {
+            scanner.moveTo(p);
+        }
         // assume there is no blank char in `type`.
         typeValue = null;
         switch (t) {


### PR DESCRIPTION
> Why I'm doing:
> What I'm doing:

CP from to branch-3.1
- https://github.com/StarRocks/starrocks/pull/33789/files
- https://github.com/StarRocks/starrocks/pull/36258/files

We can not correctly parse type like `decimal(x, y)`. 


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

