### PR TITLE
[BugFix] Check read size before reading data block from datacache. (backport #38722)

### DIFF
--- a/be/src/io/cache_input_stream.cpp
+++ b/be/src/io/cache_input_stream.cpp
@@ -65,8 +65,11 @@ Status CacheInputStream::read_at_fully(int64_t offset, void* out, int64_t count)
     char* pe = p + count;
 
     auto read_one_block = [&](size_t offset, size_t size) {
-        StatusOr<size_t> res;
+        if (UNLIKELY(size == 0)) {
+            return Status::OK();
+        }
 
+        StatusOr<size_t> res;
         DCHECK(size <= BLOCK_SIZE);
         {
             SCOPED_RAW_TIMER(&_stats.read_cache_ns);

--- a/be/test/io/cache_input_stream_test.cpp
+++ b/be/test/io/cache_input_stream_test.cpp
@@ -199,4 +199,27 @@ TEST_F(CacheInputStreamTest, test_file_overwrite) {
     ASSERT_EQ(stats2.read_cache_count, 0);
 }
 
+TEST_F(CacheInputStreamTest, test_read_with_zero_range) {
+    const int64_t block_count = 1;
+    int64_t data_size = block_size * block_count;
+    char data[data_size + 1];
+    gen_test_data(data, data_size, block_size);
+
+    std::shared_ptr<io::SeekableInputStream> stream(new MockSeekableInputStream(data, data_size));
+    io::CacheInputStream cache_stream(stream, "test_file4", data_size, 1000000);
+    cache_stream.set_enable_populate_cache(true);
+    auto& stats = cache_stream.stats();
+
+    // read from backend, cache the data
+    char buffer[block_size];
+    read_stream_data(&cache_stream, 0, block_size, buffer);
+    ASSERT_TRUE(check_data_content(buffer, block_size, 'a'));
+    ASSERT_EQ(stats.read_cache_count, 0);
+    ASSERT_EQ(stats.write_cache_count, 1);
+
+    // try read zero length data, expect no crash
+    read_stream_data(&cache_stream, 0, 0, nullptr);
+    ASSERT_EQ(stats.read_cache_count, 0);
+}
+
 } // namespace starrocks::io


### PR DESCRIPTION
Why I'm doing:
Sometimes we try to read a zero length data from `CacheInputStream`. For example, if an invalid parquet which contains a page header with 0 compressed size and 0 uncompressed size. This may cause the memory issue when reading data block from datacache.

What I'm doing:
Checking read size before reading data block from datacache.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
