### PR TITLE
[Doc] Use external service instead of search service

### DIFF
--- a/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json
+++ b/extra/grafana/kubernetes/StarRocks-Overview-kubernetes-3.0.json
@@ -8312,7 +8312,7 @@
         "name": "namespace",
         "options": [],
         "query": {
-          "query": "label_values(kube_service_info{service=~\".*-fe-search\"}, namespace)",
+          "query": "label_values(kube_service_info{service=~\".*-fe-service\"}, namespace)",
           "refId": "prometheus-namespace-Variable-Query"
         },
         "refresh": 2,
@@ -8339,7 +8339,7 @@
         "name": "feservice",
         "options": [],
         "query": {
-          "query": "label_values(kube_service_info{namespace=\"$namespace\", service=~\".*-fe-search\"}, service)",
+          "query": "label_values(kube_service_info{namespace=\"$namespace\", service=~\".*-fe-service\"}, service)",
           "refId": "prometheus-feservice-Variable-Query"
         },
         "refresh": 2,
@@ -8366,7 +8366,7 @@
         "name": "beservice",
         "options": [],
         "query": {
-          "query": "label_values(kube_service_info{namespace=\"$namespace\", service=~\".*-be-search\"}, service)",
+          "query": "label_values(kube_service_info{namespace=\"$namespace\", service=~\".*-be-service\"}, service)",
           "refId": "prometheus-beservice-Variable-Query"
         },
         "refresh": 2,


### PR DESCRIPTION
Why I'm doing:

Because StarRocks Operator will only add annotations on external service, Grafana can not detect the search service anymore. Ultimately, this results in the Grafana Dashboard being unavailable.

What I'm doing:

Use external service

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
