### PR TITLE
[BugFix] fix hang when chunk source mem bytes exceeds scan mem limit

### DIFF
--- a/be/src/connector/connector.h
+++ b/be/src/connector/connector.h
@@ -55,6 +55,7 @@ public:
     virtual int64_t cpu_time_spent() const = 0;
     // IO time of this data source
     virtual int64_t io_time_spent() const { return 0; }
+    virtual bool can_estimate_mem_usage() const { return false; }
     virtual int64_t estimated_mem_usage() const { return 0; }
 
     // following fields are set by framework

--- a/be/src/connector/hive_connector.h
+++ b/be/src/connector/hive_connector.h
@@ -75,6 +75,7 @@ public:
     int64_t cpu_time_spent() const override;
     int64_t io_time_spent() const override;
     int64_t estimated_mem_usage() const override;
+    bool can_estimate_mem_usage() const override { return true; }
 
 private:
     const HiveDataSourceProvider* _provider;

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -135,7 +135,7 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
     // order matters. we will use scan mem limit to limit chunk source mem bytes.
     scan_op->set_mem_share_arb(_mem_share_arb);
     scan_op->set_scan_mem_limit(_scan_mem_limit);
-    scan_op->set_default_data_source_mem_bytes(_estimated_data_source_mem_bytes);
+    scan_op->set_data_source_mem_bytes(_estimated_data_source_mem_bytes);
     scan_op->set_chunk_source_mem_bytes(_estimated_data_source_mem_bytes +
                                         _estimated_scan_row_bytes * runtime_state()->chunk_size());
 

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -58,16 +58,22 @@ Status ConnectorScanNode::init(const TPlanNode& tnode, RuntimeState* state) {
     if (runtime_state()->query_ctx() != nullptr) {
         _mem_share_arb = runtime_state()->query_ctx()->connector_scan_operator_mem_share_arbitrator();
     }
+    if (_mem_share_arb != nullptr) {
+        _scan_mem_limit = _mem_share_arb->set_scan_mem_ratio(mem_ratio);
+
+        // we don't want scan mem limit to exceed global memory limit.
+        int64_t global_lowest = GlobalEnv::GetInstance()->connector_scan_pool_mem_tracker()->lowest_limit();
+        if (global_lowest > 0) {
+            _scan_mem_limit = std::min(_scan_mem_limit, global_lowest);
+        }
+    }
+
     _io_tasks_per_scan_operator = config::connector_io_tasks_per_scan_operator;
     if (query_options.__isset.connector_io_tasks_per_scan_operator) {
         _io_tasks_per_scan_operator = query_options.connector_io_tasks_per_scan_operator;
     }
-
     _estimate_scan_row_bytes();
 
-    if (_mem_share_arb != nullptr) {
-        _scan_mem_limit = _mem_share_arb->set_scan_mem_ratio(mem_ratio);
-    }
     return Status::OK();
 }
 
@@ -82,15 +88,14 @@ void ConnectorScanNode::_estimate_scan_row_bytes() {
     }
 }
 
