### PR TITLE
[Enhancement] Add datacache memory tracker to trace the datacache memory usage.

### DIFF
--- a/be/src/block_cache/block_cache.h
+++ b/be/src/block_cache/block_cache.h
@@ -68,6 +68,8 @@ public:
 
     size_t block_size() const { return _block_size; }
 
+    bool is_initialized() { return _initialized.load(std::memory_order_relaxed); }
+
     static const size_t MAX_BLOCK_SIZE;
 
 private:
@@ -77,6 +79,7 @@ private:
 
     size_t _block_size = 0;
     std::unique_ptr<KvCache> _kv_cache;
+    std::atomic<bool> _initialized = false;
 };
 
 } // namespace starrocks

--- a/be/src/common/daemon.cpp
+++ b/be/src/common/daemon.cpp
@@ -36,6 +36,7 @@
 
 #include <gflags/gflags.h>
 
+#include "block_cache/block_cache.h"
 #include "column/column_helper.h"
 #include "column/column_pool.h"
 #include "common/config.h"
@@ -116,6 +117,7 @@ void gc_memory(void* arg_this) {
  * 3. max io util of all disks
  * 4. max network send bytes rate
  * 5. max network receive bytes rate
+ * 6. datacache memory usage
  */
 void calculate_metrics(void* arg_this) {
     int64_t last_ts = -1L;
@@ -172,18 +174,29 @@ void calculate_metrics(void* arg_this) {
                                                                                 &lst_net_receive_bytes);
         }
 
+        // update datacache mem_tracker
+        auto datacache_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
+        int64_t datacache_mem_bytes = 0;
+        BlockCache* block_cache = BlockCache::instance();
+        if (block_cache->is_initialized()) {
+            auto datacache_metrics = block_cache->cache_metrics();
+            datacache_mem_bytes = datacache_metrics.mem_used_bytes + datacache_metrics.meta_used_bytes;
+        }
+        datacache_mem_tracker->set(datacache_mem_bytes);
+
         auto* mem_metrics = StarRocksMetrics::instance()->system_metrics()->memory_metrics();
 
         LOG(INFO) << fmt::format(
                 "Current memory statistics: process({}), query_pool({}), load({}), "
                 "metadata({}), compaction({}), schema_change({}), column_pool({}), "
-                "page_cache({}), update({}), chunk_allocator({}), clone({}), consistency({})",
+                "page_cache({}), update({}), chunk_allocator({}), clone({}), consistency({}), "
+                "datacache({})",
                 mem_metrics->process_mem_bytes.value(), mem_metrics->query_mem_bytes.value(),
                 mem_metrics->load_mem_bytes.value(), mem_metrics->metadata_mem_bytes.value(),
                 mem_metrics->compaction_mem_bytes.value(), mem_metrics->schema_change_mem_bytes.value(),
                 mem_metrics->column_pool_mem_bytes.value(), mem_metrics->storage_page_cache_mem_bytes.value(),
                 mem_metrics->update_mem_bytes.value(), mem_metrics->chunk_allocator_mem_bytes.value(),
-                mem_metrics->clone_mem_bytes.value(), mem_metrics->consistency_mem_bytes.value());
+                mem_metrics->clone_mem_bytes.value(), mem_metrics->consistency_mem_bytes.value(), datacache_mem_bytes);
 
         nap_sleep(15, [daemon] { return daemon->stopped(); });
     }

