### PR TITLE
[BugFix] Fix not support true predicate on pk for short circuit read

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/OlapScanNode.java
@@ -1285,7 +1285,6 @@ public class OlapScanNode extends ScanNode {
 
         if (points.isPresent()) {
             rowStoreKeyLiterals = points.get();
-            return;
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlanner.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/ShortCircuitPlanner.java
@@ -30,8 +30,10 @@ import com.starrocks.sql.optimizer.operator.logical.LogicalProjectOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ColumnRefOperator;
 import com.starrocks.sql.optimizer.operator.scalar.ScalarOperator;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 
 public class ShortCircuitPlanner {
@@ -149,22 +151,30 @@ public class ShortCircuitPlanner {
         protected static boolean isPointScan(Table table, List<String> keyColumns, List<ScalarOperator> conjuncts) {
             Map<String, PartitionColumnFilter> filters = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
             filters.putAll(ColumnFilterConverter.convertColumnFilter(conjuncts, table));
+            Set<String> boolKeyColumns = new HashSet<>();
+            for (ScalarOperator conjunct : conjuncts) {
+                if (conjunct instanceof ColumnRefOperator) {
+                    boolKeyColumns.add(((ColumnRefOperator) conjunct).getName());
+                }
+            }
             if (keyColumns == null || keyColumns.isEmpty()) {
                 return false;
             }
             long cardinality = 1;
             for (String keyColumn : keyColumns) {
-                if (!filters.containsKey(keyColumn)) {
+                if (!filters.containsKey(keyColumn) && !boolKeyColumns.contains(keyColumn)) {
                     return false;
                 }
-                PartitionColumnFilter filter = filters.get(keyColumn);
-                if (filter.getInPredicateLiterals() != null) {
-                    cardinality *= filter.getInPredicateLiterals().size();
-                    if (cardinality > MAX_RETURN_ROWS) {
+                if (filters.containsKey(keyColumn)) {
+                    PartitionColumnFilter filter = filters.get(keyColumn);
+                    if (filter.getInPredicateLiterals() != null) {
+                        cardinality *= filter.getInPredicateLiterals().size();
+                        if (cardinality > MAX_RETURN_ROWS) {
+                            return false;
+                        }
+                    } else if (!filter.isPoint()) {
                         return false;
                     }
-                } else if (!filter.isPoint()) {
-                    return false;
                 }
             }
             return true;

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanTestBase.java
@@ -897,6 +897,19 @@ public class PlanTestBase extends PlanTestNoneDBBase {
                 "\"in_memory\" = \"false\"\n" +
                 ");");
 
+        starRocksAssert.withTable("CREATE TABLE `tprimary_bool` (\n" +
+                "  `pk1` bigint NOT NULL COMMENT \"\",\n" +
+                "  `pk2` BOOLEAN NOT NULL COMMENT \"\",\n" +
+                "  `v3` string NOT NULL COMMENT \"\",\n" +
+                "  `v4` int NOT NULL\n" +
+                ") ENGINE=OLAP\n" +
+                "PRIMARY KEY(pk1, pk2)\n" +
+                "DISTRIBUTED BY HASH(pk1, pk2) BUCKETS 3\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"in_memory\" = \"false\"\n" +
+                ");");
+
         starRocksAssert.withTable("CREATE TABLE `tjson` (\n" +
                 "  `v_int`  bigint NULL COMMENT \"\",\n" +
                 "  `v_json` json NULL COMMENT \"\" \n" +

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
@@ -39,10 +39,21 @@ public class ShortCircuitTest extends PlanTestBase {
         connectContext.getSessionVariable().setEnableShortCircuit(true);
         connectContext.getSessionVariable().setPreferComputeNode(true);
 
-        // support short circuit
+        // project support short circuit
         String sql = "select pk1 || v3 from tprimary1 where pk1=20";
         String planFragment = getFragmentPlan(sql);
         Assert.assertTrue(planFragment.contains("Short Circuit Scan: true"));
+
+        // boolean filter
+        sql = "select pk1 || v3 from tprimary_bool where pk1=20 and pk2=false";
+        planFragment = getFragmentPlan(sql);
+        Assert.assertTrue(planFragment.contains("Short Circuit Scan: true"));
+
+        // boolean filter
+        sql = "select pk1 || v3 from tprimary_bool where pk1=33 and pk2=true";
+        planFragment = getFragmentPlan(sql);
+        Assert.assertTrue(planFragment.contains("Short Circuit Scan: true"));
+
         //  support short circuit
         sql = "select * from tprimary1 where pk1 in (20)";
         planFragment = getFragmentPlan(sql);

--- a/test/sql/test_short_circuit/R/test_short_circuit
+++ b/test/sql/test_short_circuit/R/test_short_circuit
@@ -42,6 +42,33 @@ select c1||c2 from short_circuit where c1 = 6;
 -- result:
 66
 -- !result
+CREATE TABLE short_circuit_bool
+    (k1 int,
+     k2 boolean,
+    c2  int)
+    PRIMARY KEY(k1, k2)
+    DISTRIBUTED BY HASH(k1, k2)
+    BUCKETS 4
+    PROPERTIES ("replication_num" = "1");
+-- result:
+-- !result
+insert into short_circuit_bool values
+(1, true, 1),
+(2, true, 2),
+(3, false, 3),
+(4, true, 4),
+(5, true, 5),
+(6, true, 6),
+(7, true, 7),
+(8, true, 8),
+(9, true, 9),
+(10, true, 10);
+-- result:
+-- !result
+select * from short_circuit_bool where k1 = 6 and k2=true;
+-- result:
+6	1	6
+-- !result
 set enable_short_circuit=false;
 -- result:
 -- !result

--- a/test/sql/test_short_circuit/T/test_short_circuit
+++ b/test/sql/test_short_circuit/T/test_short_circuit
@@ -26,4 +26,25 @@ select * from short_circuit where c1 = 6;
 select * from short_circuit where c1 in (10);
 select c1||c2 from short_circuit where c1 = 6;
 
+CREATE TABLE short_circuit_bool
+    (k1 int,
+     k2 boolean,
+    c2  int)
+    PRIMARY KEY(k1, k2)
+    DISTRIBUTED BY HASH(k1, k2)
+    BUCKETS 4
+    PROPERTIES ("replication_num" = "1");
+insert into short_circuit_bool values
+(1, true, 1),
+(2, true, 2),
+(3, false, 3),
+(4, true, 4),
+(5, true, 5),
+(6, true, 6),
+(7, true, 7),
+(8, true, 8),
+(9, true, 9),
+(10, true, 10);
+select * from short_circuit_bool where k1 = 6 and k2=true;
+
 set enable_short_circuit=false;


### PR DESCRIPTION
Why I'm doing:
fix expr check bug like case :
```
select * from pk_table where pk = true;
```
What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
