### PR TITLE
[BugFix]fix bug of isOutputColumn on deltalake table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -1097,15 +1097,7 @@ public class PlanFragmentBuilder {
             TupleDescriptor tupleDescriptor = context.getDescTbl().createTupleDescriptor();
             tupleDescriptor.setTable(referenceTable);
 
-            // set slot
-            for (Map.Entry<ColumnRefOperator, Column> entry : node.getColRefToColumnMetaMap().entrySet()) {
-                SlotDescriptor slotDescriptor =
-                        context.getDescTbl().addSlotDescriptor(tupleDescriptor, new SlotId(entry.getKey().getId()));
-                slotDescriptor.setColumn(entry.getValue());
-                slotDescriptor.setIsNullable(entry.getValue().isAllowNull());
-                slotDescriptor.setIsMaterialized(true);
-                context.getColRefToExpr().put(entry.getKey(), new SlotRef(entry.getKey().toString(), slotDescriptor));
-            }
+            prepareContextSlots(node, context, tupleDescriptor);
 
             DeltaLakeScanNode deltaLakeScanNode =
                     new DeltaLakeScanNode(context.getNextNodeId(), tupleDescriptor, "DeltaLakeScanNode");

--- a/test/sql/test_deltalake/R/test_deltalake_catalog
+++ b/test/sql/test_deltalake/R/test_deltalake_catalog
@@ -1,0 +1,18 @@
+-- name: testDeltaLakeCatalog
+create external catalog delta_test_${uuid0} PROPERTIES ("type"="deltalake", "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}");
+-- result:
+-- !result
+select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='a' order by c1;;
+-- result:
+1	1	a
+6	2	a
+11	1	a
+16	2	a
+21	1	a
+26	2	a
+31	1	a
+36	2	a
+-- !result
+drop catalog delta_test_${uuid0}
+-- result:
+-- !result

--- a/test/sql/test_deltalake/T/test_deltalake_catalog
+++ b/test/sql/test_deltalake/T/test_deltalake_catalog
@@ -1,0 +1,8 @@
+-- name: testDeltaLakeCatalog
+
+create external catalog delta_test_${uuid0} PROPERTIES ("type"="deltalake", "hive.metastore.uris"="${deltalake_catalog_hive_metastore_uris}");
+
+-- only partition column Predicate with runtime filter
+select * from delta_test_${uuid0}.delta_oss_db.string_col_dict_encode where c3='a' order by c1;;
+
+drop catalog delta_test_${uuid0}


### PR DESCRIPTION
Why I'm doing:
result error on deltalake table that col use dictionary encoding and used both as predicate and output

What I'm doing:
set right isOutputCol flag

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
