### PR TITLE
[Feature] extend bitmap_and() function to accept mulitiple arguments

### DIFF
--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -198,12 +198,9 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_and(FunctionContext* context, const 
             continue;
         }
         BitmapValue bitmap;
-        for (int i = 0; i < list.size(); i++) {
-            if (i == 0) {
-                bitmap |= *(list[i].value(row));
-            } else {
-                bitmap &= *(list[i].value(row));
-            }
+        bitmap |= *(list[0].value(row));
+        for (int i = 1; i < list.size(); i++) {
+            bitmap &= *(list[i].value(row));
         }
         builder.append(&bitmap);
     }

--- a/be/src/exprs/bitmap_functions.cpp
+++ b/be/src/exprs/bitmap_functions.cpp
@@ -178,21 +178,33 @@ StatusOr<ColumnPtr> BitmapFunctions::bitmap_or(FunctionContext* context, const s
 StatusOr<ColumnPtr> BitmapFunctions::bitmap_and(FunctionContext* context, const starrocks::Columns& columns) {
     RETURN_IF_COLUMNS_ONLY_NULL(columns);
 
-    ColumnViewer<TYPE_OBJECT> lhs(columns[0]);
-    ColumnViewer<TYPE_OBJECT> rhs(columns[1]);
-
+    std::vector<ColumnViewer<TYPE_OBJECT>> list;
+    list.reserve(columns.size());
+    for (const ColumnPtr& col : columns) {
+        list.emplace_back(col);
+    }
     size_t size = columns[0]->size();
     ColumnBuilder<TYPE_OBJECT> builder(size);
     for (int row = 0; row < size; ++row) {
-        if (lhs.is_null(row) || rhs.is_null(row)) {
+        bool is_null = false;
+        for (auto& viewer : list) {
+            if (viewer.is_null(row)) {
+                is_null = true;
+                break;
+            }
+        }
+        if(is_null) {
             builder.append_null();
             continue;
         }
-
         BitmapValue bitmap;
-        bitmap |= (*lhs.value(row));
-        bitmap &= (*rhs.value(row));
-
+        for (int i = 0; i < list.size(); i++) {
+            if (i == 0) {
+                bitmap |= *(list[i].value(row));
+            } else {
+                bitmap &= *(list[i].value(row));
+            }
+        }
         builder.append(&bitmap);
     }
 

--- a/be/test/exprs/bitmap_functions_test.cpp
+++ b/be/test/exprs/bitmap_functions_test.cpp
@@ -447,6 +447,8 @@ TEST_F(VecBitmapFunctionsTest, bitmapAndTest) {
     BitmapValue b2;
     BitmapValue b3;
     BitmapValue b4;
+    BitmapValue b5;
+    BitmapValue b6;
 
     b1.add(1);
     b1.add(2);
@@ -467,6 +469,16 @@ TEST_F(VecBitmapFunctionsTest, bitmapAndTest) {
     b4.add(5);
     b4.add(6);
     b4.add(7);
+
+    b5.add(0);
+    b5.add(1);
+    b5.add(2);
+    b5.add(3);
+
+    b6.add(5);
+    b6.add(6);
+    b6.add(7);
+    b6.add(8);
 
     {
         Columns columns;
@@ -490,6 +502,34 @@ TEST_F(VecBitmapFunctionsTest, bitmapAndTest) {
 
         ASSERT_EQ(4, p->get_object(0)->cardinality());
         ASSERT_EQ(1, p->get_object(1)->cardinality());
+    }
+
+    {
+        Columns columns;
+
+        auto s1 = BitmapColumn::create();
+        auto s2 = BitmapColumn::create();
+        auto s3 = BitmapColumn::create();
+
+        s1->append(&b1);
+        s1->append(&b2);
+        s2->append(&b3);
+        s2->append(&b4);
+        s3->append(&b5);
+        s3->append(&b6);
+
+        columns.push_back(s1);
+        columns.push_back(s2);
+        columns.push_back(s3);
+
+        auto column = BitmapFunctions::bitmap_and(ctx, columns).value();
+
+        ASSERT_TRUE(column->is_object());
+
+        auto p = ColumnHelper::cast_to<TYPE_OBJECT>(column);
+
+        ASSERT_EQ(3, p->get_object(0)->cardinality());
+        ASSERT_EQ(0, p->get_object(1)->cardinality());
     }
 }
 

--- a/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_and.md
+++ b/docs/en/sql-reference/sql-functions/bitmap-functions/bitmap_and.md
@@ -6,12 +6,12 @@ displayed_sidebar: docs
 
 
 
-Calculates the intersection of two input bitmaps and returns the new bitmap.
+Calculates the intersection of multiple input bitmaps and returns the new bitmap.
 
 ## Syntax
 
 ```Haskell
-BITMAP BITMAP_AND(BITMAP lhs, BITMAP rhs)
+BITMAP BITMAP_AND(BITMAP bm, BITMAP bm [, BITMAP...])
 ```
 
 ## Examples

--- a/docs/zh/sql-reference/sql-functions/bitmap-functions/bitmap_and.md
+++ b/docs/zh/sql-reference/sql-functions/bitmap-functions/bitmap_and.md
@@ -6,19 +6,17 @@ displayed_sidebar: docs
 
 
 
-计算两个 bitmap 的交集，返回新的 bitmap。
+计算多个 bitmap 的交集，返回新的 bitmap。
 
 ## 语法
 
 ```Haskell
-BITMAP_AND(lhs, rhs)
+BITMAP_AND(bm, bm [,...])
 ```
 
 ## 参数说明
 
-`lhs`: 支持的数据类型为 BITMAP。
-
-`rhs`: 支持的数据类型为 BITMAP。
+`bm`: 支持的数据类型为 BITMAP。
 
 ## 返回值说明
 

--- a/gensrc/script/functions.py
+++ b/gensrc/script/functions.py
@@ -756,7 +756,7 @@ vectorized_functions = [
     [90030, 'bitmap_count', True, False, 'BIGINT', ['BITMAP'], 'BitmapFunctions::bitmap_count'],
     [90040, 'bitmap_empty', False, False, 'BITMAP', [], 'BitmapFunctions::bitmap_empty'],
     [90050, 'bitmap_or', False, False, 'BITMAP', ['BITMAP', 'BITMAP'], 'BitmapFunctions::bitmap_or'],
-    [90060, 'bitmap_and', False, False, 'BITMAP', ['BITMAP', 'BITMAP'], 'BitmapFunctions::bitmap_and'],
+    [90060, 'bitmap_and', False, False, 'BITMAP', ['BITMAP', 'BITMAP', '...'], 'BitmapFunctions::bitmap_and'],
     [90070, 'bitmap_to_string', False, True, 'VARCHAR', ['BITMAP'], 'BitmapFunctions::bitmap_to_string'],
     [90080, 'bitmap_from_string', False, False, 'BITMAP', ['VARCHAR'], 'BitmapFunctions::bitmap_from_string'],
     [90090, 'bitmap_contains', False, False, 'BOOLEAN', ['BITMAP', 'BIGINT'], 'BitmapFunctions::bitmap_contains'],


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #38593

## What type of PR is this:

- [ ] BugFix
- [X] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [X] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [X] This pr needs user documentation (for new or modified features or behaviors)
  - [X] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.5
  - [ ] 3.4
  - [ ] 3.3