### PR TITLE
[Feature] support primary key dump

### DIFF
--- a/be/src/fs/fs_util.h
+++ b/be/src/fs/fs_util.h
@@ -128,6 +128,31 @@ inline StatusOr<int64_t> copy(SequentialFile* src, WritableFile* dest, size_t bu
     return ncopy;
 }
 
+// copy [offset, offset + size] from src to dest file.
+inline StatusOr<int64_t> copy_by_range(RandomAccessFile* src, WritableFile* dest, int64_t offset, int64_t size,
+                                       size_t buff_size = 8192) {
+    char* buf = new char[buff_size];
+    std::unique_ptr<char[]> guard(buf);
+    int64_t ncopy = 0;
+    RETURN_IF_ERROR(src->skip(offset));
+    while (true) {
+        ASSIGN_OR_RETURN(auto nread, src->read(buf, buff_size));
+        if (nread == 0) {
+            return Status::Corruption("file length no match");
+        }
+        if (ncopy + nread < size) {
+            ncopy += nread;
+            RETURN_IF_ERROR(dest->append(Slice(buf, nread)));
+        } else {
+            // read all we need, and we don't need latest [ncopy + nread - size] data,
+            // So only keep nread - (ncopy + nread - size) = size - ncopy bytes
+            RETURN_IF_ERROR(dest->append(Slice(buf, size - ncopy)));
+            break;
+        }
+    }
+    return size;
+}
+
 // copy the file from src path to dest path, it will overwrite the existing files
 inline Status copy_file(const std::string& src_path, const std::string& dst_path) {
     TEST_ERROR_POINT("fs::copy_file");
@@ -138,6 +163,27 @@ inline Status copy_file(const std::string& src_path, const std::string& dst_path
     ASSIGN_OR_RETURN(auto dst_file, dst_fs->new_writable_file(opts, dst_path));
     RETURN_IF_ERROR(copy(src_file.get(), dst_file.get()));
     RETURN_IF_ERROR(dst_file->close());
+    return Status::OK();
+}
+
+// copy the file range [offset, offset + size] from src path to dest path, it will overwrite the existing files
+inline Status copy_file_by_range(const std::string& src_path, const std::string& dst_path, int64_t offset,
+                                 int64_t size) {
+    WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(auto src_fs, FileSystem::CreateSharedFromString(src_path));
+    ASSIGN_OR_RETURN(auto dst_fs, FileSystem::CreateSharedFromString(dst_path));
+    ASSIGN_OR_RETURN(auto src_file, src_fs->new_random_access_file(src_path));
+    ASSIGN_OR_RETURN(auto dst_file, dst_fs->new_writable_file(opts, dst_path));
+    RETURN_IF_ERROR(copy_by_range(src_file.get(), dst_file.get(), offset, size));
+    RETURN_IF_ERROR(dst_file->close());
+    return Status::OK();
+}
+
+// copy from src path and append dest path, dest must exist
+inline Status copy_append_file(const std::string& src_path, WritableFile* dst_file) {
+    ASSIGN_OR_RETURN(auto src_fs, FileSystem::CreateSharedFromString(src_path));
+    ASSIGN_OR_RETURN(auto src_file, src_fs->new_sequential_file(src_path));
+    RETURN_IF_ERROR(copy(src_file.get(), dst_file));
     return Status::OK();
 }
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -216,4 +216,5 @@ add_library(Storage STATIC
     lake/lake_persistent_index.cpp
     lake/persistent_index_memtable.cpp
     lake/local_pk_index_manager.cpp
+    primary_key_dump.cpp
     dictionary_cache_manager.cpp)

--- a/be/src/storage/persistent_index.cpp
+++ b/be/src/storage/persistent_index.cpp
@@ -25,6 +25,7 @@
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
 #include "storage/persistent_index_tablet_loader.h"
+#include "storage/primary_key_dump.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/rowset/rowset.h"
 #include "storage/storage_engine.h"
@@ -911,6 +912,15 @@ public:
 
     bool dump(phmap::BinaryOutputArchive& ar) override { return _map.dump(ar); }
 
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) override {
+        for (const auto& each : _map) {
+            RETURN_IF_ERROR(
+                    dump->add_pindex_kvs(hexdump(reinterpret_cast<const char*>(each.first.data), sizeof(KeyType)),
+                                         each.second.get_value(), dump_pb));
+        }
+        return dump->finish_pindex_kvs(dump_pb);
+    }
+
     std::vector<std::vector<KVRef>> get_kv_refs_by_shard(size_t nshard, size_t num_entry,
                                                          bool with_null) const override {
         std::vector<std::vector<KVRef>> ret(nshard);
@@ -1242,6 +1252,15 @@ public:
         // TODO: construct a large buffer and write instead of one by one.
         // TODO: dive in phmap internal detail and implement dump of std::string type inside, use ctrl_&slot_ directly to improve performance
         // return _set.dump(ar);
+    }
+
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) override {
+        for (const auto& composite_key : _set) {
+            auto value = UNALIGNED_LOAD64(composite_key.data() + composite_key.size() - kIndexValueSize);
+            RETURN_IF_ERROR(dump->add_pindex_kvs(hexdump(composite_key.data(), composite_key.size() - kIndexValueSize),
+                                                 value, dump_pb));
+        }
+        return dump->finish_pindex_kvs(dump_pb);
     }
 
     bool load_snapshot(phmap::BinaryInputArchive& ar) override {
@@ -1858,6 +1877,14 @@ bool ShardByLengthMutableIndex::dump(phmap::BinaryOutputArchive& ar_out, std::se
     return true;
 }
 
+Status ShardByLengthMutableIndex::iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) {
+    for (uint32_t i = 0; i < _shards.size(); ++i) {
+        const auto& shard = _shards[i];
+        RETURN_IF_ERROR(shard->iterate_all_kvs(dump, dump_pb));
+    }
+    return Status::OK();
+}
+
 static Status checksum_of_file(RandomAccessFile* file, uint64_t offset, uint32_t size, uint32* checksum) {
     std::string buff;
     raw::stl_string_resize_uninitialized(&buff, size);
@@ -2471,6 +2498,38 @@ Status ImmutableIndex::_get_in_shard_by_page(size_t shard_idx, size_t n, const S
     } else {
         return _get_in_varlen_shard_by_page(shard_idx, n, keys, values, found_keys_info, keys_info_by_page, pages);
     }
+}
+
+Status ImmutableIndex::iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) {
+    // put all kvs in one shard
+    std::vector<std::vector<KVRef>> kvs_by_shard(1);
+    for (size_t shard_idx = 0; shard_idx < _shards.size(); shard_idx++) {
+        const auto& shard_info = _shards[shard_idx];
+        if (shard_info.size == 0) {
+            // skip empty shard
+            continue;
+        }
+        auto shard = std::make_unique<ImmutableIndexShard>(shard_info.npage);
+        RETURN_IF_ERROR(_file->read_at_fully(shard_info.offset, shard->pages.data(), shard_info.bytes));
+        RETURN_IF_ERROR(shard->decompress_pages(_compression_type, shard_info.npage, shard_info.uncompressed_size,
+                                                shard_info.bytes));
+        if (shard_info.key_size != 0) {
+            RETURN_IF_ERROR(_get_fixlen_kvs_for_shard(kvs_by_shard, shard_idx, 0, &shard));
+        } else {
+            RETURN_IF_ERROR(_get_varlen_kvs_for_shard(kvs_by_shard, shard_idx, 0, &shard));
+        }
+    }
+
+    // read kv from KVRef
+    for (const auto& each : kvs_by_shard) {
+        for (const auto& each_kv : each) {
+            auto value = UNALIGNED_LOAD64(each_kv.kv_pos + each_kv.size - kIndexValueSize);
+            RETURN_IF_ERROR(dump->add_pindex_kvs(
+                    hexdump(reinterpret_cast<const char*>(each_kv.kv_pos), each_kv.size - kIndexValueSize), value,
+                    dump_pb));
+        }
+    }
+    return dump->finish_pindex_kvs(dump_pb);
 }
 
 Status ImmutableIndex::_get_in_shard(size_t shard_idx, size_t n, const Slice* keys, std::vector<KeyInfo>& keys_info,
@@ -5056,6 +5115,25 @@ Status PersistentIndex::_load_by_loader(TabletLoader* loader) {
               << " l0_capacity:" << _l0->capacity() << " #shard: " << (_has_l1 ? _l1_vec[0]->_shards.size() : 0)
               << " l1_size:" << (_has_l1 ? _l1_vec[0]->_size : 0) << " l2_size:" << _l2_file_size()
               << " memory: " << memory_usage() << " time: " << timer.elapsed_time() / 1000000 << "ms";
+    return Status::OK();
+}
+
+Status PersistentIndex::iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb) {
+    for (const auto& l2 : _l2_vec) {
+        PrimaryIndexDumpPB* level = dump_pb->add_primary_index_levels();
+        level->set_filename(l2->filename());
+        RETURN_IF_ERROR(l2->iterate_all_kvs(dump, level));
+    }
+    for (const auto& l1 : _l1_vec) {
+        PrimaryIndexDumpPB* level = dump_pb->add_primary_index_levels();
+        level->set_filename(l1->filename());
+        RETURN_IF_ERROR(l1->iterate_all_kvs(dump, level));
+    }
+    if (_l0) {
+        PrimaryIndexDumpPB* level = dump_pb->add_primary_index_levels();
+        level->set_filename("persistent index l0");
+        RETURN_IF_ERROR(_l0->iterate_all_kvs(dump, level));
+    }
     return Status::OK();
 }
 

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -32,6 +32,7 @@ namespace starrocks {
 class Tablet;
 class Schema;
 class Column;
+class PrimaryKeyDump;
 
 class TabletLoader {
 public:
@@ -266,6 +267,8 @@ public:
 
     virtual size_t memory_usage() = 0;
 
+    virtual Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) = 0;
+
     static StatusOr<std::unique_ptr<MutableIndex>> create(size_t key_size);
 
     static std::tuple<size_t, size_t> estimate_nshard_and_npage(const size_t total_kv_pairs_usage);
@@ -390,6 +393,8 @@ public:
 
     static StatusOr<std::unique_ptr<ShardByLengthMutableIndex>> create(size_t key_size, const std::string& path);
 
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb);
+
 private:
     friend class PersistentIndex;
     friend class starrocks::lake::LakeLocalPersistentIndex;
