### PR TITLE
[Enhancement] save memmove in compressed input stream

### DIFF
--- a/be/src/io/compressed_input_stream.cpp
+++ b/be/src/io/compressed_input_stream.cpp
@@ -19,12 +19,47 @@
 
 namespace starrocks::io {
 
+Status CompressedInputStream::CompressedBuffer::read_with_hint_size(InputStream* f, size_t hint_size) {
+    if (_eof) return Status::EndOfFile("");
+    hint_size = aligned_size(hint_size + MAX_BLOCK_HEADER_SIZE);
+    size_t buffer_size = available();
+    if (buffer_size >= hint_size) return Status::OK();
+
+    if (hint_size > _compressed_data.size()) {
+        // create tmp buffer, copy it from _compressed_data to tmp, and then swap
+        // noted that tmp resize is uninitialized.
+        raw::RawVector<uint8_t> tmp(hint_size);
+        memcpy(tmp.data(), &_compressed_data[_offset], buffer_size);
+        _compressed_data.swap(tmp);
+    } else {
+        // no need to create tmp buffer, just do memmove.
+        memmove(&_compressed_data[0], &_compressed_data[_offset], buffer_size);
+    }
+    _offset = 0;
+    _limit = buffer_size;
+
+    while (_limit < hint_size) {
+        Slice buff(write_buffer());
+        ASSIGN_OR_RETURN(buff.size, f->read(buff.data, buff.size));
+        if (buff.size == 0) {
+            _eof = true;
+            return Status::EndOfFile("");
+        }
+        _limit += buff.size;
+    }
+    return Status::OK();
+}
+
 StatusOr<int64_t> CompressedInputStream::read(void* data, int64_t size) {
     size_t output_len = size;
     size_t output_bytes = 0;
 
     while (output_bytes == 0) {
-        Status st = _compressed_buff.read(_source_stream.get());
+        InputStream* f = _source_stream.get();
+        size_t hint_size = _decompressor->get_compressed_block_size();
+        _decompressor->set_compressed_block_size(0);
+        Status st = _compressed_buff.read_with_hint_size(f, hint_size);
+
         if (!st.ok() && !st.is_end_of_file()) {
             return st;
         } else if (st.is_end_of_file() && _stream_end) {

--- a/be/src/util/compression/stream_compression.cpp
+++ b/be/src/util/compression/stream_compression.cpp
@@ -486,6 +486,7 @@ Status SnappyStreamCompression::decompress(uint8_t* input, size_t input_len, siz
         input += 4;
         input_len -= 4;
         if (input_len < compressed_len) {
+            set_compressed_block_size(compressed_len);
             return st;
         }
 
@@ -717,6 +718,7 @@ Status LzoStreamCompression::decompress(uint8_t* input, size_t input_len, size_t
 
         // 5. checksum compressed data
         if (input_len < compressed_size) {
+            set_compressed_block_size(compressed_size);
             return st;
         }
         if (do_compressed_check) {

--- a/be/src/util/compression/stream_compression.h
+++ b/be/src/util/compression/stream_compression.h
@@ -71,12 +71,17 @@ public:
 
     CompressionTypePB get_type() { return _ctype; }
 
+    size_t get_compressed_block_size() { return _compressed_block_size; }
+    size_t set_compressed_block_size(size_t size) { return _compressed_block_size = size; }
+
 protected:
     virtual Status init() { return Status::OK(); }
 
     StreamCompression(CompressionTypePB ctype) : _ctype(ctype) {}
 
     CompressionTypePB _ctype;
+
+    size_t _compressed_block_size = 0;
 };
 
 } // namespace starrocks

--- a/be/test/io/compressed_input_stream_test.cpp
+++ b/be/test/io/compressed_input_stream_test.cpp
@@ -34,6 +34,11 @@ protected:
         size_t compressed_buff_len;
     };
 
+    struct ReadContext {
+        size_t read_buffer_size = 1024;
+        size_t decompressor_buffer_size = 8 * 1024 * 1024;
+    };
+
     std::shared_ptr<InputStream> LZ4F_compress_to_file(const Slice& content) {
         const BlockCompressionCodec* codec = nullptr;
         CHECK(get_block_compression_codec(LZ4_FRAME, &codec).ok());
@@ -66,7 +71,7 @@ protected:
         ASSERT_EQ(t.data, decompressed_data);
     }
 
-    void read_compressed_file(CompressionTypePB type, const char* path, std::string& out, size_t buffer_size = 1024) {
+    void read_compressed_file_ctx(CompressionTypePB type, const char* path, std::string& out, const ReadContext& ctx) {
         auto fs = new_fs_posix();
         auto st = fs->new_random_access_file(path);
         ASSERT_TRUE(st.ok()) << st.status().message();
@@ -76,20 +81,25 @@ protected:
         std::unique_ptr<StreamCompression> dec;
         StreamCompression::create_decompressor(type, &dec);
 
-        auto compressed_input_stream =
-                std::make_shared<io::CompressedInputStream>(file->stream(), DecompressorPtr(dec.release()));
+        auto compressed_input_stream = std::make_shared<io::CompressedInputStream>(
+                file->stream(), DecompressorPtr(dec.release()), ctx.decompressor_buffer_size);
 
-        std::vector<char> vec_buf(buffer_size + 1);
+        std::vector<char> vec_buf(ctx.read_buffer_size + 1);
         char* buf = vec_buf.data();
 
         for (;;) {
-            auto st = compressed_input_stream->read(buf, buffer_size);
+            auto st = compressed_input_stream->read(buf, ctx.read_buffer_size);
             ASSERT_TRUE(st.ok()) << st.status().message();
             uint64_t sz = st.value();
             if (sz == 0) break;
             buf[sz] = 0;
             out += buf;
         }
+    }
+
+    void read_compressed_file(CompressionTypePB type, const char* path, std::string& out) {
+        ReadContext ctx;
+        read_compressed_file_ctx(type, path, out, ctx);
     }
 };
 
@@ -143,14 +153,21 @@ TEST_F(CompressedInputStreamTest, test_LZO1) {
 99999,100000
 )";
 
-    std::vector<size_t> buffer_sizes = {
+    std::vector<size_t> decompressor_buffer_sizes = {
             1024, 2048, 4096, 128 * 1024, 256 * 1024, 1024 * 1024, 2 * 1024 * 1024, 8 * 1024 * 1024};
-    for (size_t buffer_size : buffer_sizes) {
-        std::string out;
-        read_compressed_file(CompressionTypePB::LZO, path, out, buffer_size);
-        ASSERT_EQ(out.size(), 1177785);
-        ASSERT_EQ(out.substr(0, head.size()), head);
-        ASSERT_EQ(out.substr(out.size() - tail.size(), tail.size()), tail);
+    std::vector<size_t> read_buffer_sizes = {
+            32, 1024, 2048, 4096, 128 * 1024, 256 * 1024, 1024 * 1024, 2 * 1024 * 1024, 8 * 1024 * 1024};
+    for (size_t decompressor_buffer_size : decompressor_buffer_sizes) {
+        for (size_t read_buffer_size : read_buffer_sizes) {
+            std::cout << "test lzo1: read_buffer_size: " << read_buffer_size
+                      << ", decompressor_buffer_size: " << decompressor_buffer_size << std::endl;
+            std::string out;
+            ReadContext ctx{.read_buffer_size = read_buffer_size, .decompressor_buffer_size = decompressor_buffer_size};
+            read_compressed_file_ctx(CompressionTypePB::LZO, path, out, ctx);
+            ASSERT_EQ(out.size(), 1177785);
+            ASSERT_EQ(out.substr(0, head.size()), head);
+            ASSERT_EQ(out.substr(out.size() - tail.size(), tail.size()), tail);
+        }
     }
 }
 
@@ -184,9 +201,10 @@ TEST_F(CompressedInputStreamTest, test_Snappy1) {
 
     std::vector<size_t> buffer_sizes = {
             1024, 2048, 4096, 128 * 1024, 256 * 1024, 1024 * 1024, 2 * 1024 * 1024, 8 * 1024 * 1024};
-    for (size_t buffer_size : buffer_sizes) {
+    for (size_t read_buffer_size : buffer_sizes) {
         std::string out;
-        read_compressed_file(CompressionTypePB::SNAPPY, path, out, buffer_size);
+        ReadContext ctx{.read_buffer_size = read_buffer_size};
+        read_compressed_file_ctx(CompressionTypePB::SNAPPY, path, out, ctx);
         ASSERT_EQ(out.size(), 1177785);
         ASSERT_EQ(out.substr(0, head.size()), head);
         ASSERT_EQ(out.substr(out.size() - tail.size(), tail.size()), tail);


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
