### PR TITLE
[Feature] CTAS supports order by and index syntax

### DIFF
--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -85,7 +85,7 @@ struct GetResultBatchCtx {
 };
 
 // buffer used for result customer and productor
-class BufferControlBlock {
+classBufferControlBlock {
 public:
     BufferControlBlock(const TUniqueId& id, int buffer_size);
     ~BufferControlBlock();

--- a/be/src/runtime/buffer_control_block.h
+++ b/be/src/runtime/buffer_control_block.h
@@ -85,7 +85,7 @@ struct GetResultBatchCtx {
 };
 
 // buffer used for result customer and productor
-classBufferControlBlock {
+class BufferControlBlock {
 public:
     BufferControlBlock(const TUniqueId& id, int buffer_size);
     ~BufferControlBlock();

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/AstBuilder.java
@@ -979,14 +979,21 @@ public class AstBuilder extends StarRocksBaseVisitor<ParseNode> {
                 false,
                 qualifiedNameToTableName(getQualifiedName(context.qualifiedName())),
                 null,
+                context.indexDesc() == null ? null : getIndexDefs(context.indexDesc()),
                 "",
+                null,
                 context.keyDesc() == null ? null : getKeysDesc(context.keyDesc()),
                 partitionDesc,
                 context.distributionDesc() == null ? null : (DistributionDesc) visit(context.distributionDesc()),
                 properties,
                 null,
                 context.comment() == null ? null :
-                        ((StringLiteral) visit(context.comment().string())).getStringValue());
+                        ((StringLiteral) visit(context.comment().string())).getStringValue(),
+                null,
+                context.orderByDesc() == null ? null :
+                    visit(context.orderByDesc().identifierList().identifier(), Identifier.class)
+                        .stream().map(Identifier::getValue).collect(toList())
+                );
 
         List<Identifier> columns = visitIfPresent(context.identifier(), Identifier.class);
         return new CreateTableAsSelectStmt(

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -485,7 +485,7 @@ createTemporaryTableStatement
 
 createTableAsSelectStatement
     : CREATE TABLE (IF NOT EXISTS)? qualifiedName
-        ('(' (identifier (',' identifier)*)? indexDesc (',' indexDesc)* ')')?
+        ('(' (identifier (',' identifier)*  (',' indexDesc)* | indexDesc (',' indexDesc)*) ')')?
         keyDesc?
         comment?
         partitionDesc?

--- a/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/parser/StarRocks.g4
@@ -485,11 +485,12 @@ createTemporaryTableStatement
 
 createTableAsSelectStatement
     : CREATE TABLE (IF NOT EXISTS)? qualifiedName
-        ('(' identifier (',' identifier)* ')')?
+        ('(' (identifier (',' identifier)*)? indexDesc (',' indexDesc)* ')')?
         keyDesc?
         comment?
         partitionDesc?
         distributionDesc?
+        orderByDesc?
         properties?
         AS queryStatement
     ;

--- a/test/sql/test_automatic_partition/R/test_automatic_partition_ctas
+++ b/test/sql/test_automatic_partition/R/test_automatic_partition_ctas
@@ -119,3 +119,25 @@ DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 1;
 create table test_column_expr_partition partition by (event_day) as select event_day from site_access;
 -- result:
 -- !result
+CREATE TABLE `customers` (
+  `customer_id` int(11) NOT NULL COMMENT "",
+  `first_name` varchar(65533) NULL COMMENT "",
+  `last_name` varchar(65533) NULL COMMENT "",
+  `first_order` date NULL COMMENT "",
+  `most_recent_order` date NULL COMMENT "",
+  `number_of_orders` bigint(20) NULL COMMENT "",
+  `customer_lifetime_value` decimal128(38, 9) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`customer_id`)
+DISTRIBUTED BY HASH(`customer_id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+-- result:
+-- !result
+create table cust_order_by_ctas ORDER BY (first_name,last_name) as select * from customers;
+-- result:
+-- !result
+create table cust_index_ctas (INDEX idx_bitmap_customer_id (customer_id) USING BITMAP) as select * from customers;
+-- result:
+-- !result

--- a/test/sql/test_automatic_partition/T/test_automatic_partition_ctas
+++ b/test/sql/test_automatic_partition/T/test_automatic_partition_ctas
@@ -89,3 +89,19 @@ PARTITION BY RANGE(event_day)(
 )
 DISTRIBUTED BY HASH(event_day, site_id) BUCKETS 1;
 create table test_column_expr_partition partition by (event_day) as select event_day from site_access;
+CREATE TABLE `customers` (
+  `customer_id` int(11) NOT NULL COMMENT "",
+  `first_name` varchar(65533) NULL COMMENT "",
+  `last_name` varchar(65533) NULL COMMENT "",
+  `first_order` date NULL COMMENT "",
+  `most_recent_order` date NULL COMMENT "",
+  `number_of_orders` bigint(20) NULL COMMENT "",
+  `customer_lifetime_value` decimal128(38, 9) NULL COMMENT ""
+) ENGINE=OLAP
+PRIMARY KEY(`customer_id`)
+DISTRIBUTED BY HASH(`customer_id`)
+PROPERTIES (
+"replication_num" = "1"
+);
+create table cust_order_by_ctas ORDER BY (first_name,last_name) as select * from customers;
+create table cust_index_ctas (INDEX idx_bitmap_customer_id (customer_id) USING BITMAP) as select * from customers;


### PR DESCRIPTION
Why I'm doing:
Users who want to use dbt to create tables can support configuring order by and index. dbt uses ctas to create tables, so our ctas also needs to support this syntax.

What I'm doing:
Turn on this syntax restriction and let ctas support it.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
