### PR TITLE
[UT] backport close_s3_client to branch-3.1

### DIFF
--- a/be/src/fs/fs_s3.cpp
+++ b/be/src/fs/fs_s3.cpp
@@ -89,6 +89,8 @@ public:
     S3ClientPtr new_client(const TCloudConfiguration& cloud_configuration);
     S3ClientPtr new_client(const ClientConfiguration& config, const FSOptions& opts);
 
+    void close();
+
     static ClientConfiguration& getClientConfig() {
         // We cached config here and make a deep copy each time.Since aws sdk has changed the
         // Aws::Client::ClientConfiguration default constructor to search for the region
@@ -152,6 +154,13 @@ std::shared_ptr<Aws::Auth::AWSCredentialsProvider> S3ClientFactory::_get_aws_cre
                 Aws::Auth::DEFAULT_CREDS_LOAD_FREQ_SECONDS, sts);
     }
     return credential_provider;
+}
+
+void S3ClientFactory::close() {
+    std::lock_guard l(_lock);
+    for (auto& item : _clients) {
+        item.reset();
+    }
 }
 
 S3ClientFactory::S3ClientPtr S3ClientFactory::new_client(const TCloudConfiguration& t_cloud_configuration) {
@@ -837,6 +846,10 @@ Status S3FileSystem::delete_dir_recursive(const std::string& dirname) {
 
 std::unique_ptr<FileSystem> new_fs_s3(const FSOptions& options) {
     return std::make_unique<S3FileSystem>(options);
+}
+
+void close_s3_clients() {
+    S3ClientFactory::instance().close();
 }
 
 } // namespace starrocks

--- a/be/src/fs/fs_s3.h
+++ b/be/src/fs/fs_s3.h
@@ -19,5 +19,6 @@
 namespace starrocks {
 
 std::unique_ptr<FileSystem> new_fs_s3(const FSOptions& options);
+void close_s3_clients();
 
 } // namespace starrocks

--- a/be/test/fs/fs_s3_test.cpp
+++ b/be/test/fs/fs_s3_test.cpp
@@ -55,8 +55,7 @@ public:
     }
 
     static void TearDownTestCase() {
-        // TODO: uncomment the following line after the interface is backported
-        // close_s3_clients();
+        close_s3_clients();
         Aws::ShutdownAPI(_s_options);
     }
 


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [X] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [X] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [X] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

