### PR TITLE
[Enhancement] Log detail exception messages in some methods of HdfsFsManager

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
+++ b/fe/fe-core/src/main/java/com/starrocks/fs/hdfs/HdfsFsManager.java
@@ -1251,8 +1251,8 @@ public class HdfsFsManager {
         try {
             fileSystem.getDFSFileSystem().delete(filePath, true);
         } catch (IOException e) {
-            LOG.error("errors while delete path " + path);
-            throw new UserException("delete path " + path + "error");
+            LOG.error("errors while delete path " + path, e);
+            throw new UserException("delete path " + path + "error", e);
         }
     }
 
@@ -1280,8 +1280,8 @@ public class HdfsFsManager {
                 throw new UserException("failed to rename path from " + srcPath + " to " + destPath);
             }
         } catch (IOException e) {
-            LOG.error("errors while rename path from " + srcPath + " to " + destPath);
-            throw new UserException("errors while rename " + srcPath + "to " + destPath);
+            LOG.error("errors while rename path from " + srcPath + " to " + destPath, e);
+            throw new UserException("errors while rename " + srcPath + "to " + destPath, e);
         }
     }
 
@@ -1292,8 +1292,8 @@ public class HdfsFsManager {
         try {
             return fileSystem.getDFSFileSystem().exists(filePath);
         } catch (IOException e) {
-            LOG.error("errors while check path exist: " + path);
-            throw new UserException("errors while check if path " + path + " exist");
+            LOG.error("errors while check path exist: " + path, e);
+            throw new UserException("errors while check if path " + path + " exist", e);
         }
     }
 
@@ -1310,7 +1310,7 @@ public class HdfsFsManager {
             return fd;
         } catch (IOException e) {
             LOG.error("errors while open path", e);
-            throw new UserException("could not open file " + path);
+            throw new UserException("could not open file " + path, e);
         }
     }
 
@@ -1360,7 +1360,7 @@ public class HdfsFsManager {
                 }
             } catch (IOException e) {
                 LOG.error("errors while read data from stream", e);
-                throw new UserException("errors while read data from stream");
+                throw new UserException("errors while read data from stream", e);
             }
         }
     }
@@ -1376,7 +1376,7 @@ public class HdfsFsManager {
                 fsDataInputStream.close();
             } catch (IOException e) {
                 LOG.error("errors while close file input stream", e);
-                throw new UserException("errors while close file input stream");
+                throw new UserException("errors while close file input stream", e);
             } finally {
                 ioStreamManager.removeInputStream(fd);
             }
@@ -1397,7 +1397,7 @@ public class HdfsFsManager {
             return fd;
         } catch (IOException e) {
             LOG.error("errors while open path", e);
-            throw new UserException("could not open file " + path);
+            throw new UserException("could not open file " + path, e);
         }
     }
 
@@ -1413,7 +1413,7 @@ public class HdfsFsManager {
                 fsDataOutputStream.write(data);
             } catch (IOException e) {
                 LOG.error("errors while write file " + fd + " to output stream", e);
-                throw new UserException("errors while write data to output stream");
+                throw new UserException("errors while write data to output stream", e);
             }
         }
     }
@@ -1426,7 +1426,7 @@ public class HdfsFsManager {
                 fsDataOutputStream.close();
             } catch (IOException e) {
                 LOG.error("errors while close file " + fd + " output stream", e);
-                throw new UserException("errors while close file output stream");
+                throw new UserException("errors while close file output stream", e);
             } finally {
                 ioStreamManager.removeOutputStream(fd);
             }


### PR DESCRIPTION
Why I'm doing:
Some methods of HdfsFsManager, such as renamePath, does not log the detail exception from hadoop sdk, and hard to investigate problems.

What I'm doing:
log the detail exception from hadoop sdk

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
