### PR TITLE
[BugFix] Change operationType of OP_UPSERT_TRANSACTION_STATE_BATCH

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -431,6 +431,7 @@ public class OperationType {
     //Txn json format log
     public static final short OP_UPSERT_TRANSACTION_STATE_V2 = 12110;
     public static final short OP_SAVE_TRANSACTION_ID_V2 = 12111;
+    public static final short OP_UPSERT_TRANSACTION_STATE_BATCH = 12112;
 
     //colocate table json format log
     public static final short OP_COLOCATE_ADD_TABLE_V2 = 12130;
@@ -519,9 +520,6 @@ public class OperationType {
 
     // Replication job
     public static final short OP_REPLICATION_JOB = 13500;
-
-    // Batch publish
-    public static final short OP_UPSERT_TRANSACTION_STATE_BATCH = 13600;
 
     /**
      * NOTICE: OperationType cannot use a value exceeding 20000, and an error will be reported if it exceeds

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -227,8 +227,6 @@ public class OperationType {
     // light schema change for add and drop columns
     public static final short OP_MODIFY_TABLE_ADD_OR_DROP_COLUMNS = 107;
 
-    public static final short OP_UPSERT_TRANSACTION_STATE_BATCH = 108;
-
     // routine load 110~120
     @Deprecated
     public static final short OP_ROUTINE_LOAD_JOB = 110;
@@ -521,6 +519,9 @@ public class OperationType {
 
     // Replication job
     public static final short OP_REPLICATION_JOB = 13500;
+
+    // Batch publish
+    public static final short OP_UPSERT_TRANSACTION_STATE_BATCH = 13600;
 
     /**
      * NOTICE: OperationType cannot use a value exceeding 20000, and an error will be reported if it exceeds


### PR DESCRIPTION
Why I'm doing:
Newly added type should start from 10000, to avoid conflicting with community added type
What I'm doing:

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
