### PR TITLE
[Enhancement]Enhance JNI reader for date and timestamp type

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -564,6 +564,7 @@ HdfsScanner* HiveDataSource::_create_hudi_jni_scanner(const FSOptions& options) 
     jni_scanner_params["serde"] = hudi_table->get_serde_lib();
     jni_scanner_params["input_format"] = hudi_table->get_input_format();
     jni_scanner_params["fs_options_props"] = build_fs_options_properties(options);
+    jni_scanner_params["time_zone"] = hudi_table->get_time_zone();
 
     std::string scanner_factory_class = "com/starrocks/hudi/reader/HudiSliceScannerFactory";
     HdfsScanner* scanner = _pool.add(new JniScanner(scanner_factory_class, jni_scanner_params));
@@ -595,6 +596,7 @@ HdfsScanner* HiveDataSource::_create_paimon_jni_scanner(const FSOptions& options
     jni_scanner_params["predicate_info"] = _scan_range.paimon_predicate_info;
     jni_scanner_params["nested_fields"] = nested_fields;
     jni_scanner_params["native_table"] = paimon_table->get_paimon_native_table();
+    jni_scanner_params["time_zone"] = paimon_table->get_time_zone();
 
     std::string scanner_factory_class = "com/starrocks/paimon/reader/PaimonSplitScannerFactory";
     HdfsScanner* scanner = _pool.add(new JniScanner(scanner_factory_class, jni_scanner_params));
@@ -629,6 +631,7 @@ HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) 
     std::string serde;
     std::string input_format;
     std::map<std::string, std::string> serde_properties;
+    std::string time_zone;
 
     if (dynamic_cast<const FileTableDescriptor*>(_hive_table)) {
         const auto* file_table = dynamic_cast<const FileTableDescriptor*>(_hive_table);
@@ -639,6 +642,7 @@ HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) 
         hive_column_types = file_table->get_hive_column_types();
         serde = file_table->get_serde_lib();
         input_format = file_table->get_input_format();
+        time_zone = file_table->get_time_zone();
     } else {
         const auto* hdfs_table = dynamic_cast<const HdfsTableDescriptor*>(_hive_table);
 
@@ -651,6 +655,7 @@ HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) 
         serde = hdfs_table->get_serde_lib();
         input_format = hdfs_table->get_input_format();
         serde_properties = hdfs_table->get_serde_properties();
+        time_zone = hdfs_table->get_time_zone();
     }
 
     std::map<std::string, std::string> jni_scanner_params;
@@ -665,6 +670,7 @@ HdfsScanner* HiveDataSource::_create_hive_jni_scanner(const FSOptions& options) 
     jni_scanner_params["serde"] = serde;
     jni_scanner_params["input_format"] = input_format;
     jni_scanner_params["fs_options_props"] = build_fs_options_properties(options);
+    jni_scanner_params["time_zone"] = time_zone;
 
     for (const auto& pair : serde_properties) {
         jni_scanner_params[serde_property_prefix + pair.first] = pair.second;

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -706,7 +706,7 @@ HdfsScanner* HiveDataSource::_create_odps_jni_scanner(const FSOptions& options) 
     jni_scanner_params["required_fields"] = required_fields;
     jni_scanner_params.insert(_scan_range.odps_split_infos.begin(), _scan_range.odps_split_infos.end());
     jni_scanner_params["nested_fields"] = nested_fields;
-    jni_scanner_params["time_zone"] = odps_table->get_time_zone();;
+    jni_scanner_params["time_zone"] = odps_table->get_time_zone();
 
     const AliyunCloudConfiguration aliyun_cloud_configuration =
             CloudConfigurationFactory::create_aliyun(*options.cloud_configuration);

--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -706,6 +706,7 @@ HdfsScanner* HiveDataSource::_create_odps_jni_scanner(const FSOptions& options) 
     jni_scanner_params["required_fields"] = required_fields;
     jni_scanner_params.insert(_scan_range.odps_split_infos.begin(), _scan_range.odps_split_infos.end());
     jni_scanner_params["nested_fields"] = nested_fields;
+    jni_scanner_params["time_zone"] = odps_table->get_time_zone();;
 
     const AliyunCloudConfiguration aliyun_cloud_configuration =
             CloudConfigurationFactory::create_aliyun(*options.cloud_configuration);

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -177,6 +177,7 @@ HdfsTableDescriptor::HdfsTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
     _input_format = tdesc.hdfsTable.input_format;
     _serde_lib = tdesc.hdfsTable.serde_lib;
     _serde_properties = tdesc.hdfsTable.serde_properties;
+    _time_zone = tdesc.hdfsTable.time_zone;
 }
 
 const std::string& HdfsTableDescriptor::get_hive_column_names() const {
@@ -199,6 +200,10 @@ const std::map<std::string, std::string> HdfsTableDescriptor::get_serde_properti
     return _serde_properties;
 }
 
