### PR TITLE
[Enhancement] Don't do clearIORanges() in orc reader's prepareCache()

### DIFF
--- a/be/src/formats/orc/orc_input_stream.cpp
+++ b/be/src/formats/orc/orc_input_stream.cpp
@@ -54,7 +54,9 @@ void ORCHdfsFileStream::prepareCache(PrepareCacheScope scope, uint64_t offset, u
 
     doRead(_cache_buffer.data(), length, offset);
 
-    clearIORanges();
+    // Don't do clearIORanges(), because it will clear io ranges setted in startNextStripe()
+    // Just left clearIORanges() operation take place in startNextStripe()
+    // clearIORanges();
 }
 
 bool ORCHdfsFileStream::isAlreadyCachedInBuffer(uint64_t offset, uint64_t length) {


### PR DESCRIPTION
Why I'm doing:
Lot's of io request will not go through shared buffer. This bug was introduced in https://github.com/StarRocks/starrocks/pull/38115

Because in `Reader.cc` `startNextStripe()`
<img width="1142" alt="image" src="https://github.com/StarRocks/starrocks/assets/18729228/faec4647-ccf0-4dad-b185-bc6a6a87f2d3">

We will `buildIORanges()` before `loadStripeIndex()`.  But we may `prepareCache()` in `loadStripeIndex()`, if we clear io ranges, which means we will clear all io ranges built by `buildIORanges()`.

What I'm doing:
So we just don't need to clear io ranges in prepareCache,  left this operation takes place in `startNextStripe()`

Before:
```bash
 - SharedBuffered: 
   - DirectIOBytes: 7.196 GB
   - DirectIOCount: 2.780K (2780)
   - DirectIOTime: 10s40ms
   - SharedIOBytes: 2.512 MB
   - SharedIOCount: 130
   - SharedIOTime: 67.867ms
```

Changed:
```bash
 - SharedBuffered: 
   - DirectIOBytes: 730.727 KB
     - __MAX_OF_DirectIOBytes: 24.480 KB
     - __MIN_OF_DirectIOBytes: 23.971 KB
   - DirectIOCount: 190
     - __MAX_OF_DirectIOCount: 7
     - __MIN_OF_DirectIOCount: 4
   - DirectIOTime: 47.250ms
     - __MAX_OF_DirectIOTime: 54.465ms
     - __MIN_OF_DirectIOTime: 40.397ms
   - SharedIOBytes: 7.200 GB
     - __MAX_OF_SharedIOBytes: 286.917 MB
     - __MIN_OF_SharedIOBytes: 71.583 MB
   - SharedIOCount: 1.544K (1544)
     - __MAX_OF_SharedIOCount: 60
     - __MIN_OF_SharedIOCount: 16
   - SharedIOTime: 3s411ms
     - __MAX_OF_SharedIOTime: 4s811ms
     - __MIN_OF_SharedIOTime: 2s281ms
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
