### PR TITLE
[BugFix] Fix external OLAP table load failed bug

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -1841,7 +1841,12 @@ public class StmtExecutor {
         long transactionId = stmt.getTxnId();
         TransactionState txnState = null;
         String label = DebugUtil.printId(context.getExecutionId());
-        if (targetTable instanceof OlapTable) {
+        if (targetTable instanceof ExternalOlapTable) {
+            Preconditions.checkState(stmt instanceof InsertStmt,
+                    "External OLAP table only supports insert statement");
+            String stmtLabel = ((InsertStmt) stmt).getLabel();
+            label = Strings.isNullOrEmpty(stmtLabel) ? MetaUtils.genInsertLabel(context.getExecutionId()) : stmtLabel;
+        } else if (targetTable instanceof OlapTable) {
             txnState = transactionMgr.getTransactionState(database.getId(), transactionId);
             if (txnState == null) {
                 throw new DdlException("txn does not exist: " + transactionId);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -22,8 +22,6 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.LiteralExpr;
 import com.starrocks.analysis.NullLiteral;
 import com.starrocks.catalog.Column;
-import com.starrocks.catalog.Database;
-import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.HiveTable;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
@@ -34,9 +32,6 @@ import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.connector.hive.HiveWriteUtils;
-import com.starrocks.external.starrocks.TableMetaSyncer;
-import com.starrocks.meta.lock.LockType;
-import com.starrocks.meta.lock.Locker;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.CatalogMgr;
 import com.starrocks.sql.ast.DefaultValueExpr;
@@ -70,7 +65,12 @@ public class InsertAnalyzer {
         /*
          *  Target table
          */
-        Table table = getTargetTable(insertStmt, session);
+        Table table;
+        if (insertStmt.getTargetTable() != null) {
+            table = insertStmt.getTargetTable();
+        } else {
+            table = getTargetTable(insertStmt, session);
+        }
 
         if (table instanceof OlapTable) {
             OlapTable olapTable = (OlapTable) table;
@@ -286,26 +286,6 @@ public class InsertAnalyzer {
         }
     }
 
-    private static ExternalOlapTable getOLAPExternalTableMeta(Database db, ExternalOlapTable externalOlapTable) {
-        // copy the table, and release database lock when synchronize table meta
-        ExternalOlapTable copiedTable = new ExternalOlapTable();
-        externalOlapTable.copyOnlyForQuery(copiedTable);
-        int lockTimes = 0;
-        Locker locker = new Locker();
-        while (locker.isReadLockHeldByCurrentThread(db)) {
-            locker.unLockDatabase(db, LockType.READ);
-            lockTimes++;
-        }
-        try {
-            new TableMetaSyncer().syncTable(copiedTable);
-        } finally {
-            while (lockTimes-- > 0) {
-                locker.lockDatabase(db, LockType.READ);
-            }
-        }
-        return copiedTable;
-    }
-
     private static Table getTargetTable(InsertStmt insertStmt, ConnectContext session) {
         if (insertStmt.useTableFunctionAsTargetTable()) {
             return insertStmt.makeTableFunctionTable();
@@ -324,12 +304,7 @@ public class InsertAnalyzer {
             ErrorReport.reportSemanticException(ErrorCode.ERR_BAD_CATALOG_ERROR, catalogName);
         }
 
-        Database database = MetaUtils.getDatabase(catalogName, dbName);
         Table table = MetaUtils.getTable(catalogName, dbName, tableName);
-
-        if (table instanceof ExternalOlapTable) {
-            table = getOLAPExternalTableMeta(database, (ExternalOlapTable) table);
-        }
 
         if (table instanceof MaterializedView && !insertStmt.isSystem()) {
             throw new SemanticException(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/InsertAnalyzer.java
@@ -67,6 +67,8 @@ public class InsertAnalyzer {
          */
         Table table;
         if (insertStmt.getTargetTable() != null) {
+            // For the OLAP external table,
+            // the target table is synchronized from another cluster and saved into InsertStmt during beginTransaction.
             table = insertStmt.getTargetTable();
         } else {
             table = getTargetTable(insertStmt, session);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -25,6 +25,7 @@ import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
+import com.starrocks.common.util.DebugUtil;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.SqlModeHelper;
@@ -35,6 +36,7 @@ import com.starrocks.sql.ast.CreateMaterializedViewStmt;
 import com.starrocks.sql.ast.StatementBase;
 import com.starrocks.sql.optimizer.rule.mv.MVUtils;
 import com.starrocks.sql.parser.SqlParser;
+import com.starrocks.thrift.TUniqueId;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -210,5 +212,17 @@ public class MetaUtils {
                         "It is best to delete the materialized view and rebuild it to maintain the best compatibility.",
                 originStmt.originStmt);
         return Maps.newConcurrentMap();
+    }
+
+    public static String genInsertLabel(TUniqueId executionId) {
+        return "insert_" + DebugUtil.printId(executionId);
+    }
+
+    public static String genDeleteLabel(TUniqueId executionId) {
+        return "delete_" + DebugUtil.printId(executionId);
+    }
+
+    public static String genUpdateLabel(TUniqueId executionId) {
+        return "update_" + DebugUtil.printId(executionId);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/common/MetaUtils.java
@@ -20,12 +20,14 @@ import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.TableName;
 import com.starrocks.catalog.Catalog;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.ExternalOlapTable;
 import com.starrocks.catalog.InternalCatalog;
 import com.starrocks.catalog.Table;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.ErrorCode;
 import com.starrocks.common.ErrorReport;
 import com.starrocks.common.util.DebugUtil;
+import com.starrocks.external.starrocks.TableMetaSyncer;
 import com.starrocks.qe.ConnectContext;
 import com.starrocks.qe.OriginStatement;
 import com.starrocks.qe.SqlModeHelper;
@@ -224,5 +226,12 @@ public class MetaUtils {
 
     public static String genUpdateLabel(TUniqueId executionId) {
         return "update_" + DebugUtil.printId(executionId);
+    }
+
+    public static ExternalOlapTable syncOLAPExternalTableMeta(ExternalOlapTable externalOlapTable) {
+        ExternalOlapTable copiedTable = new ExternalOlapTable();
+        externalOlapTable.copyOnlyForQuery(copiedTable);
+        new TableMetaSyncer().syncTable(copiedTable);
+        return copiedTable;
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeInsertTest.java
@@ -100,15 +100,6 @@ public class AnalyzeInsertTest {
                 "Unknown catalog 'err_catalog'");
 
         MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
-        new Expectations(metadata) {
-            {
-                metadata.getDb("iceberg_catalog", "err_db");
-                result = null;
-                minTimes = 0;
-            }
-        };
-        analyzeFail("insert into iceberg_catalog.err_db.tbl values (1)",
-                "Unknown database 'err_db'");
 
         new Expectations(metadata) {
             {
@@ -235,9 +226,6 @@ public class AnalyzeInsertTest {
         MetadataMgr metadata = AnalyzeTestUtil.getConnectContext().getGlobalStateMgr().getMetadataMgr();
         new Expectations(metadata) {
             {
-                metadata.getDb(anyString, anyString);
-                result = new Database();
-
                 metadata.getTable(anyString, anyString, anyString);
                 result = hiveTable;
             }


### PR DESCRIPTION
Why I'm doing:
Load to  external OLAP table failed:
`begin remote txn failed, db: -1 not exist, label: insert_05c40d5a-a55d-11ee-86a2-5254007b45e6`

This PR #36225 put begin_txn before plan, but for the external OLAP table, the begin_txn will fail because its meta has not been synchronized yet.

What I'm doing:
Synchronize meta of external OLAP table before the begin of remote txn.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
