### PR TITLE
[Enhancement] push down adaptive dop to UnionNode

### DIFF
--- a/be/src/exec/pipeline/adaptive/event.cpp
+++ b/be/src/exec/pipeline/adaptive/event.cpp
@@ -138,7 +138,7 @@ public:
 
     ~DependsAllEvent() override = default;
 
-    void schedule(RuntimeState* state) override { finish(state); }
+    void process(RuntimeState* state) override { finish(state); }
 
     std::string name() const override { return "depends_all_event"; }
 

--- a/be/src/exec/pipeline/adaptive/event.cpp
+++ b/be/src/exec/pipeline/adaptive/event.cpp
@@ -66,8 +66,7 @@ std::string Event::to_string() const {
 
 class CollectStatsSourceInitializeEvent final : public Event {
 public:
-    CollectStatsSourceInitializeEvent(DriverExecutor* executor, SourceOperatorFactory* const leader_source_op,
-                                      std::vector<Pipeline*>&& pipelines);
+    CollectStatsSourceInitializeEvent(DriverExecutor* executor, std::vector<Pipeline*>&& pipelines);
 
     ~CollectStatsSourceInitializeEvent() override = default;
 
@@ -77,33 +76,21 @@ public:
 
 private:
     DriverExecutor* const _executor;
-    const size_t _original_leader_dop;
-    SourceOperatorFactory* const _leader_source_op;
     /// The pipelines should be in topo order, that is the upstream pipeline of a pipeline should be in front of it.
     std::vector<Pipeline*> _pipelines;
 };
 
 CollectStatsSourceInitializeEvent::CollectStatsSourceInitializeEvent(DriverExecutor* executor,
-                                                                     SourceOperatorFactory* const leader_source_op,
                                                                      std::vector<Pipeline*>&& pipelines)
-        : _executor(executor),
-          _original_leader_dop(leader_source_op->degree_of_parallelism()),
-          _leader_source_op(leader_source_op),
-          _pipelines(std::move(pipelines)) {}
+        : _executor(executor), _pipelines(std::move(pipelines)) {}
 
 DEFINE_FAIL_POINT(collect_stats_source_initialize_prepare_failed);
 
 void CollectStatsSourceInitializeEvent::process(RuntimeState* state) {
     DeferOp defer_op([this, state] { finish(state); });
 
-    _leader_source_op->adjust_dop();
-    const size_t leader_dop = _leader_source_op->degree_of_parallelism();
-    const bool adjust_dop = leader_dop != _original_leader_dop;
-
     for (auto* pipeline : _pipelines) {
-        if (adjust_dop) {
-            pipeline->source_operator_factory()->adjust_max_dop(leader_dop);
-        }
+        pipeline->source_operator_factory()->adjust_dop();
         pipeline->instantiate_drivers(state);
     }
 
@@ -142,6 +129,24 @@ void CollectStatsSourceInitializeEvent::process(RuntimeState* state) {
 }
 
 // ------------------------------------------------------------------------------------
+// DependsAllEventt
+// ------------------------------------------------------------------------------------
+
+class DependsAllEvent final : public Event {
+public:
+    explicit DependsAllEvent(const std::vector<EventPtr>& events) : _events(events) {}
+
+    ~DependsAllEvent() override = default;
+
+    void schedule(RuntimeState* state) override { finish(state); }
+
+    std::string name() const override { return "depends_all_event"; }
+
+private:
+    std::vector<EventPtr> _events;
+};
+
+// ------------------------------------------------------------------------------------
 // Event factory methods.
 // ------------------------------------------------------------------------------------
 
@@ -150,9 +155,16 @@ EventPtr Event::create_event() {
 }
 
 EventPtr Event::create_collect_stats_source_initialize_event(DriverExecutor* executor,
-                                                             SourceOperatorFactory* const leader_source_op,
                                                              std::vector<Pipeline*>&& pipelines) {
-    return std::make_shared<CollectStatsSourceInitializeEvent>(executor, leader_source_op, std::move(pipelines));
+    return std::make_shared<CollectStatsSourceInitializeEvent>(executor, std::move(pipelines));
+}
+
+EventPtr Event::depends_all(const std::vector<EventPtr>& events) {
+    EventPtr merged_event = std::make_shared<DependsAllEvent>(events);
+    for (const auto& event : events) {
+        merged_event->add_dependency(event.get());
+    }
+    return merged_event;
 }
 
 } // namespace starrocks::pipeline

--- a/be/src/exec/pipeline/adaptive/event.h
+++ b/be/src/exec/pipeline/adaptive/event.h
@@ -48,9 +48,9 @@ public:
 
 public:
     static EventPtr create_event();
-    static EventPtr create_collect_stats_source_initialize_event(DriverExecutor* const executor,
-                                                                 SourceOperatorFactory* const leader_source_op,
+    static EventPtr create_collect_stats_source_initialize_event(DriverExecutor* executor,
                                                                  std::vector<Pipeline*>&& pipelines);
+    static EventPtr depends_all(const std::vector<EventPtr>& events);
 
 protected:
     size_t _num_dependencies{0};

--- a/be/src/exec/pipeline/fragment_executor.cpp
+++ b/be/src/exec/pipeline/fragment_executor.cpp
@@ -530,8 +530,8 @@ void create_adaptive_group_initialize_events(RuntimeState* state, PipelineGroupM
 
     auto* driver_executor = state->exec_env()->wg_driver_executor();
     for (auto& [leader_source_op, pipelines] : unready_pipeline_groups) {
-        EventPtr group_initialize_event = Event::create_collect_stats_source_initialize_event(
-                driver_executor, leader_source_op, std::move(pipelines));
+        EventPtr group_initialize_event =
+                Event::create_collect_stats_source_initialize_event(driver_executor, std::move(pipelines));
 
         if (auto blocking_event = leader_source_op->adaptive_blocking_event(); blocking_event != nullptr) {
             group_initialize_event->add_dependency(blocking_event.get());
@@ -893,7 +893,7 @@ Status FragmentExecutor::_decompose_data_sink_to_operator(RuntimeState* runtime_
             auto source_op = std::make_shared<MultiCastLocalExchangeSourceOperatorFactory>(
                     context->next_operator_id(), upstream_plan_node_id, i, mcast_local_exchanger);
             source_op->set_degree_of_parallelism(dop);
-            source_op->set_group_leader(upstream_pipeline->source_operator_factory());
+            source_op->add_upstream_source(upstream_pipeline->source_operator_factory());
 
             // sink op
             auto sink_op = _create_exchange_sink_operator(context, t_stream_sink, sender.get(), dop);

--- a/be/src/exec/pipeline/pipeline_builder.cpp
+++ b/be/src/exec/pipeline/pipeline_builder.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/pipeline/pipeline_builder.h"
 
+#include "adaptive/event.h"
 #include "common/config.h"
 #include "exec/exec_node.h"
 #include "exec/pipeline/adaptive/collect_stats_context.h"
@@ -142,7 +143,7 @@ void PipelineBuilderContext::maybe_interpolate_local_passthrough_exchange_for_si
 
     local_exchange_source->set_degree_of_parallelism(desired_sink_dop);
     local_exchange_source->set_runtime_state(state);
-    local_exchange_source->set_group_leader(source_operator);
+    local_exchange_source->add_upstream_source(source_operator);
 
     OpFactories operators_source_with_local_exchange{std::move(local_exchange_source), std::move(table_sink_operator)};
 
@@ -169,7 +170,7 @@ void PipelineBuilderContext::maybe_interpolate_local_key_partition_exchange_for_
     _fragment_context->pipelines().back()->add_op_factory(local_shuffle_sink);
 
     local_shuffle_source->set_runtime_state(state);
-    local_shuffle_source->set_group_leader(source_operator);
+    local_shuffle_source->add_upstream_source(source_operator);
     local_shuffle_source->set_degree_of_parallelism(desired_sink_dop);
     OpFactories operators_source_with_local_shuffle{std::move(local_shuffle_source), std::move(table_sink_operator)};
 
@@ -300,9 +301,29 @@ OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(RuntimeState* 
     auto local_exchange_source =
             std::make_shared<LocalExchangeSourceOperatorFactory>(next_operator_id(), plan_node_id, mem_mgr);
     local_exchange_source->set_runtime_state(state);
-    inherit_upstream_source_properties(local_exchange_source.get(), source_operator(pred_operators_list[0]));
+    auto* first_upstream_source = source_operator(pred_operators_list[0]);
+    inherit_upstream_source_properties(local_exchange_source.get(), first_upstream_source);
     local_exchange_source->set_could_local_shuffle(true);
     local_exchange_source->set_degree_of_parallelism(degree_of_parallelism());
+
+    std::vector<EventPtr> group_blocking_events;
+    for (const auto& pred_ops : pred_operators_list) {
+        auto* source = source_operator(pred_ops);
+        if (auto event = source->group_leader()->adaptive_blocking_event(); event != nullptr) {
+            group_blocking_events.emplace_back(std::move(event));
+        }
+    }
+
+    for (int i = 1; i < pred_operators_list.size(); i++) {
+        auto* upstream_source = source_operator(pred_operators_list[i]);
+        local_exchange_source->add_upstream_source(upstream_source);
+        first_upstream_source->union_group(upstream_source);
+    }
+
+    if (!group_blocking_events.empty()) {
+        EventPtr merged_blocking_events = Event::depends_all(group_blocking_events);
+        local_exchange_source->group_leader()->set_adaptive_blocking_event(std::move(merged_blocking_events));
+    }
 
     auto exchanger = std::make_shared<PassthroughExchanger>(mem_mgr, local_exchange_source.get());
     for (auto& pred_operators : pred_operators_list) {
@@ -317,7 +338,7 @@ OpFactories PipelineBuilderContext::maybe_gather_pipelines_to_one(RuntimeState* 
 
 OpFactories PipelineBuilderContext::maybe_interpolate_collect_stats(RuntimeState* state, int32_t plan_node_id,
                                                                     OpFactories& pred_operators) {
-    if (_force_disable_adaptive_dop || !_fragment_context->enable_adaptive_dop()) {
+    if (!_fragment_context->enable_adaptive_dop()) {
         return pred_operators;
     }
 
@@ -434,10 +455,8 @@ void PipelineBuilderContext::inherit_upstream_source_properties(SourceOperatorFa
         downstream_source->set_partition_exprs(upstream_source->partition_exprs());
     }
 
-    if (downstream_source->adaptive_initial_state() != SourceOperatorFactory::AdaptiveState::NONE) {
-        downstream_source->set_group_leader(downstream_source);
-    } else {
-        downstream_source->set_group_leader(upstream_source);
+    if (downstream_source->adaptive_initial_state() == SourceOperatorFactory::AdaptiveState::NONE) {
+        downstream_source->add_upstream_source(upstream_source);
     }
 }
 

--- a/be/src/exec/pipeline/pipeline_builder.h
+++ b/be/src/exec/pipeline/pipeline_builder.h
@@ -138,9 +138,6 @@ public:
     void push_dependent_pipeline(const Pipeline* pipeline);
     void pop_dependent_pipeline();
 
-    bool force_disable_adaptive_dop() const { return _force_disable_adaptive_dop; }
-    void set_force_disable_adaptive_dop(bool val) { _force_disable_adaptive_dop = val; }
-
 private:
     OpFactories _maybe_interpolate_local_passthrough_exchange(RuntimeState* state, int32_t plan_node_id,
                                                               OpFactories& pred_operators, int num_receivers,
@@ -165,13 +162,11 @@ private:
     const size_t _degree_of_parallelism;
 
     const bool _is_stream_pipeline;
-
-    bool _force_disable_adaptive_dop = false;
 };
 
 class PipelineBuilder {
 public:
-    PipelineBuilder(PipelineBuilderContext& context) : _context(context) {}
+    explicit PipelineBuilder(PipelineBuilderContext& context) : _context(context) {}
 
     // Build pipeline from exec node tree
     Pipelines build(const FragmentContext& fragment, ExecNode* exec_node);

--- a/be/src/exec/pipeline/source_operator.cpp
+++ b/be/src/exec/pipeline/source_operator.cpp
@@ -19,6 +19,16 @@
 
 namespace starrocks::pipeline {
 
+void SourceOperatorFactory::adjust_dop() {
+    const size_t max_parent_dop = std::accumulate(
+            _upstream_sources.begin(), _upstream_sources.end(), static_cast<size_t>(0),
+            [](size_t max_dop, const auto* parent) { return std::max(max_dop, parent->degree_of_parallelism()); });
+
+    if (max_parent_dop > 0 && max_parent_dop < _degree_of_parallelism) {
+        _degree_of_parallelism = max_parent_dop;
+    }
+}
+
 void SourceOperatorFactory::add_group_dependent_pipeline(const Pipeline* dependent_op) {
     group_leader()->_group_dependent_pipelines.emplace_back(dependent_op);
 }
@@ -26,15 +36,26 @@ const std::vector<const Pipeline*>& SourceOperatorFactory::group_dependent_pipel
     return group_leader()->_group_dependent_pipelines;
 }
 
-void SourceOperatorFactory::set_group_leader(SourceOperatorFactory* parent) {
-    if (this == parent) {
-        return;
+void SourceOperatorFactory::add_upstream_source(SourceOperatorFactory* parent) {
+    _upstream_sources.emplace_back(parent);
+    if (_group_parent == this) { // Set the group parent once when adding the first upstream source.
+        _group_parent = parent->group_leader();
     }
-    _group_leader = parent->group_leader();
 }
 
 SourceOperatorFactory* SourceOperatorFactory::group_leader() const {
-    return _group_leader;
+    if (_group_parent != this) {
+        _group_parent = _group_parent->group_leader();
+    }
+    return _group_parent;
+}
+
+void SourceOperatorFactory::union_group(SourceOperatorFactory* other_group) {
+    auto* group_leader = this->group_leader();
+    auto* other_group_parent = other_group->group_leader();
+    if (group_leader != other_group_parent) {
+        other_group_parent->_group_parent = group_leader;
+    }
 }
 
 bool SourceOperatorFactory::is_adaptive_group_initial_active() const {

--- a/be/src/exec/pipeline/source_operator.cpp
+++ b/be/src/exec/pipeline/source_operator.cpp
@@ -52,9 +52,9 @@ SourceOperatorFactory* SourceOperatorFactory::group_leader() const {
 
 void SourceOperatorFactory::union_group(SourceOperatorFactory* other_group) {
     auto* group_leader = this->group_leader();
-    auto* other_group_parent = other_group->group_leader();
-    if (group_leader != other_group_parent) {
-        other_group_parent->_group_parent = group_leader;
+    auto* other_group_leader = other_group->group_leader();
+    if (group_leader != other_group_leader) {
+        other_group_leader->_group_parent = group_leader;
     }
 }
 

--- a/be/src/exec/pipeline/source_operator.h
+++ b/be/src/exec/pipeline/source_operator.h
@@ -42,7 +42,7 @@ public:
     // Set the DOP(degree of parallelism) of the SourceOperator, SourceOperator's DOP determine the Pipeline's DOP.
     void set_degree_of_parallelism(size_t degree_of_parallelism) { _degree_of_parallelism = degree_of_parallelism; }
     void adjust_max_dop(size_t new_dop) { _degree_of_parallelism = std::min(new_dop, _degree_of_parallelism); }
-    virtual void adjust_dop() {}
+    virtual void adjust_dop();
     size_t degree_of_parallelism() const { return _degree_of_parallelism; }
 
     MorselQueueFactory* morsel_queue_factory() { return _morsel_queue_factory; }
@@ -111,8 +111,9 @@ public:
     void add_group_dependent_pipeline(const Pipeline* dependent_op);
     const std::vector<const Pipeline*>& group_dependent_pipelines() const;
 
-    void set_group_leader(SourceOperatorFactory* parent);
+    void add_upstream_source(SourceOperatorFactory* parent);
     SourceOperatorFactory* group_leader() const;
+    void union_group(SourceOperatorFactory* other_group);
 
 protected:
     size_t _degree_of_parallelism = 1;
@@ -123,7 +124,8 @@ protected:
 
     std::vector<ExprContext*> _partition_exprs;
 
-    SourceOperatorFactory* _group_leader = this;
+    std::vector<SourceOperatorFactory*> _upstream_sources;
+    mutable SourceOperatorFactory* _group_parent = this;
     std::vector<const Pipeline*> _group_dependent_pipelines;
     EventPtr _group_initialize_event = nullptr;
     EventPtr _adaptive_blocking_event = nullptr;

--- a/be/src/exec/union_node.cpp
+++ b/be/src/exec/union_node.cpp
@@ -338,9 +338,6 @@ void UnionNode::_move_column(ChunkPtr& dest_chunk, ColumnPtr& src_column, const 
 pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilderContext* context) {
     using namespace pipeline;
 
-    bool prev_force_disable_adaptive_dop = context->force_disable_adaptive_dop();
-    context->set_force_disable_adaptive_dop(true);
-
     std::vector<OpFactories> operators_list;
     operators_list.reserve(_children.size() + 1);
     const auto num_operators_generated = _children.size() + !_const_expr_lists.empty();
@@ -424,9 +421,6 @@ pipeline::OpFactories UnionNode::decompose_to_pipeline(pipeline::PipelineBuilder
         final_operators.emplace_back(
                 std::make_shared<LimitOperatorFactory>(context->next_operator_id(), id(), limit()));
     }
-
-    context->set_force_disable_adaptive_dop(prev_force_disable_adaptive_dop);
-    final_operators = context->maybe_interpolate_collect_stats(runtime_state(), id(), final_operators);
 
     return final_operators;
 }


### PR DESCRIPTION
### Why I'm doing
For now, DOP can be modified in runtime only after LocalExchangeSourceOperator of `UNION ALL`.
Therefore, some pipelines cannot modify DOP. This is especially heavy when there are many `UNION ALL`s in the statement.

<img width="1130" alt="image" src="https://github.com/StarRocks/starrocks/assets/13313784/2b17fc6a-3657-499e-ad3e-c3a52be6c390">

What I'm doing:
Push down CollectStats{Sink,Source}Operator to `UNION ALL`.
- Create a new event `DependsAll`.
    - It depends on all all the `CsSinkOperator#blocking_event`s.
    - `CsSourceInitializeOperator` depends on `DependsAll` instead of `CsSinkOperator#blocking_event`.
<img width="562" alt="image" src="https://github.com/StarRocks/starrocks/assets/13313784/2544f953-d655-44d4-9bf8-b80a53cae420">



Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
