### PR TITLE
[Feature] support spill mode random mode

### DIFF
--- a/be/src/exec/chunks_sorter_full_sort.h
+++ b/be/src/exec/chunks_sorter_full_sort.h
@@ -72,11 +72,12 @@ private:
     void _assign_ordinals();
     template <typename T>
     void _assign_ordinals_tmpl();
-    ChunkPtr _late_materialize(const ChunkPtr& chunk);
     template <typename T>
     ChunkPtr _late_materialize_tmpl(const ChunkPtr& chunk);
 
 protected:
+    ChunkPtr _late_materialize(const ChunkPtr& chunk);
+
     size_t _total_rows = 0;        // Total rows of sorting data
     Permutation _sort_permutation; // Temp permutation for sorting
     size_t _staging_unsorted_rows = 0;

--- a/be/src/exec/pipeline/runtime_filter_types.h
+++ b/be/src/exec/pipeline/runtime_filter_types.h
@@ -249,6 +249,8 @@ public:
     }
 
     RuntimeInFilterList get_total_in_filters() {
+        // _partial_in_filters is empty means RF _is_always_true
+        if (_partial_in_filters.empty()) return {};
         return {_partial_in_filters[0].begin(), _partial_in_filters[0].end()};
     }
 

--- a/be/src/exec/spillable_chunks_sorter_sort.h
+++ b/be/src/exec/spillable_chunks_sorter_sort.h
@@ -46,8 +46,12 @@ private:
 
     Status _get_result_from_spiller(ChunkPtr* chunk, bool* eos);
 
-    size_t _process_staging_unsorted_chunk_idx = 0;
     // used in spill
+    // index for _staging_unsorted_chunk_idx
+    size_t _process_staging_unsorted_chunk_idx = 0;
+    // index for _sorted_chunk_idx
     size_t _process_sorted_chunk_idx = 0;
+    // index for _early_materialized_chunks
+    size_t _process_early_materialized_chunks_idx = 0;
 };
 } // namespace starrocks

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -349,6 +349,7 @@ public:
     bool spill_enable_direct_io() const {
         return _query_options.__isset.spill_enable_direct_io && _query_options.spill_enable_direct_io;
     }
+    double spill_rand_ratio() const { return _query_options.spill_rand_ratio; }
 
     int32_t spill_encode_level() const { return _query_options.spill_encode_level; }
 

--- a/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/SessionVariable.java
@@ -520,6 +520,8 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     public static final String SPILL_OPERATOR_MAX_BYTES = "spill_operator_max_bytes";
     public static final String SPILL_REVOCABLE_MAX_BYTES = "spill_revocable_max_bytes";
     public static final String SPILL_ENABLE_DIRECT_IO = "spill_enable_direct_io";
+    // only used in test. spill_mode="RANDOM"
+    public static final String SPILL_RAND_RATIO = "spill_rand_ratio";
     public static final String SPILL_ENCODE_LEVEL = "spill_encode_level";
 
     // full_sort_max_buffered_{rows,bytes} are thresholds that limits input size of partial_sort
@@ -955,6 +957,9 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
     
     @VarAttr(name = SPILL_ENABLE_DIRECT_IO)
     private boolean spillEnableDirectIO = false;
+    
+    @VarAttr(name = SPILL_RAND_RATIO, flag = VariableMgr.INVISIBLE)
+    private double spillRandRatio = 0.1;
 
     @VarAttr(name = ENABLE_AGG_SPILL_PREAGGREGATION, flag = VariableMgr.INVISIBLE)
     public boolean enableAggSpillPreaggregation = true;
@@ -3085,6 +3090,7 @@ public class SessionVariable implements Serializable, Writable, Cloneable {
             tResult.setSpillable_operator_mask(spillableOperatorMask);
             tResult.setEnable_agg_spill_preaggregation(enableAggSpillPreaggregation);
             tResult.setSpill_enable_direct_io(spillEnableDirectIO);
+            tResult.setSpill_rand_ratio(spillRandRatio);
         }
 
         // Compression Type

