### PR TITLE
[Enhancement] Support to use backup version map for mv rewrite in materialized view restore

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/alter/AlterJobMgr.java
@@ -77,6 +77,7 @@ import com.starrocks.common.util.PropertyAnalyzer;
 import com.starrocks.common.util.TimeUtils;
 import com.starrocks.meta.lock.LockType;
 import com.starrocks.meta.lock.Locker;
+import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.persist.AlterMaterializedViewStatusLog;
 import com.starrocks.persist.AlterViewInfo;
 import com.starrocks.persist.BatchModifyPartitionsInfo;
@@ -292,7 +293,7 @@ public class AlterJobMgr {
             String createMvSql = materializedView.getMaterializedViewDdlStmt(false);
             QueryStatement mvQueryStatement = null;
             try {
-                mvQueryStatement = recreateMVQuery(materializedView, context);
+                mvQueryStatement = recreateMVQuery(materializedView, context, createMvSql);
             } catch (SemanticException e) {
                 throw new SemanticException("Can not active materialized view [%s]" +
                         " because analyze materialized view define sql: \n\n%s" +
@@ -314,10 +315,11 @@ public class AlterJobMgr {
     /*
      * Recreate the MV query and validate the correctness of syntax and schema
      */
-    private static QueryStatement recreateMVQuery(MaterializedView materializedView, ConnectContext context) {
+    public static QueryStatement recreateMVQuery(MaterializedView materializedView,
+                                                 ConnectContext context,
+                                                 String createMvSql) {
         // If we could parse the MV sql successfully, and the schema of mv does not change,
         // we could reuse the existing MV
-        String createMvSql = materializedView.getMaterializedViewDdlStmt(false);
         Optional<Database> mayDb = GlobalStateMgr.getCurrentState().mayGetDb(materializedView.getDbId());
 
         // check database existing
@@ -345,6 +347,26 @@ public class AlterJobMgr {
         }
 
         return createStmt.getQueryStatement();
+    }
+
+    public void replayAlterMaterializedViewBaseTableInfos(AlterMaterializedViewBaseTableInfosLog log) {
+        long dbId = log.getDbId();
+        long mvId = log.getMvId();
+        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+        Locker locker = new Locker();
+        locker.lockDatabase(db, LockType.WRITE);
+        MaterializedView mv = null;
+        try {
+            mv = (MaterializedView) db.getTable(mvId);
+            mv.replayAlterMaterializedViewBaseTableInfos(log);
+        } catch (Throwable e) {
+            if (mv != null) {
+                LOG.warn("replay alter materialized-view status failed: {}", mv.getName(), e);
+                mv.setInactiveAndReason("replay alter status failed: " + e.getMessage());
+            }
+        } finally {
+            locker.unLockDatabase(db, LockType.WRITE);
+        }
     }
 
     public void replayAlterMaterializedViewStatus(AlterMaterializedViewStatusLog log) {

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -43,8 +43,10 @@ import com.starrocks.analysis.TableRef;
 import com.starrocks.backup.AbstractJob.JobType;
 import com.starrocks.backup.BackupJob.BackupJobState;
 import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
+import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
@@ -114,6 +116,8 @@ public class BackupHandler extends FrontendDaemon implements Writable {
     // user can get the error message before submitting the next one.
     // Use ConcurrentMap to get rid of locks.
     protected Map<Long, AbstractJob> dbIdToBackupOrRestoreJob = Maps.newConcurrentMap();
+
+    protected MvRestoreContext mvRestoreContext = new MvRestoreContext();
 
     // this lock is used for handling one backup or restore request at a time.
     private ReentrantLock seqlock = new ReentrantLock();
@@ -349,6 +353,11 @@ public class BackupHandler extends FrontendDaemon implements Writable {
                     ErrorReport.reportDdlException(ErrorCode.ERR_COMMON_ERROR,
                             "Failed to copy table " + tblName + " with selected partitions");
                 }
+                if (copiedTbl.isMaterializedView()) {
+                    MaterializedView copiedMv = (MaterializedView) copiedTbl;
+                    copiedMv.setInactiveAndReason(String.format("Set the materialized view %s inactive in backup and " +
+                            "active it in restore if possible", copiedMv.getName()));
+                }
                 backupTbls.add(copiedTbl);
             }
             curBackupMeta = new BackupMeta(backupTbls);
@@ -432,11 +441,12 @@ public class BackupHandler extends FrontendDaemon implements Writable {
                 if (remoteTbl.isCloudNativeTable()) {
                     ErrorReport.reportDdlException(ErrorCode.ERR_NOT_OLAP_TABLE, remoteTbl.getName());
                 }
+                mvRestoreContext.addIntoMvBaseTableBackupInfoIfNeeded(remoteTbl, jobInfo, tblInfo);
             }
         }
         restoreJob = new RestoreJob(stmt.getLabel(), stmt.getBackupTimestamp(),
                 db.getId(), db.getOriginName(), jobInfo, stmt.allowLoad(), stmt.getReplicationNum(),
-                stmt.getTimeoutMs(), globalStateMgr, repository.getId(), backupMeta);
+                stmt.getTimeoutMs(), globalStateMgr, repository.getId(), backupMeta, mvRestoreContext);
         globalStateMgr.getEditLog().logRestoreJob(restoreJob);
 
         // must put to dbIdToBackupOrRestoreJob after edit log, otherwise the state of job may be changed.
@@ -618,6 +628,7 @@ public class BackupHandler extends FrontendDaemon implements Writable {
             return;
         }
         dbIdToBackupOrRestoreJob.put(job.getDbId(), job);
+        mvRestoreContext.addIntoMvBaseTableBackupInfo(job);
     }
 
     public boolean report(TTaskType type, long jobId, long taskId, int finishedNum, int totalNum) {
@@ -665,6 +676,7 @@ public class BackupHandler extends FrontendDaemon implements Writable {
                 continue;
             }
             dbIdToBackupOrRestoreJob.put(job.getDbId(), job);
+            mvRestoreContext.addIntoMvBaseTableBackupInfo(job);
         }
         LOG.info("finished replay {} backup/store jobs from image", dbIdToBackupOrRestoreJob.size());
     }
@@ -704,6 +716,7 @@ public class BackupHandler extends FrontendDaemon implements Writable {
                 continue;
             }
             dbIdToBackupOrRestoreJob.put(job.getDbId(), job);
+            mvRestoreContext.addIntoMvBaseTableBackupInfo(job);
         }
     }
 
