### PR TITLE
[BugFix]fix some profile bug for parquet reader

### DIFF
--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -101,7 +101,9 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
 
     has_page_statistics = ADD_CHILD_COUNTER(root, "HasPageStatistics", TUnit::UNIT, kParquetProfileSectionPrefix);
     page_skip = ADD_CHILD_COUNTER(root, "PageSkipCounter", TUnit::UNIT, kParquetProfileSectionPrefix);
-    group_min_round_cost = ADD_CHILD_COUNTER(root, "GroupMinRound", TUnit::UNIT, kParquetProfileSectionPrefix);
+    group_min_round_cost = root->AddLowWaterMarkCounter(
+            "GroupMinRound", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TCounterAggregateType::AVG),
+            kParquetProfileSectionPrefix);
 
     COUNTER_UPDATE(request_bytes_read, _app_stats.request_bytes_read);
     COUNTER_UPDATE(request_bytes_read_uncompressed, _app_stats.request_bytes_read_uncompressed);
@@ -122,7 +124,7 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     int64_t page_stats = _app_stats.has_page_statistics ? 1 : 0;
     COUNTER_UPDATE(has_page_statistics, page_stats);
     COUNTER_UPDATE(page_skip, _app_stats.page_skip);
-    COUNTER_UPDATE(group_min_round_cost, _app_stats.group_min_round_cost);
+    group_min_round_cost->set(_app_stats.group_min_round_cost);
     do_update_iceberg_v2_counter(root, kParquetProfileSectionPrefix);
 }
 

--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -17,8 +17,6 @@
 #include <memory>
 
 #include "common/status.h"
-#include "exec/hdfs_scanner.h"
-#include "formats/parquet/column_reader.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/types.h"
 #include "formats/parquet/utils.h"
