### PR TITLE
[Enhancement] Do not throw exception if calling hms stats thrift api fails

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -334,7 +334,7 @@ public class HiveCommitter {
             Joiner.on("; ").appendTo(message, failedUpdateStatsTaskDescs);
             StarRocksConnectorException exception = new StarRocksConnectorException(message.toString());
             suppressedExceptions.forEach(exception::addSuppressed);
-            throw exception;
+            LOG.error(exception);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveCommitter.java
@@ -334,7 +334,13 @@ public class HiveCommitter {
             Joiner.on("; ").appendTo(message, failedUpdateStatsTaskDescs);
             StarRocksConnectorException exception = new StarRocksConnectorException(message.toString());
             suppressedExceptions.forEach(exception::addSuppressed);
-            LOG.error(exception);
+            // Insert into Hive4 table occur failure caused by compatibility issue between Hive3 and Hive4 thrift HMS client.
+            // Check https://github.com/StarRocks/starrocks/issues/38620 and HIVE-27984 for more details.
+            if (ConnectContext.get() != null && ConnectContext.get().getSessionVariable().enableHiveColumnStats()) {
+                throw exception;
+            } else {
+                LOG.error(exception);
+            }
         }
     }
 


### PR DESCRIPTION

Why I'm doing:
SR can not wirte to Hive4 tables. see details from #38620


What I'm doing:
Add a workaround to let SR to write to Hive4 tables.
Fixes #38620

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
