### PR TITLE
[Feature] Support pk table replication from another cluster for olap table and cloud-native table (backport #38330)

### DIFF
--- a/be/src/agent/publish_version.cpp
+++ b/be/src/agent/publish_version.cpp
@@ -250,6 +250,11 @@ void run_publish_version_task(ThreadPoolToken* token, const TPublishVersionReque
     auto publish_latency = MonotonicMillis() - start_ts;
     g_publish_latency << publish_latency;
     if (st.ok()) {
+        if (is_replication_txn) {
+            (void)ExecEnv::GetInstance()->delete_file_thread_pool()->submit_func([transaction_id]() {
+                StorageEngine::instance()->replication_txn_manager()->clear_txn(transaction_id);
+            });
+        }
         LOG(INFO) << "publish_version success. txn_id: " << transaction_id << " #partition:" << num_partition
                   << " #tablet:" << tablet_tasks.size() << " time:" << publish_latency << "ms"
                   << " #already_finished:" << total_tablet_cnt - num_active_tablet;

--- a/be/src/fs/fs_memory.cpp
+++ b/be/src/fs/fs_memory.cpp
@@ -592,4 +592,22 @@ Status MemoryFileSystem::read_file(const std::string& path, std::string* content
     return random_access_file->read_at_fully(0, content->data(), content->size());
 }
 
+namespace {
+
+class MemoryInputStream : public io::SeekableInputStreamWrapper {
+public:
+    explicit MemoryInputStream(std::string_view data) : io::SeekableInputStreamWrapper(&_stream, kDontTakeOwnership) {
+        _stream.reset(data.data(), static_cast<int64_t>(data.size()));
+    }
+
+private:
+    io::ArrayInputStream _stream;
+};
+
+} // namespace
+
+std::unique_ptr<RandomAccessFile> new_random_access_file_from_memory(std::string_view name, std::string_view data) {
+    return std::make_unique<RandomAccessFile>(std::make_shared<MemoryInputStream>(data), std::string(name));
+}
+
 } // namespace starrocks

--- a/be/src/fs/fs_memory.h
+++ b/be/src/fs/fs_memory.h
@@ -89,4 +89,6 @@ private:
     EnvMemoryImpl* _impl;
 };
 
+std::unique_ptr<RandomAccessFile> new_random_access_file_from_memory(std::string_view name, std::string_view data);
+
 } // namespace starrocks

--- a/be/src/storage/del_vector.cpp
+++ b/be/src/storage/del_vector.cpp
@@ -93,7 +93,7 @@ string DelVector::save() const {
     return ret;
 }
 
-void DelVector::save_to(std::string* str) {
+void DelVector::save_to(std::string* str) const {
     auto roaring_size = _roaring ? _roaring->getSizeInBytes() : 0;
     str->resize(roaring_size + 1);
     str->at(0) = 0x01; // one byte flag.
@@ -125,7 +125,11 @@ void DelVector::copy_from(const DelVector& delvec) {
     _version = delvec._version;
     _cardinality = delvec._cardinality;
     _memory_usage = delvec._memory_usage;
-    _roaring = std::make_unique<Roaring>(*delvec._roaring);
+    if (delvec._roaring) {
+        _roaring = std::make_unique<Roaring>(*delvec._roaring);
+    } else {
+        _roaring.reset();
+    }
 }
 
 } // namespace starrocks

--- a/be/src/storage/del_vector.h
+++ b/be/src/storage/del_vector.h
@@ -53,7 +53,7 @@ public:
 
     std::string save() const;
 
-    void save_to(std::string* str);
+    void save_to(std::string* str) const;
 
     std::string to_string() const;
 

--- a/be/src/storage/lake/replication_txn_manager.cpp
+++ b/be/src/storage/lake/replication_txn_manager.cpp
@@ -24,6 +24,7 @@
 #include "agent/master_info.h"
 #include "agent/task_signatures_manager.h"
 #include "fs/fs.h"
+#include "fs/fs_memory.h"
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/Types_constants.h"
 #include "gutil/strings/split.h"
@@ -35,6 +36,7 @@
 #include "runtime/exec_env.h"
 #include "service/backend_options.h"
 #include "storage/lake/location_provider.h"
+#include "storage/lake/meta_file.h"
 #include "storage/lake/tablet.h"
 #include "storage/lake/tablet_manager.h"
 #include "storage/protobuf_file.h"
@@ -85,16 +87,23 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
               << ", snapshot_version: " << request.src_visible_version << ", missed_versions: ["
               << (request.visible_version + 1) << " ... " << request.src_visible_version << "]";
 
+    Status status;
     TBackend src_backend;
-    *incremental_snapshot = true;
-    Status status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
-    if (!status.ok()) {
-        LOG(INFO) << "Fail to make incremental snapshot: " << status << ". switch to fully snapshot"
-                  << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-                  << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
-                  << ", snapshot_version: " << request.src_visible_version;
+    if (request.visible_version <= 1) { // Make full snapshot
         *incremental_snapshot = false;
         status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+    } else { // Try to make incremental snapshot first, if failed, make full snapshot
+        *incremental_snapshot = true;
+        status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
+        if (!status.ok()) {
+            LOG(INFO) << "Fail to make incremental snapshot: " << status << ". switch to fully snapshot"
+                      << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                      << ", src_tablet_id: " << request.src_tablet_id
+                      << ", visible_version: " << request.visible_version
+                      << ", snapshot_version: " << request.src_visible_version;
+            *incremental_snapshot = false;
+            status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+        }
     }
 
     if (!status.ok()) {
@@ -108,7 +117,7 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
     LOG(INFO) << "Made snapshot from " << src_backend.host << ":" << src_backend.be_port << ":" << *src_snapshot_path
               << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
               << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
-              << ", snapshot_version: " << request.src_visible_version;
+              << ", snapshot_version: " << request.src_visible_version << ", is_incremental: " << *incremental_snapshot;
 
     auto txn_log = std::make_shared<TxnLog>();
     txn_log->set_tablet_id(request.tablet_id);
@@ -145,9 +154,11 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
         }
     }
 
+    ASSIGN_OR_RETURN(auto tablet_metadata, tablet.get_metadata(request.visible_version));
+
     Status status;
     for (const auto& src_snapshot_info : request.src_snapshot_infos) {
-        auto status_or = replicate_remote_snapshot(request, src_snapshot_info);
+        auto status_or = replicate_remote_snapshot(request, src_snapshot_info, tablet_metadata);
 
         if (!status_or.ok()) {
             status = status_or.status();
@@ -163,6 +174,7 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
         LOG(INFO) << "Replicated snapshot from " << src_snapshot_info.backend.host << ":"
                   << src_snapshot_info.backend.http_port << ":" << src_snapshot_info.snapshot_path << " to "
                   << _tablet_manager->location_provider()->segment_root_location(request.tablet_id)
+                  << ", keys_type: " << KeysType_Name(tablet_metadata->schema().keys_type())
                   << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
                   << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
                   << ", snapshot_version: " << request.src_visible_version;
@@ -195,11 +207,6 @@ Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest&
                                                         request.src_schema_hash, request.src_visible_version, timeout_s,
                                                         missed_versions, missing_version_ranges, src_snapshot_path);
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to make snapshot from " << src_be.host << ":" << src_be.be_port << ", " << status
-                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-                         << ", src_tablet_id: " << request.src_tablet_id
-                         << ", visible_version: " << request.visible_version
-                         << ", snapshot_version: " << request.src_visible_version;
             continue;
         }
 
@@ -211,33 +218,78 @@ Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest&
 }
 
 StatusOr<TxnLogPtr> ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
