### PR TITLE
[BugFix] Fix race condition in BucketProcess AGG

### DIFF
--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_blocking_source_operator.cpp
@@ -119,6 +119,7 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
     auto& spiller = _aggregator->spiller();
 
     if (!_aggregator->is_spilled_eos()) {
+        DCHECK(_accumulator.need_input());
         auto executor = _aggregator->spill_channel()->io_executor();
         ASSIGN_OR_RETURN(auto chunk,
                          spiller->restore(state, *executor, TRACKER_WITH_SPILLER_READER_GUARD(state, spiller)));
@@ -131,6 +132,7 @@ StatusOr<ChunkPtr> SpillableAggregateBlockingSourceOperator::_pull_spilled_chunk
         _accumulator.push(std::move(res));
 
     } else if (_has_last_chunk) {
+        DCHECK(_accumulator.need_input());
         _has_last_chunk = false;
         ASSIGN_OR_RETURN(res, _stream_aggregator->pull_eos_chunk());
         if (res != nullptr && !res->is_empty()) {

--- a/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
+++ b/be/src/exec/pipeline/aggregate/spillable_aggregate_distinct_blocking_operator.cpp
@@ -247,7 +247,6 @@ Status SpillableAggregateDistinctBlockingSourceOperator::reset_state(RuntimeStat
 }
 
 StatusOr<ChunkPtr> SpillableAggregateDistinctBlockingSourceOperator::_pull_spilled_chunk(RuntimeState* state) {
-    DCHECK(_accumulator.need_input());
     ChunkPtr res;
 
     if (_accumulator.has_output()) {
@@ -256,6 +255,7 @@ StatusOr<ChunkPtr> SpillableAggregateDistinctBlockingSourceOperator::_pull_spill
     }
 
     if (!_aggregator->is_spilled_eos()) {
+        DCHECK(_accumulator.need_input());
         auto executor = _aggregator->spill_channel()->io_executor();
         auto& spiller = _aggregator->spiller();
         ASSIGN_OR_RETURN(auto chunk,
@@ -269,6 +269,7 @@ StatusOr<ChunkPtr> SpillableAggregateDistinctBlockingSourceOperator::_pull_spill
         _accumulator.push(std::move(res));
 
     } else if (_has_last_chunk) {
+        DCHECK(_accumulator.need_input());
         _has_last_chunk = false;
         ASSIGN_OR_RETURN(res, _stream_aggregator->pull_eos_chunk());
         if (res != nullptr && !res->is_empty()) {

--- a/be/src/exec/pipeline/chunk_accumulate_operator.h
+++ b/be/src/exec/pipeline/chunk_accumulate_operator.h
@@ -38,6 +38,8 @@ public:
     bool need_input() const override { return _acc.need_input(); }
     bool is_finished() const override { return _acc.is_finished(); }
 
+    bool ignore_empty_eos() const override { return false; }
+
     Status set_finishing(RuntimeState* state) override;
     Status set_finished(RuntimeState* state) override;
 

--- a/be/src/exec/pipeline/limit_operator.h
+++ b/be/src/exec/pipeline/limit_operator.h
@@ -31,6 +31,8 @@ public:
 
     bool is_finished() const override { return (_is_finished || _limit == 0) && _cur_chunk == nullptr; }
 
+    bool ignore_empty_eos() const override { return false; }
+
     Status set_finishing(RuntimeState* state) override {
         _is_finished = true;
         return Status::OK();

--- a/be/src/exec/pipeline/project_operator.cpp
+++ b/be/src/exec/pipeline/project_operator.cpp
@@ -38,6 +38,11 @@ StatusOr<ChunkPtr> ProjectOperator::pull_chunk(RuntimeState* state) {
 }
 
 Status ProjectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
+    if (chunk->is_empty()) {
+        DCHECK(chunk->owner_info().is_last_chunk());
+        _cur_chunk = chunk;
+        return Status::OK();
+    }
     TRY_CATCH_ALLOC_SCOPE_START();
     {
         SCOPED_TIMER(_common_sub_expr_compute_timer);
@@ -80,6 +85,7 @@ Status ProjectOperator::push_chunk(RuntimeState* state, const ChunkPtr& chunk) {
     for (size_t i = 0; i < result_columns.size(); ++i) {
         _cur_chunk->append_column(result_columns[i], _column_ids[i]);
     }
+    _cur_chunk->owner_info() = chunk->owner_info();
     TRY_CATCH_ALLOC_SCOPE_END()
     return Status::OK();
 }

--- a/be/src/exec/pipeline/project_operator.h
+++ b/be/src/exec/pipeline/project_operator.h
@@ -45,6 +45,8 @@ public:
 
     bool is_finished() const override { return _is_finished && _cur_chunk == nullptr; }
 
+    bool ignore_empty_eos() const override { return false; }
+
     Status set_finishing(RuntimeState* state) override {
         _is_finished = true;
         return Status::OK();

--- a/be/src/exec/query_cache/owner_info.h
+++ b/be/src/exec/query_cache/owner_info.h
@@ -47,6 +47,8 @@ public:
     }
     bool is_passthrough() const { return (_owner_id & PASSTHROUGH_BIT) == PASSTHROUGH_BIT; }
 
+    bool operator!=(const owner_info& other) const { return _owner_id != other._owner_id; }
+
 private:
     int64_t _owner_id = 0;
 };

--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -544,7 +544,8 @@ void ChunkPipelineAccumulator::push(const ChunkPtr& chunk) {
     if (_in_chunk == nullptr) {
         _in_chunk = chunk;
         _mem_usage = chunk->memory_usage();
-    } else if (_in_chunk->num_rows() + chunk->num_rows() > _max_size) {
+    } else if (_in_chunk->num_rows() + chunk->num_rows() > _max_size ||
+               _in_chunk->owner_info() != chunk->owner_info()) {
         _out_chunk = std::move(_in_chunk);
         _in_chunk = chunk;
         _mem_usage = chunk->memory_usage();
@@ -553,8 +554,8 @@ void ChunkPipelineAccumulator::push(const ChunkPtr& chunk) {
         _mem_usage += chunk->memory_usage();
     }
 
-    if (_out_chunk == nullptr &&
-        (_in_chunk->num_rows() >= _max_size * LOW_WATERMARK_ROWS_RATE || _mem_usage >= LOW_WATERMARK_BYTES)) {
+    if (_out_chunk == nullptr && (_in_chunk->num_rows() >= _max_size * LOW_WATERMARK_ROWS_RATE ||
+                                  _mem_usage >= LOW_WATERMARK_BYTES || _in_chunk->owner_info().is_last_chunk())) {
         _out_chunk = std::move(_in_chunk);
         _mem_usage = 0;
     }

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -262,4 +262,86 @@ TEST_F(ChunkPipelineAccumulatorTest, test_push) {
     ASSERT_FALSE(accumulator.has_output());
 }
 
+TEST_F(ChunkPipelineAccumulatorTest, test_owner_info) {
+    constexpr size_t kDesiredSize = 4096;
+
+    {
+        ChunkPipelineAccumulator accumulator;
+        accumulator.set_max_size(kDesiredSize);
+        DCHECK(accumulator.need_input());
+        // same owner info
+        {
+            auto chunk = _generate_chunk(1025, 2);
+            chunk->owner_info().set_owner_id(1, false);
+            accumulator.push(std::move(chunk));
+        }
+        DCHECK(accumulator.need_input());
+        {
+            // new empty chunk
+            auto chunk = std::make_unique<Chunk>();
+            chunk->owner_info().set_owner_id(1, true);
+            accumulator.push(std::move(chunk));
+        }
+
+        DCHECK(!accumulator.need_input());
+        DCHECK(accumulator.has_output());
+        auto chunk = std::move(accumulator.pull());
+        DCHECK(!chunk->owner_info().is_last_chunk());
+        accumulator.finalize();
+        DCHECK(accumulator.has_output());
+        chunk = std::move(accumulator.pull());
+        DCHECK(chunk->owner_info().is_last_chunk());
+    }
+
+    {
+        ChunkPipelineAccumulator accumulator;
+        accumulator.set_max_size(kDesiredSize);
+        DCHECK(accumulator.need_input());
+        // same owner info
+        {
+            auto chunk = _generate_chunk(1025, 2);
+            chunk->owner_info().set_owner_id(2, false);
+            accumulator.push(std::move(chunk));
+            chunk = _generate_chunk(1025, 2);
+            chunk->owner_info().set_owner_id(2, true);
+            accumulator.push(std::move(chunk));
+        }
+        DCHECK(accumulator.has_output());
+        auto chunk = std::move(accumulator.pull());
+        DCHECK(!chunk->owner_info().is_last_chunk());
+    }
+
+    {
+        ChunkPipelineAccumulator accumulator;
+        accumulator.set_max_size(kDesiredSize);
+        DCHECK(accumulator.need_input());
+        // not the same owner info
+        {
+            auto chunk = _generate_chunk(1025, 2);
+            chunk->owner_info().set_owner_id(3, false);
+            accumulator.push(std::move(chunk));
+            chunk = _generate_chunk(1025, 2);
+            chunk->owner_info().set_owner_id(4, false);
+            accumulator.push(std::move(chunk));
+        }
+        auto chunk = std::move(accumulator.pull());
+        DCHECK_EQ(chunk->owner_info().owner_id(), 3);
+    }
+
+    {
+        ChunkPipelineAccumulator accumulator;
+        accumulator.set_max_size(kDesiredSize);
+        DCHECK(accumulator.need_input());
+        // not the same owner info
+        {
+            auto chunk = _generate_chunk(1025, 2);
+            chunk->owner_info().set_owner_id(1, true);
+            accumulator.push(std::move(chunk));
+            DCHECK(!accumulator.need_input());
+        }
+        auto chunk = std::move(accumulator.pull());
+        DCHECK(chunk->owner_info().is_last_chunk());
+    }
+}
+
 } // namespace starrocks

--- a/test/sql/test_agg/R/test_bucket_agg
+++ b/test/sql/test_agg/R/test_bucket_agg
@@ -1,4 +1,7 @@
 -- name: test_bucket_agg
+set pipeline_dop=1;
+-- result:
+-- !result
 CREATE TABLE `t0` (
   `c0` bigint DEFAULT NULL,
   `c1` bigint DEFAULT NULL,
@@ -143,4 +146,75 @@ select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
 select count(*) from (select distinct c0 from t0 limit 100) tb;
 -- result:
 100
+-- !result
+CREATE TABLE `t1` (
+  `c0` string DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 96
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t1 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t1 select * from t1;
+-- result:
+-- !result
+select distinct c0 from t1 order by 1 limit 3;
+-- result:
+1
+10
+100
+-- !result
+select sum(c1), max(c1), min(c1), avg(c1) from t1 group by c0, c2 order by 1 limit 5;
+-- result:
+0	0	0	0.0
+2	1	1	1.0
+4	2	2	2.0
+6	3	3	3.0
+8	4	4	4.0
+-- !result
+select count(*) from (select distinct c0 from t1 limit 100) tb;
+-- result:
+100
+-- !result
+CREATE TABLE `t2` (
+  `c0` string DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 96
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+insert into t2 select * from t1 where crc32(c0) % 96 = 95;
+-- result:
+-- !result
+select distinct c0 from t2 order by 1 limit 3;
+-- result:
+1229
+1384
+1416
+-- !result
+select sum(c1), max(c1), min(c1), avg(c1) from t2 group by c0, c2 order by 1 limit 5;
+-- result:
+388	194	194	194.0
+396	198	198	198.0
+734	367	367	367.0
+900	450	450	450.0
+916	458	458	458.0
+-- !result
+select count(*) from (select distinct c0 from t2 limit 100) tb;
+-- result:
+39
 -- !result

--- a/test/sql/test_agg/T/test_bucket_agg
+++ b/test/sql/test_agg/T/test_bucket_agg
@@ -1,4 +1,5 @@
 -- name: test_bucket_agg
+set pipeline_dop=1;
 
 CREATE TABLE `t0` (
   `c0` bigint DEFAULT NULL,
@@ -43,3 +44,39 @@ select count(*) from (select distinct c0 from t0) tb;
 select count(*) from (select c0, c1, sum(c2) from t0 group by c0, c1) tb;
 -- distinct with limit
 select count(*) from (select distinct c0 from t0 limit 100) tb;
+-- 
+CREATE TABLE `t1` (
+  `c0` string DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 96
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t1 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  4096));
+insert into t1 select * from t1;
+
+select distinct c0 from t1 order by 1 limit 3;
+select sum(c1), max(c1), min(c1), avg(c1) from t1 group by c0, c2 order by 1 limit 5;
+select count(*) from (select distinct c0 from t1 limit 100) tb;
+
+CREATE TABLE `t2` (
+  `c0` string DEFAULT NULL,
+  `c1` bigint DEFAULT NULL,
+  `c2` bigint DEFAULT NULL
+) ENGINE=OLAP
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`c0`) BUCKETS 96
+PROPERTIES (
+"replication_num" = "1"
+);
+
+insert into t2 select * from t1 where crc32(c0) % 96 = 95;
+select distinct c0 from t2 order by 1 limit 3;
+select sum(c1), max(c1), min(c1), avg(c1) from t2 group by c0, c2 order by 1 limit 5;
+select count(*) from (select distinct c0 from t2 limit 100) tb;

--- a/test/sql/test_spill/R/test_spill_aggregate
+++ b/test/sql/test_spill/R/test_spill_aggregate
@@ -121,6 +121,9 @@ select count(*) from (select array_agg(c0) from t3 group by c0) tb;
 -- result:
 40961
 -- !result
+select c0, sum(c1) as sc1 from (select c0, c1 from t3 where c0 < -1 limit 100) tb group by c0;
+-- result:
+-- !result
 with agged as ( select c0 as lk, c1 from t3 group by 1,2 ) select count(*),count(l.lk),count(l.c1),count(r.lk),count(r.c1) from agged l join agged r on l.lk = r.lk;
 -- result:
 40960	40960	40960	40960	40960

--- a/test/sql/test_spill/T/test_spill_aggregate
+++ b/test/sql/test_spill/T/test_spill_aggregate
@@ -52,6 +52,7 @@ select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group
 select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
 select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
 select count(*) from (select array_agg(c0) from t3 group by c0) tb;
+select c0, sum(c1) as sc1 from (select c0, c1 from t3 where c0 < -1 limit 100) tb group by c0;
 with agged as ( select c0 as lk, c1 from t3 group by 1,2 ) select count(*),count(l.lk),count(l.c1),count(r.lk),count(r.c1) from agged l join agged r on l.lk = r.lk;
 -- short_circuit case
 create table tempty like t3;


### PR DESCRIPTION
Why I'm doing:
BucketSink call ctx->sink->set_finishing has race condition with BucketSource ctx->source->pull_chunk

What I'm doing:
port reset_state to sink side

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