--- a/be/src/http/action/memory_metrics_action.cpp
+++ b/be/src/http/action/memory_metrics_action.cpp
@@ -51,6 +51,7 @@ void MemoryMetricsAction::handle(HttpRequest* req) {
                                                        "schema_change",
                                                        "column_pool",
                                                        "page_cache",
+                                                       "datacache",
                                                        "update",
                                                        "chunk_allocator",
                                                        "clone",

--- a/be/src/http/default_path_handlers.cpp
+++ b/be/src/http/default_path_handlers.cpp
@@ -155,6 +155,9 @@ void mem_tracker_handler(MemTracker* mem_tracker, const WebPageHandler::Argument
         } else if (iter->second == "consistency") {
             start_mem_tracker = GlobalEnv::GetInstance()->consistency_mem_tracker();
             cur_level = 2;
+        } else if (iter->second == "datacache") {
+            start_mem_tracker = GlobalEnv::GetInstance()->datacache_mem_tracker();
+            cur_level = 2;
         } else {
             start_mem_tracker = mem_tracker;
             cur_level = 1;

--- a/be/src/runtime/exec_env.cpp
+++ b/be/src/runtime/exec_env.cpp
@@ -231,6 +231,7 @@ Status GlobalEnv::_init_mem_tracker() {
     _clone_mem_tracker = regist_tracker(-1, "clone", _process_mem_tracker.get());
     int64_t consistency_mem_limit = calc_max_consistency_memory(_process_mem_tracker->limit());
     _consistency_mem_tracker = regist_tracker(consistency_mem_limit, "consistency", _process_mem_tracker.get());
+    _datacache_mem_tracker = regist_tracker(-1, "datacache", _process_mem_tracker.get());
     _replication_mem_tracker = regist_tracker(-1, "replication", _process_mem_tracker.get());
 
     MemChunkAllocator::init_instance(_chunk_allocator_mem_tracker.get(), config::chunk_reserved_bytes_limit);

--- a/be/src/runtime/exec_env.h
+++ b/be/src/runtime/exec_env.h
@@ -145,6 +145,7 @@ public:
     MemTracker* clone_mem_tracker() { return _clone_mem_tracker.get(); }
     MemTracker* consistency_mem_tracker() { return _consistency_mem_tracker.get(); }
     MemTracker* replication_mem_tracker() { return _replication_mem_tracker.get(); }
+    MemTracker* datacache_mem_tracker() { return _datacache_mem_tracker.get(); }
     std::vector<std::shared_ptr<MemTracker>>& mem_trackers() { return _mem_trackers; }
 
     int64_t get_storage_page_cache_size();
@@ -212,6 +213,9 @@ private:
     std::shared_ptr<MemTracker> _consistency_mem_tracker;
 
     std::shared_ptr<MemTracker> _replication_mem_tracker;
+
+    // The memory used for datacache
+    std::shared_ptr<MemTracker> _datacache_mem_tracker;
 
     std::vector<std::shared_ptr<MemTracker>> _mem_trackers;
 };

--- a/be/src/script/script.cpp
+++ b/be/src/script/script.cpp
@@ -221,6 +221,7 @@ void bind_exec_env(ForeignModule& m) {
         REG_METHOD(GlobalEnv, clone_mem_tracker);
         REG_METHOD(GlobalEnv, consistency_mem_tracker);
         REG_METHOD(GlobalEnv, connector_scan_pool_mem_tracker);
+        REG_METHOD(GlobalEnv, datacache_mem_tracker);
 
         // level 2
         REG_METHOD(GlobalEnv, tablet_metadata_mem_tracker);

--- a/be/src/util/system_metrics.cpp
+++ b/be/src/util/system_metrics.cpp
@@ -247,6 +247,7 @@ void SystemMetrics::_install_memory_metrics(MetricRegistry* registry) {
     registry->register_metric("chunk_allocator_mem_bytes", &_memory_metrics->chunk_allocator_mem_bytes);
     registry->register_metric("clone_mem_bytes", &_memory_metrics->clone_mem_bytes);
     registry->register_metric("consistency_mem_bytes", &_memory_metrics->consistency_mem_bytes);
+    registry->register_metric("datacache_mem_bytes", &_memory_metrics->datacache_mem_bytes);
 
     registry->register_metric("total_column_pool_bytes", &_memory_metrics->column_pool_total_bytes);
     registry->register_metric("local_column_pool_bytes", &_memory_metrics->column_pool_local_bytes);
@@ -326,6 +327,7 @@ void SystemMetrics::_update_memory_metrics() {
     SET_MEM_METRIC_VALUE(clone_mem_tracker, clone_mem_bytes)
     SET_MEM_METRIC_VALUE(column_pool_mem_tracker, column_pool_mem_bytes)
     SET_MEM_METRIC_VALUE(consistency_mem_tracker, consistency_mem_bytes)
+    SET_MEM_METRIC_VALUE(datacache_mem_tracker, datacache_mem_bytes)
 #undef SET_MEM_METRIC_VALUE
 
 #define UPDATE_COLUMN_POOL_METRIC(var, type)                 \

--- a/be/src/util/system_metrics.h
+++ b/be/src/util/system_metrics.h
@@ -65,6 +65,7 @@ public:
     METRIC_DEFINE_INT_GAUGE(chunk_allocator_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(clone_mem_bytes, MetricUnit::BYTES);
     METRIC_DEFINE_INT_GAUGE(consistency_mem_bytes, MetricUnit::BYTES);
+    METRIC_DEFINE_INT_GAUGE(datacache_mem_bytes, MetricUnit::BYTES);
 
     // column pool metrics.
     METRIC_DEFINE_INT_GAUGE(column_pool_total_bytes, MetricUnit::BYTES);


### PR DESCRIPTION
Why I'm doing:
The datacache memory usage is unobservable,  which brings difficulties to analyze process memory details.

What I'm doing:
Add datacache memory tracker to trace the datacache memory usage.
You can observe the datacache memory usage by follow urls:

```
http://${BE_HOST}:${BE_WEBSERVER_PORT}/mem_tracker
http://${BE_HOST}:${BE_WEBSERVER_PORT}/metrics
http://${BE_HOST}:${BE_WEBSERVER_PORT}/metrics/memory
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