@@ -723,6 +736,9 @@ public class BackupHandler extends FrontendDaemon implements Writable {
             while (iterator.hasNext()) {
                 AbstractJob job = iterator.next().getValue();
                 if (isJobExpired(job, currentTimeMs)) {
+                    // discard mv backup table info if needed.
+                    mvRestoreContext.discordExpiredBackupTableInfo(job);
+
                     LOG.warn("discard expired job {}", job);
                     iterator.remove();
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -51,6 +51,7 @@ import com.starrocks.catalog.FsBroker;
 import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PhysicalPartition;
@@ -512,6 +513,11 @@ public class BackupJob extends AbstractJob {
                 if (copiedTbl == null) {
                     status = new Status(ErrCode.COMMON_ERROR, "faild to copy table: " + tblName);
                     return;
+                }
+                if (copiedTbl.isMaterializedView()) {
+                    MaterializedView copiedMv = (MaterializedView) copiedTbl;
+                    copiedMv.setInactiveAndReason(String.format("Set the materialized view %s inactive in backup and " +
+                            "active it in restore if possible", copiedMv.getName()));
                 }
                 copiedTables.add(copiedTbl);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/RestoreJob.java
@@ -53,6 +53,7 @@ import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
 import com.starrocks.backup.BackupJobInfo.BackupTabletInfo;
 import com.starrocks.backup.RestoreFileMapping.IdChain;
 import com.starrocks.backup.Status.ErrCode;
+import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Column;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
@@ -61,7 +62,6 @@ import com.starrocks.catalog.LocalTablet;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
 import com.starrocks.catalog.MaterializedIndexMeta;
-import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.OlapTable.OlapTableState;
 import com.starrocks.catalog.Partition;
@@ -179,6 +179,8 @@ public class RestoreJob extends AbstractJob {
 
     protected Map<Long, Long> unfinishedSignatureToId = Maps.newConcurrentMap();
 
+    private MvRestoreContext mvRestoreContext;
+
     private AgentBatchTask batchTask;
 
     public RestoreJob() {
@@ -187,7 +189,8 @@ public class RestoreJob extends AbstractJob {
 
     public RestoreJob(String label, String backupTs, long dbId, String dbName, BackupJobInfo jobInfo,
                       boolean allowLoad, int restoreReplicationNum, long timeoutMs,
-                      GlobalStateMgr globalStateMgr, long repoId, BackupMeta backupMeta) {
+                      GlobalStateMgr globalStateMgr, long repoId, BackupMeta backupMeta,
+                      MvRestoreContext mvRestoreContext) {
         super(JobType.RESTORE, label, dbId, dbName, timeoutMs, globalStateMgr, repoId);
         this.backupTimestamp = backupTs;
         this.jobInfo = jobInfo;
@@ -195,6 +198,7 @@ public class RestoreJob extends AbstractJob {
         this.restoreReplicationNum = restoreReplicationNum;
         this.state = RestoreJobState.PENDING;
         this.backupMeta = backupMeta;
+        this.mvRestoreContext = mvRestoreContext;
     }
 
     public RestoreJobState getState() {
@@ -203,6 +207,14 @@ public class RestoreJob extends AbstractJob {
 
     public RestoreFileMapping getFileMapping() {
         return fileMapping;
+    }
+
+    public BackupJobInfo getJobInfo() {
+        return jobInfo;
+    }
+
+    public BackupMeta getBackupMeta() {
+        return backupMeta;
     }
 
     public synchronized boolean finishTabletSnapshotTask(SnapshotTask task, TFinishTaskRequest request) {
@@ -733,7 +745,7 @@ public class RestoreJob extends AbstractJob {
     }
 
     protected Status resetTableForRestore(OlapTable remoteOlapTbl, Database db) {
-        return remoteOlapTbl.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum);
+        return remoteOlapTbl.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum, mvRestoreContext);
     }
 
     protected void sendCreateReplicaTasks() {
@@ -1418,14 +1430,16 @@ public class RestoreJob extends AbstractJob {
                         }
                     }
 
-                    if (tbl.isMaterializedView()) {
-                        // rebuild materialized view after restore job finished
-                        MaterializedView mv = (MaterializedView) tbl;
+                    // rebuild olap table after restore job finished,
+                    // - for base table, update existed materialized view's base table info
+                    // - for materialized view, update existed materialized view's base table infos
+                    if (tbl instanceof OlapTable) {
+                        OlapTable olapTable = (OlapTable) tbl;
                         try {
-                            mv.doAfterRestore(db);
+                            olapTable.doAfterRestore(db, mvRestoreContext);
                         } catch (Exception e) {
                             // no throw exceptions
-                            LOG.warn(String.format("rebuild materialized view %s failed: ", mv.getName()), e);
+                            LOG.warn(String.format("rebuild olap table %s failed: ", olapTable.getName()), e);
                         }
                     }
                 }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
@@ -1,0 +1,208 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup.mv;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
+import com.starrocks.analysis.TableName;
+import com.starrocks.authentication.AuthenticationMgr;
+import com.starrocks.backup.BackupJobInfo;
+import com.starrocks.backup.Status;
+import com.starrocks.catalog.Database;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
+import com.starrocks.privilege.PrivilegeBuiltinConstants;
+import com.starrocks.qe.ConnectContext;
+import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.sql.analyzer.SemanticException;
+import com.starrocks.sql.ast.QueryStatement;
+import com.starrocks.sql.ast.StatementBase;
+import com.starrocks.sql.ast.UserIdentity;
+import com.starrocks.sql.parser.SqlParser;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class MVRestoreUpdater {
+    private static final Logger LOG = LogManager.getLogger(MVRestoreUpdater.class);
+
+    /**
+     * Check materialized view's defined query can be analyzed successfully or not.
+     * @return Pair<Status, Boolean> : status means can be analyzed successfully or not, and boolean means whether to
+     *  update the old defined query or not. if it's true, mv need renew defined queries from `newDefineQueries`.
+     */
+    public static Pair<Status, Boolean> checkMvDefinedQuery(MaterializedView mv,
+                                                            Map<TableName, TableName> remoteToLocalTableName,
+                                                            Pair<String, String> newDefineQueries) {
+        ConnectContext context = new ConnectContext();
+        context.setGlobalStateMgr(GlobalStateMgr.getCurrentState());
+        context.setQualifiedUser(AuthenticationMgr.ROOT_USER);
+        context.setCurrentUserIdentity(UserIdentity.ROOT);
+        context.setCurrentRoleIds(Sets.newHashSet(PrivilegeBuiltinConstants.ROOT_ROLE_ID));
+
+        String mvName = mv.getName();
+        String viewDefineSql = mv.getViewDefineSql();
+        try {
+            analyzeMvDefineQuery(context, viewDefineSql);
+        } catch (SemanticException e) {
+            String errorMsg = String.format("Can not active materialized view [%s] and try to renew it" +
+                    " because analyze materialized view define sql: \n\n%s" +
+                    "\n\nCause an error: %s", mvName, viewDefineSql, e.getDetailMsg());
+            LOG.warn(errorMsg);
+
+            // only update defined queries when defined query can be analyzed successfully.
+            if (renewMvBaseTableNames(mv, remoteToLocalTableName, context, newDefineQueries)) {
+                return Pair.create(Status.OK, true);
+            }
+
+            return Pair.create(new Status(Status.ErrCode.COMMON_ERROR, errorMsg), false);
+        }
+        return Pair.create(Status.OK, false);
+    }
+
+    private static QueryStatement analyzeMvDefineQuery(ConnectContext connectContext,
+                                                       String defineSql) {
+        // Try to parse and analyze the creation sql
+        List<StatementBase> statementBaseList = SqlParser.parse(defineSql, connectContext.getSessionVariable());
+        StatementBase createStmt = statementBaseList.get(0);
+        com.starrocks.sql.analyzer.Analyzer.analyze(createStmt, connectContext);
+        return (QueryStatement) createStmt;
+    }
+
+    @VisibleForTesting
+    public static boolean renewMvBaseTableNames(MaterializedView mv,
+                                                Map<TableName, TableName> remoteToLocalTableName,
+                                                ConnectContext connectContext,
+                                                Pair<String, String> newDefineQueries) {
+        if (remoteToLocalTableName.size() != mv.getBaseTableInfos().size()) {
+            return false;
+        }
+
+        // try new db/tbl name to replace old defined query and check again.
+        String viewDefineSql = mv.getViewDefineSql();
+        String simpleDefineSql = mv.getSimpleDefineSql();
+        String oldViewDefineSql = viewDefineSql;
+        String oldSimpleDefineSql = simpleDefineSql;
+        String mvName = mv.getName();
+
+        String newViewDefineDql = viewDefineSql;
+        String newSimpleDefineSql = simpleDefineSql;
+        for (Map.Entry<TableName, TableName> entry : remoteToLocalTableName.entrySet()) {
+            TableName oldTableName = entry.getKey();
+            TableName newTableName = entry.getValue();
+            String oldDbTableName = String.format("`%s`.`%s`", oldTableName.getDb(), oldTableName.getTbl());
+            String newDbTableName = String.format("`%s`.`%s`", newTableName.getDb(), newTableName.getTbl());
+
+            newViewDefineDql = newViewDefineDql.replaceAll(oldDbTableName, newDbTableName);
+            newSimpleDefineSql = newSimpleDefineSql.replaceAll(oldDbTableName, newDbTableName);
+        }
+
+        try {
+            analyzeMvDefineQuery(connectContext, newViewDefineDql);
+
+            // only renew defined view sql when analyze the new query success.
+            LOG.info("Renew materialized view' defined sql from {} to {}", mvName, oldViewDefineSql, newViewDefineDql);
+            LOG.info("Renew materialized view' simple defined sql from {} to {}", mvName, oldSimpleDefineSql, newSimpleDefineSql);
+            newDefineQueries.first = newViewDefineDql;
+            newDefineQueries.second = newSimpleDefineSql;
+            return true;
+        } catch (Exception e) {
+            String errorMsg = String.format("Can not active materialized view [%s]" +
+                    " because analyze materialized view define sql failed: \n\n%s" +
+                    "\n\nCause an error: %s", mvName, newViewDefineDql, e.getMessage());
+            LOG.warn(errorMsg);
+        }
+        return false;
+    }
+
+    public static boolean isCurrentRemoteMvId(MaterializedView mv,
+                                              MvId mvId, Map<MvId, MvBackupInfo> mvIdTableNameMap) {
+        if (!mvIdTableNameMap.containsKey(mvId)) {
+            return false;
+        }
+        MvBackupInfo mvBackupInfo = mvIdTableNameMap.get(mvId);
+        if (mvBackupInfo == null) {
+            return false;
+        }
+        MvId localMvId = mvBackupInfo.getLocalMvId();
+        if (localMvId == null) {
+            return false;
+        }
+        // find the local mvId is same the current materialized view
+        return localMvId.getId() == mv.getId() && localMvId.getDbId() == mv.getDbId();
+    }
+
+    public static Optional<MvId> restoreBaseTable(MaterializedView mv,
+                                                  Database db, Table baseTable,
+                                                  MvRestoreContext mvRestoreContext) {
+        Map<MvId, MvBackupInfo> mvIdTableNameMap = mvRestoreContext.getMvIdToTableNameMap();
+        Set<MvId> mvIds = baseTable.getRelatedMaterializedViews();
+        Optional<MvId> oldMvId = mvIds.stream()
+                .filter(mvId -> isCurrentRemoteMvId(mv, mvId, mvIdTableNameMap))
+                .findFirst();
+        if (!oldMvId.isPresent()) {
+            LOG.warn(String.format("Cannot find base table info used by the table %s.%s in the materialized view %s, " +
+                            "mvIds:%s", db.getFullName(), baseTable.getName(), mv.getName(),
+                    mvIds.stream().map(x -> x.toString()).collect(Collectors.joining(","))));
+        } else {
+            LOG.info("Remove remote base table info {} used by the table {}.{} in the materialized view {}",
+                    oldMvId.get(), db.getFullName(), baseTable.getName(), mv.getName());
+            mvIds.remove(oldMvId.get());
+        }
+
+        // update base table's related mv's info
+        mvIds.add(new MvId(db.getId(), mv.getId()));
+        return oldMvId;
+    }
+
+    public static void restoreBaseTableVersionMap(
+            Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap,
+            Table localBaseTable, MvBaseTableBackupInfo mvBaseTableBackupInfo) {
+        if (baseTableVisibleVersionMap == null) {
+            return;
+        }
+        BackupJobInfo.BackupTableInfo backupTableInfo = mvBaseTableBackupInfo.getBackupTableInfo();
+        long remoteBaseTableId = mvBaseTableBackupInfo.getRemoteTableId();
+        // update version map if possible
+        if (!baseTableVisibleVersionMap.containsKey(remoteBaseTableId)) {
+            return;
+        }
+
+        Map<String, MaterializedView.BasePartitionInfo> versionMap = baseTableVisibleVersionMap.get(remoteBaseTableId);
+        for (Map.Entry<String, BackupJobInfo.BackupPartitionInfo> e : backupTableInfo.partitions.entrySet()) {
+            String partName = e.getKey();
+            // update base partition info by the new partition id
+            if (!versionMap.containsKey(partName)) {
+                continue;
+            }
+            MaterializedView.BasePartitionInfo oldBasePartitionInfo = versionMap.get(partName);
+            long oldPartId = e.getValue().id;
+            Preconditions.checkArgument(oldPartId == oldBasePartitionInfo.getId());
+            long newPartId = localBaseTable.getPartition(partName).getId();
+            MaterializedView.BasePartitionInfo newBasePartitionInfo = new MaterializedView.BasePartitionInfo(newPartId,
+                    oldBasePartitionInfo.getVersion(), oldBasePartitionInfo.getLastRefreshTime());
+            versionMap.put(partName, newBasePartitionInfo);
+        }
+        baseTableVisibleVersionMap.put(localBaseTable.getId(), versionMap);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvBackupInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvBackupInfo.java
@@ -1,0 +1,39 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup.mv;
+
+import com.starrocks.analysis.TableName;
+import com.starrocks.catalog.MvId;
+
+public class MvBackupInfo {
+    private final TableName localMvName;
+    private MvId localMvId;
+
+    public MvBackupInfo(String db, String tbl) {
+        this.localMvName = new TableName(db, tbl);
+    }
+
+    public TableName getRemoteTableName() {
+        return localMvName;
+    }
+
+    public MvId getLocalMvId() {
+        return localMvId;
+    }
+
+    public void setLocalMvId(MvId localMvId) {
+        this.localMvId = localMvId;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvBaseTableBackupInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvBaseTableBackupInfo.java
@@ -1,0 +1,49 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup.mv;
+
+import com.starrocks.backup.BackupJobInfo;
+
+public class MvBaseTableBackupInfo {
+    private final BackupJobInfo.BackupTableInfo backupTableInfo;
+    private final String localTableName;
+    private final long remoteTableId;
+    private final long backupTime;
+    public MvBaseTableBackupInfo(BackupJobInfo.BackupTableInfo backupTableInfo,
+                                 String localTableName,
+                                 long remoteTableId,
+                                 long backupTime) {
+        this.backupTableInfo = backupTableInfo;
+        this.localTableName = localTableName;
+        this.remoteTableId = remoteTableId;
+        this.backupTime = backupTime;
+    }
+
+    public BackupJobInfo.BackupTableInfo getBackupTableInfo() {
+        return backupTableInfo;
+    }
+
+    public String getLocalTableName() {
+        return localTableName;
+    }
+
+    public long getRemoteTableId() {
+        return remoteTableId;
+    }
+
+    public long getBackupTime() {
+        return backupTime;
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
@@ -1,0 +1,132 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.backup.mv;
+
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.TableName;
+import com.starrocks.backup.AbstractJob;
+import com.starrocks.backup.BackupJobInfo;
+import com.starrocks.backup.BackupMeta;
+import com.starrocks.backup.RestoreJob;
+import com.starrocks.catalog.MvId;
+import com.starrocks.catalog.Table;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.util.Map;
+
+/**
+ * MvRestoreContext is used in Restore job to track materialized view's associated infos. eg, we can use it to track
+ * remote base table which is defined in the materialized view's `baseTableInfos` and track the materialized view by
+ * remote MvId.
+ */
+public class MvRestoreContext {
+    private static final Logger LOG = LogManager.getLogger(MvRestoreContext.class);
+
+    // <remote db name, remote table name> -> BackupTableInfo and associated infos.
+    // Because materialized view only keeps remote db/table names in the BaseTable info, and materialized view and its
+    // base tables may not in the same backup/restore. We keep this to track remote backup table info by the remote db
+    // and table name, so can update materialized view's base table info in restoring the materialized view.
+    // NOTE: we only record the newest restore of the base table to avoid caching too much history metas.
+    // NOTE: we won't cache all the
+    protected Map<TableName, MvBaseTableBackupInfo> mvBaseTableToBackupTableInfo = Maps.newConcurrentMap();
+
+    // <MvId> -> <db name, table name>
+    // MvId only contains remote db id and remote table id, but remote db/table id are changed after restore, so use this
+    // to track the new db name/table name after restore.
+    protected Map<MvId, MvBackupInfo> mvIdToTableNameMap = Maps.newConcurrentMap();
+
+    public MvRestoreContext() {
+
+    }
+
+    public Map<TableName, MvBaseTableBackupInfo> getMvBaseTableToBackupTableInfo() {
+        return mvBaseTableToBackupTableInfo;
+    }
+
+    public Map<MvId, MvBackupInfo> getMvIdToTableNameMap() {
+        return mvIdToTableNameMap;
+    }
+
+    public void addIntoMvBaseTableBackupInfoIfNeeded(Table remoteTbl,
+                                                     BackupJobInfo jobInfo,
+                                                     BackupJobInfo.BackupTableInfo backupTableInfo) {
+        if (remoteTbl == null) {
+            return;
+        }
+
+        // put it into mvId->table name map
+        if (remoteTbl.isMaterializedView()) {
+            MvId mvId = new MvId(jobInfo.dbId, remoteTbl.getId());
+            mvIdToTableNameMap.put(mvId, new MvBackupInfo(jobInfo.dbName, remoteTbl.getName()));
+        }
+
+        // put it into mvBaseTableToBackupTableInfo
+        if (remoteTbl.getRelatedMaterializedViews() == null || remoteTbl.getRelatedMaterializedViews().isEmpty()) {
+            return;
+        }
+        String localTableName = jobInfo.getAliasByOriginNameIfSet(remoteTbl.getName());
+        MvBaseTableBackupInfo mvBaseTableBackupInfo =
+                new MvBaseTableBackupInfo(backupTableInfo, localTableName, remoteTbl.getId(), jobInfo.backupTime);
+        mvBaseTableToBackupTableInfo.put(new TableName(jobInfo.dbName, remoteTbl.getName()), mvBaseTableBackupInfo);
+    }
+
+    public void addIntoMvBaseTableBackupInfo(AbstractJob job) {
+        if (job == null || !(job instanceof RestoreJob)) {
+            return;
+        }
+        RestoreJob restoreJob = (RestoreJob) job;
+        BackupJobInfo jobInfo = restoreJob.getJobInfo();
+        BackupMeta backupMeta = restoreJob.getBackupMeta();
+        if (backupMeta == null) {
+            return;
+        }
+        for (BackupJobInfo.BackupTableInfo tblInfo : jobInfo.tables.values()) {
+            Table remoteTbl = backupMeta.getTable(tblInfo.name);
+            addIntoMvBaseTableBackupInfoIfNeeded(remoteTbl, jobInfo, tblInfo);
+        }
+    }
+
+    public void discordExpiredBackupTableInfo(AbstractJob job) {
+        if (!(job instanceof RestoreJob)) {
+            return;
+        }
+        RestoreJob restoreJob = (RestoreJob) job;
+        BackupJobInfo backupJobInfo = restoreJob.getJobInfo();
+        // discard expired restore db and name backup infos.
+        for (Map.Entry<String, BackupJobInfo.BackupTableInfo> e : backupJobInfo.tables.entrySet()) {
+            TableName dbTblName = new TableName(backupJobInfo.dbName, e.getKey());
+            if (mvBaseTableToBackupTableInfo.containsKey(dbTblName)) {
+                MvBaseTableBackupInfo cachedBackupTableInfo =
+                        mvBaseTableToBackupTableInfo.get(dbTblName);
+                if (cachedBackupTableInfo.getBackupTime() == backupJobInfo.backupTime) {
+                    LOG.warn("discard expired mvBaseTableToBackupTableInfo, baseTable:{}", dbTblName);
+                    mvBaseTableToBackupTableInfo.remove(dbTblName);
+                }
+            }
+
+            BackupMeta backupMeta = restoreJob.getBackupMeta();
+            Table remoteTable = backupMeta.getTable(e.getKey());
+            if (remoteTable == null || !remoteTable.isMaterializedView()) {
+                continue;
+            }
+            MvId mvId = new MvId(backupJobInfo.dbId, remoteTable.getId());
+            if (mvIdToTableNameMap.containsKey(mvId)) {
+                LOG.warn("discard expired mvIdToTableNameMap, mvId:{}", mvId);
+                mvIdToTableNameMap.remove(mvId);
+            }
+        }
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/BaseTableInfo.java
@@ -165,11 +165,12 @@ public class BaseTableInfo {
     @Deprecated
     public Table getTable() {
         if (isInternalCatalog(catalogName)) {
-            Table table = getTableById();
-            if (table == null) {
-                table = getTableByName();
+            Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
+            if (db == null) {
+                return null;
+            } else {
+                return db.getTable(tableId);
             }
-            return table;
         } else {
             if (!GlobalStateMgr.getCurrentState().getCatalogMgr().catalogExists(catalogName)) {
                 LOG.warn("catalog {} not exist", catalogName);
@@ -181,24 +182,10 @@ public class BaseTableInfo {
                 return null;
             }
 
-            if (tableIdentifier == null) {
-                this.tableIdentifier = table.getTableIdentifier();
-                return table;
-            }
-
             if (tableIdentifier != null && table.getTableIdentifier().equals(tableIdentifier)) {
                 return table;
             }
             return null;
-        }
-    }
-
-    public Table getTableById() {
-        Database db = GlobalStateMgr.getCurrentState().getDb(dbId);
-        if (db == null) {
-            return null;
-        } else {
-            return db.getTable(tableId);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -33,6 +33,9 @@ import com.starrocks.analysis.SlotRef;
 import com.starrocks.analysis.TableName;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.backup.Status;
+import com.starrocks.backup.mv.MvBackupInfo;
+import com.starrocks.backup.mv.MvBaseTableBackupInfo;
+import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.DdlException;
 import com.starrocks.common.FeConstants;
@@ -47,6 +50,7 @@ import com.starrocks.common.util.TimeUtils;
 import com.starrocks.connector.ConnectorPartitionTraits;
 import com.starrocks.connector.ConnectorTableInfo;
 import com.starrocks.connector.PartitionUtil;
+import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.persist.gson.GsonPreProcessable;
 import com.starrocks.persist.gson.GsonUtils;
@@ -62,7 +66,6 @@ import com.starrocks.sql.analyzer.Field;
 import com.starrocks.sql.analyzer.RelationFields;
 import com.starrocks.sql.analyzer.RelationId;
 import com.starrocks.sql.analyzer.Scope;
-import com.starrocks.sql.ast.AlterMaterializedViewStatusClause;
 import com.starrocks.sql.ast.UserIdentity;
 import com.starrocks.sql.common.PartitionRange;
 import com.starrocks.sql.common.RangePartitionDiff;
@@ -96,6 +99,10 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static com.starrocks.backup.mv.MVRestoreUpdater.checkMvDefinedQuery;
+import static com.starrocks.backup.mv.MVRestoreUpdater.restoreBaseTable;
+import static com.starrocks.backup.mv.MVRestoreUpdater.restoreBaseTableVersionMap;
 
 /**
  * meta structure for materialized view
@@ -1279,10 +1286,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         return tableToJoinExprMap;
     }
 
-    private boolean supportPartialPartitionQueryRewriteForExternalTable(Table table) {
-        return table.isHiveTable();
-    }
-
     /**
      * Once the materialized view's base tables have updated, we need to check correspond materialized views' partitions
      * to be refreshed.
@@ -1748,10 +1751,23 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     @Override
-    public Status resetIdsForRestore(GlobalStateMgr globalStateMgr, Database db, int restoreReplicationNum) {
+    public Status resetIdsForRestore(GlobalStateMgr globalStateMgr,
+                                     Database db, int restoreReplicationNum,
+                                     MvRestoreContext mvRestoreContext) {
         // change db_id to new restore id
+        MvId oldMvId = new MvId(dbId, id);
+
         this.dbId = db.getId();
-        return super.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum);
+        Status status = super.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum, mvRestoreContext);
+        if (!status.ok()) {
+            return status;
+        }
+        // store new mvId to for old mvId
+        MvId newMvId = new MvId(dbId, id);
+        MvBackupInfo mvBackupInfo = mvRestoreContext.getMvIdToTableNameMap()
+                .computeIfAbsent(oldMvId, x -> new MvBackupInfo(db.getFullName(), name));
+        mvBackupInfo.setLocalMvId(newMvId);
+        return Status.OK;
     }
 
     /**
@@ -1761,26 +1777,150 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * @param db : the new database after restore.
      * @return : rebuild status, ok if success other error status.
      */
-    public Status doAfterRestore(Database db) throws DdlException {
+    @Override
+    public Status doAfterRestore(Database db, MvRestoreContext mvRestoreContext) throws DdlException {
+        super.doAfterRestore(db, mvRestoreContext);
+
         if (baseTableInfos == null) {
             setInactiveAndReason("base mv is not active: base info is null");
             return new Status(Status.ErrCode.NOT_FOUND,
-                    "Materialized view's base info is not found");
+                    String.format("Materialized view %s's base info is not found", this.name));
         }
 
-        // reset its status to active
-        GlobalStateMgr.getCurrentState().getAlterJobMgr()
-                .alterMaterializedViewStatus(this, AlterMaterializedViewStatusClause.ACTIVE, false);
-        LOG.info("active materialized view {} succeed", getName());
+        List<BaseTableInfo> newBaseTableInfos = Lists.newArrayList();
+        Map<Long, Map<String, BasePartitionInfo>> baseTableVisibleVersionMap =
+                this.refreshScheme.asyncRefreshContext.baseTableVisibleVersionMap;
 
-        // rebuild mv task
+        boolean isSetInactive = false;
+        Map<TableName, MvBaseTableBackupInfo> mvBaseTableToBackupTableInfo = mvRestoreContext.getMvBaseTableToBackupTableInfo();
+        Map<TableName, TableName> remoteToLocalTableName = Maps.newHashMap();
+        MvId oldMvId = null;
+        for (BaseTableInfo baseTableInfo : baseTableInfos) {
+            String remoteDbName = baseTableInfo.getDbName();
+            String remoteTableName = baseTableInfo.getTableName();
+            TableName remoteDbTblName = new TableName(remoteDbName, remoteTableName);
+
+            if (!mvBaseTableToBackupTableInfo.containsKey(remoteDbTblName)) {
+                isSetInactive = true;
+                LOG.warn(String.format("Materialized view %s can not find the base table from mvBaseTableToBackupTableInfo, " +
+                        "old base table name:%s", this.name, remoteDbTblName));
+                continue;
+            }
+
+            MvBaseTableBackupInfo mvBaseTableBackupInfo = mvBaseTableToBackupTableInfo.get(remoteDbTblName);
+            if (mvBaseTableBackupInfo == null) {
+                isSetInactive = true;
+                LOG.warn(String.format("Materialized view %s can not find old base table name:%s because " +
+                                "mvBaseTableBackupInfo is null",
+                        this.name, remoteTableName));
+                continue;
+            }
+
+            String localTableName = mvBaseTableBackupInfo.getLocalTableName();
+            Table localTable = db.getTable(localTableName);
+            remoteToLocalTableName.put(remoteDbTblName, new TableName(db.getFullName(), localTableName));
+            if (localTable == null) {
+                isSetInactive = true;
+                LOG.warn(String.format("Materialized view %s can not find the base table %s, old base table name:%s",
+                        this.name, localTableName, remoteTableName));
+                continue;
+            }
+
+            // restore materialized view's associated base table's mvIds.
+            Optional<MvId> optOldMvId = restoreBaseTable(this, db, localTable, mvRestoreContext);
+            if (optOldMvId.isPresent() && oldMvId == null) {
+                oldMvId = optOldMvId.get();
+            }
+
+            // restore materialized view's version map if base table is also backed up and restore.
+            restoreBaseTableVersionMap(baseTableVisibleVersionMap, localTable, mvBaseTableBackupInfo);
+
+            // update base table info since materialized view's db or base table info may be changed.
+            BaseTableInfo newBaseTableInfo = new BaseTableInfo(db.getId(), db.getFullName(), localTableName,
+                    localTable.getId());
+            newBaseTableInfos.add(newBaseTableInfo);
+        }
+
+        // set it inactive if its base table infos are not complete.
+        if (isSetInactive) {
+            String errorMsg = String.format("Cannot active the materialized view %s after restore, please check whether " +
+                            "its base table has already been backup or restore:%s", name,
+                    baseTableInfos.stream().map(x -> x.toString()).collect(Collectors.joining(",")));
+            LOG.warn(errorMsg);
+            setInactiveAndReason(errorMsg);
+            return new Status(Status.ErrCode.NOT_FOUND, errorMsg);
+        }
+
+        // Check whether the materialized view's defined sql can be analyzed and built task again.
+        Pair<String, String> newDefinedQueries = Pair.create("", "");
+        Pair<Status, Boolean> result = checkMvDefinedQuery(this, remoteToLocalTableName, newDefinedQueries);
+        if (!result.first.ok()) {
+            String createMvSql = getMaterializedViewDdlStmt(false);
+            String errorMsg = String.format("Can not active materialized view [%s]" +
+                    " because analyze materialized view define sql: \n\n%s", name, createMvSql);
+            setInactiveAndReason(errorMsg);
+            return result.first;
+        }
+        if (result.second) {
+            if (!Strings.isNullOrEmpty(newDefinedQueries.first)) {
+                this.viewDefineSql = newDefinedQueries.first;
+            }
+            if (!Strings.isNullOrEmpty(newDefinedQueries.second)) {
+                this.simpleDefineSql = newDefinedQueries.second;
+            }
+        }
+
+        LOG.info("restore materialized view {} succeed, old baseTableInfo {} to new baseTableInfo {}",
+                getName(), baseTableInfos.stream().map(x -> x.toString()).collect(Collectors.joining(",")),
+                newBaseTableInfos.stream().map(x -> x.toString()).collect(Collectors.joining(",")));
+        this.baseTableInfos = newBaseTableInfos;
+        setActive();
+
+        fixRelationship();
+
+        // write edit log
+        AlterMaterializedViewBaseTableInfosLog alterMaterializedViewBaseTableInfos =
+                new AlterMaterializedViewBaseTableInfosLog(dbId, getId(), oldMvId, baseTableInfos, baseTableVisibleVersionMap);
+        GlobalStateMgr.getCurrentState().getEditLog().logAlterMvBaseTableInfos(alterMaterializedViewBaseTableInfos);
+
+        // rebuild mv tasks to be scheduled in TaskManager.
         TaskBuilder.rebuildMVTask(db.getFullName(), this);
 
         // clear baseTable ids if it exists
         if (this.baseTableIds != null) {
             this.baseTableIds.clear();
         }
-        LOG.info("rebuild materialized view success, {}", this.getName());
+
         return Status.OK;
+    }
+
+    /**
+     * Replay AlterMaterializedViewBaseTableInfosLog and update associated variables.
+     */
+    public void replayAlterMaterializedViewBaseTableInfos(AlterMaterializedViewBaseTableInfosLog log) {
+        this.setBaseTableInfos(log.getBaseTableInfos());
+        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                this.refreshScheme.asyncRefreshContext.baseTableVisibleVersionMap;
+        for (Map.Entry<Long, Map<String, MaterializedView.BasePartitionInfo>> e :
+                log.getBaseTableVisibleVersionMap().entrySet()) {
+            if (!baseTableVisibleVersionMap.containsKey(e.getKey())) {
+                baseTableVisibleVersionMap.put(e.getKey(), e.getValue());
+            } else {
+                Map<String, MaterializedView.BasePartitionInfo> partitionInfoMap = baseTableVisibleVersionMap.get(e.getKey());
+                partitionInfoMap.putAll(e.getValue());
+            }
+        }
+        for (BaseTableInfo baseTableInfo : baseTableInfos) {
+            Table baseTable = baseTableInfo.getTable();
+            if (baseTable == null) {
+                continue;
+            }
+            baseTable.getRelatedMaterializedViews().remove(log.getMvId());
+            baseTable.getRelatedMaterializedViews().add(getMvId());
+        }
+        setActive();
+
+        // recheck again
+        fixRelationship();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -55,6 +55,8 @@ import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
 import com.starrocks.backup.Status;
 import com.starrocks.backup.Status.ErrCode;
+import com.starrocks.backup.mv.MvBackupInfo;
+import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.binlog.BinlogConfig;
 import com.starrocks.catalog.DistributionInfo.DistributionInfoType;
 import com.starrocks.catalog.LocalTablet.TabletStatus;
@@ -677,7 +679,8 @@ public class OlapTable extends Table {
         }
     }
 
-    public Status resetIdsForRestore(GlobalStateMgr globalStateMgr, Database db, int restoreReplicationNum) {
+    public Status resetIdsForRestore(GlobalStateMgr globalStateMgr, Database db, int restoreReplicationNum,
+                                     MvRestoreContext mvRestoreContext) {
         // copy an origin index id to name map
         Map<Long, String> origIdxIdToName = Maps.newHashMap();
         for (Map.Entry<String, Long> entry : indexNameToId.entrySet()) {
@@ -821,6 +824,44 @@ public class OlapTable extends Table {
                         version, schemaHash);
                 newTablet.addReplica(replica, false/* update inverted index */);
             }
+        }
+        return Status.OK;
+    }
+
+    public Status doAfterRestore(Database db, MvRestoreContext mvRestoreContext) throws DdlException {
+        if (relatedMaterializedViews == null || relatedMaterializedViews.isEmpty()) {
+            return Status.OK;
+        }
+
+        Map<MvId, MvBackupInfo> mvIdTableNameMap = mvRestoreContext.getMvIdToTableNameMap();
+        for (MvId mvId : relatedMaterializedViews) {
+            // Find the associated mv if possible
+            MvBackupInfo mvBackupInfo = mvIdTableNameMap.get(mvId);
+            if (mvBackupInfo == null) {
+                continue;
+            }
+            MvId localMvId = mvBackupInfo.getLocalMvId();
+            if (localMvId == null) {
+                continue;
+            }
+            Database mvDb = GlobalStateMgr.getCurrentState().getDb(localMvId.getDbId());
+            if (mvDb == null) {
+                continue;
+            }
+            Table mvTable = mvDb.getTable(localMvId.getId());
+            if (mvTable == null) {
+                continue;
+            }
+            if (!mvTable.isMaterializedView()) {
+                LOG.warn("Base table {} related materialized view {} is not a mv, local mvId:{}, remote mvId:{}",
+                        this.name, mvTable.getName(), localMvId, mvId);
+                continue;
+            }
+            MaterializedView mv = (MaterializedView) mvTable;
+            if (mv.isActive()) {
+                continue;
+            }
+            mv.doAfterRestore(db, mvRestoreContext);
         }
         return Status.OK;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -70,6 +70,7 @@ import com.starrocks.persist.AddPartitionsInfoV2;
 import com.starrocks.persist.AddSubPartitionsInfoV2;
 import com.starrocks.persist.AlterCatalogLog;
 import com.starrocks.persist.AlterLoadJobOperationLog;
+import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.persist.AlterMaterializedViewStatusLog;
 import com.starrocks.persist.AlterRoutineLoadJobOperationLog;
 import com.starrocks.persist.AlterUserInfo;
@@ -399,6 +400,10 @@ public class JournalEntity implements Writable {
                 break;
             case OperationType.OP_ALTER_MATERIALIZED_VIEW_STATUS:
                 data = AlterMaterializedViewStatusLog.read(in);
+                isRead = true;
+                break;
+            case OperationType.OP_ALTER_MATERIALIZED_VIEW_BASE_TABLE_INFOS:
+                data = AlterMaterializedViewBaseTableInfosLog.read(in);
                 isRead = true;
                 break;
             case OperationType.OP_BACKUP_JOB: {

--- a/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/backup/LakeRestoreJob.java
@@ -28,6 +28,7 @@ import com.starrocks.backup.RestoreFileMapping.IdChain;
 import com.starrocks.backup.RestoreJob;
 import com.starrocks.backup.SnapshotInfo;
 import com.starrocks.backup.Status;
+import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.DataProperty;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.FsBroker;
@@ -84,9 +85,10 @@ public class LakeRestoreJob extends RestoreJob {
 
     public LakeRestoreJob(String label, String backupTs, long dbId, String dbName, BackupJobInfo jobInfo,
                           boolean allowLoad, int restoreReplicationNum, long timeoutMs,
-                          GlobalStateMgr globalStateMgr, long repoId, BackupMeta backupMeta) {
+                          GlobalStateMgr globalStateMgr, long repoId, BackupMeta backupMeta,
+                          MvRestoreContext mvRestoreContext) {
         super(label, backupTs, dbId, dbName, jobInfo, allowLoad, restoreReplicationNum, timeoutMs,
-                globalStateMgr, repoId, backupMeta);
+                globalStateMgr, repoId, backupMeta, mvRestoreContext);
         this.type = JobType.LAKE_RESTORE;
     }
 
@@ -315,7 +317,7 @@ public class LakeRestoreJob extends RestoreJob {
             LakeTable remoteLakeTbl = (LakeTable) remoteOlapTbl;
             StorageInfo storageInfo = remoteLakeTbl.getTableProperty().getStorageInfo();
             remoteLakeTbl.setStorageInfo(pathInfo, storageInfo.getDataCacheInfo());
-            remoteLakeTbl.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum);
+            remoteLakeTbl.resetIdsForRestore(globalStateMgr, db, restoreReplicationNum, new MvRestoreContext());
         } catch (DdlException e) {
             return new Status(Status.ErrCode.COMMON_ERROR, e.getMessage());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/AlterMaterializedViewBaseTableInfosLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/AlterMaterializedViewBaseTableInfosLog.java
@@ -1,0 +1,94 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package com.starrocks.persist;
+
+import com.google.gson.annotations.SerializedName;
+import com.starrocks.catalog.BaseTableInfo;
+import com.starrocks.catalog.MaterializedView;
+import com.starrocks.catalog.MvId;
+import com.starrocks.common.io.Text;
+import com.starrocks.common.io.Writable;
+import com.starrocks.persist.gson.GsonUtils;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class AlterMaterializedViewBaseTableInfosLog implements Writable {
+
+    @SerializedName(value = "dbId")
+    private long dbId;
+    @SerializedName(value = "mvId")
+    private long mvId;
+    @SerializedName(value = "baseTableInfos")
+    private List<BaseTableInfo> baseTableInfos;
+    @SerializedName(value = "remoteMvId")
+    private MvId remoteMvId;
+    @SerializedName("baseTableVisibleVersionMap")
+    private Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap;
+
+    public AlterMaterializedViewBaseTableInfosLog(
+            long dbId, long mvId, MvId remoteMvId,
+            List<BaseTableInfo> baseTableInfos,
+            Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMa) {
+        this.dbId = dbId;
+        this.mvId = mvId;
+        this.remoteMvId = remoteMvId;
+        this.baseTableInfos = baseTableInfos;
+        this.baseTableVisibleVersionMap = baseTableVisibleVersionMa;
+    }
+
+    public long getDbId() {
+        return dbId;
+    }
+
+    public void setDbId(long dbId) {
+        this.dbId = dbId;
+    }
+
+    public long getMvId() {
+        return mvId;
+    }
+
+    public void setMvId(long mvId) {
+        this.mvId = mvId;
+    }
+
+    public List<BaseTableInfo> getBaseTableInfos() {
+        return baseTableInfos;
+    }
+
+    public void setBaseTableInfos(List<BaseTableInfo> baseTableInfos) {
+        this.baseTableInfos = baseTableInfos;
+    }
+
+    public Map<Long, Map<String, MaterializedView.BasePartitionInfo>> getBaseTableVisibleVersionMap() {
+        return baseTableVisibleVersionMap;
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+        Text.writeString(out, GsonUtils.GSON.toJson(this));
+    }
+
+    public static AlterMaterializedViewBaseTableInfosLog read(DataInput in) throws IOException {
+        return GsonUtils.GSON.fromJson(Text.readString(in), AlterMaterializedViewBaseTableInfosLog.class);
+    }
+}

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -373,6 +373,12 @@ public class EditLog {
                     globalStateMgr.replayAlterMaterializedViewStatus(log);
                     break;
                 }
+                case OperationType.OP_ALTER_MATERIALIZED_VIEW_BASE_TABLE_INFOS: {
+                    AlterMaterializedViewBaseTableInfosLog log =
+                            (AlterMaterializedViewBaseTableInfosLog) journal.getData();
+                    globalStateMgr.replayAlterMaterializedViewBaseTableInfos(log);
+                    break;
+                }
                 case OperationType.OP_RENAME_MATERIALIZED_VIEW: {
                     RenameMaterializedViewLog log = (RenameMaterializedViewLog) journal.getData();
                     globalStateMgr.replayRenameMaterializedView(log);
@@ -2085,6 +2091,10 @@ public class EditLog {
 
     public void logAlterMvStatus(AlterMaterializedViewStatusLog log) {
         logEdit(OperationType.OP_ALTER_MATERIALIZED_VIEW_STATUS, log);
+    }
+
+    public void logAlterMvBaseTableInfos(AlterMaterializedViewBaseTableInfosLog log) {
+        logEdit(OperationType.OP_ALTER_MATERIALIZED_VIEW_BASE_TABLE_INFOS, log);
     }
 
     public void logMvRename(RenameMaterializedViewLog log) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -351,6 +351,7 @@ public class OperationType {
     public static final short OP_CREATE_INSERT_OVERWRITE = 10095;
     public static final short OP_INSERT_OVERWRITE_STATE_CHANGE = 10096;
     public static final short OP_ALTER_MATERIALIZED_VIEW_STATUS = 10097;
+    public static final short OP_ALTER_MATERIALIZED_VIEW_BASE_TABLE_INFOS = 10098;
 
     // manage system node info 10101 ~ 10120
     @Deprecated

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -184,6 +184,7 @@ import com.starrocks.meta.lock.Locker;
 import com.starrocks.metric.MetricRepo;
 import com.starrocks.mysql.privilege.Auth;
 import com.starrocks.mysql.privilege.AuthUpgrader;
+import com.starrocks.persist.AlterMaterializedViewBaseTableInfosLog;
 import com.starrocks.persist.AlterMaterializedViewStatusLog;
 import com.starrocks.persist.AuthUpgradeInfo;
 import com.starrocks.persist.BackendIdsUpdateInfo;
@@ -3146,6 +3147,10 @@ public class GlobalStateMgr {
 
     public void replayAlterMaterializedViewStatus(AlterMaterializedViewStatusLog log) {
         this.alterJobMgr.replayAlterMaterializedViewStatus(log);
+    }
+
+    public void replayAlterMaterializedViewBaseTableInfos(AlterMaterializedViewBaseTableInfosLog log) {
+        this.alterJobMgr.replayAlterMaterializedViewBaseTableInfos(log);
     }
 
     /*

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -24,6 +24,7 @@ import com.starrocks.catalog.FsBroker;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
+import com.starrocks.catalog.Table;
 import com.starrocks.common.Config;
 import com.starrocks.common.FeConstants;
 import com.starrocks.common.jmockit.Deencapsulation;
@@ -82,6 +83,7 @@ public class BackupJobMaterializedViewTest {
 
     private long repoId = 30000;
     private AtomicLong id = new AtomicLong(50000);
+    private static final String MV_LABEL = "mv_label";
 
     private static List<Path> pathsNeedToBeDeleted = Lists.newArrayList();
 
@@ -209,8 +211,7 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.MATERIALIZED_VIEW_NAME), null));
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, UnitTestUtil.TABLE_NAME), null));
 
-        job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
-        job.setTestPrimaryKey();
+        job = new BackupJob(MV_LABEL, dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
     }
 
     @Test
@@ -363,6 +364,24 @@ public class BackupJobMaterializedViewTest {
             Assert.assertEquals(UnitTestUtil.DB_NAME, restoreJobInfo.dbName);
             Assert.assertEquals(job.getLabel(), restoreJobInfo.name);
             Assert.assertEquals(2, restoreJobInfo.tables.size());
+
+            // base table
+            BackupJobInfo.BackupTableInfo baseTableBackupInfo = restoreJobInfo.getTableInfo(UnitTestUtil.TABLE_NAME);
+            Assert.assertTrue(baseTableBackupInfo != null);
+            Table remoteBaseTable = backupMeta.getTable(UnitTestUtil.TABLE_NAME);
+            Assert.assertTrue(remoteBaseTable != null);
+
+            // mv
+            BackupJobInfo.BackupTableInfo mvBackupInfo = restoreJobInfo.getTableInfo(UnitTestUtil.TABLE_NAME);
+            Assert.assertTrue(mvBackupInfo != null);
+            Table mvTable = backupMeta.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
+            Assert.assertTrue(mvTable != null);
+            Assert.assertTrue(mvTable instanceof MaterializedView);
+            MaterializedView mv = (MaterializedView) mvTable;
+            Assert.assertTrue(mv != null);
+            Assert.assertTrue(!mv.isActive());
+            Assert.assertTrue(mv.getInactiveReason().contains(String.format("Set the materialized view %s inactive in backup",
+                    UnitTestUtil.MATERIALIZED_VIEW_NAME)));
         } catch (IOException e) {
             e.printStackTrace();
             Assert.fail();
@@ -391,7 +410,7 @@ public class BackupJobMaterializedViewTest {
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_tbl"), null));
         tableRefs.add(new TableRef(new TableName(UnitTestUtil.DB_NAME, "unknown_mv"), null));
 
-        job = new BackupJob("label", dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
+        job = new BackupJob(MV_LABEL, dbId, UnitTestUtil.DB_NAME, tableRefs, 13600 * 1000, globalStateMgr, repo.getId());
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -10,32 +10,15 @@
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
-// limitations under the License.
-
-// This file is based on code available under the Apache license here:
-//   https://github.com/apache/incubator-doris/blob/master/fe/fe-core/src/test/java/org/apache/doris/backup/RestoreJobTest.java
-
-// Licensed to the Apache Software Foundation (ASF) under one
-// or more contributor license agreements.  See the NOTICE file
-// distributed with this work for additional information
-// regarding copyright ownership.  The ASF licenses this file
-// to you under the Apache License, Version 2.0 (the
-// "License"); you may not use this file except in compliance
-// with the License.  You may obtain a copy of the License at
-//
-//   http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
+// limitations under the License
 
 package com.starrocks.backup;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.starrocks.analysis.BrokerDesc;
 import com.starrocks.backup.BackupJobInfo.BackupIndexInfo;
 import com.starrocks.backup.BackupJobInfo.BackupPartitionInfo;
 import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
@@ -43,17 +26,25 @@ import com.starrocks.backup.BackupJobInfo.BackupTabletInfo;
 import com.starrocks.backup.RestoreJob.RestoreJobState;
 import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Database;
+import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
 import com.starrocks.catalog.MaterializedIndex.IndexExtState;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.Tablet;
 import com.starrocks.common.AnalysisException;
+import com.starrocks.common.UserException;
 import com.starrocks.common.jmockit.Deencapsulation;
+import com.starrocks.common.util.UnitTestUtil;
 import com.starrocks.common.util.concurrent.MarkedCountDownLatch;
+import com.starrocks.fs.HdfsUtil;
+import com.starrocks.metric.MetricRepo;
 import com.starrocks.persist.EditLog;
+import com.starrocks.qe.ConnectContext;
 import com.starrocks.server.GlobalStateMgr;
+import com.starrocks.server.MetadataMgr;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.task.AgentTask;
 import com.starrocks.task.AgentTaskQueue;
@@ -62,6 +53,7 @@ import com.starrocks.task.DownloadTask;
 import com.starrocks.task.SnapshotTask;
 import com.starrocks.thrift.TBackend;
 import com.starrocks.thrift.TFinishTaskRequest;
+import com.starrocks.thrift.THdfsProperties;
 import com.starrocks.thrift.TStatus;
 import com.starrocks.thrift.TStatusCode;
 import com.starrocks.thrift.TTaskType;
@@ -72,27 +64,37 @@ import mockit.Mock;
 import mockit.MockUp;
 import mockit.Mocked;
 import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 import java.util.zip.Adler32;
 
-public class RestoreJobPrimaryKeyTest {
+import static com.starrocks.common.util.UnitTestUtil.DB_NAME;
+import static com.starrocks.common.util.UnitTestUtil.MATERIALIZED_VIEW_NAME;
+import static com.starrocks.common.util.UnitTestUtil.TABLE_NAME;
+
+
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+public class RestoreJobMaterializedViewTest {
 
     private Database db;
-    private BackupJobInfo jobInfo;
-    private RestoreJob job;
-    private String label = "test_label";
+
+    private String label = "test_mv_label";
+
+    private static final int ID_SIZE = 10000;
 
     private AtomicLong id = new AtomicLong(50000);
-
-    private OlapTable expectedRestoreTbl;
 
     private long repoId = 30000;
 
@@ -102,6 +104,9 @@ public class RestoreJobPrimaryKeyTest {
     private MockBackupHandler backupHandler;
 
     private MockRepositoryMgr repoMgr;
+
+    private MvRestoreContext mvRestoreContext;
+
 
     // Thread is not mockable in Jmockit, use subclass instead
     private final class MockBackupHandler extends BackupHandler {
@@ -138,23 +143,30 @@ public class RestoreJobPrimaryKeyTest {
 
     private BackupMeta backupMeta;
 
-    @Before
-    public void setUp() throws AnalysisException {
-        db = CatalogMocker.mockDb();
-        backupHandler = new MockBackupHandler(globalStateMgr);
-        repoMgr = new MockRepositoryMgr();
+    private long dbId = 11;
+    private long tblId = 12;
+    private long partId = 13;
+    private long idxId = 14;
+    private long tabletId = 15;
+    private long backendId = 10000;
+    private long version = 16;
 
-        Deencapsulation.setField(globalStateMgr, "backupHandler", backupHandler);
+    private Object[] arrayIds;
+    private void setUpMocker() {
+        MetricRepo.init();
+
+        List<Long> beIds = Lists.newArrayList();
+        beIds.add(CatalogMocker.BACKEND1_ID);
+        beIds.add(CatalogMocker.BACKEND2_ID);
+        beIds.add(CatalogMocker.BACKEND3_ID);
+        arrayIds = new Object[ID_SIZE];
+        IntStream.range(0, ID_SIZE).forEach(i -> arrayIds[i] = id.getAndIncrement());
 
         new Expectations() {
             {
                 globalStateMgr.getDb(anyLong);
                 minTimes = 0;
                 result = db;
-
-                globalStateMgr.getNextId();
-                minTimes = 0;
-                result = id.getAndIncrement();
 
                 globalStateMgr.getEditLog();
                 minTimes = 0;
@@ -163,27 +175,26 @@ public class RestoreJobPrimaryKeyTest {
                 GlobalStateMgr.getCurrentSystemInfo();
                 minTimes = 0;
                 result = systemInfoService;
-            }
-        };
 
-        new Expectations() {
+                globalStateMgr.mayGetDb(anyLong);
+                minTimes = 0;
+                result = Optional.of(db);
+
+                globalStateMgr.getNextId();
+                minTimes = 0;
+                returns(arrayIds[0], arrayIds[1], Arrays.copyOfRange(arrayIds, 2, ID_SIZE));
+            }
+
             {
                 systemInfoService.seqChooseBackendIds(anyInt, anyBoolean, anyBoolean);
                 minTimes = 0;
-                result = new Delegate() {
-                    public synchronized List<Long> seqChooseBackendIds(int backendNum, boolean needAlive,
-                                                                       boolean isCreate, String clusterName) {
-                        List<Long> beIds = Lists.newArrayList();
-                        beIds.add(CatalogMocker.BACKEND1_ID);
-                        beIds.add(CatalogMocker.BACKEND2_ID);
-                        beIds.add(CatalogMocker.BACKEND3_ID);
-                        return beIds;
-                    }
-                };
-            }
-        };
+                result = beIds;
 
-        new Expectations() {
+                systemInfoService.checkExceedDiskCapacityLimit((Multimap<Long, Long>) any, anyBoolean);
+                minTimes = 0;
+                result = com.starrocks.common.Status.OK;
+            }
+
             {
                 editLog.logBackupJob((BackupJob) any);
                 minTimes = 0;
@@ -193,9 +204,7 @@ public class RestoreJobPrimaryKeyTest {
                     }
                 };
             }
-        };
 
-        new Expectations() {
             {
                 repo.upload(anyString, anyString);
                 result = Status.OK;
@@ -214,27 +223,51 @@ public class RestoreJobPrimaryKeyTest {
         };
 
         new MockUp<MarkedCountDownLatch>() {
+                @Mock
+                boolean await(long timeout, TimeUnit unit) {
+                    return true;
+                }
+            };
+
+        new MockUp<ConnectContext>() {
+                @Mock
+                GlobalStateMgr getGlobalStateMgr() {
+                    return globalStateMgr;
+                }
+            };
+        new MockUp<GlobalStateMgr>() {
+                @Mock
+                BackupHandler getBackupHandler() {
+                    return backupHandler;
+                }
+            };
+
+        new MockUp<HdfsUtil>() {
             @Mock
-            boolean await(long timeout, TimeUnit unit) {
-                return true;
+            public void getTProperties(String path, BrokerDesc brokerDesc, THdfsProperties tProperties) throws UserException {
             }
         };
+    }
 
-        // gen BackupJobInfo
-        jobInfo = new BackupJobInfo();
-        jobInfo.backupTime = System.currentTimeMillis();
-        jobInfo.dbId = CatalogMocker.TEST_DB_ID;
-        jobInfo.dbName = CatalogMocker.TEST_DB_NAME;
-        jobInfo.name = label;
-        jobInfo.success = true;
+    @BeforeEach
+    public void setUp() throws AnalysisException {
+        repoMgr = new MockRepositoryMgr();
+        backupHandler = new MockBackupHandler(globalStateMgr);
 
-        expectedRestoreTbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL3_ID);
+        Deencapsulation.setField(globalStateMgr, "backupHandler", backupHandler);
+        systemInfoService = new SystemInfoService();
+        db = UnitTestUtil.createDbWithMaterializedView(dbId, tblId, partId, idxId, tabletId,
+                backendId, version, KeysType.DUP_KEYS);
+        mvRestoreContext = new MvRestoreContext();
+        setUpMocker();
+    }
+
+    private BackupTableInfo mockBackupTableInfo(OlapTable olapTable) {
+        Assert.assertTrue(olapTable != null);
         BackupTableInfo tblInfo = new BackupTableInfo();
-        tblInfo.id = CatalogMocker.TEST_TBL3_ID;
-        tblInfo.name = CatalogMocker.TEST_TBL3_NAME;
-        jobInfo.tables.put(tblInfo.name, tblInfo);
-
-        for (Partition partition : expectedRestoreTbl.getPartitions()) {
+        tblInfo.id = olapTable.getId();
+        tblInfo.name = olapTable.getName();
+        for (Partition partition : olapTable.getPartitions()) {
             BackupPartitionInfo partInfo = new BackupPartitionInfo();
             partInfo.id = partition.getId();
             partInfo.name = partition.getName();
@@ -243,45 +276,70 @@ public class RestoreJobPrimaryKeyTest {
             for (MaterializedIndex index : partition.getMaterializedIndices(IndexExtState.VISIBLE)) {
                 BackupIndexInfo idxInfo = new BackupIndexInfo();
                 idxInfo.id = index.getId();
-                idxInfo.name = expectedRestoreTbl.getIndexNameById(index.getId());
-                idxInfo.schemaHash = expectedRestoreTbl.getSchemaHashByIndexId(index.getId());
+                idxInfo.name = olapTable.getIndexNameById(index.getId());
+                idxInfo.schemaHash = olapTable.getSchemaHashByIndexId(index.getId());
                 partInfo.indexes.put(idxInfo.name, idxInfo);
 
                 for (Tablet tablet : index.getTablets()) {
                     BackupTabletInfo tabletInfo = new BackupTabletInfo();
                     tabletInfo.id = tablet.getId();
                     tabletInfo.files.add(tabletInfo.id + ".dat");
-                    tabletInfo.files.add("meta");
+                    tabletInfo.files.add(tabletInfo.id + ".idx");
+                    tabletInfo.files.add(tabletInfo.id + ".hdr");
                     idxInfo.tablets.add(tabletInfo);
                 }
             }
         }
-
-        // drop this table, cause we want to try restoring this table
-        db.dropTable(expectedRestoreTbl.getName());
-
-        List<Table> tbls = Lists.newArrayList();
-        tbls.add(expectedRestoreTbl);
-        backupMeta = new BackupMeta(tbls);
-        job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
-                jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
+        return tblInfo;
     }
 
-    @Ignore
-    @Test
-    public void testRun() {
-        // pending
+    public RestoreJob createRestoreJob(List<String> restoreTbls) {
+        BackupJobInfo jobInfo = new BackupJobInfo();
+        jobInfo.backupTime = System.currentTimeMillis();
+        jobInfo.dbId = dbId;
+        jobInfo.dbName = DB_NAME;
+        jobInfo.name = label;
+        jobInfo.success = true;
+
+        List<Table> tbls = Lists.newArrayList();
+        for (String tbl : restoreTbls) {
+            OlapTable baseTable = (OlapTable) db.getTable(tbl);
+            BackupTableInfo baseTblInfo = mockBackupTableInfo(baseTable);
+            jobInfo.tables.put(baseTblInfo.name, baseTblInfo);
+            tbls.add(baseTable);
+        }
+        backupMeta = new BackupMeta(tbls);
+
+        // drop table to test restore
+        for (String tbl : restoreTbls) {
+            db.dropTable(tbl);
+        }
+
+        RestoreJob job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
+                jobInfo, false, 3, 100000,
+                globalStateMgr, repo.getId(), backupMeta, mvRestoreContext);
+        job.setRepo(repo);
+
+        // add job into mvRestoreContext
+        mvRestoreContext.addIntoMvBaseTableBackupInfo(job);
+
+        return job;
+    }
+
+    private void checkJobRun(RestoreJob job) {
+        globalStateMgr.setNextId(id.getAndDecrement());
+
+        int tblNums = job.getJobInfo().tables.size();
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(RestoreJobState.SNAPSHOTING, job.getState());
-        Assert.assertEquals(12, job.getFileMapping().getMapping().size());
+        Assert.assertEquals(3 * tblNums, job.getFileMapping().getMapping().size());
 
         // 2. snapshoting
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(RestoreJobState.SNAPSHOTING, job.getState());
-        Assert.assertEquals(12 * 2, AgentTaskQueue.getTaskNum());
+        Assert.assertEquals(6 * tblNums, AgentTaskQueue.getTaskNum());
 
         // 3. snapshot finished
         List<AgentTask> agentTasks = Lists.newArrayList();
@@ -289,7 +347,7 @@ public class RestoreJobPrimaryKeyTest {
         agentTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND1_ID, runningTasks));
         agentTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND2_ID, runningTasks));
         agentTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND3_ID, runningTasks));
-        Assert.assertEquals(12 * 2, agentTasks.size());
+        Assert.assertEquals(6 * tblNums, agentTasks.size());
 
         for (AgentTask agentTask : agentTasks) {
             if (agentTask.getTaskType() != TTaskType.MAKE_SNAPSHOT) {
@@ -315,7 +373,7 @@ public class RestoreJobPrimaryKeyTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(RestoreJobState.DOWNLOADING, job.getState());
-        Assert.assertEquals(9, AgentTaskQueue.getTaskNum());
+        Assert.assertEquals(3 * tblNums, AgentTaskQueue.getTaskNum());
 
         // downloading
         job.run();
@@ -327,7 +385,7 @@ public class RestoreJobPrimaryKeyTest {
         downloadTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND1_ID, runningTasks));
         downloadTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND2_ID, runningTasks));
         downloadTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND3_ID, runningTasks));
-        Assert.assertEquals(9, downloadTasks.size());
+        Assert.assertEquals(3 * tblNums, downloadTasks.size());
 
         List<Long> downloadedTabletIds = Lists.newArrayList();
         for (AgentTask agentTask : downloadTasks) {
@@ -348,7 +406,7 @@ public class RestoreJobPrimaryKeyTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(RestoreJobState.COMMITTING, job.getState());
-        Assert.assertEquals(12, AgentTaskQueue.getTaskNum());
+        Assert.assertEquals(3 * tblNums, AgentTaskQueue.getTaskNum());
 
         // committing
         job.run();
@@ -360,7 +418,7 @@ public class RestoreJobPrimaryKeyTest {
         dirMoveTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND1_ID, runningTasks));
         dirMoveTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND2_ID, runningTasks));
         dirMoveTasks.addAll(AgentTaskQueue.getDiffTasks(CatalogMocker.BACKEND3_ID, runningTasks));
-        Assert.assertEquals(12, dirMoveTasks.size());
+        Assert.assertEquals(3 * tblNums, dirMoveTasks.size());
 
         for (AgentTask agentTask : dirMoveTasks) {
             TStatus taskStatus = new TStatus(TStatusCode.OK);
@@ -373,9 +431,152 @@ public class RestoreJobPrimaryKeyTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(RestoreJobState.FINISHED, job.getState());
+
+        // clear
+        AgentTaskQueue.clearAllTasks();
     }
 
     @Test
+    @Order(1)
+    public void testMVRestore_TestOneTable1() {
+        RestoreJob job = createRestoreJob(ImmutableList.of(UnitTestUtil.MATERIALIZED_VIEW_NAME));
+        checkJobRun(job);
+    }
+
+    @Test
+    @Order(2)
+    public void testMVRestore_TestOneTable2() {
+        RestoreJob job = createRestoreJob(ImmutableList.of(UnitTestUtil.TABLE_NAME));
+        checkJobRun(job);
+    }
+
+    @Test
+    @Order(3)
+    public void testMVRestore_TestMVWithBaseTable1() {
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
+                result = true;
+
+                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
+                minTimes = 0;
+                result = db;
+            }
+        };
+
+        // gen BackupJobInfo
+        RestoreJob job = createRestoreJob(ImmutableList.of(TABLE_NAME, MATERIALIZED_VIEW_NAME));
+        // backup & restore
+        checkJobRun(job);
+
+        {
+            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
+            Assert.assertTrue(mvTable != null);
+            Assert.assertTrue(mvTable.isMaterializedView());
+            MaterializedView mv = (MaterializedView) mvTable;
+            Assert.assertTrue(mv.isActive());
+        }
+    }
+
+    @Test
+    @Order(4)
+    public void testMVRestore_TestMVWithBaseTable2() {
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
+                result = true;
+
+                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
+                minTimes = 0;
+                result = db;
+            }
+        };
+
+        // gen BackupJobInfo
+        RestoreJob job = createRestoreJob(ImmutableList.of(MATERIALIZED_VIEW_NAME, TABLE_NAME));
+        // backup & restore
+        checkJobRun(job);
+
+        {
+            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
+            Assert.assertTrue(mvTable != null);
+            Assert.assertTrue(mvTable.isMaterializedView());
+            MaterializedView mv = (MaterializedView) mvTable;
+            Assert.assertTrue(mv.isActive());
+        }
+    }
+
+    @Test
+    @Order(5)
+    public void testMVRestore_TestMVWithBaseTable3() {
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
+                result = true;
+
+                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
+                minTimes = 0;
+                result = db;
+            }
+        };
+
+        // gen BackupJobInfo
+        RestoreJob job1 = createRestoreJob(ImmutableList.of(TABLE_NAME));
+        // backup & restore
+        checkJobRun(job1);
+
+        RestoreJob job2 = createRestoreJob(ImmutableList.of(MATERIALIZED_VIEW_NAME));
+        checkJobRun(job2);
+
+        {
+            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
+            Assert.assertTrue(mvTable != null);
+            Assert.assertTrue(mvTable.isMaterializedView());
+            MaterializedView mv = (MaterializedView) mvTable;
+            Assert.assertTrue(mv.isActive());
+        }
+    }
+
+    @Test
+    @Order(6)
+    public void testMVRestore_TestMVWithBaseTable4() {
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
+                result = true;
+
+                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
+                minTimes = 0;
+                result = db;
+            }
+        };
+
+        new MockUp<MetadataMgr>() {
+            @Mock
+            public Table getTable(String catalogName, String dbName, String tblName) {
+                return db.getTable(tblName);
+            }
+        };
+
+        // gen BackupJobInfo
+        RestoreJob job1 = createRestoreJob(ImmutableList.of(MATERIALIZED_VIEW_NAME));
+        // backup & restore
+        checkJobRun(job1);
+
+        RestoreJob job2 = createRestoreJob(ImmutableList.of(TABLE_NAME));
+        checkJobRun(job2);
+
+        {
+            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
+            Assert.assertTrue(mvTable != null);
+            Assert.assertTrue(mvTable.isMaterializedView());
+            MaterializedView mv = (MaterializedView) mvTable;
+            Assert.assertTrue(mv.isActive());
+        }
+    }
+
+    @Test
+    @Order(7)
     public void testSignature() {
         Adler32 sig1 = new Adler32();
         sig1.update("name1".getBytes());
@@ -387,7 +588,7 @@ public class RestoreJobPrimaryKeyTest {
         sig2.update("name1".getBytes());
         System.out.println("sig2: " + Math.abs((int) sig2.getValue()));
 
-        OlapTable tbl = (OlapTable) db.getTable(CatalogMocker.TEST_TBL_NAME);
+        OlapTable tbl = (OlapTable) db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
         List<String> partNames = Lists.newArrayList(tbl.getPartitionNames());
         System.out.println(partNames);
         System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobTest.java
@@ -43,6 +43,7 @@ import com.starrocks.backup.BackupJobInfo.BackupPhysicalPartitionInfo;
 import com.starrocks.backup.BackupJobInfo.BackupTableInfo;
 import com.starrocks.backup.BackupJobInfo.BackupTabletInfo;
 import com.starrocks.backup.RestoreJob.RestoreJobState;
+import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.KeysType;
 import com.starrocks.catalog.MaterializedIndex;
@@ -156,7 +157,7 @@ public class RestoreJobTest {
 
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
                 jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta);
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
 
         job.resetPartitionForRestore(localTbl, expectedRestoreTbl, CatalogMocker.TEST_PARTITION1_NAME, 3);
     }
@@ -289,7 +290,7 @@ public class RestoreJobTest {
         backupMeta = new BackupMeta(tbls);
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
                 jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta);
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
         job.setRepo(repo);
         // pending
         job.run();
@@ -452,7 +453,7 @@ public class RestoreJobTest {
         backupMeta = new BackupMeta(tbls);
         job = new RestoreJob(label, "2018-01-01 01:01:01", db.getId(), db.getFullName(),
                 jobInfo, false, 3, 100000,
-                globalStateMgr, repo.getId(), backupMeta);
+                globalStateMgr, repo.getId(), backupMeta, new MvRestoreContext());
         job.setRepo(repo);
         // pending
         job.run();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/OlapTableTest.java
@@ -39,6 +39,7 @@ import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.starrocks.analysis.IndexDef;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.backup.mv.MvRestoreContext;
 import com.starrocks.catalog.Partition;
 import com.starrocks.catalog.PartitionInfo;
 import com.starrocks.catalog.Table.TableType;
@@ -86,7 +87,7 @@ public class OlapTableTest {
             if (table.getType() != TableType.OLAP) {
                 continue;
             }
-            ((OlapTable) table).resetIdsForRestore(GlobalStateMgr.getCurrentState(), db, 3);
+            ((OlapTable) table).resetIdsForRestore(GlobalStateMgr.getCurrentState(), db, 3, new MvRestoreContext());
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -16,17 +16,25 @@ package com.starrocks.planner;
 
 import com.google.api.client.util.Lists;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.starrocks.analysis.TableName;
+import com.starrocks.backup.Status;
+import com.starrocks.backup.mv.MVRestoreUpdater;
+import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
+import com.starrocks.common.Pair;
 import com.starrocks.qe.SessionVariable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.sql.plan.PlanTestBase;
+import org.apache.parquet.Strings;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
 public class MaterializedViewTest extends MaterializedViewTestBase {
@@ -5311,5 +5319,43 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 // ignore
             }
         });
+    }
+
+    @Test
+    public void testMvRestoreUpdater1() {
+        String mvName = "test0";
+        String mv = String.format("CREATE MATERIALIZED VIEW %s" +
+                " REFRESH DEFERRED MANUAL " +
+                " AS SELECT *  FROM lineorder", mvName);
+        starRocksAssert.withMaterializedView(mv,
+                () -> {
+                    MaterializedView mvTable = (MaterializedView) getTable(MATERIALIZED_DB_NAME, mvName);
+                    Pair<Status, Boolean> result = MVRestoreUpdater.checkMvDefinedQuery(mvTable, Maps.newHashMap(), Pair.create("", ""));
+                    Assert.assertTrue(result.first.ok());
+                });
+
+    }
+
+    @Test
+    public void testMvRestoreUpdater2() {
+        String mvName = "test0";
+        String mv = String.format("CREATE MATERIALIZED VIEW %s" +
+                " REFRESH DEFERRED MANUAL " +
+                " AS SELECT * FROM lineorder", mvName);
+
+        starRocksAssert.withMaterializedView(mv,
+                () -> {
+                    MaterializedView mvTable = (MaterializedView) getTable(MATERIALIZED_DB_NAME, mvName);
+                    Pair<String, String> newDefinedQueries = Pair.create("", "");
+                    Map<TableName, TableName> remoteToLocalTableName = Maps.newHashMap();
+                    remoteToLocalTableName.put(TableName.fromString("test.lineorder"),
+                            TableName.fromString("test.lineorder"));
+                    boolean result = MVRestoreUpdater.renewMvBaseTableNames(mvTable,
+                            remoteToLocalTableName, connectContext, newDefinedQueries);
+                    Assert.assertTrue(result);
+                    Assert.assertTrue(!Strings.isNullOrEmpty(newDefinedQueries.first));
+                    Assert.assertTrue(!Strings.isNullOrEmpty(newDefinedQueries.second));
+                });
+
     }
 }


### PR DESCRIPTION
Why I'm doing:
PR(https://github.com/StarRocks/starrocks/pull/29164) supports materialzied view's backup/restore, but there are a lot of limitations :
- Need refresh mv again even the materialized view's data has already backed up and restored.
- Materialized view's base table cannot change database.
- Mv and base tables must be backed up and restored at the same time.

What I'm doing:
This PR mainly supports to reuse backed-up version map for mv rewrite to avoid refreshing again after mv restore.
At the same time,  cancel the limitations about:
- Try to use a simple policy(string replace) when Materialized view's base table cannot change database, only update defined sql when analyze new replaced sql success.
- Introduce `MvRestoreContext` to track materialized view's associated infos, so Mv and base tables can be backed up and restored not at the same time.

```
/**
 * MvRestoreContext is used in Restore job to track materialized view's associated infos. eg, we can use it to track
 * remote base table which is defined in the materialized view's `baseTableInfos` and track the materialized view by
 * remote MvId.
 */
public class MvRestoreContext {
    private static final Logger LOG = LogManager.getLogger(MvRestoreContext.class);

    // <remote db name, remote table name> -> BackupTableInfo and associated infos.
    // Because materialized view only keeps remote db/table names in the BaseTable info, and materialized view and its
    // base tables may not in the same backup/restore. We keep this to track remote backup table info by the remote db
    // and table name, so can update materialized view's base table info in restoring the materialized view.
    // NOTE: we only record the newest restore of the base table to avoid caching too much history metas.
    // NOTE: we won't cache all the
    protected Map<TableName, MvBaseTableBackupInfo> mvBaseTableToBackupTableInfo = Maps.newConcurrentMap();

    // <MvId> -> <db name, table name>
    // MvId only contains remote db id and remote table id, but remote db/table id are changed after restore, so use this
    // to track the new db name/table name after restore.
    protected Map<MvId, MvBackupInfo> mvIdToTableNameMap = Maps.newConcurrentMap();

 ...

}
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