-void ConnectorScanNode::_estimate_chunk_source_mem_bytes() {
+void ConnectorScanNode::_estimate_data_source_mem_bytes() {
     const TupleDescriptor* tuple_desc = _data_source_provider->tuple_descriptor(runtime_state());
     const auto& slots = tuple_desc->slots();
     int64_t estimated_size = slots.size() * _data_source_provider->PER_FIELD_MEM_BYTES;
     int64_t min_value = 0, max_value = 0;
     _data_source_provider->default_data_source_mem_bytes(&min_value, &max_value);
     estimated_size = std::min(std::max(estimated_size, min_value), max_value);
-    _estimated_chunk_source_mem_bytes = estimated_size;
-    _estimated_chunk_source_mem_bytes += _estimated_scan_row_bytes * runtime_state()->chunk_size();
+    _estimated_data_source_mem_bytes = estimated_size;
 }
 
 int ConnectorScanNode::_estimate_max_concurrent_chunks() const {
@@ -111,7 +116,7 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
 
     // we do estimated here is because we have peeked all scang ranges and gather more infomration
     // so only here we can make more accurate decision.
-    _estimate_chunk_source_mem_bytes();
+    _estimate_data_source_mem_bytes();
 
     // port from olap scan node. to control chunk buffer usage, we can control memory consumption to avoid OOM.
     size_t max_buffer_capacity = pipeline::ScanOperator::max_buffer_capacity() * dop;
@@ -127,9 +132,12 @@ pipeline::OpFactories ConnectorScanNode::decompose_to_pipeline(pipeline::Pipelin
                                 context->next_operator_id(), this, runtime_state(), dop, std::move(buffer_limiter),
                                 is_stream_pipeline);
 
-    scan_op->set_chunk_source_mem_bytes(_estimated_chunk_source_mem_bytes);
-    scan_op->set_scan_mem_limit(_scan_mem_limit);
+    // order matters. we will use scan mem limit to limit chunk source mem bytes.
     scan_op->set_mem_share_arb(_mem_share_arb);
+    scan_op->set_scan_mem_limit(_scan_mem_limit);
+    scan_op->set_default_data_source_mem_bytes(_estimated_data_source_mem_bytes);
+    scan_op->set_chunk_source_mem_bytes(_estimated_data_source_mem_bytes +
+                                        _estimated_scan_row_bytes * runtime_state()->chunk_size());
 
     auto&& rc_rf_probe_collector = std::make_shared<RcRfProbeCollector>(1, std::move(this->runtime_filter_collector()));
     this->init_runtime_filter_for_operator(scan_op.get(), context, rc_rf_probe_collector);
@@ -677,8 +685,8 @@ StatusOr<pipeline::MorselQueuePtr> ConnectorScanNode::convert_scan_range_to_mors
         size_t num_total_scan_ranges) {
     _data_source_provider->peek_scan_ranges(scan_ranges);
     return ScanNode::convert_scan_range_to_morsel_queue(scan_ranges, node_id, pipeline_dop,
-                                                        enable_tablet_internal_parallel, tablet_internal_parallel_mode,
-                                                        num_total_scan_ranges);
-}
+                                                        size_t num_total_scan_ranges) {
+        _data_source_provider->peek_scan_ranges(scan_ranges);
+        _data_source_provider->peek_scan_ranges(scan_ranges);
 
-} // namespace starrocks
+    } // namespace starrocks

--- a/be/src/exec/connector_scan_node.cpp
+++ b/be/src/exec/connector_scan_node.cpp
@@ -685,8 +685,8 @@ StatusOr<pipeline::MorselQueuePtr> ConnectorScanNode::convert_scan_range_to_mors
         size_t num_total_scan_ranges) {
     _data_source_provider->peek_scan_ranges(scan_ranges);
     return ScanNode::convert_scan_range_to_morsel_queue(scan_ranges, node_id, pipeline_dop,
-                                                        size_t num_total_scan_ranges) {
-        _data_source_provider->peek_scan_ranges(scan_ranges);
-        _data_source_provider->peek_scan_ranges(scan_ranges);
+                                                        enable_tablet_internal_parallel, tablet_internal_parallel_mode,
+                                                        num_total_scan_ranges);
+}
 
-    } // namespace starrocks
+} // namespace starrocks

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -62,7 +62,7 @@ public:
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
             size_t num_total_scan_ranges) override;
 
-    size_t estimated_chunk_source_mem_bytes() const { return _estimated_chunk_source_mem_bytes; }
+    size_t estimated_chunk_source_mem_bytes() const { return _estimated_data_source_mem_bytes; }
 
 private:
     // non-pipeline methods.
@@ -136,11 +136,11 @@ private:
     connector::DataSourceProviderPtr _data_source_provider = nullptr;
     connector::ConnectorType _connector_type;
     void _estimate_scan_row_bytes();
-    void _estimate_chunk_source_mem_bytes();
+    void _estimate_data_source_mem_bytes();
     int _estimate_max_concurrent_chunks() const;
     int64_t _scan_mem_limit = 0;
     size_t _estimated_scan_row_bytes = 0;
