### PR TITLE
[Enhancement] reduce min publish version thread number

### DIFF
--- a/be/src/agent/agent_common.h
+++ b/be/src/agent/agent_common.h
@@ -87,11 +87,7 @@ struct AgentTaskRequestWithoutReqBody {
     int64_t recv_time;
 };
 
-#ifndef BE_TEST
-const int MIN_TRANSACTION_PUBLISH_WORKER_COUNT = 8;
-#else
 const int MIN_TRANSACTION_PUBLISH_WORKER_COUNT = 1;
-#endif
 
 using CreateTabletAgentTaskRequest = AgentTaskRequestWithReqBody<TCreateTabletReq>;
 using DropTabletAgentTaskRequest = AgentTaskRequestWithReqBody<TDropTabletReq>;


### PR DESCRIPTION
Why I'm doing:
In some low specifications servers, we need to allow fewer publish threads (< 8) to save memory.

What I'm doing:
Change `MIN_TRANSACTION_PUBLISH_WORKER_COUNT` from 8 to 1.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
