### PR TITLE
[Enhancement]Print log with partition info when finish load transaction

### DIFF
--- a/be/src/exec/pipeline/exec_state_reporter.cpp
+++ b/be/src/exec/pipeline/exec_state_reporter.cpp
@@ -89,11 +89,13 @@ TReportExecStatusParams ExecStateReporter::create_report_exec_status_params(Quer
             static std::string s_dpp_abnormal_all = "dpp.abnorm.ALL";
             static std::string s_unselected_rows = "unselected.rows";
             static std::string s_loaded_bytes = "loaded.bytes";
+            static std::string s_partition_load_rows = "partition.load.rows";
 
             params.load_counters.emplace(s_dpp_normal_all, std::to_string(runtime_state->num_rows_load_sink()));
             params.load_counters.emplace(s_dpp_abnormal_all, std::to_string(runtime_state->num_rows_load_filtered()));
             params.load_counters.emplace(s_unselected_rows, std::to_string(runtime_state->num_rows_load_unselected()));
             params.load_counters.emplace(s_loaded_bytes, std::to_string(runtime_state->num_bytes_load_sink()));
+            params.load_counters.emplace(s_partition_load_rows, std::move(runtime_state->partition_rows_string()));
         }
         if (!runtime_state->get_error_log_file_path().empty()) {
             params.__set_tracking_url(to_load_error_http_path(runtime_state->get_error_log_file_path()));

--- a/be/src/exec/tablet_sink_colocate_sender.cpp
+++ b/be/src/exec/tablet_sink_colocate_sender.cpp
@@ -226,9 +226,6 @@ Status TabletSinkColocateSender::try_close(RuntimeState* state) {
         }
     });
 
-    // update the info of partition num rows
-    state->update_partition_num_rows(_partition_to_num_rows);
-
     if (intolerable_failure) {
         return err_st;
     } else {
@@ -306,6 +303,9 @@ Status TabletSinkColocateSender::close_wait(RuntimeState* state, Status close_st
     } else {
         for_each_node_channel([&status](NodeChannel* ch) { ch->cancel(status); });
     }
+
+    // update the info of partition num rows
+    state->update_partition_num_rows(_partition_to_num_rows);
 
     Expr::close(_output_expr_ctxs, state);
     if (_vectorized_partition) {

--- a/be/src/exec/tablet_sink_sender.h
+++ b/be/src/exec/tablet_sink_sender.h
@@ -78,6 +78,14 @@ protected:
         }
     }
 
+    void _update_partition_rows(int64_t partition_id) {
+        if (auto iterator = _partition_to_num_rows.find(partition_id); iterator != _partition_to_num_rows.end()) {
+            (iterator->second)++;
+        } else {
+            _partition_to_num_rows[partition_id] = 1;
+        }
+    }
+
 protected:
     // unique load id
     PUniqueId _load_id;
@@ -100,6 +108,7 @@ protected:
     std::vector<uint32_t> _node_select_idx;
     std::vector<int64_t> _tablet_ids;
     std::set<int64_t> _failed_channels;
+    std::unordered_map<int64_t, int64_t> _partition_to_num_rows;
 };
 
 } // namespace starrocks::stream_load

--- a/be/src/runtime/runtime_state.cpp
+++ b/be/src/runtime/runtime_state.cpp
@@ -511,6 +511,7 @@ Status RuntimeState::reset_epoch() {
     std::lock_guard<std::mutex> l(_tablet_infos_lock);
     _tablet_commit_infos.clear();
     _tablet_fail_infos.clear();
+    _partition_to_num_rows.clear();
     return Status::OK();
 }
 

