### PR TITLE
[BugFix] Should not add full row column in vertical compaction's rowset writer

### DIFF
--- a/be/src/column/schema.cpp
+++ b/be/src/column/schema.cpp
@@ -209,7 +209,7 @@ std::vector<std::string> Schema::field_names() const {
 std::vector<std::string> Schema::value_field_names() const {
     std::vector<std::string> names;
     for (const auto& field : _fields) {
-        if (!field->is_key() && "__row" != field->name()) {
+        if (!field->is_key() && Schema::FULL_ROW_COLUMN != field->name()) {
             names.emplace_back(field->name());
         }
     }
@@ -219,7 +219,7 @@ std::vector<std::string> Schema::value_field_names() const {
 std::vector<ColumnId> Schema::value_field_column_ids() const {
     std::vector<ColumnId> column_ids;
     for (const auto& field : _fields) {
-        if (!field->is_key() && "__row" != field->name()) {
+        if (!field->is_key() && Schema::FULL_ROW_COLUMN != field->name()) {
             column_ids.emplace_back(field->id());
         }
     }
@@ -229,7 +229,7 @@ std::vector<ColumnId> Schema::value_field_column_ids() const {
 std::vector<ColumnId> Schema::field_column_ids(bool use_rowstore) const {
     std::vector<ColumnId> column_ids;
     for (const auto& field : _fields) {
-        if (use_rowstore || "__row" != field->name()) {
+        if (use_rowstore || Schema::FULL_ROW_COLUMN != field->name()) {
             column_ids.emplace_back(field->id());
         }
     }

--- a/be/src/column/schema.h
+++ b/be/src/column/schema.h
@@ -31,6 +31,8 @@ public:
     Schema(Schema&&) = default;
     Schema& operator=(Schema&&) = default;
 
+    inline static const std::string FULL_ROW_COLUMN = "__row";
+
 #ifdef BE_TEST
     explicit Schema(Fields fields);
 #endif

--- a/be/src/storage/delta_writer.cpp
+++ b/be/src/storage/delta_writer.cpp
@@ -201,8 +201,8 @@ Status DeltaWriter::_init() {
     RETURN_IF_ERROR(_build_current_tablet_schema(_opt.index_id, _opt.ptable_schema_param, tablet_schema_ptr));
     size_t real_num_columns = _tablet_schema->num_columns();
     if (_tablet->is_column_with_row_store()) {
-        if (_tablet_schema->columns().back().name() != "__row") {
-            return Status::InternalError("bad column_with_row schema, not __row column");
+        if (_tablet_schema->columns().back().name() != Schema::FULL_ROW_COLUMN) {
+            return Status::InternalError("bad column_with_row schema, no __row column");
         }
         real_num_columns -= 1;
     }

--- a/be/src/storage/memtable.cpp
+++ b/be/src/storage/memtable.cpp
@@ -45,7 +45,7 @@ Schema MemTable::convert_schema(const TabletSchemaCSPtr& tablet_schema,
         const auto& last_column = tablet_schema->columns().back();
         // remove last __row column if exists, because it's not used in memtable
         int ncolumn = tablet_schema->num_columns();
-        if (last_column.name() == "__row") {
+        if (last_column.name() == Schema::FULL_ROW_COLUMN) {
             ncolumn--;
         }
         vector<ColumnId> column_idxes;
@@ -157,7 +157,7 @@ bool MemTable::is_full() const {
 }
 
 bool MemTable::check_supported_column_partial_update(const Chunk& chunk) {
-    return _vectorized_schema->field_names().back() != "__row" ||
+    return _vectorized_schema->field_names().back() != Schema::FULL_ROW_COLUMN ||
            chunk.num_columns() == _vectorized_schema->num_fields() - 1;
 }
 
@@ -170,7 +170,7 @@ StatusOr<bool> MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uin
     auto full_row_col = std::make_unique<BinaryColumn>();
     if (_keys_type == PRIMARY_KEYS) {
         std::unique_ptr<Schema> schema_without_full_row_column;
-        if (_vectorized_schema->field_names().back() == "__row") {
+        if (_vectorized_schema->field_names().back() == Schema::FULL_ROW_COLUMN) {
             DCHECK_GE(chunk.num_columns(), _vectorized_schema->num_fields() - 1);
             std::vector<ColumnId> cids(_vectorized_schema->num_fields() - 1);
             for (int i = 0; i < _vectorized_schema->num_fields() - 1; i++) {
@@ -201,7 +201,7 @@ StatusOr<bool> MemTable::insert(const Chunk& chunk, const uint32_t* indexes, uin
             dest->append_selective(*src, indexes, from, size);
         }
         if (is_column_with_row) {
-            ColumnPtr& dest = _chunk->get_column_by_name("__row");
+            ColumnPtr& dest = _chunk->get_column_by_name(Schema::FULL_ROW_COLUMN);
             dest->append(*full_row_col.get());
         }
     } else {

--- a/be/src/storage/rowset/segment_writer.cpp
+++ b/be/src/storage/rowset/segment_writer.cpp
@@ -215,7 +215,7 @@ Status SegmentWriter::init(const std::vector<uint32_t>& column_indexes, bool has
         _index_builder = std::make_unique<ShortKeyIndexBuilder>(_segment_id, _opts.num_rows_per_block);
     }
     const auto& column = _tablet_schema->columns().back();
-    if (column.name() == "__row") {
+    if (column.name() == Schema::FULL_ROW_COLUMN) {
         std::vector<ColumnId> cids(_tablet_schema->num_columns() - 1);
         for (int i = 0; i < _tablet_schema->num_columns() - 1; i++) {
             cids[i] = i;
@@ -354,7 +354,12 @@ Status SegmentWriter::append_chunk(const Chunk& chunk) {
         RETURN_IF_ERROR(_column_writers[i]->append(*col));
     }
 
-    if (chunk_num_columns + 1 == _tablet_schema->num_columns() && _tablet_schema->columns().back().name() == "__row") {
+    // TODO(cbl): put the fill full row column logic here is a bit hacky, this segment writer is used in many other
+    //            situations(compaction etc.), so better to put it into somewhere early in the write pipeline
+    //            likely in _sink->flush_chunk at MemTable::flush
+    if (_column_writers.size() == _tablet_schema->num_columns() &&
+        _tablet_schema->columns().back().name() == Schema::FULL_ROW_COLUMN &&
+        chunk_num_columns + 1 == _column_writers.size()) {
         // just missing full row column, generate it and write to file
         auto full_row_col = std::make_unique<BinaryColumn>();
         auto row_encoder = RowStoreEncoderFactory::instance()->get_or_create_encoder(SIMPLE);

--- a/be/src/storage/rowset_merger.cpp
+++ b/be/src/storage/rowset_merger.cpp
@@ -433,6 +433,8 @@ private:
             Schema schema = tablet_schema->sort_key_idxes().empty()
                                     ? ChunkHelper::convert_schema(tablet_schema, column_groups[0])
                                     : ChunkHelper::get_sort_key_schema(tablet_schema);
+            // NOTE: although we switch to horizontal merge, the writer used is still VerticalRowsetWriter
+            // so it's important to make sure VerticalRowsetWriter can function properly when used in horizontal way
             RETURN_IF_ERROR(_do_merge_horizontally(tablet, tablet_schema, version, schema, rowsets, writer, cfg,
                                                    total_input_size, total_rows, total_chunk, stats, mask_buffer.get(),
                                                    &rowsets_mask_buffer));

--- a/be/src/storage/rowset_update_state.cpp
+++ b/be/src/storage/rowset_update_state.cpp
@@ -371,7 +371,7 @@ Status RowsetUpdateState::_prepare_partial_update_states(Tablet* tablet, Rowset*
     std::vector<uint32_t> read_column_ids;
     for (uint32_t i = 0; i < tablet_schema->num_columns(); i++) {
         const auto& tablet_column = tablet_schema->column(i);
-        if (tablet_column.name() == "__row") {
+        if (tablet_column.name() == Schema::FULL_ROW_COLUMN) {
             continue;
         }
         if (update_columns_set.find(tablet_column.unique_id()) == update_columns_set.end()) {
@@ -719,7 +719,7 @@ Status RowsetUpdateState::apply(Tablet* tablet, const TabletSchemaCSPtr& tablet_
             const auto& tablet_column = _tablet_schema->column(i);
             if (update_columns_set.find(tablet_column.unique_id()) == update_columns_set.end()) {
                 read_column_ids.emplace_back(i);
-                if (tablet_column.name() != "__row") {
+                if (tablet_column.name() != Schema::FULL_ROW_COLUMN) {
                     read_column_ids_without_full_row.push_back(i);
                 }
             }

--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1326,7 +1326,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
         }
         normal_request.tablet_schema.columns.emplace_back();
         TColumn& column = normal_request.tablet_schema.columns.back();
-        column.__set_column_name("__row");
+        column.__set_column_name(Schema::FULL_ROW_COLUMN);
         TColumnType ctype;
         ctype.__set_type(TPrimitiveType::VARCHAR);
         //TODO

--- a/be/src/storage/tablet_schema.cpp
+++ b/be/src/storage/tablet_schema.cpp
@@ -520,7 +520,7 @@ Status TabletSchema::build_current_tablet_schema(int64_t index_id, int32_t versi
             _cols.emplace_back(std::move(column));
             _num_columns++;
         }
-        if (ori_tablet_schema->columns().back().name() == "__row") {
+        if (ori_tablet_schema->columns().back().name() == Schema::FULL_ROW_COLUMN) {
             _cols.emplace_back(ori_tablet_schema->columns().back());
         }
     }

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -294,7 +294,7 @@ public:
         const auto nkeys = keys.size();
         const auto& column = tablet->thread_safe_get_tablet_schema()->columns().back();
         std::vector<ColumnId> cids(tablet->thread_safe_get_tablet_schema()->num_columns() - 1);
-        if (column.name() == "__row") {
+        if (column.name() == Schema::FULL_ROW_COLUMN) {
             for (int i = 0; i < tablet->thread_safe_get_tablet_schema()->num_columns() - 1; i++) {
                 cids[i] = i;
             }
@@ -538,7 +538,7 @@ public:
         request.tablet_schema.columns.push_back(k3);
 
         TColumn row;
-        row.column_name = "__row";
+        row.column_name = Schema::FULL_ROW_COLUMN;
         TColumnType ctype;
         ctype.__set_type(TPrimitiveType::VARCHAR);
         ctype.__set_len(65535);


### PR DESCRIPTION
Why I'm doing:

There is a bug in segment writer's write path, when doing vertical compaction, it will mistakenly consider it a case to add a full row column in the input chunk, causing BE to crash. 

What I'm doing:

Change the condition logic to rule out this case. Also change all "__row" usage to using a const var.

Fixes #38132

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
