### PR TITLE
[BugFix] ensure hdfsFile resource is released during close

### DIFF
--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -299,6 +299,7 @@ endif ()
 
 set(EXEC_FILES_PART2
         ./fs/fs_broker_test.cpp
+        ./fs/fs_hdfs_test.cpp
         ./fs/fs_posix_test.cpp
         ./fs/fs_memory_test.cpp
         ./fs/fs_s3_test.cpp

--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -1,0 +1,68 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "fs/hdfs/fs_hdfs.h"
+
+#include <gtest/gtest.h>
+
+#include <filesystem>
+
+#include "fs/fs_util.h"
+#include "testutil/sync_point.h"
+#include "util/defer_op.h"
+
+namespace starrocks {
+
+class HdfsFileSystemTest : public ::testing::Test {
+public:
+    HdfsFileSystemTest() = default;
+    ~HdfsFileSystemTest() override = default;
+
+    void SetUp() override {
+        const testing::TestInfo* const test_info = testing::UnitTest::GetInstance()->current_test_info();
+        std::string root = std::string("hdfs_filesystem_test_") + test_info->name();
+        std::filesystem::path rootpath(root);
+        _root_path = std::filesystem::absolute(rootpath).string();
+        ASSERT_TRUE(fs::create_directories(_root_path).ok());
+    }
+    void TearDown() override { ASSERT_TRUE(fs::remove_all(_root_path).ok()); }
+
+public:
+    std::string _root_path;
+};
+
+TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
+    auto fs = new_fs_hdfs(FSOptions());
+    // use file:// as the fs scheme, which will leverage Hadoop LocalFileSystem for testing
+    std::string filepath = "file://" + _root_path + "/create_file_and_destroy_file";
+    auto st = fs->path_exists(filepath);
+    EXPECT_TRUE(st.is_not_found());
+    auto wfile = fs->new_writable_file(filepath);
+    EXPECT_TRUE(wfile.ok());
+
+    // error injection during HDFSWritableFile::close, it is hard to simulate a sync failure with a POSIX filesystem.
+    // HDFS FileSystem sync operation will fail if the file is removed from remote name node.
+    SyncPoint::GetInstance()->SetCallBack("HDFSWritableFile::close", [](void* arg) { *(int*)arg = -1; });
+    SyncPoint::GetInstance()->EnableProcessing();
+
+    DeferOp defer([]() {
+        SyncPoint::GetInstance()->ClearCallBack("HDFSWritableFile::close");
+        SyncPoint::GetInstance()->DisableProcessing();
+    });
+
+    // done the file, check if there is any memory leak
+    (*wfile).reset();
+}
+
+} // namespace starrocks

--- a/run-be-ut.sh
+++ b/run-be-ut.sh
@@ -53,6 +53,23 @@ Usage: $0 <options>
   exit 1
 }
 
+# Append negative cases to existing $TEST_NAME
+# refer to https://github.com/google/googletest/blob/main/docs/advanced.md#running-a-subset-of-the-tests
+# for detailed explaination of `--gtest_filter`
+append_negative_case() {
+    local exclude_case=$1
+    case $TEST_NAME in
+      *-*)
+        # already has negative cases, just append the cases to the end
+        TEST_NAME=${TEST_NAME}:$exclude_case
+        ;;
+      *)
+        # doesn't have negative cases, start the negative session
+        TEST_NAME=${TEST_NAME}-$exclude_case
+        ;;
+    esac
+}
+
 # -l run and -l gtest_filter only used for compatibility
 OPTS=$(getopt \
   -n $0 \
@@ -219,6 +236,14 @@ if [ "${WITH_CACHELIB}" == "ON"  ]; then
     export LD_LIBRARY_PATH=$CACHELIB_DIR/lib:$CACHELIB_DIR/lib64:$CACHELIB_DIR/deps/lib:$CACHELIB_DIR/deps/lib64:$LD_LIBRARY_PATH
 fi
 
+THIRDPARTY_HADOOP_HOME=${STARROCKS_THIRDPARTY}/installed/hadoop/share/hadoop
+if [[ -d ${THIRDPARTY_HADOOP_HOME} ]] ; then
+    export HADOOP_CLASSPATH=${THIRDPARTY_HADOOP_HOME}/common/*:${THIRDPARTY_HADOOP_HOME}/common/lib/*:${THIRDPARTY_HADOOP_HOME}/hdfs/*:${THIRDPARTY_HADOOP_HOME}/hdfs/lib/*
+else
+    # exclude HdfsFileSystemTest related test case if no hadoop env found
+    echo "[INFO] Can't find available HADOOP common lib, disable HdfsFileSystemTest related test!"
+    append_negative_case "HdfsFileSystemTest*"
+fi
 # HADOOP_CLASSPATH defined in $STARROCKS_HOME/conf/hadoop_env.sh
 # put $STARROCKS_HOME/conf ahead of $HADOOP_CLASSPATH so that custom config can replace the config in $HADOOP_CLASSPATH
 export CLASSPATH=$STARROCKS_HOME/conf:$HADOOP_CLASSPATH:$CLASSPATH
@@ -228,7 +253,7 @@ export CLASSPATH=$STARROCKS_HOME/conf:$HADOOP_CLASSPATH:$CLASSPATH
 export STARROCKS_TEST_BINARY_DIR=${STARROCKS_TEST_BINARY_DIR}/test
 
 if [ $WITH_AWS = "OFF" ]; then
-    TEST_NAME="$TEST_NAME*:-*S3*"
+    append_negative_case "*S3*"
 fi
 
 # prepare util test_data
@@ -243,6 +268,7 @@ test_files=`find ${STARROCKS_TEST_BINARY_DIR} -type f -perm -111 -name "*test*" 
     | grep -v bench_test \
     | grep -e "$TEST_MODULE" `
 
+echo "[INFO] gtest_filter: $TEST_NAME"
 # run cases in starrocks_test in parallel if has gtest-parallel script.
 # reference: https://github.com/google/gtest-parallel
 if [[ $TEST_MODULE == '.*'  || $TEST_MODULE == 'starrocks_test' ]]; then


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [x] 3.0
  - [x] 2.5
