### PR TITLE
[BugFix] support cancel hive sink in BE

### DIFF
--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -17,6 +17,7 @@
 
 #include <fmt/format.h>
 
+#include <future>
 #include <utility>
 
 #include "formats/parquet/file_writer.h"
@@ -89,14 +90,23 @@ Status RollingAsyncParquetWriter::append_chunk(Chunk* chunk, RuntimeState* state
 }
 
 Status RollingAsyncParquetWriter::rollback(RuntimeState* state) {
-    for (auto& writer : _pending_commits) {
-        if (writer != nullptr) {
-            auto st = _fs->delete_file(writer->file_location());
-            if (!st.ok()) {
-                return st;
-            }
-        }
+    if (_pending_commits.empty()) {
+        return Status::OK();
     }
+    std::future<void> rt = std::async(
+            std::launch::async,
+            [](std::shared_ptr<FileSystem> file_system,
+               std::vector<std::shared_ptr<starrocks::parquet::AsyncFileWriter>> pending_commits) {
+                for (auto& writer : pending_commits) {
+                    if (writer != nullptr) {
+                        auto st = file_system->delete_file(writer->file_location());
+                        if (!st.ok()) {
+                            LOG(WARNING) << "delete file error: " << writer->file_location();
+                        }
+                    }
+                }
+            },
+            _fs, _pending_commits);
     return Status::OK();
 }
 

--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -88,11 +88,13 @@ Status RollingAsyncParquetWriter::append_chunk(Chunk* chunk, RuntimeState* state
     return _writer->write(chunk);
 }
 
-Status RollingAsyncParquetWriter::cancel(RuntimeState* state) {
-    if (_writer != nullptr) {
-        auto st = _fs->delete_file(_writer->file_location());
-        if (!st.ok()) {
-            return st;
+Status RollingAsyncParquetWriter::rollback(RuntimeState* state) {
+    for (auto& writer : _pending_commits) {
+        if (writer != nullptr) {
+            auto st = _fs->delete_file(writer->file_location());
+            if (!st.ok()) {
+                return st;
+            }
         }
     }
     return Status::OK();

--- a/be/src/exec/parquet_writer.cpp
+++ b/be/src/exec/parquet_writer.cpp
@@ -88,6 +88,16 @@ Status RollingAsyncParquetWriter::append_chunk(Chunk* chunk, RuntimeState* state
     return _writer->write(chunk);
 }
 
+Status RollingAsyncParquetWriter::cancel(RuntimeState* state) {
+    if (_writer != nullptr) {
+        auto st = _fs->delete_file(_writer->file_location());
+        if (!st.ok()) {
+            return st;
+        }
+    }
+    return Status::OK();
+}
+
 Status RollingAsyncParquetWriter::close_current_writer(RuntimeState* state) {
     Status st = _writer->close(state, _commit_func);
     if (st.ok()) {

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -77,7 +77,7 @@ private:
     Status close_current_writer(RuntimeState* state);
 
 private:
-    std::unique_ptr<FileSystem> _fs;
+    std::shared_ptr<FileSystem> _fs;
     std::shared_ptr<starrocks::parquet::AsyncFileWriter> _writer;
     std::shared_ptr<::parquet::WriterProperties> _properties;
     std::shared_ptr<::parquet::schema::GroupNode> _schema;

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -57,8 +57,8 @@ public:
 
     Status append_chunk(Chunk* chunk, RuntimeState* state);
     Status init();
-    Status cancel(RuntimeState* state);
     Status close(RuntimeState* state);
+    Status rollback(RuntimeState* state);
     bool writable() const { return _writer == nullptr || _writer->writable(); }
     bool closed();
 

--- a/be/src/exec/parquet_writer.h
+++ b/be/src/exec/parquet_writer.h
@@ -57,6 +57,7 @@ public:
 
     Status append_chunk(Chunk* chunk, RuntimeState* state);
     Status init();
+    Status cancel(RuntimeState* state);
     Status close(RuntimeState* state);
     bool writable() const { return _writer == nullptr || _writer->writable(); }
     bool closed();

--- a/be/src/exec/pipeline/sink/hive_table_sink_operator.cpp
+++ b/be/src/exec/pipeline/sink/hive_table_sink_operator.cpp
@@ -79,6 +79,9 @@ bool HiveTableSinkOperator::pending_finish() const {
 }
 
 Status HiveTableSinkOperator::set_cancelled(RuntimeState* state) {
+    for (const auto& writer : _partition_writers) {
+        RETURN_IF_ERROR(writer.second->cancel(state));
+    }
     return Status::OK();
 }
 

--- a/be/src/exec/pipeline/sink/hive_table_sink_operator.h
+++ b/be/src/exec/pipeline/sink/hive_table_sink_operator.h
@@ -87,6 +87,7 @@ private:
     std::vector<ExprContext*> _partition_expr;
     std::unordered_map<std::string, std::unique_ptr<starrocks::RollingAsyncParquetWriter>> _partition_writers;
     std::atomic<bool> _is_finished = false;
+    std::atomic<bool> _rollback = false;
     bool _is_static_partition_insert = false;
     std::vector<std::string> _partition_column_names;
     std::vector<std::string> _data_column_names;

--- a/be/src/fs/hdfs/fs_hdfs.cpp
+++ b/be/src/fs/hdfs/fs_hdfs.cpp
@@ -549,7 +549,7 @@ Status HdfsFileSystem::delete_file(const std::string& path) {
     std::shared_ptr<HdfsFsClient> hdfs_client;
     RETURN_IF_ERROR(HdfsFsCache::instance()->get_connection(namenode, hdfs_client, _options));
     int status = hdfsDelete(hdfs_client->hdfs_fs, path.c_str(), 0);
-    return status == 0 ? Status::OK() : Status::Unknown(fmt::format("Failed to delete file={}", path));
+    return status == 0 ? Status::OK() : Status::IOError(fmt::format("Failed to delete file={}", path));
 }
 
 Status HdfsFileSystem::_path_exists(hdfsFS fs, const std::string& path) {


### PR DESCRIPTION
Why I'm doing:
[#38368](https://github.com/StarRocks/starrocks/pull/38368) makes sure that the FE will rollback all those successful written tasks by deleting what have already written on the dir on HDFS/OSS; however, for those still writing operators, unfinished(corrupted) files will still be written. 

What I'm doing:
Delete these unfinished files to make sure that 
1. no corrupted data are inserted if it's an INSERT_STMT
2. no corrupted files are stored under the dir specified by CTAS_STMT which prevents to rerun the same CTAS_STMT due to the fact that the dir already existed

Note that for S3, when there are no files under a certain dir, the dir itself does not exist. 

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5