### PR TITLE
[BugFix] fix NullPointerException in AST2StringBuilderVisitor

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/AstToStringBuilder.java
@@ -697,12 +697,13 @@ public class AstToStringBuilder {
             StringBuilder sqlBuilder = new StringBuilder();
 
             sqlBuilder.append(node.getFunctionName());
-            sqlBuilder.append("(");
-
-            List<String> childSql = node.getChildExpressions().stream().map(this::visit).collect(toList());
-            sqlBuilder.append(Joiner.on(",").join(childSql));
-
-            sqlBuilder.append(")");
+            
+            if (node.getChildExpressions() != null) {
+                sqlBuilder.append("(");
+                List<String> childSql = node.getChildExpressions().stream().map(this::visit).collect(toList());
+                sqlBuilder.append(Joiner.on(",").join(childSql));
+                sqlBuilder.append(")");
+            }
             if (node.getAlias() != null) {
                 sqlBuilder.append(" ").append(node.getAlias().getTbl());
 


### PR DESCRIPTION
fix NullPointerException when query hive table:
```
java.lang.NullPointerException: null
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitTableFunction(AstToStringBuilder.java:693) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitTableFunction(AstToStringBuilder.java:126) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.TableFunctionRelation.accept(TableFunctionRelation.java:79) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:55) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:51) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitJoin(AstToStringBuilder.java:590) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitJoin(AstToStringBuilder.java:126) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.JoinRelation.accept(JoinRelation.java:116) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:55) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.ast.AstVisitor.visit(AstVisitor.java:51) ~[starrocks-fe.jar:?]
        at com.starrocks.sql.analyzer.AstToStringBuilder$AST2StringBuilderVisitor.visitSelect(AstToStringBuilder.java:522) ~[starrocks-fe.jar:?]
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
