### PR TITLE
[BugFix] Fix dead lock when SegmentFlushTask aborts DeltaWriter

### DIFF
--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -94,8 +94,11 @@ public:
         }
 
         if (!st.ok()) {
-            _writer->abort(true);
+            Status cancel_st = Status::InternalError("cancel writer because fail to run flush task, " + st.to_string());
+            _writer->cancel(cancel_st);
             _send_fail_response(st);
+            LOG(ERROR) << "failed to flush segment, txn_id: " << _request->txn_id()
+                       << ", tablet id: " << _request->tablet_id() << ", status: " << st;
         } else {
             _send_success_response(eos, st);
         }


### PR DESCRIPTION
Why I'm doing:
introduced by this pr #36746 
SegmentFlushTask will abort DeltaWriter if run into some errors, and DeltaWriter#abort will shutdown SegmentFlushToken. SegmentFlushToken#shutdown will block until all running tasks finish, but the current running SegmentFlushTask is waiting for the shutdown success. So there will be a deadlock, and there will be an exception

![img_v3_026q_4d9b71b1-c460-41c6-900d-41eb4b81a06g](https://github.com/StarRocks/starrocks/assets/11382970/c3010e43-4bed-4452-a6e0-e864afd48eb2)


What I'm doing:
use DeltaWriter#cancel instead of abort to avoid block the thread

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
