### PR TITLE
[Enhancement] Support customizing buffer size for lake compaction

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -925,6 +925,7 @@ CONF_mInt32(starlet_fslib_s3client_connect_timeout_ms, "1000");
 CONF_mInt64(lake_metadata_cache_limit, /*2GB=*/"2147483648");
 CONF_mBool(lake_print_delete_log, "true");
 CONF_mBool(lake_compaction_check_txn_log_first, "false");
+CONF_mInt64(lake_compaction_stream_buffer_size_bytes, "1048576"); // 1MB
 // Used to ensure service availability in extreme situations by sacrificing a certain degree of correctness
 CONF_mBool(experimental_lake_ignore_lost_segment, "false");
 CONF_mInt64(experimental_lake_wait_per_put_ms, "0");

--- a/be/src/connector/lake_connector.cpp
+++ b/be/src/connector/lake_connector.cpp
@@ -396,7 +396,7 @@ Status LakeDataSource::init_reader_params(const std::vector<OlapScanRange*>& key
     _params.profile = _runtime_profile;
     _params.runtime_state = _runtime_state;
     _params.use_page_cache = !config::disable_storage_page_cache && _scan_range.fill_data_cache;
-    _params.fill_data_cache = _scan_range.fill_data_cache;
+    _params.lake_io_opts.fill_data_cache = _scan_range.fill_data_cache;
     _params.runtime_range_pruner = OlapRuntimeScanRangePruner(parser, _conjuncts_manager.unarrived_runtime_filters());
 
     std::vector<PredicatePtr> preds;

--- a/be/src/fs/fs.h
+++ b/be/src/fs/fs.h
@@ -85,12 +85,16 @@ struct SequentialFileOptions {
     // Don't cache remote file locally on read requests.
     // This options can be ignored if the underlying filesystem does not support local cache.
     bool skip_fill_local_cache = false;
+    // Specify different buffer size for different read scenarios
+    int64_t buffer_size = -1;
 };
 
 struct RandomAccessFileOptions {
     // Don't cache remote file locally on read requests.
     // This options can be ignored if the underlying filesystem does not support local cache.
     bool skip_fill_local_cache = false;
+    // Specify different buffer size for different read scenarios
+    int64_t buffer_size = -1;
 };
 
 struct DirEntry {

--- a/be/src/fs/fs_starlet.cpp
+++ b/be/src/fs/fs_starlet.cpp
@@ -276,6 +276,7 @@ public:
         }
         auto opt = ReadOptions();
         opt.skip_fill_local_cache = opts.skip_fill_local_cache;
+        opt.buffer_size = opts.buffer_size;
         if (info.size.has_value()) {
             opt.file_size = info.size.value();
         }
@@ -304,6 +305,7 @@ public:
         }
         auto opt = ReadOptions();
         opt.skip_fill_local_cache = opts.skip_fill_local_cache;
