### PR TITLE
[Enhancement] Optimize the performance of calc mem usage for bitmap column

### DIFF
--- a/be/src/storage/chunk_helper.cpp
+++ b/be/src/storage/chunk_helper.cpp
@@ -543,26 +543,32 @@ void ChunkPipelineAccumulator::push(const ChunkPtr& chunk) {
     DCHECK(_out_chunk == nullptr);
     if (_in_chunk == nullptr) {
         _in_chunk = chunk;
+        _mem_usage = chunk->memory_usage();
     } else if (_in_chunk->num_rows() + chunk->num_rows() > _max_size) {
         _out_chunk = std::move(_in_chunk);
         _in_chunk = chunk;
+        _mem_usage = chunk->memory_usage();
     } else {
         _in_chunk->append(*chunk);
+        _mem_usage += chunk->memory_usage();
     }
 
-    if (_out_chunk == nullptr && (_in_chunk->num_rows() >= _max_size * LOW_WATERMARK_ROWS_RATE ||
-                                  _in_chunk->memory_usage() >= LOW_WATERMARK_BYTES)) {
+    if (_out_chunk == nullptr &&
+        (_in_chunk->num_rows() >= _max_size * LOW_WATERMARK_ROWS_RATE || _mem_usage >= LOW_WATERMARK_BYTES)) {
         _out_chunk = std::move(_in_chunk);
+        _mem_usage = 0;
     }
 }
 
 void ChunkPipelineAccumulator::reset() {
     _in_chunk.reset();
     _out_chunk.reset();
+    _mem_usage = 0;
 }
 
 void ChunkPipelineAccumulator::finalize() {
     _finalized = true;
+    _mem_usage = 0;
 }
 
 void ChunkPipelineAccumulator::reset_state() {

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -130,10 +130,17 @@ public:
 
 private:
     static constexpr double LOW_WATERMARK_ROWS_RATE = 0.75;          // 0.75 * chunk_size
+#ifdef BE_TEST
+    static constexpr size_t LOW_WATERMARK_BYTES = 64 * 1024; // 64KB.
+#else
     static constexpr size_t LOW_WATERMARK_BYTES = 256 * 1024 * 1024; // 256MB.
+#endif
     ChunkPtr _in_chunk = nullptr;
     ChunkPtr _out_chunk = nullptr;
     size_t _max_size = 4096;
+    // For bitmap columns, the cost of calculating mem_usage is relatively high,
+    // so incremental calculation is used to avoid becoming a performance bottleneck.
+    size_t _mem_usage = 0;
     bool _finalized = false;
 };
 

--- a/be/src/storage/chunk_helper.h
+++ b/be/src/storage/chunk_helper.h
@@ -129,7 +129,7 @@ public:
     bool is_finished() const;
 
 private:
-    static constexpr double LOW_WATERMARK_ROWS_RATE = 0.75;          // 0.75 * chunk_size
+    static constexpr double LOW_WATERMARK_ROWS_RATE = 0.75; // 0.75 * chunk_size
 #ifdef BE_TEST
     static constexpr size_t LOW_WATERMARK_BYTES = 64 * 1024; // 64KB.
 #else

--- a/be/test/storage/chunk_helper_test.cpp
+++ b/be/test/storage/chunk_helper_test.cpp
@@ -14,12 +14,9 @@
 
 #include "storage/chunk_helper.h"
 
-#include "column/binary_column.h"
 #include "column/chunk.h"
 #include "column/column.h"
-#include "column/field.h"
 #include "column/nullable_column.h"
-#include "column/schema.h"
 #include "common/object_pool.h"
 #include "gtest/gtest.h"
 #include "runtime/descriptor_helper.h"
@@ -27,23 +24,11 @@
 #include "runtime/mem_tracker.h"
 #include "runtime/runtime_state.h"
 #include "types/logical_type.h"
-#include "util/logging.h"
 
 namespace starrocks {
 
-class ChunkHelperTest : public testing::Test {
-public:
-    void add_tablet_column(TabletSchemaPB& tablet_schema_pb, int32_t id, bool is_key, const std::string& type,
-                           int32_t length, bool is_nullable);
-    SchemaPtr gen_v_schema(bool is_nullable);
-    void check_chunk(Chunk* chunk, size_t column_size, size_t row_size);
-    void check_chunk_nullable(Chunk* chunk, size_t column_size, size_t row_size);
-    void check_column(Column* column, LogicalType type, size_t row_size);
-
-private:
-    LogicalType _type[9] = {TYPE_TINYINT, TYPE_SMALLINT, TYPE_INT,     TYPE_BIGINT, TYPE_LARGEINT,
-                            TYPE_FLOAT,   TYPE_DOUBLE,   TYPE_VARCHAR, TYPE_CHAR};
-
+class ChunkHelperTest : public ::testing::Test {
+protected:
     LogicalType _primitive_type[9] = {LogicalType::TYPE_TINYINT, LogicalType::TYPE_SMALLINT, LogicalType::TYPE_INT,
                                       LogicalType::TYPE_BIGINT,  LogicalType::TYPE_LARGEINT, LogicalType::TYPE_FLOAT,
                                       LogicalType::TYPE_DOUBLE,  LogicalType::TYPE_VARCHAR,  LogicalType::TYPE_CHAR};
@@ -107,125 +92,7 @@ TupleDescriptor* ChunkHelperTest::_create_tuple_desc() {
     return tuple_desc;
 }
 
-void ChunkHelperTest::add_tablet_column(TabletSchemaPB& tablet_schema_pb, int32_t id, bool is_key,
-                                        const std::string& type, int32_t length, bool is_nullable) {
-    ColumnPB* column = tablet_schema_pb.add_column();
-    column->set_unique_id(id);
-    column->set_name("c" + std::to_string(id));
-    column->set_type(type);
-    column->set_is_key(is_key);
-    column->set_length(length);
-    column->set_is_nullable(is_nullable);
-    column->set_aggregation("NONE");
-}
-
-SchemaPtr ChunkHelperTest::gen_v_schema(bool is_nullable) {
-    Fields fields;
-    fields.emplace_back(std::make_shared<Field>(0, "c0", get_type_info(TYPE_TINYINT), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(1, "c1", get_type_info(TYPE_SMALLINT), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(2, "c2", get_type_info(TYPE_INT), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(3, "c3", get_type_info(TYPE_BIGINT), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(4, "c4", get_type_info(TYPE_LARGEINT), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(5, "c5", get_type_info(TYPE_FLOAT), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(6, "c6", get_type_info(TYPE_DOUBLE), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(7, "c7", get_type_info(TYPE_VARCHAR), is_nullable));
-    fields.emplace_back(std::make_shared<Field>(8, "c8", get_type_info(TYPE_CHAR), is_nullable));
-    return std::make_shared<Schema>(fields);
-}
-
-void ChunkHelperTest::check_chunk(Chunk* chunk, size_t column_size, size_t row_size) {
-    CHECK_EQ(chunk->columns().size(), column_size);
-    for (size_t i = 0; i < column_size; i++) {
-        check_column(chunk->get_column_by_index(i).get(), _type[i], row_size);
-    }
-}
-
-void ChunkHelperTest::check_chunk_nullable(Chunk* chunk, size_t column_size, size_t row_size) {
-    CHECK_EQ(chunk->columns().size(), column_size);
-    for (size_t i = 0; i < column_size; i++) {
-        Column* d_column =
-                (reinterpret_cast<NullableColumn*>(chunk->get_column_by_index(i).get()))->data_column().get();
-        check_column(d_column, _type[i], row_size);
-    }
-}
-
-void ChunkHelperTest::check_column(Column* column, LogicalType type, size_t row_size) {
-    ASSERT_EQ(column->size(), row_size);
-
-    switch (type) {
-    case TYPE_TINYINT: {
-        const auto* data = reinterpret_cast<const int8_t*>(static_cast<Int8Column*>(column)->raw_data());
-        for (int i = 0; i < row_size; i++) {
-            ASSERT_EQ(*(data + i), static_cast<int8_t>(i * 2));
-        }
-        break;
-    }
-    case TYPE_SMALLINT: {
-        const auto* data = reinterpret_cast<const int16_t*>(static_cast<Int16Column*>(column)->raw_data());
-        for (int i = 0; i < row_size; i++) {
-            ASSERT_EQ(*(data + i), static_cast<int16_t>(i * 2 * 10));
-        }
-        break;
-    }
-    case TYPE_INT: {
-        const auto* data = reinterpret_cast<const int32_t*>(static_cast<Int32Column*>(column)->raw_data());
-        for (int i = 0; i < row_size; i++) {
-            ASSERT_EQ(*(data + i), static_cast<int32_t>(i * 2 * 100));
-        }
-        break;
-    }
-    case TYPE_BIGINT: {
-        const auto* data = reinterpret_cast<const int64_t*>(static_cast<Int64Column*>(column)->raw_data());
-        for (int i = 0; i < row_size; i++) {
-            ASSERT_EQ(*(data + i), static_cast<int64_t>(i * 2 * 1000));
-        }
-        break;
-    }
-    case TYPE_LARGEINT: {
-        const auto* data = reinterpret_cast<const int128_t*>(static_cast<Int128Column*>(column)->raw_data());
-        for (int i = 0; i < row_size; i++) {
-            ASSERT_EQ(*(data + i), static_cast<int128_t>(i * 2 * 10000));
-        }
-        break;
-    }
-    case TYPE_FLOAT: {
-        const auto* data = reinterpret_cast<const float*>(static_cast<FloatColumn*>(column)->raw_data());
-        for (int i = 0; i < row_size; i++) {
-            ASSERT_EQ(*(data + i), static_cast<float>(i * 2 * 100000));
-        }
-        break;
-    }
-    case TYPE_DOUBLE: {
-        const auto* data = reinterpret_cast<const double*>(static_cast<DoubleColumn*>(column)->raw_data());
-        for (int i = 0; i < row_size; i++) {
-            ASSERT_EQ(*(data + i), static_cast<double>(i * 2 * 1000000));
-        }
-        break;
-    }
-    case TYPE_VARCHAR: {
-        const auto* data = reinterpret_cast<const BinaryColumn*>(column);
-        for (int i = 0; i < row_size; i++) {
-            Slice l = data->get_slice(i);
-            Slice r(std::to_string(i * 2 * 10000000));
-            ASSERT_EQ(l, r);
-        }
-        break;
-    }
-    case TYPE_CHAR: {
-        const auto* data = reinterpret_cast<const BinaryColumn*>(column);
-        for (int i = 0; i < row_size; i++) {
-            Slice l = data->get_slice(i);
-            Slice r(std::to_string(i * 2 * 100000000));
-            ASSERT_EQ(l, r);
-        }
-        break;
-    }
-    default:
-        break;
-    }
-}
-
-TEST_F(ChunkHelperTest, NewChunkWithTuple) {
+TEST_F(ChunkHelperTest, new_chunk_with_tuple) {
     auto* tuple_desc = _create_tuple_desc();
 
     auto chunk = ChunkHelper::new_chunk(*tuple_desc, 1024);
@@ -318,6 +185,81 @@ TEST_F(ChunkHelperTest, Accumulator) {
     auto output = accumulator.pull();
     EXPECT_EQ(nullptr, output);
     EXPECT_TRUE(accumulator.reach_limit());
+}
+
+class ChunkPipelineAccumulatorTest : public ::testing::Test {
+protected:
+    ChunkPtr _generate_chunk(size_t rows, size_t cols);
+};
+
+ChunkPtr ChunkPipelineAccumulatorTest::_generate_chunk(size_t rows, size_t cols) {
+    auto chunk = std::make_shared<Chunk>();
+    for (size_t i = 0; i < cols; i++) {
+        auto col = Int8Column::create(rows, 0);
+        chunk->append_column(col, i);
+    }
+    return chunk;
+}
+
+TEST_F(ChunkPipelineAccumulatorTest, test_push) {
+    ChunkPipelineAccumulator accumulator;
+
+    // rows reach limit
+    accumulator.push(_generate_chunk(4093, 1));
+    ASSERT_TRUE(accumulator.has_output());
+    auto result_chunk = std::move(accumulator.pull());
+    ASSERT_EQ(result_chunk->num_rows(), 4093);
+    accumulator.finalize();
+    ASSERT_FALSE(accumulator.has_output());
+
+    // mem reach limit
+    accumulator.reset_state();
+    accumulator.push(_generate_chunk(2048, 64));
+    ASSERT_TRUE(accumulator.has_output());
+    result_chunk = std::move(accumulator.pull());
+    ASSERT_EQ(result_chunk->num_rows(), 2048);
+    accumulator.finalize();
+    ASSERT_FALSE(accumulator.has_output());
+
+    // merge chunk and reach rows limit
+    accumulator.reset_state();
+    for (size_t i = 0; i < 3; i++) {
+        accumulator.push(_generate_chunk(1000, 1));
+        ASSERT_FALSE(accumulator.has_output());
+    }
+    accumulator.push(_generate_chunk(1000, 1));
+    ASSERT_TRUE(accumulator.has_output());
+    result_chunk = std::move(accumulator.pull());
+    ASSERT_EQ(result_chunk->num_rows(), 4000);
+    accumulator.finalize();
+    ASSERT_FALSE(accumulator.has_output());
+
+    // merge chunk and read mem limit
+    accumulator.reset_state();
+    for (size_t i = 0; i < 2; i++) {
+        accumulator.push(_generate_chunk(1000, 30));
+        ASSERT_FALSE(accumulator.has_output());
+    }
+    accumulator.push(_generate_chunk(1000, 30));
+    ASSERT_TRUE(accumulator.has_output());
+    result_chunk = std::move(accumulator.pull());
+    ASSERT_EQ(result_chunk->num_rows(), 3000);
+    accumulator.finalize();
+    ASSERT_FALSE(accumulator.has_output());
+
+    // merge chunk and rows overflow
+    accumulator.reset_state();
+    accumulator.push(_generate_chunk(3000, 1));
+    ASSERT_FALSE(accumulator.has_output());
+    accumulator.push(_generate_chunk(3000, 1));
+    ASSERT_TRUE(accumulator.has_output());
+    result_chunk = std::move(accumulator.pull());
+    ASSERT_EQ(result_chunk->num_rows(), 3000);
+    accumulator.finalize();
+    ASSERT_TRUE(accumulator.has_output());
+    result_chunk = std::move(accumulator.pull());
+    ASSERT_EQ(result_chunk->num_rows(), 3000);
+    ASSERT_FALSE(accumulator.has_output());
 }
 
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:

BitmapValue's calculation of mem usage will consume large CPU, and every time accumulator appends a chunk, it needs to calculate all the value of bitmap column.

What I'm doing:

Incrementally calculate mem usage of chunk

Benchmark case: https://github.com/StarRocks/StarRocksBenchmark/pull/471

Before Optimization: 73s

* CHUNK_ACCUMULATE: 59.5s
* OtherJoinConjunctEvaluateTime: 8s372ms
* OutputBuildColumnTime: 3s42ms
* SearchHashTableTime: 1s377ms

After Optimization: 21.8s

* CHUNK_ACCUMULATE: 8.1s
* OtherJoinConjunctEvaluateTime: 8s361ms
* OutputBuildColumnTime: 3s65ms
* SearchHashTableTime: 1s343ms

```
mysql> select count(*) from lineorder;                                                                                                                                                                                                                                            
+-----------+                                                                                                                                                                                                                                                                     
| count(*)  |                                                                                                                                                                                                                                                                     
+-----------+                                                                                                                                                                                                                                                                     
| 143999468 |                                                                                                                                                                                                                                                                     
+-----------+

mysql> select distinct(lo_linenumber) from lineorder;                                                                                     
+---------------+
| lo_linenumber |
+---------------+
|             4 |
|             1 |
|             5 |
|             2 |
|             6 |
|             3 |
|             7 |
+---------------+

mysql> select k1, bitmap_count(v1) from bitmap_1m where k1>=1 and k1<=7;
+------+------------------+
| k1   | bitmap_count(v1) |
+------+------------------+
|    2 |           239065 |
|    1 |           239149 |
|    3 |           239137 |
|    4 |           239042 |
|    5 |           238654 |
|    6 |           239415 |
|    7 |           239186 |
+------+------------------+

select count(lo_partkey), count(v1) from lineorder join bitmap_1m on lo_linenumber=k1 and bitmap_contains(v1, lo_orderkey);
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
