### PR TITLE
[BugFix] Fix Some partitions cannot analyze due to time inconsistency

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/statistic/StatisticExecutor.java
@@ -311,7 +311,7 @@ public class StatisticExecutor {
                 // for external table
                 ExternalBasicStatsMeta externalBasicStatsMeta = new ExternalBasicStatsMeta(statsJob.getCatalogName(),
                         db.getFullName(), table.getName(), statsJob.getColumns(), statsJob.getType(),
-                        analyzeStatus.getEndTime(), statsJob.getProperties());
+                        analyzeStatus.getStartTime(), statsJob.getProperties());
                 GlobalStateMgr.getCurrentAnalyzeMgr().addExternalBasicStatsMeta(externalBasicStatsMeta);
                 GlobalStateMgr.getCurrentAnalyzeMgr().refreshConnectorTableBasicStatisticsCache(statsJob.getCatalogName(),
                         db.getFullName(), table.getName(), statsJob.getColumns(), refreshAsync);


### PR DESCRIPTION
Why I'm doing:
Due to time inconsistency, statistics are not collected for some partitions during the analyze external table
What I'm doing:
Increase the table update time by 60 seconds to avoid time inconsistency that may cause the update time of some partitions to be less than the last statistics collection time. As a result, statistics cannot be collected
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
