### PR TITLE
[BugFix] Fix SegmentFlushTask heap-use-after-free exception

### DIFF
--- a/be/src/storage/segment_flush_executor.cpp
+++ b/be/src/storage/segment_flush_executor.cpp
@@ -97,8 +97,8 @@ public:
             Status cancel_st = Status::InternalError("cancel writer because fail to run flush task, " + st.to_string());
             _writer->cancel(cancel_st);
             _send_fail_response(st);
-            LOG(ERROR) << "failed to flush segment, txn_id: " << _request->txn_id()
-                       << ", tablet id: " << _request->tablet_id() << ", status: " << st;
+            LOG(ERROR) << "failed to flush segment, txn_id: " << _writer->txn_id()
+                       << ", tablet id: " << _writer->tablet()->tablet_id() << ", status: " << st;
         } else {
             _send_success_response(eos, st);
         }


### PR DESCRIPTION
Why I'm doing:
Fix https://github.com/StarRocks/StarRocksTest/issues/5627. Introduced by #38560.

The rpc request `PTabletWriterAddSegmentResult` will be freed after sending the response, but we access it after response, so a heap-use-after-free exception is raised.

What I'm doing:
get tablet id and txn id from writer rather than the `PTabletWriterAddSegmentResult`

Fixes #issue

## What type of PR is this:

- [X] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
