### PR TITLE
[BugFix] fix failed sort test case

### DIFF
--- a/be/test/exec/chunks_sorter_test.cpp
+++ b/be/test/exec/chunks_sorter_test.cpp
@@ -267,6 +267,7 @@ static Permutation make_permutation(int len) {
     Permutation perm(len);
     for (int i = 0; i < perm.size(); i++) {
         perm[i].index_in_chunk = i;
+        perm[i].chunk_index = 0;
     }
     return perm;
 }
@@ -399,7 +400,7 @@ TEST_F(ChunksSorterTest, topn_sort_limit_prune) {
     {
         // nullable column
         auto column = make_nullable_int32_column({0, 0, 0, 2, 2, 2, 3, 3, 4, 5, 6});
-        std::vector<ColumnPtr> data_columns{down_cast<NullableColumn*>(column.get())->data_column()};
+        std::vector<ColumnPtr> columns{column};
         auto null_pred = [&](PermutationItem item) { return column->is_null(item.index_in_chunk); };
         std::pair<int, int> range{0, column->size()};
 
@@ -409,9 +410,9 @@ TEST_F(ChunksSorterTest, topn_sort_limit_prune) {
             Permutation perm = make_permutation(column->size());
             Tie tie(column->size(), 1);
 
-            sort_and_tie_helper_nullable_vertical(false, data_columns, null_pred, SortDesc(true, true), perm, tie,
-                                                  range, true, limit, &limited);
-            EXPECT_EQ(expected[limit], limited);
+            sort_and_tie_helper_nullable_vertical(false, columns, null_pred, SortDesc(true, true), perm, tie, range,
+                                                  true, limit, &limited);
+            EXPECT_EQ(expected[limit], limited) << " at index " << limit;
         }
     }
 }


### PR DESCRIPTION
Why I'm doing:
- The test case `ChunksSorterTest.topn_sort_limit_prune` would fail in the DEBUG mode, but pass in the ASAN mode
- Because `NullableColumn::data_column` would not be initialized as default value in DEBUG, the test case would get different result 

What I'm doing:
- Use the `NullableColumn` instead of `data_column` as test parameter, which would be filled with default value since it's nullable

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
