### PR TITLE
[BugFix] Remove invalid predicates after mv rewrite for 3.1 (backport #38543)

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarRangePredicateExtractor.java
@@ -105,11 +105,19 @@ public class ScalarRangePredicateExtractor {
 
             if (extractMap.values().stream().allMatch(valueDescriptor -> valueDescriptor.sourceCount == cs.size())
                     && extractMap.size() == cf.size()) {
-                return extractExpr;
+                if (result.size() == conjuncts.size()) {
+                    // to keep the isPushdown/isRedundant of predicate
+                    return predicate;
+                } else {
+                    return extractExpr;
+                }
             }
         }
 
-        if (!conjuncts.contains(extractExpr)) {
+        if (!conjuncts.containsAll(result)) {
+            // remove duplicates
+            result.removeAll(conjuncts);
+            extractExpr = Utils.compoundAnd(Lists.newArrayList(result));
             result.forEach(f -> f.setFromPredicateRangeDerive(true));
             result.stream().filter(predicateOperator -> !checkStatisticsEstimateValid(predicateOperator))
                     .forEach(f -> f.setNotEvalEstimate(true));

--- a/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
+++ b/fe/fe-core/src/test/java/com/starrocks/schema/MSchema.java
@@ -260,6 +260,34 @@ public class MSchema {
     public static final MTable TABLE_WITH_DAY_PARTITION1 = TABLE_WITH_DAY_PARTITION.copyWithName("table_with_day_partition1");
     public static final MTable TABLE_WITH_DAY_PARTITION2 = TABLE_WITH_DAY_PARTITION.copyWithName("table_with_day_partition2");
 
+    public static final MTable TEST10 = new MTable("test10", "event_id",
+            ImmutableList.of(
+                    "  `event_id` int NULL",
+                    "  `event_type` varchar(65533) NULL ",
+                    "  `event_time` datetime NULL "
+            ),
+            "event_time",
+            ImmutableList.of(
+                    "PARTITION p20230105 VALUES [(\"2023-01-05 00:00:00\"), (\"2023-01-06 00:00:00\"))",
+                    "PARTITION p20230106 VALUES [(\"2023-01-06 00:00:00\"), (\"2023-01-07 00:00:00\"))"
+            )
+    ).withValues("(1, 'a', '2023-01-05 10:20:22'),(2, 'b', '2023-01-05 10:20:22')," +
+            "(11, 'aa', '2023-01-06 10:20:22'),(22, 'bb', '2023-01-06 10:20:22')");
+
+    public static final MTable TEST11 = new MTable("test11", "event_id1",
+            ImmutableList.of(
+                    "  `event_id1` int NULL",
+                    "  `event_type1` varchar(65533) NULL ",
+                    "  `event_time1` datetime NULL "
+            ),
+            "event_time1",
+            ImmutableList.of(
+                    "PARTITION p20230105 VALUES [(\"2023-01-05 00:00:00\"), (\"2023-01-06 00:00:00\"))",
+                    "PARTITION p20230106 VALUES [(\"2023-01-06 00:00:00\"), (\"2023-01-07 00:00:00\"))"
+            )
+    ).withValues("(1, 'a', '2023-01-05 10:20:22'),(2, 'b', '2023-01-05 10:20:23')," +
+            "(11, 'aa', '2023-01-06 10:20:22'),(22, 'bbx', '2023-01-06 10:20:22')");
+
     public static final List<MTable>  TABLE_MARKETING = ImmutableList.of(
             EMPS,
             EMPS_NULL,
@@ -279,7 +307,9 @@ public class MSchema {
             TEST_BASE_PART,
             T1,
             JSON_TBL,
-            T_METRICS
+            T_METRICS,
+            TEST10,
+            TEST11
     );
     public static final Map<String, MTable> TABLE_MAP = Maps.newHashMap();
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvRewriteTest.java
@@ -69,6 +69,8 @@ public class MvRewriteTest extends MvRewriteTestBase {
         starRocksAssert.withTable(cluster, "test_all_type");
         starRocksAssert.withTable(cluster, "t0");
         starRocksAssert.withTable(cluster, "t1");
+        starRocksAssert.withTable(cluster, "test10");
+        starRocksAssert.withTable(cluster, "test11");
 
         prepareDatas();
     }
@@ -2259,63 +2261,31 @@ public class MvRewriteTest extends MvRewriteTestBase {
     }
 
     @Test
-    public void test() throws Exception {
-        connectContext.executeSql("drop table if exists t11");
-        starRocksAssert.withTable("create table t11(\n" +
-                "shop_id int,\n" +
-                "region int,\n" +
-                "shop_type string,\n" +
-                "shop_flag string,\n" +
-                "store_id String,\n" +
-                "store_qty Double\n" +
-                ") DUPLICATE key(shop_id) distributed by hash(shop_id) buckets 1 " +
+    public void testOuterJoinRewrite() throws Exception {
+        starRocksAssert.withMaterializedView("CREATE MATERIALIZED VIEW `mv1` (`event_id`, `event_time`, `event_time1`)\n" +
+                "PARTITION BY (`event_time`)\n" +
+                "DISTRIBUTED BY HASH(`event_id`) BUCKETS 1\n" +
+                "REFRESH ASYNC\n" +
                 "PROPERTIES (\n" +
-                "\"replication_num\" = \"1\"\n" +
-                ");");
-        cluster.runSql("test", "insert into\n" +
-                "t11\n" +
-                "values\n" +
-                "(1, 1, 's', 'o', '1', null),\n" +
-                "(1, 1, 'm', 'o', '2', 2),\n" +
-                "(1, 1, 'b', 'c', '3', 1);");
-        connectContext.executeSql("drop materialized view if exists mv11");
-        starRocksAssert.withMaterializedView("create MATERIALIZED VIEW mv11 (region, ct) " +
-                "DISTRIBUTED BY RANDOM buckets 1 REFRESH MANUAL as\n" +
-                "select region,\n" +
-                "count(\n" +
-                "distinct (\n" +
-                "case\n" +
-                "when store_qty > 0 then store_id\n" +
-                "else null\n" +
-                "end\n" +
+                "\"replicated_storage\" = \"true\",\n" +
+                "\"partition_refresh_number\" = \"2\",\n" +
+                "\"force_external_table_query_rewrite\" = \"CHECKED\",\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"storage_medium\" = \"HDD\"\n" +
                 ")\n" +
-                ")\n" +
-                "from t11\n" +
-                "group by region;");
-        cluster.runSql("test", "refresh materialized view mv11 with sync mode");
+                "AS SELECT `a`.`event_id`, `a`.`event_time`, `b`.`event_time1`\n" +
+                "FROM `test`.`test10` AS `a` LEFT OUTER JOIN `test`.`test11` AS `b`" +
+                " ON (`a`.`event_id` = `b`.`event_id1`) AND (`a`.`event_time` = `b`.`event_time1`);");
+
+        connectContext.executeSql("refresh materialized view mv1 with sync mode");
         {
-            String query = "select region,\n" +
-                    "count(\n" +
-                    "distinct (\n" +
-                    "case\n" +
-                    "when store_qty > 0.0 then store_id\n" +
-                    "else null\n" +
-                    "end\n" +
-                    ")\n" +
-                    ") as ct\n" +
-                    "from t11\n" +
-                    "group by region\n" +
-                    "having\n" +
-                    "count(\n" +
-                    "distinct (\n" +
-                    "case\n" +
-                    "when store_qty > 0.0 then store_id\n" +
-                    "else null\n" +
-                    "end\n" +
-                    ")\n" +
-                    ") > 0\n";
+            String query = "select * from (select event_id, event_time, event_time1" +
+                    " from test10 a left outer join test11 b" +
+                    " on a.event_id = b.event_id1 and a.event_time = b.event_time1 ) xx" +
+                    " where xx.event_time >= \"2023-01-05 00:00:00\" and xx.event_time < \"2023-01-06 00:00:00\";";
             String plan = getFragmentPlan(query);
-            PlanTestBase.assertContains(plan, "mv11", "PREDICATES: 10: ct > 0");
+            PlanTestBase.assertContains(plan, "mv1");
+            PlanTestBase.assertNotContains(plan, "event_time1 >= '2023-01-05 00:00:00'");
         }
     }
 }


### PR DESCRIPTION
Why I'm doing:
For queries has pushdown derived predicates, the rewritten plan may be wrong, which will lead to invalid results. Originally, the isPushdown and isRedundant fields of ScalarOperator may be incorrectly set.
What I'm doing:
fix isPushdown and isRedundant after predicates pushdown rules.

Fixes https://github.com/StarRocks/starrocks/issues/36536
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

