### PR TITLE
[BugFix] Fix count_down_pipeline may cause use-after-free

### DIFF
--- a/be/src/exec/pipeline/fragment_context.cpp
+++ b/be/src/exec/pipeline/fragment_context.cpp
@@ -82,7 +82,10 @@ void FragmentContext::set_data_sink(std::unique_ptr<DataSink> data_sink) {
 }
 
 void FragmentContext::count_down_pipeline(size_t val) {
-    bool all_pipelines_finished = _num_finished_pipelines.fetch_add(val) + val == _pipelines.size();
+    // Note that _pipelines may be destructed after fetch_add
+    // memory_order_seq_cst semantics ensure that previous code does not reorder after fetch_add
+    size_t total_pipelines = _pipelines.size();
+    bool all_pipelines_finished = _num_finished_pipelines.fetch_add(val) + val == total_pipelines;
     if (!all_pipelines_finished) {
         return;
     }


### PR DESCRIPTION
Why I'm doing:
_pipelines may be destructed after fetch_add

What I'm doing:
port _pipelines.size() before fetch_add

Fixes https://github.com/StarRocks/StarRocksTest/issues/5573

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
