### PR TITLE
[BugFix] Fix common type is date when date compare datetime

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/ImplicitCastRule.java
@@ -165,7 +165,8 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
             if (op.isPresent()) {
                 predicate.getChildren().set(0, op.get());
                 return predicate;
-            } else if (rightChild.getType().isDateType() && Type.canCastTo(leftChild.getType(), rightChild.getType())) {
+            } else if (rightChild.getType().isDateType() && !leftChild.getType().isDateType() &&
+                    Type.canCastTo(leftChild.getType(), rightChild.getType())) {
                 // For like MySQL, convert to date type as much as possible
                 addCastChild(rightChild.getType(), predicate, 0);
                 return predicate;
@@ -175,7 +176,8 @@ public class ImplicitCastRule extends TopDownScalarOperatorRewriteRule {
             if (op.isPresent()) {
                 predicate.getChildren().set(1, op.get());
                 return predicate;
-            } else if (leftChild.getType().isDateType() && Type.canCastTo(rightChild.getType(), leftChild.getType())) {
+            } else if (leftChild.getType().isDateType() && !rightChild.getType().isDateType() &&
+                    Type.canCastTo(rightChild.getType(), leftChild.getType())) {
                 // For like MySQL, convert to date type as much as possible
                 addCastChild(leftChild.getType(), predicate, 1);
                 return predicate;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -70,6 +70,22 @@ public class ExpressionTest extends PlanTestBase {
         sql = "select t1a, t1b from test_all_type where id_datetime > 2000";
         plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: 8: id_datetime > CAST(2000 AS DATETIME)");
+
+        sql = "select t1a, t1b from test_all_type where id_date > (datetime '2000-01-01 12:00:00')";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 9: id_date >= '2000-01-02'");
+
+        sql = "select t1a, t1b from test_all_type where (datetime '2000-01-01 12:00:00') > id_date";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "9: id_date <= '2000-01-01'");
+
+        sql = "select t1a, t1b from test_all_type where (date '2000-01-01') > id_datetime";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 8: id_datetime < '2000-01-01 00:00:00'");
+
+        sql = "select t1a, t1b from test_all_type where id_datetime > (date '2000-01-01')";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: 8: id_datetime > '2000-01-01 00:00:00'");
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Bug:

When variable date compare(</<=/>/>=/=/!=) constant datetime,  common type will use DATE, let datetime's hour/mintue/second lose

```
MySQL td> select * from da0;
+----+----+------------+
| v1 | v2 | v3         |
+----+----+------------+
| 1  | 1  | 2023-12-30 |
+----+----+------------+
1 row in set
Time: 0.034s
MySQL td>   select v3 >= (datetime '2023-12-30 12:00:00') from da0;
+-----------------------------+
| v3 >= '2023-12-30 12:00:00' |
+-----------------------------+
| 1                           |
+-----------------------------+
1 row in set
Time: 0.016s
MySQL td> explain verbose select v3 >= (datetime '2023-12-30 12:00:00') from da0;
+------------------------------------------------+
| Explain String                                 |
+------------------------------------------------+
| RESOURCE GROUP: default_wg                     |
|                                                |
| PLAN FRAGMENT 0(F01)                           |
|   Output Exprs:4: expr                         |
|   Input Partition: UNPARTITIONED               |
|   RESULT SINK                                  |
|                                                |
|   2:EXCHANGE                                   |
|      cardinality: 1                            |
|                                                |
| PLAN FRAGMENT 1(F00)                           |
|                                                |
|   Input Partition: RANDOM                      |
|   OutPut Partition: UNPARTITIONED              |
|   OutPut Exchange Id: 02                       |
|                                                |
|   1:Project                                    |
|   |  output columns:                           |
|   |  4 <-> [3: v3, DATE, true] >= '2023-12-30' |
|   |  cardinality: 1                            |
|   |                                            |
|   0:OlapScanNode                               |
|      table: da0, rollup: da0                   |
|      preAggregation: on                        |
|      partitionsRatio=1/1, tabletsRatio=3/3     |
|      tabletList=7486026,7486028,7486030        |
|      actualRows=1, avgRowSize=8.0              |
|      cardinality: 1                            |
+------------------------------------------------+
28 rows in set
Time: 0.009s

```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
