### PR TITLE
[BugFix] Add more error messages for tablet lost replicas error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -80,7 +80,11 @@ import com.starrocks.lake.LakeTablet;
 import com.starrocks.load.Load;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
-import com.starrocks.sql.analyzer.*;
+import com.starrocks.sql.analyzer.Field;
+import com.starrocks.sql.analyzer.RelationFields;
+import com.starrocks.sql.analyzer.RelationId;
+import com.starrocks.sql.analyzer.Scope;
+import com.starrocks.sql.analyzer.SelectAnalyzer;
 import com.starrocks.sql.common.MetaUtils;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TColumn;
@@ -102,18 +106,17 @@ import com.starrocks.thrift.TUniqueId;
 import com.starrocks.thrift.TWriteQuorumType;
 import com.starrocks.transaction.TransactionState;
 import com.starrocks.warehouse.Warehouse;
-import java.util.Collection;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
-
 import java.util.stream.Collectors;
 
 public class OlapTableSink extends DataSink {
@@ -669,8 +672,10 @@ public class OlapTableSink extends DataSink {
                                     localTablet.getNormalReplicaBackendPathMap(table.getClusterId());
                             if (bePathsMap.keySet().size() < quorum) {
                                 throw new UserException(InternalErrorCode.REPLICA_FEW_ERR,
-                                        "Tablet lost replicas. Check if any backend is down or not. tablet_id: "
-                                                + tablet.getId() + ", replicas: " + localTablet.getReplicaInfos());
+                                        String.format("Tablet lost replicas. Check if any backend is down or not. " +
+                                                        "tablet_id: %s, replicas: %s. C：heck quorum number failed" +
+                                                        "(OlapTableSink): BeReplicaSize:%s, quorum:%s",
+                                                tablet.getId(), localTablet.getReplicaInfos(), bePathsMap.size(), quorum));
                             }
 
                             List<Replica> replicas = Lists.newArrayList(bePathsMap.keySet());

--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapTableSink.java
@@ -673,7 +673,7 @@ public class OlapTableSink extends DataSink {
                             if (bePathsMap.keySet().size() < quorum) {
                                 throw new UserException(InternalErrorCode.REPLICA_FEW_ERR,
                                         String.format("Tablet lost replicas. Check if any backend is down or not. " +
-                                                        "tablet_id: %s, replicas: %s. C：heck quorum number failed" +
+                                                        "tablet_id: %s, replicas: %s. Check quorum number failed" +
                                                         "(OlapTableSink): BeReplicaSize:%s, quorum:%s",
                                                 tablet.getId(), localTablet.getReplicaInfos(), bePathsMap.size(), quorum));
                             }

--- a/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
+++ b/fe/fe-core/src/main/java/com/starrocks/service/FrontendServiceImpl.java
@@ -2194,9 +2194,10 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                     Multimap<Replica, Long> bePathsMap =
                             localTablet.getNormalReplicaBackendPathMap(olapTable.getClusterId());
                     if (bePathsMap.keySet().size() < quorum) {
-                        throw new UserException(
-                                "Tablet lost replicas. Check if any backend is down or not. tablet_id: "
-                                        + tablet.getId() + ", replicas: " + localTablet.getReplicaInfos());
+                        throw new UserException(String.format("Tablet lost replicas. Check if any backend is down or not. " +
+                                        "tablet_id: %s, replicas: %s. Check quorum number failed(buildTablets): " +
+                                        "BeReplicaSize:%s, quorum:%s", tablet.getId(), localTablet.getReplicaInfos(),
+                                bePathsMap.size(), quorum));
                     }
                     // replicas[0] will be the primary replica
                     // getNormalReplicaBackendPathMap returns a linkedHashMap, it's keysets is stable
@@ -2367,9 +2368,11 @@ public class FrontendServiceImpl implements FrontendService.Iface {
                         Multimap<Replica, Long> bePathsMap =
                                 localTablet.getNormalReplicaBackendPathMap(olapTable.getClusterId());
                         if (bePathsMap.keySet().size() < quorum) {
-                            errorStatus.setError_msgs(Lists.newArrayList(
-                                    "Tablet lost replicas. Check if any backend is down or not. tablet_id: "
-                                            + tablet.getId() + ", replicas: " + localTablet.getReplicaInfos()));
+                            String errorMsg = String.format("Tablet lost replicas. Check if any backend is down or not. " +
+                                            "tablet_id: %s, replicas: %s. Check quorum number failed" +
+                                            "(buildCreatePartitionResponse): BeReplicaSize:%s, quorum:%s",
+                                    tablet.getId(), localTablet.getReplicaInfos(), bePathsMap.size(), quorum);
+                            errorStatus.setError_msgs(Lists.newArrayList(errorMsg));
                             result.setStatus(errorStatus);
                             return result;
                         }

--- a/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
+++ b/fe/fe-core/src/test/java/com/starrocks/utframe/StarRocksAssert.java
@@ -521,7 +521,8 @@ public class StarRocksAssert {
 
     // Add materialized view to the schema
     public StarRocksAssert withMaterializedView(String sql) throws Exception {
-        return withMaterializedView(sql, false, false);
+        // Only test mv rewrite in default 1 replica to avoid more occasional errors.
+        return withMaterializedView(sql, true, false);
     }
 
     public StarRocksAssert withMaterializedView(String sql, ExceptionConsumer action) {
@@ -620,8 +621,8 @@ public class StarRocksAssert {
                 createMaterializedViewStatement.getProperties().put(PropertyAnalyzer.PROPERTIES_REPLICATION_NUM, "1");
             }
             GlobalStateMgr.getCurrentState().createMaterializedView(createMaterializedViewStatement);
-            String mvName = createMaterializedViewStatement.getTableName().getTbl();
             if (isRefresh) {
+                String mvName = createMaterializedViewStatement.getTableName().getTbl();
                 refreshMvPartition(String.format("refresh materialized view %s", mvName));
             }
         }


### PR DESCRIPTION
Why I'm doing:

Add more error message for this :
```
Error:  Tests run: 26, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 59.625 s <<< FAILURE! - in com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTest
15092Error:  testCrossJoin  Time elapsed: 2.124 s  <<< ERROR!
15093java.sql.SQLSyntaxErrorException: Unexpected exception: execute task mv-11967 failed: Refresh materialized view cross_join_mv2 failed after retrying 3 times, error-msg : Getting analyzing error. Detail message: Tablet lost replicas. Check if any backend is down or not. tablet_id: 11970, replicas: 10001:1/-1/1/0:NORMAL:ALIVE,.
15094        at com.mysql.cj.jdbc.exceptions.SQLError.createSQLException(SQLError.java:121)
15095        at com.mysql.cj.jdbc.exceptions.SQLExceptionsMapping.translateException(SQLExceptionsMapping.java:122)
15096        at com.mysql.cj.jdbc.StatementImpl.executeInternal(StatementImpl.java:763)
15097        at com.mysql.cj.jdbc.StatementImpl.execute(StatementImpl.java:648)
15098        at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193)
15099        at org.apache.commons.dbcp2.DelegatingStatement.execute(DelegatingStatement.java:193)
15100        at com.starrocks.pseudocluster.PseudoCluster.runSingleSql(PseudoCluster.java:320)
15101        at com.starrocks.pseudocluster.PseudoCluster.runSql(PseudoCluster.java:348)
15102        at com.starrocks.pseudocluster.PseudoCluster.runSql(PseudoCluster.java:356)
15103        at com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTestBase.createAndRefreshMv(MvRewriteTestBase.java:235)
15104        at com.starrocks.sql.optimizer.rule.transformation.materialization.MvRewriteTest.testCrossJoin(MvRewriteTest.java:507)
```
What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
