### PR TITLE
[BugFix] Fix naaj when join conditions has binary equal predicates for 3.1 (backport #38348)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/scalar/ScalarOperator.java
@@ -41,6 +41,8 @@ public abstract class ScalarOperator implements Cloneable {
     // whether the ScalarOperator is pushdown from equivalence derivation
     protected boolean isPushdown = false;
 
+    protected boolean isCorrelated = false;
+
     private List<String> hints = Collections.emptyList();
 
     public ScalarOperator(OperatorType opType, Type type) {
@@ -237,6 +239,14 @@ public abstract class ScalarOperator implements Cloneable {
 
     public void setIsPushdown(boolean isPushdown) {
         this.isPushdown = isPushdown;
+    }
+
+    public boolean isCorrelated() {
+        return isCorrelated;
+    }
+
+    public void setCorrelated(boolean correlated) {
+        isCorrelated = correlated;
     }
 
     // whether ScalarOperator are equals without id

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/QuantifiedApply2JoinRule.java
@@ -90,9 +90,11 @@ public class QuantifiedApply2JoinRule extends TransformationRule {
         OptExpression joinExpression;
         if (isNotIn) {
             //@TODO: if will can filter null, use left-anti-join
+            List<ScalarOperator> correlatedConjuncts = Utils.extractConjuncts(apply.getCorrelationConjuncts());
+            correlatedConjuncts.forEach(conjunct -> conjunct.setCorrelated(true));
             joinExpression = new OptExpression(new LogicalJoinOperator(JoinOperator.NULL_AWARE_LEFT_ANTI_JOIN,
                     Utils.compoundAnd(simplifiedPredicate,
-                            Utils.compoundAnd(apply.getCorrelationConjuncts(), apply.getPredicate()))));
+                            Utils.compoundAnd(Utils.compoundAnd(correlatedConjuncts), apply.getPredicate()))));
         } else {
             joinExpression = new OptExpression(new LogicalJoinOperator(JoinOperator.LEFT_SEMI_JOIN,
                     Utils.compoundAnd(simplifiedPredicate,

--- a/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/plan/PlanFragmentBuilder.java
@@ -2901,7 +2901,6 @@ public class PlanFragmentBuilder {
 
             List<BinaryPredicateOperator> eqOnPredicates = JoinHelper.getEqualsPredicate(
                     leftChildColumns, rightChildColumns, onPredicates);
-            Preconditions.checkState(!eqOnPredicates.isEmpty(), "must be eq-join");
 
             for (BinaryPredicateOperator s : eqOnPredicates) {
                 if (!optExpr.inputAt(0).getLogicalProperty().getOutputColumns()
@@ -2909,6 +2908,8 @@ public class PlanFragmentBuilder {
                     s.swap();
                 }
             }
+            eqOnPredicates = eqOnPredicates.stream().filter(p -> !p.isCorrelated()).collect(Collectors.toList());
+            Preconditions.checkState(!eqOnPredicates.isEmpty(), "must be eq-join");
 
             List<Expr> eqJoinConjuncts =
                     eqOnPredicates.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
@@ -2921,7 +2922,7 @@ public class PlanFragmentBuilder {
                 }
             }
 
-            List<ScalarOperator> otherJoin = Utils.extractConjuncts(onPredicate);
+            List<ScalarOperator> otherJoin = onPredicates;
             otherJoin.removeAll(eqOnPredicates);
             List<Expr> otherJoinConjuncts = otherJoin.stream().map(e -> ScalarOperatorToExpr.buildExecExpression(e,
                             new ScalarOperatorToExpr.FormatterContext(context.getColRefToExpr())))

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2787,6 +2787,6 @@ public class JoinTest extends PlanTestBase {
                 "                                 FROM t0 AS t0_6\n" +
                 "                                 WHERE (t0_6.v1) = (subt0.v1)))))";
         String plan = getFragmentPlan(query);
-        assertContains(plan, "other join predicates: 4: v1 = 1: v1");
+        assertContains(plan, "other join predicates: 1: v1 = 4: v1");
     }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/JoinTest.java
@@ -2773,4 +2773,20 @@ public class JoinTest extends PlanTestBase {
             connectContext.getSessionVariable().setPreferComputeNode(false);
         }
     }
+
+    @Test
+    public void testNullAwareLeftAntiJoin() throws Exception {
+        String query = "SELECT subt0.v1\n" +
+                "FROM\n" +
+                "  (SELECT t0_6.v1,\n" +
+                "          t0_6.v2,\n" +
+                "          t0_6.v3\n" +
+                "   FROM t0 AS t0_6) subt0 \n" +
+                "WHERE (NOT ((subt0.v2) IN (\n" +
+                "                                (SELECT t0_6.v2\n" +
+                "                                 FROM t0 AS t0_6\n" +
+                "                                 WHERE (t0_6.v1) = (subt0.v1)))))";
+        String plan = getFragmentPlan(query);
+        assertContains(plan, "other join predicates: 4: v1 = 1: v1");
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/SubqueryTest.java
@@ -1173,7 +1173,7 @@ public class SubqueryTest extends PlanTestBase {
                     "  |  join op: NULL AWARE LEFT ANTI JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +
                     "  |  equal join conjunct: 2: v2 = 12: v8\n" +
-                    "  |  equal join conjunct: 2: v2 = 13: v9");
+                    "  |  other join predicates: 2: v2 = 13: v9");
             assertContains(plan, "3:HASH JOIN\n" +
                     "  |  join op: LEFT SEMI JOIN (BROADCAST)\n" +
                     "  |  colocate: false, reason: \n" +


### PR DESCRIPTION
Why I'm doing:
Now when not in is correlated subquery and the subquery has binary column equal predicate, we treat it as equal conjuncts of left anti join, which will miss the null results in null aware left anti join.

What I'm doing:
Fix naaj bug when join conditions has binary equal predicates by treating
correlated predicates as other conjuncts of left anti join.

Fixes https://github.com/StarRocks/StarRocksTest/issues/4818

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