-    size_t _estimated_chunk_source_mem_bytes = 0;
+    size_t _estimated_data_source_mem_bytes = 0;
 
 #ifdef BE_TEST
     std::atomic_bool _use_stream_load_thread_pool = false;

--- a/be/src/exec/connector_scan_node.h
+++ b/be/src/exec/connector_scan_node.h
@@ -62,8 +62,6 @@ public:
             bool enable_tablet_internal_parallel, TTabletInternalParallelMode::type tablet_internal_parallel_mode,
             size_t num_total_scan_ranges) override;
 
-    size_t estimated_chunk_source_mem_bytes() const { return _estimated_data_source_mem_bytes; }
-
 private:
     // non-pipeline methods.
     void _init_counter();

--- a/be/src/exec/pipeline/scan/chunk_source.cpp
+++ b/be/src/exec/pipeline/scan/chunk_source.cpp
@@ -82,10 +82,6 @@ Status ChunkSource::buffer_next_batch_chunks_blocking(RuntimeState* state, size_
                     chunk->owner_info().set_owner_id(owner_id, false);
                     _chunk_buffer.put(_scan_operator_seq, std::move(chunk), std::move(_chunk_token));
                     _status = Status::OK();
-                } else if (_status.is_resource_busy()) {
-                    // see ConnectorChunkSource::_read_chunk
-                    // there are too much io tasks which leads to failure of memory allocaiton
-                    _status = Status::OK();
                 }
                 break;
             }