-                                                                     const TRemoteSnapshotInfo& src_snapshot_info) {
-    std::string remote_header_file_name = std::to_string(request.src_tablet_id) + ".hdr";
-    ASSIGN_OR_RETURN(auto header_file_content,
-                     ReplicationUtils::download_remote_snapshot_file(
-                             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
-                             src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
-                             remote_header_file_name, config::download_low_speed_time));
-    TabletMeta tablet_meta;
-    RETURN_IF_ERROR(tablet_meta.create_from_memory(header_file_content));
-
+                                                                     const TRemoteSnapshotInfo& src_snapshot_info,
+                                                                     const TabletMetadataPtr& tablet_metadata) {
     auto txn_log = std::make_shared<TxnLog>();
-    std::unordered_map<std::string, std::string> segment_filename_map;
-    const auto& rowset_metas =
-            tablet_meta.all_rs_metas().empty() ? tablet_meta.all_inc_rs_metas() : tablet_meta.all_rs_metas();
-    for (const auto& rowset_meta : rowset_metas) {
-        auto* rowset_metadata = txn_log->mutable_op_replication()->add_op_writes()->mutable_rowset();
-        RETURN_IF_ERROR(
-                convert_rowset_meta(*rowset_meta, request.transaction_id, rowset_metadata, &segment_filename_map));
+    std::unordered_map<std::string, std::string> filename_map;
+
+    if (!is_primary_key(*tablet_metadata)) { // None-pk table
+        std::string remote_header_file_name = std::to_string(request.src_tablet_id) + ".hdr";
+        ASSIGN_OR_RETURN(auto header_file_content,
+                         ReplicationUtils::download_remote_snapshot_file(
+                                 src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+                                 src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
+                                 remote_header_file_name, config::download_low_speed_time));
+        TabletMeta tablet_meta;
+        auto status = tablet_meta.create_from_memory(header_file_content);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to parse remote snapshot header file: " << remote_header_file_name
+                         << ", content: " << header_file_content << ", " << status;
+            return status;
+        }
+
+        const auto& rowset_metas =
+                tablet_meta.all_rs_metas().empty() ? tablet_meta.all_inc_rs_metas() : tablet_meta.all_rs_metas();
+        for (const auto& rowset_meta : rowset_metas) {
+            auto* op_write = txn_log->mutable_op_replication()->add_op_writes();
+            RETURN_IF_ERROR(convert_rowset_meta(*rowset_meta, request.transaction_id, op_write, &filename_map));
+        }
+    } else { // Pk table
+        std::string snapshot_meta_file_name = "meta";
+        ASSIGN_OR_RETURN(auto snapshot_meta_content,
+                         ReplicationUtils::download_remote_snapshot_file(
+                                 src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+                                 src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
+                                 snapshot_meta_file_name, config::download_low_speed_time));
+
+        auto memory_file = new_random_access_file_from_memory(snapshot_meta_file_name, snapshot_meta_content);
+        SnapshotMeta snapshot_meta;
+        auto status = snapshot_meta.parse_from_file(memory_file.get());
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to parse remote snapshot meta file: " << snapshot_meta_file_name
+                         << ", content: " << snapshot_meta_content << ", " << status;
+            return status;
+        }
+
+        CHECK(((src_snapshot_info.incremental_snapshot &&
+                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_INCREMENTAL) ||
+               (!src_snapshot_info.incremental_snapshot &&
+                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_FULL)))
+                << ", incremental_snapshot: " << src_snapshot_info.incremental_snapshot
+                << ", snapshot_type: " << SnapshotTypePB_Name(snapshot_meta.snapshot_type());
+
+        const auto& rowset_metas = snapshot_meta.rowset_metas();
+        for (const auto& rowset_meta_pb : rowset_metas) {
+            RowsetMeta rowset_meta(rowset_meta_pb);
+            auto* op_write = txn_log->mutable_op_replication()->add_op_writes();
+            RETURN_IF_ERROR(convert_rowset_meta(rowset_meta, request.transaction_id, op_write, &filename_map));
+        }
+
+        for (const auto& [segment_id, delvec] : snapshot_meta.delete_vectors()) {
+            auto* delvecs = txn_log->mutable_op_replication()->mutable_delvecs();
+            auto& delvec_data = (*delvecs)[segment_id];
+            delvec_data.set_version(delvec.version());
+            delvec.save_to(delvec_data.mutable_data());
+        }
     }
 
     RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
             src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash, nullptr,
             _tablet_manager->location_provider()->segment_root_location(request.tablet_id) + '/',
-            [segment_filename_map = std::move(segment_filename_map)](const std::string& filename) {
-                auto iter = segment_filename_map.find(filename);
-                if (iter == segment_filename_map.end()) {
+            [filename_map = std::move(filename_map)](const std::string& filename) {
+                auto iter = filename_map.find(filename);
+                if (iter == filename_map.end()) {
                     return std::string();
                 }
                 return iter->second;
@@ -261,11 +313,15 @@ StatusOr<TxnLogPtr> ReplicationTxnManager::replicate_remote_snapshot(const TRepl
 }
 
 Status ReplicationTxnManager::convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,
-                                                  RowsetMetadata* rowset_metadata,
-                                                  std::unordered_map<std::string, std::string>* segment_filename_map) {
+                                                  TxnLogPB::OpWrite* op_write,
+                                                  std::unordered_map<std::string, std::string>* filename_map) {
+    // Convert rowset metadata
+    auto* rowset_metadata = op_write->mutable_rowset();
+    rowset_metadata->set_id(rowset_meta.get_rowset_seg_id());
     rowset_metadata->set_overlapped(rowset_meta.is_segments_overlapping());
     rowset_metadata->set_num_rows(rowset_meta.num_rows());
     rowset_metadata->set_data_size(rowset_meta.data_disk_size());
+    rowset_metadata->set_num_dels(rowset_meta.get_num_delete_files());
     if (rowset_meta.has_delete_predicate()) {
         rowset_metadata->mutable_delete_predicate()->CopyFrom(rowset_meta.delete_predicate());
     }
@@ -276,9 +332,25 @@ Status ReplicationTxnManager::convert_rowset_meta(const RowsetMeta& rowset_meta,
         std::string new_segment_filename = gen_segment_filename(transaction_id);
 
         rowset_metadata->add_segments(new_segment_filename);
-        auto pair = segment_filename_map->emplace(std::move(old_segment_filename), std::move(new_segment_filename));
+        auto pair = filename_map->emplace(std::move(old_segment_filename), std::move(new_segment_filename));
         if (!pair.second) {
             return Status::Corruption("Duplicated segment file: " + pair.first->first);
+        }
+    }
+
+    // Convert rowset txn meta
+    auto* rowset_txn_meta = op_write->mutable_txn_meta();
+    rowset_txn_meta->CopyFrom(rowset_meta.txn_meta());
+
+    // Convert dels
+    for (int64_t del_id = 0; del_id < rowset_meta.get_num_delete_files(); ++del_id) {
+        std::string old_del_filename = rowset_id + '_' + std::to_string(del_id) + ".del";
+        std::string new_del_filename = gen_del_filename(transaction_id);
+
+        op_write->add_dels(new_del_filename);
+        auto pair = filename_map->emplace(std::move(old_del_filename), std::move(new_del_filename));
+        if (!pair.second) {
+            return Status::Corruption("Duplicated del file: " + pair.first->first);
         }
     }
 

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -16,6 +16,7 @@
 
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
+#include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/types_fwd.h"
 #include "storage/olap_common.h"
@@ -45,10 +46,11 @@ private:
                                 std::string* src_snapshot_path);
 
     StatusOr<TxnLogPtr> replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
-                                                  const TRemoteSnapshotInfo& src_snapshot_info);
+                                                  const TRemoteSnapshotInfo& src_snapshot_info,
+                                                  const TabletMetadataPtr& tablet_metadata);
 
     Status convert_rowset_meta(const RowsetMeta& rowset_meta, TTransactionId transaction_id,
-                               RowsetMetadata* rowset_metadata,
+                               TxnLogPB::OpWrite* op_write,
                                std::unordered_map<std::string, std::string>* segment_filename_map);
 
 private:

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -88,6 +88,9 @@ public:
         if (log.has_op_alter_metadata()) {
             RETURN_IF_ERROR(apply_alter_meta_log(log.op_alter_metadata()));
         }
+        if (log.has_op_replication()) {
+            RETURN_IF_ERROR(apply_replication_log(log.op_replication(), log.txn_id()));
+        }
         return Status::OK();
     }
 
@@ -222,6 +225,65 @@ private:
                 }
             }
         }
