### PR TITLE
[Enhancement] Routine load task schduling (branch-3.1) (backport #37638) 

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaRoutineLoadJob.java
@@ -177,6 +177,10 @@ public class KafkaRoutineLoadJob extends RoutineLoadJob {
         latestPartitionOffsets.put(Integer.valueOf(partition), Long.valueOf(offset));
     }
 
+    public Long getPartitionOffset(int partition) {
+        return latestPartitionOffsets.get(Integer.valueOf(partition));
+    }
+
     @Override
     public void prepare() throws UserException {
         super.prepare();

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/KafkaTaskInfo.java
@@ -93,11 +93,35 @@ public class KafkaTaskInfo extends RoutineLoadTaskInfo {
         return new ArrayList<>(partitionIdToOffset.keySet());
     }
 
+    // checkReadyToExecuteFast compares the local latest partition offset and the consumed offset.
+    public boolean checkReadyToExecuteFast() {
+        RoutineLoadJob routineLoadJob = routineLoadManager.getJob(jobId);
+        if (routineLoadJob == null) {
+            return false;
+        }
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = (KafkaRoutineLoadJob) routineLoadJob;
+
+        for (Map.Entry<Integer, Long> entry : partitionIdToOffset.entrySet()) {
+            int partitionId = entry.getKey();
+            Long consumeOffset = entry.getValue();
+            Long localLatestOffset = kafkaRoutineLoadJob.getPartitionOffset(partitionId);
+            // If any partition has newer data, the task should be scheduled.
+            if (localLatestOffset != null && localLatestOffset > consumeOffset) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @Override
     public boolean readyToExecute() throws UserException {
         RoutineLoadJob routineLoadJob = routineLoadManager.getJob(jobId);
         if (routineLoadJob == null) {
             return false;
+        }
+
+        if (checkReadyToExecuteFast()) {
+            return true;
         }
 
         KafkaRoutineLoadJob kafkaRoutineLoadJob = (KafkaRoutineLoadJob) routineLoadJob;

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadTaskScheduler.java
@@ -79,12 +79,11 @@ public class RoutineLoadTaskScheduler extends FrontendDaemon {
 
     private static final long BACKEND_SLOT_UPDATE_INTERVAL_MS = 10000; // 10s
     private static final long SLOT_FULL_SLEEP_MS = 10000; // 10s
-    private static final int THREAD_POOL_SIZE = 10;
 
     private final RoutineLoadMgr routineLoadManager;
     private final LinkedBlockingQueue<RoutineLoadTaskInfo> needScheduleTasksQueue = Queues.newLinkedBlockingQueue();
     private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
-    private final ExecutorService threadPool = Executors.newFixedThreadPool(THREAD_POOL_SIZE);
+    private final ExecutorService threadPool = Executors.newCachedThreadPool();
 
     private long lastBackendSlotUpdateTime = -1;
 

--- a/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/routineload/KafkaTaskInfoTest.java
@@ -76,6 +76,30 @@ public class KafkaTaskInfoTest {
     }
 
     @Test
+    public void testCheckReadyToExecuteFast() {
+        KafkaRoutineLoadJob kafkaRoutineLoadJob = new KafkaRoutineLoadJob();
+        kafkaRoutineLoadJob.setPartitionOffset(0, 101);
+
+        new MockUp<RoutineLoadMgr>() {
+            @Mock
+            public RoutineLoadJob getJob(long jobId) {
+                return kafkaRoutineLoadJob;
+            }
+        };
+
+        Map<Integer, Long> offset1 = Maps.newHashMap();
+        offset1.put(0, 100L);
+        KafkaTaskInfo kafkaTaskInfo = new KafkaTaskInfo(UUID.randomUUID(),
+                1L,
+                System.currentTimeMillis(),
+                System.currentTimeMillis(),
+                offset1,
+                Config.routine_load_task_timeout_second * 1000);
+
+        Assert.assertTrue(kafkaTaskInfo.checkReadyToExecuteFast());
+    }
+
+    @Test
     public void testProgressKeepUp(@Injectable KafkaRoutineLoadJob kafkaRoutineLoadJob) throws Exception {
         new MockUp<RoutineLoadMgr>() {
             @Mock


### PR DESCRIPTION
This is a backport of https://github.com/StarRocks/starrocks/pull/37638 to branch-3.1
---
Why I'm doing:
Now, the routine load task scheduling may be slowed down by some slow tasks.
What I'm doing:
1. remove the limit of routine load task scheduler threadpool
2. Quickly determine if a task needs to be scheduled based on local offset information

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5


