### PR TITLE
[Enhancement] covert to equal for null predicate

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/Optimizer.java
@@ -37,6 +37,7 @@ import com.starrocks.sql.optimizer.rule.implementation.OlapScanImplementationRul
 import com.starrocks.sql.optimizer.rule.join.ReorderJoinRule;
 import com.starrocks.sql.optimizer.rule.mv.MaterializedViewRule;
 import com.starrocks.sql.optimizer.rule.transformation.ApplyExceptionRule;
+import com.starrocks.sql.optimizer.rule.transformation.ConvertToEqualForNullRule;
 import com.starrocks.sql.optimizer.rule.transformation.DeriveRangeJoinPredicateRule;
 import com.starrocks.sql.optimizer.rule.transformation.ForceCTEReuseRule;
 import com.starrocks.sql.optimizer.rule.transformation.GroupByCountDistinctRewriteRule;
@@ -351,6 +352,7 @@ public class Optimizer {
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownAggToMetaScanRule());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownPredicateRankingWindowRule());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new SkewJoinOptimizeRule());
+        ruleRewriteOnlyOnce(tree, rootTaskContext, new ConvertToEqualForNullRule());
         ruleRewriteOnlyOnce(tree, rootTaskContext, new PushDownJoinOnExpressionToChildProject());
         ruleRewriteOnlyOnce(tree, rootTaskContext, RuleSetType.PRUNE_COLUMNS);
         deriveLogicalProperty(tree);

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/RuleType.java
@@ -173,6 +173,8 @@ public enum RuleType {
     TF_DERIVE_RANGE_JOIN_PREDICATE,
     TF_SKEW_JOIN_OPTIMIZE_RULE,
 
+    TF_CONVERT_TO_EQUAL_FOR_NULL_RULE,
+
     // The following are implementation rules:
     IMP_OLAP_LSCAN_TO_PSCAN,
     IMP_HIVE_LSCAN_TO_PSCAN,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRule.java
@@ -1,0 +1,74 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.sql.optimizer.OptExpression;
+import com.starrocks.sql.optimizer.OptimizerContext;
+import com.starrocks.sql.optimizer.Utils;
+import com.starrocks.sql.optimizer.operator.OperatorType;
+import com.starrocks.sql.optimizer.operator.logical.LogicalJoinOperator;
+import com.starrocks.sql.optimizer.operator.pattern.Pattern;
+import com.starrocks.sql.optimizer.operator.scalar.BinaryPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.CompoundPredicateOperator;
+import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
+import com.starrocks.sql.optimizer.rule.RuleType;
+
+import java.util.List;
+
+public class ConvertToEqualForNullRule extends TransformationRule {
+    public ConvertToEqualForNullRule() {
+        super(RuleType.TF_CONVERT_TO_EQUAL_FOR_NULL_RULE, Pattern.create(OperatorType.LOGICAL_JOIN).
+                addChildren(Pattern.create(OperatorType.PATTERN_LEAF), Pattern.create(OperatorType.PATTERN_LEAF)));
+    }
+
+    @Override
+    public boolean check(final OptExpression input, OptimizerContext context) {
+        LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
+        ScalarOperator onPredicate = joinOperator.getOnPredicate();
+        return onPredicate != null;
+
+    }
+
+    @Override
+    public List<OptExpression> transform(OptExpression input, OptimizerContext context) {
+        LogicalJoinOperator joinOperator = (LogicalJoinOperator) input.getOp();
+        ScalarOperator onPredicate = joinOperator.getOnPredicate();
+        List<ScalarOperator> conjuncts = Utils.extractConjuncts(onPredicate);
+        List<ScalarOperator> newConjuncts = Lists.newArrayList();
+        for (ScalarOperator conjunct : conjuncts) {
+            if (conjunct instanceof CompoundPredicateOperator) {
+                CompoundPredicateOperator compoundOp = (CompoundPredicateOperator) conjunct;
+                if (!compoundOp.isOr()) {
+                    newConjuncts.add(conjunct);
+                } else {
+
+                }
+                ScalarOperator left = compoundOp.getChild(0);
+                ScalarOperator right = compoundOp.getChild(1);
+                if (left instanceof BinaryPredicateOperator && right instanceof CompoundPredicateOperator) {
+                    BinaryPredicateOperator leftOp = (BinaryPredicateOperator) left;
+                    CompoundPredicateOperator rightOp = (CompoundPredicateOperator) right;
+                    if (leftOp.getBinaryType().isEqual() && rightOp.isOr()) {
+
+                    }
+                }
+            }
+        }
+
+        return conjuncts.stream().anyMatch( e -> e instanceof CompoundPredicateOperator
+                && ((CompoundPredicateOperator) e).isOr());
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRule.java
@@ -97,7 +97,7 @@ public class ConvertToEqualForNullRule extends TransformationRule {
 
         IsNullPredicateOperator isNullLeft = (IsNullPredicateOperator) right.getChild(0);
         IsNullPredicateOperator isNullRight = (IsNullPredicateOperator) right.getChild(1);
-        if (isNullRight.isNotNull() || isNullRight.isNotNull()) {
+        if (isNullLeft.isNotNull() || isNullRight.isNotNull()) {
             return Optional.empty();
         }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRuleTest.java
@@ -35,7 +35,7 @@ class ConvertToEqualForNullRuleTest extends PlanTestBase {
 
     @ParameterizedTest(name = "sql_{index}: {0}.")
     @MethodSource("getSqlList")
-    void test(String sql, String expectedPlan) throws Exception {
+    void testToEqualForNull(String sql, String expectedPlan) throws Exception {
         String plan = getFragmentPlan(sql);
         assertContains(plan, expectedPlan);
     }
@@ -45,6 +45,10 @@ class ConvertToEqualForNullRuleTest extends PlanTestBase {
         List<Arguments> sqlList = Lists.newArrayList();
         sqlList.add(Arguments.of("select * from t0 join t1 on v1 = v4 or v1 is null and v4 is null",
                 "equal join conjunct: 1: v1 <=> 4: v4"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on v1 = v4 or v1 is not null and v4 is null",
+                "other join predicates: (1: v1 = 4: v4) OR ((1: v1 IS NOT NULL) AND (4: v4 IS NULL))"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on v2 = v4 or v1 is not null and v4 is null",
+                "other join predicates: (2: v2 = 4: v4) OR ((1: v1 IS NOT NULL) AND (4: v4 IS NULL))"));
         sqlList.add(Arguments.of("select * from t0 join t1 on v4 = v1 or v1 is null and v4 is null",
                 "equal join conjunct: 1: v1 <=> 4: v4"));
         sqlList.add(Arguments.of("select * from t0 join t1 on v4 = v1 or v4 is null and v1 is null",

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRuleTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/ConvertToEqualForNullRuleTest.java
@@ -1,0 +1,67 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.sql.optimizer.rule.transformation;
+
+import com.google.common.collect.Lists;
+import com.starrocks.common.FeConstants;
+import com.starrocks.sql.plan.PlanTestBase;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+class ConvertToEqualForNullRuleTest extends PlanTestBase {
+
+    @BeforeAll
+    public static void beforeClass() throws Exception {
+        PlanTestBase.beforeClass();
+        FeConstants.runningUnitTest = true;
+    }
+
+    @ParameterizedTest(name = "sql_{index}: {0}.")
+    @MethodSource("getSqlList")
+    void test(String sql, String expectedPlan) throws Exception {
+        String plan = getFragmentPlan(sql);
+        assertContains(plan, expectedPlan);
+    }
+
+
+    private static Stream<Arguments> getSqlList() {
+        List<Arguments> sqlList = Lists.newArrayList();
+        sqlList.add(Arguments.of("select * from t0 join t1 on v1 = v4 or v1 is null and v4 is null",
+                "equal join conjunct: 1: v1 <=> 4: v4"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on v4 = v1 or v1 is null and v4 is null",
+                "equal join conjunct: 1: v1 <=> 4: v4"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on v4 = v1 or v4 is null and v1 is null",
+                "equal join conjunct: 1: v1 <=> 4: v4"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on v4 is null and v1 is null or v1 = v4 ",
+                "equal join conjunct: 1: v1 <=> 4: v4"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on (v4 is null and v1 is null or v1 = v4) and v1 > v5 ",
+                "equal join conjunct: 1: v1 <=> 4: v4"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on (abs(v4) is null and abs(v1) is null or abs(v4) = abs(v1))" +
+                        " and v1 > v5 ", "equal join conjunct: 8: abs <=> 7: abs"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on (abs(v4) is null and abs(v1) is null or abs(v4) = abs(v1)) " +
+                        "and v1 > v5 ", "equal join conjunct: 8: abs <=> 7: abs"));
+        sqlList.add(Arguments.of("select * from t0 join t1 on (abs(v4) is null and abs(v1) is null or abs(v4) = abs(v1)) " +
+                "and v1 > v5 join t2 on abs(v4) = v7 or v7 is null and abs(v4) is null",
+                "equal join conjunct: 10: abs <=> 11: abs"));
+        return sqlList.stream();
+    }
+
+
+}


### PR DESCRIPTION
Why I'm doing:
BI tool may generate sql like `select * from t1 join t2 on t1.v1 = t2.v4 or t1.v1 is null and t2.v4 is null` which makes shuffle join is unavaliable for this on condition.

What I'm doing:
convert this on condition to ` t1.v1 <=> t2.v4`

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
