### PR TITLE
[Enhancement] Use concurrency map instead of lock for blacklist

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/DefaultCoordinator.java
@@ -595,7 +595,7 @@ public class DefaultCoordinator extends Coordinator {
             case TIMEOUT:
                 throw new UserException("query timeout. backend id: " + execution.getWorker().getId());
             case THRIFT_RPC_ERROR:
-                SimpleScheduler.addToBlacklist(execution.getWorker().getId());
+                SimpleScheduler.addToBlocklist(execution.getWorker().getId());
                 throw new RpcException(execution.getWorker().getHost(), "rpc failed");
             default:
                 throw new UserException(status.getErrorMsg());

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -134,7 +134,7 @@ public class ResultReceiver {
         } catch (RpcException e) {
             LOG.warn("fetch result rpc exception, finstId={}", DebugUtil.printId(finstId), e);
             status.setRpcStatus(e.getMessage());
-            SimpleScheduler.addToBlacklist(backendId);
+            SimpleScheduler.addToBlocklist(backendId);
         } catch (ExecutionException e) {
             LOG.warn("fetch result execution exception, finstId={}", DebugUtil.printId(finstId), e);
             if (e.getMessage().contains("time out")) {
@@ -144,7 +144,7 @@ public class ResultReceiver {
                                 ConnectContext.get().getSessionVariable().getQueryTimeoutS())));
             } else {
                 status.setRpcStatus(e.getMessage());
-                SimpleScheduler.addToBlacklist(backendId);
+                SimpleScheduler.addToBlocklist(backendId);
             }
         } catch (TimeoutException e) {
             LOG.warn("fetch result timeout, finstId={}", DebugUtil.printId(finstId), e);

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SimpleScheduler.java
@@ -47,38 +47,38 @@ import com.starrocks.system.ComputeNode;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TNetworkAddress;
 import com.starrocks.thrift.TScanRangeLocation;
+import org.apache.arrow.util.VisibleForTesting;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 
 public class SimpleScheduler {
-    private static Logger LOG = LogManager.getLogger(SimpleScheduler.class);
+    private static final Logger LOG = LogManager.getLogger(SimpleScheduler.class);
     //count id for compute node get TNetworkAddress
-    private static AtomicLong nextComputeNodeHostId = new AtomicLong(0);
+    private static final AtomicLong NEXT_COMPUTE_NODE_HOST_ID = new AtomicLong(0);
     //count id for backend get TNetworkAddress
-    private static AtomicLong nextBackendHostId = new AtomicLong(0);
+    private static final AtomicLong NEXT_BACKEND_HOST_ID = new AtomicLong(0);
+
     //count id for get ComputeNode
-    private static Map<Long, Integer> blacklistBackends = Maps.newHashMap();
-    private static Lock lock = new ReentrantLock();
-    private static UpdateBlacklistThread updateBlacklistThread;
-    private static AtomicBoolean enableUpdateBlacklistThread;
+    private static final ConcurrentMap<Long, Integer> BLACKLIST_BACKENDS = Maps.newConcurrentMap();
+
+    private static final AtomicBoolean ENABLE_UPDATE_BLACKLIST_THREAD;
+    private static final UpdateBlacklistThread UPDATE_BLACKLIST_THREAD;
 
     static {
-        enableUpdateBlacklistThread = new AtomicBoolean(true);
-        updateBlacklistThread = new UpdateBlacklistThread();
-        updateBlacklistThread.start();
+        ENABLE_UPDATE_BLACKLIST_THREAD = new AtomicBoolean(true);
+        UPDATE_BLACKLIST_THREAD = new UpdateBlacklistThread();
+        UPDATE_BLACKLIST_THREAD.start();
     }
 
     @Nullable
@@ -94,43 +94,38 @@ public class SimpleScheduler {
 
         ComputeNode node = computeNodes.get(nodeId);
 
-        lock.lock();
-        try {
-            if (node != null && node.isAlive() && !blacklistBackends.containsKey(nodeId)) {
-                backendIdRef.setRef(nodeId);
-                return new TNetworkAddress(node.getHost(), node.getBePort());
-            } else {
-                for (TScanRangeLocation location : locations) {
-                    if (location.backend_id == nodeId) {
-                        continue;
-                    }
-                    // choose the first alive backend(in analysis stage, the locations are random)
-                    ComputeNode candidateBackend = computeNodes.get(location.backend_id);
-                    if (candidateBackend != null && candidateBackend.isAlive()
-                            && !blacklistBackends.containsKey(location.backend_id)) {
-                        backendIdRef.setRef(location.backend_id);
-                        return new TNetworkAddress(candidateBackend.getHost(), candidateBackend.getBePort());
-                    }
+        if (node != null && node.isAlive() && !BLACKLIST_BACKENDS.containsKey(nodeId)) {
+            backendIdRef.setRef(nodeId);
+            return new TNetworkAddress(node.getHost(), node.getBePort());
+        } else {
+            for (TScanRangeLocation location : locations) {
+                if (location.backend_id == nodeId) {
+                    continue;
                 }
-
-                // In shared data mode, we can select any alive node to replace the original dead node for query
-                if (RunMode.isSharedDataMode()) {
-                    List<ComputeNode> allNodes = new ArrayList<>(computeNodes.size());
-                    allNodes.addAll(computeNodes.values());
-                    List<ComputeNode> candidateNodes = allNodes.stream()
-                            .filter(x -> x.getId() != nodeId && x.isAlive() &&
-                                    !blacklistBackends.containsKey(x.getId())).collect(Collectors.toList());
-                    if (!candidateNodes.isEmpty()) {
-                        // use modulo operation to ensure that the same node is selected for the dead node
-                        ComputeNode candidateNode = candidateNodes.get((int) (nodeId % candidateNodes.size()));
-                        backendIdRef.setRef(candidateNode.getId());
-                        return new TNetworkAddress(candidateNode.getHost(), candidateNode.getBePort());
-                    }
+                // choose the first alive backend(in analysis stage, the locations are random)
+                ComputeNode candidateBackend = computeNodes.get(location.backend_id);
+                if (candidateBackend != null && candidateBackend.isAlive() && !isInBlacklist(location.backend_id)) {
+                    backendIdRef.setRef(location.backend_id);
+                    return new TNetworkAddress(candidateBackend.getHost(), candidateBackend.getBePort());
                 }
             }
-        } finally {
-            lock.unlock();
+
+            // In shared data mode, we can select any alive node to replace the original dead node for query
+            if (RunMode.isSharedDataMode()) {
+                List<ComputeNode> allNodes = new ArrayList<>(computeNodes.size());
+                allNodes.addAll(computeNodes.values());
+                List<ComputeNode> candidateNodes = allNodes.stream()
+                        .filter(x -> x.getId() != nodeId && x.isAlive() && !isInBlacklist(x.getId()))
+                        .collect(Collectors.toList());
+                if (!candidateNodes.isEmpty()) {
+                    // use modulo operation to ensure that the same node is selected for the dead node
+                    ComputeNode candidateNode = candidateNodes.get((int) (nodeId % candidateNodes.size()));
+                    backendIdRef.setRef(candidateNode.getId());
+                    return new TNetworkAddress(candidateNode.getHost(), candidateNode.getBePort());
+                }
+            }
         }
+
         // no backend returned
         return null;
     }
@@ -162,7 +157,7 @@ public class SimpleScheduler {
         if (nodeMap == null || nodeMap.isEmpty()) {
             return null;
         }
-        return chooseNode(nodeMap.values().asList(), nextBackendHostId);
+        return chooseNode(nodeMap.values().asList(), NEXT_BACKEND_HOST_ID);
     }
 
     @Nullable
@@ -170,7 +165,7 @@ public class SimpleScheduler {
         if (nodeMap == null || nodeMap.isEmpty()) {
             return null;
         }
-        return chooseNode(nodeMap.values().asList(), nextComputeNodeHostId);
+        return chooseNode(nodeMap.values().asList(), NEXT_COMPUTE_NODE_HOST_ID);
     }
 
     @Nullable
@@ -178,7 +173,7 @@ public class SimpleScheduler {
         long id = nextId.getAndIncrement();
         for (int i = 0; i < nodes.size(); i++) {
             T node = nodes.get((int) (id % nodes.size()));
-            if (node != null && node.isAlive() && !blacklistBackends.containsKey(node.getId())) {
+            if (node != null && node.isAlive() && !isInBlacklist(node.getId())) {
                 nextId.addAndGet(i); // skip failed nodes
                 return node;
             }
@@ -191,51 +186,33 @@ public class SimpleScheduler {
         if (backendID == null) {
             return;
         }
-        lock.lock();
-        try {
-            int tryTime = Config.heartbeat_timeout_second + 1;
-            blacklistBackends.put(backendID, tryTime);
-            LOG.warn("add black list " + backendID);
-        } finally {
-            lock.unlock();
-        }
+
+        int tryTime = Config.heartbeat_timeout_second + 1;
+        BLACKLIST_BACKENDS.put(backendID, tryTime);
+        LOG.warn("add black list " + backendID);
     }
 
     public static boolean isInBlacklist(long backendId) {
-        lock.lock();
-        try {
-            return blacklistBackends.containsKey(backendId);
-        } finally {
-            lock.unlock();
-        }
+        return BLACKLIST_BACKENDS.containsKey(backendId);
     }
 
     // The function is used for unit test
+    @VisibleForTesting
     public static boolean removeFromBlacklist(Long backendID) {
         if (backendID == null) {
             return true;
         }
-        lock.lock();
-        try {
-            return blacklistBackends.remove(backendID) != null;
-        } finally {
-            lock.unlock();
-        }
+
+        return BLACKLIST_BACKENDS.remove(backendID) != null;
     }
 
     public static void updateBlacklist() {
         SystemInfoService clusterInfoService = GlobalStateMgr.getCurrentSystemInfo();
 
-        lock.lock();
-        Map<Long, Integer> blackListBackendsCopy = new HashMap<>(blacklistBackends);
-        lock.unlock();
-
         List<Long> removedBackends = new ArrayList<>();
         Map<Long, Integer> retryingBackends = new HashMap<>();
 
-        Iterator<Map.Entry<Long, Integer>> iterator = blackListBackendsCopy.entrySet().iterator();
-        while (iterator.hasNext()) {
-            Map.Entry<Long, Integer> entry = iterator.next();
+        for (Map.Entry<Long, Integer> entry : BLACKLIST_BACKENDS.entrySet()) {
             Long backendId = entry.getKey();
 
             // 1. If the backend is null, means that the backend has been removed.
@@ -266,26 +243,19 @@ public class SimpleScheduler {
             }
         }
 
-        lock.lock();
-        try {
-            // remove backends.
-            for (Long backendId : removedBackends) {
-                blacklistBackends.remove(backendId);
-            }
+        // remove backends.
+        for (Long backendId : removedBackends) {
+            BLACKLIST_BACKENDS.remove(backendId);
+        }
 
-            // update the retry times.
-            for (Map.Entry<Long, Integer> entry : retryingBackends.entrySet()) {
-                if (blacklistBackends.containsKey(entry.getKey())) {
-                    blacklistBackends.put(entry.getKey(), entry.getValue());
-                }
-            }
-        } finally {
-            lock.unlock();
+        // update the retry times.
+        for (Map.Entry<Long, Integer> entry : retryingBackends.entrySet()) {
+            BLACKLIST_BACKENDS.computeIfPresent(entry.getKey(), (k, v) -> entry.getValue());
         }
     }
 
     public static void disableUpdateBlacklistThread() {
-        enableUpdateBlacklistThread.set(false);
+        ENABLE_UPDATE_BLACKLIST_THREAD.set(false);
     }
 
     private static class UpdateBlacklistThread implements Runnable {
@@ -304,7 +274,7 @@ public class SimpleScheduler {
         @Override
         public void run() {
             LOG.debug("UpdateBlacklistThread is start to run");
-            while (enableUpdateBlacklistThread.get()) {
+            while (ENABLE_UPDATE_BLACKLIST_THREAD.get()) {
                 try {
                     Thread.sleep(1000L);
                     LOG.debug("UpdateBlacklistThread retry begin");

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/DefaultWorkerProvider.java
@@ -247,7 +247,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
         StringBuilder out = new StringBuilder("compute node: ");
         id2ComputeNode.forEach((backendID, backend) -> out.append(
                 String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
-                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
+                        backend.isAlive(), SimpleScheduler.isInBlocklist(backendID))));
         return out.toString();
     }
 
@@ -255,7 +255,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
         StringBuilder out = new StringBuilder("backend: ");
         id2Backend.forEach((backendID, backend) -> out.append(
                 String.format("[%s alive: %b inBlacklist: %b] ", backend.getHost(),
-                        backend.isAlive(), SimpleScheduler.isInBlacklist(backendID))));
+                        backend.isAlive(), SimpleScheduler.isInBlocklist(backendID))));
         return out.toString();
     }
 
@@ -304,7 +304,7 @@ public class DefaultWorkerProvider implements WorkerProvider {
     }
 
     private static boolean isWorkerAvailable(ComputeNode worker) {
-        return worker.isAlive() && !SimpleScheduler.isInBlacklist(worker.getId());
+        return worker.isAlive() && !SimpleScheduler.isInBlocklist(worker.getId());
     }
 
     private static <C extends ComputeNode> ImmutableMap<Long, C> filterAvailableWorkers(ImmutableMap<Long, C> workers) {

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/dag/FragmentInstanceExecState.java
@@ -365,7 +365,7 @@ public class FragmentInstanceExecState {
                     jobSpec.isEnablePipeline());
         } catch (RpcException e) {
             LOG.warn("cancel plan fragment get a exception, address={}:{}", brpcAddress.getHostname(), brpcAddress.getPort(), e);
-            SimpleScheduler.addToBlacklist(worker.getId());
+            SimpleScheduler.addToBlocklist(worker.getId());
             return false;
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/qe/SimpleSchedulerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/SimpleSchedulerTest.java
@@ -71,7 +71,7 @@ public class SimpleSchedulerTest {
     @Before
     public void setUp() {
         // disable updateBlackListThread
-        SimpleScheduler.disableUpdateBlacklistThread();
+        SimpleScheduler.disableUpdateBlocklistThread();
     }
 
     // Comment out these code temporatily.
@@ -244,12 +244,12 @@ public class SimpleSchedulerTest {
         threeBackends.put((long) 102, backendC);
         ImmutableMap<Long, ComputeNode> immutableThreeBackends = ImmutableMap.copyOf(threeBackends);
 
-        SimpleScheduler.addToBlacklist(Long.valueOf(100));
-        SimpleScheduler.addToBlacklist(Long.valueOf(101));
+        SimpleScheduler.addToBlocklist(Long.valueOf(100));
+        SimpleScheduler.addToBlocklist(Long.valueOf(101));
         address = SimpleScheduler.getBackendHost(immutableThreeBackends, ref);
         // only backendc can work
         Assert.assertEquals(address.hostname, "addressC");
-        SimpleScheduler.addToBlacklist(Long.valueOf(102));
+        SimpleScheduler.addToBlocklist(Long.valueOf(102));
         // no backend can work
         address = SimpleScheduler.getBackendHost(immutableThreeBackends, ref);
         Assert.assertNull(address);
@@ -267,7 +267,7 @@ public class SimpleSchedulerTest {
         backends.put((long) 100, backendA);
         ImmutableMap<Long, ComputeNode> immutableBackends = ImmutableMap.copyOf(backends);
 
-        SimpleScheduler.addToBlacklist(Long.valueOf(100));
+        SimpleScheduler.addToBlocklist(Long.valueOf(100));
         address = SimpleScheduler.getBackendHost(immutableBackends, ref);
         Assert.assertNull(address);
 
@@ -277,7 +277,7 @@ public class SimpleSchedulerTest {
         boolean accessible = NetUtils.checkAccessibleForAllPorts(host, ports);
         Assert.assertFalse(accessible);
 
-        SimpleScheduler.removeFromBlacklist(Long.valueOf(100));
+        SimpleScheduler.removeFromBlocklist(Long.valueOf(100));
         address = SimpleScheduler.getBackendHost(immutableBackends, ref);
         Assert.assertEquals(address.hostname, "addressA");
     }
@@ -310,9 +310,9 @@ public class SimpleSchedulerTest {
                                     @Mocked NetUtils utils) {
         Config.heartbeat_timeout_second = 1;
 
-        SimpleScheduler.addToBlacklist(10001L);
-        SimpleScheduler.addToBlacklist(10002L);
-        SimpleScheduler.addToBlacklist(10003L);
+        SimpleScheduler.addToBlocklist(10001L);
+        SimpleScheduler.addToBlocklist(10002L);
+        SimpleScheduler.addToBlocklist(10003L);
         new Expectations() {
             {
                 globalStateMgr.getCurrentSystemInfo();
@@ -357,15 +357,15 @@ public class SimpleSchedulerTest {
                 times = 2;
             }
         };
-        SimpleScheduler.updateBlacklist();
+        SimpleScheduler.updateBlocklist();
 
-        Assert.assertFalse(SimpleScheduler.isInBlacklist(10001L));
-        Assert.assertFalse(SimpleScheduler.isInBlacklist(10002L));
-        Assert.assertTrue(SimpleScheduler.isInBlacklist(10003L));
+        Assert.assertFalse(SimpleScheduler.isInBlocklist(10001L));
+        Assert.assertFalse(SimpleScheduler.isInBlocklist(10002L));
+        Assert.assertTrue(SimpleScheduler.isInBlocklist(10003L));
 
         //Having retried for Config.heartbeat_timeout_second + 1 times, backend 10003 will be removed.
-        SimpleScheduler.updateBlacklist();
-        Assert.assertFalse(SimpleScheduler.isInBlacklist(10003L));
+        SimpleScheduler.updateBlocklist();
+        Assert.assertFalse(SimpleScheduler.isInBlocklist(10003L));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -88,7 +88,7 @@ public class DefaultWorkerProviderTest {
         id2ComputeNode.get(deadCNId).setAlive(false);
         new MockUp<SimpleScheduler>() {
             @Mock
-            public boolean isInBlacklist(long backendId) {
+            public boolean isInBlocklist(long backendId) {
                 return backendId == inBlacklistBEId || backendId == inBlacklistCNId;
             }
         };

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/DefaultWorkerProviderTest.java
@@ -160,7 +160,7 @@ public class DefaultWorkerProviderTest {
             id2ComputeNode.get(deadCNId).setAlive(false);
             new MockUp<SimpleScheduler>() {
                 @Mock
-                public boolean isInBlacklist(long backendId) {
+                public boolean isInBlocklist(long backendId) {
                     return backendId == inBlacklistBEId || backendId == inBlacklistCNId;
                 }
             };

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/GetNextTest.java
@@ -115,9 +115,9 @@ public class GetNextTest extends SchedulerTestBase {
             }
         });
 
-        SimpleScheduler.removeFromBlacklist(BACKEND1_ID);
-        SimpleScheduler.removeFromBlacklist(backend2.getId());
-        SimpleScheduler.removeFromBlacklist(backend3.getId());
+        SimpleScheduler.removeFromBlocklist(BACKEND1_ID);
+        SimpleScheduler.removeFromBlocklist(backend2.getId());
+        SimpleScheduler.removeFromBlocklist(backend3.getId());
 
         String sql = "select count(1) from lineitem";
         DefaultCoordinator scheduler = startScheduling(sql);
@@ -159,9 +159,9 @@ public class GetNextTest extends SchedulerTestBase {
             }
         });
 
-        SimpleScheduler.removeFromBlacklist(BACKEND1_ID);
-        SimpleScheduler.removeFromBlacklist(backend2.getId());
-        SimpleScheduler.removeFromBlacklist(backend3.getId());
+        SimpleScheduler.removeFromBlocklist(BACKEND1_ID);
+        SimpleScheduler.removeFromBlocklist(backend2.getId());
+        SimpleScheduler.removeFromBlocklist(backend3.getId());
 
         String sql = "select count(1) from lineitem";
         DefaultCoordinator scheduler;

--- a/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/scheduler/StartSchedulingTest.java
@@ -157,8 +157,8 @@ public class StartSchedulingTest extends SchedulerTestBase {
         String sql = "select count(1) from lineitem";
 
         Assert.assertThrows("test runtime exception", RpcException.class, () -> startScheduling(sql));
-        SimpleScheduler.removeFromBlacklist(backend3.getId());
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlacklist(backend3.getId()));
+        SimpleScheduler.removeFromBlocklist(backend3.getId());
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlocklist(backend3.getId()));
     }
 
     @Test
@@ -185,8 +185,8 @@ public class StartSchedulingTest extends SchedulerTestBase {
         deployFuture.setRef(
                 mockFutureWithException(new ExecutionException("test execution exception", new Exception())));
         Assert.assertThrows("test execution exception", RpcException.class, () -> startScheduling(sql));
-        SimpleScheduler.removeFromBlacklist(backend3.getId());
-        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlacklist(backend3.getId()));
+        SimpleScheduler.removeFromBlocklist(backend3.getId());
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() -> !SimpleScheduler.isInBlocklist(backend3.getId()));
 
         isFirstFragmentToDeploy.set(true);
         deployFuture.setRef(mockFutureWithException(new InterruptedException("test interrupted exception")));
@@ -336,12 +336,12 @@ public class StartSchedulingTest extends SchedulerTestBase {
         // Shouldn't block by the failed cancelled instance.
         Assert.assertTrue(scheduler.isDone());
 
-        SimpleScheduler.removeFromBlacklist(BACKEND1_ID);
-        SimpleScheduler.removeFromBlacklist(backend2.getId());
-        SimpleScheduler.removeFromBlacklist(backend3.getId());
+        SimpleScheduler.removeFromBlocklist(BACKEND1_ID);
+        SimpleScheduler.removeFromBlocklist(backend2.getId());
+        SimpleScheduler.removeFromBlocklist(backend3.getId());
         Awaitility.await().atMost(5, TimeUnit.SECONDS).until(() ->
-                !SimpleScheduler.isInBlacklist(BACKEND1_ID) && !SimpleScheduler.isInBlacklist(backend2.getId()) &&
-                        !SimpleScheduler.isInBlacklist(backend3.getId()));
+                !SimpleScheduler.isInBlocklist(BACKEND1_ID) && !SimpleScheduler.isInBlocklist(backend2.getId()) &&
+                        !SimpleScheduler.isInBlocklist(backend3.getId()));
     }
 
     private static Future<PExecPlanFragmentResult> mockFutureWithException(Exception exception) {


### PR DESCRIPTION
Why I'm doing:
The `lock` in `SimpleScheduler` only protects `BLACKLIST_BACKENDS`. The lock contention of `isInBlacklist` is pretty high for the high-concurrency scenario.

What I'm doing:
Therefore, use a concurrency map instead to avoid the lock contention of `isInBlacklist`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
