### PR TITLE
[BugFix] fix wrong order by scope for distinct query

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -675,10 +675,10 @@ public class SelectAnalyzer {
                                              boolean isDistinct) {
 
         List<Field> allFields = Lists.newArrayList();
-        // order by can only "see" fields from distinct output
         if (isDistinct) {
             allFields = removeDuplicateField(outputScope.getRelationFields().getAllFields());
             Scope orderScope = new Scope(outputScope.getRelationId(), new RelationFields(allFields));
+            orderScope.setParent(sourceScope);
             analyzeState.setOrderScope(orderScope);
             return orderScope;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/SelectAnalyzer.java
@@ -14,7 +14,6 @@
 
 package com.starrocks.sql.analyzer;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -353,8 +352,6 @@ public class SelectAnalyzer {
                 }
 
                 if (!aggregations.isEmpty()) {
-                    // use parent scope to analyze agg func firstly
-                    Preconditions.checkState(orderByScope.getParent() != null, "parent scope not be set");
                     aggregations.forEach(e -> analyzeExpression(e, analyzeState, orderByScope.getParent()));
                 }
                 analyzeExpression(expression, analyzeState, orderByScope);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -136,6 +136,12 @@ public class AnalyzeAggregateTest {
                 " must be an aggregate expression or appear in GROUP BY clause");
         analyzeFail("select * from t0 order by max(v2)",
                 "column must appear in the GROUP BY clause or be used in an aggregate function.");
+        analyzeFail("select distinct max(v1) from t0",
+                "cannot combine SELECT DISTINCT with aggregate functions or GROUP BY");
+        analyzeFail("select distinct abs(v1) from t0 order by max(v1)",
+                "for SELECT DISTINCT, ORDER BY expressions must appear in select list");
+        analyzeFail("select distinct abs(v1) from t0 order by max(v2)",
+                "for SELECT DISTINCT, ORDER BY expressions must appear in select list");
 
         analyzeSuccess("select distinct v1 as v from t0 having v = 1");
         analyzeFail("select distinct v1 as v from t0 having v2 = 2",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeAggregateTest.java
@@ -131,9 +131,9 @@ public class AnalyzeAggregateTest {
         analyzeSuccess("select distinct v1, v2 as v from t0 order by v");
         analyzeSuccess("select distinct abs(v1) as v from t0 order by v");
         analyzeFail("select distinct v1 from t0 order by v2",
-                "Column 'v2' cannot be resolved");
+                "must be an aggregate expression or appear in GROUP BY clause");
         analyzeFail("select distinct v1 as v from t0 order by v2",
-                "Column 'v2' cannot be resolved");
+                " must be an aggregate expression or appear in GROUP BY clause");
         analyzeFail("select * from t0 order by max(v2)",
                 "column must appear in the GROUP BY clause or be used in an aggregate function.");
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/OrderByTest.java
@@ -676,6 +676,9 @@ class OrderByTest extends PlanTestBase {
         list.add(Arguments.of("select v1, * from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));
         list.add(Arguments.of("select distinct * from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select distinct *, v1 from t0  order by abs(v1)", "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select distinct abs(v1) v1 from t0 order by v1", "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select distinct abs(v1) from t0 order by abs(v1)", "order by: <slot 4> 4: abs ASC"));
+        list.add(Arguments.of("select distinct abs(v1) v1 from t0 order by abs(v1)", "order by: <slot 5> 5: abs ASC"));
         return list.stream();
     }
 
@@ -693,6 +696,7 @@ class OrderByTest extends PlanTestBase {
         list.add(Arguments.of("select *, v1, upper(v1) v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select distinct upper(v1) v1, *, v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
         list.add(Arguments.of("select distinct *, v1, upper(v1) v1 from t0 order by v1", "order by: <slot 1> 1: v1 ASC"));
+        list.add(Arguments.of("select distinct abs(v1) v1, v1 from t0 order by v1", "order by: <slot 4> 4: abs ASC"));
 
         return list.stream();
     }


### PR DESCRIPTION
Why I'm doing:
Fix [#5535](https://github.com/StarRocks/StarRocksTest/issues/5535)
The #37910 change the distinct order by scope from `scope([], parentScope(tbl.col1, tbl.col2, ...))` to `scope([col1, col2, ...], parentScope(null))`, which makes sql like `select distinct abs(v1) from tbl order by abs(v1)` cannot be correctly anazlyed because  `abs(v1)` in order by cannot found `v1` in order by scope.

What I'm doing:
remain the parentScope in distinct order by scope. 
Sql like `select distinct abs(v1) from tbl order by v1` cannot pass the analyzer for this below check. This check need all exprs in order by should be a `aggFunc` or  in `group by Expr`.
```
if (orderByElements.size() > 0) {
                new AggregationAnalyzer(session, analyzeState, groupByExpressions, sourceScope, sourceAndOutputScope)
                        .verify(orderByExpressions);
            }
```
Sql like `select distinct abs(v1) from tbl order by max(v2)` cannot pass the analyze for this below check.
```
if (isDistinct && !aggregations.isEmpty()) {
                    throw new SemanticException("for SELECT DISTINCT, ORDER BY expressions must appear in select list",
                            expression.getPos());
                }
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
