### PR TITLE
[BugFix] Fix shortcircuit creating wrong values chunk

### DIFF
--- a/be/src/exec/short_circuit_hybrid.cpp
+++ b/be/src/exec/short_circuit_hybrid.cpp
@@ -154,16 +154,15 @@ Status ShortCircuitHybridScanNode::_process_key_chunk() {
 // found vector value
 Status ShortCircuitHybridScanNode::_process_value_chunk(std::vector<bool>& found) {
     std::vector<string> value_field_names;
-    auto value_schema =
-            std::make_unique<Schema>(_tablet_schema->schema(), _tablet_schema->schema()->value_field_column_ids());
-
+    vector<starrocks::ColumnId> value_column_ids;
     for (auto slot_desc : _tuple_desc->slots()) {
-        auto field = value_schema->get_field_by_name(slot_desc->col_name());
+        auto field = _tablet_schema->schema()->get_field_by_name(slot_desc->col_name());
         if (field != nullptr && !field->is_key()) {
             value_field_names.emplace_back(field->name());
+            value_column_ids.emplace_back(field->id());
         }
     }
-
+    auto value_schema = std::make_unique<Schema>(_tablet_schema->schema(), value_column_ids);
     // tmp value_chunk, order not match key_chunk
     ChunkPtr value_chunk = ChunkHelper::new_chunk(*(value_schema), _num_rows);
     // final value_chunk, order match key_chunk


### PR DESCRIPTION
Why I'm doing:

In ShortCircuitHybridScanNode, it will creating a chunk to store multiget values, but the Chunk's schema contains all value columns, not specified read columns, which is incorrect.

What I'm doing:

Fix this bug

Fixes #38526

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
