### PR TITLE
[BugFix] fix potential concurrency issue when retry lake pk compaction

### DIFF
--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -34,6 +34,7 @@ CompactionState::~CompactionState() {
 Status CompactionState::load_segments(Rowset* rowset, UpdateManager* update_manager,
                                       const TabletSchemaCSPtr& tablet_schema, uint32_t segment_id) {
     TRACE_COUNTER_SCOPE_LATENCY_US("load_segments_latency_us");
+    std::lock_guard<std::mutex> lg(_state_lock);
     if (pk_cols.empty() && rowset->num_segments() > 0) {
         pk_cols.resize(rowset->num_segments());
     } else {
@@ -101,6 +102,7 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
 }
 
 void CompactionState::release_segments(uint32_t segment_id) {
+    std::lock_guard<std::mutex> lg(_state_lock);
     if (segment_id >= pk_cols.size() || pk_cols[segment_id] == nullptr) {
         return;
     }

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -53,6 +53,7 @@ private:
     size_t _memory_usage = 0;
     std::vector<ChunkIteratorPtr> _segment_iters;
     int64_t _tablet_id = 0;
+    std::mutex _state_lock;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const CompactionState& o) {


### PR DESCRIPTION
Why I'm doing:
If we have compaction task (txn 100), do compaction finish and then FE send publish to BE, BE begin to publish txn 100. At the same time, don't know what happen, this task (txn 100) re-execute again. Both of them need to load segment, they will cause potential concurrency issue

What I'm doing:
Add mutex to make it safe.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
