### PR TITLE
[UT] hdfs ut running in separate thread

### DIFF
--- a/be/test/fs/fs_hdfs_test.cpp
+++ b/be/test/fs/fs_hdfs_test.cpp
@@ -38,11 +38,13 @@ public:
     }
     void TearDown() override { ASSERT_TRUE(fs::remove_all(_root_path).ok()); }
 
+    void create_file_and_destroy();
+
 public:
     std::string _root_path;
 };
 
-TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
+void HdfsFileSystemTest::create_file_and_destroy() {
     auto fs = new_fs_hdfs(FSOptions());
     // use file:// as the fs scheme, which will leverage Hadoop LocalFileSystem for testing
     std::string filepath = "file://" + _root_path + "/create_file_and_destroy_file";
@@ -63,6 +65,12 @@ TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
 
     // done the file, check if there is any memory leak
     (*wfile).reset();
+}
+
+TEST_F(HdfsFileSystemTest, create_file_and_destroy) {
+    // NOTE: use separate thread to run the test case to avoid some weird tls memory issue introduced by JVM
+    auto thread = std::thread([this] { create_file_and_destroy(); });
+    thread.join();
 }
 
 } // namespace starrocks


### PR DESCRIPTION
* avoid jni tls polluting main thread, introduce some weird behavior

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
