### PR TITLE
[Enhancement] Add be config item: query_cache_num_lanes_per_driver (backport #38635)

### DIFF
--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -960,6 +960,12 @@ CONF_mBool(enable_pindex_rebuild_in_compaction, "false");
 // Used by query cache, cache entries are evicted when it exceeds its capacity(500MB in default)
 CONF_Int64(query_cache_capacity, "536870912");
 
+// When query cache enabled, the operators in the drivers contains cache operator are multilane
+// operators, if the number of lanes is big, Fragment Instance would spend too much time to prepare
+// operators since the number of operators scale up with the number of lanes.
+// ranges in [1,16], default value is 4.
+CONF_mInt32(query_cache_num_lanes_per_driver, "4");
+
 // Used to limit buffer size of tablet send channel.
 CONF_mInt64(send_channel_buffer_limit, "67108864");
 

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -358,7 +358,8 @@ Status FragmentExecutor::_prepare_exec_plan(ExecEnv* exec_env, const UnifiedExec
                                                          ? scan_ranges_per_driver
                                                          : request.per_driver_seq_scan_ranges_of_node(scan_node->id());
 
-        _fragment_ctx->cache_param().num_lanes = scan_node->io_tasks_per_scan_operator();
+        // num_lanes ranges in [1,16] in default 4.
+        _fragment_ctx->cache_param().num_lanes = std::min(16, std::max(1, config::query_cache_num_lanes_per_driver));
 
         for (auto& [driver_seq, scan_ranges] : scan_ranges_per_driver_seq) {
             for (auto& scan_range : scan_ranges) {


### PR DESCRIPTION
cherry-pick #38635 


---


<details>
<summary>Mergify commands and options</summary>

<br />

More conditions and actions can be found in the [documentation](https://docs.mergify.com/).

You can also trigger Mergify actions by commenting on this pull request:

- `@Mergifyio refresh` will re-evaluate the rules
- `@Mergifyio rebase` will rebase this PR on its base branch
- `@Mergifyio update` will merge the base branch into this PR
- `@Mergifyio backport <destination>` will backport this PR on `<destination>` branch

Additionally, on Mergify [dashboard](https://dashboard.mergify.com) you can:

- look at your merge queues
- generate the Mergify configuration with the config editor.

Finally, you can contact us on https://mergify.com
</details>
Why I'm doing:

The number of lanes in multilane operator of drivers involved query cache depends on degree-of-parallelism of scan io tasks.  it works well in OlapScan which io dop is 4; while it works not as expect in ConnectorScan since the io dop is 16, it causes FragmentInstance spent 4 times as much time as that does in OlapScan during prepare operators.

What I'm doing:

Introduce a be config item: query_cache_num_lanes_per_driver to specify the number of lanes in multilane operators.
it ranges in [1,16], default value is 4 to be compatible with previous versions.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