@@ -491,6 +496,8 @@ public:
 
     static StatusOr<std::unique_ptr<ImmutableIndex>> load(std::unique_ptr<RandomAccessFile>&& index_rb,
                                                           bool load_bf_data);
+
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb);
 
 private:
     friend class PersistentIndex;
@@ -778,6 +785,8 @@ public:
 
     static void modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
                                    const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta);
+
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
 
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,

--- a/be/src/storage/persistent_index.h
+++ b/be/src/storage/persistent_index.h
@@ -267,7 +267,7 @@ public:
 
     virtual size_t memory_usage() = 0;
 
-    virtual Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) = 0;
+    virtual Status pk_dump(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) = 0;
 
     static StatusOr<std::unique_ptr<MutableIndex>> create(size_t key_size);
 
@@ -393,7 +393,7 @@ public:
 
     static StatusOr<std::unique_ptr<ShardByLengthMutableIndex>> create(size_t key_size, const std::string& path);
 
-    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb);
+    Status pk_dump(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb);
 
 private:
     friend class PersistentIndex;
@@ -497,7 +497,7 @@ public:
     static StatusOr<std::unique_ptr<ImmutableIndex>> load(std::unique_ptr<RandomAccessFile>&& index_rb,
                                                           bool load_bf_data);
 
-    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb);
+    Status pk_dump(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb);
 
 private:
     friend class PersistentIndex;
@@ -786,7 +786,7 @@ public:
     static void modify_l2_versions(const std::vector<EditVersion>& input_l2_versions,
                                    const EditVersion& output_l2_version, PersistentIndexMetaPB& index_meta);
 
-    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
+    Status pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
 
 protected:
     Status _delete_expired_index_file(const EditVersion& l0_version, const EditVersion& l1_version,

--- a/be/src/storage/primary_index.cpp
+++ b/be/src/storage/primary_index.cpp
@@ -22,6 +22,7 @@
 #include "io/io_profiler.h"
 #include "runtime/large_int_value.h"
 #include "storage/chunk_helper.h"
+#include "storage/primary_key_dump.h"
 #include "storage/primary_key_encoder.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_options.h"
@@ -70,6 +71,8 @@ public:
 
     // just an estimate value for now
     virtual std::size_t memory_usage() const = 0;
+
+    virtual Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) = 0;
 };
 
 #pragma pack(push)
@@ -223,6 +226,14 @@ public:
 
     std::size_t memory_usage() const final {
         return _map.capacity() * (1 + (sizeof(Key) + 3) / 4 * 4 + sizeof(RowIdPack4));
+    }
+
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) override {
+        for (const auto& kv : _map) {
+            RETURN_IF_ERROR(dump->add_pindex_kvs(hexdump(reinterpret_cast<const char*>(&kv.first), sizeof(Key)),
+                                                 kv.second.value, dump_pb));
+        }
+        return dump->finish_pindex_kvs(dump_pb);
     }
 };
 
@@ -532,6 +543,14 @@ public:
     }
 
     std::size_t memory_usage() const final { return _map.capacity() * (1 + S * 4 + sizeof(RowIdPack4)); }
+
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) override {
+        for (const auto& kv : _map) {
+            RETURN_IF_ERROR(dump->add_pindex_kvs(
+                    hexdump(reinterpret_cast<const char*>(kv.first.v), sizeof(FixSlice<S>)), kv.second.value, dump_pb));
+        }
+        return dump->finish_pindex_kvs(dump_pb);
+    }
 };
 
 struct StringHasher1 {
@@ -668,6 +687,13 @@ public:
             ret += size() * 8;
         }
         return ret;
+    }
+
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) override {
+        for (const auto& kv : _map) {
+            RETURN_IF_ERROR(dump->add_pindex_kvs(hexdump(kv.first.data(), kv.first.size()), kv.second, dump_pb));
+        }
+        return dump->finish_pindex_kvs(dump_pb);
     }
 };
 
@@ -859,6 +885,15 @@ public:
             }
         }
         return ret;
+    }
+
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexDumpPB* dump_pb) override {
+        for (const auto& _map : _maps) {
+            if (_map) {
+                RETURN_IF_ERROR(_map->iterate_all_kvs(dump, dump_pb));
+            }
+        }
+        return Status::OK();
     }
 };
 
@@ -1450,6 +1485,17 @@ void PrimaryIndex::reset_cancel_major_compaction() {
     if (_persistent_index != nullptr) {
         _persistent_index->reset_cancel_major_compaction();
     }
+}
+
+Status PrimaryIndex::iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb) {
+    if (_persistent_index != nullptr) {
+        RETURN_IF_ERROR(_persistent_index->iterate_all_kvs(dump, dump_pb));
+    } else {
+        PrimaryIndexDumpPB* level = dump_pb->add_primary_index_levels();
+        level->set_filename("memory primary index");
+        RETURN_IF_ERROR(_pkey_to_rssid_rowid->iterate_all_kvs(dump, level));
+    }
+    return Status::OK();
 }
 
 } // namespace starrocks

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -139,6 +139,8 @@ public:
 
     void reset_cancel_major_compaction();
 
+    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
+
 protected:
     void _set_schema(const Schema& pk_schema);
 

--- a/be/src/storage/primary_index.h
+++ b/be/src/storage/primary_index.h
@@ -139,7 +139,7 @@ public:
 
     void reset_cancel_major_compaction();
 
