### PR TITLE
[BugFix] Compare with adjacent partitions for addPartition

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/RangePartitionInfo.java
@@ -182,6 +182,9 @@ public class RangePartitionInfo extends PartitionInfo {
         if (newRange == null) /* the new range's upper value is larger than any existing ranges */ {
             newRange = checkNewRange(partKeyDesc, newRangeUpper, lastRange, currentRange);
         }
+        if (lastRange != null) {
+            RangeUtils.checkRangeIntersect(newRange, lastRange);
+        }
         return newRange;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/alter/AlterTest.java
@@ -2435,6 +2435,67 @@ public class AlterTest {
     }
 
     @Test(expected = DdlException.class)
+    public void testAddRangePartitionWithMultiTypePartition() throws Exception {
+        ConnectContext ctx = starRocksAssert.getCtx();
+        String createSQL = "CREATE TABLE `partition1` (\n" +
+                "  `dtstattime` datetime NOT NULL COMMENT \"xxxx\",\n" +
+                "  `hour1` varchar(65533) NULL COMMENT \"xxx\",\n" +
+                "  `ping1` double NULL COMMENT \"xxx\"\n" +
+                ") ENGINE=OLAP\n" +
+                "DUPLICATE KEY(`dtstattime`, `hour1`)\n" +
+                "COMMENT \"test\"\n" +
+                "PARTITION BY RANGE(`dtstattime`)\n" +
+                "()\n" +
+                "DISTRIBUTED BY HASH(`dtstattime`) BUCKETS 256\n" +
+                "PROPERTIES (\n" +
+                "\"replication_num\" = \"1\",\n" +
+                "\"dynamic_partition.enable\" = \"false\",\n" +
+                "\"dynamic_partition.time_unit\" = \"hour\",\n" +
+                "\"dynamic_partition.time_zone\" = \"Asia/Shanghai\",\n" +
+                "\"dynamic_partition.start\" = \"-2147483648\",\n" +
+                "\"dynamic_partition.end\" = \"240\",\n" +
+                "\"dynamic_partition.prefix\" = \"p\",\n" +
+                "\"dynamic_partition.buckets\" = \"1\",\n" +
+                "\"dynamic_partition.history_partition_num\" = \"0\",\n" +
+                "\"in_memory\" = \"false\",\n" +
+                "\"storage_format\" = \"DEFAULT\",\n" +
+                "\"enable_persistent_index\" = \"false\",\n" +
+                "\"compression\" = \"LZ4\"\n" +
+                ");";
+
+        CreateTableStmt createTableStmt = (CreateTableStmt) UtFrameUtils.parseStmtWithNewParser(createSQL, ctx);
+        GlobalStateMgr.getCurrentState().createTable(createTableStmt);
+        Database db = GlobalStateMgr.getCurrentState().getDb("test");
+
+        try {
+            String sql = "ALTER TABLE partition1 ADD PARTITION p2023072000 " +
+                    "VALUES [(\"2023-07-20 00:00:00\"), (\"2023-07-20 01:00:00\"));";
+            AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+            GlobalStateMgr.getCurrentState().alterTable(alterTableStmt);
+
+            sql = "ALTER TABLE partition1 ADD PARTITION p2023072001 " +
+                    "VALUES [(\"2023-07-20 01:00:00\"), (\"2023-07-20 02:00:00\"));";
+            alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+            GlobalStateMgr.getCurrentState().alterTable(alterTableStmt);
+
+            sql = "ALTER TABLE partition1 ADD PARTITION p2023072002 " +
+                    "VALUES [(\"2023-07-20 02:00:00\"), (\"2023-07-20 03:00:00\"));";
+            alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+            GlobalStateMgr.getCurrentState().alterTable(alterTableStmt);
+        } catch (Exception e) {
+            Assert.assertEquals("failed to add partition", 1, 0);
+        }
+        String sql = "ALTER TABLE partition1 ADD PARTITION p2023071700 " +
+                "VALUES [(\"2023-07-17 00:00:00\"), (\"2023-07-17 01:00:00\"));";
+        AlterTableStmt alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        GlobalStateMgr.getCurrentState().alterTable(alterTableStmt);
+
+        sql = "ALTER TABLE partition1 ADD PARTITION p20230717 VALUES [(\"2023-07-17 00:00:00\"), (\"2023-07-18 00:00:00\"));";
+        alterTableStmt = (AlterTableStmt) UtFrameUtils.parseStmtWithNewParser(sql, ctx);
+        GlobalStateMgr.getCurrentState().alterTable(alterTableStmt);
+    }
+
+    @Test(expected = DdlException.class)
     public void testAddMultiListPartitionSamePartitionNameShouldThrowError() throws Exception {
         ConnectContext ctx = starRocksAssert.getCtx();
         String createSQL = "CREATE TABLE test.test_partition_2 (\n" +


### PR DESCRIPTION
Why I'm doing:
add  partition intersected with other, not throw error 

What I'm doing:
throw  p1 is intersected with range p2

Fixes #38863

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [x] 2.5
