### PR TITLE
[BugFix] fix compilation errors when WITH_CACHELIB=ON

### DIFF
--- a/be/src/block_cache/cachelib_wrapper.cpp
+++ b/be/src/block_cache/cachelib_wrapper.cpp
@@ -92,9 +92,9 @@ Status CacheLibWrapper::remove(const std::string& key) {
     return Status::OK();
 }
 
-const CacheMetrics CacheLibWrapper::cache_metrics() {
+const DataCacheMetrics CacheLibWrapper::cache_metrics() {
     // not implemented
-    CacheMetrics metrics{};
+    DataCacheMetrics metrics{};
     return metrics;
 }
 
@@ -116,6 +116,11 @@ Status CacheLibWrapper::shutdown() {
         _dump_cache_stats();
     }
     return Status::OK();
+}
+
+std::unordered_map<std::string, double> CacheLibWrapper::cache_stats() {
+    const auto navy_stats = _cache->getNvmCacheStatsMap().toMap();
+    return navy_stats;
 }
 
 void CacheLibWrapper::_dump_cache_stats() {

--- a/be/src/block_cache/cachelib_wrapper.h
+++ b/be/src/block_cache/cachelib_wrapper.h
@@ -56,7 +56,7 @@ public:
 
     Status remove(const std::string& key) override;
 
-    const CacheMetrics cache_metrics() override;
+    const DataCacheMetrics cache_metrics() override;
 
     void record_read_remote(size_t size, int64_t lateny_us) override;
 
@@ -65,6 +65,7 @@ public:
     Status shutdown() override;
 
 private:
+    std::unordered_map<std::string, double> cache_stats();
     void _dump_cache_stats();
 
     std::unique_ptr<Cache> _cache = nullptr;


### PR DESCRIPTION
Why I'm doing:
 fix compilation errors when WITH_CACHELIB=ON:
```
/data1/starrocks/starrocks/be/src/block_cache/cachelib_wrapper.h:59:11: error: ‘CacheMetrics’ does not name a type; did you mean ‘DataCacheMetrics’?
   59 |     const CacheMetrics cache_metrics() override;
      |           ^~~~~~~~~~~~


/data1/starrocks/starrocks/be/src/block_cache/cachelib_wrapper.cpp:124:24: error: ‘cache_stats’ was not declared in this scope; did you mean ‘cache_metrics’?
  124 |     const auto stats = cache_stats();
      |                        ^~~~~~~~~~~
      |                        cache_metrics
```
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