+        return Status::OK();
+    }
+
+    Status apply_replication_log(const TxnLogPB_OpReplication& op_replication, int64_t txn_id) {
+        if (op_replication.txn_meta().txn_state() != ReplicationTxnStatePB::TXN_REPLICATED) {
+            LOG(WARNING) << "Fail to apply replication log, invalid txn meta state: "
+                         << ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state());
+            return Status::Corruption("Invalid txn meta state: " +
+                                      ReplicationTxnStatePB_Name(op_replication.txn_meta().txn_state()));
+        }
+        if (op_replication.txn_meta().snapshot_version() != _new_version) {
+            LOG(WARNING) << "Fail to apply replication log, mismatched snapshot version and new version"
+                         << ", snapshot version: " << op_replication.txn_meta().snapshot_version()
+                         << ", new version: " << _new_version;
+            return Status::Corruption("mismatched snapshot version and new version");
+        }
+
+        if (op_replication.txn_meta().incremental_snapshot()) {
+            CHECK(_new_version - _base_version == op_replication.op_writes_size())
+                    << ", base_version: " << _base_version << ", new_version: " << _new_version
+                    << ", op_write_size: " << op_replication.op_writes_size();
+            for (const auto& op_write : op_replication.op_writes()) {
+                RETURN_IF_ERROR(apply_write_log(op_write, txn_id));
+            }
+            LOG(INFO) << "Apply pk incremental replication log finish. tablet_id: " << _tablet.id()
+                      << ", base_version: " << _base_version << ", new_version: " << _new_version
+                      << ", txn_id: " << txn_id;
+        } else {
+            auto old_rowsets = std::move(*_metadata->mutable_rowsets());
+            _metadata->mutable_rowsets()->Clear();
+            _metadata->mutable_delvec_meta()->Clear();
+
+            auto new_next_rowset_id = _metadata->next_rowset_id();
+            for (const auto& op_write : op_replication.op_writes()) {
+                auto rowset = _metadata->add_rowsets();
+                rowset->CopyFrom(op_write.rowset());
+                const auto new_rowset_id = rowset->id() + _metadata->next_rowset_id();
+                rowset->set_id(new_rowset_id);
+                new_next_rowset_id =
+                        std::max<uint32_t>(new_next_rowset_id, new_rowset_id + std::max(1, rowset->segments_size()));
+            }
+
+            for (const auto& [segment_id, delvec_data] : op_replication.delvecs()) {
+                auto delvec = std::make_shared<DelVector>();
+                RETURN_IF_ERROR(delvec->load(_new_version, delvec_data.data().data(), delvec_data.data().size()));
+                _builder.append_delvec(delvec, segment_id + _metadata->next_rowset_id());
+            }
+
+            _metadata->set_next_rowset_id(new_next_rowset_id);
+            _metadata->set_cumulative_point(0);
+            old_rowsets.Swap(_metadata->mutable_compaction_inputs());
+
+            _tablet.update_mgr()->unload_primary_index(_tablet.id());
+
+            LOG(INFO) << "Apply pk full replication log finish. tablet_id: " << _tablet.id()
+                      << ", base_version: " << _base_version << ", new_version: " << _new_version
+                      << ", txn_id: " << txn_id;
+        }
+
         return Status::OK();
     }
 
@@ -395,12 +457,29 @@ private:
             return Status::Corruption("mismatched snapshot version and new version");
         }
 
-        if (!op_replication.txn_meta().incremental_snapshot()) {
-            _metadata->clear_rowsets();
+        if (op_replication.txn_meta().incremental_snapshot()) {
+            for (const auto& op_write : op_replication.op_writes()) {
+                RETURN_IF_ERROR(apply_write_log(op_write));
+            }
+            LOG(INFO) << "Apply incremental replication log finish. tablet_id: " << _tablet.id()
+                      << ", base_version: " << _metadata->version() << ", new_version: " << _new_version
+                      << ", txn_id: " << op_replication.txn_meta().txn_id();
+        } else {
+            auto old_rowsets = std::move(*_metadata->mutable_rowsets());
+            _metadata->mutable_rowsets()->Clear();
+
+            for (const auto& op_write : op_replication.op_writes()) {
+                RETURN_IF_ERROR(apply_write_log(op_write));
+            }
+
+            _metadata->set_cumulative_point(0);
+            old_rowsets.Swap(_metadata->mutable_compaction_inputs());
+
+            LOG(INFO) << "Apply full replication log finish. tablet_id: " << _tablet.id()
+                      << ", base_version: " << _metadata->version() << ", new_version: " << _new_version
+                      << ", txn_id: " << op_replication.txn_meta().txn_id();
         }
-        for (const auto& op_write : op_replication.op_writes()) {
-            RETURN_IF_ERROR(apply_write_log(op_write));
-        }
+
         return Status::OK();
     }
 

--- a/be/src/storage/lake/update_manager.cpp
+++ b/be/src/storage/lake/update_manager.cpp
@@ -621,6 +621,12 @@ bool UpdateManager::try_remove_primary_index_cache(uint32_t tablet_id) {
     return _index_cache.try_remove_by_key(tablet_id);
 }
 
+void UpdateManager::unload_primary_index(int64_t tablet_id) {
+    auto index_entry = _index_cache.get_or_create(tablet_id);
+    index_entry->value().unload();
+    _index_cache.release(index_entry);
+}
+
 Status UpdateManager::check_meta_version(const Tablet& tablet, int64_t base_version) {
     auto index_entry = _index_cache.get(tablet.id());
     if (index_entry == nullptr) {

--- a/be/src/storage/lake/update_manager.h
+++ b/be/src/storage/lake/update_manager.h
@@ -101,6 +101,8 @@ public:
 
     bool try_remove_primary_index_cache(uint32_t tablet_id);
 
+    void unload_primary_index(int64_t tablet_id);
+
     // if base version != index.data_version, need to clear index cache
     Status check_meta_version(const Tablet& tablet, int64_t base_version);
 

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -24,11 +24,13 @@
 #include "agent/master_info.h"
 #include "agent/task_signatures_manager.h"
 #include "fs/fs.h"
+#include "fs/fs_memory.h"
 #include "gen_cpp/BackendService.h"
 #include "gen_cpp/Types_constants.h"
 #include "gutil/strings/split.h"
 #include "gutil/strings/stringpiece.h"
 #include "gutil/strings/substitute.h"
+#include "gutil/strings/util.h"
 #include "http/http_client.h"
 #include "runtime/client_cache.h"
 #include "runtime/current_thread.h"
@@ -107,7 +109,6 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
         }
     }
 
-    // TODO: Primary key
     std::vector<Version> missed_versions;
     tablet->calc_missed_versions(request.src_visible_version, &missed_versions);
     if (missed_versions.empty()) {
@@ -119,23 +120,29 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
         return Status::Corruption("No missing version");
     }
 
-    LOG(INFO) << "Remote snapshot tablet. "
+    LOG(INFO) << "Start make remote snapshot tablet. "
               << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-              << ", type: " << KeysType_Name(tablet->keys_type()) << ", src_tablet_id: " << request.src_tablet_id
+              << ", keys_type: " << KeysType_Name(tablet->keys_type()) << ", src_tablet_id: " << request.src_tablet_id
               << ", visible version: " << request.visible_version
               << ", snapshot version: " << request.src_visible_version
               << ", missed_versions=" << version_list_to_string(missed_versions);
 
     TBackend src_backend;