-    Status iterate_all_kvs(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
+    Status pk_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
 
 protected:
     void _set_schema(const Schema& pk_schema);

--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -16,6 +16,8 @@
 
 #include <memory>
 
+#include "fs/fs.h"
+#include "fs/fs_util.h"
 #include "storage/chunk_helper.h"
 #include "storage/chunk_iterator.h"
 #include "storage/del_vector.h"
@@ -23,6 +25,7 @@
 #include "storage/primary_key_encoder.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_options.h"
 #include "storage/rowset/segment_writer.h"
 #include "storage/tablet.h"
 #include "storage/tablet_meta_manager.h"
@@ -35,11 +38,16 @@ namespace starrocks {
 PrimaryKeyDump::PrimaryKeyDump(Tablet* tablet) {
     _tablet = tablet;
     _dump_filepath = tablet->schema_hash_path() + "/" + std::to_string(_tablet->tablet_id()) + ".pkdump";
-    _partial_pk_column_keys = std::make_unique<PartialKeysPB>();
     _partial_pindex_kvs = std::make_unique<PartialKVsPB>();
 }
 
-Status PrimaryKeyDump::_init_dump_file() {
+// for UT only
+PrimaryKeyDump::PrimaryKeyDump(const std::string& dump_filepath) {
+    _dump_filepath = dump_filepath;
+    _partial_pindex_kvs = std::make_unique<PartialKVsPB>();
+}
+
+Status PrimaryKeyDump::init_dump_file() {
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_dump_filepath));
     WritableFileOptions wblock_opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
     ASSIGN_OR_RETURN(_dump_wfile, fs->new_writable_file(wblock_opts, _dump_filepath));
@@ -57,7 +65,7 @@ Status PrimaryKeyDump::_dump_rowset_meta() {
     auto rowset_map = _tablet->updates()->get_rowset_map();
     for (const auto& each : (*rowset_map)) {
         RowsetMetaIdPB rowset_meta_id;
-        rowset_meta_id.set_rid(each.first);
+        rowset_meta_id.set_rowset_id(each.first);
         each.second->rowset_meta()->to_rowset_pb(rowset_meta_id.mutable_rowset_meta());
         rowset_meta_id.mutable_rowset_meta()->clear_tablet_schema();
         _dump_pb.add_rowset_metas()->CopyFrom(rowset_meta_id);
@@ -65,7 +73,7 @@ Status PrimaryKeyDump::_dump_rowset_meta() {
     return Status::OK();
 }
 
-Status PrimaryKeyDump::add_pindex_kvs(const std::string& key, uint64_t value, PrimaryIndexDumpPB* dump_pb) {
+Status PrimaryKeyDump::add_pindex_kvs(const std::string_view& key, uint64_t value, PrimaryIndexDumpPB* dump_pb) {
     // Avoid protobuf exceed memory limit
     if (_partial_pindex_kvs_bytes + key.size() + sizeof(uint64_t) >= MAX_PROTOBUF_SIZE) {
         std::string serialized_data;
@@ -81,7 +89,7 @@ Status PrimaryKeyDump::add_pindex_kvs(const std::string& key, uint64_t value, Pr
             return Status::InternalError("dump to file, serialize error");
         }
     }
-    _partial_pindex_kvs->add_keys(key);
+    _partial_pindex_kvs->add_keys(key.data(), key.size());
     _partial_pindex_kvs->add_values(value);
     _partial_pindex_kvs_bytes += key.size() + sizeof(uint64_t);
     return Status::OK();
@@ -105,45 +113,6 @@ Status PrimaryKeyDump::finish_pindex_kvs(PrimaryIndexDumpPB* dump_pb) {
     return Status::OK();
 }
 
-Status PrimaryKeyDump::add_pk_column_keys(const std::string& key, PrimaryKeyColumnPB* dump_pb) {
-    // Avoid protobuf exceed memory limit
-    if (_partial_pk_column_keys_bytes + key.size() >= MAX_PROTOBUF_SIZE) {
-        std::string serialized_data;
-        if (_partial_pk_column_keys->SerializeToString(&serialized_data)) {
-            PagePointerPB page;
-            page.set_offset(_dump_wfile->size());
-            RETURN_IF_ERROR(_dump_wfile->append(Slice(serialized_data)));
-            page.set_size(_dump_wfile->size() - page.offset());
-            dump_pb->add_keys()->CopyFrom(page);
-            _partial_pk_column_keys->Clear();
-            _partial_pk_column_keys_bytes = 0;
-        } else {
-            return Status::InternalError("dump to file, serialize error");
-        }
-    }
-    _partial_pk_column_keys->add_keys(key);
-    _partial_pk_column_keys_bytes += key.size();
-    return Status::OK();
-}
-
-Status PrimaryKeyDump::finish_pk_column_keys(PrimaryKeyColumnPB* dump_pb) {
-    std::string serialized_data;
-    if (_partial_pk_column_keys_bytes > 0) {
-        if (_partial_pk_column_keys->SerializeToString(&serialized_data)) {
-            PagePointerPB page;
-            page.set_offset(_dump_wfile->size());
-            RETURN_IF_ERROR(_dump_wfile->append(Slice(serialized_data)));
-            page.set_size(_dump_wfile->size() - page.offset());
-            dump_pb->add_keys()->CopyFrom(page);
-            _partial_pk_column_keys->Clear();
-            _partial_pk_column_keys_bytes = 0;
-        } else {
-            return Status::InternalError("dump to file, serialize error");
-        }
-    }
-    return Status::OK();
-}
-
 Status PrimaryKeyDump::_dump_primary_index() {
     return _tablet->updates()->primary_index_dump(this, _dump_pb.mutable_primary_index());
 }
@@ -153,7 +122,7 @@ Status PrimaryKeyDump::_dump_delvec() {
             _tablet->data_dir()->get_meta(), _tablet->tablet_id(), 0, UINT32_MAX,
             [&](uint32_t segment_id, int64_t version, std::string_view value) -> bool {
                 DeleteVectorStatPB delvec_stat;
-                delvec_stat.set_sid(segment_id);
+                delvec_stat.set_segment_id(segment_id);
                 delvec_stat.set_version(version);
                 DelVectorPtr delvec_ptr = std::make_shared<DelVector>();
                 if (!delvec_ptr->load(version, value.data(), value.size()).ok()) {
@@ -172,7 +141,7 @@ Status PrimaryKeyDump::_dump_dcg() {
                                                                                  _tablet->tablet_id(), &dcgs));
     for (const auto& each : dcgs) {
         DeltaColumnGroupListIdPB dcg_list;
-        dcg_list.set_sid(each.first);
+        dcg_list.set_segment_id(each.first);
         (void)DeltaColumnGroupListSerializer::serialize_delta_column_group_list(each.second,
                                                                                 dcg_list.mutable_dcg_list());
         _dump_pb.add_dcg_lists()->CopyFrom(dcg_list);
@@ -181,107 +150,118 @@ Status PrimaryKeyDump::_dump_dcg() {
     return Status::OK();
 }
 
-class PrimaryKeyColumnDumper {
+class PrimaryKeyChunkDumper {
 public:
-    virtual ~PrimaryKeyColumnDumper() = default;
-    virtual Status dump_columns(PrimaryKeyDump* dump, Column* pkc, PrimaryKeyColumnPB* pk_column_pb) = 0;
+    PrimaryKeyChunkDumper(PrimaryKeyDump* dump, PrimaryKeyColumnPB* pk_column_pb)
+            : _dump(dump), _pk_column_pb(pk_column_pb) {}
+    ~PrimaryKeyChunkDumper() { (void)fs::delete_file(_tmp_file); }
+    Status init(const TabletSchemaCSPtr& tablet_schema, const std::string& tablet_path) {
+        _tmp_file = tablet_path + "/PrimaryKeyChunkDumper_" + std::to_string(static_cast<int64_t>(pthread_self()));
+        (void)fs::delete_file(_tmp_file);
+        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(tablet_path));
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::OpenMode::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_RETURN(auto wfile, fs->new_writable_file(opts, _tmp_file));
+        SegmentWriterOptions writer_options;
+        _writer = std::make_unique<SegmentWriter>(std::move(wfile), _pk_column_pb->segment_id(), tablet_schema,
+                                                  writer_options);
+        RETURN_IF_ERROR(_writer->init(false));
+        return Status::OK();
+    }
+    Status dump_chunk(const Chunk& chunk) { return _writer->append_chunk(chunk); }
+    Status finalize(WritableFile* wfile) {
+        uint64_t segment_file_size = 0;
+        uint64_t index_size = 0;
+        uint64_t footer_position = 0;
+        RETURN_IF_ERROR(_writer->finalize(&segment_file_size, &index_size, &footer_position));
+        _page.set_offset(wfile->size());
+        RETURN_IF_ERROR(fs::copy_append_file(_tmp_file, wfile));
+        _page.set_size(wfile->size() - _page.offset());
+        _pk_column_pb->mutable_page()->CopyFrom(_page);
+        return Status::OK();
+    }
+
+private:
+    PrimaryKeyDump* _dump;
+    PrimaryKeyColumnPB* _pk_column_pb;
+    std::unique_ptr<SegmentWriter> _writer;
+    PagePointerPB _page;
+    std::string _tmp_file;
 };
 
-class SlicePrimaryKeyColumnDumper : public PrimaryKeyColumnDumper {
+class PrimaryKeyChunkReader {
 public:
-    Status dump_columns(PrimaryKeyDump* dump, Column* pkc, PrimaryKeyColumnPB* pk_column_pb) override {
-        auto* keys = reinterpret_cast<const Slice*>(pkc->raw_data());
-        for (int i = 0; i < pkc->size(); i++) {
-            RETURN_IF_ERROR(dump->add_pk_column_keys(hexdump(keys[i].data, keys[i].size), pk_column_pb));
-        }
-        return dump->finish_pk_column_keys(pk_column_pb);
+    PrimaryKeyChunkReader() = default;
+    ~PrimaryKeyChunkReader() { (void)fs::delete_file(_tmp_file); }
+
+    StatusOr<ChunkIteratorPtr> read(const std::string& dump_filepath, const Schema& schema,
+                                    const TabletSchemaCSPtr& tablet_schema, const PrimaryKeyColumnPB& pk_column_pb) {
+        RETURN_IF_ERROR(_copy_to_tmp_file(dump_filepath, pk_column_pb));
+        size_t footer_size_hint = 16 * 1024;
+        ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_tmp_file));
+        SegmentReadOptions seg_options;
+        seg_options.fs = fs;
+        seg_options.stats = &_stats;
+        seg_options.tablet_schema = tablet_schema;
+        ASSIGN_OR_RETURN(auto seg_ptr, Segment::open(fs, _tmp_file, pk_column_pb.segment_id(), tablet_schema,
+                                                     &footer_size_hint, nullptr));
+        return seg_ptr->new_iterator(schema, seg_options);
     }
+
+private:
+    Status _copy_to_tmp_file(const std::string& dump_filepath, const PrimaryKeyColumnPB& pk_column_pb) {
+        _tmp_file = "./PrimaryKeyChunkReader_" + std::to_string(static_cast<int64_t>(pthread_self()));
+        (void)fs::delete_file(_tmp_file);
+        RETURN_IF_ERROR(fs::copy_file_by_range(dump_filepath, _tmp_file, pk_column_pb.page().offset(),
+                                               pk_column_pb.page().size()));
+        return Status::OK();
+    }
+
+private:
+    std::string _tmp_file;
+    OlapReaderStatistics _stats;
 };
 
-template <typename T>
-class FixedPrimaryKeyColumnDumper : public PrimaryKeyColumnDumper {
-public:
-    Status dump_columns(PrimaryKeyDump* dump, Column* pkc, PrimaryKeyColumnPB* pk_column_pb) override {
-        auto* keys = reinterpret_cast<const T*>(pkc->raw_data());
-        for (int i = 0; i < pkc->size(); i++) {
-            RETURN_IF_ERROR(dump->add_pk_column_keys(hexdump(reinterpret_cast<const char*>(&(keys[i])), sizeof(T)),
-                                                     pk_column_pb));
-        }
-        return dump->finish_pk_column_keys(pk_column_pb);
+static std::pair<Schema, std::shared_ptr<TabletSchema>> build_pkey_schema(const TabletSchemaCSPtr& tablet_schema) {
+    vector<uint32_t> pk_columns;
+    vector<int32_t> pk_columns2;
+    for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns.push_back((uint32_t)i);
+        pk_columns2.push_back((int32_t)i);
     }
-};
-
-static std::unique_ptr<PrimaryKeyColumnDumper> choose_dumper(LogicalType key_type, size_t fix_size) {
-#define CASE_TYPE(type) \
-    case (type):        \
-        return std::make_unique<FixedPrimaryKeyColumnDumper<typename CppTypeTraits<type>::CppType>>()
-
-    switch (key_type) {
-        CASE_TYPE(TYPE_BOOLEAN);
-        CASE_TYPE(TYPE_TINYINT);
-        CASE_TYPE(TYPE_SMALLINT);
-        CASE_TYPE(TYPE_INT);
-        CASE_TYPE(TYPE_BIGINT);
-        CASE_TYPE(TYPE_LARGEINT);
-    case TYPE_CHAR:
-        return std::make_unique<SlicePrimaryKeyColumnDumper>();
-    case TYPE_VARCHAR:
-        return std::make_unique<SlicePrimaryKeyColumnDumper>();
-    case TYPE_DATE:
-        return std::make_unique<FixedPrimaryKeyColumnDumper<int32_t>>();
-    case TYPE_DATETIME:
-        return std::make_unique<FixedPrimaryKeyColumnDumper<int64_t>>();
-    default:
-        return nullptr;
-    }
-#undef CASE_TYPE
+    Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    auto pkey_tschema = TabletSchema::create(tablet_schema, pk_columns2);
+    return {pkey_schema, pkey_tschema};
 }
 
 Status PrimaryKeyDump::_dump_segment_keys() {
     // 1. generate primary key schema
     auto tablet_schema = _tablet->tablet_schema();
-    vector<uint32_t> pk_columns;
-    for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
-        pk_columns.push_back((uint32_t)i);
-    }
-    Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
-    std::unique_ptr<Column> pk_column;
-    if (pk_columns.size() > 1) {
-        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
-            CHECK(false) << "create column for primary key encoder failed";
-        }
-    }
-    auto enc_pk_type = PrimaryKeyEncoder::encoded_primary_key_type(pkey_schema, pk_columns);
-    auto key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
-    auto dumper = choose_dumper(enc_pk_type, key_size);
-    if (dumper == nullptr) {
-        return Status::InternalError("invalid primary key");
-    }
+    auto schema_pair = build_pkey_schema(tablet_schema);
+    Schema& pkey_schema = schema_pair.first;
+    auto pkey_tschema = schema_pair.second;
     // 2. scan all rowset
-    int64_t apply_version = 0;
-    std::vector<RowsetSharedPtr> rowsets;
-    std::vector<uint32_t> rowset_ids;
-    RETURN_IF_ERROR(_tablet->updates()->get_apply_version_and_rowsets(&apply_version, &rowsets, &rowset_ids));
+    auto rowset_map = _tablet->updates()->get_rowset_map();
     // only hold pkey, so can use larger chunk size
     OlapReaderStatistics stats;
     auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
     auto chunk = chunk_shared_ptr.get();
-    for (auto& rowset : rowsets) {
-        RowsetReleaseGuard guard(rowset);
-        auto res = rowset->get_segment_iterators2(pkey_schema, tablet_schema, _tablet->data_dir()->get_meta(),
-                                                  apply_version, &stats);
+    for (auto& rowset : *rowset_map) {
+        RowsetReleaseGuard guard(rowset.second);
+        auto res = rowset.second->get_segment_iterators2(pkey_schema, tablet_schema, nullptr, 0, &stats);
         if (!res.ok()) {
             return res.status();
         }
         auto& itrs = res.value();
-        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        CHECK(itrs.size() == rowset.second->num_segments()) << "itrs.size != num_segments";
         for (size_t i = 0; i < itrs.size(); i++) {
             auto itr = itrs[i].get();
             if (itr == nullptr) {
                 continue;
             }
             PrimaryKeyColumnPB pk_column_pb;
-            pk_column_pb.set_sid(rowset->rowset_meta()->get_rowset_seg_id() + i);
+            pk_column_pb.set_segment_id(rowset.second->rowset_meta()->get_rowset_seg_id() + i);
+            PrimaryKeyChunkDumper dumper(this, &pk_column_pb);
+            RETURN_IF_ERROR(dumper.init(pkey_tschema, _tablet->schema_hash_path()));
             while (true) {
                 chunk->reset();
                 auto st = itr->get_next(chunk);
@@ -290,17 +270,10 @@ Status PrimaryKeyDump::_dump_segment_keys() {
                 } else if (!st.ok()) {
                     return st;
                 } else {
-                    Column* pkc = nullptr;
-                    if (pk_column) {
-                        pk_column->reset_column();
-                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
-                        pkc = pk_column.get();
-                    } else {
-                        pkc = chunk->columns()[0].get();
-                    }
-                    RETURN_IF_ERROR(dumper->dump_columns(this, pkc, &pk_column_pb));
+                    RETURN_IF_ERROR(dumper.dump_chunk(*chunk));
                 }
             }
+            RETURN_IF_ERROR(dumper.finalize(_dump_wfile.get()));
             itr->close();
             _dump_pb.add_primary_key_column()->CopyFrom(pk_column_pb);
         }
@@ -313,7 +286,7 @@ Status PrimaryKeyDump::_dump_rowset_stat() {
     RETURN_IF_ERROR(_tablet->updates()->get_rowset_stats(&output_rowset_stats));
     for (const auto& each : output_rowset_stats) {
         RowsetStatIdPB rowset_stat_id;
-        rowset_stat_id.set_rid(each.first);
+        rowset_stat_id.set_rowset_id(each.first);
         rowset_stat_id.set_rowset_stat(each.second);
         _dump_pb.add_rowset_stats()->CopyFrom(rowset_stat_id);
     }
@@ -335,7 +308,7 @@ Status PrimaryKeyDump::_dump_to_file() {
 }
 
 Status PrimaryKeyDump::dump() {
-    RETURN_IF_ERROR(_init_dump_file());
+    RETURN_IF_ERROR(init_dump_file());
     RETURN_IF_ERROR(_dump_tablet_meta());
     RETURN_IF_ERROR(_dump_rowset_meta());
     RETURN_IF_ERROR(_dump_rowset_stat());
@@ -368,24 +341,32 @@ Status PrimaryKeyDump::read_deserialize_from_file(const std::string& dump_filepa
     }
 }
 
-Status PrimaryKeyDump::deserialize_kvs_from_meta(
+Status PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
         const std::string& dump_filepath, const PrimaryKeyDumpPB& dump_pb,
-        const std::function<void(const PartialKeysPB&)>& column_key_func,
+        const std::function<void(const Chunk&)>& column_key_func,
         const std::function<void(const std::string&, const PartialKVsPB&)>& index_kvs_func) {
     std::unique_ptr<RandomAccessFile> rfile;
     ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dump_filepath));
     ASSIGN_OR_RETURN(rfile, fs->new_random_access_file(dump_filepath));
     // 1. deserialize pk column
     for (const auto& primary_key_column : dump_pb.primary_key_column()) {
-        for (const auto& page : primary_key_column.keys()) {
-            std::string buff;
-            raw::stl_string_resize_uninitialized(&buff, page.size());
-            RETURN_IF_ERROR(rfile->read_at_fully(page.offset(), buff.data(), buff.size()));
-            PartialKeysPB partial_keys_pb;
-            if (partial_keys_pb.ParseFromString(buff)) {
-                column_key_func(partial_keys_pb);
+        TabletSchemaCSPtr tablet_schema = std::make_shared<TabletSchema>(dump_pb.tablet_meta().schema());
+        auto schema_pair = build_pkey_schema(tablet_schema);
+        Schema& pkey_schema = schema_pair.first;
+        auto pkey_tschema = schema_pair.second;
+        auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
+        auto chunk = chunk_shared_ptr.get();
+        PrimaryKeyChunkReader reader;
+        ASSIGN_OR_RETURN(auto itr, reader.read(dump_filepath, pkey_schema, pkey_tschema, primary_key_column));
+        while (true) {
+            chunk->reset();
+            auto st = itr->get_next(chunk);
+            if (st.is_end_of_file()) {
+                break;
+            } else if (!st.ok()) {
+                return st;
             } else {
-                return Status::Corruption("deserialize kvs from meta fail, " + dump_filepath);
+                column_key_func(*chunk);
             }
         }
     }

--- a/be/src/storage/primary_key_dump.cpp
+++ b/be/src/storage/primary_key_dump.cpp
@@ -1,0 +1,409 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/primary_key_dump.h"
+
+#include <memory>
+
+#include "storage/chunk_helper.h"
+#include "storage/chunk_iterator.h"
+#include "storage/del_vector.h"
+#include "storage/delta_column_group.h"
+#include "storage/primary_key_encoder.h"
+#include "storage/rowset/rowset.h"
+#include "storage/rowset/segment_iterator.h"
+#include "storage/rowset/segment_writer.h"
+#include "storage/tablet.h"
+#include "storage/tablet_meta_manager.h"
+#include "storage/tablet_updates.h"
+#include "storage/type_traits.h"
+#include "types/logical_type.h"
+
+namespace starrocks {
+
+PrimaryKeyDump::PrimaryKeyDump(Tablet* tablet) {
+    _tablet = tablet;
+    _dump_filepath = tablet->schema_hash_path() + "/" + std::to_string(_tablet->tablet_id()) + ".pkdump";
+    _partial_pk_column_keys = std::make_unique<PartialKeysPB>();
+    _partial_pindex_kvs = std::make_unique<PartialKVsPB>();
+}
+
+Status PrimaryKeyDump::_init_dump_file() {
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(_dump_filepath));
+    WritableFileOptions wblock_opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+    ASSIGN_OR_RETURN(_dump_wfile, fs->new_writable_file(wblock_opts, _dump_filepath));
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::_dump_tablet_meta() {
+    TabletMetaPB meta_pb;
+    _tablet->tablet_meta()->to_meta_pb(&meta_pb);
+    _dump_pb.mutable_tablet_meta()->CopyFrom(meta_pb);
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::_dump_rowset_meta() {
+    auto rowset_map = _tablet->updates()->get_rowset_map();
+    for (const auto& each : (*rowset_map)) {
+        RowsetMetaIdPB rowset_meta_id;
+        rowset_meta_id.set_rid(each.first);
+        each.second->rowset_meta()->to_rowset_pb(rowset_meta_id.mutable_rowset_meta());
+        rowset_meta_id.mutable_rowset_meta()->clear_tablet_schema();
+        _dump_pb.add_rowset_metas()->CopyFrom(rowset_meta_id);
+    }
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::add_pindex_kvs(const std::string& key, uint64_t value, PrimaryIndexDumpPB* dump_pb) {
+    // Avoid protobuf exceed memory limit
+    if (_partial_pindex_kvs_bytes + key.size() + sizeof(uint64_t) >= MAX_PROTOBUF_SIZE) {
+        std::string serialized_data;
+        if (_partial_pindex_kvs->SerializeToString(&serialized_data)) {
+            PagePointerPB page;
+            page.set_offset(_dump_wfile->size());
+            RETURN_IF_ERROR(_dump_wfile->append(Slice(serialized_data)));
+            page.set_size(_dump_wfile->size() - page.offset());
+            dump_pb->add_kvs()->CopyFrom(page);
+            _partial_pindex_kvs->Clear();
+            _partial_pindex_kvs_bytes = 0;
+        } else {
+            return Status::InternalError("dump to file, serialize error");
+        }
+    }
+    _partial_pindex_kvs->add_keys(key);
+    _partial_pindex_kvs->add_values(value);
+    _partial_pindex_kvs_bytes += key.size() + sizeof(uint64_t);
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::finish_pindex_kvs(PrimaryIndexDumpPB* dump_pb) {
+    std::string serialized_data;
+    if (_partial_pindex_kvs_bytes > 0) {
+        if (_partial_pindex_kvs->SerializeToString(&serialized_data)) {
+            PagePointerPB page;
+            page.set_offset(_dump_wfile->size());
+            RETURN_IF_ERROR(_dump_wfile->append(Slice(serialized_data)));
+            page.set_size(_dump_wfile->size() - page.offset());
+            dump_pb->add_kvs()->CopyFrom(page);
+            _partial_pindex_kvs->Clear();
+            _partial_pindex_kvs_bytes = 0;
+        } else {
+            return Status::InternalError("dump to file, serialize error");
+        }
+    }
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::add_pk_column_keys(const std::string& key, PrimaryKeyColumnPB* dump_pb) {
+    // Avoid protobuf exceed memory limit
+    if (_partial_pk_column_keys_bytes + key.size() >= MAX_PROTOBUF_SIZE) {
+        std::string serialized_data;
+        if (_partial_pk_column_keys->SerializeToString(&serialized_data)) {
+            PagePointerPB page;
+            page.set_offset(_dump_wfile->size());
+            RETURN_IF_ERROR(_dump_wfile->append(Slice(serialized_data)));
+            page.set_size(_dump_wfile->size() - page.offset());
+            dump_pb->add_keys()->CopyFrom(page);
+            _partial_pk_column_keys->Clear();
+            _partial_pk_column_keys_bytes = 0;
+        } else {
+            return Status::InternalError("dump to file, serialize error");
+        }
+    }
+    _partial_pk_column_keys->add_keys(key);
+    _partial_pk_column_keys_bytes += key.size();
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::finish_pk_column_keys(PrimaryKeyColumnPB* dump_pb) {
+    std::string serialized_data;
+    if (_partial_pk_column_keys_bytes > 0) {
+        if (_partial_pk_column_keys->SerializeToString(&serialized_data)) {
+            PagePointerPB page;
+            page.set_offset(_dump_wfile->size());
+            RETURN_IF_ERROR(_dump_wfile->append(Slice(serialized_data)));
+            page.set_size(_dump_wfile->size() - page.offset());
+            dump_pb->add_keys()->CopyFrom(page);
+            _partial_pk_column_keys->Clear();
+            _partial_pk_column_keys_bytes = 0;
+        } else {
+            return Status::InternalError("dump to file, serialize error");
+        }
+    }
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::_dump_primary_index() {
+    return _tablet->updates()->primary_index_dump(this, _dump_pb.mutable_primary_index());
+}
+
+Status PrimaryKeyDump::_dump_delvec() {
+    RETURN_IF_ERROR(TabletMetaManager::del_vector_iterate(
+            _tablet->data_dir()->get_meta(), _tablet->tablet_id(), 0, UINT32_MAX,
+            [&](uint32_t segment_id, int64_t version, std::string_view value) -> bool {
+                DeleteVectorStatPB delvec_stat;
+                delvec_stat.set_sid(segment_id);
+                delvec_stat.set_version(version);
+                DelVectorPtr delvec_ptr = std::make_shared<DelVector>();
+                if (!delvec_ptr->load(version, value.data(), value.size()).ok()) {
+                    return false;
+                }
+                delvec_stat.set_cardinality(delvec_ptr->cardinality());
+                _dump_pb.add_delvec_stats()->CopyFrom(delvec_stat);
+                return true;
+            }));
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::_dump_dcg() {
+    std::map<uint32_t, DeltaColumnGroupList> dcgs;
+    RETURN_IF_ERROR(TabletMetaManager::scan_tablet_delta_column_group_by_segment(_tablet->data_dir()->get_meta(),
+                                                                                 _tablet->tablet_id(), &dcgs));
+    for (const auto& each : dcgs) {
+        DeltaColumnGroupListIdPB dcg_list;
+        dcg_list.set_sid(each.first);
+        (void)DeltaColumnGroupListSerializer::serialize_delta_column_group_list(each.second,
+                                                                                dcg_list.mutable_dcg_list());
+        _dump_pb.add_dcg_lists()->CopyFrom(dcg_list);
+    }
+
+    return Status::OK();
+}
+
+class PrimaryKeyColumnDumper {
+public:
+    virtual ~PrimaryKeyColumnDumper() = default;
+    virtual Status dump_columns(PrimaryKeyDump* dump, Column* pkc, PrimaryKeyColumnPB* pk_column_pb) = 0;
+};
+
+class SlicePrimaryKeyColumnDumper : public PrimaryKeyColumnDumper {
+public:
+    Status dump_columns(PrimaryKeyDump* dump, Column* pkc, PrimaryKeyColumnPB* pk_column_pb) override {
+        auto* keys = reinterpret_cast<const Slice*>(pkc->raw_data());
+        for (int i = 0; i < pkc->size(); i++) {
+            RETURN_IF_ERROR(dump->add_pk_column_keys(hexdump(keys[i].data, keys[i].size), pk_column_pb));
+        }
+        return dump->finish_pk_column_keys(pk_column_pb);
+    }
+};
+
+template <typename T>
+class FixedPrimaryKeyColumnDumper : public PrimaryKeyColumnDumper {
+public:
+    Status dump_columns(PrimaryKeyDump* dump, Column* pkc, PrimaryKeyColumnPB* pk_column_pb) override {
+        auto* keys = reinterpret_cast<const T*>(pkc->raw_data());
+        for (int i = 0; i < pkc->size(); i++) {
+            RETURN_IF_ERROR(dump->add_pk_column_keys(hexdump(reinterpret_cast<const char*>(&(keys[i])), sizeof(T)),
+                                                     pk_column_pb));
+        }
+        return dump->finish_pk_column_keys(pk_column_pb);
+    }
+};
+
+static std::unique_ptr<PrimaryKeyColumnDumper> choose_dumper(LogicalType key_type, size_t fix_size) {
+#define CASE_TYPE(type) \
+    case (type):        \
+        return std::make_unique<FixedPrimaryKeyColumnDumper<typename CppTypeTraits<type>::CppType>>()
+
+    switch (key_type) {
+        CASE_TYPE(TYPE_BOOLEAN);
+        CASE_TYPE(TYPE_TINYINT);
+        CASE_TYPE(TYPE_SMALLINT);
+        CASE_TYPE(TYPE_INT);
+        CASE_TYPE(TYPE_BIGINT);
+        CASE_TYPE(TYPE_LARGEINT);
+    case TYPE_CHAR:
+        return std::make_unique<SlicePrimaryKeyColumnDumper>();
+    case TYPE_VARCHAR:
+        return std::make_unique<SlicePrimaryKeyColumnDumper>();
+    case TYPE_DATE:
+        return std::make_unique<FixedPrimaryKeyColumnDumper<int32_t>>();
+    case TYPE_DATETIME:
+        return std::make_unique<FixedPrimaryKeyColumnDumper<int64_t>>();
+    default:
+        return nullptr;
+    }
+#undef CASE_TYPE
+}
+
+Status PrimaryKeyDump::_dump_segment_keys() {
+    // 1. generate primary key schema
+    auto tablet_schema = _tablet->tablet_schema();
+    vector<uint32_t> pk_columns;
+    for (size_t i = 0; i < tablet_schema->num_key_columns(); i++) {
+        pk_columns.push_back((uint32_t)i);
+    }
+    Schema pkey_schema = ChunkHelper::convert_schema(tablet_schema, pk_columns);
+    std::unique_ptr<Column> pk_column;
+    if (pk_columns.size() > 1) {
+        if (!PrimaryKeyEncoder::create_column(pkey_schema, &pk_column).ok()) {
+            CHECK(false) << "create column for primary key encoder failed";
+        }
+    }
+    auto enc_pk_type = PrimaryKeyEncoder::encoded_primary_key_type(pkey_schema, pk_columns);
+    auto key_size = PrimaryKeyEncoder::get_encoded_fixed_size(pkey_schema);
+    auto dumper = choose_dumper(enc_pk_type, key_size);
+    if (dumper == nullptr) {
+        return Status::InternalError("invalid primary key");
+    }
+    // 2. scan all rowset
+    int64_t apply_version = 0;
+    std::vector<RowsetSharedPtr> rowsets;
+    std::vector<uint32_t> rowset_ids;
+    RETURN_IF_ERROR(_tablet->updates()->get_apply_version_and_rowsets(&apply_version, &rowsets, &rowset_ids));
+    // only hold pkey, so can use larger chunk size
+    OlapReaderStatistics stats;
+    auto chunk_shared_ptr = ChunkHelper::new_chunk(pkey_schema, 4096);
+    auto chunk = chunk_shared_ptr.get();
+    for (auto& rowset : rowsets) {
+        RowsetReleaseGuard guard(rowset);
+        auto res = rowset->get_segment_iterators2(pkey_schema, tablet_schema, _tablet->data_dir()->get_meta(),
+                                                  apply_version, &stats);
+        if (!res.ok()) {
+            return res.status();
+        }
+        auto& itrs = res.value();
+        CHECK(itrs.size() == rowset->num_segments()) << "itrs.size != num_segments";
+        for (size_t i = 0; i < itrs.size(); i++) {
+            auto itr = itrs[i].get();
+            if (itr == nullptr) {
+                continue;
+            }
+            PrimaryKeyColumnPB pk_column_pb;
+            pk_column_pb.set_sid(rowset->rowset_meta()->get_rowset_seg_id() + i);
+            while (true) {
+                chunk->reset();
+                auto st = itr->get_next(chunk);
+                if (st.is_end_of_file()) {
+                    break;
+                } else if (!st.ok()) {
+                    return st;
+                } else {
+                    Column* pkc = nullptr;
+                    if (pk_column) {
+                        pk_column->reset_column();
+                        PrimaryKeyEncoder::encode(pkey_schema, *chunk, 0, chunk->num_rows(), pk_column.get());
+                        pkc = pk_column.get();
+                    } else {
+                        pkc = chunk->columns()[0].get();
+                    }
+                    RETURN_IF_ERROR(dumper->dump_columns(this, pkc, &pk_column_pb));
+                }
+            }
+            itr->close();
+            _dump_pb.add_primary_key_column()->CopyFrom(pk_column_pb);
+        }
+    }
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::_dump_rowset_stat() {
+    std::map<uint32_t, std::string> output_rowset_stats;
+    RETURN_IF_ERROR(_tablet->updates()->get_rowset_stats(&output_rowset_stats));
+    for (const auto& each : output_rowset_stats) {
+        RowsetStatIdPB rowset_stat_id;
+        rowset_stat_id.set_rid(each.first);
+        rowset_stat_id.set_rowset_stat(each.second);
+        _dump_pb.add_rowset_stats()->CopyFrom(rowset_stat_id);
+    }
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::_dump_to_file() {
+    std::string serialized_data;
+    if (_dump_pb.SerializeToString(&serialized_data)) {
+        RETURN_IF_ERROR(_dump_wfile->append(Slice(serialized_data)));
+        faststring tail_buf;
+        // Record protobuf size
+        put_fixed64_le(&tail_buf, serialized_data.size());
+        RETURN_IF_ERROR(_dump_wfile->append(Slice(tail_buf)));
+    } else {
+        return Status::InternalError("dump to file, serialize error");
+    }
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::dump() {
+    RETURN_IF_ERROR(_init_dump_file());
+    RETURN_IF_ERROR(_dump_tablet_meta());
+    RETURN_IF_ERROR(_dump_rowset_meta());
+    RETURN_IF_ERROR(_dump_rowset_stat());
+    RETURN_IF_ERROR(_dump_delvec());
+    RETURN_IF_ERROR(_dump_dcg());
+    RETURN_IF_ERROR(_dump_segment_keys());
+    RETURN_IF_ERROR(_dump_primary_index());
+    RETURN_IF_ERROR(_dump_to_file());
+    return Status::OK();
+}
+
+Status PrimaryKeyDump::read_deserialize_from_file(const std::string& dump_filepath, PrimaryKeyDumpPB* dump_pb) {
+    std::unique_ptr<RandomAccessFile> rfile;
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dump_filepath));
+    ASSIGN_OR_RETURN(rfile, fs->new_random_access_file(dump_filepath));
+    ASSIGN_OR_RETURN(int64_t file_size, rfile->get_size());
+    // 1. get protobuf size from tail
+    std::unique_ptr<char[]> tail(new char[8]);
+    Slice tail_slice(tail.get(), 8);
+    RETURN_IF_ERROR(rfile->read_at(file_size - 8, tail_slice.data, 8));
+    uint64_t protobuf_size = decode_fixed64_le((uint8_t*)tail_slice.data);
+    // 2. read and deserialize protobuf
+    std::string buff;
+    raw::stl_string_resize_uninitialized(&buff, protobuf_size);
+    RETURN_IF_ERROR(rfile->read_at_fully(file_size - 8 - protobuf_size, buff.data(), buff.size()));
+    if (dump_pb->ParseFromString(buff)) {
+        return Status::OK();
+    } else {
+        return Status::Corruption("read deserialize from file fail, " + dump_filepath);
+    }
+}
+
+Status PrimaryKeyDump::deserialize_kvs_from_meta(
+        const std::string& dump_filepath, const PrimaryKeyDumpPB& dump_pb,
+        const std::function<void(const PartialKeysPB&)>& column_key_func,
+        const std::function<void(const std::string&, const PartialKVsPB&)>& index_kvs_func) {
+    std::unique_ptr<RandomAccessFile> rfile;
+    ASSIGN_OR_RETURN(auto fs, FileSystem::CreateSharedFromString(dump_filepath));
+    ASSIGN_OR_RETURN(rfile, fs->new_random_access_file(dump_filepath));
+    // 1. deserialize pk column
+    for (const auto& primary_key_column : dump_pb.primary_key_column()) {
+        for (const auto& page : primary_key_column.keys()) {
+            std::string buff;
+            raw::stl_string_resize_uninitialized(&buff, page.size());
+            RETURN_IF_ERROR(rfile->read_at_fully(page.offset(), buff.data(), buff.size()));
+            PartialKeysPB partial_keys_pb;
+            if (partial_keys_pb.ParseFromString(buff)) {
+                column_key_func(partial_keys_pb);
+            } else {
+                return Status::Corruption("deserialize kvs from meta fail, " + dump_filepath);
+            }
+        }
+    }
+    // 2. deserialize pk index
+    for (const auto& level : dump_pb.primary_index().primary_index_levels()) {
+        for (const auto& page : level.kvs()) {
+            std::string buff;
+            raw::stl_string_resize_uninitialized(&buff, page.size());
+            RETURN_IF_ERROR(rfile->read_at_fully(page.offset(), buff.data(), buff.size()));
+            PartialKVsPB partial_kvs_pb;
+            if (partial_kvs_pb.ParseFromString(buff)) {
+                index_kvs_func(level.filename(), partial_kvs_pb);
+            } else {
+                return Status::Corruption("deserialize kvs from meta fail, " + dump_filepath);
+            }
+        }
+    }
+    return Status::OK();
+}
+
+} // namespace starrocks

--- a/be/src/storage/primary_key_dump.h
+++ b/be/src/storage/primary_key_dump.h
@@ -1,0 +1,119 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "common/status.h"
+#include "storage/chunk_iterator.h"
+#include "storage/olap_common.h"
+#include "storage/tablet_schema.h"
+
+namespace starrocks {
+
+class WritableFile;
+class Tablet;
+class SegmentWriter;
+class PagePointerPB;
+class PartialKeysPB;
+class PartialKVsPB;
+
+/*
+* PrimaryKeyDump is desgined for providing more information about primary key tablet when issue debug,
+* such as `Tablet in error state` happen, data inconsistency and so on.
+* PrimaryKeyDump will try to get all helpfull information and generate file [tablet_id].pkdump .
+* In [tablet_id].pkdump, data layeout:
+*
+* |  ------ Begin -------  |
+* | Primary key columns (after encode) - part 1 |
+* | Primary key columns (after encode) - part 2 |
+* | Primary key columns (after encode) - part 3 |
+* | ... |
+* | Primary Index kvs - part 1 |
+* | Primary Index kvs - part 2 |
+* | Primary Index kvs - part 3 |
+* | ... |
+* | ---- Serialze by Protobuf PrimaryKeyDumpPB --- |
+* | TabletMetaPB |
+* | RowsetMetaPB (rowset 1) |
+* | RowsetMetaPB (rowset 2) |
+* | ... |
+* | RowsetStatPB (rowset 1) |
+* | RowsetStatPB (rowset 2) |
+* | ... |
+* | DeltaColumnGroupListIdPB |
+* | DeleteVectorStatPB |
+* | PrimaryKeyColumnPB (Use PagePointerPB point to real keys) |
+* | PrimaryIndexMultiLevelPB (Use PagePointerPB point to real kvs) |
+* | ---------- end ----------|
+*
+* I seperate the real primary key column data and primary index data from PrimaryKeyDumpPB,
+* because I want to control the peak memory usage when dump and Protobuf also can't support
+* too large data (better less than 2GB).
+*/
+class PrimaryKeyDump {
+public:
+    PrimaryKeyDump(Tablet* tablet);
+    ~PrimaryKeyDump() = default;
+
+    Status dump();
+
+    // Append primary index' kv into dump file
+    Status add_pindex_kvs(const std::string& key, uint64_t value, PrimaryIndexDumpPB* dump_pb);
+    Status finish_pindex_kvs(PrimaryIndexDumpPB* dump_pb);
+
+    // Append primary key column into dump file
+    Status add_pk_column_keys(const std::string& key, PrimaryKeyColumnPB* dump_pb);
+    Status finish_pk_column_keys(PrimaryKeyColumnPB* dump_pb);
+
+    // read PrimaryKeyDumpPB from dump file and deserialize it.
+    static Status read_deserialize_from_file(const std::string& dump_filepath, PrimaryKeyDumpPB* dump_pb);
+
+    // deserialize pk column and pk index from dump file.
+    static Status deserialize_kvs_from_meta(
+            const std::string& dump_filepath, const PrimaryKeyDumpPB& dump_pb,
+            const std::function<void(const PartialKeysPB&)>& column_key_func,
+            const std::function<void(const std::string&, const PartialKVsPB&)>& index_kvs_func);
+
+private:
+    Status _init_dump_file();
+    Status _dump_tablet_meta();
+    Status _dump_rowset_meta();
+    Status _dump_primary_index();
+    Status _dump_delvec();
+    Status _dump_dcg();
+    Status _dump_segment_keys();
+    Status _dump_rowset_stat();
+    Status _dump_to_file();
+
+    // 2GB
+    static const int64_t MAX_PROTOBUF_SIZE = 2147483648;
+
+private:
+    Tablet* _tablet = nullptr;
+    std::string _dump_filepath;
+    PrimaryKeyDumpPB _dump_pb;
+    // Store pk column key after encode
+    std::unique_ptr<PartialKeysPB> _partial_pk_column_keys;
+    int64_t _partial_pk_column_keys_bytes = 0;
+
+    // Store pk index kvs
+    std::unique_ptr<PartialKVsPB> _partial_pindex_kvs;
+    int64_t _partial_pindex_kvs_bytes = 0;
+    std::unique_ptr<WritableFile> _dump_wfile;
+};
+
+} // namespace starrocks

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -239,6 +239,10 @@ uint64_t SegmentWriter::estimate_segment_size() {
     return size;
 }
 
+uint64_t SegmentWriter::current_filesz() const {
+    return _wfile->size();
+}
+
 Status SegmentWriter::finalize(uint64_t* segment_file_size, uint64_t* index_size, uint64_t* footer_position) {
     RETURN_IF_ERROR(finalize_columns(index_size));
     *footer_position = _wfile->size();

--- a/be/src/storage/rowset/segment_writer.h
+++ b/be/src/storage/rowset/segment_writer.h
@@ -134,6 +134,8 @@ public:
 
     std::string segment_path() const;
 
+    uint64_t current_filesz() const;
+
 private:
     Status _write_short_key_index();
     Status _write_footer();

--- a/be/src/storage/tablet_meta_manager.h
+++ b/be/src/storage/tablet_meta_manager.h
@@ -199,6 +199,8 @@ public:
     static Status scan_delta_column_group(KVStore* meta, TTabletId tablet_id, RowsetId rowsetid, uint32_t segment_id,
                                           int64_t begin_version, int64_t end_version, DeltaColumnGroupList* dcgs);
     static Status scan_tablet_delta_column_group(KVStore* meta, TTabletId tablet_id, DeltaColumnGroupList* dcgs);
+    static Status scan_tablet_delta_column_group_by_segment(KVStore* meta, TTabletId tablet_id,
+                                                            std::map<uint32_t, DeltaColumnGroupList>* dcgs);
 
     static Status delete_delta_column_group(KVStore* meta, TTabletId tablet_id, uint32_t rowset_id, uint32_t segments);
     static Status delete_delta_column_group(KVStore* meta, WriteBatch* batch, const TabletSegmentId& tsid,

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -50,6 +50,7 @@ class Schema;
 class TabletReader;
 class ChunkChanger;
 class SegmentIterator;
+class PrimaryKeyDump;
 
 // save the context when reading from delta column files
 struct GetDeltaColumnContext {
@@ -330,6 +331,10 @@ public:
 
     // get the max rowset creation time for largest major version
     int64_t max_rowset_creation_time();
+
+    Status get_rowset_stats(std::map<uint32_t, std::string>* output_rowset_stats);
+
+    Status primary_index_dump(PrimaryKeyDump* dump, PrimaryIndexMultiLevelPB* dump_pb);
 
 private:
     friend class Tablet;

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -57,6 +57,7 @@
 #include "storage/olap_common.h"
 #include "storage/olap_define.h"
 #include "storage/options.h"
+#include "storage/primary_key_dump.h"
 #include "storage/rowset/binary_plain_page.h"
 #include "storage/rowset/column_iterator.h"
 #include "storage/rowset/column_reader.h"
@@ -87,6 +88,7 @@ using starrocks::PagePointer;
 using starrocks::ColumnIteratorOptions;
 using starrocks::PageFooterPB;
 using starrocks::DeltaColumnGroupList;
+using starrocks::PrimaryKeyDump;
 
 DEFINE_string(root_path, "", "storage root path");
 DEFINE_string(operation, "get_meta",
@@ -132,6 +134,7 @@ std::string get_usage(const std::string& progname) {
     ss << "./meta_tool.sh --operation=show_segment_footer --file=/path/to/segment/file\n";
     ss << "./meta_tool.sh --operation=dump_segment_data --file=/path/to/segment/file\n";
     ss << "./meta_tool.sh --operation=dump_column_size --file=/path/to/segment/file\n";
+    ss << "./meta_tool.sh --operation=print_pk_dump --file=/path/to/pk/dump/file\n";
     ss << "./meta_tool.sh --operation=dump_short_key_index --file=/path/to/segment/file --key_column_count=2\n";
     ss << "./meta_tool.sh --operation=calc_checksum [--column_index=xx] --file=/path/to/segment/file\n";
     ss << "./meta_tool.sh --operation=check_table_meta_consistency --root_path=/path/to/storage/path "
@@ -1036,6 +1039,37 @@ int meta_tool_main(int argc, char** argv) {
             std::cout << "dump column size failed: " << st << std::endl;
             return -1;
         }
+    } else if (FLAGS_operation == "print_pk_dump") {
+        if (FLAGS_file == "") {
+            std::cout << "no file flag for pk dump file" << std::endl;
+            return -1;
+        }
+        starrocks::PrimaryKeyDumpPB dump_pb;
+        Status st = starrocks::PrimaryKeyDump::read_deserialize_from_file(FLAGS_file, &dump_pb);
+        if (!st.ok()) {
+            std::cout << "print pk dump failed: " << st << std::endl;
+            return -1;
+        }
+        std::cout << "[pk dump] meta: " << dump_pb.Utf8DebugString() << std::endl;
+        st = starrocks::PrimaryKeyDump::deserialize_kvs_from_meta(
+                FLAGS_file, dump_pb,
+                [&](const starrocks::PartialKeysPB& keys) {
+                    std::cout << " pk column: " << std::endl;
+                    for (const auto& key : keys.keys()) {
+                        std::cout << "primary key " << key << std::endl;
+                    }
+                },
+                [&](const std::string& filename, const starrocks::PartialKVsPB& kvs) {
+                    std::cout << " pk index, filename: " << filename << std::endl;
+                    for (int i = 0; i < kvs.keys_size(); i++) {
+                        std::cout << "index key " << kvs.keys(i) << " value " << kvs.values(i) << std::endl;
+                    }
+                });
+        if (!st.ok()) {
+            std::cout << "print pk dump failed: " << st << std::endl;
+            return -1;
+        }
+
     } else if (FLAGS_operation == "dump_short_key_index") {
         starrocks::MemChunkAllocator::init_instance(nullptr, 2ul * 1024 * 1024 * 1024);
         if (FLAGS_file == "") {

--- a/be/src/tools/meta_tool.cpp
+++ b/be/src/tools/meta_tool.cpp
@@ -1051,18 +1051,18 @@ int meta_tool_main(int argc, char** argv) {
             return -1;
         }
         std::cout << "[pk dump] meta: " << dump_pb.Utf8DebugString() << std::endl;
-        st = starrocks::PrimaryKeyDump::deserialize_kvs_from_meta(
+        st = starrocks::PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
                 FLAGS_file, dump_pb,
-                [&](const starrocks::PartialKeysPB& keys) {
-                    std::cout << " pk column: " << std::endl;
-                    for (const auto& key : keys.keys()) {
-                        std::cout << "primary key " << key << std::endl;
+                [&](const starrocks::Chunk& chunk) {
+                    for (int i = 0; i < chunk.num_rows(); i++) {
+                        std::cout << "pk column " << chunk.debug_row(i) << std::endl;
                     }
                 },
                 [&](const std::string& filename, const starrocks::PartialKVsPB& kvs) {
                     std::cout << " pk index, filename: " << filename << std::endl;
                     for (int i = 0; i < kvs.keys_size(); i++) {
-                        std::cout << "index key " << kvs.keys(i) << " value " << kvs.values(i) << std::endl;
+                        std::cout << "index key " << starrocks::hexdump(kvs.keys(i).data(), kvs.keys(i).size())
+                                  << " value " << kvs.values(i) << std::endl;
                     }
                 });
         if (!st.ok()) {

--- a/be/test/storage/primary_index_test.cpp
+++ b/be/test/storage/primary_index_test.cpp
@@ -19,14 +19,47 @@
 #include "column/binary_column.h"
 #include "column/fixed_length_column.h"
 #include "column/schema.h"
+#include "fs/fs_util.h"
 #include "gutil/strings/substitute.h"
 #include "storage/chunk_helper.h"
+#include "storage/primary_key_dump.h"
 #include "storage/primary_key_encoder.h"
 #include "testutil/parallel_test.h"
 
 using namespace starrocks;
 
 namespace starrocks {
+
+template <typename DatumType>
+void test_pk_dump(PrimaryIndex* pk_index, const std::map<std::string, uint64_t>& current_index_stat) {
+    const std::string kPrimaryIndexDumpDir = "./PrimaryIndexTest_test_index_dump";
+    const std::string kPrimaryIndexDumpFile = kPrimaryIndexDumpDir + "/111.pkdump";
+    bool created;
+    FileSystem* fs = FileSystem::Default();
+    ASSERT_TRUE(fs->create_dir_if_missing(kPrimaryIndexDumpDir, &created).ok());
+    PrimaryKeyDumpPB dump_pb;
+    {
+        // dump primary index
+        PrimaryKeyDump dump(kPrimaryIndexDumpFile);
+        ASSERT_TRUE(dump.init_dump_file().ok());
+        ASSERT_TRUE(pk_index->pk_dump(&dump, dump_pb.mutable_primary_index()).ok());
+    }
+    {
+        // read primary index dump
+        ASSERT_TRUE(PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
+                            kPrimaryIndexDumpFile, dump_pb, [&](const starrocks::Chunk& chunk) {},
+                            [&](const std::string& filename, const starrocks::PartialKVsPB& kvs) {
+                                for (int i = 0; i < kvs.keys_size(); i++) {
+                                    auto search =
+                                            current_index_stat.find(hexdump(kvs.keys(i).data(), kvs.keys(i).size()));
+                                    ASSERT_TRUE(search != current_index_stat.end());
+                                    ASSERT_TRUE(search->second == kvs.values(i));
+                                }
+                            })
+                            .ok());
+    }
+    ASSERT_TRUE(fs::remove_all(kPrimaryIndexDumpDir).ok());
+}
 
 template <LogicalType field_type, typename DatumType>
 void test_integral_pk() {
@@ -43,22 +76,28 @@ void test_integral_pk() {
     pk_col->resize(kSegmentSize);
     auto pk_data = pk_col->get_data().data();
     DatumType pk_value = 0;
+    std::map<std::string, uint64_t> current_index_stat;
 
     // [0, kSegmentSize)
     for (int i = 0; i < kSegmentSize; i++) {
         pk_data[i] = pk_value++;
+        current_index_stat[hexdump(reinterpret_cast<const char*>(&pk_data[i]), sizeof(DatumType))] = i;
     }
     ASSERT_TRUE(pk_index->insert(0, 0, *pk_col).ok());
 
     // [kSegmentSize, 2*kSegmentSize)
     for (int i = 0; i < kSegmentSize; i++) {
         pk_data[i] = pk_value++;
+        current_index_stat[hexdump(reinterpret_cast<const char*>(&pk_data[i]), sizeof(DatumType))] =
+                (((uint64_t)1) << 32) + i;
     }
     ASSERT_TRUE(pk_index->insert(1, 0, *pk_col).ok());
 
     // [2*kSegmentSize, 3*kSegmentSize)
     for (int i = 0; i < kSegmentSize; i++) {
         pk_data[i] = pk_value++;
+        current_index_stat[hexdump(reinterpret_cast<const char*>(&pk_data[i]), sizeof(DatumType))] =
+                (((uint64_t)2) << 32) + i;
     }
     ASSERT_TRUE(pk_index->insert(2, 0, *pk_col).ok());
 
@@ -75,6 +114,8 @@ void test_integral_pk() {
             }
         }
     }
+
+    test_pk_dump<DatumType>(pk_index.get(), current_index_stat);
 
     PrimaryIndex::DeletesMap deletes;
 
@@ -175,12 +216,22 @@ void test_binary_pk() {
     }
     ASSERT_TRUE(pk_index->insert(0, 0, *pk_col).ok());
 
+    std::map<std::string, uint64_t> current_index_stat;
+    auto* keys = reinterpret_cast<const Slice*>(pk_col->raw_data());
+    for (int i = 0; i < pk_col->size(); i++) {
+        current_index_stat[hexdump(keys[i].data, keys[i].size)] = i;
+    }
+
     // [kSegmentSize, 2*kSegmentSize)
     pk_col->resize(0);
     for (int i = 0; i < kSegmentSize; i++) {
         pk_col->append(strings::Substitute("binary_pk_$0", pk_value++));
     }
     ASSERT_TRUE(pk_index->insert(1, 0, *pk_col).ok());
+    keys = reinterpret_cast<const Slice*>(pk_col->raw_data());
+    for (int i = 0; i < pk_col->size(); i++) {
+        current_index_stat[hexdump(keys[i].data, keys[i].size)] = (((uint64_t)1) << 32) + i;
+    }
 
     // [2*kSegmentSize, 3*kSegmentSize)
     pk_col->resize(0);
@@ -188,6 +239,10 @@ void test_binary_pk() {
         pk_col->append(strings::Substitute("binary_pk_$0", pk_value++));
     }
     ASSERT_TRUE(pk_index->insert(2, 0, *pk_col).ok());
+    keys = reinterpret_cast<const Slice*>(pk_col->raw_data());
+    for (int i = 0; i < pk_col->size(); i++) {
+        current_index_stat[hexdump(keys[i].data, keys[i].size)] = (((uint64_t)2) << 32) + i;
+    }
 
     {
         std::vector<uint64_t> rowids(pk_col->size());

--- a/be/test/storage/tablet_updates_test.cpp
+++ b/be/test/storage/tablet_updates_test.cpp
@@ -14,6 +14,8 @@
 
 #include "storage/tablet_updates_test.h"
 
+#include "storage/primary_key_dump.h"
+
 namespace starrocks {
 
 static TabletSharedPtr load_same_tablet_from_store(const TabletSharedPtr& tablet) {
@@ -740,6 +742,30 @@ TEST_F(TabletUpdatesTest, remove_expired_versions_with_persistent_index) {
     test_remove_expired_versions(true);
 }
 
+void TabletUpdatesTest::test_pk_dump(size_t rowset_cnt) {
+    PrimaryKeyDumpPB dump_pb;
+    {
+        // dump primary key tablet
+        PrimaryKeyDump dump(_tablet.get());
+        ASSERT_TRUE(dump.dump().ok());
+    }
+    const std::string dump_filepath =
+            _tablet->schema_hash_path() + "/" + std::to_string(_tablet->tablet_id()) + ".pkdump";
+    {
+        // read primary index dump
+        starrocks::PrimaryKeyDumpPB dump_pb;
+        ASSERT_TRUE(PrimaryKeyDump::read_deserialize_from_file(dump_filepath, &dump_pb).ok());
+        ASSERT_TRUE(PrimaryKeyDump::deserialize_pkcol_pkindex_from_meta(
+                            dump_filepath, dump_pb, [&](const starrocks::Chunk& chunk) {},
+                            [&](const std::string& filename, const starrocks::PartialKVsPB& kvs) {})
+                            .ok());
+        ASSERT_TRUE(dump_pb.tablet_meta().tablet_id() == _tablet->tablet_id());
+        ASSERT_TRUE(dump_pb.tablet_meta().table_id() == _tablet->belonged_table_id());
+        ASSERT_TRUE(dump_pb.rowset_metas_size() == rowset_cnt);
+        ASSERT_TRUE(dump_pb.rowset_stats_size() == rowset_cnt);
+    }
+}
+
 // NOLINTNEXTLINE
 void TabletUpdatesTest::test_apply(bool enable_persistent_index, bool has_merge_condition = false) {
     const int N = 10;
@@ -779,6 +805,7 @@ void TabletUpdatesTest::test_apply(bool enable_persistent_index, bool has_merge_
     for (int i = 2; i <= max_version; i++) {
         ASSERT_EQ(N, read_tablet(_tablet, i));
     }
+    test_pk_dump(rowsets.size());
 }
 
 TEST_F(TabletUpdatesTest, apply) {

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -823,6 +823,7 @@ public:
                           const TabletMetaSharedPtr& snapshot_tablet_meta);
     void load_snapshot(const std::string& meta_dir, const TabletSharedPtr& tablet, SegmentFooterPB* footer);
     void test_schema_change_optimiazation_adding_generated_column(bool enable_persistent_index);
+    void test_pk_dump(size_t rowset_cnt);
 
 protected:
     TabletSharedPtr _tablet;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -240,8 +240,8 @@ message TabletMetaOpPB {
     optional EditVersionPB apply = 3;
 }
 
-message TabletMetaLogPB { 
-    repeated TabletMetaOpPB ops = 1; 
+message TabletMetaLogPB {
+    repeated TabletMetaOpPB ops = 1;
 }
 
 message TabletUpdatesPB {
@@ -307,6 +307,71 @@ message OLAPDataHeaderMessage {
     required uint32 segment = 2;
 }
 
-message OLAPRawDeltaHeaderMessage { 
+message OLAPRawDeltaHeaderMessage {
     required int32 schema_hash = 2;
+}
+
+message RowsetMetaIdPB {
+    // rowset id
+    optional uint32 rid = 1;
+    optional RowsetMetaPB rowset_meta = 2;
+}
+
+message RowsetStatIdPB {
+    // rowset id
+    optional uint32 rid = 1;
+    optional string rowset_stat = 2;
+}
+
+message DeltaColumnGroupListIdPB {
+    // segment id
+    optional uint32 sid = 1;
+    optional DeltaColumnGroupListPB dcg_list = 2;
+}
+
+message DeleteVectorStatPB {
+    // segment id
+    optional uint32 sid = 1;
+    optional int64 version = 2;
+    optional uint32 cardinality = 3;
+}
+
+message PartialKeysPB {
+    // primary key column's encode keys
+    repeated string keys = 1;
+}
+
+message PartialKVsPB {
+    repeated string keys = 1;
+    repeated uint64 values = 2;
+}
+
+message PrimaryKeyColumnPB {
+    // segment id
+    optional uint32 sid = 1;
+    // Point to PartialKeys
+    repeated PagePointerPB keys = 2;
+}
+
+message PrimaryIndexDumpPB {
+    // Point to PartialKVs
+    repeated PagePointerPB kvs = 1;
+    // filename of persitent index l1 & l2
+    // While using memory index or l0, set filename to memory
+    optional string filename = 2;
+}
+
+message PrimaryIndexMultiLevelPB {
+    // there will be multi levels in pk index, order by chronologic
+    repeated PrimaryIndexDumpPB primary_index_levels = 1;
+}
+
+message PrimaryKeyDumpPB {
+    optional TabletMetaPB tablet_meta = 1;
+    repeated RowsetMetaIdPB rowset_metas = 2;
+    repeated RowsetStatIdPB rowset_stats = 3;
+    repeated DeltaColumnGroupListIdPB dcg_lists = 4;
+    repeated DeleteVectorStatPB delvec_stats = 5;
+    repeated PrimaryKeyColumnPB primary_key_column = 6;
+    optional PrimaryIndexMultiLevelPB primary_index = 7;
 }

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -313,32 +313,27 @@ message OLAPRawDeltaHeaderMessage {
 
 message RowsetMetaIdPB {
     // rowset id
-    optional uint32 rid = 1;
+    optional uint32 rowset_id = 1;
     optional RowsetMetaPB rowset_meta = 2;
 }
 
 message RowsetStatIdPB {
     // rowset id
-    optional uint32 rid = 1;
+    optional uint32 rowset_id = 1;
     optional string rowset_stat = 2;
 }
 
 message DeltaColumnGroupListIdPB {
     // segment id
-    optional uint32 sid = 1;
+    optional uint32 segment_id = 1;
     optional DeltaColumnGroupListPB dcg_list = 2;
 }
 
 message DeleteVectorStatPB {
     // segment id
-    optional uint32 sid = 1;
+    optional uint32 segment_id = 1;
     optional int64 version = 2;
     optional uint32 cardinality = 3;
-}
-
-message PartialKeysPB {
-    // primary key column's encode keys
-    repeated string keys = 1;
 }
 
 message PartialKVsPB {
@@ -348,9 +343,9 @@ message PartialKVsPB {
 
 message PrimaryKeyColumnPB {
     // segment id
-    optional uint32 sid = 1;
-    // Point to PartialKeys
-    repeated PagePointerPB keys = 2;
+    optional uint32 segment_id = 1;
+    // Point to column data (segment format)
+    optional PagePointerPB page = 2;
 }
 
 message PrimaryIndexDumpPB {
@@ -362,7 +357,7 @@ message PrimaryIndexDumpPB {
 }
 
 message PrimaryIndexMultiLevelPB {
-    // there will be multi levels in pk index, order by chronologic
+    // there will be multi levels in pk index, order by l2 -> l1 -> l0
     repeated PrimaryIndexDumpPB primary_index_levels = 1;
 }
 

--- a/gensrc/proto/types.proto
+++ b/gensrc/proto/types.proto
@@ -32,7 +32,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-syntax="proto2";
+syntax = "proto2";
 
 package starrocks;
 option java_package = "com.starrocks.proto";
@@ -56,7 +56,7 @@ message PStructField {
 
 message PTypeNode {
     // TTypeNodeType(SCALAR, ARRAY, MAP, STRUCT)
-    required int32 type = 1; 
+    required int32 type = 1;
     // only set for scalar types
     optional PScalarType scalar_type = 2;
     // only used for structs; has struct_fields.size() corresponding child types


### PR DESCRIPTION
Why I'm doing:
We need to way to dump all debug message about primary tablet include `delvec`, `dcg`, `rowse meta`, `rowset stat`, `primary index` and so on. When issue `Tablet in error state` happens, we can use these message to detect the issue.

What I'm doing:

PrimaryKeyDump is desgined for providing more information about primary key tablet when issue debug, such as `Tablet in error state` happen, data inconsistency and so on.
PrimaryKeyDump will try to get all helpfull information and generate file `[tablet_id].pkdump` .
In `[tablet_id].pkdump`, Data Layout:

```
|  ------ Begin -------  |
| Primary key columns (segment file format) - part 1 |
| Primary key columns (segment file format) - part 2 |
| Primary key columns (segment file format) - part 3 |
| ... |
| Primary Index kvs - part 1 |
| Primary Index kvs - part 2 |
| Primary Index kvs - part 3 |
| ... |
| ---- Serialze by Protobuf PrimaryKeyDumpPB --- |
| TabletMetaPB |
| RowsetMetaPB (rowset 1) |
| RowsetMetaPB (rowset 2) |
| ... |
| RowsetStatPB (rowset 1) |
| RowsetStatPB (rowset 2) |
| ... |
| DeltaColumnGroupListIdPB |
| DeleteVectorStatPB |
| PrimaryKeyColumnPB (Use PagePointerPB point to Primary key columns ) |
| PrimaryIndexMultiLevelPB (Use PagePointerPB point to Primary Index kvs) |
| ---------- end ----------|
```

* How to generate pk dump:
1. Use sql cmd :
```
admin execute on 10004 'System.print(StorageEngine.print_primary_key_dump(10139))'; // 10139 is tablet id
```
2. Audo generate when error state show up (will enable in next pr)

After PK Dump generated, there will be a file named `[tablet_id].pkdump` under tablet dir.
* How to parse pk dump
1. Use meta tool:
```
./meta_tool --operation=print_pk_dump --file=/path/to/pk/dump/file
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
