### PR TITLE
[BugFix] Increase column_with_row column length limit to MAX_VARCHAR_LENGTH

### DIFF
--- a/be/src/storage/tablet_manager.cpp
+++ b/be/src/storage/tablet_manager.cpp
@@ -1333,8 +1333,7 @@ Status TabletManager::_create_tablet_meta_unlocked(const TCreateTabletReq& reque
         column.__set_column_name(Schema::FULL_ROW_COLUMN);
         TColumnType ctype;
         ctype.__set_type(TPrimitiveType::VARCHAR);
-        //TODO
-        ctype.__set_len(65535);
+        ctype.__set_len(TypeDescriptor::MAX_VARCHAR_LENGTH);
         column.__set_column_type(ctype);
         column.__set_aggregation_type(TAggregationType::REPLACE);
         column.__set_is_allow_null(false);

--- a/be/test/storage/tablet_updates_test.h
+++ b/be/test/storage/tablet_updates_test.h
@@ -275,7 +275,8 @@ public:
         return *writer->build();
     }
 
-    RowsetSharedPtr create_rowset_column_with_row(const TabletSharedPtr& tablet, const vector<int64_t>& keys) {
+    StatusOr<RowsetSharedPtr> create_rowset_column_with_row(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                                            bool large_var_column = false) {
         RowsetWriterContext writer_context;
         RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
         writer_context.rowset_id = rowset_id;
@@ -301,13 +302,19 @@ public:
         }
         auto schema_without_full_row_column = std::make_unique<Schema>(&schema, cids);
         auto chunk = ChunkHelper::new_chunk(*schema_without_full_row_column, nkeys);
+        string varchar_value;
+        if (large_var_column) {
+            varchar_value = std::string(1024 * 1024, 'a');
+        } else {
+            varchar_value = std::string(1024, 'a');
+        }
         auto& cols = chunk->columns();
         for (int64_t key : keys) {
             cols[0]->append_datum(Datum(key));
             cols[1]->append_datum(Datum((int16_t)(nkeys - 1 - key)));
-            cols[2]->append_datum(Datum((int32_t)(key)));
+            cols[2]->append_datum(Datum(Slice(varchar_value)));
         }
-        CHECK_OK(writer->flush_chunk(*chunk));
+        RETURN_IF_ERROR(writer->flush_chunk(*chunk));
         return *writer->build();
     }
 
@@ -534,14 +541,15 @@ public:
         TColumn k3;
         k3.column_name = "v2";
         k3.__set_is_key(false);
-        k3.column_type.type = TPrimitiveType::INT;
+        k3.column_type.type = TPrimitiveType::VARCHAR;
+        k3.column_type.len = TypeDescriptor::MAX_VARCHAR_LENGTH;
         request.tablet_schema.columns.push_back(k3);
 
         TColumn row;
         row.column_name = Schema::FULL_ROW_COLUMN;
         TColumnType ctype;
         ctype.__set_type(TPrimitiveType::VARCHAR);
-        ctype.__set_len(65535);
+        ctype.__set_len(TypeDescriptor::MAX_VARCHAR_LENGTH);
         row.__set_column_type(ctype);
         row.__set_aggregation_type(TAggregationType::REPLACE);
         row.__set_is_allow_null(false);


### PR DESCRIPTION
Why I'm doing:

Current limit(65535) for column_with_row may not be enough.

What I'm doing:

Increase limit to max possible value, currently 1MB

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
