### PR TITLE
[Enhancement] reduce tablet shard read lock holding time when calc persistent index compact score

### DIFF
--- a/be/src/storage/olap_server.cpp
+++ b/be/src/storage/olap_server.cpp
@@ -404,9 +404,11 @@ void* StorageEngine::_pk_index_major_compaction_thread_callback(void* arg) {
     while (!_bg_worker_stopped.load(std::memory_order_consume)) {
         SLEEP_IN_BG_WORKER(1);
         // schedule persistent index compaction
-        _update_manager->get_pindex_compaction_mgr()->schedule([&]() {
-            return StorageEngine::instance()->tablet_manager()->pick_tablets_to_do_pk_index_major_compaction();
-        });
+        if (config::enable_pindex_minor_compaction) {
+            _update_manager->get_pindex_compaction_mgr()->schedule([&]() {
+                return StorageEngine::instance()->tablet_manager()->pick_tablets_to_do_pk_index_major_compaction();
+            });
+        }
     }
 
     return nullptr;

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -705,6 +705,7 @@ TabletSharedPtr TabletManager::find_best_tablet_to_compaction(CompactionType com
 std::vector<TabletAndScore> TabletManager::pick_tablets_to_do_pk_index_major_compaction() {
     std::vector<TabletAndScore> pick_tablets;
     // 1. pick valid tablet, which score is larger than 0
+    std::vector<TabletSharedPtr> tablet_ptr_list;
     for (const auto& tablets_shard : _tablets_shards) {
         std::shared_lock rlock(tablets_shard.lock);
         for (const auto& [tablet_id, tablet_ptr] : tablets_shard.tablet_map) {
@@ -716,14 +717,17 @@ std::vector<TabletAndScore> TabletManager::pick_tablets_to_do_pk_index_major_com
                 continue;
             }
 
-            double score = tablet_ptr->updates()->get_pk_index_write_amp_score();
-            if (score <= 0) {
-                // score == 0 means this tablet's pk index doesn't need major compaction
-                continue;
-            }
-
-            pick_tablets.emplace_back(tablet_ptr, score);
+            tablet_ptr_list.push_back(tablet_ptr);
         }
+    }
+    for (const auto& tablet_ptr : tablet_ptr_list) {
+        double score = tablet_ptr->updates()->get_pk_index_write_amp_score();
+        if (score <= 0) {
+            // score == 0 means this tablet's pk index doesn't need major compaction
+            continue;
+        }
+
+        pick_tablets.emplace_back(tablet_ptr, score);
     }
     // 2. sort tablet by score, by ascending order.
     std::sort(pick_tablets.begin(), pick_tablets.end(), [](TabletAndScore& a, TabletAndScore& b) {


### PR DESCRIPTION
Why I'm doing:
When calc persistent index compact score, if pindex not exist in index cache, we will read persistent meta from rocksdb which can be very slow. We should't hold tablet shard read lock to do this, because it will affect tablet create and drop.

What I'm doing:
Remove persistent index compact score calculation from tablet shard read lock.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