-    *incremental_snapshot = true;
-    status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
-    if (!status.ok()) {
-        LOG(INFO) << "Fail to make incremental snapshot: " << status << ", txn_id: " << request.transaction_id
-                  << ", switch to fully snapshot. tablet_id: " << request.tablet_id
-                  << ", src_tablet_id: " << request.src_tablet_id << ", visible version: " << request.visible_version
-                  << ", snapshot version: " << request.src_visible_version;
+    if (request.visible_version <= 1) { // Make full snapshot
         *incremental_snapshot = false;
         status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+    } else { // Try to make incremental snapshot first, if failed, make full snapshot
+        *incremental_snapshot = true;
+        status = make_remote_snapshot(request, &missed_versions, nullptr, &src_backend, src_snapshot_path);
+        if (!status.ok()) {
+            LOG(INFO) << "Fail to make incremental snapshot: " << status << ", txn_id: " << request.transaction_id
+                      << ", switch to fully snapshot. tablet_id: " << request.tablet_id
+                      << ", src_tablet_id: " << request.src_tablet_id
+                      << ", visible version: " << request.visible_version
+                      << ", snapshot version: " << request.src_visible_version;
+            *incremental_snapshot = false;
+            status = make_remote_snapshot(request, nullptr, nullptr, &src_backend, src_snapshot_path);
+        }
     }
 
     if (!status.ok()) {
@@ -145,6 +152,12 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
                      << ", snapshot_version: " << request.src_visible_version;
         return status;
     }
+
+    LOG(INFO) << "Made snapshot from " << src_backend.host << ":" << src_backend.be_port << ":" << *src_snapshot_path
+              << ", txn_id: " << request.transaction_id << ", keys_type: " << KeysType_Name(tablet->keys_type())
+              << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+              << ", visible_version: " << request.visible_version
+              << ", snapshot_version: " << request.src_visible_version << ", is_incremental: " << *incremental_snapshot;
 
     txn_meta_pb.set_txn_id(request.transaction_id);
     txn_meta_pb.set_txn_state(ReplicationTxnStatePB::TXN_SNAPSHOTED);
@@ -181,39 +194,12 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
     std::string tablet_snapshot_dir_path = get_tablet_snapshot_dir_path(tablet->data_dir(), request.transaction_id,
                                                                         request.partition_id, request.tablet_id);
     for (const auto& src_snapshot_info : request.src_snapshot_infos) {
-        // Check local path exist, if exist, remove it, then create the dir
-        RETURN_IF_ERROR(fs::remove_all(tablet_snapshot_dir_path));
-        RETURN_IF_ERROR(fs::create_directories(tablet_snapshot_dir_path));
-
-        const TBackend& src_be = src_snapshot_info.backend;
-        const std::string& src_snapshot_path = src_snapshot_info.snapshot_path;
-
-        status = ReplicationUtils::download_remote_snapshot(
-                src_be.host, src_be.http_port, request.src_token, src_snapshot_path, request.src_tablet_id,
-                request.src_schema_hash, tablet->data_dir(), tablet_snapshot_dir_path);
+        status = replicate_remote_snapshot(request, src_snapshot_info, tablet_snapshot_dir_path, tablet.get());
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to download snapshot from " << src_be.host << ":" << src_be.http_port << ":"
-                         << src_snapshot_path << ", " << status << ", txn_id: " << request.transaction_id
-                         << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
-                         << ", visible_version: " << request.visible_version
-                         << ", snapshot_version: " << request.src_visible_version;
-            continue;
-        }
-
-        status = convert_tablet_meta_file(tablet_snapshot_dir_path, request);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to convert tablet meta file: " << status << ", txn_id: " << request.transaction_id
-                         << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
-                         << ", visible_version: " << request.visible_version
-                         << ", snapshot_version: " << request.src_visible_version;
-            continue;
-        }
-
-        status = SnapshotManager::instance()->convert_rowset_ids(tablet_snapshot_dir_path, request.tablet_id,
-                                                                 request.schema_hash);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to convert rowset ids: " << status << ", txn_id: " << request.transaction_id
-                         << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
+            LOG(WARNING) << "Fail to download snapshot from " << src_snapshot_info.backend.host << ":"
+                         << src_snapshot_info.backend.http_port << ":" << src_snapshot_info.snapshot_path << ", "
+                         << status << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+                         << ", src_tablet_id: " << request.src_tablet_id
                          << ", visible_version: " << request.visible_version
                          << ", snapshot_version: " << request.src_visible_version;
             continue;
@@ -229,10 +215,11 @@ Status ReplicationTxnManager::replicate_snapshot(const TReplicateSnapshotRequest
                                       request.tablet_id, txn_meta_pb);
         RETURN_IF_ERROR(status);
 
-        LOG(INFO) << "Replicated snapshot from " << src_be.host << ":" << src_be.http_port << ":" << src_snapshot_path
-                  << " to " << tablet_snapshot_dir_path << ", txn_id: " << request.transaction_id
-                  << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
-                  << ", visible_version: " << request.visible_version
+        LOG(INFO) << "Replicated snapshot from " << src_snapshot_info.backend.host << ":"
+                  << src_snapshot_info.backend.http_port << ":" << src_snapshot_info.snapshot_path << " to "
+                  << tablet_snapshot_dir_path << ", txn_id: " << request.transaction_id
+                  << ", keys_type: " << KeysType_Name(tablet->keys_type()) << ", tablet_id: " << request.tablet_id
+                  << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
                   << ", snapshot_version: " << request.src_visible_version;
         break;
     }
@@ -335,11 +322,6 @@ Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest&
                                                         request.src_schema_hash, request.src_visible_version, timeout_s,
                                                         missed_versions, missing_version_ranges, src_snapshot_path);
         if (!status.ok()) {
-            LOG(WARNING) << "Fail to make snapshot from " << src_be.host << ", " << status
-                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-                         << ", src_tablet_id: " << request.src_tablet_id
-                         << ", visible_version: " << request.visible_version
-                         << ", snapshot_version: " << request.src_visible_version;
             continue;
         }
 
@@ -354,60 +336,102 @@ Status ReplicationTxnManager::make_remote_snapshot(const TRemoteSnapshotRequest&
     return status;
 }
 
-Status ReplicationTxnManager::convert_tablet_meta_file(const std::string& tablet_snapshot_path,
-                                                       const TReplicateSnapshotRequest& request) {
-    std::string src_header_file_path = tablet_snapshot_path + std::to_string(request.src_tablet_id) + ".hdr";
-    if (fs::path_exist(src_header_file_path)) {
-        TabletMeta tablet_meta;
-        Status status = tablet_meta.create_from_file(src_header_file_path);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to load tablet meta from " << src_header_file_path << ", " << status
-                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-                         << ", src_tablet_id: " << request.src_tablet_id
-                         << ", visible_version: " << request.visible_version
-                         << ", snapshot_version: " << request.src_visible_version;
-            return status;
-        }
+Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
+                                                        const TRemoteSnapshotInfo& src_snapshot_info,
+                                                        const std::string& tablet_snapshot_dir_path, Tablet* tablet) {
+    // Check local path exist, if exist, remove it, then create the dir
+    RETURN_IF_ERROR(fs::remove_all(tablet_snapshot_dir_path));
+    RETURN_IF_ERROR(fs::create_directories(tablet_snapshot_dir_path));
 
-        TabletMetaPB tablet_meta_pb;
-        tablet_meta.to_meta_pb(&tablet_meta_pb);
-        tablet_meta_pb.set_table_id(request.table_id);
-        tablet_meta_pb.set_partition_id(request.partition_id);
-        tablet_meta_pb.set_tablet_id(request.tablet_id);
+    RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
+            src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+            src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash, tablet->data_dir(),
+            tablet_snapshot_dir_path));
 
-        std::string header_file_path = tablet_snapshot_path + std::to_string(request.tablet_id) + ".hdr";
-        status = TabletMeta::save(header_file_path, tablet_meta_pb);
-        if (!status.ok()) {
-            LOG(WARNING) << "Fail to save tablet meta pb to " << header_file_path << ", " << status
-                         << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-                         << ", src_tablet_id: " << request.src_tablet_id
-                         << ", visible_version: " << request.visible_version
-                         << ", snapshot_version: " << request.src_visible_version;
-            return status;
-        }
-
-        if (request.tablet_id != request.src_tablet_id) {
-            status = fs::remove(src_header_file_path);
-            if (!status.ok()) {
-                LOG(WARNING) << "Fail to remove tablet meta " << src_header_file_path << ", " << status
-                             << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
-                             << ", src_tablet_id: " << request.src_tablet_id
-                             << ", visible_version: " << request.visible_version
-                             << ", snapshot_version: " << request.src_visible_version;
-            }
-        }
-
-        return status;
+    if (tablet->updates() == nullptr) {
+        RETURN_IF_ERROR(convert_snapshot_for_none_primary(tablet_snapshot_dir_path, request));
+    } else {
+        RETURN_IF_ERROR(convert_snapshot_for_primary(tablet_snapshot_dir_path, request));
     }
 
