### PR TITLE
[BugFix] Use delete predicates to filter data when creating sync mv

### DIFF
--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -305,8 +305,6 @@ public:
 
     bool get_is_compacting() { return is_compacting.load(); }
 
-    DeletePredicatePB* mutable_delete_predicate() { return _rowset_meta->mutable_delete_predicate(); }
-
     static bool comparator(const RowsetSharedPtr& left, const RowsetSharedPtr& right) {
         return left->end_version() < right->end_version();
     }

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -43,7 +43,10 @@ namespace starrocks {
 
 TabletReader::TabletReader(TabletSharedPtr tablet, const Version& version, Schema schema,
                            const TabletSchemaCSPtr& tablet_schema)
-        : ChunkIterator(std::move(schema)), _tablet(std::move(tablet)), _version(version) {
+        : ChunkIterator(std::move(schema)),
+          _tablet(std::move(tablet)),
+          _version(version),
+          _delete_predicates_version(version) {
     _tablet_schema = !tablet_schema ? _tablet->tablet_schema() : tablet_schema;
 }
 
@@ -52,6 +55,7 @@ TabletReader::TabletReader(TabletSharedPtr tablet, const Version& version, Schem
         : ChunkIterator(std::move(schema)),
           _tablet(std::move(tablet)),
           _version(version),
+          _delete_predicates_version(version),
           _rowsets(std::move(captured_rowsets)) {
     _tablet_schema = tablet_schema ? *tablet_schema : _tablet->tablet_schema();
 }
@@ -61,6 +65,7 @@ TabletReader::TabletReader(TabletSharedPtr tablet, const Version& version, Schem
         : ChunkIterator(std::move(schema)),
           _tablet(std::move(tablet)),
           _version(version),
+          _delete_predicates_version(version),
           _is_vertical_merge(true),
           _is_key(is_key),
           _mask_buffer(mask_buffer) {
@@ -469,15 +474,10 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
     PredicateParser pred_parser(_tablet_schema);
 
     std::shared_lock header_lock(_tablet->get_header_lock());
-    // here we can not use DeletePredicatePB from  _tablet->delete_predicates() because
-    // _rowsets maybe stale rowset, and stale rowset's delete predicates may be removed
-    // from _tablet->delete_predicates() after compation
-    for (const RowsetSharedPtr& rowset : _rowsets) {
-        const RowsetMetaSharedPtr& rowset_meta = rowset->rowset_meta();
-        if (!rowset_meta->has_delete_predicate()) {
+    for (const DeletePredicatePB& pred_pb : _tablet->delete_predicates()) {
+        if (pred_pb.version() > _delete_predicates_version.second) {
             continue;
         }
-        const DeletePredicatePB& pred_pb = rowset_meta->delete_predicate();
 
         ConjunctivePredicates conjunctions;
         for (int i = 0; i != pred_pb.sub_predicates_size(); ++i) {
@@ -525,6 +525,10 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
             conjunctions.add(pred);
             // save for memory release.
             _predicate_free_list.emplace_back(pred);
+        }
+
+        if (conjunctions.empty()) {
+            continue;
         }
 
         dels->add(pred_pb.version(), conjunctions);

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -58,6 +58,8 @@ public:
 
     size_t merged_rows() const override { return _collect_iter->merged_rows(); }
 
+    void set_delete_predicates_version(Version version) { _delete_predicates_version = version; }
+
     Status get_segment_iterators(const TabletReaderParams& params, std::vector<ChunkIteratorPtr>* iters);
 
     static Status parse_seek_range(const TabletSchemaCSPtr& tablet_schema,
@@ -87,6 +89,9 @@ private:
     TabletSharedPtr _tablet;
     TabletSchemaCSPtr _tablet_schema;
     Version _version;
+    // version of delete predicates, equal as _version by default
+    // _delete_predicates_version will be set as max_version of tablet in schema change
+    Version _delete_predicates_version;
 
     MemPool _mempool;
     ObjectPool _obj_pool;

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view2
@@ -201,3 +201,26 @@ select K1, sum(V1) from UPPER_TBL1 group by K1;
 drop materialized view UPPER_MV1;
 -- result:
 -- !result
+create table sync_mv_base_table_with_delete (k1 bigint, k2 bigint, k3 bigint) duplicate key(k1) distributed by hash(k1) buckets 1 properties ("replication_num" = "1");
+-- result:
+-- !result
+insert into sync_mv_base_table_with_delete values (1, 1, 1), (2, 2, 2);
+-- result:
+-- !result
+delete from sync_mv_base_table_with_delete where k1 = 1;
+-- result:
+-- !result
+create materialized view sync_mv_base_table_with_delete_mv1 as select k2, k3 from sync_mv_base_table_with_delete;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+select k2 from sync_mv_base_table_with_delete_mv1 [_SYNC_MV_];
+-- result:
+2
+-- !result
+drop materialized view sync_mv_base_table_with_delete_mv1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view2
@@ -99,3 +99,12 @@ insert into UPPER_TBL1 values ('2020-01-01', 1, 1), ('2020-01-01', 1, 1), ('2020
 select * from UPPER_MV1 [_SYNC_MV_] order by K1, mv_sum_V1;
 select K1, sum(V1) from UPPER_TBL1 group by K1;
 drop materialized view UPPER_MV1;
+
+-- base table with delete
+create table sync_mv_base_table_with_delete (k1 bigint, k2 bigint, k3 bigint) duplicate key(k1) distributed by hash(k1) buckets 1 properties ("replication_num" = "1");
+insert into sync_mv_base_table_with_delete values (1, 1, 1), (2, 2, 2);
+delete from sync_mv_base_table_with_delete where k1 = 1;
+create materialized view sync_mv_base_table_with_delete_mv1 as select k2, k3 from sync_mv_base_table_with_delete;
+function: wait_materialized_view_finish()
+select k2 from sync_mv_base_table_with_delete_mv1 [_SYNC_MV_];
+drop materialized view sync_mv_base_table_with_delete_mv1;


### PR DESCRIPTION
Why I'm doing:
#20362, #25027 remove delete predicates in tablet reader, and will cause wrong sync mv data (not filtered, delete column is not in sync mv) and BE crash ([#5311](https://github.com/StarRocks/StarRocksTest/issues/5311)).

What I'm doing:
1. recover delete predicates in tablet reader.
2. delay delete "delete predicate" when deleting stale rowset to fix #20362.

Fixes #38648

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
