### PR TITLE
[Enhancement] simplify binary equals expr

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/scalar/SimplifiedPredicateRule.java
@@ -329,11 +329,26 @@ public class SimplifiedPredicateRule extends BottomUpScalarOperatorRewriteRule {
     @Override
     public ScalarOperator visitBinaryPredicate(BinaryPredicateOperator predicate,
                                                ScalarOperatorRewriteContext context) {
-        if (predicate.getChild(0).isVariable() && predicate.getChild(0).equals(predicate.getChild(1))) {
+        ScalarOperator left = predicate.getChild(0);
+        ScalarOperator right = predicate.getChild(1);
+        if (left.isVariable() && left.equals(right)) {
             if (predicate.getBinaryType().equals(BinaryType.EQ_FOR_NULL)) {
                 return ConstantOperator.createBoolean(true);
             }
         }
+
+        if (predicate.getBinaryType().isEqual() && left.isConstantRef() && right.getType().isBoolean()) {
+            ConstantOperator constantOperator = (ConstantOperator) left;
+            if (constantOperator.isTrue()) {
+                return right;
+            }
+        } else if (predicate.getBinaryType().isEqual() && left.getType().isBoolean() && right.isConstantRef()) {
+            ConstantOperator constantOperator = (ConstantOperator) right;
+            if (constantOperator.isTrue()) {
+                return left;
+            }
+        }
+
         return predicate;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -148,7 +148,7 @@ public class SelectStmtTest {
                         "nullable_tuples:[false], conjuncts:[TExpr(nodes:[TExprNode(node_type:BINARY_PRED, " +
                         "type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:BOOLEAN))]), " +
                         "opcode:EQ, num_children:2, output_scale:-1, vector_opcode:INVALID_OPCODE, child_type:INT, " +
-                        "has_nullable_child:true, is_nullable:true, is_monotonic:false))";
+                        "has_nullable_child:true, is_nullable:true, is_monotonic:false)";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
         Assert.assertTrue(thrift, thrift.contains(expectString));
     }

--- a/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/analysis/SelectStmtTest.java
@@ -147,10 +147,10 @@ public class SelectStmtTest {
                 "[TPlanNode(node_id:0, node_type:OLAP_SCAN_NODE, num_children:0, limit:-1, row_tuples:[0], " +
                         "nullable_tuples:[false], conjuncts:[TExpr(nodes:[TExprNode(node_type:BINARY_PRED, " +
                         "type:TTypeDesc(types:[TTypeNode(type:SCALAR, scalar_type:TScalarType(type:BOOLEAN))]), " +
-                        "opcode:EQ, num_children:2, output_scale:-1, vector_opcode:INVALID_OPCODE, child_type:BOOLEAN, " +
-                        "has_nullable_child:true, is_nullable:true, is_monotonic:false)";
+                        "opcode:EQ, num_children:2, output_scale:-1, vector_opcode:INVALID_OPCODE, child_type:INT, " +
+                        "has_nullable_child:true, is_nullable:true, is_monotonic:false))";
         String thrift = UtFrameUtils.getPlanThriftString(ctx, sql);
-        Assert.assertTrue(thrift.contains(expectString));
+        Assert.assertTrue(thrift, thrift.contains(expectString));
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/FurtherPartitionPruneTest.java
@@ -260,6 +260,7 @@ class FurtherPartitionPruneTest extends PlanTestBase {
 
     private static Stream<Arguments> onePartitionSqlList() {
         List<String> sqlList = Lists.newArrayList();
+        sqlList.add("select * from tbl_int where k1 = 1 = true");
         sqlList.add("select * from less_than_tbl where k1 is null");
         sqlList.add("select * from less_than_tbl where k1 is null or k1 <=> null");
         sqlList.add("select * from less_than_tbl where k1 = 1 and k1 is null");
@@ -430,7 +431,6 @@ class FurtherPartitionPruneTest extends PlanTestBase {
         sqlList.add("select * from tbl_int where k1 in (1,100,200,300) or k1 > 300");
 
         sqlList.add("select * from two_key where k1 < 100 or k1 > 200");
-        sqlList.add("select * from tbl_int where k1 = 1 = true");
         sqlList.add("select * from tbl_int where b1 or (k1 < 100) or k1 > 200");
         sqlList.add("select * from tbl_int where b1");
         return sqlList.stream().map(e -> Arguments.of(e));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1690,8 +1690,9 @@ public class ExpressionTest extends PlanTestBase {
         String plan = getFragmentPlan(sql);
         assertContains(plan, "PREDICATES: (11: id_bool = FALSE) OR (11: id_bool)");
 
-        sql = "select * from test_object where bitmap_contains(b1, v1) = true";
+        sql = "select * from test_object where true = bitmap_contains(b1, v1) or bitmap_contains(b1, v2) = true";
         plan = getFragmentPlan(sql);
-        assertContains(plan, "PREDICATES: bitmap_contains(5: b1, CAST(1: v1 AS BIGINT))");
+        assertContains(plan, "PREDICATES: (bitmap_contains(5: b1, CAST(1: v1 AS BIGINT))) " +
+                "OR (bitmap_contains(5: b1, CAST(2: v2 AS BIGINT)))");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ExpressionTest.java
@@ -1683,4 +1683,15 @@ public class ExpressionTest extends PlanTestBase {
         plan = getFragmentPlan(sql);
         assertContains(plan, "<slot 4> : date_trunc('day', CAST(2: v2 AS DATETIME))");
     }
+
+    @Test
+    public void testSimplifyTruePredicate() throws Exception {
+        String sql = "select id_bool = true from test_bool where id_bool = false or id_bool = true";
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: (11: id_bool = FALSE) OR (11: id_bool)");
+
+        sql = "select * from test_object where bitmap_contains(b1, v1) = true";
+        plan = getFragmentPlan(sql);
+        assertContains(plan, "PREDICATES: bitmap_contains(5: b1, CAST(1: v1 AS BIGINT))");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ScanTest.java
@@ -335,13 +335,13 @@ public class ScanTest extends PlanTestBase {
 
     @Test
     public void testScalarReuseIsNull() throws Exception {
-        String sql =
+        String plan =
                 getFragmentPlan("SELECT (abs(1) IS NULL) = true AND ((abs(1) IS NULL) IS NOT NULL) as count FROM t1;");
-        Assert.assertTrue(sql.contains("1:Project\n"
-                + "  |  <slot 4> : (6: expr = TRUE) AND (6: expr IS NOT NULL)\n"
-                + "  |  common expressions:\n"
-                + "  |  <slot 5> : abs(1)\n"
-                + "  |  <slot 6> : 5: abs IS NULL"));
+        Assert.assertTrue(plan, plan.contains("1:Project\n" +
+                "  |  <slot 4> : (6: expr) AND (6: expr IS NOT NULL)\n" +
+                "  |  common expressions:\n" +
+                "  |  <slot 5> : abs(1)\n" +
+                "  |  <slot 6> : 5: abs IS NULL"));
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:
predicate like ` bitmap_contains(bitmap_col, int_col) = true` cannot be used as RF.

What I'm doing:
convert it to ` bitmap_contains(bitmap_col, int_col)`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
