### PR TITLE
[BugFix] fix multi view join rewrite bug for 3.2 (backport #38485)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -493,11 +493,8 @@ public class Optimizer {
                 }
             }
         } catch (Exception e) {
-            OptimizerTraceUtil.logMVRewrite("VIEW_BASED_MV_REWRITE", "single table view based mv rule rewrite failed.", e);
-        } finally {
-            // reset logical tree with view
-            // no need to try view base rewrite in cost phase again
-            context.setLogicalTreeWithView(null);
+            OptimizerTraceUtil.logMVRewrite("VIEW_BASED_MV_REWRITE",
+                    "single table view based mv rule rewrite failed.", e);
         }
     }
 


### PR DESCRIPTION
Why I'm doing:
When a query has one-view mv and another multi-view mv, if the query can not be rewritten by the one-view mv, the multi-view mv can not be applied to mv rewrite.

What I'm doing:
Fix it by applying multi-view mv to rewrite the query.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

