### PR TITLE
[Enhancement] Optimize the error message of delimiter error

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/analysis/Delimiter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/analysis/Delimiter.java
@@ -34,11 +34,11 @@ public class Delimiter {
                 throw new SemanticException("Invalid delimiter '" + originStr + ": empty hex string");
             }
             if (hexStr.length() % 2 != 0) {
-                throw new SemanticException("Invalid delimiter '" + originStr + ": hex length must be a even number");
+                throw new SemanticException("Invalid delimiter '" + originStr + ": hex length must be a even number. It will look like '\\x0102'");
             }
             for (char hexChar : hexStr.toUpperCase().toCharArray()) {
                 if (ParseUtil.HEX_STRING.indexOf(hexChar) == -1) {
-                    throw new SemanticException("Invalid delimiter '" + originStr + "': invalid hex format");
+                    throw new SemanticException("Invalid delimiter '" + originStr + "'. It will look like '\\x0102'");
                 }
             }
 


### PR DESCRIPTION
## Why I'm doing:
The error message is too simple to be understood.
I use '\\x5c\\x74' as the column_separator. The error message is:
`Getting analyzing error. Detail message: Invalid delimiter '\\x5c\\x74': invalid hex format.`
Then I don't know where is the error, and how to fix it.

## What I'm doing:
Add more useful message like `It will look like '\x0102'`.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.3 
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
