### PR TITLE
[Enhancement] Add memory statistic when process oom

### DIFF
--- a/be/src/runtime/mem_tracker.cpp
+++ b/be/src/runtime/mem_tracker.cpp
@@ -34,6 +34,8 @@
 
 #include "runtime/mem_tracker.h"
 
+#include <fmt/format.h>
+
 #include <utility>
 
 #include "gutil/strings/substitute.h"
@@ -150,9 +152,21 @@ std::string MemTracker::err_msg(const std::string& msg) const {
         str << "Mem usage has exceed the limit of single query, You can change the limit by "
                "set session variable query_mem_limit.";
         break;
-    case MemTracker::PROCESS:
+    case MemTracker::PROCESS: {
         str << "Mem usage has exceed the limit of BE";
+        auto* mem_metrics = StarRocksMetrics::instance()->system_metrics()->memory_metrics();
+        str << fmt::format(
+                " Current memory statistics: process({}), query_pool({}), load({}), "
+                "metadata({}), compaction({}), schema_change({}), column_pool({}), "
+                "page_cache({}), update({}), chunk_allocator({}), clone({}), consistency({})",
+                mem_metrics->process_mem_bytes.value(), mem_metrics->query_mem_bytes.value(),
+                mem_metrics->load_mem_bytes.value(), mem_metrics->metadata_mem_bytes.value(),
+                mem_metrics->compaction_mem_bytes.value(), mem_metrics->schema_change_mem_bytes.value(),
+                mem_metrics->column_pool_mem_bytes.value(), mem_metrics->storage_page_cache_mem_bytes.value(),
+                mem_metrics->update_mem_bytes.value(), mem_metrics->chunk_allocator_mem_bytes.value(),
+                mem_metrics->clone_mem_bytes.value(), mem_metrics->consistency_mem_bytes.value());
         break;
+    }
     case MemTracker::QUERY_POOL:
         str << "Mem usage has exceed the limit of query pool";
         break;


### PR DESCRIPTION
## Why I'm doing:
add memory statistic when process oom, make it more easy to know the error reason.

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
