### PR TITLE
[Feature] Refactor StreamLoad transaction API, and reuse it for bypass write.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/RestBaseAction.java
@@ -63,6 +63,8 @@ public class RestBaseAction extends BaseAction {
     protected static final String LABEL_KEY = "label";
     private static final Logger LOG = LogManager.getLogger(RestBaseAction.class);
 
+    protected static ObjectMapper mapper = new ObjectMapper();
+
     public RestBaseAction(ActionController controller) {
         super(controller);
     }
@@ -131,7 +133,6 @@ public class RestBaseAction extends BaseAction {
 
     public void sendResultByJson(BaseRequest request, BaseResponse response, Object obj) {
         String result = "";
-        ObjectMapper mapper = new ObjectMapper();
         try {
             result = mapper.writeValueAsString(obj);
         } catch (Exception e) {

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionLoadAction.java
@@ -35,10 +35,12 @@
 package com.starrocks.http.rest;
 
 import com.codahale.metrics.Histogram;
-import com.google.common.base.Strings;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.starrocks.catalog.Database;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.LabelAlreadyUsedException;
+import com.starrocks.common.StarRocksHttpException;
 import com.starrocks.common.UserException;
 import com.starrocks.common.util.DebugUtil;
 import com.starrocks.http.ActionController;
@@ -46,19 +48,35 @@ import com.starrocks.http.BaseRequest;
 import com.starrocks.http.BaseResponse;
 import com.starrocks.http.HttpMetricRegistry;
 import com.starrocks.http.IllegalArgException;
+import com.starrocks.http.rest.transaction.BypassWriteTransactionHandler;
+import com.starrocks.http.rest.transaction.TransactionOperation;
+import com.starrocks.http.rest.transaction.TransactionOperationHandler;
+import com.starrocks.http.rest.transaction.TransactionOperationHandler.ResultWrapper;
+import com.starrocks.http.rest.transaction.TransactionOperationParams;
+import com.starrocks.http.rest.transaction.TransactionOperationParams.Body;
+import com.starrocks.http.rest.transaction.TransactionOperationParams.Channel;
+import com.starrocks.http.rest.transaction.TransactionWithChannelHandler;
+import com.starrocks.http.rest.transaction.TransactionWithoutChannelHandler;
 import com.starrocks.metric.LongCounterMetric;
 import com.starrocks.metric.Metric;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.ComputeNode;
 import com.starrocks.thrift.TNetworkAddress;
-import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionState.LoadJobSourceType;
 import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Function;
 
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_BEGIN_LATENCY_MS;
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_BEGIN_NUM;
@@ -70,24 +88,31 @@ import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_PREPARE_LATE
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_PREPARE_NUM;
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_ROLLBACK_LATENCY_MS;
 import static com.starrocks.http.HttpMetricRegistry.TXN_STREAM_LOAD_ROLLBACK_NUM;
+import static com.starrocks.http.rest.transaction.TransactionOperation.TXN_BEGIN;
+import static com.starrocks.http.rest.transaction.TransactionOperation.TXN_COMMIT;
+import static com.starrocks.http.rest.transaction.TransactionOperation.TXN_LOAD;
+import static com.starrocks.http.rest.transaction.TransactionOperation.TXN_PREPARE;
+import static com.starrocks.http.rest.transaction.TransactionOperation.TXN_ROLLBACK;
 
 public class TransactionLoadAction extends RestBaseAction {
     private static final Logger LOG = LogManager.getLogger(TransactionLoadAction.class);
+
+    private static final long DEFAULT_TXN_TIMEOUT_MILLIS = 20000L;
+
     private static final String TXN_OP_KEY = "txn_op";
-    private static final String TXN_BEGIN = "begin";
-    private static final String TXN_LOAD = "load";
-    private static final String TXN_PREPARE = "prepare";
-    private static final String TXN_COMMIT = "commit";
-    private static final String TXN_ROLLBACK = "rollback";
     private static final String TIMEOUT_KEY = "timeout";
     private static final String CHANNEL_NUM_STR = "channel_num";
     private static final String CHANNEL_ID_STR = "channel_id";
+    private static final String SOURCE_TYPE = "source_type";
+
     private static TransactionLoadAction ac;
 
     // Map operation name to metrics
-    private final Map<String, OpMetrics> opMetricsMap = new HashMap<>();
+    private final Map<TransactionOperation, OpMetrics> opMetricsMap = new HashMap<>();
 
-    private Map<String, Long> txnNodeMap = new LinkedHashMap<String, Long>(512, 0.75f, true) {
+    private final ReadWriteLock txnNodeMapAccessLock = new ReentrantReadWriteLock();
+    private final Map<String, Long> txnNodeMap = new LinkedHashMap<>(512, 0.75f, true) {
+        @Override
         protected boolean removeEldestEntry(Map.Entry<String, Long> eldest) {
             return size() > (GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalBackendNumber() +
                     GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getTotalComputeNodeNumber()) * 512;
@@ -134,9 +159,7 @@ public class TransactionLoadAction extends RestBaseAction {
     }
 
     public int txnNodeMapSize() {
-        synchronized (this) {
-            return txnNodeMap.size();
-        }
+        return accessTxnNodeMapWithReadLock(Map::size);
     }
 
     public static TransactionLoadAction getAction() {
@@ -146,8 +169,7 @@ public class TransactionLoadAction extends RestBaseAction {
     public static void registerAction(ActionController controller) throws IllegalArgException {
         ac = new TransactionLoadAction(controller);
         controller.registerHandler(HttpMethod.POST, "/api/transaction/{" + TXN_OP_KEY + "}", ac);
-        controller.registerHandler(HttpMethod.PUT,
-                "/api/transaction/{" + TXN_OP_KEY + "}", ac);
+        controller.registerHandler(HttpMethod.PUT, "/api/transaction/{" + TXN_OP_KEY + "}", ac);
     }
 
     @Override
@@ -158,12 +180,14 @@ public class TransactionLoadAction extends RestBaseAction {
             if (redirectToLeader(request, response)) {
                 return;
             }
-            String op = request.getSingleParameter(TXN_OP_KEY);
-            opMetrics = opMetricsMap.get(op);
+            TransactionOperation txnOperation = TransactionOperation.parse(request.getSingleParameter(TXN_OP_KEY))
+                    .orElseThrow(() -> new UserException(
+                            "Unknown transaction operation: " + request.getSingleParameter(TXN_OP_KEY)));
+            opMetrics = opMetricsMap.get(txnOperation);
             if (opMetrics != null) {
                 opMetrics.opRunningNum.increase(1L);
             }
-            executeTransaction(request, response, op);
+            executeTransaction(request, response);
         } catch (Exception e) {
             TransactionResult resp = new TransactionResult();
             if (e instanceof LabelAlreadyUsedException) {
@@ -172,7 +196,7 @@ public class TransactionLoadAction extends RestBaseAction {
                 resp.addResultEntry("ExistingJobStatus", ((LabelAlreadyUsedException) e).getJobStatus());
             } else {
                 resp.status = ActionStatus.FAILED;
-                resp.msg = e.getClass().toString() + ": " + e.getMessage();
+                resp.msg = e.getClass() + ": " + e.getMessage();
             }
             LOG.warn(DebugUtil.getStackTrace(e));
             sendResult(request, response, resp);
@@ -184,183 +208,210 @@ public class TransactionLoadAction extends RestBaseAction {
         }
     }
 
-    public void executeTransaction(BaseRequest request, BaseResponse response, String op) throws UserException {
-        String dbName = request.getRequest().headers().get(DB_KEY);
-        String tableName = request.getRequest().headers().get(TABLE_KEY);
-        String label = request.getRequest().headers().get(LABEL_KEY);
-        String timeout = request.getRequest().headers().get(TIMEOUT_KEY);
-        String channelNumStr = null;
-        String channelIdStr = null;
-        if (request.getRequest().headers().contains(CHANNEL_NUM_STR)) {
-            channelNumStr = request.getRequest().headers().get(CHANNEL_NUM_STR);
-        }
-        if (request.getRequest().headers().contains(CHANNEL_ID_STR)) {
-            channelIdStr = request.getRequest().headers().get(CHANNEL_ID_STR);
+    protected void executeTransaction(BaseRequest request, BaseResponse response) throws UserException {
+        TransactionOperationParams txnOperationParams = toTxnOperationParams(request);
+        TransactionOperation txnOperation = txnOperationParams.getTxnOperation();
+        String label = txnOperationParams.getLabel();
+
+        TransactionOperationHandler txnOperationHandler = getTxnOperationHandler(txnOperationParams);
+        ResultWrapper result = txnOperationHandler.handle(request, response);
+        if (null != result.getResult()) {
+            sendResult(request, response, result.getResult());
+            return;
         }
 
-        if (channelNumStr != null && channelIdStr == null) {
+        // redirect transaction op to BE
+        TNetworkAddress redirectAddress = result.getRedirectAddress();
+        if (null == redirectAddress) {
+            Long nodeId = getNodeId(txnOperation, label);
+            ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(nodeId);
+            if (node == null) {
+                node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNode(nodeId);
+                if (node == null) {
+                    throw new UserException("Node " + nodeId + " is not alive");
+                }
+            }
+
+            redirectAddress = new TNetworkAddress(node.getHost(), node.getHttpPort());
+        }
+
+        LOG.info("Redirect transaction action to destination={}, db: {}, table: {}, op: {}, label: {}",
+                redirectAddress, txnOperationParams.getDbName(), txnOperationParams.getTableName(), txnOperation, label);
+        redirectTo(request, response, redirectAddress);
+    }
+
+    private TransactionOperationHandler getTxnOperationHandler(TransactionOperationParams params) throws UserException {
+        if (params.getChannel().notNull()) {
+            return new TransactionWithChannelHandler(params);
+        }
+
+        TransactionOperation txnOperation = params.getTxnOperation();
+        LoadJobSourceType sourceType = params.getSourceType();
+        if ((TXN_BEGIN.equals(txnOperation) || TXN_LOAD.equals(txnOperation)) && null == sourceType) {
+            return new TransactionWithoutChannelHandler(params);
+        }
+
+        String label = params.getLabel();
+        if (accessTxnNodeMapWithReadLock(txnNodeMap -> txnNodeMap.containsKey(label))) {
+            /*
+             * The Bypass Write scenario will not redirect the request to BE definitely,
+             * so if txnNodeMap contains the label, this must not be a Bypass Write scenario.
+             */
+            return new TransactionWithoutChannelHandler(params);
+        }
+
+        if (null == sourceType) {
+            String dbName = params.getDbName();
+            Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getDb(dbName))
+                    .orElseThrow(() -> new UserException(String.format("Database[%s] does not exist.", dbName)));
+
+            TransactionState txnState = GlobalStateMgr.getCurrentState()
+                    .getGlobalTransactionMgr().getLabelTransactionState(db.getId(), label);
+            if (null == txnState) {
+                throw new UserException(String.format("No transaction found by label %s", label));
+            }
+            sourceType = txnState.getSourceType();
+        }
+
+        return LoadJobSourceType.BYPASS_WRITE.equals(sourceType)
+                ? new BypassWriteTransactionHandler(params) : new TransactionWithoutChannelHandler(params);
+    }
+
+    private Long getNodeId(TransactionOperation txnOperation, String label) throws UserException {
+        Long nodeId;
+        // save label->be hashmap when begin transaction, so that subsequent operator can send to same BE
+        if (TXN_BEGIN.equals(txnOperation)) {
+            Long chosenNodeId = GlobalStateMgr.getCurrentState().getNodeMgr()
+                    .getClusterInfo().getNodeSelector().seqChooseBackendOrComputeId();
+            nodeId = chosenNodeId;
+            // txnNodeMap is LRU cache, it atomic remove unused entry
+            accessTxnNodeMapWithWriteLock(txnNodeMap -> txnNodeMap.put(label, chosenNodeId));
+        } else {
+            nodeId = accessTxnNodeMapWithReadLock(txnNodeMap -> txnNodeMap.get(label));
+        }
+
+        if (nodeId == null) {
+            throw new UserException(String.format(
+                    "Transaction with op[%s] and label[%s] has no node.", txnOperation.getValue(), label));
+        }
+
+        return nodeId;
+    }
+
+    /**
+     * Resolve and validate request, and wrap params it as {@link TransactionOperationParams} object.
+     */
+    private static TransactionOperationParams toTxnOperationParams(BaseRequest request) throws UserException {
+        String dbName = request.getRequest().headers().get(DB_KEY);
+        if (StringUtils.isBlank(dbName)) {
+            throw new UserException("No database selected.");
+        }
+
+        String tableName = request.getRequest().headers().get(TABLE_KEY);
+        String label = request.getRequest().headers().get(LABEL_KEY);
+        if (StringUtils.isBlank(label)) {
+            throw new UserException("Empty label.");
+        }
+
+        TransactionOperation txnOperation = TransactionOperation.parse(request.getSingleParameter(TXN_OP_KEY))
+                .orElseThrow(() -> new UserException(
+                        "Unknown transaction operation: " + request.getSingleParameter(TXN_OP_KEY)));
+        Long timeoutMillis = Optional.ofNullable(request.getRequest().headers().get(TIMEOUT_KEY))
+                .map(Long::parseLong)
+                .map(sec -> sec * 1000L)
+                .orElse(DEFAULT_TXN_TIMEOUT_MILLIS);
+        LoadJobSourceType sourceType = parseSourceType(request.getSingleParameter(SOURCE_TYPE));
+
+        Integer channelId = Optional
+                .ofNullable(request.getRequest().headers().get(CHANNEL_ID_STR))
+                .map(Integer::parseInt)
+                .orElse(null);
+
+        Integer channelNum = Optional
+                .ofNullable(request.getRequest().headers().get(CHANNEL_NUM_STR))
+                .map(Integer::parseInt)
+                .orElse(null);
+
+        if (channelNum != null && channelId == null) {
             throw new DdlException("Must provide channel_id when stream load begin.");
         }
-        if (channelNumStr == null && channelIdStr != null) {
+
+        if (channelNum == null && channelId != null) {
             throw new DdlException("Must provide channel_num when stream load begin.");
         }
 
-        Long nodeID = null;
-
-        if (Strings.isNullOrEmpty(dbName)) {
-            throw new UserException("No database selected.");
-        }
-        if (Strings.isNullOrEmpty(label)) {
-            throw new UserException("empty label.");
+        Channel channel = new Channel(channelId, channelNum);
+        if (LoadJobSourceType.BYPASS_WRITE.equals(sourceType) && channel.notNull()) {
+            throw new UserException(String.format(
+                    "Param %s and %s is not expected when source type is %s",
+                    CHANNEL_NUM_STR, CHANNEL_ID_STR, sourceType));
         }
 
-        // 1. handle commit/rollback PREPARED transaction
-        if ((op.equalsIgnoreCase(TXN_COMMIT) || op.equalsIgnoreCase(TXN_ROLLBACK)) && channelIdStr == null) {
-            TransactionResult resp = new TransactionResult();
-            Database db = GlobalStateMgr.getCurrentState().getDb(dbName);
-            if (db == null) {
-                throw new UserException("database " + dbName + " not exists");
-            }
-            TransactionStatus txnStatus = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelStatus(db.getId(),
-                    label);
-            Long txnID = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().getLabelTxnID(db.getId(), label);
-            if (txnStatus == TransactionStatus.PREPARED) {
-                if (txnID == -1) {
-                    throw new UserException("label " + label + " txn not exist");
+        Body body = new Body();
+        if (StringUtils.isNotBlank(request.getContent())) {
+            try {
+                LOG.info("Parse request body, label: {}, {}", label, request.getContent());
+                body = mapper.readValue(request.getContent(), new TypeReference<>() {
+                });
+                if (null == body) {
+                    throw new StarRocksHttpException(
+                            HttpResponseStatus.BAD_REQUEST, "Malformed json tablets, label is " + label);
                 }
-
-                if (op.equalsIgnoreCase(TXN_COMMIT)) {
-                    long timeoutMillis = 20000;
-                    if (timeout != null) {
-                        timeoutMillis = Long.parseLong(timeout) * 1000;
-                    }
-                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
-                            .commitPreparedTransaction(db, txnID, timeoutMillis);
-                } else if (op.equalsIgnoreCase(TXN_ROLLBACK)) {
-                    GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().abortTransaction(db.getId(), txnID,
-                            "User Aborted");
-                }
-                resp.addResultEntry("Label", label);
-                sendResult(request, response, resp);
-                return;
-            } else if (txnStatus == TransactionStatus.COMMITTED || txnStatus == TransactionStatus.VISIBLE) {
-                // whether txnId is valid or not is not important
-                if (op.equalsIgnoreCase(TXN_ROLLBACK)) {
-                    throw new UserException(String.format(
-                            "cannot abort committed transaction %s, label %s ", Long.toString(txnID), label));
-                }
-                resp.setOKMsg("label " + label + " transaction " + txnID + " has already committed");
-                resp.addResultEntry("Label", label);
-                sendResult(request, response, resp);
-                return;
-            } else if (txnStatus == TransactionStatus.ABORTED) {
-                // whether txnId is valid or not is not important
-                if (op.equalsIgnoreCase(TXN_COMMIT)) {
-                    throw new UserException(String.format(
-                            "cannot commit aborted transaction %s, label %s ", Long.toString(txnID), label));
-                }
-                resp.setOKMsg("label " + label + " transaction " + txnID + " has already aborted");
-                resp.addResultEntry("Label", label);
-                sendResult(request, response, resp);
-                return;
+            } catch (JsonProcessingException e) {
+                LOG.warn("Parse request body error, label: {}, {}", label, e.getMessage());
+                throw new StarRocksHttpException(
+                        HttpResponseStatus.BAD_REQUEST, "Malformed json tablets, label is " + label);
             }
         }
 
-        if (channelIdStr == null) {
-            // 2. redirect transaction op to BE
-            synchronized (this) {
-                // 2.1 save label->be hashmap when begin transaction, so that subsequent operator can send to same BE
-                if (op.equalsIgnoreCase(TXN_BEGIN)) {
-                    nodeID = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo()
-                               .getNodeSelector().seqChooseBackendOrComputeId();
-                    // txnNodeMap is LRU cache, it atomic remove unused entry
-                    txnNodeMap.put(label, nodeID);
-                } else {
-                    nodeID = txnNodeMap.get(label);
-                }
-            }
-        }
-
-        if (op.equalsIgnoreCase(TXN_BEGIN) && channelIdStr != null) {
-            TransactionResult resp = new TransactionResult();
-            long timeoutMillis = 20000;
-            if (timeout != null) {
-                timeoutMillis = Long.parseLong(timeout) * 1000;
-            }
-            int channelNum = Integer.parseInt(channelNumStr);
-            int channelId = Integer.parseInt(channelIdStr);
-            if (channelId >= channelNum || channelId < 0) {
-                throw new DdlException("channel id should be between [0, " + String.valueOf(channelNum - 1) + "].");
-            }
-
-            // context.parseHttpHeader(request.getRequest().headers());
-            GlobalStateMgr.getCurrentState().getStreamLoadMgr().beginLoadTask(
-                    dbName, tableName, label, timeoutMillis, channelNum, channelId, resp);
-            sendResult(request, response, resp);
-            return;
-        }
-
-        if (op.equalsIgnoreCase(TXN_LOAD) && channelIdStr != null) {
-            int channelId = Integer.parseInt(channelIdStr);
-            TransactionResult resp = new TransactionResult();
-            TNetworkAddress redirectAddr = GlobalStateMgr.getCurrentState().getStreamLoadMgr().executeLoadTask(
-                    label, channelId, request.getRequest().headers(), resp, dbName, tableName);
-            if (!resp.stateOK() || resp.containMsg()) {
-                sendResult(request, response, resp);
-                return;
-            }
-            LOG.info("redirect transaction action to destination={}, db: {}, table: {}, op: {}, label: {}",
-                    redirectAddr, dbName, tableName, op, label);
-            redirectTo(request, response, redirectAddr);
-            return;
-        }
-
-        if (op.equalsIgnoreCase(TXN_PREPARE) && channelIdStr != null) {
-            int channelId = Integer.parseInt(channelIdStr);
-            TransactionResult resp = new TransactionResult();
-            GlobalStateMgr.getCurrentState().getStreamLoadMgr().prepareLoadTask(
-                    label, channelId, request.getRequest().headers(), resp);
-            if (!resp.stateOK() || resp.containMsg()) {
-                sendResult(request, response, resp);
-                return;
-            }
-            GlobalStateMgr.getCurrentState().getStreamLoadMgr().tryPrepareLoadTaskTxn(label, resp);
-            sendResult(request, response, resp);
-            return;
-        }
-
-        if (op.equalsIgnoreCase(TXN_COMMIT) && channelIdStr != null) {
-            TransactionResult resp = new TransactionResult();
-            GlobalStateMgr.getCurrentState().getStreamLoadMgr().commitLoadTask(label, resp);
-            sendResult(request, response, resp);
-            return;
-        }
-
-        if (op.equalsIgnoreCase(TXN_ROLLBACK) && channelIdStr != null) {
-            TransactionResult resp = new TransactionResult();
-            GlobalStateMgr.getCurrentState().getStreamLoadMgr().rollbackLoadTask(label, resp);
-            sendResult(request, response, resp);
-            return;
-        }
-
-        if (nodeID == null) {
-            throw new UserException("transaction with op " + op + " label " + label + " has no node");
-        }
-
-        ComputeNode node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getBackend(nodeID);
-        if (node == null) {
-            node = GlobalStateMgr.getCurrentState().getNodeMgr().getClusterInfo().getComputeNode(nodeID);
-            if (node == null) {
-                throw new UserException("Node " + nodeID + " is not alive");
-            }
-        }
-
-        TNetworkAddress redirectAddr = new TNetworkAddress(node.getHost(), node.getHttpPort());
-
-        LOG.info("redirect transaction action to destination={}, db: {}, table: {}, op: {}, label: {}",
-                redirectAddr, dbName, tableName, op, label);
-        redirectTo(request, response, redirectAddr);
+        return new TransactionOperationParams(
+                dbName,
+                tableName,
+                label,
+                txnOperation,
+                timeoutMillis,
+                channel,
+                sourceType,
+                body
+        );
     }
+
+    private static LoadJobSourceType parseSourceType(String sourceType) throws UserException {
+        if (StringUtils.isBlank(sourceType)) {
+            return null;
+        }
+
+        try {
+            LoadJobSourceType jobSourceType = LoadJobSourceType.valueOf(Integer.parseInt(sourceType));
+            if (null == jobSourceType) {
+                throw new UserException("Unknown source type: " + sourceType);
+            }
+
+            return jobSourceType;
+        } catch (NumberFormatException e) {
+            throw new UserException("Invalid source type: " + sourceType);
+        }
+    }
+
+    private <T> T accessTxnNodeMapWithReadLock(Function<Map<String, Long>, T> function) {
+        txnNodeMapAccessLock.readLock().lock();
+        try {
+            return function.apply(txnNodeMap);
+        } finally {
+            txnNodeMapAccessLock.readLock().unlock();
+        }
+    }
+
+    private <T> T accessTxnNodeMapWithWriteLock(Function<Map<String, Long>, T> function) {
+        txnNodeMapAccessLock.writeLock().lock();
+        try {
+            return function.apply(txnNodeMap);
+        } finally {
+            txnNodeMapAccessLock.writeLock().unlock();
+        }
+    }
+
+    /* helper classes */
 
     private static class OpMetrics {
         LongCounterMetric opRunningNum;

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionResult.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TransactionResult.java
@@ -14,18 +14,27 @@
 
 package com.starrocks.http.rest;
 
-import com.google.common.collect.Maps;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import org.apache.commons.lang3.StringUtils;
 
+import java.util.HashMap;
 import java.util.Map;
 
 public class TransactionResult extends RestBaseResult {
-    private Map<String, Object> resultMap = Maps.newHashMap();
+
+    public static final String STATUS_KEY = "Status";
+    public static final String MESSAGE_KEY = "Message";
+
+    public static final String TXN_ID_KEY = "TxnId";
+    public static final String LABEL_KEY = "Label";
+
+    private final Map<String, Object> resultMap;
 
     public TransactionResult() {
         status = ActionStatus.OK;
         msg = "";
+        resultMap = new HashMap<>(0);
     }
 
     public void addResultEntry(String key, Object value) {
@@ -42,18 +51,17 @@ public class TransactionResult extends RestBaseResult {
     }
 
     public boolean containMsg() {
-        return msg.length() > 0;
+        return StringUtils.isNotEmpty(msg);
     }
 
     public boolean stateOK() {
         return status == ActionStatus.OK;
     }
-    
 
     public String toJson() {
         Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        addResultEntry("Status", status);
-        addResultEntry("Message", msg);
+        addResultEntry(STATUS_KEY, status);
+        addResultEntry(MESSAGE_KEY, msg);
         return gson.toJson(resultMap);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/BypassWriteTransactionHandler.java
@@ -1,0 +1,225 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.transaction;
+
+import com.google.common.collect.Lists;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.UserException;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.http.rest.transaction.TransactionOperationParams.Body;
+import com.starrocks.load.loadv2.MiniLoadTxnCommitAttachment;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionState.LoadJobSourceType;
+import com.starrocks.transaction.TransactionState.TxnCoordinator;
+import com.starrocks.transaction.TransactionState.TxnSourceType;
+import com.starrocks.transaction.TransactionStatus;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.starrocks.catalog.FunctionSet.HOST_NAME;
+import static com.starrocks.transaction.TransactionState.LoadJobSourceType.BYPASS_WRITE;
+
+/**
+ * Transaction management request handler for bypass writing scenario.
+ */
+public class BypassWriteTransactionHandler implements TransactionOperationHandler {
+
+    private static final Logger LOG = LogManager.getLogger(BypassWriteTransactionHandler.class);
+
+    private final TransactionOperationParams txnOperationParams;
+
+    public BypassWriteTransactionHandler(TransactionOperationParams txnOperationParams) {
+        Validate.isTrue(txnOperationParams.getChannel().isNull(), "channel isn't null");
+        this.txnOperationParams = txnOperationParams;
+    }
+
+    @Override
+    public ResultWrapper handle(BaseRequest request, BaseResponse response) throws UserException {
+        TransactionOperation txnOperation = txnOperationParams.getTxnOperation();
+        String dbName = txnOperationParams.getDbName();
+        String tableName = txnOperationParams.getTableName();
+        String label = txnOperationParams.getLabel();
+        LoadJobSourceType sourceType = txnOperationParams.getSourceType();
+        Long timeoutMillis = txnOperationParams.getTimeoutMillis();
+        Body requestBody = txnOperationParams.getBody();
+        LOG.info("Handle bypass write transaction, label: {}", label);
+
+        Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getDb(dbName))
+                .orElseThrow(() -> new UserException(String.format("Database[%s] does not exist.", dbName)));
+
+        TransactionResult result;
+        switch (txnOperation) {
+            case TXN_BEGIN:
+                Table table = Optional.ofNullable(db.getTable(tableName))
+                        .orElseThrow(() -> new UserException(
+                                String.format("Table[%s.%s] does not exist.", dbName, tableName)));
+                result = handleBeginTransaction(db, table, label, sourceType, timeoutMillis);
+                break;
+            case TXN_PREPARE:
+                result = handlePrepareTransaction(
+                        db, label,
+                        Optional.ofNullable(requestBody.getCommittedTablets()).orElse(new ArrayList<>(0)),
+                        Optional.ofNullable(requestBody.getFailedTablets()).orElse(new ArrayList<>(0))
+                );
+                break;
+            case TXN_COMMIT:
+                result = handleCommitTransaction(db, label, timeoutMillis);
+                break;
+            case TXN_ROLLBACK:
+                result = handleRollbackTransaction(
+                        db, label,
+                        Optional.ofNullable(requestBody.getFailedTablets()).orElse(new ArrayList<>(0))
+                );
+                break;
+            default:
+                throw new UserException("Unsupported operation: " + txnOperation);
+        }
+
+        return new ResultWrapper(result);
+    }
+
+    private TransactionResult handleBeginTransaction(Database db,
+                                                     Table table,
+                                                     String label,
+                                                     LoadJobSourceType sourceType,
+                                                     long timeoutMillis) throws UserException {
+        long dbId = db.getId();
+        long tableId = table.getId();
+
+        TxnCoordinator coordinator = new TxnCoordinator(TxnSourceType.FE, HOST_NAME);
+        GlobalTransactionMgr globalTxnMgr = GlobalStateMgr.getCurrentState().getGlobalTransactionMgr();
+        long txnId = globalTxnMgr.beginTransaction(
+                dbId, Lists.newArrayList(tableId), label, coordinator, sourceType, timeoutMillis);
+        TransactionResult result = new TransactionResult();
+        result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+        result.addResultEntry(TransactionResult.LABEL_KEY, label);
+        return result;
+    }
+
+    private TransactionResult handlePrepareTransaction(Database db,
+                                                       String label,
+                                                       List<TabletCommitInfo> committedTablets,
+                                                       List<TabletFailInfo> failedTablets) throws UserException {
+        long dbId = db.getId();
+        TransactionState txnState = getTxnState(dbId, label);
+        long txnId = txnState.getTransactionId();
+        TransactionStatus txnStatus = txnState.getTransactionStatus();
+        TransactionResult result = new TransactionResult();
+        switch (txnStatus) {
+            case PREPARE:
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr().prepareTransaction(
+                        dbId, txnId, committedTablets, failedTablets, new MiniLoadTxnCommitAttachment());
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            case PREPARED:
+            case COMMITTED:
+            case VISIBLE:
+                result.setOKMsg(String.format("Transaction %s has already %s, label is %s", txnId, txnStatus, label));
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            default:
+                throw new UserException(String.format(
+                        "Can not prepare %s transaction %d, label is %s", txnStatus, txnId, label));
+        }
+        return result;
+    }
+
+    private TransactionResult handleCommitTransaction(Database db,
+                                                      String label,
+                                                      long timeoutMillis) throws UserException {
+        long dbId = db.getId();
+        TransactionState txnState = getTxnState(dbId, label);
+        long txnId = txnState.getTransactionId();
+        TransactionStatus txnStatus = txnState.getTransactionStatus();
+        TransactionResult result = new TransactionResult();
+        switch (txnStatus) {
+            case PREPARED:
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .commitPreparedTransaction(db, txnId, timeoutMillis);
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            case COMMITTED:
+            case VISIBLE:
+                result.setOKMsg(String.format("Transaction %s has already committed, label is %s", txnId, label));
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            default:
+                throw new UserException(String.format(
+                        "Can not commit %s transaction %s, label is %s", txnStatus, txnId, label));
+        }
+
+        return result;
+    }
+
+    private TransactionResult handleRollbackTransaction(Database db,
+                                                        String label,
+                                                        List<TabletFailInfo> failedTablets) throws UserException {
+        long dbId = db.getId();
+        TransactionState txnState = getTxnState(dbId, label);
+        long txnId = txnState.getTransactionId();
+        TransactionStatus txnStatus = txnState.getTransactionStatus();
+        TransactionResult result = new TransactionResult();
+        switch (txnStatus) {
+            case PREPARED:
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .abortTransaction(dbId, txnId, "User Aborted", failedTablets);
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            case ABORTED:
+                result.setOKMsg(String.format("Transaction %s has already aborted, label is %s", txnId, label));
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            default:
+                throw new UserException(String.format(
+                        "Can not abort %s transaction %s, label is %s", txnStatus, txnId, label));
+        }
+
+        return result;
+    }
+
+    private static TransactionState getTxnState(long dbId, String label) throws UserException {
+        TransactionState txnState = GlobalStateMgr.getCurrentState()
+                .getGlobalTransactionMgr().getLabelTransactionState(dbId, label);
+        if (null == txnState) {
+            throw new UserException(String.format("No transaction found by label %s", label));
+        }
+
+        if (BYPASS_WRITE.equals(txnState.getSourceType())) {
+            return txnState;
+        }
+
+        throw new UserException(String.format(
+                "Transaction found by label %s isn't created in %s scenario.", label, BYPASS_WRITE.name()));
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperation.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperation.java
@@ -1,0 +1,58 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.transaction;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum TransactionOperation {
+
+    TXN_BEGIN("begin"),
+
+    TXN_PREPARE("prepare"),
+
+    TXN_COMMIT("commit"),
+
+    TXN_ROLLBACK("rollback"),
+
+    TXN_LOAD("load");
+
+    private final String value;
+
+    TransactionOperation(String value) {
+        this.value = value;
+    }
+
+    /**
+     * Parse {@code op} to {@link TransactionOperation}.
+     */
+    public static Optional<TransactionOperation> parse(String value) {
+        return Arrays.stream(values())
+                .filter(operation -> operation.getValue().equalsIgnoreCase(value))
+                .findFirst();
+    }
+
+    /**
+     * Check if {@code txnOperation} is the final operation in transaction lifecycle.
+     */
+    public static boolean isFinalOperation(TransactionOperation txnOperation) {
+        return TXN_COMMIT.equals(txnOperation) || TXN_ROLLBACK.equals(txnOperation);
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperationHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperationHandler.java
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.transaction;
+
+import com.starrocks.common.UserException;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.thrift.TNetworkAddress;
+
+/**
+ * Transaction management request handler.
+ */
+public interface TransactionOperationHandler {
+
+    /**
+     * Handle transaction management request.
+     */
+    ResultWrapper handle(BaseRequest request, BaseResponse response) throws UserException;
+
+    class ResultWrapper {
+
+        private final TransactionResult result;
+
+        private final TNetworkAddress redirectAddress;
+
+        public ResultWrapper(TransactionResult result) {
+            this(result, null);
+        }
+
+        public ResultWrapper(TNetworkAddress redirectAddress) {
+            this(null, redirectAddress);
+        }
+
+        public ResultWrapper(TransactionResult result, TNetworkAddress redirectAddress) {
+            this.result = result;
+            this.redirectAddress = redirectAddress;
+        }
+
+        public TransactionResult getResult() {
+            return result;
+        }
+
+        public TNetworkAddress getRedirectAddress() {
+            return redirectAddress;
+        }
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperationParams.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionOperationParams.java
@@ -1,0 +1,158 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.transaction;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
+import com.starrocks.transaction.TransactionState.LoadJobSourceType;
+
+import java.util.List;
+
+/**
+ * Request params parser, validator and holder.
+ */
+public class TransactionOperationParams {
+
+    /* headers */
+
+    private final String dbName;
+    private final String tableName;
+    private final String label;
+    private final TransactionOperation txnOperation;
+    private final Long timeoutMillis;
+    private final Channel channel;
+
+    /* queries */
+
+    private final LoadJobSourceType sourceType;
+
+    /* body */
+
+    private final Body body;
+
+    public TransactionOperationParams(String dbName,
+                                      String tableName,
+                                      String label,
+                                      TransactionOperation txnOperation,
+                                      Long timeoutMillis,
+                                      Channel channel,
+                                      LoadJobSourceType sourceType,
+                                      Body body) {
+        this.dbName = dbName;
+        this.tableName = tableName;
+        this.label = label;
+        this.txnOperation = txnOperation;
+        this.timeoutMillis = timeoutMillis;
+        this.channel = channel;
+        this.sourceType = sourceType;
+        this.body = body;
+    }
+
+    /**
+     * Channel info (eg. id, num) in request.
+     */
+    public static class Channel {
+
+        private final Integer id;
+        private final Integer num;
+
+        public Channel(Integer id, Integer num) {
+            this.id = id;
+            this.num = num;
+        }
+
+        public boolean isNull() {
+            return !notNull();
+        }
+
+        public boolean notNull() {
+            return null != id && null != num;
+        }
+
+        public Integer getId() {
+            return id;
+        }
+
+        public Integer getNum() {
+            return num;
+        }
+    }
+
+    /**
+     * Request body in JSON format.
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Body {
+
+        @JsonProperty("committed_tablets")
+        private List<TabletCommitInfo> committedTablets;
+
+        @JsonProperty("failed_tablets")
+        private List<TabletFailInfo> failedTablets;
+
+        public Body() {
+        }
+
+        public List<TabletCommitInfo> getCommittedTablets() {
+            return committedTablets;
+        }
+
+        public void setCommittedTablets(List<TabletCommitInfo> committedTablets) {
+            this.committedTablets = committedTablets;
+        }
+
+        public List<TabletFailInfo> getFailedTablets() {
+            return failedTablets;
+        }
+
+        public void setFailedTablets(List<TabletFailInfo> failedTablets) {
+            this.failedTablets = failedTablets;
+        }
+    }
+
+    public String getDbName() {
+        return dbName;
+    }
+
+    public String getTableName() {
+        return tableName;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+
+    public TransactionOperation getTxnOperation() {
+        return txnOperation;
+    }
+
+    public Long getTimeoutMillis() {
+        return timeoutMillis;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+
+    public LoadJobSourceType getSourceType() {
+        return sourceType;
+    }
+
+    public Body getBody() {
+        return body;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithChannelHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithChannelHandler.java
@@ -1,0 +1,90 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.transaction;
+
+import com.starrocks.common.DdlException;
+import com.starrocks.common.UserException;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.http.rest.transaction.TransactionOperationParams.Channel;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.thrift.TNetworkAddress;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+/**
+ * Transaction management request handler with channel info (eg. id, num) in request.
+ */
+public class TransactionWithChannelHandler implements TransactionOperationHandler {
+
+    private static final Logger LOG = LogManager.getLogger(TransactionWithChannelHandler.class);
+
+    private final TransactionOperationParams txnOperationParams;
+
+    public TransactionWithChannelHandler(TransactionOperationParams txnOperationParams) {
+        Validate.isTrue(txnOperationParams.getChannel().notNull(), "channel is null");
+        this.txnOperationParams = txnOperationParams;
+    }
+
+    @Override
+    public ResultWrapper handle(BaseRequest request, BaseResponse response) throws UserException {
+        TransactionOperation txnOperation = txnOperationParams.getTxnOperation();
+        String dbName = txnOperationParams.getDbName();
+        String tableName = txnOperationParams.getTableName();
+        Long timeoutMillis = txnOperationParams.getTimeoutMillis();
+        String label = txnOperationParams.getLabel();
+        Channel channel = txnOperationParams.getChannel();
+        LOG.info("Handle transaction with channel info, label: {}", label);
+
+        TransactionResult result = new TransactionResult();
+        switch (txnOperation) {
+            case TXN_BEGIN:
+                if (channel.getId() >= channel.getNum() || channel.getId() < 0) {
+                    throw new DdlException(String.format(
+                            "Channel ID should be between [0, %d].", (channel.getNum() - 1)));
+                }
+
+                GlobalStateMgr.getCurrentState().getStreamLoadMgr().beginLoadTask(
+                        dbName, tableName, label, timeoutMillis, channel.getNum(), channel.getId(), result);
+                return new ResultWrapper(result);
+            case TXN_PREPARE:
+                GlobalStateMgr.getCurrentState().getStreamLoadMgr().prepareLoadTask(
+                        label, channel.getId(), request.getRequest().headers(), result);
+                if (!result.stateOK() || result.containMsg()) {
+                    return new ResultWrapper(result);
+                }
+                GlobalStateMgr.getCurrentState().getStreamLoadMgr().tryPrepareLoadTaskTxn(label, result);
+                return new ResultWrapper(result);
+            case TXN_COMMIT:
+                GlobalStateMgr.getCurrentState().getStreamLoadMgr().commitLoadTask(label, result);
+                return new ResultWrapper(result);
+            case TXN_ROLLBACK:
+                GlobalStateMgr.getCurrentState().getStreamLoadMgr().rollbackLoadTask(label, result);
+                return new ResultWrapper(result);
+            case TXN_LOAD:
+                TNetworkAddress redirectAddr = GlobalStateMgr.getCurrentState()
+                        .getStreamLoadMgr().executeLoadTask(
+                                label, channel.getId(), request.getRequest().headers(), result, dbName, tableName);
+                if (!result.stateOK() || result.containMsg()) {
+                    return new ResultWrapper(result);
+                }
+                return new ResultWrapper(redirectAddr);
+            default:
+                throw new UserException("Unsupported operation: " + txnOperation);
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithoutChannelHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/transaction/TransactionWithoutChannelHandler.java
@@ -1,0 +1,145 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.http.rest.transaction;
+
+import com.starrocks.catalog.Database;
+import com.starrocks.common.UserException;
+import com.starrocks.http.BaseRequest;
+import com.starrocks.http.BaseResponse;
+import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionStatus;
+import org.apache.commons.lang3.Validate;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Optional;
+
+/**
+ * Transaction management request handler without channel info (eg. id, num) in request.
+ */
+public class TransactionWithoutChannelHandler implements TransactionOperationHandler {
+
+    private static final Logger LOG = LogManager.getLogger(TransactionWithoutChannelHandler.class);
+
+    private final TransactionOperationParams txnOperationParams;
+
+    public TransactionWithoutChannelHandler(TransactionOperationParams txnOperationParams) {
+        Validate.isTrue(txnOperationParams.getChannel().isNull(), "channel isn't null");
+        this.txnOperationParams = txnOperationParams;
+    }
+
+    @Override
+    public ResultWrapper handle(BaseRequest request, BaseResponse response) throws UserException {
+        TransactionOperation txnOperation = txnOperationParams.getTxnOperation();
+        String dbName = txnOperationParams.getDbName();
+        String label = txnOperationParams.getLabel();
+        Long timeoutMillis = txnOperationParams.getTimeoutMillis();
+        LOG.info("Handle transaction without channel info, label: {}", label);
+
+        Database db = Optional.ofNullable(GlobalStateMgr.getCurrentState().getDb(dbName))
+                .orElseThrow(() -> new UserException(String.format("Database[%s] does not exist.", dbName)));
+
+        TransactionResult result = null;
+        switch (txnOperation) {
+            case TXN_BEGIN:
+            case TXN_PREPARE:
+            case TXN_LOAD:
+                break;
+            case TXN_COMMIT:
+                result = handleCommitTransaction(db, label, timeoutMillis);
+                break;
+            case TXN_ROLLBACK:
+                result = handleRollbackTransaction(db, label);
+                break;
+            default:
+                throw new UserException("Unsupported operation: " + txnOperation);
+        }
+
+        return new ResultWrapper(result);
+    }
+
+    private TransactionResult handleCommitTransaction(Database db,
+                                                      String label,
+                                                      long timeoutMillis) throws UserException {
+        long dbId = db.getId();
+        TransactionState txnState = getTxnState(dbId, label);
+        long txnId = txnState.getTransactionId();
+        TransactionStatus txnStatus = txnState.getTransactionStatus();
+        TransactionResult result = new TransactionResult();
+        switch (txnStatus) {
+            case PREPARED:
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .commitPreparedTransaction(db, txnId, timeoutMillis);
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            case COMMITTED:
+            case VISIBLE:
+                result.setOKMsg(String.format("Transaction %s has already committed, label is %s", txnId, label));
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            case ABORTED:
+                throw new UserException(String.format(
+                        "Can not commit %s transaction %s, label is %s", txnStatus, txnId, label));
+            default:
+                return null;
+        }
+
+        return result;
+    }
+
+    private TransactionResult handleRollbackTransaction(Database db,
+                                                        String label) throws UserException {
+        long dbId = db.getId();
+        TransactionState txnState = getTxnState(dbId, label);
+        long txnId = txnState.getTransactionId();
+        TransactionStatus txnStatus = txnState.getTransactionStatus();
+        TransactionResult result = new TransactionResult();
+        switch (txnStatus) {
+            case PREPARED:
+                GlobalStateMgr.getCurrentState().getGlobalTransactionMgr()
+                        .abortTransaction(dbId, txnId, "User Aborted");
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            case ABORTED:
+                result.setOKMsg(String.format("Transaction %s has already aborted, label is %s", txnId, label));
+                result.addResultEntry(TransactionResult.TXN_ID_KEY, txnId);
+                result.addResultEntry(TransactionResult.LABEL_KEY, label);
+                break;
+            case COMMITTED:
+            case VISIBLE:
+                throw new UserException(String.format(
+                        "Can not abort %s transaction %s, label is %s", txnStatus, txnId, label));
+            default:
+                return null;
+        }
+
+        return result;
+    }
+
+    private static TransactionState getTxnState(long dbId, String label) throws UserException {
+        TransactionState txnState = GlobalStateMgr.getCurrentState()
+                .getGlobalTransactionMgr().getLabelTransactionState(dbId, label);
+        if (null == txnState) {
+            throw new UserException(String.format("No transaction found by label %s", label));
+        }
+        return txnState;
+    }
+
+}

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -1900,33 +1900,10 @@ public class DatabaseTransactionMgr {
         } finally {
             readUnlock();
         }
-        if (transactionState == null) {
-            return TTransactionStatus.UNKNOWN;
-        }
-        TransactionStatus status = transactionState.getTransactionStatus();
-
-        switch (status.value()) {
-            //UNKNOWN
-            case 0:
-                return TTransactionStatus.UNKNOWN;
-            //PREPARE
-            case 1:
-                return TTransactionStatus.PREPARE;
-            //COMMITTED
-            case 2:
-                return TTransactionStatus.COMMITTED;
-            //VISIBLE
-            case 3:
-                return TTransactionStatus.VISIBLE;
-            //ABORTED
-            case 4:
-                return TTransactionStatus.ABORTED;
-            //PREPARED
-            case 5:
-                return TTransactionStatus.PREPARED;
-            default:
-                return TTransactionStatus.UNKNOWN;
-        }
+        return Optional.ofNullable(transactionState)
+                .map(TransactionState::getTransactionStatus)
+                .map(TransactionStatus::toThrift)
+                .orElse(TTransactionStatus.UNKNOWN);
     }
 
     private void checkDatabaseDataQuota() throws AnalysisException {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletCommitInfo.java
@@ -55,6 +55,9 @@ public class TabletCommitInfo implements Writable {
     private List<String> validDictCacheColumns = Lists.newArrayList();
     private List<Long> validDictCollectedVersions = Lists.newArrayList();
 
+    public TabletCommitInfo() {
+    }
+
     public TabletCommitInfo(long tabletId, long backendId) {
         super();
         this.tabletId = tabletId;
@@ -88,6 +91,14 @@ public class TabletCommitInfo implements Writable {
 
     public List<Long> getValidDictCollectedVersions() {
         return validDictCollectedVersions;
+    }
+
+    public void setTabletId(long tabletId) {
+        this.tabletId = tabletId;
+    }
+
+    public void setBackendId(long backendId) {
+        this.backendId = backendId;
     }
 
     @NotNull

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TabletFailInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TabletFailInfo.java
@@ -31,6 +31,9 @@ public class TabletFailInfo implements Writable {
     private long tabletId;
     private long backendId;
 
+    public TabletFailInfo() {
+    }
+
     public TabletFailInfo(long tabletId, long backendId) {
         super();
         this.tabletId = tabletId;
@@ -41,8 +44,16 @@ public class TabletFailInfo implements Writable {
         return tabletId;
     }
 
+    public void setTabletId(long tabletId) {
+        this.tabletId = tabletId;
+    }
+
     public long getBackendId() {
         return backendId;
+    }
+
+    public void setBackendId(long backendId) {
+        this.backendId = backendId;
     }
 
     @NotNull

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -70,6 +70,7 @@ import org.apache.logging.log4j.Logger;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -105,7 +106,8 @@ public class TransactionState implements Writable {
         LAKE_COMPACTION(7),            // compaction of LakeTable
         FRONTEND_STREAMING(8),          // FE streaming load use this type
         MV_REFRESH(9),                  // Refresh MV
-        REPLICATION(10);                // Replication
+        REPLICATION(10),                // Replication
+        BYPASS_WRITE(11);               // Bypass BE, and write data file directly
 
         private final int flag;
 
@@ -118,30 +120,14 @@ public class TransactionState implements Writable {
         }
 
         public static LoadJobSourceType valueOf(int flag) {
-            switch (flag) {
-                case 1:
-                    return FRONTEND;
-                case 2:
-                    return BACKEND_STREAMING;
-                case 3:
-                    return INSERT_STREAMING;
-                case 4:
-                    return ROUTINE_LOAD_TASK;
-                case 5:
-                    return BATCH_LOAD_JOB;
-                case 6:
-                    return DELETE;
-                case 7:
-                    return LAKE_COMPACTION;
-                case 8:
-                    return FRONTEND_STREAMING;
-                case 9:
-                    return MV_REFRESH;
-                case 10:
-                    return REPLICATION;
-                default:
-                    return null;
-            }
+            return Arrays.stream(values())
+                    .filter(sourceType -> sourceType.flag == flag)
+                    .findFirst()
+                    .orElse(null);
+        }
+
+        public int getFlag() {
+            return flag;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionStatus.java
@@ -17,6 +17,10 @@
 
 package com.starrocks.transaction;
 
+import com.starrocks.thrift.TTransactionStatus;
+
+import java.util.Arrays;
+
 public enum TransactionStatus {
     UNKNOWN(0),
     PREPARE(1),
@@ -27,30 +31,39 @@ public enum TransactionStatus {
 
     private final int flag;
 
-    private TransactionStatus(int flag) {
+    TransactionStatus(int flag) {
         this.flag = flag;
     }
 
-    public int value() {
-        return flag;
+    public static TransactionStatus valueOf(int flag) {
+        return Arrays.stream(values())
+                .filter(status -> status.getFlag() == flag)
+                .findFirst()
+                .orElse(UNKNOWN);
     }
 
-    public static TransactionStatus valueOf(int flag) {
-        switch (flag) {
+    public TTransactionStatus toThrift() {
+        switch (this.getFlag()) {
+            // UNKNOWN
             case 0:
-                return UNKNOWN;
+                return TTransactionStatus.UNKNOWN;
+            // PREPARE
             case 1:
-                return PREPARE;
+                return TTransactionStatus.PREPARE;
+            // COMMITTED
             case 2:
-                return COMMITTED;
+                return TTransactionStatus.COMMITTED;
+            // VISIBLE
             case 3:
-                return VISIBLE;
+                return TTransactionStatus.VISIBLE;
+            // ABORTED
             case 4:
-                return ABORTED;
+                return TTransactionStatus.ABORTED;
+            // PREPARED
             case 5:
-                return PREPARED;
+                return TTransactionStatus.PREPARED;
             default:
-                return UNKNOWN;
+                return TTransactionStatus.UNKNOWN;
         }
     }
 
@@ -64,21 +77,10 @@ public enum TransactionStatus {
 
     @Override
     public String toString() {
-        switch (this) {
-            case UNKNOWN:
-                return "UNKNOWN";
-            case PREPARE:
-                return "PREPARE";
-            case COMMITTED:
-                return "COMMITTED";
-            case VISIBLE:
-                return "VISIBLE";
-            case ABORTED:
-                return "ABORTED";
-            case PREPARED:
-                return "PREPARED";
-            default:
-                return "UNKNOWN";
-        }
+        return this.name();
+    }
+
+    public int getFlag() {
+        return flag;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/StarRocksHttpTestCase.java
@@ -34,6 +34,7 @@
 
 package com.starrocks.http;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.starrocks.alter.MaterializedViewHandler;
 import com.starrocks.alter.SchemaChangeHandler;
@@ -68,6 +69,14 @@ import com.starrocks.thrift.TStorageMedium;
 import com.starrocks.thrift.TStorageType;
 import com.starrocks.transaction.GlobalTransactionMgr;
 import com.starrocks.transaction.TransactionStatus;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
 import junit.framework.AssertionFailedError;
 import mockit.Expectations;
 import mockit.Mock;
@@ -82,6 +91,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 
 import java.net.ServerSocket;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -102,19 +112,19 @@ public abstract class StarRocksHttpTestCase {
     public static final String DB_NAME = "testDb";
     public static final String TABLE_NAME = "testTbl";
 
-    private static long testBackendId1 = 1000;
-    private static long testBackendId2 = 1001;
-    private static long testBackendId3 = 1002;
+    protected static long testBackendId1 = 1000;
+    protected static long testBackendId2 = 1001;
+    protected static long testBackendId3 = 1002;
 
     private static long testReplicaId1 = 2000;
     private static long testReplicaId2 = 2001;
     private static long testReplicaId3 = 2002;
 
     protected static long testDbId = 100L;
-    private static long testTableId = 200L;
+    protected static long testTableId = 200L;
     private static long testPartitionId = 201L;
     public static long testIndexId = testTableId; // the base indexid == tableid
-    private static long tabletId = 400L;
+    protected static long tabletId = 400L;
 
     public static long testStartVersion = 12;
     public static int testSchemaHash = 93423942;
@@ -124,7 +134,10 @@ public abstract class StarRocksHttpTestCase {
     protected static String URI;
     protected static String BASE_URL;
 
+    protected static final String AUTH_KEY = "Authorization";
     protected String rootAuth = Credentials.basic("root", "");
+
+    protected static ObjectMapper objectMapper = new ObjectMapper();
 
     @Mocked
     private static EditLog editLog;
@@ -572,7 +585,7 @@ public abstract class StarRocksHttpTestCase {
         httpServer.shutDown();
     }
 
-    public void doSetUp() {
+    protected void doSetUp() {
 
     }
 
@@ -609,5 +622,26 @@ public abstract class StarRocksHttpTestCase {
             throw assertion;
         }
         throw new AssertionFailedError(noExceptionMessage);
+    }
+
+    protected static void writeResponse(BaseRequest request, BaseResponse response) {
+        writeResponse(request, response, HttpResponseStatus.OK);
+    }
+
+    protected static void writeResponse(BaseRequest request, BaseResponse response, HttpResponseStatus status) {
+        FullHttpResponse responseObj = new DefaultFullHttpResponse(
+                HttpVersion.HTTP_1_1,
+                status,
+                Unpooled.wrappedBuffer(response.getContent().toString().getBytes(StandardCharsets.UTF_8)));
+
+        HttpMethod method = request.getRequest().method();
+        if (!method.equals(HttpMethod.HEAD)) {
+            response.updateHeader(
+                    HttpHeaderNames.CONTENT_LENGTH.toString(),
+                    String.valueOf(responseObj.content().readableBytes())
+            );
+        }
+
+        request.getContext().write(responseObj).addListener(ChannelFutureListener.CLOSE);
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TransactionLoadActionTest.java
@@ -15,40 +15,95 @@
 package com.starrocks.http;
 
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.common.collect.ImmutableMap;
+import com.starrocks.catalog.Database;
 import com.starrocks.catalog.DiskInfo;
+import com.starrocks.common.DdlException;
+import com.starrocks.common.UserException;
+import com.starrocks.http.rest.ActionStatus;
 import com.starrocks.http.rest.TransactionLoadAction;
 import com.starrocks.http.rest.TransactionResult;
+import com.starrocks.http.rest.transaction.TransactionOperation;
+import com.starrocks.load.streamload.StreamLoadMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
+import com.starrocks.thrift.TNetworkAddress;
+import com.starrocks.transaction.BeginTransactionException;
+import com.starrocks.transaction.GlobalTransactionMgr;
+import com.starrocks.transaction.TabletCommitInfo;
+import com.starrocks.transaction.TabletFailInfo;
+import com.starrocks.transaction.TransactionState;
+import com.starrocks.transaction.TransactionState.LoadJobSourceType;
+import com.starrocks.transaction.TransactionState.TxnCoordinator;
+import com.starrocks.transaction.TransactionState.TxnSourceType;
+import com.starrocks.transaction.TransactionStatus;
+import com.starrocks.transaction.TxnCommitAttachment;
+import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpMethod;
 import io.netty.handler.codec.http.HttpResponseStatus;
+import mockit.Delegate;
+import mockit.Expectations;
 import mockit.Mock;
 import mockit.MockUp;
+import mockit.Mocked;
 import okhttp3.MediaType;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okio.BufferedSink;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.RandomUtils;
+import org.apache.http.client.utils.URIBuilder;
+import org.assertj.core.util.Lists;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.junit.AfterClass;
-import org.junit.Assert;
-import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.BiConsumer;
 
+import static com.starrocks.common.jmockit.Deencapsulation.setField;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@FixMethodOrder(MethodSorters.JVM)
 public class TransactionLoadActionTest extends StarRocksHttpTestCase {
+
+    private static final String OK = ActionStatus.OK.name();
+    private static final String FAILED = ActionStatus.FAILED.name();
+
+    private static final String DB_KEY = "db";
+    private static final String TABLE_KEY = "table";
+    private static final String LABEL_KEY = "label";
+    private static final String CHANNEL_NUM_STR = "channel_num";
+    private static final String CHANNEL_ID_STR = "channel_id";
+    private static final String SOURCE_TYPE = "source_type";
 
     private static HttpServer beServer;
     private static int TEST_HTTP_PORT = 0;
 
+    @Mocked
+    private StreamLoadMgr streamLoadMgr;
+
+    @Mocked
+    private GlobalTransactionMgr globalTransactionMgr;
+
     @Override
-    @Before
-    public void setUp() {
+    protected void doSetUp() {
         Backend backend4 = new Backend(1234, "localhost", 8040);
         backend4.setBePort(9300);
         backend4.setAlive(true);
@@ -60,6 +115,21 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
             boolean isLeader() {
                 return true;
             }
+        };
+
+        new MockUp<TransactionLoadAction>() {
+
+            @Mock
+            public void redirectTo(BaseRequest request,
+                                   BaseResponse response,
+                                   TNetworkAddress addr) throws DdlException {
+                TransactionResult result = new TransactionResult();
+                result.setOKMsg("mock redirect to BE");
+                response.setContentType(JSON.toString());
+                response.appendContent(result.toJson());
+                writeResponse(request, response);
+            }
+
         };
     }
 
@@ -73,9 +143,8 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
     }
 
     @BeforeClass
-    public static void initBeServer() throws IllegalArgException, InterruptedException {
+    public static void initBeServer() throws Exception {
         TEST_HTTP_PORT = detectUsableSocketPort();
-
         beServer = new HttpServer(TEST_HTTP_PORT);
         BaseAction ac = new BaseAction(beServer.getController()) {
 
@@ -86,6 +155,7 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
                 writeResponse(request, response, HttpResponseStatus.OK);
             }
         };
+
         beServer.getController().registerHandler(HttpMethod.POST, "/api/transaction/begin", ac);
         beServer.getController().registerHandler(HttpMethod.POST, "/api/transaction/prepare", ac);
         beServer.getController().registerHandler(HttpMethod.POST, "/api/transaction/commit", ac);
@@ -95,289 +165,1509 @@ public class TransactionLoadActionTest extends StarRocksHttpTestCase {
         while (!beServer.isStarted()) {
             Thread.sleep(500);
         }
+        assertTrue(beServer.isStarted());
     }
 
     @Test
     @Ignore("test whether this case affect cases in TableQueryPlanActionTest")
-    public void beginTransactionTimes() throws IOException {
-        String pathUri = "http://localhost:" + HTTP_PORT + "/api/transaction/begin";
-
+    public void beginTransactionTimes() throws Exception {
         for (int i = 0; i < 4096; i++) {
-            Request request = new Request.Builder()
-                    .get()
-                    .addHeader("Authorization", rootAuth)
-                    .addHeader("db", "testDb")
-                    .addHeader("label", String.valueOf(i))
-                    .url(pathUri)
-                    .method("POST", new RequestBody() {
-
-                        @Override
-                        public MediaType contentType() {
-                            return null;
-                        }
-
-                        @Override
-                        public void writeTo(@NotNull BufferedSink arg0) {
-                        }
-
-                    })
-                    .build();
+            final String label = Objects.toString(i);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
             try (Response response = networkClient.newCall(request).execute()) {
-                ResponseBody responseBody = response.body();
-                Assert.assertNotNull(responseBody);
-                String res = responseBody.string();
-                Assert.assertTrue(res.contains("OK"));
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
             }
 
-            Assert.assertTrue(TransactionLoadAction.getAction().txnNodeMapSize() <= 2048);
+            assertTrue(TransactionLoadAction.getAction().txnNodeMapSize() <= 2048);
         }
     }
 
     @Test
-    public void beginTransaction() throws IOException {
-        String pathUri = "http://localhost:" + HTTP_PORT + "/api/transaction/begin";
-        Request request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .url(pathUri)
-                .method("POST", new RequestBody() {
-
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
+    public void operateTransactionWithBadRequestTest() throws Exception {
+        {
+            Request request = newRequest(TransactionOperation.TXN_BEGIN);
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("No database selected."));
+            }
         }
 
-        request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .addHeader("db", "abc")
-                .url(pathUri)
-                .method("POST", new RequestBody() {
-
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
+        {
+            Request request = newRequest(
+                    TransactionOperation.TXN_BEGIN,
+                    (uriBuilder, reqBuilder) -> reqBuilder.addHeader(DB_KEY, DB_NAME));
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Empty label."));
+            }
         }
 
-        request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .addHeader("db", "abc")
-                .addHeader("label", "abcdbcef")
-                .url(pathUri)
-                .method("POST", new RequestBody() {
+        {
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "8");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "5");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Channel ID should be between"));
+            }
+        }
 
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertTrue(res.contains("OK"));
+        {
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            }, RequestBody.create("not json", JSON));
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Malformed json tablets"));
+            }
         }
     }
 
     @Test
-    public void commitTransaction() throws IOException {
-        String pathUri = "http://localhost:" + HTTP_PORT + "/api/transaction/commit";
-        Request request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .url(pathUri)
-                .method("POST", new RequestBody() {
+    public void beginTransactionWithChannelInfoTest() throws Exception {
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.beginLoadTask(
+                            anyString, anyString, anyString, anyLong, anyInt, anyInt, (TransactionResult) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
 
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
+                        public void beginLoadTask(String dbName,
+                                                  String tableName,
+                                                  String label,
+                                                  long timeoutMillis,
+                                                  int channelNum,
+                                                  int channelId,
+                                                  TransactionResult resp) {
+                            resp.addResultEntry(TransactionResult.LABEL_KEY, label);
+                        }
 
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
+                    };
+                }
+            };
 
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "0");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "2");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, Objects.toString(body.get(TransactionResult.LABEL_KEY)));
+            }
         }
 
-        request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .addHeader("db", "abc")
-                .url(pathUri)
-                .method("POST", new RequestBody() {
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.beginLoadTask(
+                            anyString, anyString, anyString, anyLong, anyInt, anyInt, (TransactionResult) any);
+                    times = 1;
+                    result = new UserException("begin load task error");
+                }
+            };
 
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
-        }
-
-    }
-
-    @Test
-    public void rollbackTransaction() throws IOException {
-        String pathUri = "http://localhost:" + HTTP_PORT + "/api/transaction/rollback";
-        Request request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .url(pathUri)
-                .method("POST", new RequestBody() {
-
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
-        }
-
-        request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .addHeader("db", "abc")
-                .url(pathUri)
-                .method("POST", new RequestBody() {
-
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
-        }
-
-        request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .addHeader("db", "testDb")
-                .url(pathUri)
-                .method("POST", new RequestBody() {
-
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
-        try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "0");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "2");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("begin load task error"));
+            }
         }
     }
 
     @Test
-    public void prepareTransaction() throws IOException {
-        String pathUri = "http://localhost:" + HTTP_PORT + "/api/transaction/prepare";
-        Request request = new Request.Builder()
-                .get()
-                .addHeader("Authorization", rootAuth)
-                .url(pathUri)
-                .method("POST", new RequestBody() {
-
-                    @Override
-                    public MediaType contentType() {
-                        return null;
-                    }
-
-                    @Override
-                    public void writeTo(@NotNull BufferedSink arg0) {
-                    }
-
-                })
-                .build();
-
+    public void beginTransactionWithoutChannelInfoTest() throws Exception {
+        String label = RandomStringUtils.randomAlphanumeric(32);
+        Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
         try (Response response = networkClient.newCall(request).execute()) {
-            ResponseBody responseBody = response.body();
-            Assert.assertNotNull(responseBody);
-            String res = responseBody.string();
-            Assert.assertFalse(res.contains("OK"));
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+    }
+
+    @Test
+    public void beginTransactionForBypassWriteTest() throws Exception {
+        {
+            new Expectations() {
+                {
+                    globalTransactionMgr.beginTransaction(
+                            anyLong,
+                            (List<Long>) any,
+                            anyString,
+                            (TxnCoordinator) any,
+                            LoadJobSourceType.BYPASS_WRITE,
+                            anyLong);
+                    times = 1;
+                    result = new BeginTransactionException("begin transaction error");
+                }
+            };
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+
+                uriBuilder.addParameter(SOURCE_TYPE, Objects.toString(LoadJobSourceType.BYPASS_WRITE.getFlag()));
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("begin transaction error"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(0, Integer.MAX_VALUE);
+            new Expectations() {
+                {
+                    globalTransactionMgr.beginTransaction(
+                            anyLong,
+                            (List<Long>) any,
+                            anyString,
+                            (TxnCoordinator) any,
+                            LoadJobSourceType.BYPASS_WRITE,
+                            anyLong);
+                    times = 1;
+                    result = txnId;
+                }
+            };
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+
+                uriBuilder.addParameter(SOURCE_TYPE, Objects.toString(LoadJobSourceType.BYPASS_WRITE.getFlag()));
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+    }
+
+    @Test
+    public void prepareTransactionWithChannelInfoTest() throws Exception {
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.prepareLoadTask(anyString, anyInt, (HttpHeaders) any, (TransactionResult) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
+
+                        public void prepareLoadTask(String label,
+                                                    int channelId,
+                                                    HttpHeaders headers,
+                                                    TransactionResult resp) throws UserException {
+                            resp.setErrorMsg("prepare load task error");
+                        }
+
+                    };
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("prepare load task error"));
+            }
+        }
+
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.prepareLoadTask(anyString, anyInt, (HttpHeaders) any, (TransactionResult) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
+
+                        public void prepareLoadTask(String label,
+                                                    int channelId,
+                                                    HttpHeaders headers,
+                                                    TransactionResult resp) throws UserException {
+                            resp.setOKMsg("");
+                        }
+
+                    };
+
+                    streamLoadMgr.tryPrepareLoadTaskTxn(anyString, (TransactionResult) any);
+                    times = 1;
+                    result = new UserException("try prepare load task txn error");
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("try prepare load task txn error"));
+            }
+        }
+
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.prepareLoadTask(anyString, anyInt, (HttpHeaders) any, (TransactionResult) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
+
+                        public void prepareLoadTask(String label,
+                                                    int channelId,
+                                                    HttpHeaders headers,
+                                                    TransactionResult resp) throws UserException {
+                            resp.setOKMsg("");
+                        }
+
+                    };
+
+                    streamLoadMgr.tryPrepareLoadTaskTxn(anyString, (TransactionResult) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
+
+                        public void tryPrepareLoadTaskTxn(String label, TransactionResult resp) throws UserException {
+                            resp.addResultEntry(TransactionResult.LABEL_KEY, label);
+                        }
+
+                    };
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+            }
+        }
+    }
+
+    @Test
+    public void prepareTransactionWithoutChannelInfoTest() throws Exception {
+        String label = RandomStringUtils.randomAlphanumeric(32);
+        setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            private static final long serialVersionUID = -4276328107866085321L;
+
+            {
+                put(label, 1234L);
+            }
+        });
+
+        Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+    }
+
+    @Test
+    public void prepareTransactionForBypassWriteTest() throws Exception {
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.UNKNOWN),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.UNKNOWN)
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Can not prepare"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.COMMITTED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.COMMITTED)
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("has already COMMITTED"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE)
+                    );
+
+                    globalTransactionMgr.prepareTransaction(
+                            anyLong, anyLong,
+                            (List<TabletCommitInfo>) any,
+                            (List<TabletFailInfo>) any,
+                            (TxnCommitAttachment) any);
+                    times = 1;
+                    result = new UserException("prepare transaction error");
+
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("prepare transaction error"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE)
+                    );
+
+                    globalTransactionMgr.prepareTransaction(
+                            anyLong, anyLong,
+                            (List<TabletCommitInfo>) any,
+                            (List<TabletFailInfo>) any,
+                            (TxnCommitAttachment) any);
+                    times = 1;
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            }, RequestBody.create(
+                    objectMapper.writeValueAsString(
+                            new Body(Lists.newArrayList(new TabletCommitInfo(400L, 1234L)), new ArrayList<>(0))),
+                    JSON
+            ));
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+    }
+
+    @Test
+    public void commitTransactionWithChannelInfoTest() throws Exception {
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.commitLoadTask(anyString, (TransactionResult) any);
+                    times = 1;
+                    result = new UserException("commit load task error");
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("commit load task error"));
+            }
+        }
+
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.commitLoadTask(anyString, (TransactionResult) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
+
+                        public void commitLoadTask(String label, TransactionResult resp) throws UserException {
+                            resp.addResultEntry(TransactionResult.LABEL_KEY, label);
+                        }
+
+                    };
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+            }
+        }
+    }
+
+    @Test
+    public void commitTransactionWithoutChannelInfoTest() throws Exception {
+        {
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = null;
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = 5890524883711716645L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("No transaction found by label"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.UNKNOWN);
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = -4276328107866085321L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.ABORTED);
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = 8612091611347668755L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Can not commit"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.COMMITTED);
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = 3214813746415023231L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("has already committed"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.PREPARED);
+
+                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    times = 1;
+                    result = new UserException("commit prepared transaction error");
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = 6893430743492341004L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(
+                        Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("commit prepared transaction error"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.PREPARED);
+
+                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    times = 1;
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = 8165080593735535441L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+    }
+
+    @Test
+    public void commitTransactionForBypassWriteTest() throws Exception {
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED),
+                            null
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("No transaction found by label"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE)
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Can not commit"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.COMMITTED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.COMMITTED)
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("has already committed"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED)
+                    );
+
+                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    times = 1;
+                    result = new UserException("commit prepared transaction error");
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(
+                        Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("commit prepared transaction error"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED)
+                    );
+
+                    globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                    times = 1;
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+    }
+
+    @Test
+    public void commitTransactionForBypassWriteWithLifeCycleTest() throws Exception {
+        long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+        String label = RandomStringUtils.randomAlphanumeric(32);
+        new Expectations() {
+            {
+                globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                times = 4;
+                returns(
+                        newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE),
+                        newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARE),
+                        newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED),
+                        newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED)
+                );
+
+                globalTransactionMgr.beginTransaction(
+                        anyLong,
+                        (List<Long>) any,
+                        anyString,
+                        (TxnCoordinator) any,
+                        LoadJobSourceType.BYPASS_WRITE,
+                        anyLong);
+                times = 1;
+                result = txnId;
+
+                globalTransactionMgr.prepareTransaction(
+                        anyLong, anyLong,
+                        (List<TabletCommitInfo>) any,
+                        (List<TabletFailInfo>) any,
+                        (TxnCommitAttachment) any);
+                times = 1;
+
+                globalTransactionMgr.commitPreparedTransaction((Database) any, anyLong, anyLong);
+                times = 1;
+            }
+        };
+
+        {
+            Request request = newRequest(TransactionOperation.TXN_BEGIN, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(TABLE_KEY, TABLE_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+
+                uriBuilder.addParameter(SOURCE_TYPE, Objects.toString(LoadJobSourceType.BYPASS_WRITE.getFlag()));
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+
+        {
+            Request request = newRequest(TransactionOperation.TXN_PREPARE, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            }, RequestBody.create(
+                    objectMapper.writeValueAsString(
+                            new Body(Lists.newArrayList(new TabletCommitInfo(400L, 1234L)), new ArrayList<>(0))),
+                    JSON
+            ));
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+
+        {
+            Request request = newRequest(TransactionOperation.TXN_COMMIT, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+    }
+
+    @Test
+    public void rollbackTransactionWithChannelInfoTest() throws Exception {
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.rollbackLoadTask(anyString, (TransactionResult) any);
+                    times = 1;
+                    result = new UserException("rollback load task error");
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("rollback load task error"));
+            }
+        }
+
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.rollbackLoadTask(anyString, (TransactionResult) any);
+                    times = 1;
+                    result = new Delegate<Void>() {
+
+                        public void rollbackLoadTask(String label, TransactionResult resp) throws UserException {
+                            resp.addResultEntry(TransactionResult.LABEL_KEY, label);
+                        }
+
+                    };
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+            }
+        }
+    }
+
+    @Test
+    public void rollbackTransactionWithoutChannelInfoTest() throws Exception {
+        {
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = null;
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = 5890524883711716645L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("No transaction found by label"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.UNKNOWN);
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = -4276328107866085321L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.COMMITTED);
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = -5731416357248595041L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Can not abort"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.ABORTED);
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = -6655156575562250213L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("has already aborted"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.PREPARED);
+
+                    globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString);
+                    times = 1;
+                    result = new UserException("abort transaction error");
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = -891006164191904128L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("abort transaction error"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 1;
+                    result = newTxnState(txnId, label, LoadJobSourceType.FRONTEND_STREAMING, TransactionStatus.PREPARED);
+
+                    globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString);
+                    times = 1;
+                }
+            };
+
+            setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+                private static final long serialVersionUID = 4824168412840558066L;
+
+                {
+                    put(label, 1234L);
+                }
+            });
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+    }
+
+    @Test
+    public void rollbackTransactionForBypassWriteTest() throws Exception {
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED),
+                            null
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("No transaction found by label"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.COMMITTED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.COMMITTED)
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("Can not abort"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.ABORTED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.ABORTED)
+                    );
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("has already aborted"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED)
+                    );
+
+                    globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString, (List<TabletFailInfo>) any);
+                    times = 1;
+                    result = new UserException("abort transaction error");
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("abort transaction error"));
+            }
+        }
+
+        {
+            long txnId = RandomUtils.nextLong(1, Integer.MAX_VALUE);
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            new Expectations() {
+                {
+                    globalTransactionMgr.getLabelTransactionState(anyLong, anyString);
+                    times = 2;
+                    returns(
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED),
+                            newTxnState(txnId, label, LoadJobSourceType.BYPASS_WRITE, TransactionStatus.PREPARED)
+                    );
+
+                    globalTransactionMgr.abortTransaction(anyLong, anyLong, anyString, (List<TabletFailInfo>) any);
+                    times = 1;
+                }
+            };
+
+            Request request = newRequest(TransactionOperation.TXN_ROLLBACK, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertEquals(label, body.get(TransactionResult.LABEL_KEY));
+                assertEquals(txnId, Long.parseLong(Objects.toString(body.get(TransactionResult.TXN_ID_KEY))));
+            }
+        }
+    }
+
+    @Test
+    public void loadTransactionWithChannelInfoTest() throws Exception {
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.executeLoadTask(
+                            anyString, anyInt, (HttpHeaders) any, (TransactionResult) any, anyString, anyString);
+                    times = 1;
+                    result = new Delegate<TNetworkAddress>() {
+
+                        public TNetworkAddress executeLoadTask(
+                                String label,
+                                int channelId,
+                                HttpHeaders headers,
+                                TransactionResult resp,
+                                String dbName,
+                                String tableName)
+                                throws UserException {
+                            resp.setErrorMsg("execute load task error");
+                            return null;
+                        }
+                    };
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_LOAD, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(FAILED, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("execute load task error"));
+            }
+        }
+
+        {
+            new Expectations() {
+                {
+                    streamLoadMgr.executeLoadTask(
+                            anyString, anyInt, (HttpHeaders) any, (TransactionResult) any, anyString, anyString);
+                    times = 1;
+                    result = new TNetworkAddress("localhost", 8040);
+                }
+            };
+
+            String label = RandomStringUtils.randomAlphanumeric(32);
+            Request request = newRequest(TransactionOperation.TXN_LOAD, (uriBuilder, reqBuilder) -> {
+                reqBuilder.addHeader(DB_KEY, DB_NAME);
+                reqBuilder.addHeader(LABEL_KEY, label);
+                reqBuilder.addHeader(CHANNEL_ID_STR, "1");
+                reqBuilder.addHeader(CHANNEL_NUM_STR, "3");
+            });
+            try (Response response = networkClient.newCall(request).execute()) {
+                Map<String, Object> body = parseResponseBody(response);
+                assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+                assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+            }
+        }
+    }
+
+    @Test
+    public void loadTransactionWithoutChannelInfoTest() throws Exception {
+        String label = RandomStringUtils.randomAlphanumeric(32);
+        setField(TransactionLoadAction.getAction(), "txnNodeMap", new LinkedHashMap<String, Long>() {
+            private static final long serialVersionUID = -4276328107866085321L;
+
+            {
+                put(label, 1234L);
+            }
+        });
+
+        Request request = newRequest(TransactionOperation.TXN_LOAD, (uriBuilder, reqBuilder) -> {
+            reqBuilder.addHeader(DB_KEY, DB_NAME);
+            reqBuilder.addHeader(LABEL_KEY, label);
+        });
+        try (Response response = networkClient.newCall(request).execute()) {
+            Map<String, Object> body = parseResponseBody(response);
+            assertEquals(OK, body.get(TransactionResult.STATUS_KEY));
+            assertTrue(Objects.toString(body.get(TransactionResult.MESSAGE_KEY)).contains("mock redirect to BE"));
+        }
+    }
+
+    private Request newRequest(TransactionOperation operation) throws Exception {
+        return newRequest(operation, (uriBuilder, reqBuilder) -> {
+        });
+    }
+
+    private Request newRequest(TransactionOperation txnOpt,
+                               BiConsumer<URIBuilder, Request.Builder> consumer) throws Exception {
+        return newRequest(txnOpt, consumer, new RequestBody() {
+            @Nullable
+            @Override
+            public MediaType contentType() {
+                return JSON;
+            }
+
+            @Override
+            public void writeTo(@NotNull BufferedSink sink) throws IOException {
+
+            }
+        });
+    }
+
+    private Request newRequest(TransactionOperation txnOpt,
+                               BiConsumer<URIBuilder, Request.Builder> consumer,
+                               RequestBody requestBody) throws Exception {
+        URIBuilder uriBuilder = new URIBuilder(toUri(txnOpt));
+        Request.Builder reqBuilder = new Request.Builder()
+                .addHeader(AUTH_KEY, rootAuth)
+                .method(HttpMethod.POST.name(), requestBody);
+
+        if (null != consumer) {
+            consumer.accept(uriBuilder, reqBuilder);
+        }
+
+        return reqBuilder
+                .url(uriBuilder.build().toURL())
+                .build();
+    }
+
+    private static String toUri(TransactionOperation txnOpt) {
+        return String.format("http://localhost:%d/api/transaction/%s", HTTP_PORT, txnOpt.getValue());
+    }
+
+    private static Map<String, Object> parseResponseBody(Response response) throws IOException {
+        assertNotNull(response);
+        ResponseBody body = response.body();
+        assertNotNull(body);
+        String bodyStr = body.string();
+        System.out.println("Response body:\n" + bodyStr);
+        return objectMapper.readValue(bodyStr, new TypeReference<>() {
+        });
+    }
+
+    private static TransactionState newTxnState(long txnId,
+                                                String label,
+                                                LoadJobSourceType sourceType,
+                                                TransactionStatus txnStatus) {
+        TransactionState txnState = new TransactionState(
+                testDbId,
+                new ArrayList<>(0),
+                txnId,
+                label,
+                null,
+                sourceType,
+                new TxnCoordinator(TxnSourceType.FE, "127.0.0.1"),
+                -1,
+                20000L
+        );
+        txnState.setTransactionStatus(txnStatus);
+        return txnState;
+    }
+
+    private static class Body {
+
+        @JsonProperty("committed_tablets")
+        private List<TabletCommitInfo> committedTablets;
+
+        @JsonProperty("failed_tablets")
+        private List<TabletFailInfo> failedTablets;
+
+        public Body(List<TabletCommitInfo> committedTablets, List<TabletFailInfo> failedTablets) {
+            this.committedTablets = committedTablets;
+            this.failedTablets = failedTablets;
+        }
+
+        public List<TabletCommitInfo> getCommittedTablets() {
+            return committedTablets;
+        }
+
+        public List<TabletFailInfo> getFailedTablets() {
+            return failedTablets;
         }
     }
 }


### PR DESCRIPTION
__Why I'm doing:__

StarRocks is a next-gen, high-performance analytical data warehouse. However, the limitations of the MPP architecture still cause it to face some problems in large-data ETL scenarios. For example:

- __Low resource utilization__: StarRocks clusters adopt the resource reservation mode mostly, but in order to support large-data ETL scenarios, which require a large amount of resource overhead in a relatively short period of time, plan redundant resources in advance may reduce the overall resource utilization of the cluster.
- __Poor resource isolation__: In terms of resource isolation, StarRocks adopts _Group_ rather than _Query_ level isolation. In large-data ETL scenarios, there is a risk that a query with large resource overhead will run out of resources, thereby starving some small queries to death.
- __Lack of failure tolerance__: Due to the lack of task-level failure tolerance mechanism, when an ETL job fails, it will usually still fail even if rerun it manually.

In order to solve the above problems, we have proposed the idea of ​​direct reading and writing of StarRocks data files on storage and calculation separation scenarios. Taking the _Apache Spark_ as an example, the overall architecture design is as follows:

![image](https://github.com/plotor/plotor.github.io/blob/master/images/2024/starrocks-drw-overview.jpg?raw=false)

For complex query scenarios, users can submit jobs through the `spark-sql` client. Spark interacts with StarRocks to obtain tables's metadata information, manages data write transaction, and read and write data on shared storage media (eg. aws s3) through the SDK directly. Finally, for one piece of StarRocks's internal format data, multiple sets of analysis engines can read and write it on storage and calculation separation scenarios.

In terms of implementation, we enhanced the existing _StarRocks Spark Connector_. Compared with the existing _Spark Load_ and _Spark Connector_, the enhanced Spark Connector has the following advantages:

- Spark reads and writes StarRocks data files through the SDK in JNI mode directly, which avoid the overhead of BE node's resources.
- Fully reuse the advantages of the Spark engine in large-data ETL scenarios to make up for the shortcomings that StarRocks currently faces.
- Spark Catalog can connect and fetch StarRocks tables' metadata information directly by enhanced connector, which simplify the usage greatly.

__What I'm doing:__

This is a relatively big feature, and we will split it into multiple PRs. This PR is one of them, and mainly includes the refactor and reuse of the `StreamLoad` transaction [API](https://docs.starrocks.io/docs/loading/Stream_Load_transaction_interface/) to support direct read and write scenario. The changes to the API are as follows:

- Begin Transaction

Parameter | Data Type | Required | Default | Desc
--- | --- | --- | --- | ---
source_type | int | No | | __New added and Query parameter__, which corresponding to the `LoadJobSourceType` flag. This parameter is used to identify the job type of the request, and control some different execution logic of the backend.

Note: We have added a new `LoadJobSourceType` definition called `BYPASS_WRITE` for direct read and write scenario. `BYPASS_WRITE` means "Bypassing the BE node, and directly reading and writing StarRocks data files". We are not sure this is the most appropriate one. Naming, other candidate names also include `RAW_WRITE`, `SDK_WRITE`, etc.

- Prepare Transaction

Parameter | Data Type | Required | Default | Desc
--- | --- | --- | --- | ---
failed_tablets | JSON | No | | __New added and Body parameter__, which represent Failed Tablet list.

- Commit Transaction

Unchanged.

- Rollback Transaction

Parameter | Data Type | Required | Default | Desc
--- | --- | --- | --- | ---
committed_tablets | JSON | No | | __New added and Body parameter__, which represent Committed Tablet list.
failed_tablets | JSON | No | | __New added and Body parameter__, which represent Failed Tablet list.

- Load Transaction

Unsupported in the direct read and write scenario.

__Fixes #issue__

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:

- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
