### PR TITLE
[UT] Fix unstable primary key backup FEUT

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -164,6 +164,10 @@ public class BackupJob extends AbstractJob {
         testPrimaryKey = true;
     }
 
+    public Path getLocalJobDirPath() {
+        return localJobDirPath;
+    }
+
     public BackupJobState getState() {
         return state;
     }

--- a/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/BackupJobMaterializedViewTest.java
@@ -83,6 +83,8 @@ public class BackupJobMaterializedViewTest {
     private long repoId = 30000;
     private AtomicLong id = new AtomicLong(50000);
 
+    private static List<Path> pathsNeedToBeDeleted = Lists.newArrayList();
+
     @Mocked
     private GlobalStateMgr globalStateMgr;
 
@@ -124,19 +126,21 @@ public class BackupJobMaterializedViewTest {
     public static void start() {
         Config.tmp_dir = "./";
         File backupDir = new File(BackupHandler.TEST_BACKUP_ROOT_DIR.toString());
-        backupDir.mkdirs();
+        if (!backupDir.exists()) {
+            backupDir.mkdirs();
+        }
 
         MetricRepo.init();
     }
 
     @AfterAll
     public static void end() throws IOException {
-        Config.tmp_dir = "./";
-        File backupDir = new File(BackupHandler.TEST_BACKUP_ROOT_DIR.toString());
-        if (backupDir.exists()) {
-            Files.walk(BackupHandler.TEST_BACKUP_ROOT_DIR,
-                            FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
-                    .forEach(File::delete);
+        for (Path path : pathsNeedToBeDeleted) {
+            File backupDir = new File(path.toString());
+            if (backupDir.exists()) {
+                Files.walk(path, FileVisitOption.FOLLOW_LINKS).sorted(Comparator.reverseOrder()).map(Path::toFile)
+                        .forEach(File::delete);
+            }
         }
     }
 
@@ -371,6 +375,10 @@ public class BackupJobMaterializedViewTest {
         job.run();
         Assert.assertEquals(Status.OK, job.getStatus());
         Assert.assertEquals(BackupJobState.FINISHED, job.getState());
+
+        if (job.getLocalJobDirPath() != null) {
+            pathsNeedToBeDeleted.add(job.getLocalJobDirPath());
+        }
     }
 
     @Test
@@ -387,5 +395,9 @@ public class BackupJobMaterializedViewTest {
         job.run();
         Assert.assertEquals(Status.ErrCode.NOT_FOUND, job.getStatus().getErrCode());
         Assert.assertEquals(BackupJobState.CANCELLED, job.getState());
+
+        if (job.getLocalJobDirPath() != null) {
+            pathsNeedToBeDeleted.add(job.getLocalJobDirPath());
+        }
     }
 }


### PR DESCRIPTION
Why I'm doing:
primary key backup FEUT will failed sometime.The problem is BackupJobMaterializedViewTest and
BackupJobPrimaryKeyTest use the same root meta data snapshot path. And it may be deleted in
BackupJobMaterializedViewTest'end() when BackupJobPrimaryKeyTest is running. BackupJobPrimaryKeyTest
will get no file and dictoinary exception sometime.

What I'm doing:
Save all paths which needed to be deleted in all sub UT. And delete the paths in the end() function.
Do not delete the root path.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
