### PR TITLE
[BugFix] fix array cardinality with empty array

### DIFF
--- a/be/src/storage/meta_reader.cpp
+++ b/be/src/storage/meta_reader.cpp
@@ -235,6 +235,11 @@ Status SegmentMetaCollecter::_collect_dict(ColumnId cid, Column* column, Logical
         return Status::GlobalDictError("global dict greater than DICT_DECODE_MAX_SIZE");
     }
 
+    // array<string> has none dict, return directly
+    if (words.size() < 1) {
+        return Status::OK();
+    }
+
     [[maybe_unused]] NullableColumn* nullable_column = nullptr;
     ArrayColumn* array_column = nullptr;
 

--- a/be/src/storage/rowset/scalar_column_iterator.cpp
+++ b/be/src/storage/rowset/scalar_column_iterator.cpp
@@ -424,7 +424,7 @@ Status ScalarColumnIterator::_do_next_batch_dict_codes(const SparseRange<>& rang
     size_t end_ord = _page->first_ordinal() + _page->num_rows();
     SparseRange<> read_range;
 
-    DCHECK_EQ(range.begin(), _current_ordinal);
+    DCHECK(range.empty() || range.begin() == _current_ordinal);
     // similar to ScalarColumnIterator::next_batch
     while (iter.has_more()) {
         if (_page->remaining() == 0 && iter.begin() == end_ord) {

--- a/test/sql/test_low_cardinality/R/test_low_cardinality_empty_array
+++ b/test/sql/test_low_cardinality/R/test_low_cardinality_empty_array
@@ -1,0 +1,139 @@
+-- name: test_null_low_array
+CREATE TABLE `s2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `a1` array<varchar(65533)> NULL COMMENT "",
+  `a2` array<varchar(65533)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into s2 values
+(1, 1, null, []);
+-- result:
+-- !result
+[UC] analyze full table s2;
+-- result:
+test_db_5d39852aabaf11ee91b700163e04d4c2.s2	analyze	status	OK
+-- !result
+select * from s2 order by v1 limit 2;
+-- result:
+1	1	None	[]
+-- !result
+select * from s2 where a1[1] = 'Jiangsu' order by v1 limit 2;
+-- result:
+-- !result
+select * from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select array_length(array_distinct(a1)), array_min(reverse(array_sort(a1))), a1, array_max(array_slice(a2, 2, 5))
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select lower(upper(array_min(reverse(array_sort(a1))))) from s2;
+-- result:
+None
+-- !result
+-- name: test_spec_low_array
+CREATE TABLE `s2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `a1` array<varchar(65533)> NULL COMMENT "",
+  `a2` array<varchar(65533)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+-- result:
+-- !result
+insert into s2 values
+(1, 1, null, []),
+(2, 1, null, []),
+(3, 1, null, null),
+(4, 1, [], null),
+(5, 1, [], null),
+(6, 1, null, null),
+(7, 1, ["e", "f"], ["c", "d"]),
+(8, 1, null, null),
+(9, 1, ["g", "h"], null),
+(10, 1, null, ["a", "b"]);
+-- result:
+-- !result
+[UC] analyze full table s2;
+-- result:
+test_db_5d3ac106abaf11ee9b6400163e04d4c2.s2	analyze	status	OK
+-- !result
+function: wait_global_dict_ready('a2', 's2')
+-- result:
+
+-- !result
+function: wait_global_dict_ready('a1', 's2')
+-- result:
+
+-- !result
+select * from s2 order by v1 limit 2;
+-- result:
+1	1	None	[]
+2	1	None	[]
+-- !result
+select * from s2 where a1[1] = 'Jiangsu' order by v1 limit 2;
+-- result:
+-- !result
+select * from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select array_length(array_distinct(a1)), array_min(reverse(array_sort(a1))), a1, array_max(array_slice(a2, 2, 5))
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+-- result:
+-- !result
+select lower(upper(array_min(reverse(array_sort(a1))))) from s2;
+-- result:
+None
+None
+None
+None
+None
+None
+None
+None
+e
+g
+-- !result

--- a/test/sql/test_low_cardinality/T/test_low_cardinality_empty_array
+++ b/test/sql/test_low_cardinality/T/test_low_cardinality_empty_array
@@ -1,0 +1,102 @@
+-- name: test_null_low_array
+
+CREATE TABLE `s2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `a1` array<varchar(65533)> NULL COMMENT "",
+  `a2` array<varchar(65533)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into s2 values
+(1, 1, null, []);
+
+
+[UC] analyze full table s2;
+
+select * from s2 order by v1 limit 2;
+
+select * from s2 where a1[1] = 'Jiangsu' order by v1 limit 2;
+select * from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+
+select array_length(array_distinct(a1)), array_min(reverse(array_sort(a1))), a1, array_max(array_slice(a2, 2, 5))
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+
+select lower(upper(array_min(reverse(array_sort(a1))))) from s2;
+
+-- name: test_spec_low_array
+
+CREATE TABLE `s2` (
+  `v1` bigint(20) NULL COMMENT "",
+  `v2` int(11) NULL COMMENT "",
+  `a1` array<varchar(65533)> NULL COMMENT "",
+  `a2` array<varchar(65533)> NULL COMMENT ""
+) ENGINE=OLAP
+DUPLICATE KEY(`v1`)
+COMMENT "OLAP"
+DISTRIBUTED BY HASH(`v1`) BUCKETS 10
+PROPERTIES (
+"replication_num" = "1",
+"in_memory" = "false",
+"enable_persistent_index" = "false",
+"replicated_storage" = "false",
+"light_schema_change" = "true",
+"compression" = "LZ4"
+);
+
+
+insert into s2 values
+(1, 1, null, []),
+(2, 1, null, []),
+(3, 1, null, null),
+(4, 1, [], null),
+(5, 1, [], null),
+(6, 1, null, null),
+(7, 1, ["e", "f"], ["c", "d"]),
+(8, 1, null, null),
+(9, 1, ["g", "h"], null),
+(10, 1, null, ["a", "b"]);
+
+
+[UC] analyze full table s2;
+
+function: wait_global_dict_ready('a2', 's2')
+function: wait_global_dict_ready('a1', 's2')
+
+select * from s2 order by v1 limit 2;
+
+select * from s2 where a1[1] = 'Jiangsu' order by v1 limit 2;
+select * from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+
+select array_length(a1), array_max(a2), array_min(a1), array_distinct(a1), array_sort(a2),
+       reverse(a1), array_slice(a2, 2, 4), cardinality(a2)
+from s2 where a1[1] = 'Jiangsu' or a2[2] = 'GD' order by v1 limit 2;
+
+select array_length(array_distinct(a1)), array_min(reverse(array_sort(a1))), a1, array_max(array_slice(a2, 2, 5))
+from s2 where a1[1] = 'Jiangsu' and a2[2] = 'GD' order by v1 limit 2;
+
+select lower(upper(array_min(reverse(array_sort(a1))))) from s2;
+


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

when only one row and string is `NULL`, storage dict will return a default value
when only one row and  array<string> is `NULL`, storage dict will return 0 row, but DCHECK will faild and statistics_write will set error rows(1)

Fixes https://github.com/StarRocks/StarRocksTest/issues/5572

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