-    // TODO: convert meta file and dcgs_snapshot file
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::convert_snapshot_for_none_primary(const std::string& tablet_snapshot_path,
+                                                                const TReplicateSnapshotRequest& request) {
+    std::string src_header_file_path = tablet_snapshot_path + std::to_string(request.src_tablet_id) + ".hdr";
+    TabletMeta tablet_meta;
+    RETURN_IF_ERROR(tablet_meta.create_from_file(src_header_file_path));
+
+    TabletMetaPB tablet_meta_pb;
+    tablet_meta.to_meta_pb(&tablet_meta_pb);
+    tablet_meta_pb.set_table_id(request.table_id);
+    tablet_meta_pb.set_partition_id(request.partition_id);
+    tablet_meta_pb.set_tablet_id(request.tablet_id);
+    tablet_meta_pb.set_schema_hash(request.schema_hash);
+    for (auto& rowset_meta : *tablet_meta_pb.mutable_rs_metas()) {
+        rowset_meta.set_partition_id(request.partition_id);
+        rowset_meta.set_tablet_id(request.tablet_id);
+    }
+    for (auto& rowset_meta : *tablet_meta_pb.mutable_inc_rs_metas()) {
+        rowset_meta.set_partition_id(request.partition_id);
+        rowset_meta.set_tablet_id(request.tablet_id);
+    }
+
+    std::string header_file_path = tablet_snapshot_path + std::to_string(request.tablet_id) + ".hdr";
+    RETURN_IF_ERROR(TabletMeta::save(header_file_path, tablet_meta_pb));
+
+    if (request.tablet_id != request.src_tablet_id) {
+        auto status = fs::delete_file(src_header_file_path);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to delete file: " << src_header_file_path << ", " << status;
+        }
+    }
+
+    RETURN_IF_ERROR(SnapshotManager::instance()->convert_rowset_ids(tablet_snapshot_path, request.tablet_id,
+                                                                    request.schema_hash));
+    return Status::OK();
+}
+
+Status ReplicationTxnManager::convert_snapshot_for_primary(const std::string& tablet_snapshot_path,
+                                                           const TReplicateSnapshotRequest& request) {
+    std::string snapshot_meta_file_path = tablet_snapshot_path + "meta";
+    ASSIGN_OR_RETURN(auto snapshot_meta, SnapshotManager::instance()->parse_snapshot_meta(snapshot_meta_file_path));
+
+    TabletMetaPB& tablet_meta_pb = snapshot_meta.tablet_meta();
+    tablet_meta_pb.set_table_id(request.table_id);
+    tablet_meta_pb.set_partition_id(request.partition_id);
+    tablet_meta_pb.set_tablet_id(request.tablet_id);
+    tablet_meta_pb.set_schema_hash(request.schema_hash);
+    for (auto& rowset_meta : *tablet_meta_pb.mutable_rs_metas()) {
+        rowset_meta.set_partition_id(request.partition_id);
+        rowset_meta.set_tablet_id(request.tablet_id);
+    }
+    for (auto& rowset_meta : *tablet_meta_pb.mutable_inc_rs_metas()) {
+        rowset_meta.set_partition_id(request.partition_id);
+        rowset_meta.set_tablet_id(request.tablet_id);
+    }
+
+    for (auto& rowset_meta : snapshot_meta.rowset_metas()) {
+        rowset_meta.set_partition_id(request.partition_id);
+        rowset_meta.set_tablet_id(request.tablet_id);
+    }
+
+    RETURN_IF_ERROR(snapshot_meta.serialize_to_file(snapshot_meta_file_path));
+
+    RETURN_IF_ERROR(SnapshotManager::instance()->assign_new_rowset_id(&snapshot_meta, tablet_snapshot_path));
+
     return Status::OK();
 }
 
 Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,
                                                bool incremental_snapshot) {
+    if (tablet->max_version().second >= snapshot_version) {
+        return Status::OK();
+    }
+
     if (tablet->updates() != nullptr) {
-        return Status::NotSupported("Pk table not supported");
+        return publish_snapshot_for_primary(tablet, snapshot_dir);
     }
 
     Status res;
@@ -544,6 +568,62 @@ Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& sna
     }
 
     return res;
+}
+
+Status ReplicationTxnManager::publish_snapshot_for_primary(Tablet* tablet, const std::string& snapshot_dir) {
+    auto meta_file = strings::Substitute("$0/meta", snapshot_dir);
+    ASSIGN_OR_RETURN(auto snapshot_meta, SnapshotManager::instance()->parse_snapshot_meta(meta_file));
+
+    // check all files in /clone and /tablet
+    std::set<std::string> clone_files;
+    RETURN_IF_ERROR(fs::list_dirs_files(snapshot_dir, nullptr, &clone_files));
+    clone_files.erase("meta");
+
+    std::set<std::string> local_files;
+    const std::string& tablet_dir = tablet->schema_hash_path();
+    RETURN_IF_ERROR(fs::list_dirs_files(tablet_dir, nullptr, &local_files));
+
+    // Files that are found in both |clone_files| and |local_files|.
+    std::vector<std::string> duplicate_files;
+    std::set_intersection(clone_files.begin(), clone_files.end(), local_files.begin(), local_files.end(),
+                          std::back_inserter(duplicate_files));
+    for (const auto& fname : duplicate_files) {
+        ASSIGN_OR_RETURN(auto md5sum1, fs::md5sum(snapshot_dir + "/" + fname));
+        ASSIGN_OR_RETURN(auto md5sum2, fs::md5sum(tablet_dir + "/" + fname));
+        if (md5sum1 != md5sum2) {
+            LOG(WARNING) << "duplicated file `" << fname << "` with different md5sum";
+            return Status::InternalError("duplicate file with different md5");
+        }
+        clone_files.erase(fname);
+        local_files.erase(fname);
+    }
+
+    auto fs = FileSystem::Default();
+    std::set<std::string> tablet_files;
+    for (const std::string& filename : clone_files) {
+        std::string from = snapshot_dir + "/" + filename;
+        std::string to = tablet_dir + "/" + filename;
+        tablet_files.insert(to);
+        RETURN_IF_ERROR(fs->link_file(from, to));
+    }
+    LOG(INFO) << "Linked " << clone_files.size() << " files from " << snapshot_dir << " to " << tablet_dir;
+
+    Status status = tablet->updates()->load_snapshot(snapshot_meta);
+    if (!status.ok()) {
+        Status clear_st;
+        for (const std::string& filename : tablet_files) {
+            clear_st = fs::delete_file(filename);
+            if (!clear_st.ok()) {
+                LOG(WARNING) << "remove tablet file: " << filename << " failed, status: " << clear_st;
+            }
+        }
+    }
+
+    int64_t expired_stale_sweep_endtime = UnixSeconds() - config::tablet_rowset_stale_sweep_time_sec;
+    tablet->updates()->remove_expired_versions(expired_stale_sweep_endtime);
+    LOG(INFO) << "Loaded snapshot of tablet " << tablet->tablet_id() << " from " << snapshot_dir;
+
+    return status;
 }
 
 Status ReplicationTxnManager::publish_incremental_meta(Tablet* tablet, const TabletMeta& cloned_tablet_meta,

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -44,17 +44,25 @@ private:
                                 const std::vector<int64_t>* missing_version_ranges, TBackend* src_backend,
                                 std::string* src_snapshot_path);
 
-    Status convert_tablet_meta_file(const std::string& tablet_snapshot_path, const TReplicateSnapshotRequest& request);
+    Status replicate_remote_snapshot(const TReplicateSnapshotRequest& request,
+                                     const TRemoteSnapshotInfo& src_snapshot_info,
+                                     const std::string& tablet_snapshot_dir_path, Tablet* tablet);
+
+    Status convert_snapshot_for_none_primary(const std::string& tablet_snapshot_path,
+                                             const TReplicateSnapshotRequest& request);
+
+    Status convert_snapshot_for_primary(const std::string& tablet_snapshot_path,
+                                        const TReplicateSnapshotRequest& request);
 
     Status publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,
                             bool incremental_snapshot);
+
+    Status publish_snapshot_for_primary(Tablet* tablet, const std::string& snapshot_dir);
 
     Status publish_incremental_meta(Tablet* tablet, const TabletMeta& cloned_tablet_meta, int64_t snapshot_version);
 
     Status publish_full_meta(Tablet* tablet, TabletMeta* cloned_tablet_meta,
                              std::vector<RowsetMetaSharedPtr>& rs_to_clone);
-
-    Status publish_snapshot_primary(Tablet* tablet, const std::string& snapshot_dir);
 
     void clear_txn_snapshots(TTransactionId transaction_id);
 

--- a/be/src/storage/replication_utils.h
+++ b/be/src/storage/replication_utils.h
@@ -14,9 +14,6 @@
 
 #pragma once
 
