### PR TITLE
[Enhancement] Using LazyColumnReader in orc lazy materialization

### DIFF
--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
@@ -2112,28 +2112,28 @@ std::unique_ptr<ColumnReader> buildReader(const Type& type, std::shared_ptr<Stri
 
     case FLOAT:
     case DOUBLE:
-        return std::unique_ptr<ColumnReader>(new DoubleColumnReader(type, *stripePtr.get()));
+        return std::unique_ptr<ColumnReader>(new DoubleColumnReader(type, *stripe.get()));
 
     case TIMESTAMP:
-        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, *stripePtr.get(), false));
+        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, *stripe.get(), false));
 
     case TIMESTAMP_INSTANT:
-        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, *stripePtr.get(), true));
+        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, *stripe.get(), true));
 
     case DECIMAL:
         // is this a Hive 0.11 or 0.12 file?
         if (type.getPrecision() == 0) {
-            return std::unique_ptr<ColumnReader>(new DecimalHive11ColumnReader(type, *stripePtr.get()));
+            return std::unique_ptr<ColumnReader>(new DecimalHive11ColumnReader(type, *stripe.get()));
         }
         // can we represent the values using int64_t?
         if (type.getPrecision() <= Decimal64ColumnReader::MAX_PRECISION_64) {
-            if (stripePtr->isDecimalAsLong()) {
-                return std::unique_ptr<ColumnReader>(new Decimal64ColumnReaderV2(type, *stripePtr.get()));
+            if (stripe->isDecimalAsLong()) {
+                return std::unique_ptr<ColumnReader>(new Decimal64ColumnReaderV2(type, *stripe.get()));
             }
-            return std::unique_ptr<ColumnReader>(new Decimal64ColumnReader(type, *stripePtr.get()));
+            return std::unique_ptr<ColumnReader>(new Decimal64ColumnReader(type, *stripe.get()));
         }
         // otherwise we use the Int128 implementation
-        return std::unique_ptr<ColumnReader>(new Decimal128ColumnReader(type, *stripePtr.get()));
+        return std::unique_ptr<ColumnReader>(new Decimal128ColumnReader(type, *stripe.get()));
 
     default:
         throw NotImplementedYet("buildReader unhandled type");

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.cc
@@ -145,6 +145,69 @@ void expandBytesToLongs(int64_t* buffer, uint64_t numValues) {
     }
 }
 
+class LazyColumnReader final : public ColumnReader {
+public:
+    LazyColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe) : type(type), stripe(stripe) {
+        columnId = type.getColumnId();
+    }
+
+    ~LazyColumnReader() override = default;
+
+    uint64_t skip(uint64_t numValues) override {
+        tryInit();
+        return childColumnReader->skip(numValues);
+    }
+
+    void next(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override {
+        tryInit();
+        childColumnReader->next(rowBatch, numValues, notNull);
+    }
+
+    void nextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override {
+        tryInit();
+        childColumnReader->nextEncoded(rowBatch, numValues, notNull);
+    }
+
+    void seekToRowGroup(PositionProviderMap* providers) override {
+        tryInit();
+        childColumnReader->seekToRowGroup(providers);
+    }
+
+    void lazyLoadSkip(uint64_t numValues) override {
+        tryInit();
+        childColumnReader->lazyLoadSkip(numValues);
+    }
+
+    void lazyLoadNext(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override {
+        tryInit();
+        childColumnReader->lazyLoadNext(rowBatch, numValues, notNull);
+    }
+
+    void lazyLoadNextEncoded(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull) override {
+        tryInit();
+        childColumnReader->lazyLoadNextEncoded(rowBatch, numValues, notNull);
+    }
+
+    void lazyLoadSeekToRowGroup(PositionProviderMap* providers) override {
+        tryInit();
+        childColumnReader->lazyLoadSeekToRowGroup(providers);
+    }
+
+private:
+    void tryInit() {
+        if (!isInit) {
+            childColumnReader = buildReader(type, stripe);
+            isInit = true;
+        }
+    }
+
+    bool isInit = false;
+    const Type& type;
+    // We need use shared_ptr to hold stripe, otherwise, when LazyColumnReader is created, the life cycle of stripe has ended.
+    std::shared_ptr<StripeStreams> stripe;
+    std::unique_ptr<ColumnReader> childColumnReader;
+};
+
 class BooleanColumnReader : public ColumnReader {
 private:
     std::unique_ptr<orc::ByteRleDecoder> rle;
@@ -995,7 +1058,7 @@ private:
     std::vector<uint64_t> lazyLoadFieldIndex;
 
 public:
-    StructColumnReader(const Type& type, StripeStreams& stipe);
+    StructColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe);
 
     uint64_t skip(uint64_t numValues) override;
 
@@ -1026,11 +1089,12 @@ private:
     bool isAllFieldsLazy();
 };
 
