### PR TITLE
[Enhancement] Make the number of automatic buckets more conducive to even distribution on the backend

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/CatalogUtils.java
@@ -309,6 +309,24 @@ public class CatalogUtils {
         }
     }
 
+    public static int divisibleBucketNum(int backendNum) {
+        while (backendNum > 7) {
+            if (backendNum % 2 == 0) {
+                backendNum = backendNum / 2;
+            } else if (backendNum % 3 == 0) {
+                backendNum = backendNum / 3;
+            } else if (backendNum % 5 == 0) {
+                backendNum = backendNum / 5;
+            } else if (backendNum % 7 == 0) {
+                backendNum = backendNum / 7;
+            } else {
+                backendNum = backendNum / 2;
+            }
+        }
+
+        return backendNum;
+    }
+
     public static int calPhysicalPartitionBucketNum() {
         int backendNum = GlobalStateMgr.getCurrentSystemInfo().getBackendIds().size();
 
@@ -316,7 +334,7 @@ public class CatalogUtils {
             backendNum = backendNum + GlobalStateMgr.getCurrentSystemInfo().getAliveComputeNodeNumber();
         }
 
-        return Math.min(backendNum, 16);
+        return divisibleBucketNum(backendNum);
     }
 
     public static int calBucketNumAccordingToBackends() {

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogUtilsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/CatalogUtilsTest.java
@@ -1,0 +1,45 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.starrocks.catalog;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CatalogUtilsTest {
+    @Test
+    public void testDivisibleByTwo() {
+        Assertions.assertEquals(1, CatalogUtils.divisibleBucketNum(1));
+        Assertions.assertEquals(2, CatalogUtils.divisibleBucketNum(2));
+        Assertions.assertEquals(3, CatalogUtils.divisibleBucketNum(3));
+        Assertions.assertEquals(4, CatalogUtils.divisibleBucketNum(4));
+        Assertions.assertEquals(5, CatalogUtils.divisibleBucketNum(5));
+        Assertions.assertEquals(6, CatalogUtils.divisibleBucketNum(6));
+        Assertions.assertEquals(7, CatalogUtils.divisibleBucketNum(7));
+        Assertions.assertEquals(4, CatalogUtils.divisibleBucketNum(8));
+        Assertions.assertEquals(3, CatalogUtils.divisibleBucketNum(9));
+        Assertions.assertEquals(5, CatalogUtils.divisibleBucketNum(10));
+        Assertions.assertEquals(5, CatalogUtils.divisibleBucketNum(11));
+        Assertions.assertEquals(6, CatalogUtils.divisibleBucketNum(12));
+        Assertions.assertEquals(6, CatalogUtils.divisibleBucketNum(13));
+        Assertions.assertEquals(7, CatalogUtils.divisibleBucketNum(14));
+        Assertions.assertEquals(5, CatalogUtils.divisibleBucketNum(15));
+        Assertions.assertEquals(4, CatalogUtils.divisibleBucketNum(16));
+        Assertions.assertEquals(4, CatalogUtils.divisibleBucketNum(17));
+        Assertions.assertEquals(3, CatalogUtils.divisibleBucketNum(18));
+        Assertions.assertEquals(3, CatalogUtils.divisibleBucketNum(19));
+        Assertions.assertEquals(5, CatalogUtils.divisibleBucketNum(20));
+        Assertions.assertEquals(7, CatalogUtils.divisibleBucketNum(21));
+    }
+}


### PR DESCRIPTION
## Why I'm doing:
1. automatic bucket divisible by backends num will make it  more conducive to even distribution
2. no need too large bucket num since we will automatic create new bucket when current bucket is full

## What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