-#include "common/status.h"
-#include "storage/olap_common.h"
-#include "storage/olap_define.h"
 #include "storage/storage_engine.h"
 
 namespace starrocks {

--- a/be/src/storage/rowset/rowset_meta.h
+++ b/be/src/storage/rowset/rowset_meta.h
@@ -135,6 +135,8 @@ public:
     // for determining whether the rowset is in column partial update is whether it contains the .upt files
     bool is_column_mode_partial_update() const { return _rowset_meta_pb->num_update_files() > 0; }
 
+    const RowsetTxnMetaPB& txn_meta() const { return _rowset_meta_pb->txn_meta(); }
+
     void clear_txn_meta() { _rowset_meta_pb->clear_txn_meta(); }
 
     bool empty() const { return _rowset_meta_pb->empty(); }

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -24,6 +24,7 @@
 #include "fs/fs.h"
 #include "fs/fs_util.h"
 #include "runtime/exec_env.h"
+#include "storage/chunk_helper.h"
 #include "storage/lake/fixed_location_provider.h"
 #include "storage/lake/join_path.h"
 #include "storage/lake/location_provider.h"
@@ -32,6 +33,11 @@
 #include "storage/lake/update_manager.h"
 #include "storage/olap_define.h"
 #include "storage/options.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset/segment.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_schema.h"
 #include "testutil/assert.h"
@@ -40,7 +46,7 @@
 
 namespace starrocks {
 
-class LakeReplicationTxnManagerTest : public testing::Test {
+class LakeReplicationTxnManagerTest : public testing::TestWithParam<TKeysType::type> {
 public:
     LakeReplicationTxnManagerTest() : _test_dir(){};
 
@@ -58,40 +64,139 @@ public:
         _tablet_manager = std::make_unique<lake::TabletManager>(_location_provider.get(), _update_manager.get(), 16384);
         _replication_txn_manager = std::make_unique<lake::ReplicationTxnManager>(_tablet_manager.get());
 
-        TCreateTabletReq create_tablet_req = get_create_tablet_request(_tablet_id, _schema_hash, _version);
-        Status create_st = _tablet_manager->create_tablet(create_tablet_req);
-        ASSERT_TRUE(create_st.ok());
+        ASSERT_TRUE(_tablet_manager->create_tablet(get_create_tablet_req(_tablet_id, _version, _schema_hash)).ok());
 
-        TCreateTabletReq src_create_tablet_req = get_create_tablet_request(_src_tablet_id, _schema_hash, _src_version);
-        Status src_create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
-                src_create_tablet_req, StorageEngine::instance()->get_stores());
-        ASSERT_TRUE(src_create_st.ok());
+        if (GetParam() != TKeysType::type::PRIMARY_KEYS) {
+            create_tablet(_src_tablet_id, _src_version, _schema_hash);
+        } else {
+            auto src_tablet = create_tablet(_src_tablet_id, 1, _schema_hash);
+
+            std::vector<int64_t> keys{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+            for (int i = 2; i <= _src_version; i++) {
+                ASSERT_TRUE(src_tablet->rowset_commit(i, create_rowset(src_tablet, keys)).ok());
+            }
+        }
     }
 
-    void TearDown() override { (void)FileSystem::Default()->delete_dir_recursive(_test_dir); }
+    void TearDown() override {
+        auto status = StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = fs::remove_all(config::storage_root_path);
+        EXPECT_TRUE(status.ok()) << status;
+    }
 
-    TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int schema_hash, int64_t version) {
-        TColumnType col_type;
-        col_type.__set_type(TPrimitiveType::SMALLINT);
-        TColumn col1;
-        col1.__set_column_name("col1");
-        col1.__set_column_type(col_type);
-        col1.__set_is_key(true);
-        std::vector<TColumn> cols;
-        cols.push_back(col1);
-        TTabletSchema tablet_schema;
-        tablet_schema.__set_id(1);
-        tablet_schema.__set_short_key_column_count(1);
-        tablet_schema.__set_schema_hash(schema_hash);
-        tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
-        tablet_schema.__set_storage_type(TStorageType::COLUMN);
-        tablet_schema.__set_columns(cols);
-        TCreateTabletReq create_tablet_req;
-        create_tablet_req.__set_tablet_schema(tablet_schema);
-        create_tablet_req.__set_tablet_id(tablet_id);
-        create_tablet_req.__set_version(version);
-        create_tablet_req.__set_version_hash(0);
-        return create_tablet_req;
+    TCreateTabletReq get_create_tablet_req(int64_t tablet_id, int64_t version, int32_t schema_hash,
+                                           bool multi_column_key = false) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(version);
+        request.__set_version_hash(0);
+        request.tablet_schema.__set_id(GetParam() + 1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = GetParam();
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        if (multi_column_key) {
+            TColumn pk1;
+            pk1.column_name = "pk1_bigint";
+            pk1.__set_is_key(true);
+            pk1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(pk1);
+            TColumn pk2;
+            pk2.column_name = "pk2_varchar";
+            pk2.__set_is_key(true);
+            pk2.column_type.type = TPrimitiveType::VARCHAR;
+            pk2.column_type.len = 128;
+            request.tablet_schema.columns.push_back(pk2);
+            TColumn pk3;
+            pk3.column_name = "pk3_int";
+            pk3.__set_is_key(true);
+            pk3.column_type.type = TPrimitiveType::INT;
+            request.tablet_schema.columns.push_back(pk3);
+        } else {
+            TColumn k1;
+            k1.column_name = "pk";
+            k1.__set_is_key(true);
+            k1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(k1);
+        }
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        return request;
+    }
+
+    TabletSharedPtr create_tablet(int64_t tablet_id, int64_t version, int32_t schema_hash,
+                                  bool multi_column_key = false) {
+        auto st = StorageEngine::instance()->create_tablet(
+                get_create_tablet_req(tablet_id, version, schema_hash, multi_column_key));
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                  Column* one_delete = nullptr, bool empty = false, bool has_merge_condition = false) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        if (has_merge_condition) {
+            writer_context.merge_condition = "v2";
+        }
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        if (empty) {
+            return *writer->build();
+        }
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            if (schema.num_key_fields() == 1) {
+                cols[0]->append_datum(Datum(key));
+            } else {
+                cols[0]->append_datum(Datum(key));
+                string v = fmt::to_string(key * 234234342345);
+                cols[1]->append_datum(Datum(Slice(v)));
+                cols[2]->append_datum(Datum((int32_t)key));
+            }
+            int vcol_start = schema.num_key_fields();
+            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            if (cols[vcol_start + 1]->is_binary()) {
+                string v = fmt::to_string(key % 1000 + 2);
+                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+            } else {
+                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            }
+        }
+        if (one_delete == nullptr && !keys.empty()) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        } else if (one_delete == nullptr) {
+            CHECK_OK(writer->flush());
+        } else if (one_delete != nullptr) {
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+        }
+        return *writer->build();
     }
 
 protected:
@@ -111,7 +216,7 @@ protected:
     int64_t _src_version = 10;
 };
 
