### PR TITLE
[Refactor] Delete meaningless obsolete code in Transaction Manager

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -211,7 +211,6 @@ public class JournalEntity implements Writable {
         LOG.debug("get opcode: {}", opCode);
         switch (opCode) {
             case OperationType.OP_SAVE_NEXTID:
-            case OperationType.OP_SAVE_TRANSACTION_ID:
             case OperationType.OP_ERASE_DB:
             case OperationType.OP_ERASE_TABLE:
             case OperationType.OP_ERASE_PARTITION:
@@ -614,13 +613,6 @@ public class JournalEntity implements Writable {
             case OperationType.OP_UPDATE_CLUSTER_AND_BACKENDS: {
                 data = new BackendIdsUpdateInfo();
                 ((BackendIdsUpdateInfo) data).readFields(in);
-                isRead = true;
-                break;
-            }
-            case OperationType.OP_UPSERT_TRANSACTION_STATE:
-            case OperationType.OP_DELETE_TRANSACTION_STATE: {
-                data = new TransactionState();
-                ((TransactionState) data).readFields(in);
                 isRead = true;
                 break;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/EditLog.java
@@ -157,13 +157,6 @@ public class EditLog {
                     globalStateMgr.setNextId(id + 1);
                     break;
                 }
-                case OperationType.OP_SAVE_TRANSACTION_ID: {
-                    String idString = journal.getData().toString();
-                    long id = Long.parseLong(idString);
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator()
-                            .initTransactionId(id + 1);
-                    break;
-                }
                 case OperationType.OP_SAVE_TRANSACTION_ID_V2: {
                     TransactionIdInfo idInfo = (TransactionIdInfo) journal.getData();
                     GlobalStateMgr.getCurrentGlobalTransactionMgr().getTransactionIDGenerator()
@@ -625,8 +618,7 @@ public class EditLog {
                     globalStateMgr.replayUpdateClusterAndBackends(info);
                     break;
                 }
-                case OperationType.OP_UPSERT_TRANSACTION_STATE_V2:
-                case OperationType.OP_UPSERT_TRANSACTION_STATE: {
+                case OperationType.OP_UPSERT_TRANSACTION_STATE_V2: {
                     final TransactionState state = (TransactionState) journal.getData();
                     GlobalStateMgr.getCurrentGlobalTransactionMgr().replayUpsertTransactionState(state);
                     LOG.debug("opcode: {}, tid: {}", opCode, state.getTransactionId());
@@ -636,12 +628,6 @@ public class EditLog {
                     final TransactionStateBatch stateBatch = (TransactionStateBatch) journal.getData();
                     GlobalStateMgr.getCurrentGlobalTransactionMgr().replayUpsertTransactionStateBatch(stateBatch);
                     LOG.debug("opcode: {}, tids: {}", opCode, stateBatch.getTxnIds());
-                    break;
-                }
-                case OperationType.OP_DELETE_TRANSACTION_STATE: {
-                    final TransactionState state = (TransactionState) journal.getData();
-                    GlobalStateMgr.getCurrentGlobalTransactionMgr().replayDeleteTransactionState(state);
-                    LOG.debug("opcode: {}, tid: {}", opCode, state.getTransactionId());
                     break;
                 }
                 case OperationType.OP_CREATE_REPOSITORY:
@@ -1313,11 +1299,7 @@ public class EditLog {
     }
 
     public void logSaveTransactionId(long transactionId) {
-        if (FeConstants.STARROCKS_META_VERSION >= StarRocksFEMetaVersion.VERSION_4) {
-            logJsonObject(OperationType.OP_SAVE_TRANSACTION_ID_V2, new TransactionIdInfo(transactionId));
-        } else {
-            logEdit(OperationType.OP_SAVE_TRANSACTION_ID, new Text(Long.toString(transactionId)));
-        }
+        logJsonObject(OperationType.OP_SAVE_TRANSACTION_ID_V2, new TransactionIdInfo(transactionId));
     }
 
     public void logSaveAutoIncrementId(AutoIncrementInfo info) {
@@ -1722,11 +1704,7 @@ public class EditLog {
 
     // for TransactionState
     public void logInsertTransactionState(TransactionState transactionState) {
-        if (FeConstants.STARROCKS_META_VERSION >= StarRocksFEMetaVersion.VERSION_4) {
-            logJsonObject(OperationType.OP_UPSERT_TRANSACTION_STATE_V2, transactionState);
-        } else {
-            logEdit(OperationType.OP_UPSERT_TRANSACTION_STATE, transactionState);
-        }
+        logJsonObject(OperationType.OP_UPSERT_TRANSACTION_STATE_V2, transactionState);
     }
 
     public void logInsertTransactionStateBatch(TransactionStateBatch stateBatch) {

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -213,15 +213,9 @@ public class OperationType {
 
     //real time load 100 -108
     @Deprecated
-    public static final short OP_UPSERT_TRANSACTION_STATE = 100;
-    @Deprecated
-    public static final short OP_DELETE_TRANSACTION_STATE = 101;
-    @Deprecated
     public static final short OP_FINISHING_ROLLUP = 102;
     @Deprecated
     public static final short OP_FINISHING_SCHEMA_CHANGE = 103;
-    @Deprecated
-    public static final short OP_SAVE_TRANSACTION_ID = 104;
     public static final short OP_SAVE_AUTO_INCREMENT_ID = 105;
     public static final short OP_DELETE_AUTO_INCREMENT_ID = 106;
     // light schema change for add and drop columns

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/GlobalTransactionMgr.java
@@ -631,15 +631,6 @@ public class GlobalTransactionMgr {
         }
     }
 
-    public void replayDeleteTransactionState(TransactionState transactionState) {
-        try {
-            DatabaseTransactionMgr dbTransactionMgr = getDatabaseTransactionMgr(transactionState.getDbId());
-            dbTransactionMgr.deleteTransaction(transactionState);
-        } catch (AnalysisException e) {
-            LOG.warn("replay delete transaction [" + transactionState.getTransactionId() + "] failed", e);
-        }
-    }
-
     public List<List<Comparable>> getDbInfo() {
         List<List<Comparable>> infos = new ArrayList<List<Comparable>>();
         List<Long> dbIds = Lists.newArrayList(dbIdToDatabaseTransactionMgrs.keySet());

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -35,7 +35,6 @@
 package com.starrocks.transaction;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -49,12 +48,10 @@ import com.starrocks.catalog.Replica.ReplicaState;
 import com.starrocks.common.Config;
 import com.starrocks.common.TraceManager;
 import com.starrocks.common.UserException;
-import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.meta.lock.LockType;
 import com.starrocks.meta.lock.Locker;
 import com.starrocks.metric.MetricRepo;
-import com.starrocks.persist.gson.GsonUtils;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.service.FrontendOptions;
 import com.starrocks.system.Backend;
@@ -65,13 +62,10 @@ import com.starrocks.thrift.TTabletLocation;
 import com.starrocks.thrift.TTxnType;
 import com.starrocks.thrift.TUniqueId;
 import io.opentelemetry.api.trace.Span;
-import io.opentelemetry.api.trace.StatusCode;
-import org.apache.commons.codec.binary.Hex;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -328,8 +322,6 @@ public class TransactionState implements Writable {
     // tbl id -> (index ids)
     private final Map<Long, Set<Long>> loadedTblIndexes = Maps.newHashMap();
 
-    private String errorLogUrl = null;
-
     // record some error msgs during the transaction operation.
     // this msg will be shown in show proc "/transactions/dbId/";
     // no need to persist.
@@ -516,14 +508,6 @@ public class TransactionState implements Writable {
         return timeoutMs;
     }
 
-    public void setErrorLogUrl(String errorLogUrl) {
-        this.errorLogUrl = errorLogUrl;
-    }
-
-    public String getErrorLogUrl() {
-        return errorLogUrl;
-    }
-
     public void setTransactionStatus(TransactionStatus transactionStatus) {
         // status changed
         this.transactionStatus = transactionStatus;
@@ -672,17 +656,7 @@ public class TransactionState implements Writable {
     }
 
     public List<Long> getTableIdList() {
-        if (tableIdList.isEmpty()) {
-            // Old version sometimes forgot to set the tabletIdList, collect tabletIdList
-            // from idToTableCommitInfos.
-            // NOTE: this works only when the state is COMMITTED or VISIBLE
-            tableIdList = Lists.newArrayList(idToTableCommitInfos.keySet());
-        }
         return tableIdList;
-    }
-
-    public void setTableIdList(List<Long> tableIdList) {
-        this.tableIdList = tableIdList;
     }
 
     public Map<Long, TableCommitInfo> getIdToTableCommitInfos() {
@@ -811,142 +785,6 @@ public class TransactionState implements Writable {
     public void clearAfterPublished() {
         publishVersionTasks.clear();
         finishChecker = null;
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-        out.writeLong(transactionId);
-        Text.writeString(out, label);
-        out.writeLong(dbId);
-        out.writeInt(idToTableCommitInfos.size());
-        for (TableCommitInfo info : idToTableCommitInfos.values()) {
-            info.write(out);
-        }
-        out.writeInt(txnCoordinator.sourceType.value());
-        Text.writeString(out, txnCoordinator.ip);
-        out.writeInt(transactionStatus.value());
-        out.writeInt(sourceType.value());
-        out.writeLong(prepareTime);
-        out.writeLong(commitTime);
-        out.writeLong(finishTime);
-        // if txn use new publish mechanism, store state in the space originally used by `reason`
-        // if new publish with TxnFinishState, write json {"normal":[xx],"abnormal":[xxx,xxx]}
-        // else write `reason` field
-        // they are both String, so they are compatible
-        if (transactionStatus == TransactionStatus.VISIBLE) {
-            if (newFinish) {
-                Preconditions.checkNotNull(finishState);
-                Text.writeString(out, GsonUtils.GSON.toJson(finishState));
-            } else {
-                Text.writeString(out, "");
-            }
-        } else {
-            Text.writeString(out, reason);
-        }
-        out.writeInt(errorReplicas.size());
-        for (long errorReplicaId : errorReplicas) {
-            out.writeLong(errorReplicaId);
-        }
-
-        if (txnCommitAttachment == null) {
-            out.writeBoolean(false);
-        } else {
-            out.writeBoolean(true);
-            txnCommitAttachment.write(out);
-        }
-        out.writeLong(callbackId);
-        out.writeLong(timeoutMs);
-        out.writeInt(tableIdList.size());
-        for (Long tableId : tableIdList) {
-            out.writeLong(tableId);
-        }
-    }
-
-    public void readFields(DataInput in) throws IOException {
-        transactionId = in.readLong();
-        label = Text.readString(in);
-        dbId = in.readLong();
-        int size = in.readInt();
-        for (int i = 0; i < size; i++) {
-            TableCommitInfo info = new TableCommitInfo();
-            info.readFields(in);
-            idToTableCommitInfos.put(info.getTableId(), info);
-        }
-        txnCoordinator = new TxnCoordinator(TxnSourceType.valueOf(in.readInt()), Text.readString(in));
-        transactionStatus = TransactionStatus.valueOf(in.readInt());
-        sourceType = LoadJobSourceType.valueOf(in.readInt());
-        prepareTime = in.readLong();
-        commitTime = in.readLong();
-        finishTime = in.readLong();
-        if (transactionStatus == TransactionStatus.VISIBLE) {
-            int len = in.readInt();
-            if (len == 0) {
-                newFinish = false;
-            } else {
-                byte[] bytes = new byte[len];
-                in.readFully(bytes);
-                try {
-                    // originally, TxnFinishState is serialized using protobuf(baidu jprotobuf),
-                    // but looks like the ser/deser is not compatible with java native serialization
-                    // causing FE error when upgrading, so changed to json serialization, but keep
-                    // the old deserialization code here for compatibility
-                    // see: https://github.com/StarRocks/starrocks/issues/15248
-                    byte version = bytes[0];
-                    if (version == 1) {
-                        if (finishState == null) {
-                            finishState = new TxnFinishState();
-                        }
-                        byte[] pbBytes = new byte[len - 1];
-                        System.arraycopy(bytes, 1, pbBytes, 0, len - 1);
-                        finishState.fromBytes(pbBytes);
-                        newFinish = true;
-                    } else {
-                        String content = Text.decode(bytes);
-                        if (content.length() > 2 && content.charAt(0) == '{') {
-                            finishState = GsonUtils.GSON.fromJson(content, TxnFinishState.class);
-                            newFinish = true;
-                        } else {
-                            // old reason
-                            reason = content;
-                            newFinish = false;
-                        }
-                    }
-                } catch (IOException e) {
-                    LOG.warn("failed to deserialize TxnFinishState data: " + Hex.encodeHexString(bytes));
-                }
-            }
-        } else {
-            reason = Text.readString(in);
-        }
-        int errorReplicaNum = in.readInt();
-        for (int i = 0; i < errorReplicaNum; ++i) {
-            errorReplicas.add(in.readLong());
-        }
-
-        if (in.readBoolean()) {
-            txnCommitAttachment = TxnCommitAttachment.read(in);
-        }
-        callbackId = in.readLong();
-        timeoutMs = in.readLong();
-
-        tableIdList = Lists.newArrayList();
-        int tableListSize = in.readInt();
-        for (int i = 0; i < tableListSize; i++) {
-            tableIdList.add(in.readLong());
-        }
-
-        txnSpan.setAttribute("txn_id", transactionId);
-        txnSpan.setAttribute("label", label);
-        if (transactionStatus == TransactionStatus.COMMITTED) {
-            txnSpan.addEvent("set_committed");
-        } else if (transactionStatus == TransactionStatus.ABORTED) {
-            txnSpan.setAttribute("state", "aborted");
-            txnSpan.setStatus(StatusCode.ERROR, reason);
-            txnSpan.end();
-        } else if (transactionStatus == TransactionStatus.VISIBLE) {
-            txnSpan.addEvent("set_visible");
-            txnSpan.end();
-        }
     }
 
     public void setErrorMsg(String errMsg) {
@@ -1143,4 +981,8 @@ public class TransactionState implements Writable {
         tabletIdToTTabletLocation.clear();
     }
 
+    @Override
+    public void write(DataOutput out) throws IOException {
+
+    }
 }

--- a/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/transaction/TransactionStateTest.java
@@ -33,13 +33,7 @@ import org.junit.After;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -59,29 +53,16 @@ public class TransactionStateTest {
     }
 
     @Test
-    public void testSerDe() throws IOException {
-        // 1. Write objects to file
-        File file = new File(fileName);
-        file.createNewFile();
-        DataOutputStream out = new DataOutputStream(new FileOutputStream(file));
-
+    public void testSerDe() {
         UUID uuid = UUID.randomUUID();
         TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
                 3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
                 LoadJobSourceType.BACKEND_STREAMING, new TxnCoordinator(TxnSourceType.BE, "127.0.0.1"), 50000L,
                 60 * 1000L);
 
-        transactionState.write(out);
-        out.flush();
-        out.close();
-
-        // 2. Read objects from file
-        DataInputStream in = new DataInputStream(new FileInputStream(file));
-        TransactionState readTransactionState = new TransactionState();
-        readTransactionState.readFields(in);
-
+        String json = GsonUtils.GSON.toJson(transactionState);
+        TransactionState readTransactionState = GsonUtils.GSON.fromJson(json, TransactionState.class);
         Assert.assertEquals(transactionState.getCoordinator().ip, readTransactionState.getCoordinator().ip);
-        in.close();
     }
 
     @Test
@@ -125,9 +106,7 @@ public class TransactionStateTest {
     }
 
     @Test
-    public void testSerDeTxnStateNewFinish() throws IOException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        DataOutputStream dataOut = new DataOutputStream(out);
+    public void testSerDeTxnStateNewFinish() {
         UUID uuid = UUID.randomUUID();
         TransactionState transactionState = new TransactionState(1000L, Lists.newArrayList(20000L, 20001L),
                 3000, "label123", new TUniqueId(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
@@ -140,18 +119,9 @@ public class TransactionStateTest {
         transactionState.clearErrorMsg();
         transactionState.setNewFinish();
         transactionState.setTransactionStatus(TransactionStatus.VISIBLE);
-        transactionState.write(dataOut);
 
-        byte[] bytes = out.toByteArray();
-        System.out.printf("TransactionState size: %d\n", bytes.length);
-
-        DataInputStream in = new DataInputStream(new ByteArrayInputStream(bytes));
-        TransactionState readTransactionState = new TransactionState();
-        try {
-            readTransactionState.readFields(in);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        String json = GsonUtils.GSON.toJson(transactionState);
+        TransactionState readTransactionState = GsonUtils.GSON.fromJson(json, TransactionState.class);
         Assert.assertTrue(readTransactionState.isNewFinish());
     }
 


### PR DESCRIPTION
Why I'm doing:
ensureTableIdListIsPresent has no meaning. It was a temporary logic added for bugfix. The table list must be set in beginTransaction.
What I'm doing:
Delete meaningless obsolete code in Transaction Manager
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
