### PR TITLE
[Enhancement]table function generate_series support datetime type

### DIFF
--- a/be/src/exprs/table_function/generate_series.h
+++ b/be/src/exprs/table_function/generate_series.h
@@ -83,8 +83,8 @@ public:
             if (arg_start.is_null(curr_row) || arg_stop.is_null(curr_row) || step_is_null(curr_row)) {
                 move_to_next_row();
             } else {
-                auto start = (SeriesRunTimeType)arg_start.value(curr_row);
-                auto stop = (SeriesRunTimeType)arg_stop.value(curr_row);
+                auto start = static_cast<SeriesRunTimeType>(arg_start.value(curr_row));
+                auto stop = static_cast<SeriesRunTimeType>(arg_stop.value(curr_row));
                 auto step = get_step(curr_row);
                 auto offset = state->get_offset();
                 auto current = start;

--- a/be/src/exprs/table_function/table_function_factory.cpp
+++ b/be/src/exprs/table_function/table_function_factory.cpp
@@ -117,15 +117,55 @@ TableFunctionResolver::TableFunctionResolver() {
 
     // ----=====---- generate_series ----====----
     // implicit step size
-#define M(TYPE) add_function_mapping("generate_series", {TYPE, TYPE}, {TYPE}, std::make_shared<GenerateSeries<TYPE>>());
+#define M(TYPE) \
+    add_function_mapping("generate_series", {TYPE, TYPE}, {TYPE}, std::make_shared<GenerateSeries<TYPE, TYPE>>());
     APPLY_FOR_ALL_INT_TYPE(M)
 #undef M
 
     // explicit step size
-#define M(TYPE) \
-    add_function_mapping("generate_series", {TYPE, TYPE, TYPE}, {TYPE}, std::make_shared<GenerateSeries<TYPE>>());
+#define M(TYPE)                                                         \
+    add_function_mapping("generate_series", {TYPE, TYPE, TYPE}, {TYPE}, \
+                         std::make_shared<GenerateSeries<TYPE, TYPE, TimeUnit::DAY>>());
     APPLY_FOR_ALL_INT_TYPE(M)
 #undef M
+
+    // generate time series with implicit step size
+    add_function_mapping("generate_series_by_year", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::YEAR>>());
+
+    add_function_mapping("generate_series_by_month", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MONTH>>());
+
+    add_function_mapping("generate_series_by_day", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::DAY>>());
+
+    add_function_mapping("generate_series_by_hour", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::HOUR>>());
+
+    add_function_mapping("generate_series_by_minute", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MINUTE>>());
+
+    add_function_mapping("generate_series_by_second", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::SECOND>>());
+
+    // generate time series with explicit step size
+    add_function_mapping("generate_series_by_year", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::YEAR>>());
+
+    add_function_mapping("generate_series_by_month", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MONTH>>());
+
+    add_function_mapping("generate_series_by_day", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::DAY>>());
+
+    add_function_mapping("generate_series_by_hour", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::HOUR>>());
+
+    add_function_mapping("generate_series_by_minute", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MINUTE>>());
+
+    add_function_mapping("generate_series_by_second", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::SECOND>>());
 
     // ----=====---- list_rowsets ----====----
     add_function_mapping("list_rowsets", {TYPE_BIGINT, TYPE_BIGINT},

--- a/be/src/exprs/table_function/table_function_factory.cpp
+++ b/be/src/exprs/table_function/table_function_factory.cpp
@@ -129,43 +129,19 @@ TableFunctionResolver::TableFunctionResolver() {
     APPLY_FOR_ALL_INT_TYPE(M)
 #undef M
 
-    // generate time series with implicit step size
-    add_function_mapping("generate_series_by_year", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::YEAR>>());
-
-    add_function_mapping("generate_series_by_month", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MONTH>>());
-
-    add_function_mapping("generate_series_by_day", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::DAY>>());
-
-    add_function_mapping("generate_series_by_hour", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::HOUR>>());
-
-    add_function_mapping("generate_series_by_minute", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MINUTE>>());
-
-    add_function_mapping("generate_series_by_second", {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::SECOND>>());
-
-    // generate time series with explicit step size
-    add_function_mapping("generate_series_by_year", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::YEAR>>());
-
-    add_function_mapping("generate_series_by_month", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MONTH>>());
-
-    add_function_mapping("generate_series_by_day", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::DAY>>());
-
-    add_function_mapping("generate_series_by_hour", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::HOUR>>());
-
-    add_function_mapping("generate_series_by_minute", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::MINUTE>>());
-
-    add_function_mapping("generate_series_by_second", {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},
-                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::SECOND>>());
+    // generate time series
+#define M(NAME, TIMEUNIT)                                                                                  \
+    add_function_mapping(#NAME, {TYPE_DATETIME, TYPE_DATETIME}, {TYPE_DATETIME},                           \
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::TIMEUNIT>>()); \
+    add_function_mapping(#NAME, {TYPE_DATETIME, TYPE_DATETIME, TYPE_INT}, {TYPE_DATETIME},                 \
+                         std::make_shared<GenerateSeries<TYPE_DATETIME, TYPE_INT, TimeUnit::TIMEUNIT>>());
+    M(generate_series_by_year, YEAR)
+    M(generate_series_by_month, MONTH)
+    M(generate_series_by_day, DAY)
+    M(generate_series_by_hour, HOUR)
+    M(generate_series_by_minute, MINUTE)
+    M(generate_series_by_second, SECOND)
+#undef M
 
     // ----=====---- list_rowsets ----====----
     add_function_mapping("list_rowsets", {TYPE_BIGINT, TYPE_BIGINT},

--- a/docs/en/sql-reference/sql-functions/table-functions/generate_series.md
+++ b/docs/en/sql-reference/sql-functions/table-functions/generate_series.md
@@ -6,7 +6,7 @@ displayed_sidebar: "English"
 
 ## Description
 
-Generates a series of values within the interval specified by `start` and `end`, and with an optional `step`.
+Generates a series of integer or datetime values within the interval specified by `start` and `end`, and with an optional `step`.
 
 generate_series() is a table function. A table function can return a row set for each input row. The row set can contain zero, one, or multiple rows. Each row can contain one or more columns.
 
@@ -22,11 +22,12 @@ generate_series(start, end [,step])
 
 ## Parameters
 
-- `start`: the starting value of the series, required. Supported data types are INT, BIGINT, and LARGEINT.
-- `end`: the ending value of the series, required. Supported data types are INT, BIGINT, and LARGEINT.
-- `step`: the value to increment or decrement, optional.  Supported data types are INT, BIGINT, and LARGEINT. If not specified, the default step is 1. `step` can be either negative or positive, but cannot be zero.
+- `start`: the starting value of the series, required. Supported data types are INT, BIGINT, LARGEINT, DATE, and DATETIME.
+- `end`: the ending value of the series, required. Supported data types are INT, BIGINT, LARGEINT, DATE, and DATETIME.
+- `step`: the value to increment or decrement, optional. Supported data types are INT, BIGINT, and LARGEINT. If not specified, the default step is 1. `step` can be either negative or positive, but cannot be zero. when generate time series, `step` can support integer(default unit DAY) and time interval with following values: YEAR, MONTH, DAY, HOUR, MINUTE, SECOND.
 
-The three parameters must have the same data type, for example, `generate_series(INT start, INT end [, INT step])`.
+When generate integer series, the three parameters must have the same data type, for example, `generate_series(INT start, INT end [, INT step])`.
+When generate time series, `start` and `end` must be DATE/DATETIME or can be cast to DATETIME, invalid input datetime parameter will return zero rows, for example, `generate_series(DATETIME start, DATETIME end [, INTERVAL step DAY])`
 
 It supports named arguments from v3.3, where all parameters are input with names, like `name=>expr`, for example, `generate_series(start=>3, end=>7, step=>2)`. Named arguments can disorder arguments and optionally set default arguments, but can't mix with positional arguments.
 
@@ -151,6 +152,98 @@ MySQL > select * from TABLE(generate_series(start=>2, end=>5, step=>2));
 |               2 |
 |               4 |
 +-----------------+
+```
+Example 7: Generate time series within the range ['2023-12-31 23:59:56', '2024-01-01 00:00:06'] in ascending order with the specified time interval step `3` second.
+
+```SQL
+MySQL > select * from TABLE(generate_series('2023-12-31 23:59:56', '2024-01-01 00:00:06', interval 3 second));
++---------------------+
+| generate_series     |
++---------------------+
+| 2023-12-31 23:59:56 |
+| 2023-12-31 23:59:59 |
+| 2024-01-01 00:00:02 |
+| 2024-01-01 00:00:05 |
++---------------------+
+```
+Example 8: Generate time series within the range ['2023-11-25', '2024-01-20'] with the specified integer step `15`, default time unit DAY.
+
+```SQL
+MySQL > select * from TABLE(generate_series('2023-11-25', '2024-01-20', 15));
++---------------------+
+| generate_series     |
++---------------------+
+| 2023-11-25 00:00:00 |
+| 2023-12-10 00:00:00 |
+| 2023-12-25 00:00:00 |
+| 2024-01-09 00:00:00 |
++---------------------+
+```
+Example 9: Generate time series within the range ['2023-02-27', '2023-03-02'] without specified step, default step `INTERVAL 1 DAY`.
+
+```SQL
+MySQL > select * from table(generate_series('2023-02-27', '2023-03-02'));
++---------------------+
+| generate_series     |
++---------------------+
+| 2023-02-27 00:00:00 |
+| 2023-02-28 00:00:00 |
+| 2023-03-01 00:00:00 |
+| 2023-03-02 00:00:00 |
++---------------------+
+```
+Example 10: Use table columns as the input parameters of when generate time series. In this use case, you do not need to use `TABLE()` with generate_series().
+
+```SQL
+CREATE TABLE t_datetime (seq int, start datetime, end datetime, step int)
+DUPLICATE KEY (seq)
+DISTRIBUTED BY HASH(seq) BUCKETS 1;
+
+INSERT INTO t_datetime VALUES
+(1, '2023-12-31 23:59:57', '2024-01-01 00:00:04', 2),
+(2, '2024-01-01 00:00:06', '2023-12-31 23:59:56', -3),
+(3, NULL, '2024-01-01 00:00:04', 2),
+(4, '2023-12-31 23:59:57', NULL, 2),
+(5, '2023-12-31 23:59:57', '2024-01-01 00:00:04', NULL);
+
+SELECT * FROM t_datetime;
++------+---------------------+---------------------+------+
+| seq  | start               | end                 | step |
++------+---------------------+---------------------+------+
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 |
+|    2 | 2024-01-01 00:00:06 | 2023-12-31 23:59:56 |   -3 |
+|    3 | NULL                | 2024-01-01 00:00:04 |    2 |
+|    4 | 2023-12-31 23:59:57 | NULL                |    2 |
+|    5 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 | NULL |
++------+---------------------+---------------------+------+
+
+-- Generate multiple rows for rows with step interval 3 second.
+SELECT * FROM t_datetime, generate_series(t_datetime.start, t_datetime.end, interval 3 second);
++------+---------------------+---------------------+------+---------------------+
+| seq  | start               | end                 | step | generate_series     |
++------+---------------------+---------------------+------+---------------------+
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 | 2023-12-31 23:59:57 |
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 | 2024-01-01 00:00:00 |
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 | 2024-01-01 00:00:03 |
+|    5 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 | NULL | 2023-12-31 23:59:57 |
+|    5 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 | NULL | 2024-01-01 00:00:00 |
+|    5 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 | NULL | 2024-01-01 00:00:03 |
++------+---------------------+---------------------+------+---------------------+
+
+-- Generate multiple rows for rows with step column.
+SELECT * FROM t_datetime, generate_series(t_datetime.start, t_datetime.end, interval t_datetime.step second);
++------+---------------------+---------------------+------+---------------------+
+| seq  | start               | end                 | step | generate_series     |
++------+---------------------+---------------------+------+---------------------+
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 | 2023-12-31 23:59:57 |
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 | 2023-12-31 23:59:59 |
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 | 2024-01-01 00:00:01 |
+|    1 | 2023-12-31 23:59:57 | 2024-01-01 00:00:04 |    2 | 2024-01-01 00:00:03 |
+|    2 | 2024-01-01 00:00:06 | 2023-12-31 23:59:56 |   -3 | 2024-01-01 00:00:06 |
+|    2 | 2024-01-01 00:00:06 | 2023-12-31 23:59:56 |   -3 | 2024-01-01 00:00:03 |
+|    2 | 2024-01-01 00:00:06 | 2023-12-31 23:59:56 |   -3 | 2024-01-01 00:00:00 |
+|    2 | 2024-01-01 00:00:06 | 2023-12-31 23:59:56 |   -3 | 2023-12-31 23:59:57 |
++------+---------------------+---------------------+------+---------------------+
 ```
 
 ## keywords

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/FunctionSet.java
@@ -462,6 +462,9 @@ public class FunctionSet {
     public static final String STRUCT = "struct";
     public static final String NAMED_STRUCT = "named_struct";
 
+    // table function
+    public static final String GENERATE_SERIES = "generate_series";
+
     // JSON functions
     public static final Function JSON_QUERY_FUNC = new Function(
             new FunctionName(JSON_QUERY), new Type[] {Type.JSON, Type.VARCHAR}, Type.JSON, false);

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TableFunction.java
@@ -21,6 +21,7 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.analysis.Expr;
 import com.starrocks.analysis.FunctionName;
 import com.starrocks.analysis.LiteralExpr;
+import com.starrocks.analysis.TimestampArithmeticExpr.TimeUnit;
 import com.starrocks.common.AnalysisException;
 import com.starrocks.common.Pair;
 import com.starrocks.common.io.Text;
@@ -126,6 +127,25 @@ public class TableFunction extends Function {
                     Lists.newArrayList("generate_series"),
                     Lists.newArrayList(type, type, type),
                     Lists.newArrayList(type), defaultArgs);
+            functionSet.addBuiltin(func);
+        }
+
+        //generate time series
+        for (TimeUnit timeUnit : Lists.newArrayList(TimeUnit.YEAR, TimeUnit.MONTH, TimeUnit.DAY, TimeUnit.HOUR,
+                TimeUnit.MINUTE, TimeUnit.SECOND)) {
+            String funcOpName = String.format("%s_BY_%s", FunctionSet.GENERATE_SERIES, timeUnit.name());
+
+            Vector<Pair<String, Expr>> defaultArgs = new Vector<>();
+            try {
+                defaultArgs.add(new Pair("step", LiteralExpr.create("1", Type.INT)));
+            } catch (AnalysisException ex) { //ignored
+            }
+            // generate time series
+            TableFunction func = new TableFunction(new FunctionName(funcOpName),
+                    Lists.newArrayList("start", "end", "step"),
+                    Lists.newArrayList("generate_series"),
+                    Lists.newArrayList(Type.DATETIME, Type.DATETIME, Type.INT),
+                    Lists.newArrayList(Type.DATETIME), defaultArgs);
             functionSet.addBuiltin(func);
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/analyzer/QueryAnalyzer.java
@@ -904,13 +904,20 @@ public class QueryAnalyzer {
                     }
 
                     String unit = TimestampArithmeticExpr.TimeUnit.DAY.name();
-                    if (args.size() > stepParamIndex && args.get(stepParamIndex) instanceof IntervalLiteral) {
-                        IntervalLiteral stepExpr = (IntervalLiteral) args.get(stepParamIndex);
-                        Expr intervalValue = stepExpr.getValue();
-                        analyzeExpression(intervalValue, analyzeState, scope);
-                        argTypes[stepParamIndex] = intervalValue.getType();
-                        node.getFunctionParams().exprs().set(stepParamIndex, intervalValue);
-                        unit = stepExpr.getUnitIdentifier().getDescription();
+                    if (args.size() > stepParamIndex) {
+                        if (args.get(stepParamIndex) instanceof IntervalLiteral) {
+                            IntervalLiteral stepExpr = (IntervalLiteral) args.get(stepParamIndex);
+                            Expr intervalValue = stepExpr.getValue();
+                            analyzeExpression(intervalValue, analyzeState, scope);
+                            argTypes[stepParamIndex] = intervalValue.getType();
+                            node.getFunctionParams().exprs().set(stepParamIndex, intervalValue);
+                            unit = stepExpr.getUnitIdentifier().getDescription();
+                        }
+                        if (!argTypes[stepParamIndex].isFixedPointType()) {
+                            throw new SemanticException("step/interval value expr must be integer type " +
+                                "when use table function '%s' generate time series, currently '%s'",
+                                functionName, argTypes[stepParamIndex]);
+                        }
                     }
 
                     functionName = String.format("%s_BY_%s", FunctionSet.GENERATE_SERIES, unit);

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -299,6 +299,9 @@ public class AnalyzeFunctionTest {
     @Test
     public void testTableFunction() throws Exception {
         analyzeSuccess("SELECT * FROM TABLE(generate_series(2, 5, 2));");
+        analyzeSuccess("SELECT * FROM TABLE(generate_series(start => 2, end => 5, step => 2));");
         analyzeSuccess("select * from table(generate_series('2023-12-31 19:00:00', '2024-01-01 00:00:00', interval 3 hour));");
+        analyzeSuccess("select * from table(generate_series"
+                + "(start => '2023-12-31 19:00:00', end => '2024-01-01 00:00:00', step => interval 3 hour));");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/AnalyzeFunctionTest.java
@@ -295,4 +295,10 @@ public class AnalyzeFunctionTest {
         analyzeFail("select covar_pop(v1,3) from t0");
         analyzeFail("select corr(v1) from t0");
     }
+
+    @Test
+    public void testTableFunction() throws Exception {
+        analyzeSuccess("SELECT * FROM TABLE(generate_series(2, 5, 2));");
+        analyzeSuccess("select * from table(generate_series('2023-12-31 19:00:00', '2024-01-01 00:00:00', interval 3 hour));");
+    }
 }

--- a/test/sql/test_generate_series/R/test_generate_time_series
+++ b/test/sql/test_generate_series/R/test_generate_time_series
@@ -133,3 +133,39 @@ select * from table(generate_series('2024-03-08', '1996-04-02', interval -3 year
 2000-03-08 00:00:00
 1997-03-08 00:00:00
 -- !result
+-- name: generate_series_abnormal_case_01
+SELECT * from table(generate_series('2023-12-29 00:00:00', '2024-01-02 00:00:00', 2.4));
+-- result:
+E: (1064, "Getting analyzing error. Detail message: step/interval value expr must be integer type when use table function 'generate_series' generate time series, currently 'DECIMAL32(2,1)'.")
+-- !result
+SELECT * from table(generate_series('2023-12-29 00:00:00', '2024-01-02 00:00:00', interval 2.3 second));
+-- result:
+E: (1064, "Getting analyzing error. Detail message: step/interval value expr must be integer type when use table function 'generate_series' generate time series, currently 'DECIMAL32(2,1)'.")
+-- !result
+-- name: generate_series_abnormal_case_02
+CREATE TABLE t_datetime (seq int, start datetime, end datetime, step int) DUPLICATE KEY(`seq`) DISTRIBUTED BY HASH(seq) BUCKETS 1;
+-- result:
+-- !result
+INSERT INTO t_datetime VALUES(1, '2023-12-31 23:59:57', '2024-01-01 00:00:04', 2),(2, NULL, '2024-01-01 00:00:04', 2),(3, '2023-12-31 23:59:57', NULL, 2),(4, '2023-12-31 23:59:57', '2024-01-01 00:00:04', NULL);
+-- result:
+-- !result
+SELECT * FROM t_datetime, generate_series(t_datetime.start, t_datetime.end, interval 3 second);
+-- result:
+1	2023-12-31 23:59:57	2024-01-01 00:00:04	2	2023-12-31 23:59:57
+1	2023-12-31 23:59:57	2024-01-01 00:00:04	2	2024-01-01 00:00:00
+1	2023-12-31 23:59:57	2024-01-01 00:00:04	2	2024-01-01 00:00:03
+5	2023-12-31 23:59:57	2024-01-01 00:00:04	NULL	2023-12-31 23:59:57
+5	2023-12-31 23:59:57	2024-01-01 00:00:04	NULL	2024-01-01 00:00:00
+5	2023-12-31 23:59:57	2024-01-01 00:00:04	NULL	2024-01-01 00:00:03
+-- !result
+SELECT * FROM t_datetime, generate_series(start, end, interval step second);
+-- result:
+1	2023-12-31 23:59:57	2024-01-01 00:00:04	2	2023-12-31 23:59:57
+1	2023-12-31 23:59:57	2024-01-01 00:00:04	2	2023-12-31 23:59:59
+1	2023-12-31 23:59:57	2024-01-01 00:00:04	2	2024-01-01 00:00:01
+1	2023-12-31 23:59:57	2024-01-01 00:00:04	2	2024-01-01 00:00:03
+2	2024-01-01 00:00:06	2023-12-31 23:59:56	-3	2024-01-01 00:00:06
+2	2024-01-01 00:00:06	2023-12-31 23:59:56	-3	2024-01-01 00:00:03
+2	2024-01-01 00:00:06	2023-12-31 23:59:56	-3	2024-01-01 00:00:00
+2	2024-01-01 00:00:06	2023-12-31 23:59:56	-3	2023-12-31 23:59:57
+-- !result

--- a/test/sql/test_generate_series/R/test_generate_time_series
+++ b/test/sql/test_generate_series/R/test_generate_time_series
@@ -1,0 +1,135 @@
+-- name: generate_series_by_seconds_01
+select * from table(generate_series('2023-12-31 23:59:56', '2024-01-01 00:00:06', interval 3 second));
+-- result:
+2023-12-31 23:59:56
+2023-12-31 23:59:59
+2024-01-01 00:00:02
+2024-01-01 00:00:05
+-- !result
+-- name: generate_series_by_seconds_02
+select * from table(generate_series('2024-01-01 00:00:06', '2023-12-31 23:59:56', interval 3 second));
+-- result:
+-- !result
+-- name: generate_series_by_seconds_03
+select * from table(generate_series('2024-01-01 00:00:06', '2023-12-31 23:59:56', interval -3 second));
+-- result:
+2024-01-01 00:00:06
+2024-01-01 00:00:03
+2024-01-01 00:00:00
+2023-12-31 23:59:57
+-- !result
+-- name: generate_series_by_minute_01
+select * from table(generate_series('2023-12-31 23:57:56', '2024-01-01 00:05:06', interval 2 minute));
+-- result:
+2023-12-31 23:57:56
+2023-12-31 23:59:56
+2024-01-01 00:01:56
+2024-01-01 00:03:56
+-- !result
+-- name: generate_series_by_minute_02
+select * from table(generate_series('2024-01-01 00:05:06', '2023-12-31 23:57:56', interval -2 minute));
+-- result:
+2024-01-01 00:05:06
+2024-01-01 00:03:06
+2024-01-01 00:01:06
+2023-12-31 23:59:06
+-- !result
+-- name: generate_series_by_hour_01
+select * from table(generate_series('2023-12-31 19:59:56', '2024-01-01 02:00:06', interval 3 hour));
+-- result:
+2023-12-31 19:59:56
+2023-12-31 22:59:56
+2024-01-01 01:59:56
+-- !result
+-- name: generate_series_by_hour_02
+select * from table(generate_series('2024-01-01 02:00:06', '2023-12-31 19:59:56', interval -3 hour));
+-- result:
+2024-01-01 02:00:06
+2023-12-31 23:00:06
+2023-12-31 20:00:06
+-- !result
+-- name: generate_series_by_day_01
+select * from table(generate_series('2023-02-27', '2023-03-02'));
+-- result:
+2023-02-27 00:00:00
+2023-02-28 00:00:00
+2023-03-01 00:00:00
+2023-03-02 00:00:00
+-- !result
+-- name: generate_series_by_day_02
+select * from table(generate_series('2024-02-27 02:05:15', '2024-03-02 04:11:17'));
+-- result:
+2024-02-27 02:05:15
+2024-02-28 02:05:15
+2024-02-29 02:05:15
+2024-03-01 02:05:15
+2024-03-02 02:05:15
+-- !result
+-- name: generate_series_by_day_03
+select * from table(generate_series('2023-02-02', '2023-01-30'));
+-- result:
+-- !result
+-- name: generate_series_by_day_04
+select * from table(generate_series('2023-11-25', '2024-01-20', 15));
+-- result:
+2023-11-25 00:00:00
+2023-12-10 00:00:00
+2023-12-25 00:00:00
+2024-01-09 00:00:00
+-- !result
+-- name: generate_series_by_day_04
+select * from table(generate_series('2023-01-30', '2023-02-02', interval 2 day));
+-- result:
+2023-01-30 00:00:00
+2023-02-01 00:00:00
+-- !result
+-- name: generate_series_by_day_06
+select * from table(generate_series('2023-02-02', '2023-01-30', -2));
+-- result:
+2023-02-02 00:00:00
+2023-01-31 00:00:00
+-- !result
+-- name: generate_series_by_month_01
+select * from table(generate_series('2023-04-02', '2024-03-08', interval 3 month));
+-- result:
+2023-04-02 00:00:00
+2023-07-02 00:00:00
+2023-10-02 00:00:00
+2024-01-02 00:00:00
+-- !result
+-- name: generate_series_by_month_02
+select * from table(generate_series('2024-03-08', '2023-04-02', interval -3 month));
+-- result:
+2024-03-08 00:00:00
+2023-12-08 00:00:00
+2023-09-08 00:00:00
+2023-06-08 00:00:00
+-- !result
+-- name: generate_series_by_month_01
+select * from table(generate_series('1996-04-02', '2024-03-08', interval 3 year));
+-- result:
+1996-04-02 00:00:00
+1999-04-02 00:00:00
+2002-04-02 00:00:00
+2005-04-02 00:00:00
+2008-04-02 00:00:00
+2011-04-02 00:00:00
+2014-04-02 00:00:00
+2017-04-02 00:00:00
+2020-04-02 00:00:00
+2023-04-02 00:00:00
+-- !result
+-- name: generate_series_by_month_02
+select * from table(generate_series('2024-03-08', '1996-04-02', interval -3 year));
+-- result:
+2024-03-08 00:00:00
+2021-03-08 00:00:00
+2018-03-08 00:00:00
+2015-03-08 00:00:00
+2012-03-08 00:00:00
+2009-03-08 00:00:00
+2006-03-08 00:00:00
+2003-03-08 00:00:00
+2000-03-08 00:00:00
+1997-03-08 00:00:00
+-- !result

--- a/test/sql/test_generate_series/T/test_generate_time_series
+++ b/test/sql/test_generate_series/T/test_generate_time_series
@@ -32,3 +32,11 @@ select * from table(generate_series('2024-03-08', '2023-04-02', interval -3 mont
 select * from table(generate_series('1996-04-02', '2024-03-08', interval 3 year));
 -- name: generate_series_by_month_02
 select * from table(generate_series('2024-03-08', '1996-04-02', interval -3 year));
+-- name: generate_series_abnormal_case_01
+SELECT * from table(generate_series('2023-12-29 00:00:00', '2024-01-02 00:00:00', 2.4));
+SELECT * from table(generate_series('2023-12-29 00:00:00', '2024-01-02 00:00:00', interval 2.3 second));
+-- name: generate_series_abnormal_case_02
+CREATE TABLE t_datetime (seq int, start datetime, end datetime, step int) DUPLICATE KEY(`seq`) DISTRIBUTED BY HASH(seq) BUCKETS 1;
+INSERT INTO t_datetime VALUES(1, '2023-12-31 23:59:57', '2024-01-01 00:00:04', 2),(2, '2024-01-01 00:00:06', '2023-12-31 23:59:56', -3),(3, NULL, '2024-01-01 00:00:04', 2),(4, '2023-12-31 23:59:57', NULL, 2),(5, '2023-12-31 23:59:57', '2024-01-01 00:00:04', NULL);
+SELECT * FROM t_datetime, generate_series(t_datetime.start, t_datetime.end, interval 3 second);
+SELECT * FROM t_datetime, generate_series(start, end, interval step second);

--- a/test/sql/test_generate_series/T/test_generate_time_series
+++ b/test/sql/test_generate_series/T/test_generate_time_series
@@ -1,0 +1,34 @@
+-- name: generate_series_by_seconds_01
+select * from table(generate_series('2023-12-31 23:59:56', '2024-01-01 00:00:06', interval 3 second));
+-- name: generate_series_by_seconds_02
+select * from table(generate_series('2024-01-01 00:00:06', '2023-12-31 23:59:56', interval 3 second));
+-- name: generate_series_by_seconds_03
+select * from table(generate_series('2024-01-01 00:00:06', '2023-12-31 23:59:56', interval -3 second));
+-- name: generate_series_by_minute_01
+select * from table(generate_series('2023-12-31 23:57:56', '2024-01-01 00:05:06', interval 2 minute));
+-- name: generate_series_by_minute_02
+select * from table(generate_series('2024-01-01 00:05:06', '2023-12-31 23:57:56', interval -2 minute));
+-- name: generate_series_by_hour_01
+select * from table(generate_series('2023-12-31 19:59:56', '2024-01-01 02:00:06', interval 3 hour));
+-- name: generate_series_by_hour_02
+select * from table(generate_series('2024-01-01 02:00:06', '2023-12-31 19:59:56', interval -3 hour));
+-- name: generate_series_by_day_01
+select * from table(generate_series('2023-02-27', '2023-03-02'));
+-- name: generate_series_by_day_02
+select * from table(generate_series('2024-02-27 02:05:15', '2024-03-02 04:11:17'));
+-- name: generate_series_by_day_03
+select * from table(generate_series('2023-02-02', '2023-01-30'));
+-- name: generate_series_by_day_04
+select * from table(generate_series('2023-11-25', '2024-01-20', 15));
+-- name: generate_series_by_day_04
+select * from table(generate_series('2023-01-30', '2023-02-02', interval 2 day));
+-- name: generate_series_by_day_06
+select * from table(generate_series('2023-02-02', '2023-01-30', -2));
+-- name: generate_series_by_month_01
+select * from table(generate_series('2023-04-02', '2024-03-08', interval 3 month));
+-- name: generate_series_by_month_02
+select * from table(generate_series('2024-03-08', '2023-04-02', interval -3 month));
+-- name: generate_series_by_month_01
+select * from table(generate_series('1996-04-02', '2024-03-08', interval 3 year));
+-- name: generate_series_by_month_02
+select * from table(generate_series('2024-03-08', '1996-04-02', interval -3 year));


### PR DESCRIPTION
Why I'm doing:
In some case we need generate a series of datetime values from start to stop.

What I'm doing:

generate_series support datetime type, and the result is a set of datetime values
```
generate_series(start [DATETIME], stop [DATETIME], INTERVAL step [INT] YEAR/MONTH/DAY/HOUR/MINUTE/SECOND)

mysql> select * from table(generate_series('2023-12-31 19:59:56', '2024-01-01 02:00:06', interval 3 hour));
| generate_series     |
+---------------------+
| 2023-12-31 19:59:56 |
| 2023-12-31 22:59:56 |
| 2024-01-01 01:59:56 |
+---------------------+
3 rows in set (0.01 sec)
```

```
generate_series(start [DATETIME], stop [DATETIME], step [INT])，  default interval unit day

mysql> select * from table(generate_series('2023-11-25', '2024-01-20', 15));
+---------------------+
| generate_series     |
+---------------------+
| 2023-11-25 00:00:00 |
| 2023-12-10 00:00:00 |
| 2023-12-25 00:00:00 |
| 2024-01-09 00:00:00 |
+---------------------+
4 rows in set (0.01 sec)
```

```
generate_series(start [DATETIME], stop [DATETIME]), default step is "interal 1 day"

mysql> select * from table(generate_series('2023-02-27', '2023-03-02'));
+---------------------+
| generate_series     |
+---------------------+
| 2023-02-27 00:00:00 |
| 2023-02-28 00:00:00 |
| 2023-03-01 00:00:00 |
| 2023-03-02 00:00:00 |
+---------------------+
4 rows in set (0.01 sec)
```

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5