### PR TITLE
[BugFix] Fix the bug of hive udf processing null

### DIFF
--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapCount.java
@@ -46,7 +46,7 @@ public class UDFBitmapCount extends GenericUDF {
 
     @Override
     public Object evaluate(DeferredObject[] args) throws HiveException {
-        if (args[0] == null) {
+        if (args[0].get() == null) {
             return null;
         }
 

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapFromString.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapFromString.java
@@ -44,7 +44,7 @@ public class UDFBitmapFromString extends GenericUDF {
 
     @Override
     public Object evaluate(DeferredObject[] args) throws HiveException {
-        if (args[0] == null) {
+        if (args[0].get() == null) {
             return null;
         }
 

--- a/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
+++ b/fe/hive-udf/src/main/java/com/starrocks/hive/udf/UDFBitmapToString.java
@@ -46,7 +46,7 @@ public class UDFBitmapToString extends GenericUDF {
 
     @Override
     public Object evaluate(DeferredObject[] args) throws HiveException {
-        if (args[0] == null) {
+        if (args[0].get() == null) {
             return null;
         }
 


### PR DESCRIPTION
Why I'm doing:

select bitmap_to_string(null);

```
Error: java.lang.RuntimeException: org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing row {"c1":1,"c2":null,"c3":null}                                                                                                                         
        at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:157)                                                                                                                                                                                                  
        at org.apache.hadoop.mapred.MapRunner.run(MapRunner.java:54)                                                                                                                                                                                                              
        at org.apache.hadoop.mapred.MapTask.runOldMapper(MapTask.java:453)                                                                                                                                                                                                        
        at org.apache.hadoop.mapred.MapTask.run(MapTask.java:343)                                                                                                                                                                                                                 
        at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:175)                                                                                                                                                                                                           
        at java.security.AccessController.doPrivileged(Native Method)                                                                                                                                                                                                             
        at javax.security.auth.Subject.doAs(Subject.java:422)                                                                                                                                                                                                                     
        at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1911)                                                                                                                                                                                   
        at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:169)                                                                                                                                                                                                            
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Hive Runtime Error while processing row {"c1":1,"c2":null,"c3":null}                                                                                                                                                 
        at org.apache.hadoop.hive.ql.exec.MapOperator.process(MapOperator.java:562)                                                                                                                                                                                               
        at org.apache.hadoop.hive.ql.exec.mr.ExecMapper.map(ExecMapper.java:148)                                                                                                                                                                                                  
        ... 8 more                                                                                                                                                                                                                                                                
Caused by: org.apache.hadoop.hive.ql.metadata.HiveException: Error evaluating USAGE: bitmap_to_string(bitmap)                                                                                                                                                                     
        at org.apache.hadoop.hive.ql.exec.SelectOperator.process(SelectOperator.java:93)                                                                                                                                                                                          
        at org.apache.hadoop.hive.ql.exec.Operator.forward(Operator.java:897)                                                                                                                                                                                                     
        at org.apache.hadoop.hive.ql.exec.TableScanOperator.process(TableScanOperator.java:130)                                                                                                                                                                                   
        at org.apache.hadoop.hive.ql.exec.MapOperator$MapOpCtx.forward(MapOperator.java:148)                                                                                                                                                                                      
        at org.apache.hadoop.hive.ql.exec.MapOperator.process(MapOperator.java:547)                                                                                                                                                                                               
        ... 9 more                                                                                                                                                                                                                                                                
Caused by: java.lang.NullPointerException                                                                                                                                                                                                                                         
        at com.starrocks.hive.udf.UDFBitmapToString.evaluate(UDFBitmapToString.java:53)                                                                                                                                                                                           
        at org.apache.hadoop.hive.ql.exec.ExprNodeGenericFuncEvaluator._evaluate(ExprNodeGenericFuncEvaluator.java:187)                                                                                                                                                           
        at org.apache.hadoop.hive.ql.exec.ExprNodeEvaluator.evaluate(ExprNodeEvaluator.java:80)                                                                                                                                                                                   
        at org.apache.hadoop.hive.ql.exec.ExprNodeEvaluator.evaluate(ExprNodeEvaluator.java:68)                                                                                                                                                                                   
        at org.apache.hadoop.hive.ql.exec.SelectOperator.process(SelectOperator.java:88)                                                                                                                                                                                          
        ... 13 more   
```

What I'm doing:

We should check the object of `DeferredObject` not the `DeferredObject` self.

The test case will be added to `StarRocksTest` framework later.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
