### PR TITLE
[BugFix] Check read size before reading data block from datacache.

### DIFF
--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -69,6 +69,9 @@ CacheInputStream::~CacheInputStream() {
 }
 
 Status CacheInputStream::_read_block(int64_t offset, int64_t size, char* out, bool can_zero_copy) {
+    if (UNLIKELY(size == 0)) {
+        return Status::OK();
+    }
     DCHECK(size <= _block_size);
     int64_t block_id = offset / _block_size;
 


### PR DESCRIPTION
Why I'm doing:
Sometimes we try to read a zero length data from `CacheInputStream`. For example, if an invalid parquet which contains a page header with 0 compressed size and 0 uncompressed size. This may cause the memory issue when reading data block from datacache.

What I'm doing:
Checking read size before reading data block from datacache.

Fixes [#5618](https://github.com/StarRocks/StarRocksTest/issues/5618)

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