@@ -90,7 +88,7 @@ Status ColumnChunkReader::skip_page() {
 }
 
 Status ColumnChunkReader::next_page() {
-    if (_page_parse_state != PAGE_DATA_PARSED) {
+    if (_page_parse_state != PAGE_DATA_PARSED && _page_parse_state == PAGE_HEADER_PARSED) {
         _opts.stats->page_skip += 1;
     }
     _page_parse_state = PAGE_DATA_PARSED;
@@ -98,6 +96,7 @@ Status ColumnChunkReader::next_page() {
 }
 
 Status ColumnChunkReader::_parse_page_header() {
+    SCOPED_RAW_TIMER(&_opts.stats->page_read_ns);
     DCHECK(_page_parse_state == INITIALIZED || _page_parse_state == PAGE_DATA_PARSED);
     size_t off = _page_reader->get_offset();
     RETURN_IF_ERROR(_page_reader->next_header());
@@ -120,6 +119,7 @@ Status ColumnChunkReader::_parse_page_header() {
 }
 
 Status ColumnChunkReader::_parse_page_data() {
+    SCOPED_RAW_TIMER(&_opts.stats->page_read_ns);
     switch (_page_reader->current_header()->type) {
     case tparquet::PageType::DATA_PAGE:
         RETURN_IF_ERROR(_parse_data_page());

--- a/be/src/formats/parquet/column_chunk_reader.h
+++ b/be/src/formats/parquet/column_chunk_reader.h
@@ -21,12 +21,15 @@
 
 #include "column/column.h"
 #include "common/status.h"
+#include "exec/hdfs_scanner.h"
+#include "formats/parquet/column_reader.h"
 #include "formats/parquet/encoding.h"
 #include "formats/parquet/level_codec.h"
 #include "formats/parquet/page_reader.h"
 #include "fs/fs.h"
 #include "gen_cpp/parquet_types.h"
 #include "util/compression/block_compression.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks {
 class BlockCompressionCodec;
@@ -66,6 +69,7 @@ public:
     // enough levels.
     // User should call next_page() to get more levels
     size_t decode_def_levels(size_t n, level_t* levels) {
+        SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
         DCHECK_GT(_max_def_level, 0);
         return _def_level_decoder.decode_batch(n, levels);
     }
@@ -74,11 +78,13 @@ public:
     LevelDecoder& rep_level_decoder() { return _rep_level_decoder; }
 
     size_t decode_rep_levels(size_t n, level_t* levels) {
+        SCOPED_RAW_TIMER(&_opts.stats->level_decode_ns);
         DCHECK_GT(_max_rep_level, 0);
         return _rep_level_decoder.decode_batch(n, levels);
     }
 
     Status decode_values(size_t n, const uint16_t* is_nulls, ColumnContentType content_type, Column* dst) {
+        SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
         size_t idx = 0;
         while (idx < n) {
             bool is_null = is_nulls[idx++];
@@ -97,6 +103,7 @@ public:
     }
 
     Status decode_values(size_t n, ColumnContentType content_type, Column* dst) {
+        SCOPED_RAW_TIMER(&_opts.stats->value_decode_ns);
         return _cur_decoder->next_batch(n, content_type, dst);
     }
 

--- a/be/src/util/runtime_profile.cpp
+++ b/be/src/util/runtime_profile.cpp
@@ -441,6 +441,7 @@ void RuntimeProfile::copy_all_info_strings_from(RuntimeProfile* src_profile) {
     }
 
 ADD_COUNTER_IMPL(AddHighWaterMarkCounter, HighWaterMarkCounter)
+ADD_COUNTER_IMPL(AddLowWaterMarkCounter, LowWaterMarkCounter)
 
 RuntimeProfile::Counter* RuntimeProfile::add_child_counter(const std::string& name, TUnit::type type,
                                                            const TCounterStrategy& strategy,

--- a/be/src/util/runtime_profile.h
+++ b/be/src/util/runtime_profile.h
@@ -203,22 +203,24 @@ public:
     class ConcurrentTimerCounter;
     class DerivedCounter;
     class EventSequence;
-    class HighWaterMarkCounter;
     class SummaryStatsCounter;
     class ThreadCounters;
     class TimeSeriesCounter;
 
-    /// A counter that keeps track of the highest value seen (reporting that
+    /// A counter that keeps track of the highest/lowest value seen (reporting that
     /// as value()) and the current value.
-    class HighWaterMarkCounter : public Counter {
+    template <bool is_high>
+    class WaterMarkCounter : public Counter {
     public:
-        explicit HighWaterMarkCounter(TUnit::type type, int64_t value = 0) : Counter(type, value) {}
-        explicit HighWaterMarkCounter(TUnit::type type, const TCounterStrategy& strategy, int64_t value = 0)
-                : Counter(type, strategy, value) {}
+        explicit WaterMarkCounter(TUnit::type type, int64_t value = 0) : Counter(type, value) { _set_init_value(); }
+        explicit WaterMarkCounter(TUnit::type type, const TCounterStrategy& strategy, int64_t value = 0)
+                : Counter(type, strategy, value) {
+            _set_init_value();
+        }
 
         virtual void add(int64_t delta) {
             int64_t new_val = current_value_.fetch_add(delta, std::memory_order_relaxed) + delta;
-            UpdateMax(new_val);
+            Update(new_val);
         }
 
         /// Tries to increase the current value by delta. If current_value() + delta
@@ -229,7 +231,7 @@ public:
                 int64_t new_val = old_val + delta;
                 if (UNLIKELY(new_val > max)) return false;
                 if (LIKELY(current_value_.compare_exchange_strong(old_val, new_val, std::memory_order_relaxed))) {
-                    UpdateMax(new_val);
+                    Update(new_val);
                     return true;
                 }
             }
@@ -237,27 +239,46 @@ public:
 
         void set(int64_t v) override {
             current_value_.store(v, std::memory_order_relaxed);
-            UpdateMax(v);
+            Update(v);
         }
 
         int64_t current_value() const { return current_value_.load(std::memory_order_relaxed); }
 
     private:
-        /// Set '_value' to 'v' if 'v' is larger than '_value'. The entire operation is
+        void _set_init_value() {
+            if constexpr (is_high) {
+                _value.store(0, std::memory_order_relaxed);
+                current_value_.store(0, std::memory_order_relaxed);
+            } else {
+                _value.store(MAX_INT64, std::memory_order_relaxed);
+                current_value_.store(MAX_INT64, std::memory_order_relaxed);
+            }
+        }
+
+        /// Set '_value' to 'v' if 'v' is larger/lower than '_value'. The entire operation is
         /// atomic.
-        void UpdateMax(int64_t v) {
+        void Update(int64_t v) {
             while (true) {
-                int64_t old_max = _value.load(std::memory_order_relaxed);
-                int64_t new_max = std::max(old_max, v);
-                if (new_max == old_max) break; // Avoid atomic update.
-                if (LIKELY(_value.compare_exchange_strong(old_max, new_max, std::memory_order_relaxed))) break;
+                int64_t old_value = _value.load(std::memory_order_relaxed);
+                int64_t new_value;
+                if constexpr (is_high) {
+                    new_value = std::max(old_value, v);
+                } else {
+                    new_value = std::min(old_value, v);
+                }
+                if (new_value == old_value) break; // Avoid atomic update.
+                if (LIKELY(_value.compare_exchange_strong(old_value, new_value, std::memory_order_relaxed))) break;
             }
         }
 
         /// The current value of the counter. _value in the super class represents
         /// the high water mark.
-        std::atomic<int64_t> current_value_{0};
+        std::atomic<int64_t> current_value_;
+        static const int64_t MAX_INT64 = 9223372036854775807ll;
     };
+
+    using HighWaterMarkCounter = WaterMarkCounter<true>;
+    using LowWaterMarkCounter = WaterMarkCounter<false>;
 
     typedef std::function<int64_t()> DerivedCounterFunction;
 
@@ -505,6 +526,9 @@ public:
     HighWaterMarkCounter* AddHighWaterMarkCounter(const std::string& name, TUnit::type unit,
                                                   const TCounterStrategy& strategy,
                                                   const std::string& parent_name = "");
+
+    LowWaterMarkCounter* AddLowWaterMarkCounter(const std::string& name, TUnit::type unit,
+                                                const TCounterStrategy& strategy, const std::string& parent_name = "");
 
     // Recursively compute the fraction of the 'total_time' spent in this profile and
     // its children.


### PR DESCRIPTION
Why I'm doing:
some profile entry is not correct

What I'm doing:
1. move some profile entry (page_read_ns, value_decode_ns, level_decode_ns) into the execution body, so that we don't need count on calling these functions which is easy to be missed.
2. correct group_chunk_read_ns, column_read_ns, column_convert_ns, page_skip
3. add lowwatermarkcounter for group_min_round_cost, because the minimum value avg of this is useful to check the effect of round-by-round. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
