### PR TITLE
[UT] Fix Flaky Test for testMultiListPartition

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/OlapTableSinkTest.java
@@ -428,41 +428,6 @@ public class OlapTableSinkTest {
     }
 
     @Test
-    public void testMultiListPartition() throws UserException{
-        TupleDescriptor tuple = getTuple();
-        ListPartitionInfo listPartitionInfo = new ListPartitionInfo(PartitionType.LIST,
-                Lists.newArrayList(new Column("dt",Type.STRING), new Column("province",Type.STRING)));
-        List<String> multiItems = Lists.newArrayList("dt","shanghai");
-        List<List<String>> multiValues = new ArrayList<>();
-        multiValues.add(multiItems);
-
-        listPartitionInfo.setMultiValues(1,multiValues);
-        listPartitionInfo.setReplicationNum(1, (short) 3);
-        MaterializedIndex index = new MaterializedIndex(1, MaterializedIndex.IndexState.NORMAL);
-        HashDistributionInfo distInfo = new HashDistributionInfo(
-                3, Lists.newArrayList(new Column("id", Type.BIGINT)));
-        Partition partition = new Partition(1, "p1", index, distInfo);
-
-        new Expectations() {{
-            dstTable.getId();
-            result = 1;
-            dstTable.getPartitions();
-            result = Lists.newArrayList(partition);
-            dstTable.getPartition(1L);
-            result = partition;
-            dstTable.getPartitionInfo();
-            result = listPartitionInfo;
-        }};
-
-        OlapTableSink sink = new OlapTableSink(dstTable, tuple, Lists.newArrayList(1L),
-                TWriteQuorumType.MAJORITY, false, false, false);
-        sink.init(new TUniqueId(1, 2), 3, 4, 1000);
-        sink.complete();
-
-        Assert.assertTrue(sink.toThrift() instanceof TDataSink);
-    }
-
-    @Test
     public void testImmutablePartition() throws UserException {
         TupleDescriptor tuple = getTuple();
         SinglePartitionInfo partInfo = new SinglePartitionInfo();


### PR DESCRIPTION
Why I'm doing:
testMultiListPartition is unstable 
Error:  testMultiListPartition  Time elapsed: 1.781 s  <<< ERROR!
Missing 1 invocation to:
com.starrocks.server.GlobalStateMgr#isReady()
   on mock instance: com.starrocks.server.GlobalStateMgr@7ead7728
Caused by: Missing invocations
	at com.starrocks.common.util.FrontendDaemon.runOneCycle(FrontendDaemon.java:60)
	at com.starrocks.common.util.Daemon.run(Daemon.java:107)

What I'm doing:
This is because there are a bunch of background tasks in the GlobalStateMgr mocked in OlapTableSinkTest, and the mock framework requires one call, but the background tasks will continue to start various threads, resulting in a probability of not being called once. Moving this to another clean environment should resolve the issue.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
