### PR TITLE
[BugFix] Fix incorrect memory usage stats in compaction state

### DIFF
--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -94,6 +94,7 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
         itr->close();
     }
     dest = std::move(col);
+    dest->raw_data();
     _memory_usage += dest->memory_usage();
     _update_manager->compaction_state_mem_tracker()->consume(dest->memory_usage());
     return Status::OK();

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -120,6 +120,7 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
         CHECK(col->size() == num_rows) << "read segment: iter rows != num rows";
     }
     dest = std::move(col);
+    dest->raw_data();
     _memory_usage += dest->memory_usage();
     tracker->consume(dest->memory_usage());
 


### PR DESCRIPTION
Why I'm doing:
Memory usage of compaction state is incorrect. Because `raw_data()` will cause extra memory for `build_slices`.
What I'm doing:
Call `raw_data` before consuming the memory
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
