### PR TITLE
[BugFix] fix bool_col predicate not support in column filter converter

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/operator/ColumnFilterConverter.java
@@ -173,6 +173,11 @@ public class ColumnFilterConverter {
 
     public static void convertColumnFilter(ScalarOperator predicate, Map<String, PartitionColumnFilter> result,
                                            Table table) {
+        // convert bool_col predicate to bool_col = true
+        if (predicate instanceof ColumnRefOperator) {
+            predicate = new BinaryPredicateOperator(BinaryType.EQ, predicate, ConstantOperator.TRUE);
+        }
+
         if (CollectionUtils.isEmpty(predicate.getChildren())) {
             return;
         }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
@@ -36,10 +36,13 @@ import java.util.List;
 
 public class ShortCircuitTest extends PlanTestBase {
 
+    private static boolean OLD_VALUE;
+
     @Test
     public void testShortcircuit() throws Exception {
         connectContext.getSessionVariable().setEnableShortCircuit(true);
         connectContext.getSessionVariable().setPreferComputeNode(true);
+        OLD_VALUE = FeConstants.runningUnitTest;
         FeConstants.runningUnitTest = true;
 
         // project support short circuit
@@ -108,7 +111,7 @@ public class ShortCircuitTest extends PlanTestBase {
 
     @AfterClass
     public static void afterClass() {
-        FeConstants.runningUnitTest = false;
+        FeConstants.runningUnitTest = OLD_VALUE;
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
@@ -108,7 +108,7 @@ public class ShortCircuitTest extends PlanTestBase {
 
     @AfterClass
     public static void afterClass() {
-        FeConstants.runningUnitTest = true;
+        FeConstants.runningUnitTest = false;
     }
 
 }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/ShortCircuitTest.java
@@ -17,6 +17,7 @@ package com.starrocks.sql.plan;
 import com.google.common.collect.ImmutableList;
 import com.starrocks.analysis.DescriptorTable;
 import com.starrocks.analysis.TupleDescriptor;
+import com.starrocks.common.FeConstants;
 import com.starrocks.planner.OlapScanNode;
 import com.starrocks.qe.DefaultCoordinator;
 import com.starrocks.qe.scheduler.dag.ExecutionFragment;
@@ -27,6 +28,7 @@ import com.starrocks.thrift.TScanRangeLocation;
 import com.starrocks.thrift.TScanRangeLocations;
 import com.starrocks.thrift.TUniqueId;
 import com.starrocks.utframe.UtFrameUtils;
+import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,6 +40,7 @@ public class ShortCircuitTest extends PlanTestBase {
     public void testShortcircuit() throws Exception {
         connectContext.getSessionVariable().setEnableShortCircuit(true);
         connectContext.getSessionVariable().setPreferComputeNode(true);
+        FeConstants.runningUnitTest = true;
 
         // project support short circuit
         String sql = "select pk1 || v3 from tprimary1 where pk1=20";
@@ -52,7 +55,11 @@ public class ShortCircuitTest extends PlanTestBase {
         // boolean filter
         sql = "select pk1 || v3 from tprimary_bool where pk1=33 and pk2=true";
         planFragment = getFragmentPlan(sql);
-        Assert.assertTrue(planFragment.contains("Short Circuit Scan: true"));
+        assertCContains(planFragment, "Short Circuit Scan: true", "tabletRatio=1/3");
+
+        sql = "select pk1 || v3 from tprimary_bool where pk1=33 and pk2";
+        planFragment = getFragmentPlan(sql);
+        assertCContains(planFragment, "Short Circuit Scan: true", "tabletRatio=1/3");
 
         //  support short circuit
         sql = "select * from tprimary1 where pk1 in (20)";
@@ -98,4 +105,10 @@ public class ShortCircuitTest extends PlanTestBase {
         ExecutionFragment execFragment = coord.getExecutionDAG().getRootFragment();
         Assert.assertEquals(true, execFragment.getPlanFragment().isShortCircuit());
     }
+
+    @AfterClass
+    public static void afterClass() {
+        FeConstants.runningUnitTest = true;
+    }
+
 }


### PR DESCRIPTION
Why I'm doing:
`bool_col` preidicate is not processed in column filter converter.
What I'm doing:
just transformt it to `bool_col = true` when process filter converter.
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
