### PR TITLE
[UT] fix unstable UT BufferControlBlockTest.add_then_cancel

### DIFF
--- a/be/test/runtime/buffer_control_block_test.cpp
+++ b/be/test/runtime/buffer_control_block_test.cpp
@@ -37,6 +37,8 @@
 #include <gtest/gtest.h>
 #include <pthread.h>
 
+#include <future>
+
 #include "gen_cpp/InternalService_types.h"
 
 namespace starrocks {
@@ -107,17 +109,24 @@ TEST_F(BufferControlBlockTest, add_then_cancel) {
     BufferControlBlock control_block(TUniqueId(), 1);
     ASSERT_TRUE(control_block.init().ok());
 
-    pthread_t id;
-    pthread_create(&id, nullptr, cancel_thread, &control_block);
+    // add_batch in main thread -> cancel in cancel_thread -> add_batch in main thread
+    std::promise<void> p1, p2;
+    std::future<void> f1 = p1.get_future(), f2 = p2.get_future();
+    auto cancel_thread = std::thread([&]() {
+        f1.wait();
+        control_block.cancel();
+        p2.set_value();
+    });
 
     {
         std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.emplace_back("hello test1");
         add_result->result_batch.rows.emplace_back("hello test2");
         ASSERT_TRUE(control_block.add_batch(add_result).ok());
+        p1.set_value();
     }
-    sleep(1);
     {
+        f2.wait();
         std::unique_ptr<TFetchDataResult> add_result(new TFetchDataResult());
         add_result->result_batch.rows.emplace_back("hello test1");
         add_result->result_batch.rows.emplace_back("hello test2");
@@ -127,7 +136,7 @@ TEST_F(BufferControlBlockTest, add_then_cancel) {
     TFetchDataResult get_result;
     ASSERT_FALSE(control_block.get_batch(&get_result).ok());
 
-    pthread_join(id, nullptr);
+    cancel_thread.join();
 }
 
 TEST_F(BufferControlBlockTest, get_then_cancel) {


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

 the previous implementation use sleep to control the execution order which is not reliable, using future/promise is more reasonable.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
