### PR TITLE
[BugFix] Make sys.fe_locks work

### DIFF
--- a/be/src/exec/schema_scanner.cpp
+++ b/be/src/exec/schema_scanner.cpp
@@ -50,6 +50,7 @@
 #include "exec/schema_scanner/schema_views_scanner.h"
 #include "exec/schema_scanner/starrocks_grants_to_scanner.h"
 #include "exec/schema_scanner/starrocks_role_edges_scanner.h"
+#include "exec/schema_scanner/sys_fe_locks.h"
 #include "exec/schema_scanner/sys_object_dependencies.h"
 #include "gen_cpp/Descriptors_types.h"
 #include "gen_cpp/FrontendService_types.h"
@@ -183,6 +184,8 @@ std::unique_ptr<SchemaScanner> SchemaScanner::create(TSchemaTableType::type type
         return std::make_unique<SchemaTablePipeFiles>();
     case TSchemaTableType::SCH_PIPES:
         return std::make_unique<SchemaTablePipes>();
+    case TSchemaTableType::SYS_FE_LOCKS:
+        return std::make_unique<SysFeLocks>();
     case TSchemaTableType::SCH_BE_DATACACHE_METRICS:
         return std::make_unique<SchemaBeDataCacheMetricsScanner>();
     default:

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
@@ -18,6 +18,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.PrimitiveType;
 import com.starrocks.catalog.ScalarType;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.system.SystemId;
@@ -52,9 +53,9 @@ public class SysFeLocks {
                         .column("lock_type", ScalarType.createVarcharType(64))
                         .column("lock_object", ScalarType.createVarcharType(64))
                         .column("lock_mode", ScalarType.createVarcharType(64))
-                        .column("lock_start_time", ScalarType.createVarcharType(64))
+                        .column("lock_start_time", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("thread_info", ScalarType.createVarcharType(64))
-                        .column("granted", ScalarType.createVarchar(64))
+                        .column("granted", ScalarType.createType(PrimitiveType.BOOLEAN))
                         .column("waiter_list", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
                         .build(),
                 TSchemaTableType.SYS_FE_LOCKS);


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
```
mysql> select * from sys.fe_locks where lock_object = "tmp";
+-----------+-------------+-----------+-----------------+------------------------------------------------------------+---------+---------------------------------------------+
| lock_type | lock_object | lock_mode | lock_start_time | thread_info                                                | granted | waiter_list                                 |
+-----------+-------------+-----------+-----------------+------------------------------------------------------------+---------+---------------------------------------------+
| DATABASE  | tmp         | EXCLUSIVE |   1704426589734 | {"threadId":336,"threadName":"starrocks-mysql-nio-pool-2"} |       1 | [{"threadId":66,"threadName":"autovacuum"}] |
+-----------+-------------+-----------+-----------------+------------------------------------------------------------+---------+---------------------------------------------+
1 row in set (0.02 sec)
```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
