### PR TITLE
[Refactor] move spill block serialization logic before allocation

### DIFF
--- a/be/src/column/column_for_each.h
+++ b/be/src/column/column_for_each.h
@@ -5,8 +5,8 @@
 
 namespace starrocks {
 template <typename Func>
-concept IntCallable = std::invocable<Func, int> && std::invocable<Func, int64_t> && std::invocable<Func, size_t> &&
-        std::invocable<Func, int8_t> && std::invocable<Func, int16_t>;
+concept IntCallable = std::invocable<Func, int>&& std::invocable<Func, int64_t>&& std::invocable<Func, size_t>&&
+        std::invocable<Func, int8_t>&& std::invocable<Func, int16_t>;
 
 template <class Applier>
 class ForEachElementVisitor final : public ColumnVisitorAdapter<ForEachElementVisitor<Applier>> {

--- a/be/src/column/column_for_each.h
+++ b/be/src/column/column_for_each.h
@@ -5,8 +5,8 @@
 
 namespace starrocks {
 template <typename Func>
-concept IntCallable = std::invocable<Func, int>&& std::invocable<Func, int64_t>&& std::invocable<Func, size_t>&&
-        std::invocable<Func, int8_t>&& std::invocable<Func, int16_t>;
+concept IntCallable = std::invocable<Func, int> && std::invocable<Func, int64_t> && std::invocable<Func, size_t> &&
+        std::invocable<Func, int8_t> && std::invocable<Func, int16_t>;
 
 template <class Applier>
 class ForEachElementVisitor final : public ColumnVisitorAdapter<ForEachElementVisitor<Applier>> {

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -62,6 +62,7 @@ struct AcquireBlockOptions {
     int32_t plan_node_id;
     std::string name;
     bool direct_io = false;
+    size_t block_size = 0;
 };
 
 // BlockManager is used to manage the life cycle of the Block.

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -158,7 +158,7 @@ struct SyncTaskExecutor {
     } while (false)
 
 #define RETURN_IF_YIELD(yield) \
-    if (*yield) {              \
+    if (yield) {               \
         return Status::OK();   \
     }
 

--- a/be/src/exec/spill/executor.h
+++ b/be/src/exec/spill/executor.h
@@ -141,13 +141,11 @@ struct SyncTaskExecutor {
     }
 #define RETURN_OK_IF_NEED_YIELD(wg, yield, time_spent_ns)                                       \
     if (time_spent_ns >= workgroup::WorkGroup::YIELD_MAX_TIME_SPENT) {                          \
-        LOG(INFO) << "yield";                                                                   \
         *yield = true;                                                                          \
         return Status::OK();                                                                    \
     }                                                                                           \
     if (wg != nullptr && time_spent_ns >= workgroup::WorkGroup::YIELD_PREEMPT_MAX_TIME_SPENT && \
         wg->scan_sched_entity()->in_queue()->should_yield(wg, time_spent_ns)) {                 \
-        LOG(INFO) << "yield wg";                                                                \
         *yield = true;                                                                          \
         return Status::OK();                                                                    \
     }

--- a/be/src/exec/spill/input_stream.h
+++ b/be/src/exec/spill/input_stream.h
@@ -64,7 +64,7 @@ public:
     YieldableRestoreTask(InputStreamPtr input_stream) : _input_stream(std::move(input_stream)) {
         _input_stream->get_io_stream(&_sub_stream);
     }
-    Status do_read(workgroup::YieldContext& ctx, SerdeContext& context, int* yield);
+    Status do_read(workgroup::YieldContext& ctx, SerdeContext& context);
 
 private:
     InputStreamPtr _input_stream;

--- a/be/src/exec/spill/log_block_manager.cpp
+++ b/be/src/exec/spill/log_block_manager.cpp
@@ -248,6 +248,7 @@ Status LogBlockManager::open() {
 void LogBlockManager::close() {}
 
 StatusOr<BlockPtr> LogBlockManager::acquire_block(const AcquireBlockOptions& opts) {
+    DCHECK(opts.block_size > 0) << "block size should be larger than 0";
     AcquireDirOptions acquire_dir_opts;
 #ifdef BE_TEST
     ASSIGN_OR_RETURN(auto dir, _dir_mgr->acquire_writable_dir(acquire_dir_opts));

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -81,6 +81,7 @@ bool UnorderedMemTable::is_empty() {
 }
 
 Status UnorderedMemTable::append(ChunkPtr chunk) {
+    DCHECK(chunk != nullptr);
     _tracker->consume(chunk->memory_usage());
     COUNTER_ADD(_spiller->metrics().mem_table_peak_memory_usage, chunk->memory_usage());
     _num_rows += chunk->num_rows();
@@ -143,6 +144,7 @@ bool OrderedMemTable::is_empty() {
 }
 
 Status OrderedMemTable::append(ChunkPtr chunk) {
+    DCHECK(chunk != nullptr);
     if (_chunk == nullptr) {
         _chunk = chunk->clone_empty();
     }

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -137,7 +137,6 @@ Status UnorderedMemTable::finalize(workgroup::YieldContext& yield_ctx) {
     auto& serde = _spiller->serde();
     SerdeContext serde_ctx;
     {
-        LOG(INFO) << fmt::format("finalize mem table, idx[{}] total[{}]", _processed_index, _chunks.size());
         while (_processed_index < _chunks.size()) {
             SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
             auto chunk = _chunks[_processed_index++];
@@ -145,8 +144,8 @@ Status UnorderedMemTable::finalize(workgroup::YieldContext& yield_ctx) {
             RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
         }
     }
-    LOG(INFO) << fmt::format("finalize spillable unordered memtable done, rows[{}], size[{}] {}", num_rows(),
-                             _block->size(), (void*)this);
+    TRACE_SPILL_LOG << fmt::format("finalize spillable unordered memtable done, rows[{}], size[{}] {}", num_rows(),
+                                   _block->size(), (void*)this);
     return Status::OK();
 }
 
@@ -219,8 +218,8 @@ Status OrderedMemTable::finalize(workgroup::YieldContext& yield_ctx) {
         RETURN_IF_ERROR(serde->serialize_to_block(serde_ctx, chunk, _block));
         RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
     }
-    LOG(INFO) << fmt::format("finalize spillable ordered memtable done, rows[{}], size[{}]", num_rows(),
-                             _block->size());
+    TRACE_SPILL_LOG << fmt::format("finalize spillable ordered memtable done, rows[{}], size[{}]", num_rows(),
+                                   _block->size());
     // clear all data
     _chunk_slice.reset(nullptr);
     int64_t old_consumption = _tracker->consumption();

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -117,8 +117,7 @@ Status UnorderedMemTable::finalize() {
     }
     TRACE_SPILL_LOG << fmt::format("finalize spillable unordered memtable done, rows[{}], size[{}]", num_rows(),
                                    _block->size());
-    // after serializing data, clear all chunks, only keep serialized data in _block
-    _chunks.clear();
+    // since mem table may be read in partition split stage, we can't clear _chunks here
     int64_t old_consumption = _tracker->consumption();
     int64_t new_consumption = _block->get_data().get_size();
     _tracker->set(new_consumption);

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -21,9 +21,12 @@
 #include "column/chunk.h"
 #include "column/vectorized_fwd.h"
 #include "exec/chunks_sorter.h"
+#include "exec/spill/executor.h"
 #include "exec/spill/input_stream.h"
 #include "exec/spill/serde.h"
+#include "exec/workgroup/scan_task_queue.h"
 #include "runtime/current_thread.h"
+#include "util/runtime_profile.h"
 
 namespace starrocks::spill {
 
@@ -35,7 +38,7 @@ public:
 
     Status append(const std::vector<Slice>& data) override {
         std::for_each(data.begin(), data.end(), [&](const Slice& slice) {
-            _buffer.append(slice.data, slice.size);
+            _buffer.emplace_back(std::string(slice.data, slice.size));
             _size += slice.get_size();
         });
         return Status::OK();
@@ -53,17 +56,36 @@ public:
 
     std::string debug_string() const override { return fmt::format("MemoryBlock[len={}]", _size); }
 
-    Slice get_data() { return {_buffer.data(), _buffer.size()}; }
+    size_t get_data_size() const { return _size; }
 
-    void reset() { _buffer.clear(); }
+    StatusOr<Slice> get_next() {
+        if (_next_idx >= _buffer.size()) {
+            return Status::EndOfFile("no more data");
+        }
+        Slice slice(_buffer[_next_idx].data(), _buffer[_next_idx].size());
+        _next_idx++;
+        return slice;
+    }
+
+    void reset() {
+        _buffer.clear();
+        _size = 0;
+        _next_idx = 0;
+    }
 
 private:
-    std::string _buffer;
+    std::vector<std::string> _buffer;
+    size_t _next_idx = 0;
 };
 
-StatusOr<Slice> SpillableMemTable::get_serialized_data() const {
+StatusOr<Slice> SpillableMemTable::get_next_serialized_data() {
     DCHECK(_block != nullptr) << "block should not be null";
-    return _block->get_data();
+    return _block->get_next();
+}
+
+size_t SpillableMemTable::get_serialized_data_size() const {
+    DCHECK(_block != nullptr) << "block should not be null";
+    return _block->get_data_size();
 }
 
 void SpillableMemTable::reset() {
@@ -107,28 +129,31 @@ Status UnorderedMemTable::append_selective(const Chunk& src, const uint32_t* ind
     return Status::OK();
 }
 
-Status UnorderedMemTable::finalize() {
+Status UnorderedMemTable::finalize(workgroup::YieldContext& yield_ctx) {
+    SCOPED_TIMER(_spiller->metrics().mem_table_finalize_timer);
     if (_block == nullptr) {
         _block = std::make_shared<MemoryBlock>();
     }
     auto& serde = _spiller->serde();
     SerdeContext serde_ctx;
-    for (const auto& chunk : _chunks) {
-        RETURN_IF_ERROR(serde->serialize_to_block(serde_ctx, chunk, _block));
+    {
+        LOG(INFO) << fmt::format("finalize mem table, idx[{}] total[{}]", _processed_index, _chunks.size());
+        while (_processed_index < _chunks.size()) {
+            SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
+            auto chunk = _chunks[_processed_index++];
+            RETURN_IF_ERROR(serde->serialize_to_block(serde_ctx, chunk, _block));
+            RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
+        }
     }
-    TRACE_SPILL_LOG << fmt::format("finalize spillable unordered memtable done, rows[{}], size[{}]", num_rows(),
-                                   _block->size());
-    // since mem table may be read in partition split stage, we can't clear _chunks here
-    int64_t old_consumption = _tracker->consumption();
-    int64_t new_consumption = _block->get_data().get_size();
-    _tracker->set(new_consumption);
-    COUNTER_ADD(_spiller->metrics().mem_table_peak_memory_usage, new_consumption - old_consumption);
+    LOG(INFO) << fmt::format("finalize spillable unordered memtable done, rows[{}], size[{}] {}", num_rows(),
+                             _block->size(), (void*)this);
     return Status::OK();
 }
 
 void UnorderedMemTable::reset() {
     SpillableMemTable::reset();
     _chunks.clear();
+    _processed_index = 0;
 }
 
 StatusOr<std::shared_ptr<SpillInputStream>> UnorderedMemTable::as_input_stream(bool shared) {
@@ -173,11 +198,15 @@ Status OrderedMemTable::append_selective(const Chunk& src, const uint32_t* index
     return Status::OK();
 }
 
-Status OrderedMemTable::finalize() {
-    // do sort
-    ASSIGN_OR_RETURN(_chunk, _do_sort(_chunk));
-    _chunk_slice.reset(_chunk);
-
+Status OrderedMemTable::finalize(workgroup::YieldContext& yield_ctx) {
+    SCOPED_TIMER(_spiller->metrics().mem_table_finalize_timer);
+    if (!_sort_done) {
+        SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
+        // do sort
+        ASSIGN_OR_RETURN(_chunk, _do_sort(_chunk));
+        _chunk_slice.reset(_chunk);
+    }
+    RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
     // seriealize data, store result into _block
     auto& serde = _spiller->serde();
     if (_block == nullptr) {
@@ -185,11 +214,13 @@ Status OrderedMemTable::finalize() {
     }
     SerdeContext serde_ctx;
     while (!_chunk_slice.empty()) {
+        SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
         auto chunk = _chunk_slice.cutoff(_runtime_state->chunk_size());
         RETURN_IF_ERROR(serde->serialize_to_block(serde_ctx, chunk, _block));
+        RETURN_OK_IF_NEED_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
     }
-    TRACE_SPILL_LOG << fmt::format("finalize spillable ordered memtable done, rows[{}], size[{}]", num_rows(),
-                                   _block->size());
+    LOG(INFO) << fmt::format("finalize spillable ordered memtable done, rows[{}], size[{}]", num_rows(),
+                             _block->size());
     // clear all data
     _chunk_slice.reset(nullptr);
     int64_t old_consumption = _tracker->consumption();
@@ -204,9 +235,11 @@ void OrderedMemTable::reset() {
     SpillableMemTable::reset();
     _chunk_slice.reset(nullptr);
     _chunk.reset();
+    _sort_done = false;
 }
 
 StatusOr<ChunkPtr> OrderedMemTable::_do_sort(const ChunkPtr& chunk) {
+    DCHECK(!_sort_done) << " cannot sort multiple times";
     RETURN_IF_ERROR(chunk->upgrade_if_overflow());
     DataSegment segment(_sort_exprs, chunk);
     _permutation.resize(0);
@@ -222,6 +255,7 @@ StatusOr<ChunkPtr> OrderedMemTable::_do_sort(const ChunkPtr& chunk) {
         SCOPED_TIMER(_spiller->metrics().materialize_chunk_timer);
         materialize_by_permutation(sorted_chunk.get(), {_chunk}, _permutation);
     }
+    _sort_done = true;
 
     return sorted_chunk;
 }

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -38,7 +38,10 @@ public:
 
     Status append(const std::vector<Slice>& data) override {
         std::for_each(data.begin(), data.end(), [&](const Slice& slice) {
-            _buffer.emplace_back(std::string(slice.data, slice.size));
+            AlignedBuffer buffer;
+            buffer.resize(slice.size);
+            memcpy(buffer.data(), slice.data, slice.size);
+            _buffer.emplace_back(std::move(buffer));
             _size += slice.get_size();
         });
         return Status::OK();
@@ -74,7 +77,8 @@ public:
     }
 
 private:
-    std::vector<std::string> _buffer;
+    // use aligned buffer to make direct io happy
+    std::vector<AlignedBuffer> _buffer;
     size_t _next_idx = 0;
 };
 

--- a/be/src/exec/spill/mem_table.cpp
+++ b/be/src/exec/spill/mem_table.cpp
@@ -55,9 +55,7 @@ public:
 
     Slice get_data() { return {_buffer.data(), _buffer.size()}; }
 
-    void reset() {
-        _buffer.clear();
-    }
+    void reset() { _buffer.clear(); }
 
 private:
     std::string _buffer;
@@ -232,7 +230,6 @@ void OrderedMemTable::reset() {
     SpillableMemTable::reset();
     _chunk_slice.reset(nullptr);
     _chunk.reset();
-
 }
 
 StatusOr<ChunkPtr> OrderedMemTable::_do_sort(const ChunkPtr& chunk) {

--- a/be/src/exec/spill/mem_table.h
+++ b/be/src/exec/spill/mem_table.h
@@ -75,9 +75,7 @@ public:
         return Status::NotSupported("unsupport to call as_input_stream");
     }
 
-    // virtual StatusOr<Slice> get_serialized_data() const;
     StatusOr<Slice> get_next_serialized_data();
-    // StatusOr<Slice> get_next_serialized_data();
     size_t get_serialized_data_size() const;
     virtual void reset() = 0;
 

--- a/be/src/exec/spill/mem_table.h
+++ b/be/src/exec/spill/mem_table.h
@@ -67,7 +67,8 @@ public:
                                                   uint32_t size) = 0;
 
     // all data has been added, call `finalize` to serialize data
-    // after `finalize` is successfully called, we can get serialized data by `get_serialized_data`.
+    // after `finalize` is successfully called, we can get serialized data by `get_next_serialized_data`.
+    // NOTE: The implementation of `finalize` needs to ensure reentrancy in order to implement io task yield mechanism
     virtual Status finalize(workgroup::YieldContext& yield_ctx) = 0;
 
     virtual StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(bool shared) {

--- a/be/src/exec/spill/mem_table.h
+++ b/be/src/exec/spill/mem_table.h
@@ -108,7 +108,7 @@ public:
     Status finalize() override;
     Status done() override { return Status::OK(); };
     Status flush(FlushCallBack callback) override;
-    void reset() override {}
+    void reset() override;
 
     StatusOr<std::shared_ptr<SpillInputStream>> as_input_stream(bool shared) override;
 
@@ -132,7 +132,7 @@ public:
     Status finalize() override;
     Status done() override;
     Status flush(FlushCallBack callback) override;
-    void reset() override {}
+    void reset() override;
 
 private:
     StatusOr<ChunkPtr> _do_sort(const ChunkPtr& chunk);

--- a/be/src/exec/spill/serde.cpp
+++ b/be/src/exec/spill/serde.cpp
@@ -85,6 +85,7 @@ size_t ColumnarSerde::_max_serialized_size(const ChunkPtr& chunk) const {
 }
 
 Status ColumnarSerde::serialize_to_block(SerdeContext& ctx, const ChunkPtr& chunk, BlockPtr block) {
+    DCHECK(block != nullptr) << "block should not be null";
     const auto& columns = chunk->columns();
     size_t max_serialized_size = _max_serialized_size(chunk);
     auto& serialize_buffer = ctx.aligned_buffer;

--- a/be/src/exec/spill/serde.h
+++ b/be/src/exec/spill/serde.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <butil/macros.h>
 #include <cstring>
 
 #include "column/vectorized_fwd.h"
@@ -21,6 +22,7 @@
 #include "common/statusor.h"
 #include "exec/spill/block_manager.h"
 #include "gen_cpp/types.pb.h"
+#include "gutil/macros.h"
 #include "util/raw_container.h"
 
 namespace starrocks::spill {
@@ -38,6 +40,19 @@ struct AlignedBuffer {
             free(_data);
             _data = nullptr;
         }
+    }
+
+    DISALLOW_COPY(AlignedBuffer);
+    AlignedBuffer(AlignedBuffer&& other) noexcept : _data(other._data), _capacity(other._capacity), _size(other._size) {
+        other._data = nullptr;
+    }
+    AlignedBuffer& operator=(AlignedBuffer&& other) noexcept {
+        if (this != &other) {
+           std::swap(_data, other._data);
+           std::swap(_capacity, other._capacity);
+           std::swap(_size, other._size); 
+        }
+        return *this;
     }
 
     uint8_t* data() const { return (uint8_t*)_data; }

--- a/be/src/exec/spill/serde.h
+++ b/be/src/exec/spill/serde.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include <butil/macros.h>
+
 #include <cstring>
 
 #include "column/vectorized_fwd.h"
@@ -48,9 +49,9 @@ struct AlignedBuffer {
     }
     AlignedBuffer& operator=(AlignedBuffer&& other) noexcept {
         if (this != &other) {
-           std::swap(_data, other._data);
-           std::swap(_capacity, other._capacity);
-           std::swap(_size, other._size); 
+            std::swap(_data, other._data);
+            std::swap(_capacity, other._capacity);
+            std::swap(_size, other._size);
         }
         return *this;
     }

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -87,7 +87,7 @@ Status RawSpillerWriter::yieldable_flush_task(workgroup::YieldContext& yield_ctx
         RETURN_IF_ERROR(block->append({data}));
         RETURN_IF_ERROR(block->flush());
     }
-    LOG(INFO) << fmt::format("flush block[{}]", block->debug_string());
+    TRACE_SPILL_LOG << fmt::format("flush block[{}]", block->debug_string());
     RETURN_IF_ERROR(_spiller->block_manager()->release_block(block));
     mem_table->reset();
     {
@@ -258,7 +258,7 @@ Status PartitionedSpillerWriter::_choose_partitions_to_flush(bool is_final_flush
             // partition not in memory
             if (!partition->in_mem && partition->level < config::spill_max_partition_level &&
                 mem_table->mem_usage() + partition->bytes > options().spill_mem_table_bytes_size) {
-                RETURN_IF_ERROR(mem_table->done());
+                RETURN_IF_ERROR(mem_table->finalize());
                 partition->in_mem = false;
                 partition->mem_size = 0;
                 partition->bytes += mem_table->mem_usage();

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -583,135 +583,109 @@ Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield
         auto flush_partition = [this, &spill_ctx, &yield_ctx](SpilledPartition* partition) -> Status {
             auto mem_table = partition->spill_writer->mem_table();
             if (mem_table->num_rows() == 0) {
-                if (mem_table->mem_usage() < _spiller->min_mem_to_spill()) {
-                    TRACE_SPILL_LOG << "skip to flush empty partition: " << partition->debug_string();
-                    return Status::OK();
-                }
+                TRACE_SPILL_LOG << "skip to flush empty partition: " << partition->debug_string();
+                return Status::OK();
                 return this->spill_partition(yield_ctx, spill_ctx, partition);
             };
+        };
 
-            auto defer = DeferOp([&]() {
-                RETURN_IF(st = flush_partition(left_partition); !st.ok(), (void)0);
-                RETURN_IF(yield_ctx.need_yield, (void)0);
-                RETURN_IF(st = flush_partition(right_partition); !st.ok(), (void)0);
-                RETURN_IF(yield_ctx.need_yield, (void)0);
-
-                // RETURN_IF_YIELD()
-                // if (st = flush_partition(left_partition); !st.ok()) {
-                //     if(st.is_yield() || *yield) {
-                //         LOG(INFO) << fmt::format("yield when flush left partition[{}]", left_partition->debug_string());
-                //         *yield = true;
-                //         st = Status::OK();
-                //         return;
-                //     }
-                //     if (!st.ok()) {
-                //         return;
-                //     }
-                // }
-                // if (st = flush_partition(right_partition); ! st.ok()) {
-                //     if(st.is_yield() | *yield) {
-                //         LOG(INFO) << fmt::format("yield when flush right partition[{}]", right_partition->debug_string());
-                //         *yield = true;
-                //         st = Status::OK();
-                //         return;
-                //     }
-                //     if (!st.ok()) {
-                //         return;
-                //     }
-                // }
-            });
-            TRY_CATCH_ALLOC_SCOPE_START()
-            while (true) {
-                {
-                    SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
-                    RETURN_IF_ERROR(reader->trigger_restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
-                    if (!reader->has_output_data()) {
-                        break;
-                    }
-                    ASSIGN_OR_RETURN(auto chunk, reader->restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
-                    if (chunk->is_empty()) {
-                        continue;
-                    }
-                    auto hash_column = down_cast<SpillHashColumn*>(chunk->columns().back().get());
-                    const auto& hash_data = hash_column->get_data();
-                    // hash data
-                    std::vector<uint32_t> shuffle_result;
-                    shuffle_result.resize(hash_data.size());
-                    size_t left_channel_size = 0;
-                    for (size_t i = 0; i < hash_data.size(); ++i) {
-                        shuffle_result[i] = hash_data[i] >> current_level & 0x01;
-                        left_channel_size += !shuffle_result[i];
-                    }
-                    size_t left_cursor = 0;
-                    size_t right_cursor = left_channel_size;
-                    std::vector<uint32_t> selection(hash_data.size());
-                    for (size_t i = 0; i < hash_data.size(); ++i) {
-                        if (shuffle_result[i] == 0) {
-                            selection[left_cursor++] = i;
-                        } else {
-                            selection[right_cursor++] = i;
-                        }
-                    }
-
-#ifndef NDEBUG
-                    for (size_t i = 0; i < left_cursor; i++) {
-                        DCHECK_EQ(hash_data[selection[i]] & left_partition->mask(),
-                                  left_partition->partition_id & left_partition->mask());
-                    }
-
-                    for (size_t i = left_cursor; i < right_cursor; i++) {
-                        DCHECK_EQ(hash_data[selection[i]] & right_partition->mask(),
-                                  right_partition->partition_id & right_partition->mask());
-                    }
-#endif
-
-                    if (left_channel_size > 0) {
-                        left_partition->num_rows += left_channel_size;
-                        RETURN_IF_ERROR(
-                                left_mem_table->append_selective(*chunk, selection.data(), 0, left_channel_size));
-                    }
-                    if (hash_data.size() != left_channel_size) {
-                        right_partition->num_rows += hash_data.size() - left_channel_size;
-                        RETURN_IF_ERROR(right_mem_table->append_selective(*chunk, selection.data(), left_channel_size,
-                                                                          hash_data.size() - left_channel_size));
+        auto defer = DeferOp([&]() {
+            RETURN_IF(st = flush_partition(left_partition); !st.ok(), (void)0);
+            RETURN_IF(yield_ctx.need_yield, (void)0);
+            RETURN_IF(st = flush_partition(right_partition); !st.ok(), (void)0);
+            RETURN_IF(yield_ctx.need_yield, (void)0);
+        });
+        TRY_CATCH_ALLOC_SCOPE_START()
+        while (true) {
+            {
+                SCOPED_RAW_TIMER(&yield_ctx.time_spent_ns);
+                RETURN_IF_ERROR(reader->trigger_restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
+                if (!reader->has_output_data()) {
+                    break;
+                }
+                ASSIGN_OR_RETURN(auto chunk, reader->restore(_runtime_state, SyncTaskExecutor{}, EmptyMemGuard{}));
+                if (chunk->is_empty()) {
+                    continue;
+                }
+                auto hash_column = down_cast<SpillHashColumn*>(chunk->columns().back().get());
+                const auto& hash_data = hash_column->get_data();
+                // hash data
+                std::vector<uint32_t> shuffle_result;
+                shuffle_result.resize(hash_data.size());
+                size_t left_channel_size = 0;
+                for (size_t i = 0; i < hash_data.size(); ++i) {
+                    shuffle_result[i] = hash_data[i] >> current_level & 0x01;
+                    left_channel_size += !shuffle_result[i];
+                }
+                size_t left_cursor = 0;
+                size_t right_cursor = left_channel_size;
+                std::vector<uint32_t> selection(hash_data.size());
+                for (size_t i = 0; i < hash_data.size(); ++i) {
+                    if (shuffle_result[i] == 0) {
+                        selection[left_cursor++] = i;
+                    } else {
+                        selection[right_cursor++] = i;
                     }
                 }
-                BREAK_IF_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
+
+#ifndef NDEBUG
+                for (size_t i = 0; i < left_cursor; i++) {
+                    DCHECK_EQ(hash_data[selection[i]] & left_partition->mask(),
+                              left_partition->partition_id & left_partition->mask());
+                }
+
+                for (size_t i = left_cursor; i < right_cursor; i++) {
+                    DCHECK_EQ(hash_data[selection[i]] & right_partition->mask(),
+                              right_partition->partition_id & right_partition->mask());
+                }
+#endif
+
+                if (left_channel_size > 0) {
+                    left_partition->num_rows += left_channel_size;
+                    RETURN_IF_ERROR(left_mem_table->append_selective(*chunk, selection.data(), 0, left_channel_size));
+                }
+                if (hash_data.size() != left_channel_size) {
+                    right_partition->num_rows += hash_data.size() - left_channel_size;
+                    RETURN_IF_ERROR(right_mem_table->append_selective(*chunk, selection.data(), left_channel_size,
+                                                                      hash_data.size() - left_channel_size));
+                }
             }
-            TRY_CATCH_ALLOC_SCOPE_END()
+            BREAK_IF_YIELD(yield_ctx.wg, &yield_ctx.need_yield, yield_ctx.time_spent_ns);
         }
-        // TODO: add restore rows check
-        return st;
+        TRY_CATCH_ALLOC_SCOPE_END()
+    }
+    // TODO: add restore rows check
+    return st;
+}
+
+Status PartitionedSpillerWriter::yieldable_flush_task(workgroup::YieldContext& ctx,
+                                                      const std::vector<SpilledPartition*>& splitting_partitions,
+                                                      const std::vector<SpilledPartition*>& spilling_partitions) {
+    enum PartitionWriterStage { SPILL = 0, SPLIT = 1, FINISH = 2 };
+
+    ctx.total_yield_point_cnt = FINISH;
+    DCHECK(ctx.task_context_data.has_value()) << "spill flush context must be set";
+
+    // partition memory usage
+    // now we partitioned sorted spill
+    SerdeContext spill_ctx;
+    switch (ctx.yield_point) {
+    case SPILL:
+        RETURN_IF_ERROR(_spill_input_partitions(ctx, spill_ctx, spilling_partitions));
+        RETURN_IF_YIELD(ctx.need_yield);
+        TO_NEXT_STAGE(ctx.yield_point);
+        [[fallthrough]];
+    case SPLIT:
+        RETURN_IF_ERROR(_split_input_partitions(ctx, spill_ctx, splitting_partitions));
+        RETURN_IF_YIELD(ctx.need_yield);
+        TO_NEXT_STAGE(ctx.yield_point);
+        [[fallthrough]];
+    default: {
+        DCHECK_EQ(ctx.yield_point, 2);
+    }
     }
 
-    Status PartitionedSpillerWriter::yieldable_flush_task(workgroup::YieldContext & ctx,
-                                                          const std::vector<SpilledPartition*>& splitting_partitions,
-                                                          const std::vector<SpilledPartition*>& spilling_partitions) {
-        enum PartitionWriterStage { SPILL = 0, SPLIT = 1, FINISH = 2 };
-
-        ctx.total_yield_point_cnt = FINISH;
-        DCHECK(ctx.task_context_data.has_value()) << "spill flush context must be set";
-
-        // partition memory usage
-        // now we partitioned sorted spill
-        SerdeContext spill_ctx;
-        switch (ctx.yield_point) {
-        case SPILL:
-            RETURN_IF_ERROR(_spill_input_partitions(ctx, spill_ctx, spilling_partitions));
-            RETURN_IF_YIELD(ctx.need_yield);
-            TO_NEXT_STAGE(ctx.yield_point);
-            [[fallthrough]];
-        case SPLIT:
-            RETURN_IF_ERROR(_split_input_partitions(ctx, spill_ctx, splitting_partitions));
-            RETURN_IF_YIELD(ctx.need_yield);
-            TO_NEXT_STAGE(ctx.yield_point);
-            [[fallthrough]];
-        default: {
-            DCHECK_EQ(ctx.yield_point, 2);
-        }
-        }
-
-        return Status::OK();
-    }
+    return Status::OK();
+}
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -591,6 +591,7 @@ Status PartitionedSpillerWriter::_split_partition(workgroup::YieldContext& yield
                 TRACE_SPILL_LOG << fmt::format("skip to flush small partition: {}", partition->debug_string());
                 return Status::OK();
             }
+            RETURN_IF_ERROR(mem_table->done());
             return this->spill_partition(yield_ctx, spill_ctx, partition);
         };
 

--- a/be/src/exec/spill/spill_components.cpp
+++ b/be/src/exec/spill/spill_components.cpp
@@ -376,8 +376,9 @@ Status PartitionedSpillerWriter::spill_partition(SerdeContext& ctx, SpilledParti
 
     auto mem_table = partition->spill_writer->mem_table();
     ASSIGN_OR_RETURN(auto serialized_data, mem_table->get_serialized_data());
-    TRACE_SPILL_LOG << fmt::format("spill partition[{}], mem_table_size[{}] bytes[{}] rows[{}]", partition->debug_string(),
-                             serialized_data.get_size(), mem_table->mem_usage(), mem_table->num_rows());
+    TRACE_SPILL_LOG << fmt::format("spill partition[{}], mem_table_size[{}] bytes[{}] rows[{}]",
+                                   partition->debug_string(), serialized_data.get_size(), mem_table->mem_usage(),
+                                   mem_table->num_rows());
 
     partition->bytes += mem_table->mem_usage();
 
@@ -386,7 +387,7 @@ Status PartitionedSpillerWriter::spill_partition(SerdeContext& ctx, SpilledParti
         std::lock_guard<std::mutex> l(_mutex);
         partition->spill_writer->block_group().append(block);
         TRACE_SPILL_LOG << "add block to partition: " << partition->partition_id << "block: " << block->debug_string()
-                  << ", num_rows:" << mem_table->num_rows();
+                        << ", num_rows:" << mem_table->num_rows();
     }
     RETURN_IF_ERROR(block->flush());
     RETURN_IF_ERROR(_spiller->block_manager()->release_block(block));
@@ -454,7 +455,8 @@ Status PartitionedSpillerWriter::_spill_input_partitions(workgroup::YieldContext
     auto& flush_ctx = std::any_cast<PartitionedFlushContextPtr>(yield_ctx.task_context_data)->spill_stage_ctx;
     for (; flush_ctx.processing_idx < spilling_partitions.size();) {
         auto partition = spilling_partitions[flush_ctx.processing_idx];
-        TRACE_SPILL_LOG << fmt::format("spill input partition[{}], processing idx[{}]", partition->debug_string(), flush_ctx.processing_idx);
+        TRACE_SPILL_LOG << fmt::format("spill input partition[{}], processing idx[{}]", partition->debug_string(),
+                                       flush_ctx.processing_idx);
         {
             SCOPED_RAW_TIMER(time_spent_ns);
             RETURN_IF_ERROR(spill_partition(context, partition));

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -214,8 +214,8 @@ struct SpilledPartition : public SpillPartitionInfo {
     }
 
     std::string debug_string() {
-        return fmt::format("[id={},bytes={},mem_size={},in_mem={},is_spliting={}]", partition_id, bytes, mem_size,
-                           in_mem, is_spliting);
+        return fmt::format("[id={},bytes={},mem_size={},num_rows={},in_mem={},is_spliting={}]", partition_id, bytes,
+                           mem_size, num_rows, in_mem, is_spliting);
     }
 
     bool is_spliting = false;

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -176,12 +176,10 @@ public:
 
     void get_spill_partitions(std::vector<const SpillPartitionInfo*>* partitions) override {}
 
-    Status yieldable_flush_task(workgroup::YieldContext& ctx, RuntimeState* state, const MemTablePtr& mem_table,
-                                int* yield);
+    Status yieldable_flush_task(workgroup::YieldContext& ctx, RuntimeState* state, const MemTablePtr& mem_table);
 
 public:
     struct FlushContext {
-        FlushContext(BlockPtr b) : block(b) {}
         BlockPtr block;
     };
     using FlushContextPtr = std::shared_ptr<FlushContext>;
@@ -295,7 +293,7 @@ public:
 
     const auto& level_to_partitions() { return _level_to_partitions; }
 
-    Status spill_partition(SerdeContext& context, SpilledPartition* partition);
+    Status spill_partition(workgroup::YieldContext& ctx, SerdeContext& context, SpilledPartition* partition);
 
     int64_t mem_consumption() const { return _mem_tracker->consumption(); }
 
@@ -332,7 +330,7 @@ public:
 
     Status yieldable_flush_task(workgroup::YieldContext& ctx,
                                 const std::vector<SpilledPartition*>& splitting_partitions,
-                                const std::vector<SpilledPartition*>& spilling_partitions, int* yield);
+                                const std::vector<SpilledPartition*>& spilling_partitions);
 
 private:
     void _init_with_partition_nums(RuntimeState* state, int num_partitions);
@@ -340,12 +338,10 @@ private:
     void _prepare_partitions(RuntimeState* state);
 
     Status _spill_input_partitions(workgroup::YieldContext& ctx, SerdeContext& context,
-                                   const std::vector<SpilledPartition*>& spilling_partitions, int64_t* time_spent_ns,
-                                   int* yield);
+                                   const std::vector<SpilledPartition*>& spilling_partitions);
 
     Status _split_input_partitions(workgroup::YieldContext& ctx, SerdeContext& context,
-                                   const std::vector<SpilledPartition*>& splitting_partitions, int64_t* time_spent_ns,
-                                   int* yield);
+                                   const std::vector<SpilledPartition*>& splitting_partitions);
 
     // split partition by hash
     // hash-based partitioning can have significant degradation in the case of heavily skewed data.
@@ -355,7 +351,7 @@ private:
     // 2. If our input is ordered, we can use some sorting-based algorithm to split the partition. This way the probe side can do full streaming of the data
     Status _split_partition(workgroup::YieldContext& ctx, SerdeContext& context, SpillerReader* reader,
                             SpilledPartition* partition, SpilledPartition* left_partition,
-                            SpilledPartition* right_partition, int64_t* time_spent_ns, int* yield);
+                            SpilledPartition* right_partition);
 
     void _add_partition(SpilledPartitionPtr&& partition);
     void _remove_partition(const SpilledPartition* partition);

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -164,9 +164,7 @@ public:
 
     BlockPtr& block() { return _block; }
 
-    void reset_block() {
-        _block = nullptr;
-    }
+    void reset_block() { _block = nullptr; }
 
     BlockGroup& block_group() { return _block_group; }
 

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -166,7 +166,6 @@ public:
 
     void reset_block() {
         _block = nullptr;
-        // _block.reset();
     }
 
     BlockGroup& block_group() { return _block_group; }
@@ -297,9 +296,6 @@ public:
     }
 
     const auto& level_to_partitions() { return _level_to_partitions; }
-
-    // template <class ChunkProvider>
-    // Status spill_partition(SerdeContext& context, SpilledPartition* partition, ChunkProvider&& provider);
 
     Status spill_partition(SerdeContext& context, SpilledPartition* partition);
 

--- a/be/src/exec/spill/spill_components.h
+++ b/be/src/exec/spill/spill_components.h
@@ -164,6 +164,11 @@ public:
 
     BlockPtr& block() { return _block; }
 
+    void reset_block() {
+        _block = nullptr;
+        // _block.reset();
+    }
+
     BlockGroup& block_group() { return _block_group; }
 
     Status acquire_stream(std::shared_ptr<SpillInputStream>* stream) override;
@@ -179,8 +184,10 @@ public:
 
 public:
     struct FlushContext {
+        FlushContext(BlockPtr b) : block(b) {}
         BlockPtr block;
     };
+    using FlushContextPtr = std::shared_ptr<FlushContext>;
 
 private:
     template <class Provider>
@@ -291,8 +298,10 @@ public:
 
     const auto& level_to_partitions() { return _level_to_partitions; }
 
-    template <class ChunkProvider>
-    Status spill_partition(SerdeContext& context, SpilledPartition* partition, ChunkProvider&& provider);
+    // template <class ChunkProvider>
+    // Status spill_partition(SerdeContext& context, SpilledPartition* partition, ChunkProvider&& provider);
+
+    Status spill_partition(SerdeContext& context, SpilledPartition* partition);
 
     int64_t mem_consumption() const { return _mem_tracker->consumption(); }
 

--- a/be/src/exec/spill/spiller.cpp
+++ b/be/src/exec/spill/spiller.cpp
@@ -80,6 +80,10 @@ SpillProcessMetrics::SpillProcessMetrics(RuntimeProfile* profile, std::atomic_in
     restore_io_task_count = ADD_CHILD_COUNTER(profile, "RestoreIOTaskCount", TUnit::UNIT, parent);
     peak_restore_io_task_count = profile->AddHighWaterMarkCounter(
             "PeakRestoreIOTaskCount", TUnit::UNIT, RuntimeProfile::Counter::create_strategy(TUnit::UNIT), parent);
+
+    mem_table_finalize_timer = ADD_CHILD_TIMER(profile, "MemTableFinalizeTime", parent);
+    flush_task_yield_times = ADD_CHILD_COUNTER(profile, "FlushIOTaskYieldCount", TUnit::UNIT, parent);
+    restore_task_yield_times = ADD_CHILD_COUNTER(profile, "RestoreIOTaskYieldCount", TUnit::UNIT, parent);
 }
 
 Status Spiller::prepare(RuntimeState* state) {

--- a/be/src/exec/spill/spiller.h
+++ b/be/src/exec/spill/spiller.h
@@ -99,6 +99,10 @@ public:
     RuntimeProfile::HighWaterMarkCounter* peak_flush_io_task_count = nullptr;
     RuntimeProfile::Counter* restore_io_task_count = nullptr;
     RuntimeProfile::HighWaterMarkCounter* peak_restore_io_task_count = nullptr;
+
+    RuntimeProfile::Counter* mem_table_finalize_timer = nullptr;
+    RuntimeProfile::Counter* flush_task_yield_times = nullptr;
+    RuntimeProfile::Counter* restore_task_yield_times = nullptr;
 };
 
 // major spill interfaces

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -150,7 +150,6 @@ Status RawSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, Mem
     spill::AcquireBlockOptions opts;
     opts.query_id = state->query_id();
     opts.plan_node_id = _spiller->options().plan_node_id;
-    ;
     opts.name = _spiller->options().name;
     opts.block_size = serialized_data.get_size();
     ASSIGN_OR_RETURN(auto block, _spiller->block_manager()->acquire_block(opts));

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -313,6 +313,8 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
         // mark done for all partitiones need spill
         for (auto partition : spilling_partitions) {
             auto mem_table = partition->spill_writer->mem_table();
+            LOG(INFO) << "mark done partition: " << partition->debug_string()
+                      << ", mem table rows:" << mem_table->num_rows() << ", mem:" << mem_table->mem_usage();
             RETURN_IF_ERROR(mem_table->finalize());
             // allocate block here
             DCHECK(partition->spill_writer->block() == nullptr)

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -143,6 +143,7 @@ Status RawSpillerWriter::flush(RuntimeState* state, TaskExecutor&& executor, Mem
     if (captured_mem_table == nullptr) {
         return Status::OK();
     }
+    RETURN_IF_ERROR(captured_mem_table->done());
 
     _running_flush_tasks++;
     // TODO: handle spill queue

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -227,13 +227,12 @@ Status SpillerReader::trigger_restore(RuntimeState* state, TaskExecutor&& execut
                 });
                 Status res;
                 SerdeContext serd_ctx;
-                int yield = false;
 
                 yield_ctx.time_spent_ns = 0;
                 yield_ctx.need_yield = false;
 
                 YieldableRestoreTask task(_stream);
-                res = task.do_read(yield_ctx, serd_ctx, &yield);
+                res = task.do_read(yield_ctx, serd_ctx);
 
                 if (yield_ctx.need_yield) {
                     COUNTER_UPDATE(_spiller->metrics().restore_task_yield_times, 1);

--- a/be/src/exec/spill/spiller.hpp
+++ b/be/src/exec/spill/spiller.hpp
@@ -313,8 +313,6 @@ Status PartitionedSpillerWriter::flush(RuntimeState* state, bool is_final_flush,
         // mark done for all partitiones need spill
         for (auto partition : spilling_partitions) {
             auto mem_table = partition->spill_writer->mem_table();
-            LOG(INFO) << "mark done partition: " << partition->debug_string()
-                      << ", mem table rows:" << mem_table->num_rows() << ", mem:" << mem_table->mem_usage();
             RETURN_IF_ERROR(mem_table->finalize());
             // allocate block here
             DCHECK(partition->spill_writer->block() == nullptr)

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -57,6 +57,9 @@ struct YieldContext {
     size_t yield_point{};
     size_t total_yield_point_cnt{};
     const workgroup::WorkGroup* wg = nullptr;
+    // time spent in current invoke
+    int64_t time_spent_ns = 0;
+    bool need_yield = false;
 };
 
 struct ScanTask {

--- a/be/src/exec/workgroup/scan_task_queue.h
+++ b/be/src/exec/workgroup/scan_task_queue.h
@@ -57,7 +57,8 @@ struct YieldContext {
     size_t yield_point{};
     size_t total_yield_point_cnt{};
     const workgroup::WorkGroup* wg = nullptr;
-    // time spent in current invoke
+    // used to record the runtime information of a single call in order to decide whether to trigger yield.
+    // It needs to be reset every time when the task is executed.
     int64_t time_spent_ns = 0;
     bool need_yield = false;
 };

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -401,6 +401,7 @@ TEST_F(SpillTest, unsorted_process) {
             input.emplace_back(chunk->clone_unique());
             ASSERT_OK(mem_table->append(std::move(chunk)));
         }
+        ASSERT_OK(mem_table->done());
         //
         workgroup::YieldContext yield_ctx;
         do {

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -402,7 +402,12 @@ TEST_F(SpillTest, unsorted_process) {
             ASSERT_OK(mem_table->append(std::move(chunk)));
         }
         //
-        ASSERT_OK(mem_table->finalize());
+        workgroup::YieldContext yield_ctx;
+        do {
+            yield_ctx.time_spent_ns = 0;
+            yield_ctx.need_yield = false;
+            ASSERT_OK(mem_table->finalize(yield_ctx));
+        } while (yield_ctx.need_yield);
     }
 }
 

--- a/be/test/io/spill_test.cpp
+++ b/be/test/io/spill_test.cpp
@@ -402,14 +402,7 @@ TEST_F(SpillTest, unsorted_process) {
             ASSERT_OK(mem_table->append(std::move(chunk)));
         }
         //
-        size_t next_index = 0;
-        while (next_index < 500) {
-            auto st = mem_table->flush([&](const auto& chunk) {
-                chunk_equals(input[next_index++], chunk);
-                return Status::Yield();
-            });
-            ASSERT_TRUE(st.is_yield() || st.ok());
-        }
+        ASSERT_OK(mem_table->finalize());
     }
 }
 


### PR DESCRIPTION
Why I'm doing:

Currently, after a mem table is full, an io task will be submitted to the io thread. When the io task is executed, it first applies for a block from the BlockManager, and then serializes the mem table. The serialization results are continuously appended to the block, and finally flushed to the disk.

Block application is before serialization, and the space required by Block is unknown at this time. There may be a situation where two io tasks apply for a Block under the same disk at the same time, but when appending, it is found that the disk is not writable due to capacity limit, and the final query fails. 
Although the user can configure multiple disks and  if other disks have sufficient space, there is still no way to avoid the above failure under the existing implementation. 


What I'm doing:

1. move mem table serialization process logic before block allcation.
2. move time_spent_ns and need_yield into YieldContext to simplify the yield-related interface 


**NOTE**
This PR does not change the allocation strategy of spill dir. The above problems still exist and will be solved in subsequent PR

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