+        opt.buffer_size = opts.buffer_size;
         auto file_st = (*fs_st)->open(pair.first, std::move(opt));
 
         if (!file_st.ok()) {

--- a/be/src/storage/lake/rowset.cpp
+++ b/be/src/storage/lake/rowset.cpp
@@ -71,7 +71,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     seg_options.unused_output_column_ids = options.unused_output_column_ids;
     seg_options.runtime_range_pruner = options.runtime_range_pruner;
     seg_options.tablet_schema = options.tablet_schema;
-    seg_options.fill_data_cache = options.fill_data_cache;
+    seg_options.lake_io_opts = options.lake_io_opts;
     if (options.is_primary_keys) {
         seg_options.is_primary_keys = true;
         seg_options.delvec_loader = std::make_shared<LakeDelvecLoader>(_tablet_mgr->update_mgr(), nullptr);
@@ -109,7 +109,7 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::read(const Schema& schema, const
     }
 
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(load_segments(&segments, options.fill_data_cache));
+    RETURN_IF_ERROR(load_segments(&segments, options.lake_io_opts.fill_data_cache, options.lake_io_opts.buffer_size));
     for (auto& seg_ptr : segments) {
         if (seg_ptr->num_rows() == 0) {
             continue;
@@ -210,20 +210,23 @@ StatusOr<std::vector<ChunkIteratorPtr>> Rowset::get_each_segment_iterator_with_d
 }
 
 StatusOr<std::vector<SegmentPtr>> Rowset::segments(bool fill_cache) {
-    return segments(fill_cache, fill_cache);
+    LakeIOOptions lake_io_opts{.fill_data_cache = fill_cache};
+    return segments(lake_io_opts, fill_cache);
 }
 
-StatusOr<std::vector<SegmentPtr>> Rowset::segments(bool fill_data_cache, bool fill_metadata_cache) {
+StatusOr<std::vector<SegmentPtr>> Rowset::segments(const LakeIOOptions& lake_io_opts, bool fill_metadata_cache) {
     std::vector<SegmentPtr> segments;
-    RETURN_IF_ERROR(load_segments(&segments, fill_data_cache, fill_metadata_cache));
+    RETURN_IF_ERROR(load_segments(&segments, lake_io_opts, fill_metadata_cache));
     return segments;
 }
 
-Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_cache) {
-    return load_segments(segments, fill_cache, fill_cache);
+Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_cache, int64_t buffer_size) {
+    LakeIOOptions lake_io_opts{.fill_data_cache = fill_cache, .buffer_size = buffer_size};
+    return load_segments(segments, lake_io_opts, fill_cache);
 }
 
-Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_data_cache, bool fill_metadata_cache) {
+Status Rowset::load_segments(std::vector<SegmentPtr>* segments, const LakeIOOptions& lake_io_opts,
+                             bool fill_metadata_cache) {
 #ifndef BE_TEST
     RETURN_IF_ERROR(tls_thread_status.mem_tracker()->check_mem_limit("LoadSegments"));
 #endif
@@ -253,7 +256,7 @@ Status Rowset::load_segments(std::vector<SegmentPtr>* segments, bool fill_data_c
         }
         index++;
 
-        auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, fill_data_cache,
+        auto segment_or = _tablet_mgr->load_segment(segment_info, seg_id++, &footer_size_hint, lake_io_opts,
                                                     fill_metadata_cache, _tablet_schema);
         if (segment_or.ok()) {
             segments->emplace_back(std::move(segment_or.value()));

--- a/be/src/storage/lake/rowset.h
+++ b/be/src/storage/lake/rowset.h
@@ -19,6 +19,7 @@
 #include "storage/lake/tablet.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"
+#include "storage/options.h"
 
 namespace starrocks::lake {
 
@@ -89,11 +90,13 @@ public:
 
     [[nodiscard]] StatusOr<std::vector<SegmentPtr>> segments(bool fill_cache);
 
-    [[nodiscard]] StatusOr<std::vector<SegmentPtr>> segments(bool fill_data_cache, bool fill_metadata_cache);
+    [[nodiscard]] StatusOr<std::vector<SegmentPtr>> segments(const LakeIOOptions& lake_io_opts,
+                                                             bool fill_metadata_cache);
 
-    [[nodiscard]] Status load_segments(std::vector<SegmentPtr>* segments, bool fill_cache);
+    // `fill_cache` controls `fill_data_cache` and `fill_meta_cache`
+    [[nodiscard]] Status load_segments(std::vector<SegmentPtr>* segments, bool fill_cache, int64_t buffer_size = -1);
 
-    [[nodiscard]] Status load_segments(std::vector<SegmentPtr>* segments, bool fill_data_cache,
+    [[nodiscard]] Status load_segments(std::vector<SegmentPtr>* segments, const LakeIOOptions& lake_io_opts,
                                        bool fill_metadata_cache);
 
     int64_t tablet_id() const { return _tablet_id; }

--- a/be/src/storage/lake/schema_change.cpp
+++ b/be/src/storage/lake/schema_change.cpp
@@ -143,7 +143,8 @@ Status ConvertedSchemaChange::init() {
     _read_params.skip_aggregation = false;
     _read_params.chunk_size = config::vector_chunk_size;
     _read_params.use_page_cache = false;
-    _read_params.fill_data_cache = false;
+    // not fill data cache
+    _read_params.lake_io_opts.fill_data_cache = false;
     _read_params.sorted_by_keys_per_tablet = true;
 
     auto base_tablet_schema = _base_tablet.get_schema();

--- a/be/src/storage/lake/tablet_manager.cpp
+++ b/be/src/storage/lake/tablet_manager.cpp
@@ -570,7 +570,7 @@ StatusOr<VersionedTablet> TabletManager::get_tablet(int64_t tablet_id, int64_t v
 }
 
 StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
-                                                 bool fill_data_cache, bool fill_metadata_cache,
+                                                 const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
                                                  TabletSchemaPtr tablet_schema) {
     auto segment = metacache()->lookup_segment(segment_info.path);
     if (segment == nullptr) {
@@ -588,7 +588,7 @@ StatusOr<SegmentPtr> TabletManager::load_segment(const FileInfo& segment_info, i
     // segment->open will read the footer, and it is time-consuming.
     // separate it from static Segment::open is to prevent a large number of cache misses,
     // and many temporary segment objects generation when loading the same segment concurrently.
-    RETURN_IF_ERROR(segment->open(footer_size_hint, nullptr, !fill_data_cache));
+    RETURN_IF_ERROR(segment->open(footer_size_hint, nullptr, lake_io_opts));
     return segment;
 }
 

--- a/be/src/storage/lake/tablet_manager.h
+++ b/be/src/storage/lake/tablet_manager.h
@@ -25,6 +25,7 @@
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/types_fwd.h"
+#include "storage/options.h"
 
 namespace starrocks {
 struct FileInfo;
@@ -164,7 +165,8 @@ public:
     void update_segment_cache_size(std::string_view key, intptr_t segment_addr_hint = 0);
 
     StatusOr<SegmentPtr> load_segment(const FileInfo& segment_info, int segment_id, size_t* footer_size_hint,
-                                      bool fill_data_cache, bool fill_metadata_cache, TabletSchemaPtr tablet_schema);
+                                      const LakeIOOptions& lake_io_opts, bool fill_metadata_cache,
+                                      TabletSchemaPtr tablet_schema);
 
 private:
     static std::string global_schema_cache_key(int64_t index_id);

--- a/be/src/storage/lake/tablet_reader.cpp
+++ b/be/src/storage/lake/tablet_reader.cpp
@@ -142,7 +142,8 @@ Status TabletReader::get_segment_iterators(const TabletReaderParams& params, std
     rs_opts.global_dictmaps = params.global_dictmaps;
     rs_opts.unused_output_column_ids = params.unused_output_column_ids;
     rs_opts.runtime_range_pruner = params.runtime_range_pruner;
-    rs_opts.fill_data_cache = params.fill_data_cache;
+    rs_opts.lake_io_opts = params.lake_io_opts;
+
     if (keys_type == KeysType::PRIMARY_KEYS) {
         rs_opts.is_primary_keys = true;
         rs_opts.version = _tablet_metadata->version();

--- a/be/src/storage/lake/vertical_compaction_task.cpp
+++ b/be/src/storage/lake/vertical_compaction_task.cpp
@@ -118,7 +118,10 @@ StatusOr<int32_t> VerticalCompactionTask::calculate_chunk_size_for_column_group(
         //
         // test case: 4k columns, 150 segments, 60w rows
         // compaction task cost: 272s (fill metadata cache) vs 2400s (not fill metadata cache)
-        ASSIGN_OR_RETURN(auto segments, rowset->segments(false, true));
+        LakeIOOptions lake_io_opts{.fill_data_cache = false,
+                                   .buffer_size = config::lake_compaction_stream_buffer_size_bytes};
+        auto fill_meta_cache = true;
+        ASSIGN_OR_RETURN(auto segments, rowset->segments(lake_io_opts, fill_meta_cache));
         for (auto& segment : segments) {
             for (auto column_index : column_group) {
                 const auto* column_reader = segment->column(column_index);
@@ -152,7 +155,8 @@ Status VerticalCompactionTask::compact_column_group(bool is_key, int column_grou
     reader_params.chunk_size = chunk_size;
     reader_params.profile = nullptr;
     reader_params.use_page_cache = false;
-    reader_params.fill_data_cache = config::lake_enable_vertical_compaction_fill_data_cache;
+    reader_params.lake_io_opts = {config::lake_enable_vertical_compaction_fill_data_cache,
+                                  config::lake_compaction_stream_buffer_size_bytes};
     RETURN_IF_ERROR(reader.open(reader_params));
 
     auto chunk = ChunkHelper::new_chunk(schema, chunk_size);

--- a/be/src/storage/options.h
+++ b/be/src/storage/options.h
@@ -69,4 +69,14 @@ struct EngineOptions {
     // if start as cn, no need to write cluster id
     bool need_write_cluster_id = true;
 };
+
+// Options only applies to cloud-native table r/w IO
+struct LakeIOOptions {
+    // Cache remote file locally on read requests.
+    // This options can be ignored if the underlying filesystem does not support local cache.
+    bool fill_data_cache = false;
+    // Specify different buffer size for different read scenarios
+    int64_t buffer_size = -1;
+};
+
 } // namespace starrocks

--- a/be/src/storage/rowset/column_iterator.h
+++ b/be/src/storage/rowset/column_iterator.h
@@ -36,6 +36,7 @@
 
 #include "common/status.h"
 #include "storage/olap_common.h"
+#include "storage/options.h"
 #include "storage/range.h"
 #include "storage/rowset/common.h"
 
@@ -55,7 +56,7 @@ struct ColumnIteratorOptions {
     // reader statistics
     OlapReaderStatistics* stats = nullptr;
     bool use_page_cache = false;
-    bool fill_data_cache = true;
+    LakeIOOptions lake_io_opts{.fill_data_cache = true};
 
     // check whether column pages are all dictionary encoding.
     bool check_dict_encoding = false;

--- a/be/src/storage/rowset/options.h
+++ b/be/src/storage/rowset/options.h
@@ -57,7 +57,7 @@ public:
     bool use_page_cache = false;
     bool kept_in_memory = false;
     // for lake tablet
-    bool skip_fill_data_cache = false;
+    LakeIOOptions lake_io_opts{.fill_data_cache = true};
 
     RandomAccessFile* read_file = nullptr;
     OlapReaderStatistics* stats = nullptr;

--- a/be/src/storage/rowset/rowset_options.h
+++ b/be/src/storage/rowset/rowset_options.h
@@ -22,6 +22,7 @@
 #include "runtime/global_dict/types.h"
 #include "storage/olap_common.h"
 #include "storage/olap_runtime_range_pruner.h"
+#include "storage/options.h"
 #include "storage/seek_range.h"
 #include "storage/tablet_schema.h"
 
@@ -68,7 +69,7 @@ public:
     RuntimeState* runtime_state = nullptr;
     RuntimeProfile* profile = nullptr;
     bool use_page_cache = false;
-    bool fill_data_cache = true;
+    LakeIOOptions lake_io_opts;
 
     ColumnIdToGlobalDictMap* global_dictmaps = &EMPTY_GLOBAL_DICTMAPS;
     const std::unordered_set<uint32_t>* unused_output_column_ids = nullptr;

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -52,7 +52,7 @@ Status ScalarColumnIterator::init(const ColumnIteratorOptions& opts) {
     IndexReadOptions index_opts;
     index_opts.use_page_cache = config::enable_ordinal_index_memory_page_cache || !config::disable_storage_page_cache;
     index_opts.kept_in_memory = config::enable_ordinal_index_memory_page_cache;
-    index_opts.skip_fill_data_cache = _skip_fill_data_cache();
+    index_opts.lake_io_opts = opts.lake_io_opts;
     index_opts.read_file = _opts.read_file;
     index_opts.stats = _opts.stats;
     RETURN_IF_ERROR(_reader->load_ordinal_index(index_opts));
@@ -312,7 +312,7 @@ Status ScalarColumnIterator::get_row_ranges_by_zone_map(const std::vector<const 
         IndexReadOptions opts;
         opts.use_page_cache = config::enable_zonemap_index_memory_page_cache || !config::disable_storage_page_cache;
         opts.kept_in_memory = config::enable_zonemap_index_memory_page_cache;
-        opts.skip_fill_data_cache = _skip_fill_data_cache();
+        opts.lake_io_opts = _opts.lake_io_opts;
         opts.read_file = _opts.read_file;
         opts.stats = _opts.stats;
         RETURN_IF_ERROR(_reader->zone_map_filter(predicates, del_predicate, &_delete_partial_satisfied_pages,
@@ -335,7 +335,7 @@ Status ScalarColumnIterator::get_row_ranges_by_bloom_filter(const std::vector<co
     IndexReadOptions opts;
     opts.use_page_cache = !config::disable_storage_page_cache;
     opts.kept_in_memory = false;
-    opts.skip_fill_data_cache = _skip_fill_data_cache();
+    opts.lake_io_opts = _opts.lake_io_opts;
     opts.read_file = _opts.read_file;
     opts.stats = _opts.stats;
     RETURN_IF_ERROR(_reader->bloom_filter(predicates, row_ranges, opts));

--- a/be/src/storage/rowset/scalar_column_iterator.h
+++ b/be/src/storage/rowset/scalar_column_iterator.h
@@ -126,8 +126,6 @@ private:
 
     bool _contains_deleted_row(uint32_t page_index) const;
 
-    bool _skip_fill_data_cache() const { return !_opts.fill_data_cache; }
-
     ColumnReader* _reader;
 
     // 1. The _page represents current page.

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -86,7 +86,7 @@ public:
                                                    uint32_t segment_id, TabletSchemaCSPtr tablet_schema,
                                                    size_t* footer_length_hint = nullptr,
                                                    const FooterPointerPB* partial_rowset_footer = nullptr,
-                                                   bool skip_fill_local_cache = true,
+                                                   const LakeIOOptions& lake_io_opts = {},
                                                    lake::TabletManager* tablet_manager = nullptr);
 
     [[nodiscard]] static StatusOr<size_t> parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer,
@@ -100,7 +100,8 @@ public:
 
     ~Segment();
 
-    Status open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer, bool skip_fill_local_cache);
+    Status open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer,
+                const LakeIOOptions& lake_io_opts);
 
     // may return EndOfFile
     StatusOr<ChunkIteratorPtr> new_iterator(const Schema& schema, const SegmentReadOptions& read_options);
@@ -190,7 +191,7 @@ public:
 
     // Load and decode short key index.
     // May be called multiple times, subsequent calls will no op.
-    [[nodiscard]] Status load_index(bool skip_fill_local_cache = true);
+    [[nodiscard]] Status load_index(const LakeIOOptions& lake_io_opts = {});
     bool has_loaded_index() const;
 
     const ShortKeyIndexDecoder* decoder() const { return _sk_index_decoder.get(); }
@@ -242,7 +243,7 @@ private:
         TabletSchemaCSPtr _schema;
     };
 
-    Status _load_index(bool skip_fill_local_cache);
+    Status _load_index(const LakeIOOptions& lake_io_opts);
 
     void _reset();
 
@@ -259,7 +260,8 @@ private:
     size_t _column_index_mem_usage() const;
 
     // open segment file and read the minimum amount of necessary information (footer)
-    Status _open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer, bool skip_fill_local_cache);
+    Status _open(size_t* footer_length_hint, const FooterPointerPB* partial_rowset_footer,
+                 const LakeIOOptions& lake_io_opts);
     Status _create_column_readers(SegmentFooterPB* footer);
 
     StatusOr<ChunkIteratorPtr> _new_iterator(const Schema& schema, const SegmentReadOptions& read_options);

--- a/be/src/storage/rowset/segment_options.h
+++ b/be/src/storage/rowset/segment_options.h
@@ -24,6 +24,7 @@
 #include "storage/del_vector.h"
 #include "storage/disjunctive_predicates.h"
 #include "storage/olap_runtime_range_pruner.h"
+#include "storage/options.h"
 #include "storage/seek_range.h"
 #include "storage/tablet_schema.h"
 
@@ -72,7 +73,7 @@ public:
     RuntimeProfile* profile = nullptr;
 
     bool use_page_cache = false;
-    bool fill_data_cache = true;
+    LakeIOOptions lake_io_opts{.fill_data_cache = true};
 
     ReaderType reader_type = READER_QUERY;
     int chunk_size = DEFAULT_CHUNK_SIZE;

--- a/be/src/storage/rowset/segment_rewriter.cpp
+++ b/be/src/storage/rowset/segment_rewriter.cpp
@@ -190,11 +190,13 @@ Status SegmentRewriter::rewrite(const std::string& src_path, FileInfo* dest_path
     Schema src_schema = ChunkHelper::convert_schema(tschema, src_column_ids);
 
     size_t footer_sine_hint = 16 * 1024;
-    auto fill_cache = false;
     auto tablet_mgr = tablet->tablet_mgr();
     auto segment_path = tablet->segment_location(op_write.rowset().segments(segment_id));
     auto segment_info = FileInfo{.path = segment_path};
-    ASSIGN_OR_RETURN(auto segment, tablet_mgr->load_segment(segment_info, segment_id, &footer_sine_hint, fill_cache,
+    // not fill data and meta cache
+    auto fill_cache = false;
+    LakeIOOptions lake_io_opts{fill_cache, -1};
+    ASSIGN_OR_RETURN(auto segment, tablet_mgr->load_segment(segment_info, segment_id, &footer_sine_hint, lake_io_opts,
                                                             fill_cache, tschema));
     uint32_t num_rows = segment->num_rows();
 

--- a/be/src/storage/tablet_reader_params.h
+++ b/be/src/storage/tablet_reader_params.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "column/column_access_path.h"
+#include "options.h"
 #include "runtime/global_dict/types.h"
 #include "storage/chunk_iterator.h"
 #include "storage/olap_common.h"
@@ -57,9 +58,8 @@ struct TabletReaderParams {
     //     if config::disable_storage_page_cache is false, we use page cache
     bool use_page_cache = false;
 
-    // Allow this query to cache remote data on local disk or not.
-    // Only work for cloud native tablet(LakeTablet) now.
-    bool fill_data_cache = true;
+    // Options only applies to cloud-native table r/w IO
+    LakeIOOptions lake_io_opts{.fill_data_cache = true};
 
     RangeStartOperation range = RangeStartOperation::GT;
     RangeEndOperation end_range = RangeEndOperation::LT;

--- a/be/test/storage/lake/rowset_test.cpp
+++ b/be/test/storage/lake/rowset_test.cpp
@@ -161,7 +161,8 @@ TEST_F(LakeRowsetTest, test_load_segments) {
     }
 
     // fill data cache: false, fill metadata cache: true
-    ASSIGN_OR_ABORT(auto segments2, rowset->segments(false, true));
+    LakeIOOptions lake_io_opts{.fill_data_cache = false};
+    ASSIGN_OR_ABORT(auto segments2, rowset->segments(lake_io_opts, true));
     ASSERT_EQ(2, segments2.size());
     for (const auto& seg : segments2) {
         auto segment = cache->lookup_segment(seg->file_name());
@@ -198,7 +199,8 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
 
         auto mirror_segment =
                 std::make_shared<Segment>(fs, FileInfo{path}, sample_segment->id(), schema, _tablet_mgr.get());
-        auto st = mirror_segment->open(nullptr, nullptr, true);
+        LakeIOOptions lake_io_opts{.fill_data_cache = true};
+        auto st = mirror_segment->open(nullptr, nullptr, lake_io_opts);
         EXPECT_TRUE(st.ok());
         auto sz2 = cache->memory_usage();
         // no memory_usage change, because the instance in metacache is different from this mirror_segment
@@ -216,7 +218,8 @@ TEST_F(LakeRowsetTest, test_segment_update_cache_size) {
         auto sz1 = cache->memory_usage();
         auto ssz1 = mirror_segment->mem_usage();
 
-        auto st = mirror_segment->open(nullptr, nullptr, true);
+        LakeIOOptions lake_io_opts{.fill_data_cache = true};
+        auto st = mirror_segment->open(nullptr, nullptr, lake_io_opts);
         EXPECT_TRUE(st.ok());
         auto sz2 = cache->memory_usage();
         auto ssz2 = mirror_segment->mem_usage();

--- a/be/test/storage/rowset/bitmap_index_test.cpp
+++ b/be/test/storage/rowset/bitmap_index_test.cpp
@@ -62,7 +62,6 @@ protected:
 
         _opts.use_page_cache = true;
         _opts.kept_in_memory = false;
-        _opts.skip_fill_data_cache = false;
         _opts.stats = &_stats;
     }
     void TearDown() override { StoragePageCache::instance()->prune(); }
@@ -263,7 +262,6 @@ TEST_F(BitmapIndexTest, test_concurrent_load) {
     opts.read_file = rfile.get();
     opts.use_page_cache = true;
     opts.kept_in_memory = false;
-    opts.skip_fill_data_cache = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     auto reader = std::make_unique<BitmapIndexReader>();

--- a/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
+++ b/be/test/storage/rowset/bloom_filter_index_reader_writer_test.cpp
@@ -57,7 +57,6 @@ protected:
 
         _opts.use_page_cache = true;
         _opts.kept_in_memory = false;
-        _opts.skip_fill_data_cache = false;
         _opts.stats = &_stats;
     }
     void TearDown() override { StoragePageCache::instance()->prune(); }

--- a/be/test/storage/rowset/ordinal_page_index_test.cpp
+++ b/be/test/storage/rowset/ordinal_page_index_test.cpp
@@ -89,7 +89,6 @@ TEST_F(OrdinalPageIndexTest, normal) {
     opts.read_file = rfile.get();
     opts.use_page_cache = true;
     opts.kept_in_memory = false;
-    opts.skip_fill_data_cache = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     OrdinalIndexReader index;
@@ -151,7 +150,6 @@ TEST_F(OrdinalPageIndexTest, one_data_page) {
     opts.read_file = nullptr;
     opts.use_page_cache = true;
     opts.kept_in_memory = false;
-    opts.skip_fill_data_cache = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     OrdinalIndexReader index;

--- a/be/test/storage/rowset/zone_map_index_test.cpp
+++ b/be/test/storage/rowset/zone_map_index_test.cpp
@@ -93,7 +93,6 @@ protected:
         opts.read_file = rfile.get();
         opts.use_page_cache = false;
         opts.kept_in_memory = false;
-        opts.skip_fill_data_cache = false;
         OlapReaderStatistics stats;
         opts.stats = &stats;
         ZoneMapIndexReader column_zone_map;
@@ -148,7 +147,6 @@ void ColumnZoneMapTest::load_zone_map(ZoneMapIndexReader& reader, ColumnIndexMet
     opts.read_file = rfile.get();
     opts.use_page_cache = false;
     opts.kept_in_memory = false;
-    opts.skip_fill_data_cache = false;
     OlapReaderStatistics stats;
     opts.stats = &stats;
     ASSERT_TRUE(reader.load(opts, meta.zone_map_index()).value());


### PR DESCRIPTION
Why I'm doing:

The current global settings of cloud-native stream buffer size is 128KB, it might not reasonable for some  workloads such as compaction which might need a higher buffer size to accelerate the process.

What I'm doing:

Put the stream buffer size as an reader option, and  make it configurable (`lake_compaction_stream_buffer_size_bytes`) for different workloads.
With the default value setting as 1MB, the vertical compaction total time could reduced by 1x factor.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
