### PR TITLE
[BugFix] Set instance memtracker in Connector Sink IO task

### DIFF
--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -72,7 +72,7 @@ public:
 private:
     std::string _new_file_location();
 
-    Status _new_file_writer();
+    Status _new_file_writer(RuntimeState* state);
     Status close_current_writer(RuntimeState* state);
 
 private:

--- a/be/src/formats/parquet/file_writer.cpp
+++ b/be/src/formats/parquet/file_writer.cpp
@@ -19,6 +19,7 @@
 #include <arrow/io/file.h>
 #include <arrow/io/interfaces.h>
 #include <parquet/arrow/writer.h>
+#include <runtime/current_thread.h>
 
 #include "column/array_column.h"
 #include "column/chunk.h"
@@ -436,13 +437,14 @@ AsyncFileWriter::AsyncFileWriter(std::unique_ptr<WritableFile> writable_file, st
                                  std::shared_ptr<::parquet::WriterProperties> properties,
                                  std::shared_ptr<::parquet::schema::GroupNode> schema,
                                  const std::vector<ExprContext*>& output_expr_ctxs, PriorityThreadPool* executor_pool,
-                                 RuntimeProfile* parent_profile, int64_t max_file_size)
+                                 RuntimeProfile* parent_profile, int64_t max_file_size, RuntimeState* state)
         : FileWriterBase(std::move(writable_file), std::move(properties), std::move(schema), output_expr_ctxs,
                          max_file_size),
           _file_location(std::move(file_location)),
           _partition_location(std::move(partition_location)),
           _executor_pool(executor_pool),
-          _parent_profile(parent_profile) {
+          _parent_profile(parent_profile),
+          _state(state) {
     _io_timer = ADD_TIMER(_parent_profile, "FileWriterIoTimer");
 }
 
@@ -453,6 +455,7 @@ Status AsyncFileWriter::_flush_row_group() {
     }
 
     bool ok = _executor_pool->try_offer([&]() {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_state->instance_mem_tracker());
         SCOPED_TIMER(_io_timer);
         if (_chunk_writer != nullptr) {
             try {
@@ -487,6 +490,7 @@ Status AsyncFileWriter::_flush_row_group() {
 Status AsyncFileWriter::close(RuntimeState* state,
                               const std::function<void(starrocks::parquet::AsyncFileWriter*, RuntimeState*)>& cb) {
     bool ret = _executor_pool->try_offer([&, state, cb]() {
+        SCOPED_THREAD_LOCAL_MEM_TRACKER_SETTER(_state->instance_mem_tracker());
         SCOPED_TIMER(_io_timer);
         {
             auto lock = std::unique_lock(_m);

--- a/be/src/formats/parquet/file_writer.h
+++ b/be/src/formats/parquet/file_writer.h
@@ -181,7 +181,7 @@ public:
                     std::string partition_location, std::shared_ptr<::parquet::WriterProperties> properties,
                     std::shared_ptr<::parquet::schema::GroupNode> schema,
                     const std::vector<ExprContext*>& output_expr_ctxs, PriorityThreadPool* executor_pool,
-                    RuntimeProfile* parent_profile, int64_t max_file_size);
+                    RuntimeProfile* parent_profile, int64_t max_file_size, RuntimeState* state);
 
     ~AsyncFileWriter() override = default;
 
@@ -225,6 +225,8 @@ private:
 
     RuntimeProfile* _parent_profile = nullptr;
     RuntimeProfile::Counter* _io_timer = nullptr;
+
+    RuntimeState* _state;
 
     std::condition_variable _cv;
     bool _rg_writer_closing = false;


### PR DESCRIPTION
Why I'm doing:

In the current implementation, memory allocation at executor threads will be recorded. But the reclamation of these memory at IO threads will not be recorded. This causes the query pool memory to accumulate during the query process. 

What I'm doing:

Set instance memtracker at the beginning of IO task. Then the task is submitted to the IO threadpool.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
