### PR TITLE
[Feature](1/n) Support fast schema evolution in shared data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobV2Builder.java
@@ -86,8 +86,18 @@ public abstract class AlterJobV2Builder {
         return this;
     }
 
+    public AlterJobV2Builder withNewIndexShortKeyCount(Map<Long, Short> shortKeyCount) {
+        this.newIndexShortKeyCount.putAll(shortKeyCount);
+        return this;
+    }
+
     public AlterJobV2Builder withNewIndexSchema(long indexId, @NotNull List<Column> indexSchema) {
         newIndexSchema.put(indexId, indexSchema);
+        return this;
+    }
+
+    public AlterJobV2Builder withNewIndexSchema(@NotNull Map<Long, List<Column>> indexSchema) {
+        newIndexSchema.putAll(indexSchema);
         return this;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/LakeTableSchemaChangeJob.java
@@ -299,20 +299,6 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                     long originIndexId = indexIdMap.get(shadowIdxId);
                     KeysType originKeysType = table.getKeysTypeByIndexId(originIndexId);
                     List<Column> originSchema = table.getSchemaByIndexId(originIndexId);
-
-                    // copy for generate some const default value
-                    List<Column> copiedShadowSchema = Lists.newArrayList();
-                    for (Column column : shadowSchema) {
-                        Column.DefaultValueType defaultValueType = column.getDefaultValueType();
-                        if (defaultValueType == Column.DefaultValueType.CONST) {
-                            Column copiedColumn = new Column(column);
-                            copiedColumn.setDefaultValue(column.calculatedDefaultValueWithTime(startTime));
-                            copiedShadowSchema.add(copiedColumn);
-                        } else {
-                            copiedShadowSchema.add(column);
-                        }
-                    }
-
                     List<Integer> copiedSortKeyIdxes = indexMeta.getSortKeyIdxes();
                     if (indexMeta.getSortKeyIdxes() != null) {
                         if (originSchema.size() > shadowSchema.size()) {
@@ -362,7 +348,7 @@ public class LakeTableSchemaChangeJob extends AlterJobV2 {
                                 new CreateReplicaTask(backendId, dbId, tableId, partitionId,
                                         shadowIdxId, shadowTabletId, shadowShortKeyColumnCount, 0,
                                         Partition.PARTITION_INIT_VERSION,
-                                        originKeysType, TStorageType.COLUMN, storageMedium, copiedShadowSchema,
+                                        originKeysType, TStorageType.COLUMN, storageMedium, shadowSchema,
                                         bfColumns, bfFpp,
                                         countDownLatch, indexes, table.isInMemory(), table.enablePersistentIndex(),
                                         table.primaryIndexCacheExpireSec(), TTabletType.TABLET_TYPE_LAKE,

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeData.java
@@ -1,0 +1,196 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.alter;
+
+import com.starrocks.catalog.Column;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Index;
+import com.starrocks.catalog.OlapTable;
+import com.starrocks.common.Config;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+class SchemaChangeData {
+    private final Database database;
+    private final OlapTable table;
+    private final long timeoutInSeconds;
+    private final Map<Long, List<Column>> newIndexSchema;
+    private final List<Index> indexes;
+    private final boolean bloomFilterColumnsChanged;
+    private final Set<String> bloomFilterColumns;
+    private final double bloomFilterFpp;
+    private final boolean hasIndexChanged;
+    private final Map<Long, Short> newIndexShortKeyCount;
+    private final List<Integer> sortKeyIdxes;
+    private final List<Integer> sortKeyUniqueIds;
+
+    static Builder newBuilder() {
+        return new Builder();
+    }
+
+    @NotNull
+    Database getDatabase() {
+        return database;
+    }
+
+    @NotNull
+    OlapTable getTable() {
+        return table;
+    }
+
+    long getTimeoutInSeconds() {
+        return timeoutInSeconds;
+    }
+
+    @NotNull
+    Map<Long, List<Column>> getNewIndexSchema() {
+        return Collections.unmodifiableMap(newIndexSchema);
+    }
+
+    @Nullable
+    List<Index> getIndexes() {
+        return indexes;
+    }
+
+    boolean isBloomFilterColumnsChanged() {
+        return bloomFilterColumnsChanged;
+    }
+
+    @Nullable
+    Set<String> getBloomFilterColumns() {
+        return bloomFilterColumns;
+    }
+
+    double getBloomFilterFpp() {
+        return bloomFilterFpp;
+    }
+
+    boolean isHasIndexChanged() {
+        return hasIndexChanged;
+    }
+
+
+    @NotNull
+    Map<Long, Short> getNewIndexShortKeyCount() {
+        return Collections.unmodifiableMap(newIndexShortKeyCount);
+    }
+
+    @Nullable
+    List<Integer> getSortKeyIdxes() {
+        return sortKeyIdxes;
+    }
+
+    @Nullable
+    List<Integer> getSortKeyUniqueIds() {
+        return sortKeyUniqueIds;
+    }
+
+    private SchemaChangeData(Builder builder) {
+        this.database = Objects.requireNonNull(builder.database, "database is null");
+        this.table = Objects.requireNonNull(builder.table, "table is null");
+        this.timeoutInSeconds = builder.timeoutInSeconds;
+        this.newIndexSchema = Objects.requireNonNull(builder.newIndexSchema, "newIndexSchema is null");
+        this.indexes = builder.indexes;
+        this.bloomFilterColumnsChanged = builder.bloomFilterColumnsChanged;
+        this.bloomFilterColumns = builder.bloomFilterColumns;
+        this.bloomFilterFpp = builder.bloomFilterFpp;
+        this.hasIndexChanged = builder.hasIndexChanged;
+        this.newIndexShortKeyCount = Objects.requireNonNull(builder.newIndexShortKeyCount, "newIndexShortKeyCount is null");
+        this.sortKeyIdxes = builder.sortKeyIdxes;
+        this.sortKeyUniqueIds = builder.sortKeyUniqueIds;
+    }
+
+    static class Builder {
+        private Database database;
+        private OlapTable table;
+        private long timeoutInSeconds = Config.alter_table_timeout_second;
+        private Map<Long, List<Column>> newIndexSchema = new HashMap<>();
+        private List<Index> indexes;
+        private boolean bloomFilterColumnsChanged = false;
+        private Set<String> bloomFilterColumns;
+        private double bloomFilterFpp;
+        private boolean hasIndexChanged = false;
+        private Map<Long, Short> newIndexShortKeyCount = new HashMap<>();
+        private List<Integer> sortKeyIdxes;
+        private List<Integer> sortKeyUniqueIds;
+
+        private Builder() {
+        }
+
+        Builder withDatabase(@NotNull Database database) {
+            this.database = Objects.requireNonNull(database, "database is null");
+            return this;
+        }
+
+        Builder withTable(@NotNull OlapTable table) {
+            this.table = Objects.requireNonNull(table, "table is null");
+            return this;
+        }
+
+        Builder withTimeoutInSeconds(long timeoutInSeconds) {
+            this.timeoutInSeconds = timeoutInSeconds;
+            return this;
+        }
+
+        Builder withBloomFilterColumnsChanged(boolean changed) {
+            this.bloomFilterColumnsChanged = changed;
+            return this;
+        }
+
+        Builder withBloomFilterColumns(@Nullable Set<String> bfColumns, double bfFpp) {
+            this.bloomFilterColumns = bfColumns;
+            this.bloomFilterFpp = bfFpp;
+            return this;
+        }
+
+        Builder withAlterIndexInfo(boolean hasIndexChanged, @NotNull List<Index> indexes) {
+            this.hasIndexChanged = hasIndexChanged;
+            this.indexes = indexes;
+            return this;
+        }
+
+        Builder withNewIndexShortKeyCount(long indexId, short shortKeyCount) {
+            this.newIndexShortKeyCount.put(indexId, shortKeyCount);
+            return this;
+        }
+
+        Builder withNewIndexSchema(long indexId, @NotNull List<Column> indexSchema) {
+            newIndexSchema.put(indexId, indexSchema);
+            return this;
+        }
+
+        Builder withSortKeyIdxes(@Nullable List<Integer> sortKeyIdxes) {
+            this.sortKeyIdxes = sortKeyIdxes;
+            return this;
+        }
+
+        Builder withSortKeyUniqueIds(@Nullable List<Integer> sortKeyUniqueIds) {
+            this.sortKeyUniqueIds = sortKeyUniqueIds;
+            return this;
+        }
+
+        @NotNull
+        SchemaChangeData build() {
+            return new SchemaChangeData(this);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeHandler.java
@@ -51,11 +51,8 @@ import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.AggregateType;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
-import com.starrocks.catalog.DistributionInfo;
-import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.catalog.DynamicPartitionProperty;
 import com.starrocks.catalog.ForeignKeyConstraint;
-import com.starrocks.catalog.HashDistributionInfo;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.LocalTablet;
@@ -65,10 +62,7 @@ import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
-import com.starrocks.catalog.PartitionInfo;
-import com.starrocks.catalog.PartitionType;
 import com.starrocks.catalog.PhysicalPartition;
-import com.starrocks.catalog.RangePartitionInfo;
 import com.starrocks.catalog.Replica;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableProperty;
@@ -96,6 +90,7 @@ import com.starrocks.persist.TableAddOrDropColumnsInfo;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.ShowResultSet;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.RunMode;
 import com.starrocks.sql.analyzer.SemanticException;
 import com.starrocks.sql.ast.AddColumnClause;
 import com.starrocks.sql.ast.AddColumnsClause;
@@ -133,6 +128,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.IntSupplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 
 import static com.starrocks.sql.optimizer.rule.transformation.materialization.MvUtils.inactiveRelatedMaterializedViews;
 
@@ -269,8 +265,7 @@ public class SchemaChangeHandler extends AlterHandler {
      */
     private boolean processDropColumn(DropColumnClause alterClause, OlapTable olapTable,
                                       Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes) throws DdlException {
-        boolean fastSchemaEvolution = 
-                (olapTable.getUseFastSchemaEvolution() == null) ? false : olapTable.getUseFastSchemaEvolution();
+        boolean fastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
         String dropColName = alterClause.getColName();
         String targetIndexName = alterClause.getRollupName();
         checkIndexExists(olapTable, targetIndexName);
@@ -408,8 +403,10 @@ public class SchemaChangeHandler extends AlterHandler {
     }
 
     // User can modify column type and column position
-    private void processModifyColumn(ModifyColumnClause alterClause, OlapTable olapTable,
+    private boolean processModifyColumn(ModifyColumnClause alterClause, OlapTable olapTable,
                                      Map<Long, LinkedList<Column>> indexSchemaMap) throws DdlException {
+        // The fast schema evolution mechanism is only supported for modified columns in shared data mode.
+        boolean fastSchemaEvolution = RunMode.isSharedDataMode() && olapTable.getUseFastSchemaEvolution();
         Column modColumn = alterClause.getColumn();
         if (KeysType.PRIMARY_KEYS == olapTable.getKeysType()) {
             if (olapTable.getBaseColumn(modColumn.getName()) != null && olapTable.getBaseColumn(modColumn.getName()).isKey()) {
@@ -644,6 +641,8 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
             }
         } // end for handling other indices
+
+        return fastSchemaEvolution;
     }
 
     // Because modifying the sort key columns and reordering table schema use the same syntax(Alter table xxx ORDER BY(...))
@@ -772,12 +771,11 @@ public class SchemaChangeHandler extends AlterHandler {
                                       Set<String> newColNameSet) throws DdlException {
 
         Column.DefaultValueType defaultValueType = newColumn.getDefaultValueType();
-        if (defaultValueType == Column.DefaultValueType.VARY) {
+        if (defaultValueType != Column.DefaultValueType.CONST && defaultValueType != Column.DefaultValueType.NULL) {
             throw new DdlException("unsupported default expr:" + newColumn.getDefaultExpr().getExpr());
         }
 
-        boolean fastSchemaEvolution = 
-                (olapTable.getUseFastSchemaEvolution() == null) ? false : olapTable.getUseFastSchemaEvolution();
+        boolean fastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
         // if column is generated column, need to rewrite table data, so we can not use light schema change
         if (newColumn.isAutoIncrement() || newColumn.isGeneratedColumn()) {
             fastSchemaEvolution = false;
@@ -785,6 +783,10 @@ public class SchemaChangeHandler extends AlterHandler {
 
         if (newColumn.getDefaultValue() != null && newColumn.getDefaultExpr() != null) {
             fastSchemaEvolution = false;
+        }
+        if (newColumn.getDefaultExpr() != null && newColumn.getDefaultValueType() == Column.DefaultValueType.CONST) {
+            long startTime = ConnectContext.get().getStartTime();
+            newColumn.setDefaultValue(newColumn.calculatedDefaultValueWithTime(startTime));
         }
 
         String newColName = newColumn.getName();
@@ -1056,8 +1058,10 @@ public class SchemaChangeHandler extends AlterHandler {
         }
     }
 
-    private AlterJobV2 createJob(long dbId, OlapTable olapTable, Map<Long, LinkedList<Column>> indexSchemaMap,
-                                 Map<String, String> propertyMap, List<Index> indexes) throws UserException {
+    private SchemaChangeData finalAnalyze(Database db, OlapTable olapTable,
+                                          Map<Long, LinkedList<Column>> indexSchemaMap,
+                                          Map<String, String> propertyMap,
+                                          List<Index> indexes) throws UserException {
         if (olapTable.getState() == OlapTableState.ROLLUP) {
             throw new DdlException("Table[" + olapTable.getName() + "]'s is doing ROLLUP job");
         }
@@ -1072,27 +1076,25 @@ public class SchemaChangeHandler extends AlterHandler {
         //     "indexname1#short_key" = "3"
         //     "indexname2#short_key" = "4"
         Map<Long, Map<String, String>> indexIdToProperties = new HashMap<Long, Map<String, String>>();
-        if (propertyMap.size() > 0) {
-            for (String key : propertyMap.keySet()) {
-                if (key.endsWith(PropertyAnalyzer.PROPERTIES_SHORT_KEY)) {
-                    // short key
-                    String[] keyArray = key.split("#");
-                    if (keyArray.length != 2 || keyArray[0].isEmpty()
-                            || !keyArray[1].equals(PropertyAnalyzer.PROPERTIES_SHORT_KEY)) {
-                        throw new DdlException("Invalid alter table property: " + key);
-                    }
-
-                    HashMap<String, String> prop = new HashMap<String, String>();
-
-                    if (!olapTable.hasMaterializedIndex(keyArray[0])) {
-                        throw new DdlException("Index[" + keyArray[0] + "] does not exist");
-                    }
-
-                    prop.put(PropertyAnalyzer.PROPERTIES_SHORT_KEY, propertyMap.get(key));
-                    indexIdToProperties.put(olapTable.getIndexIdByName(keyArray[0]), prop);
+        for (String key : propertyMap.keySet()) {
+            if (key.endsWith(PropertyAnalyzer.PROPERTIES_SHORT_KEY)) {
+                // short key
+                String[] keyArray = key.split("#");
+                if (keyArray.length != 2 || keyArray[0].isEmpty()
+                        || !keyArray[1].equals(PropertyAnalyzer.PROPERTIES_SHORT_KEY)) {
+                    throw new DdlException("Invalid alter table property: " + key);
                 }
-            } // end for property keys
-        }
+
+                HashMap<String, String> prop = new HashMap<String, String>();
+
+                if (!olapTable.hasMaterializedIndex(keyArray[0])) {
+                    throw new DdlException("Index[" + keyArray[0] + "] does not exist");
+                }
+
+                prop.put(PropertyAnalyzer.PROPERTIES_SHORT_KEY, propertyMap.get(key));
+                indexIdToProperties.put(olapTable.getIndexIdByName(keyArray[0]), prop);
+            }
+        } // end for property keys
 
         // for bitmapIndex
         boolean hasIndexChange = false;
@@ -1168,19 +1170,16 @@ public class SchemaChangeHandler extends AlterHandler {
         // property 3: timeout
         long timeoutSecond = PropertyAnalyzer.analyzeTimeout(propertyMap, Config.alter_table_timeout_second);
 
-        // create job
-        AlterJobV2Builder jobBuilder = olapTable.alterTable();
-        jobBuilder.withJobId(GlobalStateMgr.getCurrentState().getNextId())
-                .withDbId(dbId)
-                .withTimeoutSeconds(timeoutSecond)
+        SchemaChangeData.Builder dataBuilder = SchemaChangeData.newBuilder();
+        dataBuilder.withDatabase(db)
+                .withTable(olapTable)
+                .withTimeoutInSeconds(timeoutSecond)
                 .withAlterIndexInfo(hasIndexChange, indexes)
-                .withStartTime(ConnectContext.get().getStartTime())
                 .withBloomFilterColumns(bfColumns, bfFpp)
                 .withBloomFilterColumnsChanged(hasBfChange);
 
         // begin checking each table
         // ATTN: DO NOT change any meta in this loop
-        long tableId = olapTable.getId();
         for (Long alterIndexId : indexSchemaMap.keySet()) {
             List<Column> originSchema = olapTable.getSchemaByIndexId(alterIndexId);
             List<Column> alterSchema = indexSchemaMap.get(alterIndexId);
@@ -1252,43 +1251,38 @@ public class SchemaChangeHandler extends AlterHandler {
             }
 
             // 3. check partition key
-            if (hasColumnChange && olapTable.getPartitionInfo().isRangePartition()) {
-                List<Column> partitionColumns = ((RangePartitionInfo) olapTable.getPartitionInfo()).getPartitionColumns();
-                for (Column partitionCol : partitionColumns) {
-                    String colName = partitionCol.getName();
-                    Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
-                    if (col.isPresent() && !col.get().equals(partitionCol)) {
-                        throw new DdlException("Can not modify partition column[" + colName + "]. index["
-                                + olapTable.getIndexNameById(alterIndexId) + "]");
-                    }
-                    if (!col.isPresent() && alterIndexId == olapTable.getBaseIndexId()) {
-                        // 2.1 partition column cannot be deleted.
-                        throw new DdlException("Partition column[" + partitionCol.getName()
-                                + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
-                        // ATTN. partition columns' order also need remaining unchanged.
-                        // for now, we only allow one partition column, so no need to check order.
-                    }
-                } // end for partitionColumns
-            }
+            List<Column> partitionColumns = olapTable.getPartitionInfo().getPartitionColumns();
+            for (Column partitionCol : partitionColumns) {
+                String colName = partitionCol.getName();
+                Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
+                if (col.isPresent() && !col.get().equals(partitionCol)) {
+                    throw new DdlException("Can not modify partition column[" + colName + "]. index["
+                            + olapTable.getIndexNameById(alterIndexId) + "]");
+                }
+                if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexId()) {
+                    // 2.1 partition column cannot be deleted.
+                    throw new DdlException("Partition column[" + partitionCol.getName()
+                            + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
+                    // ATTN. partition columns' order also need remaining unchanged.
+                    // for now, we only allow one partition column, so no need to check order.
+                }
+            } // end for partitionColumns
 
             // 4. check distribution key:
-            if (hasColumnChange && olapTable.getDefaultDistributionInfo().getType() == DistributionInfoType.HASH) {
-                List<Column> distributionColumns =
-                        ((HashDistributionInfo) olapTable.getDefaultDistributionInfo()).getDistributionColumns();
-                for (Column distributionCol : distributionColumns) {
-                    String colName = distributionCol.getName();
-                    Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
-                    if (col.isPresent() && !col.get().equals(distributionCol)) {
-                        throw new DdlException("Can not modify distribution column[" + colName + "]. index["
-                                + olapTable.getIndexNameById(alterIndexId) + "]");
-                    }
-                    if (!col.isPresent() && alterIndexId == olapTable.getBaseIndexId()) {
-                        // 2.2 distribution column cannot be deleted.
-                        throw new DdlException("Distribution column[" + distributionCol.getName()
-                                + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
-                    }
-                } // end for distributionCols
-            }
+            List<Column> distributionColumns = olapTable.getDefaultDistributionInfo().getDistributionColumns();
+            for (Column distributionCol : distributionColumns) {
+                String colName = distributionCol.getName();
+                Optional<Column> col = alterSchema.stream().filter(c -> c.nameEquals(colName, true)).findFirst();
+                if (col.isPresent() && !col.get().equals(distributionCol)) {
+                    throw new DdlException("Can not modify distribution column[" + colName + "]. index["
+                            + olapTable.getIndexNameById(alterIndexId) + "]");
+                }
+                if (col.isEmpty() && alterIndexId == olapTable.getBaseIndexId()) {
+                    // 2.2 distribution column cannot be deleted.
+                    throw new DdlException("Distribution column[" + distributionCol.getName()
+                            + "] cannot be dropped. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
+                }
+            } // end for distributionCols
 
             // 5. calc short key
             List<Integer> sortKeyIdxes = new ArrayList<>();
@@ -1304,7 +1298,7 @@ public class SchemaChangeHandler extends AlterHandler {
                     String columnName = index.getSchema().get(colIdx).getName();
                     Optional<Column> oneCol =
                             alterSchema.stream().filter(c -> c.getName().equalsIgnoreCase(columnName)).findFirst();
-                    if (!oneCol.isPresent()) {
+                    if (oneCol.isEmpty()) {
                         LOG.warn("Sort Key Column[" + columnName + "] not exists in new schema");
                         throw new DdlException("Sort Key Column[" + columnName + "] not exists in new schema");
                     }
@@ -1320,22 +1314,20 @@ public class SchemaChangeHandler extends AlterHandler {
                         indexIdToProperties.get(alterIndexId),
                         sortKeyIdxes);
                 LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
-                jobBuilder.withNewIndexShortKeyCount(alterIndexId,
+                dataBuilder.withNewIndexShortKeyCount(alterIndexId,
                         newShortKeyCount).withNewIndexSchema(alterIndexId, alterSchema);
-                jobBuilder.withSortKeyIdxes(sortKeyIdxes);
-                jobBuilder.withSortKeyUniqueIds(sortKeyUniqueIds);
-                LOG.debug("schema change[{}-{}-{}] check pass.", dbId, tableId, alterIndexId);
+                dataBuilder.withSortKeyIdxes(sortKeyIdxes);
+                dataBuilder.withSortKeyUniqueIds(sortKeyUniqueIds);
             } else {
                 short newShortKeyCount = GlobalStateMgr.calcShortKeyColumnCount(alterSchema,
                         indexIdToProperties.get(alterIndexId));
                 LOG.debug("alter index[{}] short key column count: {}", alterIndexId, newShortKeyCount);
-                jobBuilder.withNewIndexShortKeyCount(alterIndexId,
+                dataBuilder.withNewIndexShortKeyCount(alterIndexId,
                         newShortKeyCount).withNewIndexSchema(alterIndexId, alterSchema);
-                LOG.debug("schema change[{}-{}-{}] check pass.", dbId, tableId, alterIndexId);
             }
         } // end for indices
 
-        return jobBuilder.build();
+        return dataBuilder.build();
     }
 
     private AlterJobV2 createJobForProcessModifySortKeyColumn(long dbId, OlapTable olapTable,
@@ -1450,8 +1442,7 @@ public class SchemaChangeHandler extends AlterHandler {
         if (olapTable == null) {
             throw new DdlException("olapTable is null");
         }
-        boolean fastSchemaEvolution = 
-                (olapTable.getUseFastSchemaEvolution() == null) ? false : olapTable.getUseFastSchemaEvolution();
+        boolean fastSchemaEvolution = olapTable.getUseFastSchemaEvolution();
         //for multi add colmuns clauses
         IntSupplier colUniqueIdSupplier = new IntSupplier() {
             private int pendingMaxColUniqueId = olapTable.getMaxColUniqueId();
@@ -1470,7 +1461,6 @@ public class SchemaChangeHandler extends AlterHandler {
         }
         List<Index> newIndexes = olapTable.getCopiedIndexes();
         Map<String, String> propertyMap = new HashMap<>();
-        Set<String> addColumnsName = Sets.newHashSet();
         for (AlterClause alterClause : alterClauses) {
             Map<String, String> properties = alterClause.getProperties();
             if (properties != null) {
@@ -1554,16 +1544,11 @@ public class SchemaChangeHandler extends AlterHandler {
 
             if (alterClause instanceof AddColumnClause) {
                 // add column
-                addColumnsName.add(((AddColumnClause) alterClause).getColumn().getName());
                 fastSchemaEvolution &=
                         processAddColumn((AddColumnClause) alterClause, olapTable, indexSchemaMap,
                                 colUniqueIdSupplier);
             } else if (alterClause instanceof AddColumnsClause) {
                 // add columns
-                List<Column> columns = ((AddColumnsClause) alterClause).getColumns();
-                for (Column column : columns) {
-                    addColumnsName.add(column.getName());
-                }
                 fastSchemaEvolution &=
                         processAddColumns((AddColumnsClause) alterClause, olapTable, indexSchemaMap, colUniqueIdSupplier);
             } else if (alterClause instanceof DropColumnClause) {
@@ -1584,8 +1569,7 @@ public class SchemaChangeHandler extends AlterHandler {
                 checkModifiedColumWithMaterializedViews(olapTable, modifiedColumns);
 
                 // modify column
-                processModifyColumn(modifyColumnClause, olapTable, indexSchemaMap);
-                fastSchemaEvolution = false;
+                fastSchemaEvolution &= processModifyColumn(modifyColumnClause, olapTable, indexSchemaMap);
             } else if (alterClause instanceof ReorderColumnsClause) {
                 // reorder column
                 fastSchemaEvolution = false;
@@ -1617,27 +1601,20 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         } // end for alter clauses
 
-        LOG.debug("processAddColumns, table: {}({}), ligthSchemaChange: {}", olapTable.getName(), olapTable.getId(),
-                fastSchemaEvolution);
+        SchemaChangeData schemaChangeData = finalAnalyze(db, olapTable, indexSchemaMap, propertyMap, newIndexes);
 
-        if (fastSchemaEvolution) {
-            GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
-            long jobId = globalStateMgr.getNextId();
-            long txnId = GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
-            long startTime = ConnectContext.get().getStartTime();
-            // for schema change add/drop value column optimize, direct modify table meta.
-            // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
-            // try to copy first before modifying, avoiding in-place changes.
-            Map<Long, Long> indexToNewSchemaId = new HashMap<Long, Long>();
-            for (Long alterIndexId : indexSchemaMap.keySet()) {
-                indexToNewSchemaId.put(alterIndexId, globalStateMgr.getNextId());
-            }
-            //for schema change add/drop value column optimize, direct modify table meta.
-            modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, newIndexes, jobId, txnId, startTime,
-                                        addColumnsName, indexToNewSchemaId, false);
+        if (schemaChangeData.getNewIndexSchema().isEmpty() && !schemaChangeData.isHasIndexChanged()) {
+            // Nothing changed.
+            return null;
+        }
+
+        if (!fastSchemaEvolution) {
+            return createJob(schemaChangeData);
+        } else if (RunMode.isSharedNothingMode()) {
+            fastSchemaEvolutionInShareNothingMode(schemaChangeData);
             return null;
         } else {
-            return createJob(db.getId(), olapTable, indexSchemaMap, propertyMap, newIndexes);
+            throw new NotImplementedException("fast schema evolution not supported for shared data mode yet");
         }
     }
 
@@ -1914,7 +1891,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_TTL)) {
-            Long binlogTtl = Long.parseLong(properties.get(
+            long binlogTtl = Long.parseLong(properties.get(
                     PropertyAnalyzer.PROPERTIES_BINLOG_TTL));
             if (binlogTtl != newBinlogConfig.getBinlogTtlSecond()) {
                 newBinlogConfig.setBinlogTtlSecond(binlogTtl);
@@ -1922,7 +1899,7 @@ public class SchemaChangeHandler extends AlterHandler {
             }
         }
         if (properties.containsKey(PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE)) {
-            Long binlogMaxSize = Long.parseLong(properties.get(
+            long binlogMaxSize = Long.parseLong(properties.get(
                     PropertyAnalyzer.PROPERTIES_BINLOG_MAX_SIZE));
             if (binlogMaxSize != newBinlogConfig.getBinlogMaxSize()) {
                 newBinlogConfig.setBinlogMaxSize(binlogMaxSize);
@@ -2304,7 +2281,7 @@ public class SchemaChangeHandler extends AlterHandler {
             List<AlterJobV2> schemaChangeJobV2List = getUnfinishedAlterJobV2ByTableId(olapTable.getId());
             // current schemaChangeJob job doesn't support batch operation,so just need to get one job
             schemaChangeJobV2 =
-                    schemaChangeJobV2List.size() == 0 ? null : Iterables.getOnlyElement(schemaChangeJobV2List);
+                    schemaChangeJobV2List.isEmpty() ? null : Iterables.getOnlyElement(schemaChangeJobV2List);
             if (schemaChangeJobV2 == null) {
                 throw new DdlException(
                         "Table[" + tableName + "] is under SCHEMA_CHANGE but job does not exits.");
@@ -2391,10 +2368,9 @@ public class SchemaChangeHandler extends AlterHandler {
 
     // the invoker should keep write lock
     public void modifyTableAddOrDropColumns(Database db, OlapTable olapTable,
-                                            Map<Long, LinkedList<Column>> indexSchemaMap,
-                                            List<Index> indexes, long jobId, long txnId, long startTime,
-                                            Set<String> addColumnsName, Map<Long, Long> indexToNewSchemaId, 
-                                            boolean isReplay)
+                                            Map<Long, List<Column>> indexSchemaMap,
+                                            List<Index> indexes, long jobId, long txnId,
+                                            Map<Long, Long> indexToNewSchemaId, boolean isReplay)
             throws DdlException, NotImplementedException {
         Locker locker = new Locker();
         locker.lockDatabase(db, LockType.WRITE);
@@ -2408,109 +2384,12 @@ public class SchemaChangeHandler extends AlterHandler {
             Preconditions.checkState(olapTable.getState() == OlapTableState.NORMAL, olapTable.getState().name());
             SchemaChangeJobV2 schemaChangeJob = new SchemaChangeJobV2(jobId, db.getId(), olapTable.getId(),
                                                                       olapTable.getName(), 1000);
-            // for bitmapIndex
-            boolean hasIndexChange = false;
-            Set<Index> newSet = new HashSet<>(indexes);
-            Set<Index> oriSet = new HashSet<>(olapTable.getIndexes());
-            if (!newSet.equals(oriSet)) {
-                hasIndexChange = true;
-            }
-
-            // begin checking each table
-            // ATTN: DO NOT change any meta in this loop
-            Map<Long, List<Column>> changedIndexIdToSchema = Maps.newHashMap();
-            for (Long alterIndexId : indexSchemaMap.keySet()) {
-                // Must get all columns including invisible columns.
-                // Because in alter process, all columns must be considered.
-                List<Column> alterSchema = indexSchemaMap.get(alterIndexId);
-
-                LOG.debug("index[{}] is changed. start checking...", alterIndexId);
-                // 1. check new schema id
-                if (indexToNewSchemaId != null && !indexToNewSchemaId.containsKey(alterIndexId)) {
-                    throw new DdlException("index[" + olapTable.getIndexNameById(alterIndexId) + "] does not assign" +
-                                           " new schema id");
-                }
-                // 2. check order: a) has key; b) value after key
-                boolean meetValue = false;
-                boolean hasKey = false;
-                for (Column column : alterSchema) {
-                    if (column.isKey() && meetValue) {
-                        throw new DdlException(
-                                "Invalid column order. value should be after key. index[" + olapTable.getIndexNameById(
-                                        alterIndexId) + "]");
-                    }
-                    if (!column.isKey()) {
-                        meetValue = true;
-                    } else {
-                        hasKey = true;
-                    }
-                }
-                if (!hasKey) {
-                    throw new DdlException("No key column left. index[" + olapTable.getIndexNameById(alterIndexId) + "]");
-                }
-
-                // 3. check partition key
-                PartitionInfo partitionInfo = olapTable.getPartitionInfo();
-                if (partitionInfo.getType() == PartitionType.RANGE || partitionInfo.getType() == PartitionType.LIST) {
-                    List<Column> partitionColumns = partitionInfo.getPartitionColumns();
-                    for (Column partitionCol : partitionColumns) {
-                        boolean found = false;
-                        for (Column alterColumn : alterSchema) {
-                            if (alterColumn.nameEquals(partitionCol.getName(), true)) {
-                                found = true;
-                                break;
-                            }
-                        } // end for alterColumns
-
-                        if (!found && alterIndexId == olapTable.getBaseIndexId()) {
-                            // 2.1 partition column cannot be deleted.
-                            throw new DdlException(
-                                    "Partition column[" + partitionCol.getName() + "] cannot be dropped. index["
-                                            + olapTable.getIndexNameById(alterIndexId) + "]");
-                        }
-                    } // end for partitionColumns
-                }
-
-                // 4. check distribution key:
-                DistributionInfo distributionInfo = olapTable.getDefaultDistributionInfo();
-                if (distributionInfo.getType() == DistributionInfoType.HASH) {
-                    List<Column> distributionColumns = ((HashDistributionInfo) distributionInfo).getDistributionColumns();
-                    for (Column distributionCol : distributionColumns) {
-                        boolean found = false;
-                        for (Column alterColumn : alterSchema) {
-                            if (alterColumn.nameEquals(distributionCol.getName(), true)) {
-                                found = true;
-                                break;
-                            }
-                        } // end for alterColumns
-                        if (!found && alterIndexId == olapTable.getBaseIndexId()) {
-                            // 2.2 distribution column cannot be deleted.
-                            throw new DdlException(
-                                    "Distribution column[" + distributionCol.getName() + "] cannot be dropped. index["
-                                            + olapTable.getIndexNameById(alterIndexId) + "]");
-                        }
-                    } // end for distributionCols
-                }
-
-                // 5. store the changed columns for edit log
-                changedIndexIdToSchema.put(alterIndexId, alterSchema);
-
-                LOG.debug("schema change[{}-{}-{}] check pass.", db.getId(), olapTable.getId(), alterIndexId);
-            } // end for indices
-
-            if (changedIndexIdToSchema.isEmpty() && !hasIndexChange) {
-                throw new DdlException("Nothing is changed. please check your alter stmt.");
-            }
-
             // update base index schema
-            long baseIndexId = olapTable.getBaseIndexId();
-            List<Long> indexIds = new ArrayList<Long>();
-            indexIds.add(baseIndexId);
-            indexIds.addAll(olapTable.getIndexIdListExceptBaseIndex());
             Set<String> modifiedColumns = Sets.newHashSet();
-            Boolean hasMv = !olapTable.getRelatedMaterializedViews().isEmpty();
-            for (long idx : indexIds) {
-                List<Column> indexSchema = indexSchemaMap.get(idx);
+            boolean hasMv = !olapTable.getRelatedMaterializedViews().isEmpty();
+            for (Map.Entry<Long, List<Column>> entry : indexSchemaMap.entrySet()) {
+                Long idx = entry.getKey();
+                List<Column> indexSchema = entry.getValue();
                 // modify the copied indexMeta and put the update result in the indexIdToMeta
                 MaterializedIndexMeta currentIndexMeta = olapTable.getIndexMetaByIndexId(idx).shallowCopy();
                 List<Column> originSchema = currentIndexMeta.getSchema();
@@ -2525,32 +2404,15 @@ public class SchemaChangeHandler extends AlterHandler {
                 }
 
                 List<Integer> sortKeyUniqueIds = currentIndexMeta.getSortKeyUniqueIds();
-                List<Integer> newSortKeyIdxes = new ArrayList<Integer>();
+                List<Integer> newSortKeyIdxes = new ArrayList<>();
                 if (sortKeyUniqueIds != null) {
                     for (Integer uniqueId : sortKeyUniqueIds) {
                         Optional<Column> col = indexSchema.stream().filter(c -> c.getUniqueId() == uniqueId).findFirst();
-                        if (!col.isPresent()) {
+                        if (col.isEmpty()) {
                             throw new DdlException("Sork key col with unique id: " + uniqueId + " not exists");
                         }
                         int sortKeyIdx = indexSchema.indexOf(col.get());
                         newSortKeyIdxes.add(sortKeyIdx);
-                    }
-                }
-
-                // upgrade from old version and replay task, addColumnsName maybe null
-                if (addColumnsName != null) {
-                    for (String columnName : addColumnsName) {
-                        Optional<Column> col = indexSchema.stream().filter(c -> c.nameEquals(columnName, true)).findFirst();
-                        if (!col.isPresent()) {
-                            continue;
-                        }
-                        Column column = col.get();
-                        if (column.getDefaultExpr() != null) {
-                            Column.DefaultValueType defaultValueType = column.getDefaultValueType();
-                            if (defaultValueType == Column.DefaultValueType.CONST) {
-                                column.setDefaultValue(column.calculatedDefaultValueWithTime(startTime));
-                            }
-                        }
                     }
                 }
 
@@ -2590,7 +2452,7 @@ public class SchemaChangeHandler extends AlterHandler {
 
             if (!isReplay) {
                 TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(db.getId(), olapTable.getId(),
-                        indexSchemaMap, indexes, jobId, txnId, startTime, addColumnsName, indexToNewSchemaId);
+                        indexSchemaMap, indexes, jobId, txnId, indexToNewSchemaId);
                 LOG.debug("logModifyTableAddOrDropColumns info:{}", info);
                 GlobalStateMgr.getCurrentState().getEditLog().logModifyTableAddOrDropColumns(info);
             }
@@ -2613,7 +2475,7 @@ public class SchemaChangeHandler extends AlterHandler {
         LOG.debug("info:{}", info);
         long dbId = info.getDbId();
         long tableId = info.getTableId();
-        Map<Long, LinkedList<Column>> indexSchemaMap = info.getIndexSchemaMap();
+        Map<Long, List<Column>> indexSchemaMap = info.getIndexSchemaMap();
         Map<Long, Long> indexToNewSchemaId = info.getIndexToNewSchemaId();
         List<Index> indexes = info.getIndexes();
         long jobId = info.getJobId();
@@ -2627,8 +2489,7 @@ public class SchemaChangeHandler extends AlterHandler {
         try {
             locker.lockDatabase(db, LockType.WRITE);
             modifyTableAddOrDropColumns(db, olapTable, indexSchemaMap, indexes, jobId, info.getTxnId(),
-                                        info.getStartTime(), info.getAddColumnsName(), indexToNewSchemaId, 
-                                        true);
+                                        indexToNewSchemaId, true);
         } catch (DdlException e) {
             // should not happen
             LOG.warn("failed to replay modify table add or drop columns", e);
@@ -2637,5 +2498,44 @@ public class SchemaChangeHandler extends AlterHandler {
         } finally {
             locker.unLockDatabase(db, LockType.WRITE);
         }
+    }
+
+    private void fastSchemaEvolutionInShareNothingMode(SchemaChangeData schemaChangeData)
+            throws DdlException, NotImplementedException {
+        Preconditions.checkState(RunMode.isSharedNothingMode());
+        GlobalStateMgr globalStateMgr = GlobalStateMgr.getCurrentState();
+        long jobId = globalStateMgr.getNextId();
+        long txnId =
+                GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator().getNextTransactionId();
+        long baseIndexId = schemaChangeData.getTable().getBaseIndexId();
+        // for schema change add/drop value column optimize, direct modify table meta.
+        // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
+        // try to copy first before modifying, avoiding in-place changes.
+        Map<Long, Long> indexToNewSchemaId = new HashMap<Long, Long>();
+        for (Long alterIndexId : schemaChangeData.getNewIndexSchema().keySet()) {
+            indexToNewSchemaId.put(alterIndexId, globalStateMgr.getNextId());
+        }
+        // for schema change add/drop value column optimize, direct modify table meta.
+        // when modify this, please also pay attention to the OlapTable#copyOnlyForQuery() operation.
+        // try to copy first before modifying, avoiding in-place changes.
+        modifyTableAddOrDropColumns(schemaChangeData.getDatabase(), schemaChangeData.getTable(),
+                schemaChangeData.getNewIndexSchema(), schemaChangeData.getIndexes(), jobId, txnId,
+                indexToNewSchemaId, false);
+    }
+
+    private AlterJobV2 createJob(@NotNull SchemaChangeData schemaChangeData) throws UserException {
+        AlterJobV2Builder jobBuilder = schemaChangeData.getTable().alterTable();
+        return jobBuilder.withJobId(GlobalStateMgr.getCurrentState().getNextId())
+                .withDbId(schemaChangeData.getDatabase().getId())
+                .withTimeoutSeconds(schemaChangeData.getTimeoutInSeconds())
+                .withAlterIndexInfo(schemaChangeData.isHasIndexChanged(), schemaChangeData.getIndexes())
+                .withStartTime(ConnectContext.get().getStartTime())
+                .withBloomFilterColumns(schemaChangeData.getBloomFilterColumns(), schemaChangeData.getBloomFilterFpp())
+                .withBloomFilterColumnsChanged(schemaChangeData.isBloomFilterColumnsChanged())
+                .withNewIndexShortKeyCount(schemaChangeData.getNewIndexShortKeyCount())
+                .withSortKeyIdxes(schemaChangeData.getSortKeyIdxes())
+                .withSortKeyUniqueIds(schemaChangeData.getSortKeyUniqueIds())
+                .withNewIndexSchema(schemaChangeData.getNewIndexSchema())
+                .build();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/SchemaChangeJobV2.java
@@ -312,20 +312,6 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                     int originSchemaHash = tbl.getSchemaHashByIndexId(originIndexId);
                     KeysType originKeysType = tbl.getKeysTypeByIndexId(originIndexId);
                     List<Column> originSchema = tbl.getSchemaByIndexId(originIndexId);
-
-                    // copy for generate some const default value
-                    List<Column> copiedShadowSchema = Lists.newArrayList();
-                    for (Column column : shadowSchema) {
-                        Column.DefaultValueType defaultValueType = column.getDefaultValueType();
-                        if (defaultValueType == Column.DefaultValueType.CONST) {
-                            Column copiedColumn = new Column(column);
-                            copiedColumn.setDefaultValue(column.calculatedDefaultValueWithTime(startTime));
-                            copiedShadowSchema.add(copiedColumn);
-                        } else {
-                            copiedShadowSchema.add(column);
-                        }
-                    }
-
                     List<Integer> copiedSortKeyIdxes = index.getSortKeyIdxes();
                     List<Integer> copiedSortKeyUniqueIds = index.getSortKeyUniqueIds();
                     // TODO
@@ -377,7 +363,7 @@ public class SchemaChangeJobV2 extends AlterJobV2 {
                                     shadowShortKeyColumnCount, shadowSchemaHash, shadowSchemaVersion,
                                     Partition.PARTITION_INIT_VERSION,
                                     originKeysType, TStorageType.COLUMN, storageMedium,
-                                    copiedShadowSchema, bfColumns, bfFpp, countDownLatch, indexes,
+                                    shadowSchema, bfColumns, bfFpp, countDownLatch, indexes,
                                     tbl.isInMemory(),
                                     tbl.enablePersistentIndex(),
                                     tbl.primaryIndexCacheExpireSec(),

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/DistributionInfo.java
@@ -43,6 +43,7 @@ import org.apache.commons.lang.NotImplementedException;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.List;
 
 public abstract class DistributionInfo implements Writable {
 
@@ -76,6 +77,8 @@ public abstract class DistributionInfo implements Writable {
     }
 
     public abstract boolean supportColocate();
+
+    public abstract List<Column> getDistributionColumns();
 
     public String getDistributionKey() {
         return "";

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HashDistributionInfo.java
@@ -50,6 +50,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import static java.util.Objects.requireNonNull;
+
 /**
  * Hash Distribution Info.
  */
@@ -63,12 +65,12 @@ public class HashDistributionInfo extends DistributionInfo {
 
     public HashDistributionInfo() {
         super();
-        this.distributionColumns = new ArrayList<Column>();
+        this.distributionColumns = new ArrayList<>();
     }
 
     public HashDistributionInfo(int bucketNum, List<Column> distributionColumns) {
         super(DistributionInfoType.HASH);
-        this.distributionColumns = distributionColumns;
+        this.distributionColumns = requireNonNull(distributionColumns, "distributionColumns is null");
         this.bucketNum = bucketNum;
     }
 
@@ -77,6 +79,7 @@ public class HashDistributionInfo extends DistributionInfo {
         return true;
     }
 
+    @Override
     public List<Column> getDistributionColumns() {
         return distributionColumns;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ListPartitionInfo.java
@@ -46,6 +46,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -74,7 +75,7 @@ public class ListPartitionInfo extends PartitionInfo {
     public ListPartitionInfo(PartitionType partitionType,
                              List<Column> partitionColumns) {
         super(partitionType);
-        this.partitionColumns = partitionColumns;
+        this.partitionColumns = Objects.requireNonNull(partitionColumns, "partitionColumns is null");
         this.setIsMultiColumnPartition();
 
         this.idToValues = new HashMap<>();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -123,7 +123,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     @Override
-    public Boolean getUseFastSchemaEvolution() {
+    public boolean getUseFastSchemaEvolution() {
         return false;
     }
 
@@ -1616,7 +1616,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 continue;
             }
             List<Column> partitionColumns = PartitionUtil.getPartitionColumns(table);
-            if (partitionColumns == null) {
+            if (partitionColumns.isEmpty()) {
                 continue;
             }
             SlotRef slotRef = tableToSlotMap.get(table);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -2788,7 +2788,7 @@ public class OlapTable extends Table {
         tableProperty.setForeignKeyConstraints(foreignKeyConstraints);
     }
 
-    public Boolean getUseFastSchemaEvolution() {
+    public boolean getUseFastSchemaEvolution() {
         if (tableProperty != null) {
             return tableProperty.getUseFastSchemaEvolution();
         }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PartitionInfo.java
@@ -37,7 +37,6 @@ package com.starrocks.catalog;
 import com.google.common.base.Preconditions;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.DdlException;
-import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.lake.DataCacheInfo;
@@ -52,9 +51,11 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.validation.constraints.NotNull;
 
 /*
  * Repository of a partition's related infos
@@ -226,8 +227,9 @@ public class PartitionInfo implements Cloneable, Writable, GsonPreProcessable, G
         return "";
     }
 
-    public List<Column> getPartitionColumns() throws NotImplementedException {
-        throw new NotImplementedException("method not implemented yet");
+    @NotNull
+    public List<Column> getPartitionColumns() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RandomDistributionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RandomDistributionInfo.java
@@ -43,6 +43,7 @@ import com.starrocks.sql.ast.RandomDistributionDesc;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -112,6 +113,11 @@ public class RandomDistributionInfo extends DistributionInfo {
         DistributionInfo distributionInfo = new RandomDistributionInfo();
         distributionInfo.readFields(in);
         return distributionInfo;
+    }
+
+    @Override
+    public List<Column> getDistributionColumns() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -98,7 +99,7 @@ public class RangePartitionInfo extends PartitionInfo {
 
     public RangePartitionInfo(List<Column> partitionColumns) {
         super(PartitionType.RANGE);
-        this.partitionColumns = partitionColumns;
+        this.partitionColumns = Objects.requireNonNull(partitionColumns, "partitionColumns is null");
         this.isMultiColumnPartition = partitionColumns.size() > 1;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableProperty.java
@@ -212,7 +212,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
     // foreign key constraint for mv rewrite
     private List<ForeignKeyConstraint> foreignKeyConstraints;
 
-    private Boolean useFastSchemaEvolution;
+    private boolean useFastSchemaEvolution;
 
     private PeriodDuration dataCachePartitionDuration;
 
@@ -807,7 +807,7 @@ public class TableProperty implements Writable, GsonPostProcessable {
         return this;
     }
 
-    public Boolean getUseFastSchemaEvolution() {
+    public boolean getUseFastSchemaEvolution() {
         return useFastSchemaEvolution;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2641,6 +2641,10 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static boolean enable_fast_schema_evolution = true;
 
+    // This configuration will be removed after the shared data mode supports fast schema evolution
+    @ConfField(mutable = true)
+    public static boolean experimental_enable_fast_schema_evolution_in_shared_data = false;
+
     @ConfField(mutable = false)
     public static int pipe_listener_interval_millis = 1000;
     @ConfField(mutable = false)

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/PropertyAnalyzer.java
@@ -612,7 +612,8 @@ public class PropertyAnalyzer {
 
     public static Boolean analyzeUseFastSchemaEvolution(Map<String, String> properties) throws AnalysisException {
         if (properties == null || properties.isEmpty()) {
-            return Config.enable_fast_schema_evolution;
+            return RunMode.isSharedNothingMode() ? Config.enable_fast_schema_evolution
+                    : Config.experimental_enable_fast_schema_evolution_in_shared_data;
         }
         String value = properties.get(PROPERTIES_USE_FAST_SCHEMA_EVOLUTION);
         if (null == value) {

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -377,11 +377,7 @@ public abstract class ConnectorPartitionTraits {
 
         public List<Column> getPartitionColumns() {
             // TODO: check partition type
-            try {
-                return ((OlapTable) table).getPartitionInfo().getPartitionColumns();
-            } catch (com.starrocks.common.NotImplementedException e) {
-                return null;
-            }
+            return ((OlapTable) table).getPartitionInfo().getPartitionColumns();
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorPartitionTraits.java
@@ -376,7 +376,6 @@ public abstract class ConnectorPartitionTraits {
         }
 
         public List<Column> getPartitionColumns() {
-            // TODO: check partition type
             return ((OlapTable) table).getPartitionInfo().getPartitionColumns();
         }
     }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/TableAddOrDropColumnsInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/TableAddOrDropColumnsInfo.java
@@ -45,11 +45,9 @@ import com.starrocks.persist.gson.GsonUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 /**
  * PersistInfo for Table properties
@@ -61,32 +59,25 @@ public class TableAddOrDropColumnsInfo implements Writable {
     @SerializedName(value = "tableId")
     private long tableId;
     @SerializedName(value = "indexSchemaMap")
-    private Map<Long, LinkedList<Column>> indexSchemaMap;
+    private Map<Long, List<Column>> indexSchemaMap;
     @SerializedName(value = "indexes")
     private List<Index> indexes;
     @SerializedName(value = "jobId")
     private long jobId;
     @SerializedName(value = "txnId")
     private long txnId;
-    @SerializedName(value = "startTime")
-    private long startTime;
-    @SerializedName(value = "addColumnsName")
-    private Set<String> addColumnsName;
     @SerializedName(value = "indexToNewSchemaId")
     private Map<Long, Long> indexToNewSchemaId;
 
-    public TableAddOrDropColumnsInfo(long dbId, long tableId,
-            Map<Long, LinkedList<Column>> indexSchemaMap, List<Index> indexes, long jobId,
-            long txnId, long startTime, Set<String> addColumnsName,
-            Map<Long, Long> indexToNewSchemaId) {
+    public TableAddOrDropColumnsInfo(long dbId, long tableId, Map<Long, List<Column>> indexSchemaMap,
+                                     List<Index> indexes, long jobId, long txnId,
+                                     Map<Long, Long> indexToNewSchemaId) {
         this.dbId = dbId;
         this.tableId = tableId;
         this.indexSchemaMap = indexSchemaMap;
         this.indexes = indexes;
         this.jobId = jobId;
         this.txnId = txnId;
-        this.startTime = startTime;
-        this.addColumnsName = addColumnsName;
         this.indexToNewSchemaId = indexToNewSchemaId;
     }
 
@@ -98,7 +89,7 @@ public class TableAddOrDropColumnsInfo implements Writable {
         return tableId;
     }
 
-    public Map<Long, LinkedList<Column>> getIndexSchemaMap() {
+    public Map<Long, List<Column>> getIndexSchemaMap() {
         return indexSchemaMap;
     }
 
@@ -116,14 +107,6 @@ public class TableAddOrDropColumnsInfo implements Writable {
     
     public Map<Long, Long> getIndexToNewSchemaId() {
         return indexToNewSchemaId;
-    }
-
-    public long getStartTime() {
-        return startTime;
-    }
-
-    public Set<String> getAddColumnsName() {
-        return addColumnsName;
     }
 
     @Override
@@ -166,8 +149,6 @@ public class TableAddOrDropColumnsInfo implements Writable {
         sb.append(" indexes: ").append(indexes);
         sb.append(" jobId: ").append(jobId);
         sb.append(" txnId: ").append(txnId);
-        sb.append(" startTime: ").append(startTime);
-        sb.append(" addColumnsName: ").append(addColumnsName);
         sb.append(" indexToNewSchemaId: ").append(indexToNewSchemaId);
         return sb.toString();
     }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -215,7 +215,6 @@ public class OlapTableFactory implements AbstractTableFactory {
                 }
                 String storageVolumeId = svm.getStorageVolumeIdOfTable(tableId);
                 metastore.setLakeStorageInfo(table, storageVolumeId, properties);
-                useFastSchemaEvolution = false;
             } else {
                 table = new OlapTable(tableId, tableName, baseSchema, keysType, partitionInfo, distributionInfo, indexes);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/OlapTableFactory.java
@@ -215,6 +215,7 @@ public class OlapTableFactory implements AbstractTableFactory {
                 }
                 String storageVolumeId = svm.getStorageVolumeIdOfTable(tableId);
                 metastore.setLakeStorageInfo(table, storageVolumeId, properties);
+                useFastSchemaEvolution = false;
             } else {
                 table = new OlapTable(tableId, tableName, baseSchema, keysType, partitionInfo, distributionInfo, indexes);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/InformationSchemaDataSource.java
@@ -31,7 +31,6 @@ import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Table.TableType;
 import com.starrocks.cluster.ClusterNamespace;
 import com.starrocks.common.CaseSensibility;
-import com.starrocks.common.NotImplementedException;
 import com.starrocks.common.PatternMatcher;
 import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.meta.lock.LockType;
@@ -257,17 +256,12 @@ public class InformationSchemaDataSource {
         StringBuilder partitionKeySb = new StringBuilder();
         if (partitionInfo.isRangePartition()) {
             int idx = 0;
-            try {
-                for (Column column : partitionInfo.getPartitionColumns()) {
-                    if (idx != 0) {
-                        partitionKeySb.append(", ");
-                    }
-                    partitionKeySb.append("`").append(column.getName()).append("`");
-                    idx++;
+            for (Column column : partitionInfo.getPartitionColumns()) {
+                if (idx != 0) {
+                    partitionKeySb.append(", ");
                 }
-            } catch (NotImplementedException e) {
-                partitionKeySb.append(DEFAULT_EMPTY_STRING);
-                LOG.warn("The partition of type range seems not implement getPartitionColumns");
+                partitionKeySb.append("`").append(column.getName()).append("`");
+                idx++;
             }
         } else {
             partitionKeySb.append(DEFAULT_EMPTY_STRING);

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterJobV2Test.java
@@ -200,6 +200,7 @@ public class AlterJobV2Test {
             MaterializedView mv2 = (MaterializedView) GlobalStateMgr.getCurrentState().getDb("test").getTable("mv2");
             Assert.assertFalse(mv2.isActive());
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.fail();
         }
     }
@@ -322,6 +323,7 @@ public class AlterJobV2Test {
                 Assert.assertTrue(mv.getInactiveReason().contains("base table schema changed for columns: k2"));
             }
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.fail();
         } finally {
             starRocksAssert.dropTable("modify_column_test4");

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerTest.java
@@ -34,14 +34,12 @@
 
 package com.starrocks.alter;
 
-import com.google.common.collect.Sets;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.Index;
 import com.starrocks.catalog.MaterializedIndexMeta;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
-import com.starrocks.catalog.Type;
 import com.starrocks.common.DdlException;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.ast.AlterTableStmt;
@@ -52,7 +50,6 @@ import org.junit.Assert;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -373,7 +370,7 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         Map<Long, AlterJobV2> alterJobs = globalStateMgr.getSchemaChangeHandler().getAlterJobsV2();
 
         // origin columns
-        Map<Long, LinkedList<Column>> indexSchemaMap = new HashMap<>();
+        Map<Long, List<Column>> indexSchemaMap = new HashMap<>();
         Map<Long, Long> indexToNewSchemaId = new HashMap<>();
         for (Map.Entry<Long, List<Column>> entry : tbl.getIndexIdToSchema().entrySet()) {
             indexSchemaMap.put(entry.getKey(), new LinkedList<>(entry.getValue()));
@@ -383,15 +380,15 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
 
         Assertions.assertDoesNotThrow(
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 100, 100, 100,
-                                                     Collections.emptySet(), indexToNewSchemaId, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 100, 100,
+                                                     indexToNewSchemaId, false));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
         Assertions.assertDoesNotThrow(
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 101, 101, 101,
-                                                     Collections.emptySet(), indexToNewSchemaId, true));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 101, 101,
+                                                     indexToNewSchemaId, true));
         jobSize++;
         Assertions.assertEquals(jobSize, alterJobs.size());
 
@@ -399,36 +396,9 @@ public class SchemaChangeHandlerTest extends TestWithFeService {
         tbl.setState(OlapTableState.ROLLUP);
         Assertions.assertThrows(DdlException.class,
                 () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 102, 102, 102,
-                                                     Collections.emptySet(), indexToNewSchemaId, false));
+                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMap, newIndexes, 102, 102, indexToNewSchemaId,
+                                                     false));
         tbl.setState(beforeState);
-
-        Map<Long, LinkedList<Column>> indexSchemaMapInvalid2 = new HashMap<>(indexSchemaMap);
-
-        // value before key
-        indexSchemaMapInvalid2.get(tbl.getBaseIndexId()).add(0, new Column("kk", Type.INT));
-
-        Assertions.assertThrows(DdlException.class,
-                () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid2, newIndexes, 103, 103, 103,
-                                                     Sets.newHashSet("kk"), indexToNewSchemaId, false));
-
-        Map<Long, LinkedList<Column>> indexSchemaMapInvalid3 = new HashMap<>(indexSchemaMap);
-
-        // not key
-        indexSchemaMapInvalid3.get(tbl.getBaseIndexId()).removeIf(Column::isKey);
-        Assertions.assertThrows(DdlException.class,
-                () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, indexSchemaMapInvalid3, newIndexes, 104, 104, 104,
-                                                     Collections.emptySet(), indexToNewSchemaId, false));
-
-        Map<Long, LinkedList<Column>> emptyIndexMap = new HashMap<>();
-
-        Assertions.assertThrows(DdlException.class,
-                () -> ((SchemaChangeHandler) GlobalStateMgr.getCurrentState().getAlterJobMgr().getSchemaChangeHandler())
-                        .modifyTableAddOrDropColumns(db, tbl, emptyIndexMap, newIndexes, 105, 105, 105, 
-                                                     Collections.emptySet(), indexToNewSchemaId, false));
-
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -224,6 +224,7 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 drop column op_id");
         } catch (Exception e) {
+            e.printStackTrace();
             Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
                     "is used in the related rollup mv1, please drop the rollup index first."));
         }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -224,8 +224,7 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 drop column op_id");
         } catch (Exception e) {
-            e.printStackTrace();
-            Assert.assertTrue(e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
+            Assert.assertTrue(e.getMessage(), e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
                     "is used in the related rollup mv1, please drop the rollup index first."));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/SchemaChangeHandlerWithMVTest.java
@@ -224,7 +224,8 @@ public class SchemaChangeHandlerWithMVTest extends TestWithFeService {
                             "group by timestamp",
                     "alter table sc_dup3 drop column op_id");
         } catch (Exception e) {
-            Assert.assertTrue(e.getMessage(), e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
+            Assert.assertTrue(e.getMessage(),
+                    e.getMessage().contains("Can not drop/modify the column timestamp, because the column " +
                     "is used in the related rollup mv1, please drop the rollup index first."));
         }
     }

--- a/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/persist/TableAddOrDropColumnsInfoTest.java
@@ -23,8 +23,7 @@ public class TableAddOrDropColumnsInfoTest {
     @Test
     public void test() {
         TableAddOrDropColumnsInfo info = new TableAddOrDropColumnsInfo(1, 1,
-                Collections.emptyMap(), Collections.emptyList(), 0, 1, 0,
-                Collections.emptySet(), Collections.emptyMap());
+                Collections.emptyMap(), Collections.emptyList(), 0, 1, Collections.emptyMap());
 
         Assert.assertEquals(1, info.getDbId());
         Assert.assertEquals(1, info.getTableId());
@@ -32,13 +31,10 @@ public class TableAddOrDropColumnsInfoTest {
         Assert.assertEquals(0, info.getIndexSchemaMap().size());
         Assert.assertEquals(0, info.getJobId());
         Assert.assertEquals(1, info.getTxnId());
-        Assert.assertEquals(0, info.getStartTime());
-        Assert.assertEquals(0, info.getAddColumnsName().size());
         Assert.assertEquals(0, info.getIndexToNewSchemaId().size());
 
         TableAddOrDropColumnsInfo info2 = new TableAddOrDropColumnsInfo(1, 1,
-                Collections.emptyMap(), Collections.emptyList(), 0, 1, 0,
-                Collections.emptySet(), Collections.emptyMap());
+                Collections.emptyMap(), Collections.emptyList(), 0, 1, Collections.emptyMap());
 
         Assert.assertEquals(info.hashCode(), info2.hashCode());
         Assert.assertEquals(info, info2);

--- a/test/sql/test_alter_table/R/test_alter_table_abnormal
+++ b/test/sql/test_alter_table/R/test_alter_table_abnormal
@@ -44,7 +44,6 @@ E: (1064, 'Unexpected exception: Can not modify sort column in primary data mode
 -- !result
 ALTER TABLE t0 MODIFY COLUMN v1 VARCHAR(100) MAX;
 -- result:
-E: (1064, 'Unexpected exception: Nothing is changed. please check your alter stmt.')
 -- !result
 ALTER TABLE t0 ADD column k2 SMALLINT KEY;
 -- result:
@@ -226,3 +225,60 @@ SELECT * from t2;
 -- result:
 0	2024-01-01 00:00:00	10	100
 -- !result
+-- name: test_drop_partition_or_distribution_column
+CREATE TABLE t9 (
+c0 int(11) NULL COMMENT "",
+c1 int(11) NOT NULL COMMENT ""
+)
+DUPLICATE KEY(c0)
+PARTITION BY LIST(c1)(
+PARTITION p0 VALUES IN ('0'),
+PARTITION p1 VALUES IN ('1')
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES ("fast_schema_evolution" = "true", "replication_num"="1");
+-- result:
+-- !result
+ALTER TABLE t9 DROP COLUMN c1;
+-- result:
+E: (1064, 'Unexpected exception: Partition column[c1] cannot be dropped. index[t9]')
+-- !result
+CREATE TABLE t10 (
+c0 int(11) NULL COMMENT "",
+c1 int(11) NOT NULL COMMENT ""
+)
+DUPLICATE KEY(c0)
+PARTITION BY LIST(c1)(
+PARTITION p0 VALUES IN ('0'),
+PARTITION p1 VALUES IN ('1')
+)
+DISTRIBUTED BY HASH(c0) BUCKETS 1
+PROPERTIES ("fast_schema_evolution" = "false", "replication_num"="1");
+-- result:
+-- !result
+ALTER TABLE t10 DROP COLUMN c1;
+-- result:
+E: (1064, 'Unexpected exception: Partition column[c1] cannot be dropped. index[t10]')
+-- !result
+CREATE TABLE site_access1 (
+    event_day DATETIME NOT NULL,
+    site_id INT DEFAULT '10',
+    city_code VARCHAR(100),
+    user_name VARCHAR(32) DEFAULT '',
+    pv BIGINT DEFAULT '0'
+)
+DUPLICATE KEY(event_day, site_id, city_code, user_name)
+PARTITION BY date_trunc('day', event_day)
+DISTRIBUTED BY HASH(event_day, site_id)
+PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+ALTER TABLE site_access1 DROP COLUMN event_day;
+-- result:
+E: (1064, 'Unexpected exception: Partition column[event_day] cannot be dropped. index[site_access1]')
+-- !result
+ALTER TABLE site_access1 DROP COLUMN site_id;
+-- result:
+E: (1064, 'Unexpected exception: Distribution column[site_id] cannot be dropped. index[site_access1]')
+-- !result
+


### PR DESCRIPTION
This PR is part of the PR stack to support fast schema evolution in shared data mode.

The PR itself doesn't add any new functionality, it's just a refactoring of existing code to facilitate the development of fast schema evolution in the future.
- Unified analyze code between fast and non-fast schema evolution paths for consistency
- Removed duplicate default value calculation logic
- Eliminated unnecessary null checks
- Added PartitionInfo::getPartitionColumns() to reduce schema change coupling  
- Added DistributionInfo::getDistributionColumns() to reduce schema change coupling

Fixes #38263 

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
