### PR TITLE
[Enhancement] skip preload if memory exceed

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -725,7 +725,8 @@ void UpdateManager::preload_update_state(const TxnLog& txnlog, Tablet* tablet) {
     _update_state_cache.update_object_size(state_entry, state.memory_usage());
     // get latest metadata from cache, it is not matter if it isn't the real latest metadata.
     auto metadata_ptr = _tablet_mgr->get_latest_cached_tablet_metadata(tablet->id());
-    if (metadata_ptr != nullptr) {
+    // skip preload if memory limit exceed
+    if (metadata_ptr != nullptr && !_update_state_mem_tracker->any_limit_exceeded()) {
         auto st = state.load(txnlog.op_write(), *metadata_ptr, metadata_ptr->version(), tablet, nullptr, false, true);
         if (!st.ok()) {
             _update_state_cache.remove(state_entry);
@@ -759,9 +760,10 @@ void UpdateManager::preload_compaction_state(const TxnLog& txnlog, const Tablet&
     auto& compaction_state = compaction_entry->value();
     // preload compaction state, only load first output segment, to avoid too much memory cost
     auto st = Status::OK();
-    for (int i = 0; i < segments_size; i++) {
+    // skip preload if memory limit exceed
+    for (int i = 0; i < segments_size && !_compaction_state_mem_tracker->any_limit_exceeded(); i++) {
         st = compaction_state.load_segments(&output_rowset, this, tablet_schema, i);
-        if (!st.ok() || _compaction_state_mem_tracker->any_limit_exceeded()) {
+        if (!st.ok()) {
             break;
         }
     }


### PR DESCRIPTION
Why I'm doing:
We have preload update & compaction state when data loading & compaction finish to accelerate publish, but if `update` memory exceed, we should skip do preload.

What I'm doing:
skip preload if memory exceed

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