-TEST_F(LakeReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
+TEST_P(LakeReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -134,7 +239,7 @@ TEST_F(LakeReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) 
     EXPECT_FALSE(status.ok());
 }
 
-TEST_F(LakeReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
+TEST_P(LakeReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -157,7 +262,7 @@ TEST_F(LakeReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
     EXPECT_FALSE(status.ok());
 }
 
-TEST_F(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
+TEST_P(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -177,10 +282,10 @@ TEST_F(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     bool incremental_snapshot = false;
     Status status =
             _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     status = _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
     replicate_snapshot_request.__set_transaction_id(_transaction_id);
@@ -202,16 +307,16 @@ TEST_F(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
-    EXPECT_FALSE(status.ok());
+    EXPECT_FALSE(status.ok()) << status;
 
     auto slog_path = _tablet_manager->txn_slog_location(_tablet_id, _transaction_id);
     auto txn_slog_or = _tablet_manager->get_txn_log(slog_path, false);
-    EXPECT_TRUE(txn_slog_or.ok());
+    EXPECT_TRUE(txn_slog_or.ok()) << txn_slog_or.status();
 
     _replication_txn_manager->clear_snapshots(txn_slog_or.value());
 }
 
-TEST_F(LakeReplicationTxnManagerTest, test_publish_failed) {
+TEST_P(LakeReplicationTxnManagerTest, test_publish_failed) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -231,19 +336,19 @@ TEST_F(LakeReplicationTxnManagerTest, test_publish_failed) {
     bool incremental_snapshot = false;
     Status status =
             _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     const int64_t txn_ids[] = {_transaction_id};
     auto txn_id_span = std::span<const int64_t>(txn_ids, 1);
     auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_id_span, 0);
-    EXPECT_TRUE(!status_or.ok());
+    EXPECT_TRUE(!status_or.ok()) << status_or.status();
 
     const int32_t txn_types[] = {TxnTypePB::TXN_REPLICATION};
     auto txn_type_span = std::span<const int32_t>(txn_types, 1);
     lake::abort_txn(_tablet_manager.get(), _tablet_id, txn_id_span, txn_type_span);
 }
 
-TEST_F(LakeReplicationTxnManagerTest, test_run_normal) {
+TEST_P(LakeReplicationTxnManagerTest, test_run_normal) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -263,7 +368,7 @@ TEST_F(LakeReplicationTxnManagerTest, test_run_normal) {
     bool incremental_snapshot = false;
     Status status =
             _replication_txn_manager->remote_snapshot(remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
     replicate_snapshot_request.__set_transaction_id(_transaction_id);
@@ -285,10 +390,10 @@ TEST_F(LakeReplicationTxnManagerTest, test_run_normal) {
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     status = _replication_txn_manager->replicate_snapshot(replicate_snapshot_request);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     const int64_t txn_ids[] = {_transaction_id};
     auto txn_id_span = std::span<const int64_t>(txn_ids, 1);
@@ -297,5 +402,8 @@ TEST_F(LakeReplicationTxnManagerTest, test_run_normal) {
 
     EXPECT_EQ(_src_version, status_or.value()->version());
 }
+
+INSTANTIATE_TEST_SUITE_P(LakeReplicationTxnManagerTest, LakeReplicationTxnManagerTest,
+                         testing::Values(TKeysType::type::AGG_KEYS, TKeysType::type::PRIMARY_KEYS));
 
 } // namespace starrocks

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -20,66 +20,172 @@
 #include "fs/fs_util.h"
 #include "gen_cpp/AgentService_types.h"
 #include "runtime/exec_env.h"
+#include "storage/chunk_helper.h"
 #include "storage/olap_define.h"
+#include "storage/rowset/rowset_factory.h"
+#include "storage/rowset/rowset_options.h"
+#include "storage/rowset/rowset_writer.h"
+#include "storage/rowset/rowset_writer_context.h"
+#include "storage/rowset/segment.h"
 #include "storage/tablet_manager.h"
 #include "testutil/assert.h"
 #include "util/uuid_generator.h"
 
 namespace starrocks {
 
-class ReplicationTxnManagerTest : public testing::Test {
+class ReplicationTxnManagerTest : public testing::TestWithParam<TKeysType::type> {
 public:
     ReplicationTxnManagerTest() = default;
     ~ReplicationTxnManagerTest() override = default;
     void SetUp() override {
-        TCreateTabletReq create_tablet_req = get_create_tablet_request(_tablet_id, _schema_hash, _version);
-        Status create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
-                create_tablet_req, StorageEngine::instance()->get_stores());
-        ASSERT_TRUE(create_st.ok());
+        if (GetParam() != TKeysType::type::PRIMARY_KEYS) {
+            create_tablet(_tablet_id, _version, _schema_hash);
+            create_tablet(_src_tablet_id, _src_version, _schema_hash);
+        } else {
+            auto tablet = create_tablet(_tablet_id, 1, _schema_hash);
+            auto src_tablet = create_tablet(_src_tablet_id, 1, _schema_hash);
 
-        TCreateTabletReq src_create_tablet_req = get_create_tablet_request(_src_tablet_id, _schema_hash, _src_version);
-        Status src_create_st = StorageEngine::instance()->tablet_manager()->create_tablet(
-                src_create_tablet_req, StorageEngine::instance()->get_stores());
-        ASSERT_TRUE(src_create_st.ok());
+            std::vector<int64_t> keys{0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+            for (int i = 2; i <= _version; i++) {
+                ASSERT_TRUE(tablet->rowset_commit(i, create_rowset(tablet, keys)).ok());
+            }
+            for (int i = 2; i <= _src_version; i++) {
+                ASSERT_TRUE(src_tablet->rowset_commit(i, create_rowset(src_tablet, keys)).ok());
+            }
+        }
     }
 
-    void TearDown() override {}
+    void TearDown() override {
+        auto status = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = fs::remove_all(config::storage_root_path);
+        EXPECT_TRUE(status.ok()) << status;
+    }
 
-    TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int schema_hash, int64_t version) {
-        TColumnType col_type;
-        col_type.__set_type(TPrimitiveType::SMALLINT);
-        TColumn col1;
-        col1.__set_column_name("col1");
-        col1.__set_column_type(col_type);
-        col1.__set_is_key(true);
-        std::vector<TColumn> cols;
-        cols.push_back(col1);
-        TTabletSchema tablet_schema;
-        tablet_schema.__set_short_key_column_count(1);
-        tablet_schema.__set_schema_hash(schema_hash);
-        tablet_schema.__set_keys_type(TKeysType::AGG_KEYS);
-        tablet_schema.__set_storage_type(TStorageType::COLUMN);
-        tablet_schema.__set_columns(cols);
-        TCreateTabletReq create_tablet_req;
-        create_tablet_req.__set_tablet_schema(tablet_schema);
-        create_tablet_req.__set_tablet_id(tablet_id);
-        create_tablet_req.__set_version(version);
-        create_tablet_req.__set_version_hash(0);
-        return create_tablet_req;
+    TabletSharedPtr create_tablet(int64_t tablet_id, int64_t version, int32_t schema_hash,
+                                  bool multi_column_key = false) {
+        TCreateTabletReq request;
+        request.tablet_id = tablet_id;
+        request.__set_version(version);
+        request.__set_version_hash(0);
+        request.tablet_schema.__set_id(GetParam() + 1);
+        request.tablet_schema.schema_hash = schema_hash;
+        request.tablet_schema.short_key_column_count = 1;
+        request.tablet_schema.keys_type = GetParam();
+        request.tablet_schema.storage_type = TStorageType::COLUMN;
+
+        if (multi_column_key) {
+            TColumn pk1;
+            pk1.column_name = "pk1_bigint";
+            pk1.__set_is_key(true);
+            pk1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(pk1);
+            TColumn pk2;
+            pk2.column_name = "pk2_varchar";
+            pk2.__set_is_key(true);
+            pk2.column_type.type = TPrimitiveType::VARCHAR;
+            pk2.column_type.len = 128;
+            request.tablet_schema.columns.push_back(pk2);
+            TColumn pk3;
+            pk3.column_name = "pk3_int";
+            pk3.__set_is_key(true);
+            pk3.column_type.type = TPrimitiveType::INT;
+            request.tablet_schema.columns.push_back(pk3);
+        } else {
+            TColumn k1;
+            k1.column_name = "pk";
+            k1.__set_is_key(true);
+            k1.column_type.type = TPrimitiveType::BIGINT;
+            request.tablet_schema.columns.push_back(k1);
+        }
+
+        TColumn k2;
+        k2.column_name = "v1";
+        k2.__set_is_key(false);
+        k2.column_type.type = TPrimitiveType::SMALLINT;
+        request.tablet_schema.columns.push_back(k2);
+
+        TColumn k3;
+        k3.column_name = "v2";
+        k3.__set_is_key(false);
+        k3.column_type.type = TPrimitiveType::INT;
+        request.tablet_schema.columns.push_back(k3);
+        auto st = StorageEngine::instance()->create_tablet(request);
+        CHECK(st.ok()) << st.to_string();
+        return StorageEngine::instance()->tablet_manager()->get_tablet(tablet_id, false);
+    }
+
+    RowsetSharedPtr create_rowset(const TabletSharedPtr& tablet, const vector<int64_t>& keys,
+                                  Column* one_delete = nullptr, bool empty = false, bool has_merge_condition = false) {
+        RowsetWriterContext writer_context;
+        RowsetId rowset_id = StorageEngine::instance()->next_rowset_id();
+        writer_context.rowset_id = rowset_id;
+        writer_context.tablet_id = tablet->tablet_id();
+        writer_context.tablet_schema_hash = tablet->schema_hash();
+        writer_context.partition_id = 0;
+        writer_context.rowset_path_prefix = tablet->schema_hash_path();
+        writer_context.rowset_state = COMMITTED;
+        writer_context.tablet_schema = tablet->thread_safe_get_tablet_schema();
+        writer_context.version.first = 0;
+        writer_context.version.second = 0;
+        writer_context.segments_overlap = NONOVERLAPPING;
+        if (has_merge_condition) {
+            writer_context.merge_condition = "v2";
+        }
+        std::unique_ptr<RowsetWriter> writer;
+        EXPECT_TRUE(RowsetFactory::create_rowset_writer(writer_context, &writer).ok());
+        if (empty) {
+            return *writer->build();
+        }
+        auto schema = ChunkHelper::convert_schema(tablet->thread_safe_get_tablet_schema());
+        auto chunk = ChunkHelper::new_chunk(schema, keys.size());
+        auto& cols = chunk->columns();
+        for (int64_t key : keys) {
+            if (schema.num_key_fields() == 1) {
+                cols[0]->append_datum(Datum(key));
+            } else {
+                cols[0]->append_datum(Datum(key));
+                string v = fmt::to_string(key * 234234342345);
+                cols[1]->append_datum(Datum(Slice(v)));
+                cols[2]->append_datum(Datum((int32_t)key));
+            }
+            int vcol_start = schema.num_key_fields();
+            cols[vcol_start]->append_datum(Datum((int16_t)(key % 100 + 1)));
+            if (cols[vcol_start + 1]->is_binary()) {
+                string v = fmt::to_string(key % 1000 + 2);
+                cols[vcol_start + 1]->append_datum(Datum(Slice(v)));
+            } else {
+                cols[vcol_start + 1]->append_datum(Datum((int32_t)(key % 1000 + 2)));
+            }
+        }
+        if (one_delete == nullptr && !keys.empty()) {
+            CHECK_OK(writer->flush_chunk(*chunk));
+        } else if (one_delete == nullptr) {
+            CHECK_OK(writer->flush());
+        } else if (one_delete != nullptr) {
+            CHECK_OK(writer->flush_chunk_with_deletes(*chunk, *one_delete));
+        }
+        return *writer->build();
     }
 
 protected:
-    int64_t _transaction_id = 200;
-    int64_t _table_id = 20001;
-    int64_t _partition_id = 20002;
-    int64_t _tablet_id = 20003;
-    int64_t _src_tablet_id = 20004;
+    int64_t _transaction_id = 100;
+    int64_t _table_id = 10001;
+    int64_t _partition_id = 10002;
+    int64_t _tablet_id = 10003;
+    int64_t _src_tablet_id = 10004;
     int32_t _schema_hash = 368169781;
-    int64_t _version = 2;
+    int64_t _version = 1;
     int64_t _src_version = 10;
 };
 
-TEST_F(ReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
+TEST_P(ReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -99,14 +205,14 @@ TEST_F(ReplicationTxnManagerTest, test_remote_snapshot_no_missing_versions) {
     bool incremental_snapshot = false;
     Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
             remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_FALSE(status.ok());
+    EXPECT_FALSE(status.ok()) << status;
 
     StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
 
     StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
 }
 
-TEST_F(ReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
+TEST_P(ReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -126,14 +232,14 @@ TEST_F(ReplicationTxnManagerTest, test_remote_snapshot_no_versions) {
     bool incremental_snapshot = false;
     Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
             remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_FALSE(status.ok());
+    EXPECT_FALSE(status.ok()) << status;
 
     StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
 
     StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
 }
 
-TEST_F(ReplicationTxnManagerTest, test_replicate_snapshot_failed) {
+TEST_P(ReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -153,11 +259,11 @@ TEST_F(ReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     bool incremental_snapshot = false;
     Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
             remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
             remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
     replicate_snapshot_request.__set_transaction_id(_transaction_id);
@@ -179,14 +285,14 @@ TEST_F(ReplicationTxnManagerTest, test_replicate_snapshot_failed) {
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);
-    EXPECT_FALSE(status.ok());
+    EXPECT_FALSE(status.ok()) << status;
 
     StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
 
     StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
 }
 
-TEST_F(ReplicationTxnManagerTest, test_publish_failed) {
+TEST_P(ReplicationTxnManagerTest, test_publish_failed) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -206,21 +312,21 @@ TEST_F(ReplicationTxnManagerTest, test_publish_failed) {
     bool incremental_snapshot = false;
     Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
             remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     TabletSharedPtr tablet_ptr = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
     EXPECT_TRUE(tablet_ptr != nullptr);
 
     status = StorageEngine::instance()->replication_txn_manager()->publish_txn(_transaction_id, _partition_id,
                                                                                tablet_ptr, _src_version);
-    EXPECT_TRUE(!status.ok());
+    EXPECT_TRUE(!status.ok()) << status;
 
     StorageEngine::instance()->replication_txn_manager()->clear_txn(_transaction_id);
 
     StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
 }
 
-TEST_F(ReplicationTxnManagerTest, test_run_normal) {
+TEST_P(ReplicationTxnManagerTest, test_run_normal) {
     TRemoteSnapshotRequest remote_snapshot_request;
     remote_snapshot_request.__set_transaction_id(_transaction_id);
     remote_snapshot_request.__set_table_id(_table_id);
@@ -240,7 +346,7 @@ TEST_F(ReplicationTxnManagerTest, test_run_normal) {
     bool incremental_snapshot = false;
     Status status = StorageEngine::instance()->replication_txn_manager()->remote_snapshot(
             remote_snapshot_request, &snapshot_path, &incremental_snapshot);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     TReplicateSnapshotRequest replicate_snapshot_request;
     replicate_snapshot_request.__set_transaction_id(_transaction_id);
@@ -262,21 +368,21 @@ TEST_F(ReplicationTxnManagerTest, test_run_normal) {
     replicate_snapshot_request.__set_src_snapshot_infos({remote_snapshot_info});
 
     status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     status = StorageEngine::instance()->replication_txn_manager()->replicate_snapshot(replicate_snapshot_request);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     TabletSharedPtr tablet_ptr = StorageEngine::instance()->tablet_manager()->get_tablet(_tablet_id);
     EXPECT_TRUE(tablet_ptr != nullptr);
 
     status = StorageEngine::instance()->replication_txn_manager()->publish_txn(_transaction_id, _partition_id,
                                                                                tablet_ptr, _src_version);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     status = StorageEngine::instance()->replication_txn_manager()->publish_txn(_transaction_id, _partition_id,
                                                                                tablet_ptr, _src_version);
-    EXPECT_TRUE(status.ok());
+    EXPECT_TRUE(status.ok()) << status;
 
     EXPECT_EQ(_src_version, tablet_ptr->max_version().second);
 
@@ -284,5 +390,8 @@ TEST_F(ReplicationTxnManagerTest, test_run_normal) {
 
     StorageEngine::instance()->replication_txn_manager()->clear_expired_snapshots();
 }
+
+INSTANTIATE_TEST_SUITE_P(ReplicationTxnManagerTest, ReplicationTxnManagerTest,
+                         testing::Values(TKeysType::type::AGG_KEYS, TKeysType::type::PRIMARY_KEYS));
 
 } // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/compaction/CompactionMgr.java
@@ -90,8 +90,7 @@ public class CompactionMgr {
             v.setCurrentVersion(currentVersion);
             v.setCompactionScore(compactionScore);
             if (v.getCompactionVersion() == null) {
-                // Set version-1 as last compaction version
-                v.setCompactionVersion(new PartitionVersion(version - 1, versionTime));
+                v.setCompactionVersion(new PartitionVersion(0, versionTime));
             }
             return v;
         });

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -91,8 +91,10 @@ public class ReplicationJobTest {
 
     @Before
     public void setUp() throws Exception {
-        srcTable.getPartitions().iterator().next()
-                .updateVisibleVersion(table.getPartitions().iterator().next().getCommittedVersion() + 100);
+        Partition partition = table.getPartitions().iterator().next();
+        Partition srcPartition = srcTable.getPartitions().iterator().next();
+        partition.updateVersionForRestore(10);
+        srcPartition.updateVersionForRestore(partition.getCommittedVersion() + 100);
 
         job = new ReplicationJob("test_token", db.getId(), table, srcTable, GlobalStateMgr.getCurrentSystemInfo());
     }

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -92,8 +92,10 @@ public class ReplicationMgrTest {
 
     @Before
     public void setUp() throws Exception {
-        srcTable.getPartitions().iterator().next()
-                .updateVisibleVersion(table.getPartitions().iterator().next().getCommittedVersion() + 100);
+        Partition partition = table.getPartitions().iterator().next();
+        Partition srcPartition = srcTable.getPartitions().iterator().next();
+        partition.updateVersionForRestore(10);
+        srcPartition.updateVersionForRestore(partition.getCommittedVersion() + 100);
 
         job = new ReplicationJob("test_token", db.getId(), table, srcTable, GlobalStateMgr.getCurrentSystemInfo());
         replicationMgr = new ReplicationMgr();

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -21,6 +21,12 @@ import "types.proto";
 import "tablet_schema.proto";
 import "olap_file.proto";
 
+message DelvecDataPB {
+    optional int64 version = 1;
+    // serialized data
+    optional bytes data = 2;
+}
+
 message DelvecPagePB {
     optional int64 version = 1;
     // position in file
@@ -133,6 +139,7 @@ message TxnLogPB {
     message OpReplication {
         optional ReplicationTxnMetaPB txn_meta = 1;
         repeated OpWrite op_writes = 2;
+        map<uint32, DelvecDataPB> delvecs = 3;
     }
 
     optional int64 tablet_id = 1;


### PR DESCRIPTION
Why I'm doing: To support starrocks cluster migration, from shared-nothing cluster to shared-nothing cluster or shared-data cluster.
What I'm doing:
Implement a replication job to support pk table replication from another source starrocks cluster

backport of pr https://github.com/StarRocks/starrocks/pull/38330

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