--- a/be/src/runtime/runtime_state.h
+++ b/be/src/runtime/runtime_state.h
@@ -280,14 +280,12 @@ public:
     const std::map<int64_t, int64_t> partition_rows() const noexcept { return _partition_to_num_rows; };
 
     std::string partition_rows_string() {
-        LOG(INFO) << "partition_rows_string";
         std::ostringstream oss;
         for (const auto& pair : _partition_to_num_rows) {
             oss << pair.first << ": " << pair.second << ", ";
         }
 
         std::string result = oss.str();
-        LOG(INFO) << "result" << result;
         if (!result.empty()) {
             result.pop_back(); // remove colon
             result.pop_back(); // remove comma

--- a/be/src/runtime/stream_load/stream_load_context.h
+++ b/be/src/runtime/stream_load/stream_load_context.h
@@ -229,6 +229,7 @@ public:
     int64_t number_filtered_rows = 0;
     int64_t number_unselected_rows = 0;
     int64_t loaded_bytes = 0;
+    std::map<int64_t, int64_t> partition_num_rows;
     int64_t start_nanos = 0;
     int64_t start_write_data_nanos = 0;
     int64_t load_cost_nanos = 0;
@@ -277,6 +278,7 @@ public:
 
     int64_t load_deadline_sec = -1;
     std::unique_ptr<ConcurrentLimiterGuard> _http_limiter_guard;
+    const std::map<int64_t, int64_t> get_partition_num_rows() { return partition_num_rows; }
 
 public:
     bool is_channel_stream_load_context() { return channel_id != -1; }

--- a/be/src/runtime/stream_load/stream_load_executor.cpp
+++ b/be/src/runtime/stream_load/stream_load_executor.cpp
@@ -95,6 +95,7 @@ Status StreamLoadExecutor::execute_plan_fragment(StreamLoadContext* ctx) {
                     ctx->number_filtered_rows = executor->runtime_state()->num_rows_load_filtered();
                     ctx->number_unselected_rows = executor->runtime_state()->num_rows_load_unselected();
                     ctx->loaded_bytes = executor->runtime_state()->num_bytes_load_sink();
+                    ctx->partition_num_rows = executor->runtime_state()->partition_rows();
 
                     int64_t num_selected_rows = ctx->number_total_rows - ctx->number_unselected_rows;
                     if ((double)ctx->number_filtered_rows / num_selected_rows > ctx->max_filter_ratio) {
@@ -420,6 +421,7 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
         manual_load_attach.__set_receivedBytes(ctx->receive_bytes);
         manual_load_attach.__set_loadedBytes(ctx->loaded_bytes);
         manual_load_attach.__set_unselectedRows(ctx->number_unselected_rows);
+        manual_load_attach.__set_partitionRows(ctx->get_partition_num_rows());
         if (!ctx->error_url.empty()) {
             manual_load_attach.__set_errorLogUrl(ctx->error_url);
         }
@@ -440,6 +442,7 @@ bool StreamLoadExecutor::collect_load_stat(StreamLoadContext* ctx, TTxnCommitAtt
         rl_attach.__set_receivedBytes(ctx->receive_bytes);
         rl_attach.__set_loadedBytes(ctx->loaded_bytes);
         rl_attach.__set_loadCostMs(ctx->load_cost_nanos / 1000 / 1000);
+        rl_attach.__set_partitionRows(ctx->get_partition_num_rows());
 
         attach->rlTaskTxnCommitAttachment = rl_attach;
         attach->__isset.rlTaskTxnCommitAttachment = true;

--- a/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/EtlStatus.java
@@ -45,7 +45,6 @@ import com.google.gson.annotations.SerializedName;
 import com.starrocks.common.io.Text;
 import com.starrocks.common.io.Writable;
 import com.starrocks.common.util.DebugUtil;
-import com.starrocks.load.loadv2.LoadJob;
 import com.starrocks.load.loadv2.dpp.DppResult;
 import com.starrocks.metric.TableMetricsEntity;
 import com.starrocks.persist.gson.GsonUtils;
@@ -383,8 +382,6 @@ public class EtlStatus implements Writable {
         @SerializedName("sinkBytesCounterTbl")
         private Table<String, String, Long> sinkBytesCounterTbl = HashBasedTable.create();
 
-        private Table<String, String, String> sinkPartitionRows = HashBasedTable.create();
-
         @SerializedName("sourceRowsCounterTbl")
         private Table<String, String, Long> sourceRowsCounterTbl = HashBasedTable.create();
 
@@ -523,9 +520,6 @@ public class EtlStatus implements Writable {
                 unselectedRowsCounterTbl.put(loadStr, fragmentStr, params.unselected_rows);
                 sourceScanBytesCounterTbl.put(loadStr, fragmentStr, params.source_scan_bytes);
             }
-            if (params.isSetLoad_counters() && params.load_counters.containsKey(LoadJob.PARTITION_LOADED_ROWS)) {
-                sinkPartitionRows.put(loadStr, fragmentStr, params.load_counters.get(LoadJob.PARTITION_LOADED_ROWS));
-            }
 
             if (params.done && unfinishedBackendIds.containsKey(loadStr)) {
                 unfinishedBackendIds.get(loadStr).remove(params.backend_id);
@@ -537,11 +531,6 @@ public class EtlStatus implements Writable {
             long totalSinkRows = 0;
             for (long rows : counterTbl.values()) {
                 totalSinkRows += rows;
-            }
-
-            StringBuilder sinkPartitonRows = new StringBuilder();
-            for (String partitionRows : sinkPartitionRows.values()) {
-                sinkPartitonRows.append(partitionRows);
             }
 
             long totalSourceRows = 0;
@@ -568,7 +557,6 @@ public class EtlStatus implements Writable {
             details.put("ScanBytes", totalSourceBytes);
             details.put("InternalTableLoadRows", totalSinkRows);
             details.put("InternalTableLoadBytes", totalSinkBytes);
-            details.put("InternalTablePartitionRows", sinkPartitonRows);
             details.put("FileNumber", fileNum);
             details.put("FileSize", totalFileSizeB);
             details.put("TaskNumber", counterTbl.rowMap().size());

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadJob.java
@@ -455,6 +455,7 @@ public class BrokerLoadJob extends BulkLoadJob {
                 increaseCounter(DPP_NORMAL_ALL, attachment.getCounter(DPP_NORMAL_ALL)));
         loadingStatus.replaceCounter(UNSELECTED_ROWS,
                 increaseCounter(UNSELECTED_ROWS, attachment.getCounter(UNSELECTED_ROWS)));
+        loadingStatus.replaceCounter(PARTITION_LOADED_ROWS, attachment.getCounter(PARTITION_LOADED_ROWS));
         if (attachment.getTrackingUrl() != null) {
             loadingStatus.setTrackingUrl(attachment.getTrackingUrl());
         }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/BrokerLoadingTaskAttachment.java
@@ -89,4 +89,9 @@ public class BrokerLoadingTaskAttachment extends TaskAttachment {
     public long getWriteDurationMs() {
         return writeDurationMs;
     }
+
+    @Override
+    public String toString() {
+        return "BrokerLoadingTxnCommitAttachment " + counters.toString();
+    }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -105,6 +105,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
     public static final String DPP_ABNORMAL_ALL = "dpp.abnorm.ALL";
     public static final String UNSELECTED_ROWS = "unselected.rows";
     public static final String LOADED_BYTES = "loaded.bytes";
+    public static final String PARTITION_LOADED_ROWS = "partition.load.rows";
 
     private static final int TASK_SUBMIT_RETRY_NUM = 2;
 

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/ManualLoadTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/ManualLoadTxnCommitAttachment.java
@@ -24,6 +24,7 @@ import com.starrocks.transaction.TxnCommitAttachment;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 
 public class ManualLoadTxnCommitAttachment extends TxnCommitAttachment {
     @SerializedName("ls")
@@ -34,6 +35,8 @@ public class ManualLoadTxnCommitAttachment extends TxnCommitAttachment {
     private long unselectedRows;
     private long receivedBytes;
     private long loadedBytes;
+
+    private Map<Long, Long> partitionRows;
     // optional
     @SerializedName("eu")
     private String errorLogUrl;
@@ -49,6 +52,7 @@ public class ManualLoadTxnCommitAttachment extends TxnCommitAttachment {
         this.receivedBytes = tManualLoadTxnCommitAttachment.getReceivedBytes();
         this.filteredRows = tManualLoadTxnCommitAttachment.getFilteredRows();
         this.unselectedRows = tManualLoadTxnCommitAttachment.getUnselectedRows();
+        this.partitionRows = tManualLoadTxnCommitAttachment.getPartitionRows();
         if (tManualLoadTxnCommitAttachment.isSetErrorLogUrl()) {
             this.errorLogUrl = tManualLoadTxnCommitAttachment.getErrorLogUrl();
         }
@@ -106,5 +110,15 @@ public class ManualLoadTxnCommitAttachment extends TxnCommitAttachment {
         //     receivedBytes = in.readLong();
         //     loadedBytes = in.readLong();
         // }
+    }
+
+    @Override
+    public String toString() {
+        return "ManualLoadTxnCommitAttachment [filteredRows=" + filteredRows
+                + ", loadedRows=" + loadedRows
+                + ", loadBytes=" + loadedBytes
+                + ", partitionRows=" + partitionRows
+                + ", unselectedRows=" + unselectedRows
+                + ", receivedBytes=" + receivedBytes + "]";
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RLTaskTxnCommitAttachment.java
@@ -43,6 +43,7 @@ import com.starrocks.transaction.TxnCommitAttachment;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 
 // {"progress": "", "backendId": "", "taskSignature": "", "numOfErrorData": "",
 // "numOfTotalData": "", "taskId": "", "jobId": ""}
@@ -67,6 +68,8 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
     private String errorLogUrl;
     private long loadedBytes;
 
+    private Map<Long, Long> partitionRows;
+
     public RLTaskTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.ROUTINE_LOAD_TASK);
     }
@@ -81,6 +84,7 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
         this.receivedBytes = rlTaskTxnCommitAttachment.getReceivedBytes();
         this.loadedBytes = rlTaskTxnCommitAttachment.getLoadedBytes();
         this.taskExecutionTimeMs = rlTaskTxnCommitAttachment.getLoadCostMs();
+        this.partitionRows = rlTaskTxnCommitAttachment.getPartitionRows();
 
         switch (rlTaskTxnCommitAttachment.getLoadSourceType()) {
             case KAFKA:
@@ -154,6 +158,7 @@ public class RLTaskTxnCommitAttachment extends TxnCommitAttachment {
     public String toString() {
         return "RLTaskTxnCommitAttachment [filteredRows=" + filteredRows
                 + ", loadedRows=" + loadedRows
+                + ", partitionRows=" + partitionRows
                 + ", unselectedRows=" + unselectedRows
                 + ", receivedBytes=" + receivedBytes
                 + ", taskExecutionTimeMs=" + taskExecutionTimeMs

--- a/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/StmtExecutor.java
@@ -2094,7 +2094,7 @@ public class StmtExecutor {
                         transactionId,
                         TabletCommitInfo.fromThrift(coord.getCommitInfos()),
                         TabletFailInfo.fromThrift(coord.getFailInfos()),
-                        new InsertTxnCommitAttachment(loadedRows),
+                        new InsertTxnCommitAttachment(loadedRows, coord.getLoadCounters()),
                         jobDeadLineMs - System.currentTimeMillis());
 
                 long publishWaitMs = Config.enable_sync_publish ? jobDeadLineMs - System.currentTimeMillis() :

--- a/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/scheduler/QueryRuntimeProfile.java
@@ -567,6 +567,9 @@ public class QueryRuntimeProfile {
         this.loadCounters.put(LoadEtlTask.DPP_ABNORMAL_ALL, String.valueOf(numRowsAbnormal));
         this.loadCounters.put(LoadJob.UNSELECTED_ROWS, String.valueOf(numRowsUnselected));
         this.loadCounters.put(LoadJob.LOADED_BYTES, String.valueOf(numLoadBytesTotal));
+        if (newLoadCounters.containsKey(LoadJob.PARTITION_LOADED_ROWS)) {
+            this.loadCounters.put(LoadJob.PARTITION_LOADED_ROWS, newLoadCounters.get(LoadJob.PARTITION_LOADED_ROWS));
+        }
     }
 
     private long getCounterLongValueOrDefault(Map<String, String> counters, String key, long defaultValue) {

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/InsertTxnCommitAttachment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/InsertTxnCommitAttachment.java
@@ -21,10 +21,13 @@ import com.starrocks.persist.gson.GsonUtils;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Map;
 
 public class InsertTxnCommitAttachment extends TxnCommitAttachment {
     @SerializedName("loadedRows")
     private long loadedRows;
+
+    private Map<String, String> loadCounters;
 
     public InsertTxnCommitAttachment() {
         super(TransactionState.LoadJobSourceType.INSERT_STREAMING);
@@ -33,6 +36,11 @@ public class InsertTxnCommitAttachment extends TxnCommitAttachment {
     public InsertTxnCommitAttachment(long loadedRows) {
         super(TransactionState.LoadJobSourceType.INSERT_STREAMING);
         this.loadedRows = loadedRows;
+    }
+
+    public InsertTxnCommitAttachment(long loadedRows, Map<String, String> loadCounters) {
+        this(loadedRows);
+        this.loadCounters = loadCounters;
     }
 
     public long getLoadedRows() {
@@ -52,5 +60,10 @@ public class InsertTxnCommitAttachment extends TxnCommitAttachment {
         InsertTxnCommitAttachment insertTxnCommitAttachment =
                 GsonUtils.GSON.fromJson(s, InsertTxnCommitAttachment.class);
         this.loadedRows = insertTxnCommitAttachment.getLoadedRows();
+    }
+
+    @Override
+    public String toString() {
+        return "InsertTxnCommitAttachment " + loadCounters.toString();
     }
 }

--- a/gensrc/thrift/FrontendService.thrift
+++ b/gensrc/thrift/FrontendService.thrift
@@ -931,6 +931,7 @@ struct TRLTaskTxnCommitAttachment {
     10: optional TKafkaRLTaskProgress kafkaRLTaskProgress
     11: optional string errorLogUrl
     12: optional TPulsarRLTaskProgress pulsarRLTaskProgress
+    13: optional map<i64,i64> partitionRows
 }
 
 struct TMiniLoadTxnCommitAttachment {
@@ -946,6 +947,7 @@ struct TManualLoadTxnCommitAttachment {
     4: optional i64 receivedBytes
     5: optional i64 loadedBytes
     6: optional i64 unselectedRows
+    7: optional map<i64,i64> partitionRows
 }
 
 struct TTxnCommitAttachment {


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
1. Add partition-level statistics about load: 
`{parititonId:  num_rows}`

![image](https://github.com/StarRocks/starrocks/assets/13373748/90431f2c-ff27-48ea-a488-6c785088146c)

3. TransactionState will be logged when finish transaction, but some txnAttachment do not override `toString`, as a result objectAddress logged.  This pr also override the method of `toString`.
Transactio 
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5