### PR TITLE
[BugFix] Fix jit constant error

### DIFF
--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -108,7 +108,7 @@ StatusOr<ColumnPtr> JITExpr::evaluate_checked(starrocks::ExprContext* context, C
     }
 #endif
 
-    auto result_column = ColumnHelper::create_column(type(), is_nullable(), is_constant(), ptr->num_rows(), false);
+    auto result_column = ColumnHelper::create_column(type(), !is_constant() && is_nullable(), is_constant(), ptr->num_rows(), false);
     args.emplace_back(result_column);
 
     RETURN_IF_ERROR(JITFunction::llvm_function(_jit_function, args));

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -108,7 +108,8 @@ StatusOr<ColumnPtr> JITExpr::evaluate_checked(starrocks::ExprContext* context, C
     }
 #endif
 
-    auto result_column = ColumnHelper::create_column(type(), !is_constant() && is_nullable(), is_constant(), ptr->num_rows(), false);
+    auto result_column =
+            ColumnHelper::create_column(type(), !is_constant() && is_nullable(), is_constant(), ptr->num_rows(), false);
     args.emplace_back(result_column);
 
     RETURN_IF_ERROR(JITFunction::llvm_function(_jit_function, args));

--- a/be/src/exprs/jit/jit_expr.cpp
+++ b/be/src/exprs/jit/jit_expr.cpp
@@ -95,7 +95,7 @@ StatusOr<ColumnPtr> JITExpr::evaluate_checked(starrocks::ExprContext* context, C
         if (column->only_null()) { // TODO(Yueyang): remove this when support ifnull expr.
             return ColumnHelper::align_return_type(column, type(), column->size(), true);
         }
-        args.emplace_back(ColumnHelper::unpack_and_duplicate_const_column(column->size(), column));
+        args.emplace_back(column);
     }
 
 #ifdef DEBUG

--- a/test/sql/test_jit/R/test_arithmetic
+++ b/test/sql/test_jit/R/test_arithmetic
@@ -900,6 +900,10 @@ SELECT (k1 * k2 + v1) * v2 + v3 * v4 - v5 as result FROM jit_basic ORDER BY resu
 9223361033148563457
 9223372036854775807
 -- !result
+select bitnot(cast(power(-2,127) as largeint)+1);
+-- result:
+170141183460469231731687303715884105726
+-- !result
 DROP TABLE IF EXISTS `jit_basic`;
 -- result:
 -- !result

--- a/test/sql/test_jit/T/test_arithmetic
+++ b/test/sql/test_jit/T/test_arithmetic
@@ -85,5 +85,7 @@ SELECT (k1 * k2 + v1) * (k1 - v2) as result FROM jit_basic ORDER BY result;
 SELECT k1 + k2 - v1 * v2 + v3 as result FROM jit_basic ORDER BY result;
 SELECT (v1 - v2) * (k1 + k2 - v3) as result FROM jit_basic ORDER BY result;
 SELECT (k1 * k2 + v1) * v2 + v3 * v4 - v5 as result FROM jit_basic ORDER BY result;
+-- hard
+select bitnot(cast(power(-2,127) as largeint)+1);
 
 DROP TABLE IF EXISTS `jit_basic`;


### PR DESCRIPTION
Why I'm doing:

When jit is enabled, there will be an error when running this sql:
`select bitnot(cast(power(-2,127) as largeint)+1);`

What I'm doing:

Fix crash error caused by jit compilation.

Fixes https://github.com/StarRocks/StarRocksTest/issues/5556

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