+const std::string& HdfsTableDescriptor::get_time_zone() const {
+    return _time_zone;
+}
+
 FileTableDescriptor::FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
         : HiveTableDescriptor(tdesc, pool) {
     _table_location = tdesc.fileTable.location;
@@ -207,6 +212,7 @@ FileTableDescriptor::FileTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
     _hive_column_types = tdesc.fileTable.hive_column_types;
     _input_format = tdesc.fileTable.input_format;
     _serde_lib = tdesc.fileTable.serde_lib;
+    _time_zone = tdesc.fileTable.time_zone;
 }
 
 const std::string& FileTableDescriptor::get_hive_column_names() const {
@@ -223,6 +229,10 @@ const std::string& FileTableDescriptor::get_input_format() const {
 
 const std::string& FileTableDescriptor::get_serde_lib() const {
     return _serde_lib;
+}
+
+const std::string& FileTableDescriptor::get_time_zone() const {
+    return _time_zone;
 }
 
 IcebergTableDescriptor::IcebergTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
@@ -301,6 +311,7 @@ HudiTableDescriptor::HudiTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
     _hive_column_types = tdesc.hudiTable.hive_column_types;
     _input_format = tdesc.hudiTable.input_format;
     _serde_lib = tdesc.hudiTable.serde_lib;
+    _time_zone = tdesc.hudiTable.time_zone;
 }
 
 const std::string& HudiTableDescriptor::get_instant_time() const {
@@ -323,13 +334,22 @@ const std::string& HudiTableDescriptor::get_serde_lib() const {
     return _serde_lib;
 }
 
+const std::string& HudiTableDescriptor::get_time_zone() const {
+    return _time_zone;
+}
+
 PaimonTableDescriptor::PaimonTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
         : HiveTableDescriptor(tdesc, pool) {
     _paimon_native_table = tdesc.paimonTable.paimon_native_table;
+    _time_zone = tdesc.paimonTable.time_zone;
 }
 
 const std::string& PaimonTableDescriptor::get_paimon_native_table() const {
     return _paimon_native_table;
+}
+
+const std::string& PaimonTableDescriptor::get_time_zone() const {
+    return _time_zone;
 }
 
 OdpsTableDescriptor::OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool)
@@ -338,6 +358,7 @@ OdpsTableDescriptor::OdpsTableDescriptor(const TTableDescriptor& tdesc, ObjectPo
     _partition_columns = tdesc.hdfsTable.partition_columns;
     _database_name = tdesc.dbName;
     _table_name = tdesc.tableName;
+    _time_zone = tdesc.hdfsTable.time_zone;
 }
 
 const std::string& OdpsTableDescriptor::get_database_name() const {
@@ -346,6 +367,10 @@ const std::string& OdpsTableDescriptor::get_database_name() const {
 
 const std::string& OdpsTableDescriptor::get_table_name() const {
     return _table_name;
+}
+
+const std::string& PaimonTableDescriptor::get_time_zone() const {
+    return _time_zone;
 }
 
 HiveTableDescriptor::HiveTableDescriptor(const TTableDescriptor& tdesc, ObjectPool* pool) : TableDescriptor(tdesc) {}

--- a/be/src/runtime/descriptors.cpp
+++ b/be/src/runtime/descriptors.cpp
@@ -369,7 +369,7 @@ const std::string& OdpsTableDescriptor::get_table_name() const {
     return _table_name;
 }
 
-const std::string& PaimonTableDescriptor::get_time_zone() const {
+const std::string& OdpsTableDescriptor::get_time_zone() const {
     return _time_zone;
 }
 

--- a/be/src/runtime/descriptors.h
+++ b/be/src/runtime/descriptors.h
@@ -224,6 +224,7 @@ public:
     const std::string& get_input_format() const;
     const std::string& get_serde_lib() const;
     const std::map<std::string, std::string> get_serde_properties() const;
+    const std::string& get_time_zone() const;
 
 private:
     std::string _serde_lib;
@@ -231,6 +232,7 @@ private:
     std::string _hive_column_names;
     std::string _hive_column_types;
     std::map<std::string, std::string> _serde_properties;
+    std::string _time_zone;
 };
 
 class IcebergTableDescriptor : public HiveTableDescriptor {
@@ -262,12 +264,14 @@ public:
     const std::string& get_hive_column_types() const;
     const std::string& get_input_format() const;
     const std::string& get_serde_lib() const;
+    const std::string& get_time_zone() const;
 
 private:
     std::string _serde_lib;
     std::string _input_format;
     std::string _hive_column_names;
     std::string _hive_column_types;
+    std::string _time_zone;
 };
 
 class DeltaLakeTableDescriptor : public HiveTableDescriptor {
@@ -287,6 +291,7 @@ public:
     const std::string& get_hive_column_types() const;
     const std::string& get_input_format() const;
     const std::string& get_serde_lib() const;
+    const std::string& get_time_zone() const;
 
 private:
     std::string _hudi_instant_time;
@@ -294,6 +299,7 @@ private:
     std::string _hive_column_types;
     std::string _input_format;
     std::string _serde_lib;
+    std::string _time_zone;
 };
 
 class PaimonTableDescriptor : public HiveTableDescriptor {
@@ -302,9 +308,11 @@ public:
     ~PaimonTableDescriptor() override = default;
     bool has_partition() const override { return false; }
     const std::string& get_paimon_native_table() const;
+    const std::string& get_time_zone() const;
 
 private:
     std::string _paimon_native_table;
+    std::string _time_zone;
 };
 
 class OdpsTableDescriptor : public HiveTableDescriptor {
@@ -314,10 +322,12 @@ public:
     bool has_partition() const override { return false; }
     const std::string& get_database_name() const;
     const std::string& get_table_name() const;
+    const std::string& get_time_zone() const;
 
 private:
     std::string _database_name;
     std::string _table_name;
+    std::string _time_zone;
 };
 
 // ===========================================

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -25,6 +25,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.io.Text;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ColumnTypeConverter;
 import com.starrocks.connector.HdfsEnvironment;
 import com.starrocks.connector.RemoteFileDesc;
@@ -35,7 +36,6 @@ import com.starrocks.connector.hive.HiveStorageFormat;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 import com.starrocks.connector.hive.TextFileFormatDesc;
 import com.starrocks.credential.azure.AzureCloudConfigurationProvider;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TFileTable;
 import com.starrocks.thrift.TTableDescriptor;
@@ -204,7 +204,7 @@ public class FileTable extends Table {
 
         tFileTable.setHive_column_names(columnNames);
         tFileTable.setHive_column_types(columnTypes);
-        tFileTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
+        tFileTable.setTime_zone(TimeUtils.getSessionTimeZone());
 
         return tTableDescriptor;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FileTable.java
@@ -35,6 +35,7 @@ import com.starrocks.connector.hive.HiveStorageFormat;
 import com.starrocks.connector.hive.RemoteFileInputFormat;
 import com.starrocks.connector.hive.TextFileFormatDesc;
 import com.starrocks.credential.azure.AzureCloudConfigurationProvider;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TColumn;
 import com.starrocks.thrift.TFileTable;
 import com.starrocks.thrift.TTableDescriptor;
@@ -203,6 +204,7 @@ public class FileTable extends Table {
 
         tFileTable.setHive_column_names(columnNames);
         tFileTable.setHive_column_types(columnTypes);
+        tFileTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
 
         return tTableDescriptor;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -383,6 +383,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         tHdfsTable.setHive_column_names(hiveProperties.get(HIVE_TABLE_COLUMN_NAMES));
         tHdfsTable.setHive_column_types(hiveProperties.get(HIVE_TABLE_COLUMN_TYPES));
         tHdfsTable.setSerde_properties(serdeProperties);
+        tHdfsTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.HDFS_TABLE, fullSchema.size(),
                 0, hiveTableName, hiveDbName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HiveTable.java
@@ -54,6 +54,7 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.common.Config;
 import com.starrocks.common.StarRocksFEMetaVersion;
 import com.starrocks.common.io.Text;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
 import com.starrocks.connector.hive.HiveStorageFormat;
@@ -383,7 +384,7 @@ public class HiveTable extends Table implements HiveMetaStoreTable {
         tHdfsTable.setHive_column_names(hiveProperties.get(HIVE_TABLE_COLUMN_NAMES));
         tHdfsTable.setHive_column_types(hiveProperties.get(HIVE_TABLE_COLUMN_TYPES));
         tHdfsTable.setSerde_properties(serdeProperties);
-        tHdfsTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
+        tHdfsTable.setTime_zone(TimeUtils.getSessionTimeZone());
 
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.HDFS_TABLE, fullSchema.size(),
                 0, hiveTableName, hiveDbName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -33,6 +33,7 @@ import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.common.io.Text;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TColumn;
@@ -293,6 +294,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         tHudiTable.setHive_column_types(hudiProperties.get(HUDI_TABLE_COLUMN_TYPES));
         tHudiTable.setInput_format(hudiProperties.get(HUDI_TABLE_INPUT_FOAMT));
         tHudiTable.setSerde_lib(hudiProperties.get(HUDI_TABLE_SERDE_LIB));
+        tHudiTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
 
         TTableDescriptor tTableDescriptor =
                 new TTableDescriptor(id, TTableType.HUDI_TABLE, fullSchema.size(), 0, hiveTableName, hiveDbName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/HudiTable.java
@@ -31,9 +31,9 @@ import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.common.io.Text;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.RemoteFileInfo;
 import com.starrocks.connector.exception.StarRocksConnectorException;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.thrift.TColumn;
@@ -294,7 +294,7 @@ public class HudiTable extends Table implements HiveMetaStoreTable {
         tHudiTable.setHive_column_types(hudiProperties.get(HUDI_TABLE_COLUMN_TYPES));
         tHudiTable.setInput_format(hudiProperties.get(HUDI_TABLE_INPUT_FOAMT));
         tHudiTable.setSerde_lib(hudiProperties.get(HUDI_TABLE_SERDE_LIB));
-        tHudiTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
+        tHudiTable.setTime_zone(TimeUtils.getSessionTimeZone());
 
         TTableDescriptor tTableDescriptor =
                 new TTableDescriptor(id, TTableType.HUDI_TABLE, fullSchema.size(), 0, hiveTableName, hiveDbName);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OdpsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OdpsTable.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.connector.odps.EntityConvertUtils;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
@@ -127,6 +128,7 @@ public class OdpsTable extends Table implements HiveMetaStoreTable {
         hdfsTable.setColumns(getColumns().stream().map(Column::toThrift).collect(Collectors.toList()));
         // for be, partition column is equals to data column
         hdfsTable.setPartition_columnsIsSet(false);
+        hdfsTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
         tTableDescriptor.setHdfsTable(hdfsTable);
         return tTableDescriptor;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OdpsTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OdpsTable.java
@@ -16,8 +16,8 @@ package com.starrocks.catalog;
 
 import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.odps.EntityConvertUtils;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.THdfsTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
@@ -128,7 +128,7 @@ public class OdpsTable extends Table implements HiveMetaStoreTable {
         hdfsTable.setColumns(getColumns().stream().map(Column::toThrift).collect(Collectors.toList()));
         // for be, partition column is equals to data column
         hdfsTable.setPartition_columnsIsSet(false);
-        hdfsTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
+        hdfsTable.setTime_zone(TimeUtils.getSessionTimeZone());
         tTableDescriptor.setHdfsTable(hdfsTable);
         return tTableDescriptor;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -17,6 +17,7 @@ package com.starrocks.catalog;
 
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.planner.PaimonScanNode;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TPaimonTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
@@ -115,6 +116,7 @@ public class PaimonTable extends Table {
         TPaimonTable tPaimonTable = new TPaimonTable();
         String encodedTable = PaimonScanNode.encodeObjectToString(paimonNativeTable);
         tPaimonTable.setPaimon_native_table(encodedTable);
+        tPaimonTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.PAIMON_TABLE,
                 fullSchema.size(), 0, tableName, databaseName);
         tTableDescriptor.setPaimonTable(tPaimonTable);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/PaimonTable.java
@@ -16,8 +16,8 @@
 package com.starrocks.catalog;
 
 import com.starrocks.analysis.DescriptorTable;
+import com.starrocks.common.util.TimeUtils;
 import com.starrocks.planner.PaimonScanNode;
-import com.starrocks.qe.ConnectContext;
 import com.starrocks.thrift.TPaimonTable;
 import com.starrocks.thrift.TTableDescriptor;
 import com.starrocks.thrift.TTableType;
@@ -116,7 +116,7 @@ public class PaimonTable extends Table {
         TPaimonTable tPaimonTable = new TPaimonTable();
         String encodedTable = PaimonScanNode.encodeObjectToString(paimonNativeTable);
         tPaimonTable.setPaimon_native_table(encodedTable);
-        tPaimonTable.setTime_zone(ConnectContext.get().getSessionVariable().getTimeZone());
+        tPaimonTable.setTime_zone(TimeUtils.getSessionTimeZone());
         TTableDescriptor tTableDescriptor = new TTableDescriptor(id, TTableType.PAIMON_TABLE,
                 fullSchema.size(), 0, tableName, databaseName);
         tTableDescriptor.setPaimonTable(tPaimonTable);

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/TimeUtils.java
@@ -347,4 +347,14 @@ public class TimeUtils {
                     + DurationStyle.LONG.toString(periodDuration.getDuration());
         }
     }
+
+    public static String getSessionTimeZone() {
+        String timezone;
+        if (ConnectContext.get() != null) {
+            timezone = ConnectContext.get().getSessionVariable().getTimeZone();
+        } else {
+            timezone = VariableMgr.getDefaultSessionVariable().getTimeZone();
+        }
+        return timezone;
+    }
 }

--- a/gensrc/thrift/Descriptors.thrift
+++ b/gensrc/thrift/Descriptors.thrift
@@ -408,6 +408,9 @@ struct THdfsTable {
 
     // hive table serde properties
     10: optional map<string, string> serde_properties
+
+    // timezone
+    11: optional string time_zone
 }
 
 struct TFileTable {
@@ -424,6 +427,9 @@ struct TFileTable {
     5: optional string input_format
 
     6: optional string serde_lib
+
+    // timezone
+    7: optional string time_zone
 }
 
 struct TTableFunctionTable {
@@ -524,6 +530,9 @@ struct THudiTable {
 
     // hudi table serde_lib
     10: optional string serde_lib
+
+    // timezone
+    11: optional string time_zone
 }
 
 struct TPaimonTable {
@@ -531,6 +540,9 @@ struct TPaimonTable {
     1: optional string paimon_options
     // paimon table
     2: optional string paimon_native_table
+
+    // timezone
+    3: optional string time_zone
 }
 
 struct TDeltaLakeTable {

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
@@ -17,31 +17,32 @@ package com.starrocks.hive.reader;
 import com.starrocks.jni.connector.ColumnType;
 import com.starrocks.jni.connector.ColumnValue;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
-import org.apache.hadoop.hive.serde2.io.TimestampWritableV2;
 import org.apache.hadoop.hive.serde2.objectinspector.ListObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.MapObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.ObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.PrimitiveObjectInspector;
 import org.apache.hadoop.hive.serde2.objectinspector.StructField;
 import org.apache.hadoop.hive.serde2.objectinspector.StructObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspector;
+import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 
 public class HiveColumnValue implements ColumnValue {
-    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     private final Object fieldData;
     private final ObjectInspector fieldInspector;
+    private final String timeZone;
 
-    HiveColumnValue(ObjectInspector fieldInspector, Object fieldData) {
+    HiveColumnValue(ObjectInspector fieldInspector, Object fieldData, String timeZone) {
         this.fieldInspector = fieldInspector;
         this.fieldData = fieldData;
+        this.timeZone = timeZone;
     }
 
     private Object inspectObject() {
@@ -95,23 +96,6 @@ public class HiveColumnValue implements ColumnValue {
     }
 
     @Override
-    public String getTimestamp(ColumnType.TypeValue type) {
-        // for rcfile with LazyBinaryColumnarSerDe, it will store timestamp type as UTC
-        // So we need adjust timestamp type's value according to current time zone
-        if (fieldData instanceof TimestampWritableV2) {
-            TimestampWritableV2 localTimestampWritable = (TimestampWritableV2) fieldData;
-            LocalDateTime localDateTime = LocalDateTime.ofInstant(
-                    Instant.ofEpochSecond(localTimestampWritable.getSeconds(), localTimestampWritable.getNanos()),
-                    ZoneId.systemDefault());
-            return localDateTime.format(DATETIME_FORMATTER);
-        } else if (fieldData instanceof Timestamp) {
-            return fieldData.toString();
-        } else {
-            return inspectObject().toString();
-        }
-    }
-
-    @Override
     public byte[] getBytes() {
         return (byte[]) inspectObject();
     }
@@ -124,7 +108,7 @@ public class HiveColumnValue implements ColumnValue {
         for (Object item : items) {
             HiveColumnValue cv = null;
             if (item != null) {
-                cv = new HiveColumnValue(itemInspector, item);
+                cv = new HiveColumnValue(itemInspector, item, timeZone);
             }
             values.add(cv);
         }
@@ -139,10 +123,10 @@ public class HiveColumnValue implements ColumnValue {
             HiveColumnValue cv0 = null;
             HiveColumnValue cv1 = null;
             if (kv.getKey() != null) {
-                cv0 = new HiveColumnValue(keyObjectInspector, kv.getKey());
+                cv0 = new HiveColumnValue(keyObjectInspector, kv.getKey(), timeZone);
             }
             if (kv.getValue() != null) {
-                cv1 = new HiveColumnValue(valueObjectInspector, kv.getValue());
+                cv1 = new HiveColumnValue(valueObjectInspector, kv.getValue(), timeZone);
             }
             keys.add(cv0);
             values.add(cv1);
@@ -160,7 +144,7 @@ public class HiveColumnValue implements ColumnValue {
                 StructField sf = fields.get(idx);
                 Object o = inspector.getStructFieldData(fieldData, sf);
                 if (o != null) {
-                    cv = new HiveColumnValue(sf.getFieldObjectInspector(), o);
+                    cv = new HiveColumnValue(sf.getFieldObjectInspector(), o, timeZone);
                 }
             }
             values.add(cv);
@@ -180,5 +164,17 @@ public class HiveColumnValue implements ColumnValue {
     @Override
     public BigDecimal getDecimal() {
         return ((HiveDecimal) inspectObject()).bigDecimalValue();
+    }
+
+    @Override
+    public LocalDate getDate() {
+        return LocalDate.ofEpochDay((((DateObjectInspector) fieldInspector).getPrimitiveJavaObject(fieldData))
+                .toEpochDay());
+    }
+
+    @Override
+    public LocalDateTime getDateTime(ColumnType.TypeValue type) {
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond((((TimestampObjectInspector) fieldInspector)
+                .getPrimitiveJavaObject(fieldData)).toEpochSecond()), ZoneId.of(timeZone));
     }
 }

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveColumnValue.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hive.serde2.objectinspector.primitive.DateObjectInspect
 import org.apache.hadoop.hive.serde2.objectinspector.primitive.TimestampObjectInspector;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -174,6 +175,9 @@ public class HiveColumnValue implements ColumnValue {
 
     @Override
     public LocalDateTime getDateTime(ColumnType.TypeValue type) {
+        if (fieldData instanceof Timestamp) {
+            return LocalDateTime.ofInstant(((Timestamp) fieldData).toInstant(), ZoneId.of(timeZone));
+        }
         return LocalDateTime.ofInstant(Instant.ofEpochSecond((((TimestampObjectInspector) fieldInspector)
                 .getPrimitiveJavaObject(fieldData)).toEpochSecond()), ZoneId.of(timeZone));
     }

--- a/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
+++ b/java-extensions/hive-reader/src/main/java/com/starrocks/hive/reader/HiveScanner.java
@@ -86,6 +86,8 @@ public class HiveScanner extends ConnectorScanner {
     // The value buffer used to store the value data.
     private Writable value;
 
+    private final String timeZone;
+
     public HiveScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;
         this.hiveColumnNames = params.get("hive_column_names");
@@ -107,6 +109,7 @@ public class HiveScanner extends ConnectorScanner {
             }
             LOG.debug("key = " + kv.getKey() + ", value = " + kv.getValue());
         }
+        this.timeZone = params.get("time_zone");
     }
 
     private JobConf makeJobConf(Properties properties) {
@@ -242,7 +245,7 @@ public class HiveScanner extends ConnectorScanner {
                     if (fieldData == null) {
                         appendData(i, null);
                     } else {
-                        ColumnValue fieldValue = new HiveColumnValue(fieldInspectors[i], fieldData);
+                        ColumnValue fieldValue = new HiveColumnValue(fieldInspectors[i], fieldData, timeZone);
                         appendData(i, fieldValue);
                     }
                 }

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiScannerUtils.java
@@ -19,15 +19,12 @@ import com.starrocks.jni.connector.ColumnType;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 public class HudiScannerUtils {
-    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
     public static final Map<String, String> HIVE_TYPE_MAPPING = new HashMap<>();
     public static Map<ColumnType.TypeValue, TimeUnit> TIMESTAMP_UNIT_MAPPING = new HashMap<>();
 
@@ -45,12 +42,7 @@ public class HudiScannerUtils {
     private static final long MICRO = 1_000_000;
     private static final long NANO = 1_000_000_000;
 
-    public static LocalDateTime getTimestamp(long value, TimeUnit timeUnit, boolean isAdjustedToUTC) {
-
-        ZoneId zone = ZoneOffset.UTC;
-        if (isAdjustedToUTC) {
-            zone = ZoneId.systemDefault();
-        }
+    public static LocalDateTime getTimestamp(long value, TimeUnit timeUnit, String timeZone) {
         long seconds = 0L;
         long nanoseconds = 0L;
 
@@ -77,11 +69,7 @@ public class HudiScannerUtils {
             default:
                 break;
         }
-        return LocalDateTime.ofInstant(Instant.ofEpochSecond(seconds, nanoseconds), zone);
-    }
-
-    public static String formatDateTime(LocalDateTime dateTime) {
-        return dateTime.format(DATETIME_FORMATTER);
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(seconds, nanoseconds), ZoneId.of(timeZone));
     }
 
     public static boolean isMaybeInt64Timestamp(ColumnType.TypeValue type) {

--- a/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
+++ b/java-extensions/hudi-reader/src/main/java/com/starrocks/hudi/reader/HudiSliceScanner.java
@@ -78,6 +78,7 @@ public class HudiSliceScanner extends ConnectorScanner {
     private final int fetchSize;
     private final ClassLoader classLoader;
     private final String fsOptionsProps;
+    private final String timeZone;
 
     public HudiSliceScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;
@@ -103,6 +104,7 @@ public class HudiSliceScanner extends ConnectorScanner {
         for (Map.Entry<String, String> kv : params.entrySet()) {
             LOG.debug("key = " + kv.getKey() + ", value = " + kv.getValue());
         }
+        this.timeZone = params.get("time_zone");
     }
 
     private JobConf makeJobConf(Properties properties) {
@@ -248,7 +250,7 @@ public class HudiSliceScanner extends ConnectorScanner {
                     if (fieldData == null) {
                         appendData(i, null);
                     } else {
-                        ColumnValue fieldValue = new HudiColumnValue(fieldInspectors[i], fieldData);
+                        ColumnValue fieldValue = new HudiColumnValue(fieldInspectors[i], fieldData, timeZone);
                         appendData(i, fieldValue);
                     }
                 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnType.java
@@ -114,6 +114,10 @@ public class ColumnType {
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DECIMAL32, 4);
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DECIMAL64, 8);
         PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DECIMAL128, 16);
+        PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DATE, 16);
+        PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DATETIME, 16);
+        PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DATETIME_MICROS, 16);
+        PRIMITIVE_TYPE_VALUE_SIZE.put(TypeValue.DATETIME_MILLIS, 16);
     }
 
     @Override
@@ -261,9 +265,7 @@ public class ColumnType {
     }
 
     public boolean isByteStorageType() {
-        return typeValue == TypeValue.STRING || typeValue == TypeValue.DATE
-                || typeValue == TypeValue.BINARY || typeValue == TypeValue.DATETIME
-                || typeValue == TypeValue.DATETIME_MICROS || typeValue == TypeValue.DATETIME_MILLIS;
+        return typeValue == TypeValue.STRING || typeValue == TypeValue.BINARY;
     }
 
     public boolean isArray() {

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/ColumnValue.java
@@ -15,6 +15,8 @@
 package com.starrocks.jni.connector;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ColumnValue {
@@ -31,7 +33,6 @@ public interface ColumnValue {
     double getDouble();
 
     String getString(ColumnType.TypeValue type);
-    String getTimestamp(ColumnType.TypeValue type);
     byte[] getBytes();
 
     void unpackArray(List<ColumnValue> values);
@@ -43,4 +44,8 @@ public interface ColumnValue {
     byte getByte();
 
     BigDecimal getDecimal();
+
+    LocalDate getDate();
+
+    LocalDateTime getDateTime(ColumnType.TypeValue type);
 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -20,6 +20,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -440,6 +442,19 @@ public class OffHeapColumnVector {
         return elementsAppended++;
     }
 
+    public int appendDate(LocalDate v) {
+        reserve(elementsAppended + 1);
+        int date = convertToDate(v.getYear(), v.getMonthValue(), v.getDayOfMonth());
+        return appendInt(date);
+    }
+
+    public int appendDateTime(LocalDateTime v) {
+        reserve(elementsAppended + 1);
+        long datetime = convertToDateTime(v.getYear(), v.getMonthValue(), v.getDayOfMonth(), v.getHour(),
+                v.getMinute(), v.getSecond(), v.getNano() / 1000);
+        return appendLong(datetime);
+    }
+
     public void updateMeta(OffHeapColumnVector meta) {
         if (type.isUnknown()) {
             meta.appendLong(0);
@@ -502,7 +517,7 @@ public class OffHeapColumnVector {
                 break;
             case STRING:
             case DATE:
-                appendString(o.getString(typeValue));
+                appendDate(o.getDate());
                 break;
             case DECIMALV2:
             case DECIMAL32:
@@ -513,7 +528,7 @@ public class OffHeapColumnVector {
             case DATETIME:
             case DATETIME_MICROS:
             case DATETIME_MILLIS:
-                appendString(o.getTimestamp(typeValue));
+                appendDateTime(o.getDateTime(typeValue));
                 break;
             case ARRAY: {
                 List<ColumnValue> values = new ArrayList<>();
@@ -695,5 +710,41 @@ public class OffHeapColumnVector {
             bytes[length - 1 - i] = temp;
         }
         return bytes;
+    }
+
+    /**
+     * logical components in be: time_types.cpp, date::from_date
+     */
+    private int convertToDate(int year, int month, int day) {
+        int century;
+        int julianDate;
+
+        if (month > 2) {
+            month += 1;
+            year += 4800;
+        } else {
+            month += 13;
+            year += 4799;
+        }
+        century = year / 100;
+        julianDate = year * 365 - 32167;
+        julianDate += year / 4 - century + century / 4;
+        julianDate += 7834 * month / 256 + day;
+
+        return julianDate;
+    }
+
+    /**
+     * logical components in be: time_types.h, timestamp::from_datetime
+     */
+    private long convertToDateTime(int year, int month, int day, int hour, int minute, int second, int microsecond) {
+        int secsPerMinute = 60;
+        int minsPerHour = 60;
+        long usecsPerSec = 1000000;
+        int timeStampBits = 40;
+        long julianDate = convertToDate(year, month, day);
+        long timestamp = (((((hour * minsPerHour) + minute) * secsPerMinute) + second) * usecsPerSec)
+                + microsecond;
+        return julianDate << timeStampBits | timestamp;
     }
 }

--- a/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
+++ b/java-extensions/jni-connector/src/main/java/com/starrocks/jni/connector/OffHeapColumnVector.java
@@ -516,6 +516,8 @@ public class OffHeapColumnVector {
                 appendBinary(o.getBytes());
                 break;
             case STRING:
+                appendString(o.getString(typeValue));
+                break;
             case DATE:
                 appendDate(o.getDate());
                 break;

--- a/java-extensions/odps-reader/src/main/java/com/starrocks/odps/reader/OdpsSplitScanner.java
+++ b/java-extensions/odps-reader/src/main/java/com/starrocks/odps/reader/OdpsSplitScanner.java
@@ -67,6 +67,8 @@ public class OdpsSplitScanner extends ConnectorScanner {
     private SplitReader<VectorSchemaRoot> reader;
     private Map<String, Integer> nameIndexMap;
 
+    private final String timezone;
+
     public OdpsSplitScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;
         this.projectName = params.get("project_name");
@@ -117,6 +119,7 @@ public class OdpsSplitScanner extends ConnectorScanner {
         }
         settings = builder.build();
         this.classLoader = this.getClass().getClassLoader();
+        this.timezone = params.get("time_zone");
     }
 
     @Override
@@ -178,7 +181,7 @@ public class OdpsSplitScanner extends ConnectorScanner {
                         if (data == null) {
                             appendData(fieldIndex, null);
                         } else {
-                            appendData(fieldIndex, new OdpsColumnValue(data, requireColumns[fieldIndex].getTypeInfo()));
+                            appendData(fieldIndex, new OdpsColumnValue(data, requireColumns[fieldIndex].getTypeInfo(), timezone));
                         }
                     }
                 }

--- a/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScanner.java
+++ b/java-extensions/paimon-reader/src/main/java/com/starrocks/paimon/reader/PaimonSplitScanner.java
@@ -52,6 +52,8 @@ public class PaimonSplitScanner extends ConnectorScanner {
     private final ClassLoader classLoader;
     private final String[] nestedFields;
 
+    private String timeZone;
+
     public PaimonSplitScanner(int fetchSize, Map<String, String> params) {
         this.fetchSize = fetchSize;
         this.requiredFields = params.get("required_fields").split(",");
@@ -60,6 +62,7 @@ public class PaimonSplitScanner extends ConnectorScanner {
         this.predicateInfo = params.get("predicate_info");
         this.encodedTable = params.get("native_table");
         this.classLoader = this.getClass().getClassLoader();
+        this.timeZone = params.get("time_zone");
     }
 
     private void parseRequiredTypes() {
@@ -145,7 +148,7 @@ public class PaimonSplitScanner extends ConnectorScanner {
                     if (fieldData == null) {
                         appendData(i, null);
                     } else {
-                        ColumnValue fieldValue = new PaimonColumnValue(fieldData, logicalTypes[i]);
+                        ColumnValue fieldValue = new PaimonColumnValue(fieldData, logicalTypes[i], timeZone);
                         appendData(i, fieldValue);
                     }
                 }


### PR DESCRIPTION
Why I'm doing:
Now jni reader use format string to convert date and timestamp type.
This cost too much time

What I'm doing:
In jni reader, we convert date and timestamp type to starrocks date and datetime, then we can use memcpy in be to reduce
the [format string ] overhead

#36712
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
