### PR TITLE
[BugFix] Support to restore materialized views only without restoring base tables

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -737,7 +737,7 @@ public class BackupHandler extends FrontendDaemon implements Writable {
                 AbstractJob job = iterator.next().getValue();
                 if (isJobExpired(job, currentTimeMs)) {
                     // discard mv backup table info if needed.
-                    mvRestoreContext.discordExpiredBackupTableInfo(job);
+                    mvRestoreContext.discardExpiredBackupTableInfo(job);
 
                     LOG.warn("discard expired job {}", job);
                     iterator.remove();

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
@@ -21,6 +21,7 @@ import com.starrocks.analysis.TableName;
 import com.starrocks.authentication.AuthenticationMgr;
 import com.starrocks.backup.BackupJobInfo;
 import com.starrocks.backup.Status;
+import com.starrocks.catalog.BaseTableInfo;
 import com.starrocks.catalog.Database;
 import com.starrocks.catalog.MaterializedView;
 import com.starrocks.catalog.MvId;
@@ -204,5 +205,71 @@ public class MVRestoreUpdater {
             versionMap.put(partName, newBasePartitionInfo);
         }
         baseTableVisibleVersionMap.put(localBaseTable.getId(), versionMap);
+    }
+
+    public static boolean restoreBaseTableInfoIfNoRestored(Database restoreDb,
+                                                           MaterializedView mv,
+                                                           BaseTableInfo baseTableInfo,
+                                                           List<BaseTableInfo> newBaseTableInfos) {
+
+        String remoteDbName = baseTableInfo.getDbName();
+        String remoteTableName = baseTableInfo.getTableName();
+        Database baseTableDb = GlobalStateMgr.getCurrentState().getDb(remoteDbName);
+        if (baseTableDb == null) {
+            LOG.warn(String.format("Materialized view %s can not find old base table's db name:%s.%s",
+                    mv.getName(), remoteDbName, remoteTableName));
+            return false;
+        }
+        Table baseTable = baseTableDb.getTable(remoteTableName);
+        if (baseTable == null) {
+            LOG.warn(String.format("Materialized view %s can not find old base table:%s.%s",
+                    mv.getName(), remoteDbName, remoteTableName));
+            return false;
+        }
+        BaseTableInfo newBaseTableInfo = new BaseTableInfo(restoreDb.getId(), restoreDb.getFullName(),
+                baseTable.getName(), baseTable.getId());
+        newBaseTableInfos.add(newBaseTableInfo);
+        return true;
+    }
+
+    public static Pair<Boolean, Optional<MvId>> restoreBaseTableInfoIfRestored(
+            Database restoreDb,
+            MvRestoreContext mvRestoreContext,
+            MaterializedView mv,
+            MvBaseTableBackupInfo mvBaseTableBackupInfo,
+            BaseTableInfo baseTableInfo,
+            Map<TableName, TableName> remoteToLocalTableName,
+            List<BaseTableInfo> newBaseTableInfos) {
+        String remoteDbName = baseTableInfo.getDbName();
+        String remoteTableName = baseTableInfo.getTableName();
+        TableName remoteDbTblName = new TableName(remoteDbName, remoteTableName);
+        if (mvBaseTableBackupInfo == null) {
+            LOG.warn("Materialized view {} can not find old base table name:{} because " +
+                            "mvBaseTableBackupInfo is null",
+                    mv.getName(), remoteTableName);
+            return Pair.create(false, Optional.empty());
+        }
+
+        String localTableName = mvBaseTableBackupInfo.getLocalTableName();
+        Table localTable = restoreDb.getTable(localTableName);
+        remoteToLocalTableName.put(remoteDbTblName, new TableName(restoreDb.getFullName(), localTableName));
+        if (localTable == null) {
+            LOG.warn("Materialized view {} can not find the base table {}, old base table name:{}",
+                    mv.getName(), localTableName, remoteTableName);
+            return Pair.create(false, Optional.empty());
+        }
+
+        // restore materialized view's associated base table's mvIds.
+        Optional<MvId> oldMvIdOpt = restoreBaseTable(mv, restoreDb, localTable, mvRestoreContext);
+        // restore materialized view's version map if base table is also backed up and restore.
+        Map<Long, Map<String, MaterializedView.BasePartitionInfo>> baseTableVisibleVersionMap =
+                mv.getRefreshScheme().getAsyncRefreshContext().getBaseTableVisibleVersionMap();
+        restoreBaseTableVersionMap(baseTableVisibleVersionMap, localTable, mvBaseTableBackupInfo);
+
+        // update base table info since materialized view's db or base table info may be changed.
+        BaseTableInfo newBaseTableInfo = new BaseTableInfo(restoreDb.getId(), restoreDb.getFullName(), localTableName,
+                localTable.getId());
+        newBaseTableInfos.add(newBaseTableInfo);
+        return Pair.create(true, oldMvIdOpt);
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MvRestoreContext.java
@@ -99,7 +99,7 @@ public class MvRestoreContext {
         }
     }
 
-    public void discordExpiredBackupTableInfo(AbstractJob job) {
+    public void discardExpiredBackupTableInfo(AbstractJob job) {
         if (!(job instanceof RestoreJob)) {
             return;
         }

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/Task.java
@@ -158,7 +158,6 @@ public class Task implements Writable {
     }
 
     public void setProperties(Map<String, String> properties) {
-        ;
         this.properties = properties;
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/TaskBuilder.java
@@ -168,8 +168,8 @@ public class TaskBuilder {
         Task task = new Task(getMvTaskName(materializedView.getId()));
         task.setSource(Constants.TaskSource.MV);
         task.setDbName(dbName);
-        previousTaskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID,
-                String.valueOf(materializedView.getId()));
+        String mvId = String.valueOf(materializedView.getId());
+        previousTaskProperties.put(PartitionBasedMvRefreshProcessor.MV_ID, mvId);
         task.setProperties(previousTaskProperties);
         task.setDefinition(
                 "insert overwrite " + materializedView.getName() + " " + materializedView.getViewDefineSql());
@@ -245,7 +245,9 @@ public class TaskBuilder {
             TaskBuilder.updateTaskInfo(task, materializedView);
             taskManager.createTask(task, false);
         } else {
-            Task changedTask = TaskBuilder.rebuildMvTask(materializedView, dbName, currentTask.getProperties());
+            Map<String, String> previousTaskProperties = currentTask.getProperties() == null ?
+                     Maps.newHashMap() : Maps.newHashMap(currentTask.getProperties());
+            Task changedTask = TaskBuilder.rebuildMvTask(materializedView, dbName, previousTaskProperties);
             TaskBuilder.updateTaskInfo(changedTask, materializedView);
             taskManager.alterTask(currentTask, changedTask, false);
             task = currentTask;

--- a/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/backup/RestoreJobMaterializedViewTest.java
@@ -78,7 +78,6 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
-import java.util.zip.Adler32;
 
 import static com.starrocks.common.util.UnitTestUtil.DB_NAME;
 import static com.starrocks.common.util.UnitTestUtil.MATERIALIZED_VIEW_NAME;
@@ -221,7 +220,6 @@ public class RestoreJobMaterializedViewTest {
                 };
             }
         };
-
         new MockUp<MarkedCountDownLatch>() {
                 @Mock
                 boolean await(long timeout, TimeUnit unit) {
@@ -439,8 +437,19 @@ public class RestoreJobMaterializedViewTest {
     @Test
     @Order(1)
     public void testMVRestore_TestOneTable1() {
+        new Expectations() {
+            {
+                globalStateMgr.getCurrentState().getCatalogMgr().catalogExists("default_catalog");
+                result = true;
+
+                globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
+                minTimes = 0;
+                result = db;
+            }
+        };
         RestoreJob job = createRestoreJob(ImmutableList.of(UnitTestUtil.MATERIALIZED_VIEW_NAME));
         checkJobRun(job);
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
     @Test
@@ -448,6 +457,7 @@ public class RestoreJobMaterializedViewTest {
     public void testMVRestore_TestOneTable2() {
         RestoreJob job = createRestoreJob(ImmutableList.of(UnitTestUtil.TABLE_NAME));
         checkJobRun(job);
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
     @Test
@@ -463,19 +473,11 @@ public class RestoreJobMaterializedViewTest {
                 result = db;
             }
         };
-
         // gen BackupJobInfo
         RestoreJob job = createRestoreJob(ImmutableList.of(TABLE_NAME, MATERIALIZED_VIEW_NAME));
         // backup & restore
         checkJobRun(job);
-
-        {
-            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
-            Assert.assertTrue(mvTable != null);
-            Assert.assertTrue(mvTable.isMaterializedView());
-            MaterializedView mv = (MaterializedView) mvTable;
-            Assert.assertTrue(mv.isActive());
-        }
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
     @Test
@@ -491,19 +493,11 @@ public class RestoreJobMaterializedViewTest {
                 result = db;
             }
         };
-
         // gen BackupJobInfo
         RestoreJob job = createRestoreJob(ImmutableList.of(MATERIALIZED_VIEW_NAME, TABLE_NAME));
         // backup & restore
         checkJobRun(job);
-
-        {
-            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
-            Assert.assertTrue(mvTable != null);
-            Assert.assertTrue(mvTable.isMaterializedView());
-            MaterializedView mv = (MaterializedView) mvTable;
-            Assert.assertTrue(mv.isActive());
-        }
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
     @Test
@@ -519,22 +513,15 @@ public class RestoreJobMaterializedViewTest {
                 result = db;
             }
         };
-
         // gen BackupJobInfo
         RestoreJob job1 = createRestoreJob(ImmutableList.of(TABLE_NAME));
         // backup & restore
         checkJobRun(job1);
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
 
         RestoreJob job2 = createRestoreJob(ImmutableList.of(MATERIALIZED_VIEW_NAME));
         checkJobRun(job2);
-
-        {
-            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
-            Assert.assertTrue(mvTable != null);
-            Assert.assertTrue(mvTable.isMaterializedView());
-            MaterializedView mv = (MaterializedView) mvTable;
-            Assert.assertTrue(mv.isActive());
-        }
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
     @Test
@@ -548,53 +535,35 @@ public class RestoreJobMaterializedViewTest {
                 globalStateMgr.getCurrentState().getMetadataMgr().getDb("default_catalog", DB_NAME);
                 minTimes = 0;
                 result = db;
+
+                globalStateMgr.getCurrentState().getDb(DB_NAME);
+                minTimes = 0;
+                result = db;
             }
         };
-
         new MockUp<MetadataMgr>() {
             @Mock
             public Table getTable(String catalogName, String dbName, String tblName) {
                 return db.getTable(tblName);
             }
         };
-
         // gen BackupJobInfo
         RestoreJob job1 = createRestoreJob(ImmutableList.of(MATERIALIZED_VIEW_NAME));
         // backup & restore
         checkJobRun(job1);
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
 
         RestoreJob job2 = createRestoreJob(ImmutableList.of(TABLE_NAME));
         checkJobRun(job2);
-
-        {
-            Table mvTable = db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
-            Assert.assertTrue(mvTable != null);
-            Assert.assertTrue(mvTable.isMaterializedView());
-            MaterializedView mv = (MaterializedView) mvTable;
-            Assert.assertTrue(mv.isActive());
-        }
+        assertMVActiveEquals(MATERIALIZED_VIEW_NAME, true);
     }
 
-    @Test
-    @Order(7)
-    public void testSignature() {
-        Adler32 sig1 = new Adler32();
-        sig1.update("name1".getBytes());
-        sig1.update("name2".getBytes());
-        System.out.println("sig1: " + Math.abs((int) sig1.getValue()));
-
-        Adler32 sig2 = new Adler32();
-        sig2.update("name2".getBytes());
-        sig2.update("name1".getBytes());
-        System.out.println("sig2: " + Math.abs((int) sig2.getValue()));
-
-        OlapTable tbl = (OlapTable) db.getTable(UnitTestUtil.MATERIALIZED_VIEW_NAME);
-        List<String> partNames = Lists.newArrayList(tbl.getPartitionNames());
-        System.out.println(partNames);
-        System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
-        tbl.setName("newName");
-        partNames = Lists.newArrayList(tbl.getPartitionNames());
-        System.out.println("tbl signature: " + tbl.getSignature(BackupHandler.SIGNATURE_VERSION, partNames, true));
+    private void assertMVActiveEquals(String mvName, boolean expect) {
+        Table mvTable = db.getTable(mvName);
+        Assert.assertTrue(mvTable != null);
+        Assert.assertTrue(mvTable.isMaterializedView());
+        MaterializedView mv = (MaterializedView) mvTable;
+        Assert.assertEquals(mv.isActive(), expect);
     }
 }
 


### PR DESCRIPTION
Why I'm doing:

PR(https://github.com/StarRocks/starrocks/pull/38642) only considers  that mv and base tables are both backed up & restored even though they are not in the same order/time.

But maybe only materialized view is backed up & restored but the base tables are not changed.

What I'm doing:
- Support to restore materialized views only without restoring base tables
- Refactor some codes.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
