### PR TITLE
[Feature] support display cloud native pk table index usage in show cmd

### DIFF
--- a/be/src/storage/lake/lake_primary_index.h
+++ b/be/src/storage/lake/lake_primary_index.h
@@ -58,6 +58,8 @@ public:
         return nullptr;
     }
 
+    static StatusOr<int64_t> get_disk_size(uint32_t tablet_id);
+
 private:
     Status _do_lake_load(TabletManager* tablet_mgr, const TabletMetadataPtr& metadata, int64_t base_version,
                          const MetaFileBuilder* builder);

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -152,6 +152,8 @@ public:
 
     void try_remove_cache(uint32_t tablet_id, int64_t txn_id);
 
+    std::pair<int64_t, int64_t> primary_index_mem_disk_size(uint32_t tablet_id);
+
 private:
     // print memory tracker state
     void _print_memory_stats();

--- a/be/test/storage/lake/primary_key_publish_test.cpp
+++ b/be/test/storage/lake/primary_key_publish_test.cpp
@@ -214,6 +214,9 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_read_success) {
         EXPECT_EQ(k0[i], read_chunk_ptr->get(i)[0].get_int32());
         EXPECT_EQ(v0[i], read_chunk_ptr->get(i)[1].get_int32());
     }
+
+    auto primary_index_size_pair = _update_mgr->primary_index_mem_disk_size(_tablet_metadata->id());
+    EXPECT_TRUE(primary_index_size_pair.first > 0);
 }
 
 TEST_P(LakePrimaryKeyPublishTest, test_write_multitime_check_result) {
@@ -574,8 +577,13 @@ TEST_P(LakePrimaryKeyPublishTest, test_write_largedata) {
     for (int i = 0; i < N; i++) {
         EXPECT_EQ(new_tablet_metadata->rowsets(i).num_dels(), 0);
     }
+    auto primary_index_size_pair = _update_mgr->primary_index_mem_disk_size(_tablet_metadata->id());
     if (GetParam().enable_persistent_index) {
         check_local_persistent_index_meta(tablet_id, version);
+        EXPECT_TRUE(primary_index_size_pair.first > 0);
+        EXPECT_TRUE(primary_index_size_pair.second > 0);
+    } else {
+        EXPECT_TRUE(primary_index_size_pair.first > 0);
     }
     config::l0_max_mem_usage = old_config;
 }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/TabletStatMgr.java
@@ -377,6 +377,8 @@ public class TabletStatMgr extends FrontendDaemon {
                             LakeTablet tablet = (LakeTablet) tablets.get(stat.tabletId);
                             tablet.setDataSize(stat.dataSize);
                             tablet.setRowCount(stat.numRows);
+                            tablet.setPrimaryIndexMemSize(stat.primaryIndexMemSize);
+                            tablet.setPrimaryIndexDiskSize(stat.primaryIndexDiskSize);
                             tablet.setDataSizeUpdateTime(collectStatTime);
                         }
                     }

--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/LakeTabletsProcDir.java
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 package com.starrocks.common.proc;
 
 import com.google.common.base.Preconditions;
