### PR TITLE
[Enhancement] Add log when update cache expires

### DIFF
--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -494,9 +494,32 @@ Status UpdateManager::get_del_vec_in_meta(const TabletSegmentId& tsid, int64_t m
 
 void UpdateManager::expire_cache() {
     if (MonotonicMillis() - _last_clear_expired_cache_millis > _cache_expire_ms) {
+        ssize_t update_state_orig_size = _update_state_cache.size();
+        ssize_t update_state_orig_obj_size = _update_state_cache.object_size();
         _update_state_cache.clear_expired();
+        ssize_t update_state_size = _update_state_cache.size();
+        ssize_t update_state_obj_size = _update_state_cache.object_size();
+
+        ssize_t index_orig_size = _index_cache.size();
+        ssize_t index_orig_obj_size = _index_cache.object_size();
         _index_cache.clear_expired();
+        ssize_t index_size = _index_cache.size();
+        ssize_t index_obj_size = _index_cache.object_size();
+
+        ssize_t compaction_cache_orig_size = _compaction_cache.size();
+        ssize_t compaction_cache_orig_obj_size = _compaction_cache.object_size();
         _compaction_cache.clear_expired();
+        ssize_t compaction_cache_size = _compaction_cache.size();
+        ssize_t compaction_cache_obj_size = _compaction_cache.object_size();
+
+        LOG(INFO) << strings::Substitute(
+                "update state cache expire: ($0 $1), index cache expire: ($2 $3), compaction cache expire: ($4 $5)",
+                update_state_orig_obj_size - update_state_obj_size,
+                PrettyPrinter::print_bytes(update_state_orig_size - update_state_size),
+                index_orig_obj_size - index_obj_size, PrettyPrinter::print_bytes(index_orig_size - index_size),
+                compaction_cache_orig_obj_size - compaction_cache_obj_size,
+                PrettyPrinter::print_bytes(compaction_cache_orig_size - compaction_cache_size));
+
         _last_clear_expired_cache_millis = MonotonicMillis();
     }
 }


### PR DESCRIPTION
Why I'm doing:
There is no log when update cache expires. It is hard to know the memory can be released by update cache.
What I'm doing:
Add log when update cache expires.
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