--- a/gensrc/thrift/InternalService.thrift
+++ b/gensrc/thrift/InternalService.thrift
@@ -102,7 +102,8 @@ enum TPipelineProfileLevel {
 enum TSpillMode {
   AUTO,
   FORCE,
-  NONE
+  NONE,
+  RANDOM,
 }
 
 enum TSpillableOperatorType {
@@ -204,6 +205,10 @@ struct TQueryOptions {
   78: optional i32 spill_encode_level;
   79: optional i64 spill_revocable_max_bytes;
   80: optional bool spill_enable_direct_io;
+  // only used in spill_mode="random"
+  // probability of triggering operator spill
+  // (0.0,1.0)
+  81: optional double spill_rand_ratio;
 
   85: optional TSpillMode spill_mode;
   

--- a/test/sql/test_spill/R/test_spill_random
+++ b/test/sql/test_spill/R/test_spill_random
@@ -15,13 +15,19 @@ DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
 insert into t1 values (1,"1");
 -- result:
 -- !result
-create table t2 as select sum(k1),k2 from t1 group by k2;
+CREATE TABLE t2 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
 -- result:
-E: (1064, 'Table replication num should be less than of equal to the number of available BE nodes. You can change this default by setting the replication_num table properties. Current alive backend is [10004]. table=t2, properties.replication_num=3')
+-- !result
+insert into t2 select sum(k1),k2 from t1 group by k2;
+-- result:
 -- !result
 select * from t2;
 -- result:
-E: (1064, "Getting analyzing error. Detail message: Unknown table 'test_db_6b74f34caebe11eeaab22586a6fea491.t2'.")
+1	1
 -- !result
 create table t0 (
     c0 INT,
@@ -147,7 +153,6 @@ PROPERTIES (
 -- !result
 insert into t2 select * from t1;
 -- result:
-E: (1064, 'Getting analyzing error. Detail message: Table t2 is not found.')
 -- !result
 select distinct c0, c1 from t4 order by 1, 2 limit 2;
 -- result:
@@ -196,4 +201,12 @@ select distinct c0, c1 from t5 order by 1, 2 limit 1;
 select count(*) from (select distinct c0, c1 from t5 limit 10) tb;
 -- result:
 10
+-- !result
+select count(*), sum(rn) from (select row_number() over (partition by c0, c1) as rn from t0) tb;
+-- result:
+16384	40960
+-- !result
+select count(*), sum(rk) from (select rank() over (partition by c0, c1) as rk from t0) tb;
+-- result:
+16384	16384
 -- !result

--- a/test/sql/test_spill/R/test_spill_random
+++ b/test/sql/test_spill/R/test_spill_random
@@ -1,0 +1,199 @@
+-- name: test_spill_random
+set enable_spill=true;
+-- result:
+-- !result
+set spill_mode="random";
+-- result:
+-- !result
+CREATE TABLE t1 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+-- result:
+-- !result
+insert into t1 values (1,"1");
+-- result:
+-- !result
+create table t2 as select sum(k1),k2 from t1 group by k2;
+-- result:
+E: (1064, 'Table replication num should be less than of equal to the number of available BE nodes. You can change this default by setting the replication_num table properties. Current alive backend is [10004]. table=t2, properties.replication_num=3')
+-- !result
+select * from t2;
+-- result:
+E: (1064, "Getting analyzing error. Detail message: Unknown table 'test_db_6b74f34caebe11eeaab22586a6fea491.t2'.")
+-- !result
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+insert into t0 select * from t0;
+-- result:
+-- !result
+select max(sl) from (select sum(c1) sl from t0 group by c0) tb;
+-- result:
+16380
+-- !result
+select avg(sl) from (select sum(c1) sl from t0 group by c0) tb;
+-- result:
+8190.0
+-- !result
+select count(sl) from (select sum(c1) sl from t0 group by c0) tb;
+-- result:
+4096
+-- !result
+select count(sl) from (select count(c1) sl from t0 group by c0) tb;
+-- result:
+4096
+-- !result
+set pipeline_dop = 1;
+-- result:
+-- !result
+create table t3 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t3 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  40960));
+-- result:
+-- !result
+insert into t3 values (null,null);
+-- result:
+-- !result
+insert into t3 select * from t3;
+-- result:
+-- !result
+insert into t3 select * from t3;
+-- result:
+-- !result
+select count(*) from t3;
+-- result:
+163844
+-- !result
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+-- result:
+None	None
+1	40959
+-- !result
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+-- result:
+40961	40960	0
+-- !result
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+-- result:
+100
+-- !result
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+-- result:
+40961	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+-- result:
+40860	40960	0
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+-- result:
+10	110	163400
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+-- result:
+100	100	163440
+-- !result
+select count(*) from (select array_agg(c0) from t3 group by c0) tb;
+-- result:
+40961
+-- !result
+with agged as ( select c0 as lk, c1 from t3 group by 1,2 ) select count(*),count(l.lk),count(l.c1),count(r.lk),count(r.c1) from agged l join agged r on l.lk = r.lk;
+-- result:
+40960	40960	40960	40960	40960
+-- !result
+create table tempty like t3;
+-- result:
+-- !result
+select count(*) from (select distinct c0, c1 from t3 l left semi join tempty r on l.c0 = r.c0) tb; 
+
+CREATE TABLE `t4` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c0`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"colocate_with" = "spill_agg_colocate_1",
+"compression" = "LZ4"
+);
+-- result:
+0
+-- !result
+insert into t2 select * from t1;
+-- result:
+E: (1064, 'Getting analyzing error. Detail message: Table t2 is not found.')
+-- !result
+select distinct c0, c1 from t4 order by 1, 2 limit 2;
+-- result:
+-- !result
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t4) tb;
+-- result:
+0	None	None
+-- !result
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t4 group by c0 having c0 > 100) tb;
+-- result:
+0	None	None
+-- !result
+create table t5 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 16 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+insert into t5 SELECT generate_series, 650000 - generate_series FROM TABLE(generate_series(1,  650000));
+-- result:
+-- !result
+select max(s1) from (select sum(c1) s1 from t5 group by c0) tb;
+-- result:
+649999
+-- !result
+select max(s1), avg(s2) from (select sum(c1) s1, sum(c0) s2 from t5 group by c0) tb;
+-- result:
+649999	325000.5
+-- !result
+select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2 from t5 group by c0 limit 10) tb;
+-- result:
+10	10
+-- !result
+select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0 from t5 group by c0 limit 10) tb;
+-- result:
+10	10
+-- !result
+select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0, c1 from t5 group by c0, c1 limit 10) tb;
+-- result:
+10	10
+-- !result
+select distinct c0, c1 from t5 order by 1, 2 limit 1;
+-- result:
+1	649999
+-- !result
+select count(*) from (select distinct c0, c1 from t5 limit 10) tb;
+-- result:
+10
+-- !result

--- a/test/sql/test_spill/T/test_spill_random
+++ b/test/sql/test_spill/T/test_spill_random
@@ -1,0 +1,93 @@
+-- name: test_spill_random
+
+set enable_spill=true;
+set spill_mode="random";
+
+CREATE TABLE t1 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+
+insert into t1 values (1,"1");
+create table t2 as select sum(k1),k2 from t1 group by k2;
+select * from t2;
+--
+create table t0 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+insert into t0 SELECT generate_series, 4096 - generate_series FROM TABLE(generate_series(1,  4096));
+insert into t0 select * from t0;
+insert into t0 select * from t0;
+
+select max(sl) from (select sum(c1) sl from t0 group by c0) tb;
+select avg(sl) from (select sum(c1) sl from t0 group by c0) tb;
+select count(sl) from (select sum(c1) sl from t0 group by c0) tb;
+select count(sl) from (select count(c1) sl from t0 group by c0) tb;
+
+set pipeline_dop = 1;
+create table t3 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 1 PROPERTIES('replication_num' = '1');
+
+insert into t3 SELECT generate_series, 40960 - generate_series FROM TABLE(generate_series(1,  40960));
+insert into t3 values (null,null);
+insert into t3 select * from t3;
+insert into t3 select * from t3;
+
+select count(*) from t3;
+select distinct c0, c1 from t3 order by 1, 2 limit 2;
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t3) tb;
+select count(*) from (select distinct c0, c1 from t3 limit 100) tb;
+select count(*), max(c0), min(c1) from (select c0, c1 from t3 group by c0, c1) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 having c0 > 100 limit 10) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t3 group by c0 limit 100) tb;
+select count(*) from (select array_agg(c0) from t3 group by c0) tb;
+with agged as ( select c0 as lk, c1 from t3 group by 1,2 ) select count(*),count(l.lk),count(l.c1),count(r.lk),count(r.c1) from agged l join agged r on l.lk = r.lk;
+-- short_circuit case
+create table tempty like t3;
+select count(*) from (select distinct c0, c1 from t3 l left semi join tempty r on l.c0 = r.c0) tb; 
+
+CREATE TABLE `t4` (
+  `c0` int(11) NOT NULL COMMENT "",
+  `c1` int(11) NOT NULL
+) ENGINE=OLAP 
+DUPLICATE KEY(`c0`)
+COMMENT "OLAP"
+PARTITION BY RANGE(`c0`)
+(
+PARTITION p1 VALUES [("-2147483648"), ("0")),
+PARTITION p2 VALUES [("0"), ("1024")),
+PARTITION p3 VALUES [("1024"), ("2048")),
+PARTITION p4 VALUES [("2048"), ("4096")),
+PARTITION p5 VALUES [("4096"), ("8192")),
+PARTITION p6 VALUES [("8192"), ("65536")),
+PARTITION p7 VALUES [("65536"), ("2100000000")))
+DISTRIBUTED BY HASH(`c0`) BUCKETS 1
+PROPERTIES (
+"replication_num" = "1",
+"colocate_with" = "spill_agg_colocate_1",
+"compression" = "LZ4"
+);
+insert into t2 select * from t1;
+
+select distinct c0, c1 from t4 order by 1, 2 limit 2;
+select count(*), max(tb.c0), min(tb.c1) from (select distinct c0, c1 from t4) tb;
+select count(*), max(c0), min(sc1) from (select c0, sum(c1) as sc1 from t4 group by c0 having c0 > 100) tb;
+-- 
+create table t5 (
+    c0 INT,
+    c1 BIGINT
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 16 PROPERTIES('replication_num' = '1');
+insert into t5 SELECT generate_series, 650000 - generate_series FROM TABLE(generate_series(1,  650000));
+-- 
+select max(s1) from (select sum(c1) s1 from t5 group by c0) tb;
+select max(s1), avg(s2) from (select sum(c1) s1, sum(c0) s2 from t5 group by c0) tb;
+select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2 from t5 group by c0 limit 10) tb;
+select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0 from t5 group by c0 limit 10) tb;
+select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0, c1 from t5 group by c0, c1 limit 10) tb;
+select distinct c0, c1 from t5 order by 1, 2 limit 1;
+select count(*) from (select distinct c0, c1 from t5 limit 10) tb;

--- a/test/sql/test_spill/T/test_spill_random
+++ b/test/sql/test_spill/T/test_spill_random
@@ -10,7 +10,12 @@ DUPLICATE KEY(k1)
 DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
 
 insert into t1 values (1,"1");
-create table t2 as select sum(k1),k2 from t1 group by k2;
+CREATE TABLE t2 (
+    k1 INT,
+    k2 VARCHAR(20))
+DUPLICATE KEY(k1)
+DISTRIBUTED BY HASH(k1) PROPERTIES('replication_num'='1');
+insert into t2 select sum(k1),k2 from t1 group by k2;
 select * from t2;
 --
 create table t0 (
@@ -91,3 +96,7 @@ select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0 from t5 grou
 select count(s1), count(s2) from (select sum(c1) s1, sum(c0) s2, c0, c1 from t5 group by c0, c1 limit 10) tb;
 select distinct c0, c1 from t5 order by 1, 2 limit 1;
 select count(*) from (select distinct c0, c1 from t5 limit 10) tb;
+
+-- test full sort
+select count(*), sum(rn) from (select row_number() over (partition by c0, c1) as rn from t0) tb;
+select count(*), sum(rk) from (select rank() over (partition by c0, c1) as rk from t0) tb;


### PR DESCRIPTION
Why I'm doing:
Most SQL test data will not trigger auto spill mode, so we introduce a random mode to override the auto mode test case.

What I'm doing:
introduce spill_mode "random"

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
