### PR TITLE
[Enhancement] unify __int128 to string conversion

### DIFF
--- a/be/src/runtime/large_int_value.cpp
+++ b/be/src/runtime/large_int_value.cpp
@@ -24,26 +24,7 @@
 namespace starrocks {
 
 std::ostream& operator<<(std::ostream& os, __int128 const& value) {
-    std::ostream::sentry s(os);
-    if (s) {
-        unsigned __int128 tmp = value < 0 ? -value : value;
-        char buffer[48];
-        char* d = std::end(buffer);
-        do {
-            --d;
-            *d = "0123456789"[tmp % 10];
-            tmp /= 10;
-        } while (tmp != 0);
-        if (value < 0) {
-            --d;
-            *d = '-';
-        }
-        int len = std::end(buffer) - d;
-        if (os.rdbuf()->sputn(d, len) != len) {
-            os.setstate(std::ios_base::badbit);
-        }
-    }
-    return os;
+    return os << LargeIntValue::to_string(value);
 }
 
 std::istream& operator>>(std::istream& is, __int128& value) {

--- a/be/src/runtime/large_int_value.h
+++ b/be/src/runtime/large_int_value.h
@@ -51,23 +51,6 @@ namespace starrocks {
 
 class LargeIntValue {
 public:
-    static char* to_string(__int128 value, char* buffer, int* len) {
-        DCHECK(*len >= 40);
-        unsigned __int128 tmp = value < 0 ? -value : value;
-        char* d = buffer + *len;
-        do {
-            --d;
-            *d = "0123456789"[tmp % 10];
-            tmp /= 10;
-        } while (tmp != 0);
-        if (value < 0) {
-            --d;
-            *d = '-';
-        }
-        *len = (buffer + *len) - d;
-        return d;
-    }
-
     static std::string to_string(__int128 value) { return integer_to_string<__int128>(value); }
 };
 


### PR DESCRIPTION
* leverage `integer_to_string` templating conversion
* remove unused c-style LargeIntValue::to_string implementation

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [X] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [X] 3.2
  - [X] 3.1
  - [ ] 3.0
  - [ ] 2.5
