### PR TITLE
[BugFix] support abort sink in the connector metadata

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/CatalogConnectorMetadata.java
@@ -197,6 +197,11 @@ public class CatalogConnectorMetadata implements ConnectorMetadata {
     }
 
     @Override
+    public void abortSink(String dbName, String table, List<TSinkCommitInfo> commitInfos) {
+        normal.abortSink(dbName, table, commitInfos);
+    }
+
+    @Override
     public void alterTable(AlterTableStmt stmt) throws UserException {
         normal.alterTable(stmt);
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/ConnectorMetadata.java
@@ -226,6 +226,9 @@ public interface ConnectorMetadata {
         throw new StarRocksConnectorException("This connector doesn't support sink");
     }
 
+    default void abortSink(String dbName, String table, List<TSinkCommitInfo> commitInfos) {
+    }
+
     default void alterTable(AlterTableStmt stmt) throws UserException {
         throw new StarRocksConnectorException("This connector doesn't support alter table");
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetadata.java
@@ -44,6 +44,7 @@ import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.Statistics;
 import com.starrocks.statistic.StatisticUtils;
+import com.starrocks.thrift.THiveFileInfo;
 import com.starrocks.thrift.TSinkCommitInfo;
 import org.apache.hadoop.fs.Path;
 import org.apache.logging.log4j.LogManager;
@@ -328,6 +329,24 @@ public class HiveMetadata implements ConnectorMetadata {
         HiveCommitter committer = new HiveCommitter(
                 hmsOps, fileOps, updateExecutor, refreshOthersFeExecutor, table, new Path(stagingDir));
         committer.commit(partitionUpdates);
+    }
+
+    @Override
+    public void abortSink(String dbName, String tableName, List<TSinkCommitInfo> commitInfos) {
+        if (commitInfos == null || commitInfos.isEmpty()) {
+            return;
+        }
+        boolean hasHiveSinkInfo = commitInfos.stream().anyMatch(TSinkCommitInfo::isSetHive_file_info);
+        if (!hasHiveSinkInfo) {
+            return;
+        }
+
+        for (TSinkCommitInfo sinkCommitInfo : commitInfos) {
+            if (sinkCommitInfo.isSetHive_file_info()) {
+                THiveFileInfo hiveFileInfo = sinkCommitInfo.getHive_file_info();
+                fileOps.deleteIfExists(new Path(hiveFileInfo.getPartition_path(), hiveFileInfo.getFile_name()), false);
+            }
+        }
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2108,7 +2108,8 @@ public class StmtExecutor {
                             externalTable.getSourceTablePort(),
                             errMsg);
                 } else if (targetTable.isExternalTableWithFileSystem()) {
-                    // ignored
+                    GlobalStateMgr.getCurrentState().getMetadataMgr().abortSink(
+                            catalogName, dbName, tableName, coord.getSinkCommitInfos());
                 } else {
                     transactionMgr.abortTransaction(
                             database.getId(), transactionId,

--- a/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/MetadataMgr.java
@@ -486,4 +486,16 @@ public class MetadataMgr {
             }
         });
     }
+
+    public void abortSink(String catalogName, String dbName, String tableName, List<TSinkCommitInfo> sinkCommitInfos) {
+        Optional<ConnectorMetadata> connectorMetadata = getOptionalMetadata(catalogName);
+        connectorMetadata.ifPresent(metadata -> {
+            try {
+                metadata.abortSink(dbName, tableName, sinkCommitInfos);
+            } catch (StarRocksConnectorException e) {
+                LOG.error("table sink abort failed", e);
+                throw new StarRocksConnectorException(e.getMessage());
+            }
+        });
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/CatalogConnectorMetadataTest.java
@@ -179,6 +179,7 @@ public class CatalogConnectorMetadataTest {
                 connectorMetadata.truncateTable(null);
                 connectorMetadata.alterTableComment(null, null, null);
                 connectorMetadata.finishSink("test_db", "test_tbl", null);
+                connectorMetadata.abortSink("test_db", "test_tbl", null);
                 connectorMetadata.createTableLike(null);
                 connectorMetadata.createTable(null);
                 connectorMetadata.createDb("test_db");
@@ -214,6 +215,7 @@ public class CatalogConnectorMetadataTest {
         catalogConnectorMetadata.truncateTable(null);
         catalogConnectorMetadata.alterTableComment(null, null, null);
         catalogConnectorMetadata.finishSink("test_db", "test_tbl", null);
+        catalogConnectorMetadata.abortSink("test_db", "test_tbl", null);
         catalogConnectorMetadata.createTableLike(null);
         catalogConnectorMetadata.createTable(null);
         catalogConnectorMetadata.createDb("test_db");

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetadataTest.java
@@ -367,6 +367,21 @@ public class HiveMetadataTest {
         hiveMetadata.finishSink("hive_db", "hive_table", Lists.newArrayList(tSinkCommitInfo));
     }
 
+    @Test
+    public void testAbortSink() {
+        TSinkCommitInfo tSinkCommitInfo = new TSinkCommitInfo();
+        hiveMetadata.abortSink("hive_db", "hive_table", Lists.newArrayList());
+        hiveMetadata.abortSink("hive_db", "hive_table", Lists.newArrayList(tSinkCommitInfo));
+
+        THiveFileInfo fileInfo = new THiveFileInfo();
+        fileInfo.setFile_name("myfile.parquet");
+        fileInfo.setPartition_path("hdfs://127.0.0.1:10000/tmp/starrocks/queryid/col1=2");
+        fileInfo.setRecord_count(10);
+        fileInfo.setFile_size_in_bytes(100);
+        tSinkCommitInfo.setHive_file_info(fileInfo);
+        hiveMetadata.abortSink("hive_db", "hive_table", Lists.newArrayList(tSinkCommitInfo));
+    }
+
     @Test(expected = StarRocksConnectorException.class)
     public void testAddPartition() throws Exception {
         String stagingDir = "hdfs://127.0.0.1:10000/tmp/starrocks/queryid";

--- a/test/sql/test_hive/R/test_hive_sink
+++ b/test/sql/test_hive/R/test_hive_sink
@@ -1,0 +1,53 @@
+-- name: test_hive_sink
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+-- result:
+[]
+-- !result
+set catalog hive_sink_test_${uuid0};
+-- result:
+[]
+-- !result
+create database hive_db_${uuid0};
+-- result:
+[]
+-- !result
+use hive_db_${uuid0};
+-- result:
+[]
+-- !result
+create table t1 (k1 int, k2 int, k3 date, k4 smallint) partition by (k3, k4);
+-- result:
+[]
+-- !result
+insert into t1 select 999,888,'9999-12-03', 3;
+-- result:
+[]
+-- !result
+select * from t1;
+-- result:
+999	888	9999-12-03	3
+-- !result
+insert into t1 values( 999,888,'9999-12-03', 3),( 999,888,'9999-12-33', 3);
+-- result:
+E: (1064, "Partition value can't be null.")
+-- !result
+select * from t1;
+-- result:
+999	888	9999-12-03	3
+-- !result
+drop table t1 force;
+-- result:
+[]
+-- !result
+drop database hive_db_${uuid0};
+-- result:
+[]
+-- !result
+drop catalog hive_sink_test_${uuid0};
+-- result:
+[]
+-- !result
+set catalog default_catalog;
+-- result:
+[]
+-- !result

--- a/test/sql/test_hive/T/test_hive_sink
+++ b/test/sql/test_hive/T/test_hive_sink
@@ -1,0 +1,15 @@
+-- name: test_hive_sink
+
+create external catalog hive_sink_test_${uuid0} PROPERTIES ("type"="hive", "hive.metastore.uris"="${hive_metastore_uris}");
+set catalog hive_sink_test_${uuid0};
+create database hive_db_${uuid0};
+use hive_db_${uuid0};
+create table t1 (k1 int, k2 int, k3 date, k4 smallint) partition by (k3, k4);
+insert into t1 select 999,888,'9999-12-03', 3;
+select * from t1;
+insert into t1 values( 999,888,'9999-12-03', 3),( 999,888,'9999-12-33', 3);
+select * from t1;
+drop table t1 force;
+drop database hive_db_${uuid0};
+drop catalog hive_sink_test_${uuid0};
+set catalog default_catalog;


### PR DESCRIPTION
Why I'm doing:

When multiple be execute sink tasks, if a be fails to write, the query will fail, but some of the files may be written successfully in the others nodes. These files are not written to temporary directories on s3, but directly under the target table, and the written files need to be aborted.

What I'm doing:

Fixes #issue
https://github.com/StarRocks/StarRocksTest/issues/5281

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
