### PR TITLE
[BugFix] accumulate ndv in or predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/statistics/PredicateStatisticsCalculator.java
@@ -341,6 +341,9 @@ public class PredicateStatisticsCalculator {
                 ColumnStatistic rightColumnStatistic = orItemStatistics.getColumnStatistic(columnRefOperator);
                 columnBuilder.setMinValue(Math.min(columnStatistic.getMinValue(), rightColumnStatistic.getMinValue()));
                 columnBuilder.setMaxValue(Math.max(columnStatistic.getMaxValue(), rightColumnStatistic.getMaxValue()));
+                double originalNdv = statistics.getColumnStatistic(columnRefOperator).getDistinctValuesCount();
+                double accumulatedNdv = columnStatistic.getDistinctValuesCount() + rightColumnStatistic.getDistinctValuesCount();
+                columnBuilder.setDistinctValuesCount(Math.min(originalNdv, accumulatedNdv));
                 builder.addColumnStatistic(columnRefOperator, columnBuilder.build());
             });
             return builder.build();

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/DistributedEnvPlanWithCostTest.java
@@ -1575,4 +1575,12 @@ public class DistributedEnvPlanWithCostTest extends DistributedEnvPlanTestBase {
                 "  |  equal join conjunct: 3: C_ADDRESS = 11: P_NAME");
 
     }
+
+    @Test
+    public void testNdvInOrPredicate() throws Exception {
+        String sql = "select count(*) from customer where C_NAME = 'b' or C_NATIONKEY = 1";
+        String plan = getCostExplain(sql);
+        assertCContains(plan, "C_NAME-->[-Infinity, Infinity, 0.0, 25.0, 600000.0] ESTIMATE",
+                "C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/MockTpchStatisticStorage.java
@@ -140,6 +140,7 @@ public class MockTpchStatisticStorage implements StatisticStorage {
         tableCustomer.put("c_mktsegment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 10, 5));
         // C_COMMENT VARCHAR(117)
         tableCustomer.put("c_comment", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 117, 149968));
+        tableCustomer.put("pad", new ColumnStatistic(NEGATIVE_INFINITY, POSITIVE_INFINITY, 0, 1, 1));
         tableStatistics.put("customer", tableCustomer);
 
         Map<String, ColumnStatistic> tableLineitem = new CaseInsensitiveMap<>();


### PR DESCRIPTION
Why I'm doing:
The ndv result of a or predicate is dominated by its first child making a unreasonable estimated result.
Like this `C_NAME(ndv: 15000000), C_NATIONKEY(ndv:25, minvalue:0, maxValue:24)`
```
select count(*) from customer where C_NAME = 'b' or C_NATIONKEY = 1  or C_NAME = 'c'

0:OlapScanNode
     table: customer, rollup: customer
     preAggregation: on
     Predicates: ((2: C_NAME = 'b') OR (4: C_NATIONKEY = 1)) OR (2: C_NAME = 'c')
     partitionsRatio=1/1, tabletsRatio=10/10
     tabletList=10238,10240,10242,10244,10246,10248,10250,10252,10254,10256
     actualRows=0, avgRowSize=30.0
     cardinality: 1
     column statistics: 
     * C_NAME-->[-Infinity, Infinity, 0.0, 25.0, 1.0] ESTIMATE
     * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 1.0] ESTIMATE
     * auto_fill_col-->[1.0, 1.0, 0.0, 1.0, 1.0] ESTIMATE
```

What I'm doing:
accumulate ndv in or predicate. Now the plan fragment is like:
```
0:OlapScanNode
     table: customer, rollup: customer
     preAggregation: on
     Predicates: ((2: C_NAME = 'b') OR (4: C_NATIONKEY = 1)) OR (2: C_NAME = 'c')
     partitionsRatio=1/1, tabletsRatio=10/10
     tabletList=10238,10240,10242,10244,10246,10248,10250,10252,10254,10256
     actualRows=0, avgRowSize=30.0
     cardinality: 600000
     column statistics: 
     * C_NAME-->[-Infinity, Infinity, 0.0, 25.0, 600000.0] ESTIMATE
     * C_NATIONKEY-->[0.0, 24.0, 0.0, 4.0, 25.0] ESTIMATE
     * auto_fill_col-->[1.0, 1.0, 0.0, 1.0, 1.0] ESTIMATE
```


Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
