### PR TITLE
[Enhancement][Cherry-Pick] Memory pool for orc reader to detect bad alloc (backport #25396)

### DIFF
--- a/be/src/exec/vectorized/hdfs_scanner_orc.cpp
+++ b/be/src/exec/vectorized/hdfs_scanner_orc.cpp
@@ -8,8 +8,10 @@
 #include "formats/orc/fill_function.h"
 #include "formats/orc/orc_chunk_reader.h"
 #include "formats/orc/orc_input_stream.h"
+#include "formats/orc/orc_memory_pool.h"
 #include "formats/orc/orc_min_max_decoder.h"
 #include "gen_cpp/orc_proto.pb.h"
+#include "simd/simd.h"
 #include "storage/chunk_helper.h"
 #include "util/runtime_profile.h"
 #include "util/timezone_utils.h"
@@ -291,6 +293,7 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     std::unique_ptr<orc::Reader> reader;
     try {
         orc::ReaderOptions options;
+        options.setMemoryPool(*getOrcMemoryPool());
         reader = orc::createReader(std::move(input_stream), options);
     } catch (std::exception& e) {
         auto s = strings::Substitute("HdfsOrcScanner::do_open failed. reason = $0", e.what());

--- a/be/src/formats/CMakeLists.txt
+++ b/be/src/formats/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(Formats STATIC
         orc/orc_chunk_reader.cpp
         orc/orc_input_stream.cpp
         orc/orc_mapping.cpp
+        orc/orc_memory_pool.cpp
         orc/orc_min_max_decoder.cpp
         orc/fill_function.cpp
         orc/utils.cpp

--- a/be/src/formats/orc/orc_chunk_reader.cpp
+++ b/be/src/formats/orc/orc_chunk_reader.cpp
@@ -19,6 +19,7 @@
 #include "formats/orc/fill_function.h"
 #include "formats/orc/orc_input_stream.h"
 #include "formats/orc/orc_mapping.h"
+#include "formats/orc/orc_memory_pool.h"
 #include "fs/fs.h"
 #include "gen_cpp/orc_proto.pb.h"
 #include "gutil/casts.h"
@@ -62,6 +63,7 @@ OrcChunkReader::OrcChunkReader(RuntimeState* state, std::vector<SlotDescriptor*>
 
 Status OrcChunkReader::init(std::unique_ptr<orc::InputStream> input_stream) {
     try {
+        _reader_options.setMemoryPool(*getOrcMemoryPool());
         auto reader = orc::createReader(std::move(input_stream), _reader_options);
         return init(std::move(reader));
     } catch (std::exception& e) {

--- a/be/src/formats/orc/orc_memory_pool.cpp
+++ b/be/src/formats/orc/orc_memory_pool.cpp
@@ -1,0 +1,42 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <glog/logging.h>
+
+#include <orc/OrcFile.hh>
+
+namespace starrocks {
+
+class OrcMemoryPoolImpl : public orc::MemoryPool {
+public:
+    ~OrcMemoryPoolImpl() override = default;
+
+    char* malloc(uint64_t size) override {
+        auto p = static_cast<char*>(std::malloc(size));
+        if (p == nullptr) {
+            LOG(WARNING) << "malloc failed, size=" << size;
+            throw std::bad_alloc();
+        }
+        return p;
+    }
+
+    void free(char* p) override { std::free(p); }
+};
+
+orc::MemoryPool* getOrcMemoryPool() {
+    static OrcMemoryPoolImpl internal;
+    return &internal;
+}
+
+} // namespace starrocks

--- a/be/src/formats/orc/orc_memory_pool.h
+++ b/be/src/formats/orc/orc_memory_pool.h
@@ -1,0 +1,25 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <glog/logging.h>
+
+#include <orc/OrcFile.hh>
+
+namespace starrocks {
+
+orc::MemoryPool* getOrcMemoryPool();
+
+} // namespace starrocks


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

backport #25396

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [x] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

