### PR TITLE
[BugFix] support map function with exact two non-array argument under Trino dialect

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/parser/trino/Trino2SRFunctionCallTransformer.java
@@ -283,9 +283,6 @@ public class Trino2SRFunctionCallTransformer {
     }
 
     private static void registerMapFunctionTransformer() {
-        // map(array, array) -> map_from_arrays
-        registerFunctionTransformer("map", 2, "map_from_arrays",
-                ImmutableList.of(Expr.class, Expr.class));
     }
 
     private static void registerBinaryFunctionTransformer() {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -82,7 +82,10 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
     @Test
     public void testMapFnTransform() throws Exception {
-        String sql = "select map(1,'2')";
+        String sql = "select map()";
+        assertPlanContains(sql, "map{}");
+
+        sql = "select map(1,'2')";
         assertPlanContains(sql, "map{1:'2'}");
 
         sql = "select map(1,'2',3,4)";
@@ -90,6 +93,9 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
 
         sql = "select map(array[1,2], array['3','4'])";
         assertPlanContains(sql, "map_from_arrays([1,2], ['3','4'])");
+
+        sql = "select map(1,2,3)";
+        analyzeFail(sql, "Incorrect number 3 of arguments in expr 'map()', Arguments must be in key/value pairs");
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/parser/trino/TrinoFunctionTransformTest.java
@@ -81,6 +81,18 @@ public class TrinoFunctionTransformTest extends TrinoTestBase {
     }
 
     @Test
+    public void testMapFnTransform() throws Exception {
+        String sql = "select map(1,'2')";
+        assertPlanContains(sql, "map{1:'2'}");
+
+        sql = "select map(1,'2',3,4)";
+        assertPlanContains(sql, "map{1:'2',3:'4'}");
+
+        sql = "select map(array[1,2], array['3','4'])";
+        assertPlanContains(sql, "map_from_arrays([1,2], ['3','4'])");
+    }
+
+    @Test
     public void testArrayFnWithLambdaExpr() throws Exception {
         String sql = "select filter(array[], x -> true);";
         assertPlanContains(sql, "array_filter(CAST([] AS ARRAY<BOOLEAN>), array_map(<slot 2> -> TRUE, []))");


### PR DESCRIPTION
Why I'm doing:
Currently, trino parser transformer only supports to transform map(k,v) to map_from_arrays(k,v) even though k/v are not arrays. This pr fixes this edge case.

What I'm doing:
To support successfully parsing map(k,v) to a map expr if k/v are not arrays.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5