### PR TITLE
[BugFix] reuse the task and label when resuming task

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/LabelAlreadyUsedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/LabelAlreadyUsedException.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang3.StringUtils;
 public class LabelAlreadyUsedException extends DdlException {
 
     private static final long serialVersionUID = -6798925248765094813L;
-    private static final Pattern ERROR_PATTERN = Pattern.compile("Label \\[.*\\] has already been used.");
+    private static final Pattern ERROR_PATTERN = Pattern.compile(".*Label \\[.*\\] has already been used.*");
 
     // status of existing load job
     // RUNNING or FINISHED

--- a/fe/fe-core/src/main/java/com/starrocks/common/LabelAlreadyUsedException.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/LabelAlreadyUsedException.java
@@ -18,11 +18,14 @@
 package com.starrocks.common;
 
 import com.google.common.base.Preconditions;
+import com.google.re2j.Pattern;
 import com.starrocks.transaction.TransactionStatus;
+import org.apache.commons.lang3.StringUtils;
 
 public class LabelAlreadyUsedException extends DdlException {
 
     private static final long serialVersionUID = -6798925248765094813L;
+    private static final Pattern ERROR_PATTERN = Pattern.compile("Label \\[.*\\] has already been used.");
 
     // status of existing load job
     // RUNNING or FINISHED
@@ -52,6 +55,10 @@ public class LabelAlreadyUsedException extends DdlException {
 
     public LabelAlreadyUsedException(String label, String subLabel) {
         super("Sub label [" + subLabel + "] has already been used.");
+    }
+
+    public static boolean isLabelAlreadyUsed(String errorMessage) {
+        return StringUtils.isNotEmpty(errorMessage) && ERROR_PATTERN.matches(errorMessage);
     }
 
     public String getJobStatus() {

--- a/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/pipe/Pipe.java
@@ -17,7 +17,6 @@ package com.starrocks.load.pipe;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.TableName;
@@ -503,22 +502,14 @@ public class Pipe implements GsonPostProcessable {
             if (this.state == State.RUNNING) {
                 this.state = State.SUSPEND;
 
-                List<PipeFileRecord> loadingFiles = Lists.newArrayList();
                 for (PipeTaskDesc task : runningTasks.values()) {
                     if (task.isTaskRunning()) {
                         task.interrupt();
-                        loadingFiles.addAll(task.getPiece().getFiles());
                     }
                 }
                 LOG.info("suspend pipe {}", this);
 
                 loadStatus.loadingFiles = 0;
-
-                // Change LOADING files to UNLOADED
-                if (CollectionUtils.isNotEmpty(loadingFiles)) {
-                    FileListRepo repo = getPipeSource().getFileListRepo();
-                    repo.updateFileState(loadingFiles, FileListRepo.PipeFileState.UNLOADED, null);
-                }
             }
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/load/pipe/PipeManagerTest.java
@@ -14,10 +14,12 @@
 
 package com.starrocks.load.pipe;
 
+import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.fs.HdfsUtil;
@@ -36,6 +38,8 @@ import com.starrocks.scheduler.ExecuteOption;
 import com.starrocks.scheduler.SubmitResult;
 import com.starrocks.scheduler.Task;
 import com.starrocks.scheduler.TaskManager;
+import com.starrocks.scheduler.TaskRun;
+import com.starrocks.scheduler.TaskRunExecutor;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.server.WarehouseManager;
 import com.starrocks.service.ExecuteEnv;
@@ -80,7 +84,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
 import java.util.concurrent.FutureTask;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 public class PipeManagerTest {
@@ -155,6 +163,29 @@ public class PipeManagerTest {
         String sql = "alter pipe " + name + " resume";
         AlterPipeStmt alterStmt = (AlterPipeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
         pm.alterPipe(alterStmt);
+    }
+
+    private void suspendPipe(String name) throws Exception {
+        PipeManager pm = ctx.getGlobalStateMgr().getPipeManager();
+        String sql = "alter pipe " + name + " suspend";
+        AlterPipeStmt alterStmt = (AlterPipeStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        pm.alterPipe(alterStmt);
+    }
+
+    private void waitPipeTaskFinish(String name) {
+        Pipe pipe = getPipe(name);
+        Stopwatch watch = Stopwatch.createStarted();
+        while (pipe.getState() != Pipe.State.FINISHED) {
+            if (watch.elapsed(TimeUnit.SECONDS) > 60) {
+                Assert.fail("wait for pipe but failed: elapsed " + watch.elapsed(TimeUnit.SECONDS));
+            }
+            pipe.schedule();
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException e) {
+                Assert.fail("wait for pipe but failed: " + e);
+            }
+        }
     }
 
     @Test
@@ -247,6 +278,35 @@ public class PipeManagerTest {
         p2.schedule();
         p1 = follower.mayGetPipe(new PipeName(PIPE_TEST_DB, "p1")).get();
         Assert.assertEquals(Pipe.State.SUSPEND, p1.getState());
+    }
+
+    private void mockTaskLongRunning(long runningSecs, Constants.TaskRunState result) {
+        new MockUp<TaskRunExecutor>() {
+            @Mock
+            public void executeTaskRun(TaskRun taskRun) {
+
+                ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+                executorService.schedule(() -> {
+                    taskRun.getFuture().complete(result);
+                }, runningSecs, TimeUnit.SECONDS);
+            }
+        };
+    }
+
+    private void mockTaskExecutor(Supplier<Constants.TaskRunState> runnable) {
+
+        new MockUp<TaskRunExecutor>() {
+            @Mock
+            public void executeTaskRun(TaskRun taskRun) {
+                try {
+                    Constants.TaskRunState result = runnable.get();
+                    taskRun.getFuture().complete(result);
+                } catch (Exception e) {
+                    taskRun.getFuture().completeExceptionally(e);
+                }
+
+            }
+        };
     }
 
     private void mockTaskExecution(Constants.TaskRunState executionState) {
@@ -602,6 +662,41 @@ public class PipeManagerTest {
         resumePipe(pipeName);
         Assert.assertEquals(Pipe.State.RUNNING, p3.getState());
         Assert.assertEquals(0, p3.getFailedTaskExecutionCount());
+    }
+
+    /**
+     * The suspend operation could either interrupt the normal execution of task, or
+     */
+    @Test
+    public void testSuspend() throws Exception {
+        mockRepoExecutor();
+        final String name = "p_suspend";
+        String sql = "create pipe p_suspend " +
+                "properties('auto_ingest'='false') " +
+                "as " +
+                "insert into tbl1 select * from files('path'='fake://pipe', 'format'='parquet')";
+        createPipe(sql);
+
+        // normal execution of task, will retry after interruption
+        mockTaskLongRunning(10, Constants.TaskRunState.SUCCESS);
+        Pipe p = getPipe(name);
+        p.poll();
+        p.schedule();
+
+        // suspend make the pipe-task enter RUNNABLE state
+        suspendPipe(name);
+        Assert.assertEquals(1, p.getRunningTasks().size());
+        Assert.assertEquals(PipeTaskDesc.PipeTaskState.RUNNABLE, p.getRunningTasks().get(0).getState());
+
+        // Throw the LabelAlreadyUsed exception
+        // But Pipe could finish since this exception is acceptable
+        mockTaskExecutor(() -> {
+            throw new RuntimeException(new LabelAlreadyUsedException("h"));
+        });
+        resumePipe(name);
+        waitPipeTaskFinish(name);
+
+        dropPipe(name);
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
- Suspending the pipe would kill the task and create another one to load duplicated data

What I'm doing:
- When suspending the pipe, drop task but not kill it, so that the same label could be used later to stop duplicated data loading
- When suspending the pipe, change the `PipeTask` as `RUNNABLE` state 

Fixes https://github.com/StarRocks/StarRocksTest/issues/5462

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