--- a/be/src/exec/pipeline/scan/connector_scan_operator.cpp
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.cpp
@@ -36,8 +36,12 @@ struct ConnectorScanOperatorIOTasksMemLimiter {
     mutable std::mutex lock;
 
     const int64_t dop = 0;
+    // total scan mem limit means limit for all scan nodes.
+    // scan mem limit means limit for this scan node.
+    int64_t total_scan_mem_limit = std::numeric_limits<int64_t>::max();
     std::atomic<int64_t> scan_mem_limit = 0;
     std::atomic<int64_t> running_chunk_source_count = 0;
+    int64_t default_data_source_mem_bytes = 0;
     std::atomic<int64_t> chunk_source_mem_bytes = 0;
     int64_t chunk_source_mem_bytes_update_count = 0;
     int64_t last_arb_chunk_source_mem_bytes = 0;
@@ -62,7 +66,7 @@ struct ConnectorScanOperatorIOTasksMemLimiter {
         [[maybe_unused]] auto build_debug_string = [&]() {
             std::stringstream ss;
             ss << "available_chunk_source_count. max_count=" << max_count << "(" << scan_mem_limit_value << "/"
-               << chunk_source_mem_bytes_value << ")"
+               << chunk_source_mem_bytes_value << "), total_scan_mem_limit = " << total_scan_mem_limit
                << ", running_count = " << running_count << ", dop = " << dop << ", avail_count = " << avail_count
                << ", op_id = " << plan_node_id << "/" << driver_sequence << ", per_count = " << per_count;
             return ss.str();
@@ -79,12 +83,11 @@ struct ConnectorScanOperatorIOTasksMemLimiter {
         return per_count;
     }
 
-    void update_running_chunk_source_count(int delta) {
-        running_chunk_source_count.fetch_add(delta, std::memory_order_relaxed);
-    }
+    int64_t update_running_chunk_source_count(int delta) { return running_chunk_source_count.fetch_add(delta); }
 
     void update_chunk_source_mem_bytes(int64_t value) {
         if (value == 0) return;
+        value = std::min(value, total_scan_mem_limit);
 
         std::lock_guard<std::mutex> L(lock);
         int64_t total =
@@ -92,6 +95,16 @@ struct ConnectorScanOperatorIOTasksMemLimiter {
         chunk_source_mem_bytes_update_count += 1;
         chunk_source_mem_bytes.store(total / chunk_source_mem_bytes_update_count, std::memory_order_relaxed);
     }
+
+    void set_total_scan_mem_limit(int64_t value) { total_scan_mem_limit = value; }
+    void update_scan_mem_limit(int64_t value) { scan_mem_limit.store(value, std::memory_order_relaxed); }
+    void update_last_arb_chunk_source_mem_bytes(int64_t value) {
+        value = std::min(value, total_scan_mem_limit);
+        last_arb_chunk_source_mem_bytes = value;
+    }
+
+    void set_default_data_source_mem_bytes(int64_t value) { default_data_source_mem_bytes = value; }
+    int64_t get_default_data_source_mem_bytes() const { return default_data_source_mem_bytes; }
 };
 
 ConnectorScanOperatorFactory::ConnectorScanOperatorFactory(int32_t id, ScanNode* scan_node, RuntimeState* state,
@@ -126,15 +139,20 @@ const std::vector<ExprContext*>& ConnectorScanOperatorFactory::partition_exprs()
 
 void ConnectorScanOperatorFactory::set_chunk_source_mem_bytes(int64_t value) {
     _io_tasks_mem_limiter->update_chunk_source_mem_bytes(value);
-    _io_tasks_mem_limiter->last_arb_chunk_source_mem_bytes = value;
+    _io_tasks_mem_limiter->update_last_arb_chunk_source_mem_bytes(value);
 }
 
 void ConnectorScanOperatorFactory::set_scan_mem_limit(int64_t value) {
-    _io_tasks_mem_limiter->scan_mem_limit = value;
+    _io_tasks_mem_limiter->update_scan_mem_limit(value);
+    _io_tasks_mem_limiter->set_total_scan_mem_limit(value);
 }
 
 void ConnectorScanOperatorFactory::set_mem_share_arb(ConnectorScanOperatorMemShareArbitrator* arb) {
     _mem_share_arb = arb;
+}
+
+void ConnectorScanOperatorFactory::set_default_data_source_mem_bytes(int64_t value) {
+    _io_tasks_mem_limiter->set_default_data_source_mem_bytes(value);
 }
 
 // ===============================================================
@@ -192,8 +210,8 @@ int64_t ConnectorScanOperator::_adjust_scan_mem_limit(int64_t old_value, int64_t
     ConnectorScanOperatorMemShareArbitrator* arb = factory->_mem_share_arb;
     int64_t new_scan_mem_limit = arb->update_chunk_source_mem_bytes(old_value, new_value);
 
-    L->scan_mem_limit.store(new_scan_mem_limit, std::memory_order_relaxed);
-    L->last_arb_chunk_source_mem_bytes = new_value;
+    L->update_scan_mem_limit(new_scan_mem_limit);
+    L->update_last_arb_chunk_source_mem_bytes(new_value);
     ChunkBufferLimiter* limiter = factory->get_chunk_buffer().limiter();
     limiter->update_mem_limit(new_scan_mem_limit * ConnectorScanOperatorMemShareArbitrator::kChunkBufferMemRatio);
 
@@ -588,10 +606,22 @@ void ConnectorChunkSource::close(RuntimeState* state) {
         limiter->update_running_chunk_source_count(-1);
         uint64_t chunk_num = std::min<uint64_t>(state->chunk_size(), _chunk_rows_read);
 
-        // if we don't know chunk source mem bytes for sure, we use estimated old value.
-        int64_t chunk_source_mem_bytes = _data_source->estimated_mem_usage();
-        if (chunk_source_mem_bytes != 0) {
-            chunk_source_mem_bytes += avg_row_mem_bytes() * chunk_num;
+        bool need_update = true;
+        int64_t data_source_mem_bytes = _data_source->estimated_mem_usage();
+        // 1. if this data source can estimate memory usage but estimated mem usage == 0
+        // it means in this chunk source, estimated memory usage is not available, then we don't update
+        // 2. but if this data sourcen can not estimate memory usage, we will use default mem usage
+        // in following code. We can adjust chunk mem usage.
+        if (data_source_mem_bytes == 0 && _data_source->can_estimate_mem_usage()) {
+            need_update = false;
+        }
+
+        int64_t chunk_source_mem_bytes = 0;
+        if (need_update) {
+            if (data_source_mem_bytes == 0) {
+                data_source_mem_bytes = limiter->get_default_data_source_mem_bytes();
+            }
+            chunk_source_mem_bytes = data_source_mem_bytes + avg_row_mem_bytes() * chunk_num;
             limiter->update_chunk_source_mem_bytes(chunk_source_mem_bytes);
         }
 
@@ -602,7 +632,7 @@ void ConnectorChunkSource::close(RuntimeState* state) {
                << ", release. this = " << (void*)this << ", request mem bytes = " << _request_mem_tracker_bytes
                << ", chunk source mem bytes = " << chunk_source_mem_bytes
                << ", chunk mem bytes = " << avg_row_mem_bytes() << " * " << chunk_num
-               << ", data source mem usage = " << _data_source->estimated_mem_usage();
+               << ", data source mem usage = " << data_source_mem_bytes;
             return ss.str();
         };
         VLOG_OPERATOR << build_debug_string();
@@ -647,13 +677,24 @@ Status ConnectorChunkSource::_open_data_source(RuntimeState* state, bool* mem_al
             // VLOG_OPERATOR << build_debug_string("alloc failed");
             sched_yield();
         }
+
         if (*mem_alloc_failed) {
-            _request_mem_tracker_bytes = 0;
-            return Status::OK();
+            // if there is no running chunk source of this node,
+            // perhaps we want to make sure one is running to avoid deadlock of data flow.
+            // and memory is over-committed.
+            if (limiter->update_running_chunk_source_count(1) == 0) {
+                *mem_alloc_failed = false;
+                mem_tracker->consume(_request_mem_tracker_bytes);
+            } else {
+                limiter->update_running_chunk_source_count(-1);
+                _request_mem_tracker_bytes = 0;
+                return Status::OK();
+            }
+        } else {
+            limiter->update_running_chunk_source_count(1);
         }
 
         VLOG_OPERATOR << build_debug_string("consume");
-        limiter->update_running_chunk_source_count(1);
     }
 
     RETURN_IF_ERROR(_data_source->open(state));
@@ -686,7 +727,7 @@ Status ConnectorChunkSource::_read_chunk(RuntimeState* state, ChunkPtr* chunk) {
         RETURN_IF_ERROR(_open_data_source(state, &mem_alloc_failed));
         if (mem_alloc_failed) {
             _mem_alloc_failed_count += 1;
-            return Status::ResourceBusy("");
+            return Status::TimedOut("");
         }
         if (state->is_cancelled()) {
             return Status::Cancelled("canceled state");

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -69,7 +69,7 @@ public:
     void set_chunk_source_mem_bytes(int64_t mem_bytes);
     void set_scan_mem_limit(int64_t scan_mem_limit);
     void set_mem_share_arb(ConnectorScanOperatorMemShareArbitrator* arb);
-    void set_default_data_source_mem_bytes(int64_t value);
+    void set_data_source_mem_bytes(int64_t value);
 
 private:
     // TODO: refactor the OlapScanContext, move them into the context

--- a/be/src/exec/pipeline/scan/connector_scan_operator.h
+++ b/be/src/exec/pipeline/scan/connector_scan_operator.h
@@ -69,6 +69,7 @@ public:
     void set_chunk_source_mem_bytes(int64_t mem_bytes);
     void set_scan_mem_limit(int64_t scan_mem_limit);
     void set_mem_share_arb(ConnectorScanOperatorMemShareArbitrator* arb);
+    void set_default_data_source_mem_bytes(int64_t value);
 
 private:
     // TODO: refactor the OlapScanContext, move them into the context


### PR DESCRIPTION
> Why I'm doing:

If chunk source mem bytes exceeds scan mem limit, we can not schedule any chunk source because of memory allocation failure.

> What I'm doing:

This PR includes:
- limit chunk source mem bytes under scan mem limit, so at least one chunk source of scan node can run
- if there is no running chunk source of this scan node, we will at least to run one to avoid deadlock

Fixes https://github.com/StarRocks/StarRocksTest/issues/5570

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
