### PR TITLE
[Enhancement] disable hdfs scan count optimization when exists iceberg equality files

### DIFF
--- a/be/src/connector/hive_connector.cpp
+++ b/be/src/connector/hive_connector.cpp
@@ -294,6 +294,7 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
     // 1. can_use_any_column = true
     // 2. only one materialized slot
     // 3. besides that, all slots are partition slots.
+    // 4. scan iceberg data file without equality delete files.
     auto check_opt_on_iceberg = [&]() {
         if (!_can_use_any_column) {
             return false;
@@ -302,6 +303,9 @@ void HiveDataSource::_init_tuples_and_slots(RuntimeState* state) {
             return false;
         }
         if (_materialize_slots.size() != 1) {
+            return false;
+        }
+        if (!_scan_range.delete_column_slot_ids.empty()) {
             return false;
         }
         return true;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
Explicitly disable hdfs scan count optimization when iceberg equality files exist

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