-StructColumnReader::StructColumnReader(const Type& type, StripeStreams& stripe) : ColumnReader(type, stripe) {
+StructColumnReader::StructColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe)
+        : ColumnReader(type, *stripe.get()) {
     // count the number of selected sub-columns
-    const std::vector<bool> selectedColumns = stripe.getSelectedColumns();
-    const std::vector<bool> lazyLoadColumns = stripe.getLazyLoadColumns();
-    switch (static_cast<int64_t>(stripe.getEncoding(columnId).kind())) {
+    const std::vector<bool> selectedColumns = stripe->getSelectedColumns();
+    const std::vector<bool> lazyLoadColumns = stripe->getLazyLoadColumns();
+    switch (static_cast<int64_t>(stripe->getEncoding(columnId).kind())) {
     case proto::ColumnEncoding_Kind_DIRECT: {
         uint64_t fi = 0;
         for (unsigned int i = 0; i < type.getSubtypeCount(); ++i) {
@@ -1038,7 +1102,9 @@ StructColumnReader::StructColumnReader(const Type& type, StripeStreams& stripe) 
             auto columnId = static_cast<uint64_t>(child.getColumnId());
             if (selectedColumns[columnId]) {
                 if (lazyLoadColumns[columnId]) {
-                    lazyLoadChildren.push_back(buildReader(child, stripe));
+                    // Using LazyColumnReader, will initilize ColumnReader when need it
+                    lazyLoadChildren.push_back(std::make_unique<LazyColumnReader>(child, stripe));
+                    // lazyLoadChildren.push_back(buildReader(child, stripe));
                     lazyLoadFieldIndex.push_back(fi);
                 } else {
                     children.push_back(buildReader(child, stripe));
@@ -1153,7 +1219,7 @@ private:
     std::unique_ptr<RleDecoder> rle;
 
 public:
-    ListColumnReader(const Type& type, StripeStreams& stipe);
+    ListColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe);
     ~ListColumnReader() override;
 
     uint64_t skip(uint64_t numValues) override;
@@ -1175,13 +1241,14 @@ private:
     void nextInternal(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull);
 };
 
-ListColumnReader::ListColumnReader(const Type& type, StripeStreams& stripe) : ColumnReader(type, stripe) {
+ListColumnReader::ListColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe)
+        : ColumnReader(type, *stripe.get()) {
     // count the number of selected sub-columns
-    const std::vector<bool> selectedColumns = stripe.getSelectedColumns();
-    RleVersion vers = convertRleVersion(stripe.getEncoding(columnId).kind());
-    std::unique_ptr<SeekableInputStream> stream = stripe.getStream(columnId, proto::Stream_Kind_LENGTH, true);
+    const std::vector<bool> selectedColumns = stripe->getSelectedColumns();
+    RleVersion vers = convertRleVersion(stripe->getEncoding(columnId).kind());
+    std::unique_ptr<SeekableInputStream> stream = stripe->getStream(columnId, proto::Stream_Kind_LENGTH, true);
     if (stream == nullptr) throw ParseError("LENGTH stream not found in List column");
-    rle = createRleDecoder(std::move(stream), false, vers, memoryPool, metrics, stripe.getSharedBuffer());
+    rle = createRleDecoder(std::move(stream), false, vers, memoryPool, metrics, stripe->getSharedBuffer());
     const Type& childType = *type.getSubtype(0);
     if (selectedColumns[static_cast<uint64_t>(childType.getColumnId())]) {
         child = buildReader(childType, stripe);
@@ -1310,7 +1377,7 @@ private:
     std::unique_ptr<RleDecoder> rle;
 
 public:
-    MapColumnReader(const Type& type, StripeStreams& stipe);
+    MapColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe);
     ~MapColumnReader() override;
 
     uint64_t skip(uint64_t numValues) override;
@@ -1332,13 +1399,14 @@ private:
     void nextInternal(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull);
 };
 
-MapColumnReader::MapColumnReader(const Type& type, StripeStreams& stripe) : ColumnReader(type, stripe) {
+MapColumnReader::MapColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe)
+        : ColumnReader(type, *stripe.get()) {
     // Determine if the key and/or value columns are selected
-    const std::vector<bool> selectedColumns = stripe.getSelectedColumns();
-    RleVersion vers = convertRleVersion(stripe.getEncoding(columnId).kind());
-    std::unique_ptr<SeekableInputStream> stream = stripe.getStream(columnId, proto::Stream_Kind_LENGTH, true);
+    const std::vector<bool> selectedColumns = stripe->getSelectedColumns();
+    RleVersion vers = convertRleVersion(stripe->getEncoding(columnId).kind());
+    std::unique_ptr<SeekableInputStream> stream = stripe->getStream(columnId, proto::Stream_Kind_LENGTH, true);
     if (stream == nullptr) throw ParseError("LENGTH stream not found in Map column");
-    rle = createRleDecoder(std::move(stream), false, vers, memoryPool, metrics, stripe.getSharedBuffer());
+    rle = createRleDecoder(std::move(stream), false, vers, memoryPool, metrics, stripe->getSharedBuffer());
     const Type& keyType = *type.getSubtype(0);
     if (selectedColumns[static_cast<uint64_t>(keyType.getColumnId())]) {
         keyReader = buildReader(keyType, stripe);
@@ -1505,7 +1573,7 @@ private:
     uint64_t numChildren;
 
 public:
-    UnionColumnReader(const Type& type, StripeStreams& stipe);
+    UnionColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe);
 
     uint64_t skip(uint64_t numValues) override;
 
@@ -1520,16 +1588,17 @@ private:
     void nextInternal(ColumnVectorBatch& rowBatch, uint64_t numValues, char* notNull);
 };
 
-UnionColumnReader::UnionColumnReader(const Type& type, StripeStreams& stripe) : ColumnReader(type, stripe) {
+UnionColumnReader::UnionColumnReader(const Type& type, std::shared_ptr<StripeStreams>& stripe)
+        : ColumnReader(type, *stripe.get()) {
     numChildren = type.getSubtypeCount();
     childrenReader.resize(numChildren);
     childrenCounts.resize(numChildren);
 
-    std::unique_ptr<SeekableInputStream> stream = stripe.getStream(columnId, proto::Stream_Kind_DATA, true);
+    std::unique_ptr<SeekableInputStream> stream = stripe->getStream(columnId, proto::Stream_Kind_DATA, true);
     if (stream == nullptr) throw ParseError("LENGTH stream not found in Union column");
     rle = createByteRleDecoder(std::move(stream), metrics);
     // figure out which types are selected
-    const std::vector<bool> selectedColumns = stripe.getSelectedColumns();
+    const std::vector<bool> selectedColumns = stripe->getSelectedColumns();
     for (unsigned int i = 0; i < numChildren; ++i) {
         const Type& child = *type.getSubtype(i);
         if (selectedColumns[static_cast<size_t>(child.getColumnId())]) {
@@ -2001,33 +2070,33 @@ void DecimalHive11ColumnReader::next(ColumnVectorBatch& rowBatch, uint64_t numVa
 /**
    * Create a reader for the given stripe.
    */
-std::unique_ptr<ColumnReader> buildReader(const Type& type, StripeStreams& stripe) {
+std::unique_ptr<ColumnReader> buildReader(const Type& type, std::shared_ptr<StripeStreams>& stripe) {
     switch (static_cast<int64_t>(type.getKind())) {
     case DATE:
     case INT:
     case LONG:
     case SHORT:
-        return std::unique_ptr<ColumnReader>(new IntegerColumnReader(type, stripe));
+        return std::unique_ptr<ColumnReader>(new IntegerColumnReader(type, *stripe.get()));
     case BINARY:
     case CHAR:
     case STRING:
     case VARCHAR:
-        switch (static_cast<int64_t>(stripe.getEncoding(type.getColumnId()).kind())) {
+        switch (static_cast<int64_t>(stripe->getEncoding(type.getColumnId()).kind())) {
         case proto::ColumnEncoding_Kind_DICTIONARY:
         case proto::ColumnEncoding_Kind_DICTIONARY_V2:
-            return std::unique_ptr<ColumnReader>(new StringDictionaryColumnReader(type, stripe));
+            return std::unique_ptr<ColumnReader>(new StringDictionaryColumnReader(type, *stripe.get()));
         case proto::ColumnEncoding_Kind_DIRECT:
         case proto::ColumnEncoding_Kind_DIRECT_V2:
-            return std::unique_ptr<ColumnReader>(new StringDirectColumnReader(type, stripe));
+            return std::unique_ptr<ColumnReader>(new StringDirectColumnReader(type, *stripe.get()));
         default:
             throw NotImplementedYet("buildReader unhandled string encoding");
         }
 
     case BOOLEAN:
-        return std::unique_ptr<ColumnReader>(new BooleanColumnReader(type, stripe));
+        return std::unique_ptr<ColumnReader>(new BooleanColumnReader(type, *stripe.get()));
 
     case BYTE:
-        return std::unique_ptr<ColumnReader>(new ByteColumnReader(type, stripe));
+        return std::unique_ptr<ColumnReader>(new ByteColumnReader(type, *stripe.get()));
 
     case LIST:
         return std::unique_ptr<ColumnReader>(new ListColumnReader(type, stripe));
@@ -2043,28 +2112,28 @@ std::unique_ptr<ColumnReader> buildReader(const Type& type, StripeStreams& strip
 
     case FLOAT:
     case DOUBLE:
-        return std::unique_ptr<ColumnReader>(new DoubleColumnReader(type, stripe));
+        return std::unique_ptr<ColumnReader>(new DoubleColumnReader(type, *stripePtr.get()));
 
     case TIMESTAMP:
-        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, stripe, false));
+        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, *stripePtr.get(), false));
 
     case TIMESTAMP_INSTANT:
-        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, stripe, true));
+        return std::unique_ptr<ColumnReader>(new TimestampColumnReader(type, *stripePtr.get(), true));
 
     case DECIMAL:
         // is this a Hive 0.11 or 0.12 file?
         if (type.getPrecision() == 0) {
-            return std::unique_ptr<ColumnReader>(new DecimalHive11ColumnReader(type, stripe));
+            return std::unique_ptr<ColumnReader>(new DecimalHive11ColumnReader(type, *stripePtr.get()));
         }
         // can we represent the values using int64_t?
         if (type.getPrecision() <= Decimal64ColumnReader::MAX_PRECISION_64) {
-            if (stripe.isDecimalAsLong()) {
-                return std::unique_ptr<ColumnReader>(new Decimal64ColumnReaderV2(type, stripe));
+            if (stripePtr->isDecimalAsLong()) {
+                return std::unique_ptr<ColumnReader>(new Decimal64ColumnReaderV2(type, *stripePtr.get()));
             }
-            return std::unique_ptr<ColumnReader>(new Decimal64ColumnReader(type, stripe));
+            return std::unique_ptr<ColumnReader>(new Decimal64ColumnReader(type, *stripePtr.get()));
         }
         // otherwise we use the Int128 implementation
-        return std::unique_ptr<ColumnReader>(new Decimal128ColumnReader(type, stripe));
+        return std::unique_ptr<ColumnReader>(new Decimal128ColumnReader(type, *stripePtr.get()));
 
     default:
         throw NotImplementedYet("buildReader unhandled type");

--- a/be/src/formats/orc/apache-orc/c++/src/ColumnReader.hh
+++ b/be/src/formats/orc/apache-orc/c++/src/ColumnReader.hh
@@ -134,6 +134,8 @@ protected:
     ReaderMetrics* metrics;
 
 public:
+    // Default construtor, only used for LazyColumnReader
+    ColumnReader() : columnId(0), memoryPool(*getDefaultPool()), metrics(nullptr) {}
     ColumnReader(const Type& type, StripeStreams& stipe);
 
     virtual ~ColumnReader();
@@ -194,7 +196,7 @@ public:
 /**
    * Create a reader for the given stripe.
    */
-std::unique_ptr<ColumnReader> buildReader(const Type& type, StripeStreams& stripe);
+std::unique_ptr<ColumnReader> buildReader(const Type& type, std::shared_ptr<StripeStreams>& stripe);
 
 // collect string dictionary from column reader
 void collectStringDictionary(ColumnReader* reader, std::unordered_map<uint64_t, StringDictionary*>& coll);

--- a/be/src/formats/orc/apache-orc/c++/src/Reader.cc
+++ b/be/src/formats/orc/apache-orc/c++/src/Reader.cc
@@ -435,7 +435,8 @@ void RowReaderImpl::loadStripeIndex() {
     for (int i = 0; i < currentStripeFooter.streams_size(); ++i) {
         const proto::Stream& pbStream = currentStripeFooter.streams(i);
         uint64_t colId = pbStream.column();
-        if (selectedColumns[colId] && pbStream.has_kind() &&
+        // We only need to load active column's RowIndex
+        if (selectedColumns[colId] && !lazyLoadColumns[colId] && pbStream.has_kind() &&
             (pbStream.kind() == proto::Stream_Kind_ROW_INDEX ||
              pbStream.kind() == proto::Stream_Kind_BLOOM_FILTER_UTF8)) {
             std::unique_ptr<SeekableInputStream> inStream =
@@ -1108,9 +1109,10 @@ void RowReaderImpl::startNextStripe() {
                                                      ? getTimezoneByName(currentStripeFooter.writertimezone())
                                                      : getLocalTimezone();
 
-            StripeStreamsImpl stripeStreams(*this, currentStripe, currentStripeInfo, currentStripeFooter,
-                                            currentStripeInfo.offset(), *contents->stream, writerTimezone,
-                                            readerTimezone);
+            // We need use shared_ptr to hold stripe, otherwise, when LazyColumnReader is created, the life cycle of stripe has ended.
+            std::shared_ptr<StripeStreams> stripeStreams = std::make_shared<StripeStreamsImpl>(
+                    *this, currentStripe, currentStripeInfo, currentStripeFooter, currentStripeInfo.offset(),
+                    *contents->stream, writerTimezone, readerTimezone);
             reader = buildReader(*contents->schema, stripeStreams);
 
             if (sargsApplier) {


### PR DESCRIPTION
Why I'm doing:
Although the ORC reader has implemented lazy materialization, the lazy column's ColumnReader will still be created before reading. Creating ColumnReader itself will bring a lot of overhead(including `memset()` and `malloc()`). If the lazy columns are not used, which means these ColumnReader's overheads are unnecessary.

![me-original](https://github.com/StarRocks/starrocks/assets/18729228/7ab01b15-6004-4d98-8656-45400a8e5437)

What I'm doing:
Introducing LazyColumnReader, It will only be created when it is needed.

Reduce `loadStripeIndex()` and `buildReader()` overhead.

Now flame graph is:
![me-new-new](https://github.com/StarRocks/starrocks/assets/18729228/52dd84fb-aca5-4f42-b399-89fc2a98ff0c)


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
