### PR TITLE
[Tool] CI: release cluster immediately

### DIFF
--- a/.github/workflows/ci-pipeline-branch.yml
+++ b/.github/workflows/ci-pipeline-branch.yml
@@ -316,23 +316,6 @@ jobs:
           bucket_prefix=`echo ${repo%/*} | tr '[:upper:]' '[:lower:]'` 
           echo "bucket_prefix=${bucket_prefix}" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Checkout PR
-        run: |
-          BRANCH=${{steps.branch.outputs.branch}}
-          git config --global user.name "wanpengfei-git";
-          git config --global user.email "wanpengfei91@163.com";
-          git checkout $BRANCH;
-          git pull;
-          BRANCH_NAME="${BRANCH}-${PR_NUMBER}";
-          git fetch origin pull/${PR_NUMBER}/head:${BRANCH_NAME};
-          git checkout $BRANCH_NAME;
-          git checkout -b merge_pr;
-          git merge --squash --no-edit ${BRANCH} || (echo "::error::Merge conflict, please check." && exit -1);
-
       - name: UPDATE ECI & RUN UT
         id: run_ut
         shell: bash

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -276,8 +276,6 @@ jobs:
               - 'java-extensions/**'
               - 'build.sh'
 
-      - run: echo ${{ steps.changes.outputs.fe }}
-
       - name: FE CHECK INFO
         id: fe-changes-info
         run: |
@@ -440,14 +438,6 @@ jobs:
           repo="${{ github.repository }}"
           bucket_prefix=`echo ${repo%/*} | tr '[:upper:]' '[:lower:]'` 
           echo "bucket_prefix=${bucket_prefix}" >> $GITHUB_OUTPUT
-
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-
-      - name: Checkout PR
-        run: |
-          cd /var/lib/ci-tool/ && git pull && ./bin/checkout.sh
 
       - name: UPDATE ECI & RUN UT
         id: run_ut
@@ -760,11 +750,7 @@ jobs:
           ADMIT_RESULT: ${{ needs.admit.result }}
         run: |
           cd ci-tool && source lib/init.sh
-          if [[ "${SQL_TESTER_RESULT}" == 'success' && "${ADMIT_RESULT}" == 'success' ]]; then
-              ./bin/elastic-cluster.sh --delete
-          else
-              ./bin/elastic-cluster.sh --renew 0.5
-          fi
+          ./bin/elastic-cluster.sh --delete
 
       - name: clean ECI
         if: always() && needs.SQL-Tester.outputs.MYSQL_ECI_ID != ''

--- a/.github/workflows/ci-report.yml
+++ b/.github/workflows/ci-report.yml
@@ -231,7 +231,7 @@ jobs:
         env:
           bucket_prefix: ${{ steps.info.outputs.bucket_prefix }}
         run: |
-          oss_path=oss://${bucket_prefix}-ci-release/$BASE_REF/ASAN/pr/UT-Report/${PR_NUMBER}
+          oss_path=oss://${bucket_prefix}-ci-release/$BASE_REF/DEBUG/pr/UT-Report/${PR_NUMBER}
           size=$(ossutil64 --config-file ~/.ossutilconfig ls ${oss_path}/be_ut_coverage.xml | grep "Object Number is" | awk '{print $NF}')
           echo "size=${size}" >> $GITHUB_OUTPUT
           if [[ "$size" != "0" ]]; then

--- a/.github/workflows/inspection-pipeline.yml
+++ b/.github/workflows/inspection-pipeline.yml
@@ -435,7 +435,7 @@ jobs:
           ./bin/elastic-cluster.sh --renew 0.5
 
       - name: save unstable cases
-        if: always() && github.event_name == 'schedule'
+        if: always() && github.event_name == 'schedule' && steps.backup.outcome == 'success'
         run: |
           cd ci-tool && source lib/init.sh
           ./bin/save_unstable_cases.sh


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
Optimize CI: release cluster immediately, cancel the renew operation.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [x] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
