### PR TITLE
[Enhancement]tune default virtual node to be more friendly to cache

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/HDFSBackendSelector.java
@@ -86,7 +86,7 @@ public class HDFSBackendSelector implements BackendSelector {
     // After testing, this value can ensure that the scan range size assigned to each BE is as uniform as possible,
     // and the largest scan data is not more than 1.1 times of the average value
     private final double kMaxImbalanceRatio = 1.1;
-    public static final int CONSISTENT_HASH_RING_VIRTUAL_NUMBER = 128;
+    public static final int CONSISTENT_HASH_RING_VIRTUAL_NUMBER = 256;
 
     class HdfsScanRangeHasher {
         String basePath;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -1224,7 +1224,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     private String hdfsBackendSelectorHashAlgorithm = "consistent";
 
     @VariableMgr.VarAttr(name = CONSISTENT_HASH_VIRTUAL_NUMBER, flag = VariableMgr.INVISIBLE)
-    private int consistentHashVirtualNodeNum = 128;
+    private int consistentHashVirtualNodeNum = 256;
 
     // binary, json, compact,
     @VarAttr(name = THRIFT_PLAN_PROTOCOL)


### PR DESCRIPTION
Why I'm doing:
rebalance may lead to cache miss in be, enlarge virtual node will reduce the rebalance rate. the test result is as below:
<!--StartFragment--><byte-sheet-html-origin data-id="1704197801636" data-version="4" data-is-embed="true" data-grid-line-hidden="false" data-copy-type="col">
  | 32 | 64 | 128 | 256 | 512 | 1024
-- | -- | -- | -- | -- | -- | --
max | 0.0834 | 0.0395 | 0.0199 | 0.0115 | 0.008 | 0.0017
avg | 0.03412 | 0.01697 | 0.00671 | 0.00187 | 0.00039 | 0.00004
var | 0.000141 | 0.000056 | 0.000018 | 0.000004 | 0.000001 | 0

</byte-sheet-html-origin><!--EndFragment-->

What I'm doing:
enlarge virtual node to get better cache hit rate.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
