### PR TITLE
[BugFix] improve the performance of aws client cache manage

### DIFF
--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -112,8 +112,10 @@ private:
         AWSCloudConfigurationPtr aws_cloud_configuration;
 
         bool operator==(const ClientCacheKey& rhs) const {
-            return !config && !(rhs.config) && *config == *(rhs.config) && !aws_cloud_configuration &&
-                   !(rhs.aws_cloud_configuration) && *aws_cloud_configuration == *(rhs.aws_cloud_configuration);
+            if (config && rhs.config && aws_cloud_configuration && rhs.aws_cloud_configuration) {
+                return *config == *(rhs.config) && *aws_cloud_configuration == *(rhs.aws_cloud_configuration);
+            }
+            return !config && !rhs.config && !aws_cloud_configuration && !rhs.aws_cloud_configuration;
         }
     };
 

--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -199,9 +199,8 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const TCloudConfigurati
         config.requestTimeoutMs = config::object_storage_request_timeout_ms;
     }
 
-    auto client_conf = std::make_shared<Aws::Client::ClientConfiguration>(config);
-    auto aws_config = std::make_shared<AWSCloudConfiguration>(aws_cloud_configuration);
-    ClientCacheKey client_cache_key{client_conf, aws_config};
+    ClientCacheKey client_cache_key{std::make_shared<Aws::Client::ClientConfiguration>(config),
+                                    std::make_shared<AWSCloudConfiguration>(aws_cloud_configuration)};
     {
         // Duplicate code for cache s3 client
         std::lock_guard l(_lock);
@@ -232,8 +231,8 @@ S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const TCloudConfigurati
 
 S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const ClientConfiguration& config, const FSOptions& opts) {
     std::lock_guard l(_lock);
-    auto client_conf = std::make_shared<Aws::Client::ClientConfiguration>(config);
-    ClientCacheKey client_cache_key{client_conf, std::make_shared<AWSCloudConfiguration>()};
+    ClientCacheKey client_cache_key{std::make_shared<Aws::Client::ClientConfiguration>(config),
+                                    std::make_shared<AWSCloudConfiguration>()};
     for (size_t i = 0; i < _items; i++) {
         if (_client_cache_keys[i] == client_cache_key) return _clients[i];
     }


### PR DESCRIPTION
Why I'm doing:
When  aws  client_cache_keys initialization，8 ClientConfigurations will be constructed, which will take a long time.
What I'm doing:
use std::shared_ptr<ClientConfiguration> in client_cache_keys to Improve performance during initialization.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5