### PR TITLE
[Enhancement] Add more lock info in sys fe_locks

### DIFF
--- a/be/src/exec/schema_scanner/sys_fe_locks.cpp
+++ b/be/src/exec/schema_scanner/sys_fe_locks.cpp
@@ -26,8 +26,8 @@ SchemaScanner::ColumnDesc SysFeLocks::_s_columns[] = {
         {"lock_type", TYPE_VARCHAR, sizeof(StringValue), true},
         {"lock_object", TYPE_VARCHAR, sizeof(StringValue), true},
         {"lock_mode", TYPE_VARCHAR, sizeof(StringValue), true},
-        {"lock_start_time", TYPE_BIGINT, sizeof(long), true},
-
+        {"start_time", TYPE_DATETIME, sizeof(DateTimeValue), true},
+        {"hold_time_ms", TYPE_BIGINT, sizeof(long), true},
         {"thread_info", TYPE_VARCHAR, sizeof(StringValue), true},
         {"granted", TYPE_BOOLEAN, sizeof(bool), true},
         {"waiter_list", TYPE_VARCHAR, sizeof(StringValue), true},
@@ -42,6 +42,8 @@ Status SysFeLocks::start(RuntimeState* state) {
     RETURN_IF(!_is_init, Status::InternalError("used before initialized."));
     RETURN_IF(!_param->ip || !_param->port, Status::InternalError("IP or port not exists"));
 
+    RETURN_IF_ERROR(SchemaScanner::start(state));
+
     TAuthInfo auth = build_auth_info();
     TFeLocksReq request;
     request.__set_auth_info(auth);
@@ -52,11 +54,12 @@ Status SysFeLocks::start(RuntimeState* state) {
 Status SysFeLocks::_fill_chunk(ChunkPtr* chunk) {
     auto& slot_id_map = (*chunk)->get_slot_id_to_index_map();
     const TFeLocksItem& info = _result.items[_index];
+    auto start_time = TimestampValue::create_from_unixtime(info.start_time / 1000, _runtime_state->timezone_obj());
     DatumArray datum_array{
             // clang-format: off
-            Slice(info.lock_type),   Slice(info.lock_object), Slice(info.lock_mode),   info.lock_start_time,
+            Slice(info.lock_type), Slice(info.lock_object), Slice(info.lock_mode), start_time,
 
-            Slice(info.thread_info), (info.granted),          Slice(info.waiter_list),
+            info.hold_time_ms,     Slice(info.thread_info), info.granted,          Slice(info.waiter_list),
             // clang-format: on
     };
     for (const auto& [slot_id, index] : slot_id_map) {

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/system/sys/SysFeLocks.java
@@ -53,7 +53,8 @@ public class SysFeLocks {
                         .column("lock_type", ScalarType.createVarcharType(64))
                         .column("lock_object", ScalarType.createVarcharType(64))
                         .column("lock_mode", ScalarType.createVarcharType(64))
-                        .column("lock_start_time", ScalarType.createType(PrimitiveType.BIGINT))
+                        .column("start_time", ScalarType.createType(PrimitiveType.DATETIME))
+                        .column("hold_time_ms", ScalarType.createType(PrimitiveType.BIGINT))
                         .column("thread_info", ScalarType.createVarcharType(64))
                         .column("granted", ScalarType.createType(PrimitiveType.BOOLEAN))
                         .column("waiter_list", ScalarType.createVarcharType(SystemTable.NAME_CHAR_LEN))
@@ -98,6 +99,7 @@ public class SysFeLocks {
 
         Thread owner = lock.getOwner();
         List<Long> sharedLockThreadIds = lock.getSharedLockThreadIds();
+        long currentTime = System.currentTimeMillis();
 
         if (owner != null) {
             lockItem.setLock_mode("EXCLUSIVE");
@@ -109,7 +111,8 @@ public class SysFeLocks {
 
             // wait start
             long lockStartTime = lock.getExclusiveLockTime();
-            lockItem.setLock_start_time(lockStartTime);
+            lockItem.setStart_time(lockStartTime);
+            lockItem.setHold_time_ms(currentTime - lockStartTime);
         } else if (CollectionUtils.isNotEmpty(sharedLockThreadIds)) {
             lockItem.setLock_mode("SHARED");
             lockItem.setGranted(true);
@@ -119,7 +122,8 @@ public class SysFeLocks {
                     .map(lock::getSharedLockTime)
                     .filter(x -> x > 0)
                     .min(Comparator.naturalOrder()).orElse(0L);
-            lockItem.setLock_start_time(lockStart);
+            lockItem.setStart_time(lockStart);
+            lockItem.setHold_time_ms(currentTime - lockStart);
 
             // thread info
             JsonArray sharedLockInfo = new JsonArray();

--- a/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/catalog/system/sys/SysFeLocksTest.java
@@ -59,7 +59,8 @@ public class SysFeLocksTest {
 
             assertEquals("EXCLUSIVE", item.getLock_mode());
             assertTrue(item.isGranted());
-            assertTrue(item.getLock_start_time() > 0);
+            assertTrue(item.getStart_time() > 0);
+            assertTrue(item.getHold_time_ms() >= 0);
             assertEquals("[]", item.getWaiter_list());
 
             // add a waiter
@@ -87,6 +88,8 @@ public class SysFeLocksTest {
 
             assertEquals("SHARED", item.getLock_mode());
             assertTrue(item.isGranted());
+            assertTrue(item.getStart_time() > 0);
+            assertTrue(item.getHold_time_ms() >= 0);
             assertEquals("[]", item.getWaiter_list());
 
             // add a waiter
@@ -109,7 +112,6 @@ public class SysFeLocksTest {
             assertEquals(String.format("[{\"threadId\":%d,\"threadName\":\"%s\"}]", waiter.getId(), waiter.getName()),
                     item.getWaiter_list());
             db.readUnlock();
-
         }
     }
 

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -1558,7 +1558,8 @@ struct TFeLocksItem {
     1: optional string lock_type
     2: optional string lock_object
     3: optional string lock_mode
-    4: optional i64 lock_start_time
+    4: optional i64 start_time
+    5: optional i64 hold_time_ms
     
     11: optional string thread_info
     12: optional bool granted


### PR DESCRIPTION
1. change start_time type to DATETIME
2. add hold_time_ms

```
mysql> select * from sys.fe_locks where lock_object = "tmp";
+-----------+-------------+-----------+---------------------+--------------+------------------------------------------------------------+---------+-------------------------------------------------------------------------------------------------+
| lock_type | lock_object | lock_mode | start_time          | hold_time_ms | thread_info                                                | granted | waiter_list                                                                                     |
+-----------+-------------+-----------+---------------------+--------------+------------------------------------------------------------+---------+-------------------------------------------------------------------------------------------------+
| DATABASE  | tmp         | EXCLUSIVE | 2024-01-12 14:23:09 |        66783 | {"threadId":683,"threadName":"starrocks-mysql-nio-pool-5"} |       1 | [{"threadId":133,"threadName":"COMPACTION_DISPATCH"},{"threadId":66,"threadName":"autovacuum"}] |
+-----------+-------------+-----------+---------------------+--------------+------------------------------------------------------------+---------+-------------------------------------------------------------------------------------------------+
1 row in set (0.01 sec)
```

Why I'm doing:

What I'm doing:

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
