### PR TITLE
[BugFix] Use delete predicates to filter data when creating sync mv (backport #38652)

### DIFF
--- a/be/src/storage/rowset/rowset.h
+++ b/be/src/storage/rowset/rowset.h
@@ -264,8 +264,6 @@ public:
 
     bool contains_version(Version version) const { return rowset_meta()->version().contains(version); }
 
-    DeletePredicatePB* mutable_delete_predicate() { return _rowset_meta->mutable_delete_predicate(); }
-
     static bool comparator(const RowsetSharedPtr& left, const RowsetSharedPtr& right) {
         return left->end_version() < right->end_version();
     }

--- a/be/src/storage/schema_change.cpp
+++ b/be/src/storage/schema_change.cpp
@@ -1079,12 +1079,6 @@ Status SchemaChangeHandler::_convert_historical_rowsets(SchemaChangeParams& sc_p
             LOG(WARNING) << "failed to build rowset: " << new_rowset.status() << ". exit alter process";
             break;
         }
-        LOG(INFO) << "new rowset has " << (*new_rowset)->num_segments() << " segments";
-        if (sc_params.rowsets_to_change[i]->rowset_meta()->has_delete_predicate()) {
-            (*new_rowset)
-                    ->mutable_delete_predicate()
-                    ->CopyFrom(sc_params.rowsets_to_change[i]->rowset_meta()->delete_predicate());
-        }
         status = sc_params.new_tablet->add_rowset(*new_rowset, false);
         if (status.is_already_exist()) {
             LOG(WARNING) << "version already exist, version revert occurred. "

--- a/be/src/storage/tablet_meta.cpp
+++ b/be/src/storage/tablet_meta.cpp
@@ -375,9 +375,8 @@ void TabletMeta::modify_rs_metas(const std::vector<RowsetMetaSharedPtr>& to_add,
         auto it = _rs_metas.begin();
         while (it != _rs_metas.end()) {
             if (rs_to_del->version() == (*it)->version()) {
-                if ((*it)->has_delete_predicate()) {
-                    remove_delete_predicate_by_version((*it)->version());
-                }
+                // delay delete "delete predicate" when deleting stale rowset
+                // fix https://github.com/StarRocks/starrocks/pull/20362
                 _rs_metas.erase(it);
                 // there should be only one rowset match the version
                 break;
@@ -411,6 +410,9 @@ void TabletMeta::delete_stale_rs_meta_by_version(const Version& version) {
     auto it = _stale_rs_metas.begin();
     while (it != _stale_rs_metas.end()) {
         if ((*it)->version() == version) {
+            if ((*it)->has_delete_predicate()) {
+                remove_delete_predicate_by_version((*it)->version());
+            }
             it = _stale_rs_metas.erase(it);
             // version wouldn't be duplicate
             break;

--- a/be/src/storage/tablet_reader.cpp
+++ b/be/src/storage/tablet_reader.cpp
@@ -458,15 +458,10 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
     PredicateParser pred_parser(_tablet->tablet_schema());
 
     std::shared_lock header_lock(_tablet->get_header_lock());
-    // here we can not use DeletePredicatePB from  _tablet->delete_predicates() because
-    // _rowsets maybe stale rowset, and stale rowset's delete predicates may be removed
-    // from _tablet->delete_predicates() after compation
-    for (const RowsetSharedPtr& rowset : _rowsets) {
-        const RowsetMetaSharedPtr& rowset_meta = rowset->rowset_meta();
-        if (!rowset_meta->has_delete_predicate()) {
+    for (const DeletePredicatePB& pred_pb : _tablet->delete_predicates()) {
+        if (pred_pb.version() > _delete_predicates_version.second) {
             continue;
         }
-        const DeletePredicatePB& pred_pb = rowset_meta->delete_predicate();
 
         ConjunctivePredicates conjunctions;
         for (int i = 0; i != pred_pb.sub_predicates_size(); ++i) {
@@ -514,6 +509,10 @@ Status TabletReader::_init_delete_predicates(const TabletReaderParams& params, D
             conjunctions.add(pred);
             // save for memory release.
             _predicate_free_list.emplace_back(pred);
+        }
+
+        if (conjunctions.empty()) {
+            continue;
         }
 
         dels->add(pred_pb.version(), conjunctions);

--- a/be/src/storage/tablet_reader.h
+++ b/be/src/storage/tablet_reader.h
@@ -86,7 +86,7 @@ private:
     TabletSharedPtr _tablet;
     Version _version;
     // version of delete predicates, equal as _version by default
-    // _delete_predicates_version will be set as max_version of tablet in schema change vectorized
+    // _delete_predicates_version will be set as max_version of tablet in schema change
     Version _delete_predicates_version;
 
     MemPool _mempool;

--- a/test/sql/test_materialized_view/R/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/R/test_sync_materialized_view2
@@ -1,0 +1,24 @@
+-- name: test_sync_materialized_view
+create table sync_mv_base_table_with_delete (k1 bigint, k2 bigint, k3 bigint) duplicate key(k1) distributed by hash(k1) buckets 1 properties ("replication_num" = "1");
+-- result:
+-- !result
+insert into sync_mv_base_table_with_delete values (1, 1, 1), (2, 2, 2);
+-- result:
+-- !result
+delete from sync_mv_base_table_with_delete where k1 = 1;
+-- result:
+-- !result
+create materialized view sync_mv_base_table_with_delete_mv1 as select k2, k3 from sync_mv_base_table_with_delete;
+-- result:
+-- !result
+function: wait_materialized_view_finish()
+-- result:
+None
+-- !result
+select k2 from sync_mv_base_table_with_delete_mv1 [_SYNC_MV_];
+-- result:
+2
+-- !result
+drop materialized view sync_mv_base_table_with_delete_mv1;
+-- result:
+-- !result

--- a/test/sql/test_materialized_view/T/test_sync_materialized_view2
+++ b/test/sql/test_materialized_view/T/test_sync_materialized_view2
@@ -1,0 +1,10 @@
+-- name: test_sync_materialized_view2
+
+-- base table with delete
+create table sync_mv_base_table_with_delete (k1 bigint, k2 bigint, k3 bigint) duplicate key(k1) distributed by hash(k1) buckets 1 properties ("replication_num" = "1");
+insert into sync_mv_base_table_with_delete values (1, 1, 1), (2, 2, 2);
+delete from sync_mv_base_table_with_delete where k1 = 1;
+create materialized view sync_mv_base_table_with_delete_mv1 as select k2, k3 from sync_mv_base_table_with_delete;
+function: wait_materialized_view_finish()
+select k2 from sync_mv_base_table_with_delete_mv1 [_SYNC_MV_];
+drop materialized view sync_mv_base_table_with_delete_mv1;


### PR DESCRIPTION

Why I'm doing:

What I'm doing:

Fixes #38652

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