@@ -42,6 +41,7 @@ import java.util.List;
 public class LakeTabletsProcDir implements ProcDirInterface {
     public static final ImmutableList<String> TITLE_NAMES = new ImmutableList.Builder<String>()
             .add("TabletId").add("BackendId").add("DataSize").add("RowCount")
+            .add("PrimaryIndexMem").add("PrimaryIndexDisk")
             .build();
 
     private final Database db;
@@ -81,6 +81,8 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                 tabletInfo.add(new Gson().toJson(lakeTablet.getBackendIds()));
                 tabletInfo.add(new ByteSizeValue(lakeTablet.getDataSize(true)));
                 tabletInfo.add(lakeTablet.getRowCount(0L));
+                tabletInfo.add(new ByteSizeValue(lakeTablet.getPrimaryIndexMemSize()));
+                tabletInfo.add(new ByteSizeValue(lakeTablet.getPrimaryIndexDiskSize()));
                 tabletInfos.add(tabletInfo);
             }
         } finally {
@@ -147,6 +149,7 @@ public class LakeTabletsProcDir implements ProcDirInterface {
     // Handle showing single tablet info
     public static class LakeTabletProcNode implements ProcNodeInterface {
         private final LakeTablet tablet;
+
         public LakeTabletProcNode(LakeTablet tablet) {
             this.tablet = tablet;
         }
@@ -159,8 +162,9 @@ public class LakeTabletsProcDir implements ProcDirInterface {
                     String.valueOf(tablet.getId()),
                     new Gson().toJson(tablet.getBackendIds()),
                     new ByteSizeValue(tablet.getDataSize(true)).toString(),
-                    String.valueOf(tablet.getRowCount(0L))
-            );
+                    String.valueOf(tablet.getRowCount(0L)),
+                    new ByteSizeValue(tablet.getPrimaryIndexMemSize()).toString(),
+                    new ByteSizeValue(tablet.getPrimaryIndexDiskSize()).toString());
             result.addRow(row);
             return result;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/LakeTablet.java
@@ -42,7 +42,8 @@ import static com.starrocks.catalog.Replica.ReplicaState.NORMAL;
 /**
  * This class represents the StarRocks lake tablet related metadata.
  * LakeTablet is based on cloud object storage, such as S3, OSS.
- * Data replicas are managed by object storage and compute replicas are managed by StarOS through Shard.
+ * Data replicas are managed by object storage and compute replicas are managed
+ * by StarOS through Shard.
  * Tablet id is same as StarOS Shard id.
  */
 public class LakeTablet extends Tablet {
@@ -55,6 +56,8 @@ public class LakeTablet extends Tablet {
     private static final String JSON_KEY_DATA_SIZE = "dataSize";
     private static final String JSON_KEY_ROW_COUNT = "rowCount";
     private static final String JSON_KEY_DATA_SIZE_UPDATE_TIME = "dataSizeUpdateTime";
+    private static final String JSON_KEY_PK_INDEX_MEM_SIZE = "primaryIndexMem";
+    private static final String JSON_KEY_PK_INDEX_DISK_SIZE = "primaryIndexDisk";
 
     @SerializedName(value = JSON_KEY_DATA_SIZE)
     private volatile long dataSize = 0L;
@@ -62,6 +65,10 @@ public class LakeTablet extends Tablet {
     private volatile long rowCount = 0L;
     @SerializedName(value = JSON_KEY_DATA_SIZE_UPDATE_TIME)
     private volatile long dataSizeUpdateTime = 0L;
+    @SerializedName(value = JSON_KEY_PK_INDEX_MEM_SIZE)
+    private volatile long primaryIndexMemSize = 0L;
+    @SerializedName(value = JSON_KEY_PK_INDEX_DISK_SIZE)
+    private volatile long primaryIndexDiskSize = 0L;
 
     public LakeTablet(long id) {
         super(id);
@@ -97,6 +104,22 @@ public class LakeTablet extends Tablet {
 
     public void setRowCount(long rowCount) {
         this.rowCount = rowCount;
+    }
+
+    public void setPrimaryIndexMemSize(long primaryIndexMemSize) {
+        this.primaryIndexMemSize = primaryIndexMemSize;
+    }
+
+    public long getPrimaryIndexMemSize() {
+        return primaryIndexMemSize;
+    }
+
+    public void setPrimaryIndexDiskSize(long primaryIndexDiskSize) {
+        this.primaryIndexDiskSize = primaryIndexDiskSize;
+    }
+
+    public long getPrimaryIndexDiskSize() {
+        return primaryIndexDiskSize;
     }
 
     public long getPrimaryComputeNodeId() throws UserException {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/TabletStatMgrTest.java
@@ -201,6 +201,8 @@ public class TabletStatMgrTest {
         long tablet2NumRows = 21L;
         long tablet1DataSize = 30L;
         long tablet2DataSize = 31L;
+        long tabletPrimaryIndexMemSize = 32L;
+        long tabletPrimaryIndexDiskSize = 33L;
 
         new Expectations() {
             {
@@ -237,11 +239,15 @@ public class TabletStatMgrTest {
                                 stat1.tabletId = tablet1Id;
                                 stat1.numRows = tablet1NumRows;
                                 stat1.dataSize = tablet1DataSize;
+                                stat1.primaryIndexMemSize = tabletPrimaryIndexMemSize;
+                                stat1.primaryIndexDiskSize = tabletPrimaryIndexDiskSize;
                                 stats.add(stat1);
                                 TabletStat stat2 = new TabletStat();
                                 stat2.tabletId = tablet2Id;
                                 stat2.numRows = tablet2NumRows;
                                 stat2.dataSize = tablet2DataSize;
+                                stat2.primaryIndexMemSize = tabletPrimaryIndexMemSize;
+                                stat2.primaryIndexDiskSize = tabletPrimaryIndexDiskSize;
                                 stats.add(stat2);
 
                                 TabletStatResponse response = new TabletStatResponse();
@@ -269,8 +275,12 @@ public class TabletStatMgrTest {
 
         Assert.assertEquals(tablet1.getRowCount(-1), tablet1NumRows);
         Assert.assertEquals(tablet1.getDataSize(true), tablet1DataSize);
+        Assert.assertEquals(tablet1.getPrimaryIndexMemSize(), tabletPrimaryIndexMemSize);
+        Assert.assertEquals(tablet1.getPrimaryIndexDiskSize(), tabletPrimaryIndexDiskSize);
         Assert.assertEquals(tablet2.getRowCount(-1), tablet2NumRows);
         Assert.assertEquals(tablet2.getDataSize(true), tablet2DataSize);
+        Assert.assertEquals(tablet2.getPrimaryIndexMemSize(), tabletPrimaryIndexMemSize);
+        Assert.assertEquals(tablet2.getPrimaryIndexDiskSize(), tabletPrimaryIndexDiskSize);
         Assert.assertTrue(tablet1.getDataSizeUpdateTime() >= t1 && tablet1.getDataSizeUpdateTime() <= t2);
         Assert.assertTrue(tablet2.getDataSizeUpdateTime() >= t1 && tablet2.getDataSizeUpdateTime() <= t2);
     }
@@ -317,8 +327,12 @@ public class TabletStatMgrTest {
 
         Assert.assertEquals(0, tablet1.getRowCount(-1));
         Assert.assertEquals(0, tablet1.getDataSize(true));
+        Assert.assertEquals(0, tablet1.getPrimaryIndexMemSize());
+        Assert.assertEquals(0, tablet1.getPrimaryIndexDiskSize());
         Assert.assertEquals(0, tablet2.getRowCount(-1));
         Assert.assertEquals(0, tablet2.getDataSize(true));
+        Assert.assertEquals(0, tablet2.getPrimaryIndexMemSize());
+        Assert.assertEquals(0, tablet2.getPrimaryIndexDiskSize());
         Assert.assertEquals(0L, tablet1.getDataSizeUpdateTime());
         Assert.assertEquals(0L, tablet2.getDataSizeUpdateTime());
     }
@@ -408,8 +422,12 @@ public class TabletStatMgrTest {
 
         Assert.assertEquals(0, tablet1.getRowCount(-1));
         Assert.assertEquals(0, tablet1.getDataSize(true));
+        Assert.assertEquals(0, tablet1.getPrimaryIndexMemSize());
+        Assert.assertEquals(0, tablet1.getPrimaryIndexDiskSize());
         Assert.assertEquals(0, tablet2.getRowCount(-1));
         Assert.assertEquals(0, tablet2.getDataSize(true));
+        Assert.assertEquals(0, tablet2.getPrimaryIndexMemSize());
+        Assert.assertEquals(0, tablet2.getPrimaryIndexDiskSize());
         Assert.assertEquals(0L, tablet1.getDataSizeUpdateTime());
         Assert.assertEquals(0L, tablet2.getDataSizeUpdateTime());
     }

--- a/gensrc/proto/lake_service.proto
+++ b/gensrc/proto/lake_service.proto
@@ -127,6 +127,8 @@ message TabletStatResponse {
         optional int64 tablet_id = 1;
         optional int64 num_rows = 2;
         optional int64 data_size = 3;
+        optional int64 primary_index_mem_size = 4;
+        optional int64 primary_index_disk_size = 5;
     }
 
     repeated TabletStat tablet_stats = 1;


### PR DESCRIPTION
Why I'm doing:
We need to display each cloud native pk tablet's memory and disk usage about primary index.

What I'm doing:
support display cloud native pk table index usage in show cmd, e.g:
```
mysql> show tablet from tbl_pk_novarchar;
+----------+-----------+----------+-----------+-----------------+------------------+
| TabletId | BackendId | DataSize | RowCount  | PrimaryIndexMem | PrimaryIndexDisk |
+----------+-----------+----------+-----------+-----------------+------------------+
| 11005    | [10004]   | 10.2GB   | 191996368 | 262MB           | 5.4GB            |
+----------+-----------+----------+-----------+-----------------+------------------+
1 row in set (0.00 sec)
```

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
