### PR TITLE
[BugFix] Remove invalid predicates after mv rewrite

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -85,6 +85,7 @@ public class ScalarRangePredicateExtractor {
             }
         }
 
+        result.removeAll(conjuncts);
         ScalarOperator extractExpr = Utils.compoundAnd(Lists.newArrayList(result));
         if (extractExpr == null) {
             return predicate;

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -85,7 +85,6 @@ public class ScalarRangePredicateExtractor {
             }
         }
 
-        result.removeAll(conjuncts);
         ScalarOperator extractExpr = Utils.compoundAnd(Lists.newArrayList(result));
         if (extractExpr == null) {
             return predicate;
@@ -106,11 +105,19 @@ public class ScalarRangePredicateExtractor {
 
             if (extractMap.values().stream().allMatch(valueDescriptor -> valueDescriptor.sourceCount == cs.size())
                     && extractMap.size() == cf.size()) {
-                return extractExpr;
+                if (result.size() == conjuncts.size()) {
+                    // to keep the isPushdown/isRedundant of predicate
+                    return predicate;
+                } else {
+                    return extractExpr;
+                }
             }
         }
 
-        if (!conjuncts.contains(extractExpr)) {
+        if (!conjuncts.containsAll(result)) {
+            // remove duplicates
+            result.removeAll(conjuncts);
+            extractExpr = Utils.compoundAnd(Lists.newArrayList(result));
             result.forEach(f -> f.setFromPredicateRangeDerive(true));
             result.stream().filter(predicateOperator -> !checkStatisticsEstimateValid(predicateOperator))
                     .forEach(f -> f.setNotEvalEstimate(true));

--- a/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
+++ b/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
@@ -279,6 +279,34 @@ public class MSchema {
     public static final MTable TABLE_WITH_DAY_PARTITION1 = TABLE_WITH_DAY_PARTITION.copyWithName("table_with_day_partition1");
     public static final MTable TABLE_WITH_DAY_PARTITION2 = TABLE_WITH_DAY_PARTITION.copyWithName("table_with_day_partition2");
 
+    public static final MTable TEST10 = new MTable("test10", "event_id",
+            List.of(
+                    "  `event_id` int NULL",
+                    "  `event_type` varchar(65533) NULL ",
+                    "  `event_time` datetime NULL "
+            ),
+            "event_time",
+            List.of(
+                    "PARTITION p20230105 VALUES [(\"2023-01-05 00:00:00\"), (\"2023-01-06 00:00:00\"))",
+                    "PARTITION p20230106 VALUES [(\"2023-01-06 00:00:00\"), (\"2023-01-07 00:00:00\"))"
+            )
+    ).withValues("(1, 'a', '2023-01-05 10:20:22'),(2, 'b', '2023-01-05 10:20:22')," +
+            "(11, 'aa', '2023-01-06 10:20:22'),(22, 'bb', '2023-01-06 10:20:22')");
+
+    public static final MTable TEST11 = new MTable("test11", "event_id1",
+            List.of(
+                    "  `event_id1` int NULL",
+                    "  `event_type1` varchar(65533) NULL ",
+                    "  `event_time1` datetime NULL "
+            ),
+            "event_time1",
+            List.of(
+                    "PARTITION p20230105 VALUES [(\"2023-01-05 00:00:00\"), (\"2023-01-06 00:00:00\"))",
+                    "PARTITION p20230106 VALUES [(\"2023-01-06 00:00:00\"), (\"2023-01-07 00:00:00\"))"
+            )
+    ).withValues("(1, 'a', '2023-01-05 10:20:22'),(2, 'b', '2023-01-05 10:20:23')," +
+            "(11, 'aa', '2023-01-06 10:20:22'),(22, 'bbx', '2023-01-06 10:20:22')");
+
     public static final List<MTable>  TABLE_MARKETING = List.of(
             EMPS,
             EMPS_NULL,
@@ -299,7 +327,9 @@ public class MSchema {
             TEST_BASE_PART,
             T1,
             JSON_TBL,
-            T_METRICS
+            T_METRICS,
+            TEST10,
+            TEST11
     );
     public static final Map<String, MTable> TABLE_MAP = Maps.newHashMap();
 


### PR DESCRIPTION
Why I'm doing:
For queries has pushdown derived predicates, the rewritten plan may be wrong, which will lead to invalid results. Originally, the isPushdown and isRedundant fields of ScalarOperator may be incorrectly set.
What I'm doing:
fix isPushdown and isRedundant after predicates pushdown rules.

Fixes #36536 

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
