### PR TITLE
[BugFix] Fix the bug of release pk column memory in the apply stage

### DIFF
--- a/be/src/column/column.h
+++ b/be/src/column/column.h
@@ -389,6 +389,7 @@ public:
 
     virtual void swap_column(Column& rhs) = 0;
 
+    // The interface will not free memory!!!
     virtual void reset_column() { _delete_state = DEL_NOT_SATISFIED; }
 
     virtual bool capacity_limit_reached(std::string* msg = nullptr) const = 0;

--- a/be/src/storage/tablet_updates.cpp
+++ b/be/src/storage/tablet_updates.cpp
@@ -75,8 +75,6 @@ std::string EditVersion::to_string() const {
     }
 }
 
-using IteratorList = TabletUpdates::IteratorList;
-
 TabletUpdates::TabletUpdates(Tablet& tablet) : _tablet(tablet), _unused_rowsets(UINT64_MAX) {}
 
 TabletUpdates::~TabletUpdates() {
@@ -2075,7 +2073,7 @@ void TabletUpdates::_apply_compaction_commit(const EditVersionInfo& version_info
             total_deletes += tmp_deletes.size();
         }
         delvecs.emplace_back(rssid, dv);
-        _compaction_state->release_segments(rowset, i);
+        _compaction_state->release_segment(i);
     }
     // release memory
     _compaction_state.reset();

--- a/be/src/storage/update_compaction_state.cpp
+++ b/be/src/storage/update_compaction_state.cpp
@@ -143,7 +143,7 @@ Status CompactionState::_load_segments(Rowset* rowset, uint32_t segment_id) {
     return Status::OK();
 }
 
-void CompactionState::release_segments(Rowset* rowset, uint32_t segment_id) {
+void CompactionState::release_segment(uint32_t segment_id) {
     if (segment_id >= pk_cols.size() || pk_cols[segment_id] == nullptr) {
         return;
     }
@@ -151,7 +151,7 @@ void CompactionState::release_segments(Rowset* rowset, uint32_t segment_id) {
     auto tracker = update_manager->compaction_state_mem_tracker();
     _memory_usage -= pk_cols[segment_id]->memory_usage();
     tracker->release(pk_cols[segment_id]->memory_usage());
-    pk_cols[segment_id]->reset_column();
+    pk_cols[segment_id].reset();
 }
 
 Status CompactionState::_do_load(Rowset* rowset) {

--- a/be/src/storage/update_compaction_state.h
+++ b/be/src/storage/update_compaction_state.h
@@ -36,7 +36,7 @@ public:
     Status load(Rowset* rowset);
 
     Status load_segments(Rowset* rowset, uint32_t segment_id);
-    void release_segments(Rowset* rowset, uint32_t segment_id);
+    void release_segment(uint32_t segment_id);
 
     size_t memory_usage() const { return _memory_usage; }
 


### PR DESCRIPTION
Why I'm doing:

`reset_column` will not releaese the memory of column.

What I'm doing:

Release the memory of pk column in the apply stage.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
