### PR TITLE
[Feature] Support rewriting footer of segment files replicated from another cluster to correct column unique id

### DIFF
--- a/be/src/agent/agent_task.cpp
+++ b/be/src/agent/agent_task.cpp
@@ -889,7 +889,6 @@ void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskReque
     } else {
         finish_task_request.__set_snapshot_path(src_snapshot_path);
         finish_task_request.__set_incremental_snapshot(incremental_snapshot);
-        LOG(INFO) << "remote snapshot success, signature:" << agent_task_req->signature;
     }
 
     task_status.__set_status_code(status_code);
@@ -899,7 +898,9 @@ void run_remote_snapshot_task(const std::shared_ptr<RemoteSnapshotAgentTaskReque
 #ifndef BE_TEST
     finish_task(finish_task_request);
 #endif
-    remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+    auto task_queue_size = remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+    LOG(INFO) << "Remove task success. type=" << agent_task_req->task_type
+              << ", signature=" << agent_task_req->signature << ", task_count_in_queue=" << task_queue_size;
 }
 
 void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTaskRequest>& agent_task_req,
@@ -923,8 +924,6 @@ void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTas
         status_code = TStatusCode::RUNTIME_ERROR;
         LOG(WARNING) << "replicate snapshot failed. status: " << res << ", signature:" << agent_task_req->signature;
         error_msgs.emplace_back("replicate snapshot failed, " + res.to_string());
-    } else {
-        LOG(INFO) << "replicate snapshot success, signature:" << agent_task_req->signature;
     }
 
     // Return result to fe
@@ -941,7 +940,9 @@ void run_replicate_snapshot_task(const std::shared_ptr<ReplicateSnapshotAgentTas
 #ifndef BE_TEST
     finish_task(finish_task_request);
 #endif
-    remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+    auto task_queue_size = remove_task_info(agent_task_req->task_type, agent_task_req->signature);
+    LOG(INFO) << "Remove task success. type=" << agent_task_req->task_type
+              << ", signature=" << agent_task_req->signature << ", task_count_in_queue=" << task_queue_size;
 }
 
 } // namespace starrocks

--- a/be/src/common/config.h
+++ b/be/src/common/config.h
@@ -150,8 +150,7 @@ CONF_mInt32(compact_threads, "4");
 CONF_Int32(compact_thread_pool_queue_size, "100");
 
 // The count of thread to replication
-CONF_Int32(replication_threads, "64");
-CONF_Int32(replication_thread_pool_queue_size, "2048");
+CONF_Int32(replication_threads, "0");
 CONF_Int32(clear_expired_replcation_snapshots_interval_seconds, "3600");
 
 // The log dir.

--- a/be/src/http/action/update_config_action.cpp
+++ b/be/src/http/action/update_config_action.cpp
@@ -139,6 +139,10 @@ Status UpdateConfigAction::update_config(const std::string& name, const std::str
             _exec_env->agent_server()->update_max_thread_by_type(TTaskType::CLONE,
                                                                  config::parallel_clone_task_per_path);
         });
+        _config_callback.emplace("replication_threads", [&]() {
+            _exec_env->agent_server()->update_max_thread_by_type(TTaskType::REPLICATE_SNAPSHOT,
+                                                                 config::replication_threads);
+        });
         _config_callback.emplace("alter_tablet_worker_count", [&]() {
             _exec_env->agent_server()->update_max_thread_by_type(TTaskType::ALTER, config::alter_tablet_worker_count);
         });

--- a/be/src/http/http_client.cpp
+++ b/be/src/http/http_client.cpp
@@ -204,7 +204,7 @@ StatusOr<uint64_t> HttpClient::download(const std::string& local_path) {
     return output_file->size();
 }
 
-StatusOr<std::string> HttpClient::download() {
+Status HttpClient::download(const std::function<Status(const void* data, size_t length)>& callback) {
     // set method to GET
     set_method(GET);
 
@@ -214,13 +214,17 @@ StatusOr<std::string> HttpClient::download() {
     curl_easy_setopt(_curl, CURLOPT_LOW_SPEED_TIME, config::download_low_speed_time);
     curl_easy_setopt(_curl, CURLOPT_MAX_RECV_SPEED_LARGE, config::max_download_speed_kbps * 1024);
 
-    std::string result;
-    auto callback = [&result](const void* data, size_t length) {
-        result.append((const char*)data, length);
+    Status status;
+    auto download_cb = [&callback, &status](const void* data, size_t length) {
+        status = callback(data, length);
+        if (!status.ok()) {
+            LOG(WARNING) << "fail to download file, status: " << status;
+            return false;
+        }
         return true;
     };
-    RETURN_IF_ERROR(execute(callback));
-    return result;
+    RETURN_IF_ERROR(execute(download_cb));
+    return status;
 }
 
 Status HttpClient::execute(std::string* response) {

--- a/be/src/http/http_client.h
+++ b/be/src/http/http_client.h
@@ -113,7 +113,7 @@ public:
     // a file to local_path
     StatusOr<uint64_t> download(const std::string& local_path);
 
-    StatusOr<std::string> download();
+    Status download(const std::function<Status(const void* data, size_t length)>& callback);
 
     Status execute_post_request(const std::string& payload, std::string* response);
 

--- a/be/src/storage/CMakeLists.txt
+++ b/be/src/storage/CMakeLists.txt
@@ -49,6 +49,7 @@ add_library(Storage STATIC
     protobuf_file.cpp
     replication_txn_manager.cpp
     replication_utils.cpp
+    segment_stream_converter.cpp
     rowset_update_state.cpp
     rowset_column_update_state.cpp
     update_compaction_state.cpp

--- a/be/src/storage/file_stream_converter.h
+++ b/be/src/storage/file_stream_converter.h
@@ -1,0 +1,61 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "fs/fs.h"
+#include "gutil/macros.h"
+
+namespace starrocks {
+
+class FileStreamConverter {
+public:
+    explicit FileStreamConverter(std::string_view input_file_name, uint64_t input_file_size,
+                                 std::unique_ptr<WritableFile> output_file)
+            : _input_file_name(input_file_name),
+              _input_file_size(input_file_size),
+              _output_file(std::move(output_file)) {}
+
+    virtual ~FileStreamConverter() = default;
+
+    DISALLOW_COPY_AND_MOVE(FileStreamConverter);
+
+    const std::string& input_file_name() const { return _input_file_name; }
+
+    const std::string& output_file_name() const { return _output_file->filename(); }
+
+    uint64_t input_file_size() const { return _input_file_size; }
+
+    uint64_t output_file_size() const { return _output_file->size(); }
+
+    virtual Status append(const void* data, size_t size) {
+        return _output_file->append(Slice((const char*)data, size));
+    }
+
+    virtual Status close() {
+        if (_input_file_size != _output_file->size()) {
+            LOG(WARNING) << "File size not matched, input_file_size: " << _input_file_size
+                         << ", output_file_size: " << _output_file->size();
+            return Status::Corruption("File size not matched, input_file_size");
+        }
+        return _output_file->close();
+    }
+
+protected:
+    const std::string _input_file_name;
+    const uint64_t _input_file_size;
+    std::unique_ptr<WritableFile> _output_file;
+};
+
+} // namespace starrocks

--- a/be/src/storage/lake/replication_txn_manager.h
+++ b/be/src/storage/lake/replication_txn_manager.h
@@ -16,6 +16,7 @@
 
 #include "common/status.h"
 #include "gen_cpp/AgentService_types.h"
+#include "gutil/macros.h"
 #include "storage/lake/tablet_metadata.h"
 #include "storage/lake/txn_log.h"
 #include "storage/lake/types_fwd.h"

--- a/be/src/storage/lake/txn_log_applier.cpp
+++ b/be/src/storage/lake/txn_log_applier.cpp
@@ -284,6 +284,10 @@ private:
                       << ", txn_id: " << txn_id;
         }
 
+        if (op_replication.has_source_schema()) {
+            _metadata->mutable_source_schema()->CopyFrom(op_replication.source_schema());
+        }
+
         return Status::OK();
     }
 
@@ -478,6 +482,10 @@ private:
             LOG(INFO) << "Apply full replication log finish. tablet_id: " << _tablet.id()
                       << ", base_version: " << _metadata->version() << ", new_version: " << _new_version
                       << ", txn_id: " << op_replication.txn_meta().txn_id();
+        }
+
+        if (op_replication.has_source_schema()) {
+            _metadata->mutable_source_schema()->CopyFrom(op_replication.source_schema());
         }
 
         return Status::OK();

--- a/be/src/storage/replication_txn_manager.cpp
+++ b/be/src/storage/replication_txn_manager.cpp
@@ -40,6 +40,7 @@
 #include "storage/replication_utils.h"
 #include "storage/rowset/rowset.h"
 #include "storage/rowset/rowset_factory.h"
+#include "storage/segment_stream_converter.h"
 #include "storage/snapshot_manager.h"
 #include "storage/tablet_manager.h"
 #include "storage/tablet_updates.h"
@@ -154,9 +155,8 @@ Status ReplicationTxnManager::remote_snapshot(const TRemoteSnapshotRequest& requ
     }
 
     LOG(INFO) << "Made snapshot from " << src_backend.host << ":" << src_backend.be_port << ":" << *src_snapshot_path
-              << ", txn_id: " << request.transaction_id << ", keys_type: " << KeysType_Name(tablet->keys_type())
-              << ", tablet_id: " << request.tablet_id << ", src_tablet_id: " << request.src_tablet_id
-              << ", visible_version: " << request.visible_version
+              << ", txn_id: " << request.transaction_id << ", tablet_id: " << request.tablet_id
+              << ", src_tablet_id: " << request.src_tablet_id << ", visible_version: " << request.visible_version
               << ", snapshot_version: " << request.src_visible_version << ", is_incremental: " << *incremental_snapshot;
 
     txn_meta_pb.set_txn_id(request.transaction_id);
@@ -343,22 +343,93 @@ Status ReplicationTxnManager::replicate_remote_snapshot(const TReplicateSnapshot
     RETURN_IF_ERROR(fs::remove_all(tablet_snapshot_dir_path));
     RETURN_IF_ERROR(fs::create_directories(tablet_snapshot_dir_path));
 
+    TabletSchemaCSPtr source_schema;
+    if (tablet->updates() == nullptr) { // None-pk table
+        std::string remote_header_file_name = std::to_string(request.src_tablet_id) + ".hdr";
+        ASSIGN_OR_RETURN(auto header_file_content,
+                         ReplicationUtils::download_remote_snapshot_file(
+                                 src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+                                 src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
+                                 remote_header_file_name, config::download_low_speed_time));
+        TabletMeta tablet_meta;
+        auto status = tablet_meta.create_from_memory(header_file_content);
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to parse remote snapshot header file: " << remote_header_file_name
+                         << ", content: " << header_file_content << ", " << status;
+            return status;
+        }
+        // None-pk table always has tablet schema in tablet meta
+        source_schema = std::move(tablet_meta.tablet_schema_ptr());
+    } else { // Pk table
+        std::string snapshot_meta_file_name = "meta";
+        ASSIGN_OR_RETURN(auto snapshot_meta_content,
+                         ReplicationUtils::download_remote_snapshot_file(
+                                 src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
+                                 src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash,
+                                 snapshot_meta_file_name, config::download_low_speed_time));
+
+        auto memory_file = new_random_access_file_from_memory(snapshot_meta_file_name, snapshot_meta_content);
+        SnapshotMeta snapshot_meta;
+        auto status = snapshot_meta.parse_from_file(memory_file.get());
+        if (!status.ok()) {
+            LOG(WARNING) << "Fail to parse remote snapshot meta file: " << snapshot_meta_file_name
+                         << ", content: " << snapshot_meta_content << ", " << status;
+            return status;
+        }
+
+        CHECK(((src_snapshot_info.incremental_snapshot &&
+                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_INCREMENTAL) ||
+               (!src_snapshot_info.incremental_snapshot &&
+                snapshot_meta.snapshot_type() == SnapshotTypePB::SNAPSHOT_TYPE_FULL)))
+                << ", incremental_snapshot: " << src_snapshot_info.incremental_snapshot
+                << ", snapshot_type: " << SnapshotTypePB_Name(snapshot_meta.snapshot_type());
+
+        if (snapshot_meta.tablet_meta().has_schema()) {
+            // Try to get source schema from tablet meta, only full snapshot has tablet meta
+            source_schema = TabletSchema::create(snapshot_meta.tablet_meta().schema());
+        } else if (!snapshot_meta.rowset_metas().empty() && snapshot_meta.rowset_metas().front().has_tablet_schema()) {
+            // Try to get source schema from rowset meta, rowset meta has schema if light schema change enabled in source cluster
+            source_schema = TabletSchema::create(
+                    TabletMeta::rowset_meta_pb_with_max_rowset_version(snapshot_meta.rowset_metas()).tablet_schema());
+        } else {
+            // Get source schema from previous saved in tablet meta
+            source_schema = tablet->tablet_meta()->source_schema();
+        }
+    }
+
+    std::unordered_map<uint32_t, uint32_t> column_unique_id_map;
+    ReplicationUtils::calc_column_unique_id_map(source_schema->columns(), tablet->tablet_schema()->columns(),
+                                                &column_unique_id_map);
+
+    auto file_converters = [&](const std::string& file_name,
+                               uint64_t file_size) -> StatusOr<std::unique_ptr<FileStreamConverter>> {
+        WritableFileOptions opts{.sync_on_close = true, .mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE};
+        ASSIGN_OR_RETURN(auto output_file, fs::new_writable_file(opts, tablet_snapshot_dir_path + file_name));
+
+        if (HasSuffixString(file_name, ".dat") && !column_unique_id_map.empty()) {
+            return std::make_unique<SegmentStreamConverter>(file_name, file_size, std::move(output_file),
+                                                            &column_unique_id_map);
+        }
+        return std::make_unique<FileStreamConverter>(file_name, file_size, std::move(output_file));
+    };
+
     RETURN_IF_ERROR(ReplicationUtils::download_remote_snapshot(
             src_snapshot_info.backend.host, src_snapshot_info.backend.http_port, request.src_token,
-            src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash, tablet->data_dir(),
-            tablet_snapshot_dir_path));
+            src_snapshot_info.snapshot_path, request.src_tablet_id, request.src_schema_hash, file_converters,
+            tablet->data_dir()));
 
     if (tablet->updates() == nullptr) {
-        RETURN_IF_ERROR(convert_snapshot_for_none_primary(tablet_snapshot_dir_path, request));
+        RETURN_IF_ERROR(convert_snapshot_for_none_primary(tablet_snapshot_dir_path, column_unique_id_map, request));
     } else {
-        RETURN_IF_ERROR(convert_snapshot_for_primary(tablet_snapshot_dir_path, request));
+        RETURN_IF_ERROR(convert_snapshot_for_primary(tablet_snapshot_dir_path, column_unique_id_map, request));
     }
 
     return Status::OK();
 }
 
-Status ReplicationTxnManager::convert_snapshot_for_none_primary(const std::string& tablet_snapshot_path,
-                                                                const TReplicateSnapshotRequest& request) {
+Status ReplicationTxnManager::convert_snapshot_for_none_primary(
+        const std::string& tablet_snapshot_path, const std::unordered_map<uint32_t, uint32_t>& column_unique_id_map,
+        const TReplicateSnapshotRequest& request) {
     std::string src_header_file_path = tablet_snapshot_path + std::to_string(request.src_tablet_id) + ".hdr";
     TabletMeta tablet_meta;
     RETURN_IF_ERROR(tablet_meta.create_from_file(src_header_file_path));
@@ -369,13 +440,24 @@ Status ReplicationTxnManager::convert_snapshot_for_none_primary(const std::strin
     tablet_meta_pb.set_partition_id(request.partition_id);
     tablet_meta_pb.set_tablet_id(request.tablet_id);
     tablet_meta_pb.set_schema_hash(request.schema_hash);
+    // None-pk table must convert column unique ids in tablet schema before convert_rowset_ids
+    ReplicationUtils::convert_column_unique_ids(tablet_meta_pb.mutable_schema()->mutable_column(),
+                                                column_unique_id_map);
     for (auto& rowset_meta : *tablet_meta_pb.mutable_rs_metas()) {
         rowset_meta.set_partition_id(request.partition_id);
         rowset_meta.set_tablet_id(request.tablet_id);
+        if (!column_unique_id_map.empty() && rowset_meta.has_tablet_schema()) {
+            ReplicationUtils::convert_column_unique_ids(rowset_meta.mutable_tablet_schema()->mutable_column(),
+                                                        column_unique_id_map);
+        }
     }
     for (auto& rowset_meta : *tablet_meta_pb.mutable_inc_rs_metas()) {
         rowset_meta.set_partition_id(request.partition_id);
         rowset_meta.set_tablet_id(request.tablet_id);
+        if (!column_unique_id_map.empty() && rowset_meta.has_tablet_schema()) {
+            ReplicationUtils::convert_column_unique_ids(rowset_meta.mutable_tablet_schema()->mutable_column(),
+                                                        column_unique_id_map);
+        }
     }
 
     std::string header_file_path = tablet_snapshot_path + std::to_string(request.tablet_id) + ".hdr";
@@ -393,8 +475,9 @@ Status ReplicationTxnManager::convert_snapshot_for_none_primary(const std::strin
     return Status::OK();
 }
 
-Status ReplicationTxnManager::convert_snapshot_for_primary(const std::string& tablet_snapshot_path,
-                                                           const TReplicateSnapshotRequest& request) {
+Status ReplicationTxnManager::convert_snapshot_for_primary(
+        const std::string& tablet_snapshot_path, const std::unordered_map<uint32_t, uint32_t>& column_unique_id_map,
+        const TReplicateSnapshotRequest& request) {
     std::string snapshot_meta_file_path = tablet_snapshot_path + "meta";
     ASSIGN_OR_RETURN(auto snapshot_meta, SnapshotManager::instance()->parse_snapshot_meta(snapshot_meta_file_path));
 
@@ -406,15 +489,27 @@ Status ReplicationTxnManager::convert_snapshot_for_primary(const std::string& ta
     for (auto& rowset_meta : *tablet_meta_pb.mutable_rs_metas()) {
         rowset_meta.set_partition_id(request.partition_id);
         rowset_meta.set_tablet_id(request.tablet_id);
+        if (!column_unique_id_map.empty() && rowset_meta.has_tablet_schema()) {
+            ReplicationUtils::convert_column_unique_ids(rowset_meta.mutable_tablet_schema()->mutable_column(),
+                                                        column_unique_id_map);
+        }
     }
     for (auto& rowset_meta : *tablet_meta_pb.mutable_inc_rs_metas()) {
         rowset_meta.set_partition_id(request.partition_id);
         rowset_meta.set_tablet_id(request.tablet_id);
+        if (!column_unique_id_map.empty() && rowset_meta.has_tablet_schema()) {
+            ReplicationUtils::convert_column_unique_ids(rowset_meta.mutable_tablet_schema()->mutable_column(),
+                                                        column_unique_id_map);
+        }
     }
 
     for (auto& rowset_meta : snapshot_meta.rowset_metas()) {
         rowset_meta.set_partition_id(request.partition_id);
         rowset_meta.set_tablet_id(request.tablet_id);
+        if (!column_unique_id_map.empty() && rowset_meta.has_tablet_schema()) {
+            ReplicationUtils::convert_column_unique_ids(rowset_meta.mutable_tablet_schema()->mutable_column(),
+                                                        column_unique_id_map);
+        }
     }
 
     RETURN_IF_ERROR(snapshot_meta.serialize_to_file(snapshot_meta_file_path));
@@ -426,6 +521,10 @@ Status ReplicationTxnManager::convert_snapshot_for_primary(const std::string& ta
 
 Status ReplicationTxnManager::publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,
                                                bool incremental_snapshot) {
+    if (tablet->max_version().second >= snapshot_version) {
+        return Status::OK();
+    }
+
     if (tablet->updates() != nullptr) {
         return publish_snapshot_for_primary(tablet, snapshot_dir);
     }
@@ -604,7 +703,7 @@ Status ReplicationTxnManager::publish_snapshot_for_primary(Tablet* tablet, const
     }
     LOG(INFO) << "Linked " << clone_files.size() << " files from " << snapshot_dir << " to " << tablet_dir;
 
-    Status status = tablet->updates()->load_snapshot(snapshot_meta);
+    Status status = tablet->updates()->load_snapshot(snapshot_meta, false, true);
     if (!status.ok()) {
         Status clear_st;
         for (const std::string& filename : tablet_files) {

--- a/be/src/storage/replication_txn_manager.h
+++ b/be/src/storage/replication_txn_manager.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "gutil/macros.h"
 #include "storage/storage_engine.h"
 
 namespace starrocks {
@@ -49,9 +50,11 @@ private:
                                      const std::string& tablet_snapshot_dir_path, Tablet* tablet);
 
     Status convert_snapshot_for_none_primary(const std::string& tablet_snapshot_path,
+                                             const std::unordered_map<uint32_t, uint32_t>& column_unique_id_map,
                                              const TReplicateSnapshotRequest& request);
 
     Status convert_snapshot_for_primary(const std::string& tablet_snapshot_path,
+                                        const std::unordered_map<uint32_t, uint32_t>& column_unique_id_map,
                                         const TReplicateSnapshotRequest& request);
 
     Status publish_snapshot(Tablet* tablet, const string& snapshot_dir, int64_t snapshot_version,

--- a/be/src/storage/replication_utils.cpp
+++ b/be/src/storage/replication_utils.cpp
@@ -35,12 +35,13 @@
 
 namespace starrocks {
 
-const std::string HTTP_REQUEST_PREFIX = "/api/_tablet/_download";
-const uint32_t DOWNLOAD_FILE_MAX_RETRY = 3;
-const uint32_t LIST_REMOTE_FILE_TIMEOUT = 15;
-const uint32_t GET_LENGTH_TIMEOUT = 10;
-
 #ifndef BE_TEST
+
+static const std::string HTTP_REQUEST_PREFIX = "/api/_tablet/_download";
+static const uint32_t DOWNLOAD_FILE_MAX_RETRY = 3;
+static const uint32_t LIST_REMOTE_FILE_TIMEOUT = 15;
+static const uint32_t GET_LENGTH_TIMEOUT = 10;
+
 static Status list_remote_files(const std::string& remote_url_prefix, std::vector<string>* file_name_list,
                                 std::vector<int64_t>* file_size_list) {
     // Get remote dir file list
@@ -94,17 +95,22 @@ static StatusOr<uint64_t> get_remote_file_size(const std::string& remote_file_ur
     return file_size;
 }
 
-static StatusOr<uint64_t> download_remote_file(const std::string& remote_file_url, const std::string& local_file_path,
-                                               uint64_t timeout_sec) {
-    uint64_t file_size = 0;
-    auto download_cb = [&remote_file_url, timeout_sec, &local_file_path, &file_size](HttpClient* client) {
+static Status download_remote_file(
+        const std::string& remote_file_url, uint64_t timeout_sec,
+        const std::function<StatusOr<std::unique_ptr<FileStreamConverter>>()>& converter_creator) {
+    auto download_cb = [&](HttpClient* client) {
+        ASSIGN_OR_RETURN(auto converter, converter_creator());
+        if (converter == nullptr) {
+            return Status::OK();
+        }
+
         RETURN_IF_ERROR(client->init(remote_file_url));
         client->set_timeout_ms(timeout_sec * 1000);
-        ASSIGN_OR_RETURN(file_size, client->download(local_file_path));
+        RETURN_IF_ERROR(client->download([&](const void* data, size_t size) { return converter->append(data, size); }));
+        RETURN_IF_ERROR(converter->close());
         return Status::OK();
     };
-    RETURN_IF_ERROR(HttpClient::execute_with_retry(DOWNLOAD_FILE_MAX_RETRY, 1, download_cb));
-    return file_size;
+    return HttpClient::execute_with_retry(DOWNLOAD_FILE_MAX_RETRY, 1, download_cb);
 }
 #endif
 
@@ -194,9 +200,17 @@ Status ReplicationUtils::release_remote_snapshot(const std::string& ip, int32_t 
 Status ReplicationUtils::download_remote_snapshot(
         const std::string& host, int32_t http_port, const std::string& remote_token,
         const std::string& remote_snapshot_path, TTabletId remote_tablet_id, TSchemaHash remote_schema_hash,
-        DataDir* data_dir, const std::string& local_path_prefix,
-        const std::function<std::string(const std::string&)>& name_converter) {
+        const std::function<StatusOr<std::unique_ptr<FileStreamConverter>>(const std::string& file_name,
+                                                                           uint64_t file_size)>& file_converters,
+        DataDir* data_dir) {
 #ifdef BE_TEST
+    std::string test_file = "test_file";
+    ASSIGN_OR_RETURN(auto file_converter, file_converters(test_file, 0));
+    if (file_converter == nullptr) {
+        return Status::OK();
+    }
+    auto output_file_name = file_converter->output_file_name();
+    auto local_path_prefix = output_file_name.substr(0, output_file_name.size() - test_file.size());
     std::error_code error_code;
     std::filesystem::copy(strings::Substitute("$0/$1/$2/", remote_snapshot_path, remote_tablet_id, remote_schema_hash),
                           local_path_prefix, error_code);
@@ -214,23 +228,8 @@ Status ReplicationUtils::download_remote_snapshot(
     std::vector<int64_t> file_size_list;
     RETURN_IF_ERROR(list_remote_files(remote_url_prefix, &file_name_list, &file_size_list));
 
-    // If the header file is not exist, the table could't loaded by olap engine.
-    // Avoid of data is not complete, we copy the header file at last.
-    // The header file's name is end of .hdr.
-    for (int i = 0; i < file_name_list.size() - 1; ++i) {
-        StringPiece sp(file_name_list[i]);
-        if (sp.ends_with(".hdr")) {
-            std::swap(file_name_list[i], file_name_list[file_name_list.size() - 1]);
-            if (!file_size_list.empty()) {
-                std::swap(file_size_list[i], file_size_list[file_size_list.size() - 1]);
-            }
-            break;
-        }
-    }
-
-    // Get copy from remote
+    // Copy files from remote backend
     uint64_t total_file_size = 0;
-    uint64_t skipped_file_count = 0;
     MonotonicStopWatch watch;
     watch.start();
     for (int i = 0; i < file_name_list.size(); ++i) {
@@ -250,32 +249,19 @@ Status ReplicationUtils::download_remote_snapshot(
         }
 
         total_file_size += file_size;
-        uint64_t estimate_timeout = file_size / config::download_low_speed_limit_kbps / 1024;
-        if (estimate_timeout < config::download_low_speed_time) {
-            estimate_timeout = config::download_low_speed_time;
+        uint64_t estimate_timeout_sec = file_size / config::download_low_speed_limit_kbps / 1024;
+        if (estimate_timeout_sec < config::download_low_speed_time) {
+            estimate_timeout_sec = config::download_low_speed_time;
         }
 
-        std::string local_file_name = name_converter ? name_converter(remote_file_name) : remote_file_name;
-        if (local_file_name.empty()) {
-            ++skipped_file_count;
-            LOG(INFO) << "Skipped download remote file: " << remote_file_url << ", file_size: " << file_size;
-            continue;
-        }
+        VLOG(1) << "Downloading " << remote_file_url << ", bytes: " << file_size
+                << ", timeout: " << estimate_timeout_sec << "s";
 
-        std::string local_file_path = local_path_prefix + local_file_name;
-
-        VLOG(1) << "Downloading " << remote_file_url << " to " << local_file_path << ", bytes: " << file_size
-                << ", timeout: " << estimate_timeout;
-
-        ASSIGN_OR_RETURN(uint64_t local_file_size,
-                         download_remote_file(remote_file_url, local_file_path, estimate_timeout));
-        // Check file length
-        if (local_file_size != file_size) {
-            LOG(WARNING) << "Fail to download " << remote_file_url << ", file_size: " << local_file_size << "/"
-                         << file_size;
-            return Status::InternalError("mismatched file size");
-        }
-    } // Clone files from remote backend
+        RETURN_IF_ERROR(download_remote_file(remote_file_url, estimate_timeout_sec,
+                                             [&file_converters, &remote_file_name, file_size]() {
+                                                 return file_converters(remote_file_name, file_size);
+                                             }));
+    } // Copy files from remote backend
 
     double total_time_sec = watch.elapsed_time() / 1000. / 1000. / 1000.;
     double copy_rate = 0.0;
@@ -283,7 +269,7 @@ Status ReplicationUtils::download_remote_snapshot(
         copy_rate = (total_file_size / 1024. / 1024.) / total_time_sec;
     }
     LOG(INFO) << "Copied tablet file count: " << file_name_list.size() << ", total bytes: " << total_file_size
-              << ", cost: " << total_time_sec << " s, rate: " << copy_rate << " MB/s";
+              << ", cost: " << total_time_sec << "s, rate: " << copy_rate << "MB/s";
     return Status::OK();
 #endif
 }

--- a/be/src/storage/replication_utils.h
+++ b/be/src/storage/replication_utils.h
@@ -14,10 +14,12 @@
 
 #pragma once
 
+#include "storage/file_stream_converter.h"
 #include "storage/storage_engine.h"
 
 namespace starrocks {
 
+class TabletSchemaPB;
 class ReplicationUtils {
 public:
     static Status make_remote_snapshot(const std::string& host, int32_t be_port, TTabletId tablet_id,
@@ -31,10 +33,10 @@ public:
 
     static Status download_remote_snapshot(const std::string& host, int32_t http_port, const std::string& remote_token,
                                            const std::string& remote_snapshot_path, TTabletId remote_tablet_id,
-                                           TSchemaHash remote_schema_hash, DataDir* data_dir,
-                                           const std::string& local_path_prefix,
-                                           const std::function<std::string(const std::string&)>& name_converter =
-                                                   std::function<std::string(const std::string&)>());
+                                           TSchemaHash remote_schema_hash,
+                                           const std::function<StatusOr<std::unique_ptr<FileStreamConverter>>(
+                                                   const std::string& file_name, uint64_t file_size)>& file_converters,
+                                           DataDir* data_dir = nullptr);
 
     static StatusOr<std::string> download_remote_snapshot_file(const std::string& host, int32_t http_port,
                                                                const std::string& remote_token,
@@ -42,6 +44,49 @@ public:
                                                                TTabletId remote_tablet_id,
                                                                TSchemaHash remote_schema_hash,
                                                                const std::string& file_name, uint64_t timeout_sec);
+
+    template <typename T>
+    static void calc_column_unique_id_map(const T& source_columns, const T& target_columns,
+                                          std::unordered_map<uint32_t, uint32_t>* column_unique_id_map) {
+        std::unordered_map<std::string_view, typename T::const_pointer> target_columns_map;
+        for (const auto& target_column : target_columns) {
+            target_columns_map.emplace(target_column.name(), &target_column);
+        }
+
+        bool need_convert = false;
+        for (const auto& source_column : source_columns) {
+            auto iter = target_columns_map.find(source_column.name());
+            if (iter != target_columns_map.end()) {
+                const auto& target_column = *iter->second;
+                if (source_column.unique_id() != target_column.unique_id()) {
+                    need_convert = true;
+                }
+                column_unique_id_map->emplace(source_column.unique_id(), target_column.unique_id());
+            }
+        }
+
+        if (!need_convert) {
+            column_unique_id_map->clear();
+        }
+    }
+
+    template <typename T>
+    static void convert_column_unique_ids(T* columns,
+                                          const std::unordered_map<uint32_t, uint32_t>& column_unique_id_map) {
+        if (column_unique_id_map.empty()) {
+            return;
+        }
+
+        uint32_t column_unique_id_max_value = -1;
+        for (auto& column : *columns) {
+            auto iter = column_unique_id_map.find(column.unique_id());
+            if (iter != column_unique_id_map.end()) {
+                column.set_unique_id(iter->second);
+            } else {
+                column.set_unique_id(column_unique_id_max_value--);
+            }
+        }
+    }
 };
 
 } // namespace starrocks

--- a/be/src/storage/rowset/segment.h
+++ b/be/src/storage/rowset/segment.h
@@ -89,9 +89,11 @@ public:
                                                    bool skip_fill_local_cache = true,
                                                    lake::TabletManager* tablet_manager = nullptr);
 
-    [[nodiscard]] static Status parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer,
-                                                     size_t* footer_length_hint,
-                                                     const FooterPointerPB* partial_rowset_footer);
+    [[nodiscard]] static StatusOr<size_t> parse_segment_footer(RandomAccessFile* read_file, SegmentFooterPB* footer,
+                                                               size_t* footer_length_hint,
+                                                               const FooterPointerPB* partial_rowset_footer);
+
+    [[nodiscard]] static Status write_segment_footer(WritableFile* write_file, const SegmentFooterPB& footer);
 
     Segment(std::shared_ptr<FileSystem> fs, FileInfo segment_file_info, uint32_t segment_id,
             TabletSchemaCSPtr tablet_schema, lake::TabletManager* tablet_manager);

--- a/be/src/storage/segment_stream_converter.cpp
+++ b/be/src/storage/segment_stream_converter.cpp
@@ -1,0 +1,118 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/segment_stream_converter.h"
+
+#include <atomic>
+
+#include "fs/fs_memory.h"
+#include "replication_utils.h"
+#include "storage/rowset/segment.h"
+
+namespace starrocks {
+
+#ifndef BE_TEST
+static
+#endif
+        std::atomic<size_t>
+                s_segment_footer_buffer_size = 4 * 1024 * 1024; // 4MB
+
+SegmentStreamConverter::SegmentStreamConverter(std::string_view input_file_name, uint64_t input_file_size,
+                                               std::unique_ptr<WritableFile> output_file,
+                                               const std::unordered_map<uint32_t, uint32_t>* column_unique_id_map)
+        : FileStreamConverter(input_file_name, input_file_size, std::move(output_file)),
+          _column_unique_id_map(column_unique_id_map) {
+    if (_column_unique_id_map != nullptr && !_column_unique_id_map->empty()) {
+        _segment_footer_buffer.reserve(s_segment_footer_buffer_size.load(std::memory_order::acquire));
+    }
+}
+
+Status SegmentStreamConverter::append(const void* data, size_t size) {
+    if (_column_unique_id_map == nullptr || _column_unique_id_map->empty()) {
+        return FileStreamConverter::append(data, size);
+    }
+
+    uint64_t remaining_file_size = _input_file_size - _output_file->size();
+    if (size > remaining_file_size) {
+        LOG(WARNING) << "Append size is larger than remaining file size, append size: " << size
+                     << ", input_file_size: " << _input_file_size << ", output_file_size: " << _output_file->size()
+                     << ", segment_footer_buffer_size: " << _segment_footer_buffer.size()
+                     << ", segment_footer_buffer_capacity: " << _segment_footer_buffer.capacity();
+        return Status::Corruption("Append size is larger than remaining file size");
+    }
+
+    // remaining file size can put in buffer
+    if (remaining_file_size <= _segment_footer_buffer.capacity()) {
+        if (size > _segment_footer_buffer.capacity() - _segment_footer_buffer.size()) {
+            LOG(WARNING) << "Append size is large than free buffer size, append size: " << size
+                         << ", input_file_size: " << _input_file_size << ", output_file_size: " << _output_file->size()
+                         << ", segment_footer_buffer_size: " << _segment_footer_buffer.size()
+                         << ", segment_footer_buffer_capacity: " << _segment_footer_buffer.capacity();
+            return Status::Corruption("Append size is large than free buffer size");
+        }
+        _segment_footer_buffer.append((const char*)data, size);
+        return Status::OK();
+    }
+
+    uint64_t remaining_stream_size = remaining_file_size - size;
+    if (remaining_stream_size >= _segment_footer_buffer.capacity()) {
+        return _output_file->append(Slice((const char*)data, size));
+    }
+
+    uint64_t to_append_output_file_size = remaining_file_size - _segment_footer_buffer.capacity();
+    RETURN_IF_ERROR(_output_file->append(Slice((const char*)data, to_append_output_file_size)));
+
+    _segment_footer_buffer.append((const char*)data + to_append_output_file_size, size - to_append_output_file_size);
+
+    return Status::OK();
+}
+
+Status SegmentStreamConverter::close() {
+    if (_column_unique_id_map == nullptr || _column_unique_id_map->empty()) {
+        return FileStreamConverter::close();
+    }
+
+    if (_output_file->size() + _segment_footer_buffer.size() != _input_file_size) {
+        LOG(WARNING) << "File size not matched, input_file_size: " << _input_file_size
+                     << ", output_file_size: " << _output_file->size()
+                     << ", segment_footer_buffer_size: " << _segment_footer_buffer.size()
+                     << ", segment_footer_buffer_capacity: " << _segment_footer_buffer.capacity();
+        return Status::Corruption("File size not matched");
+    }
+
+    auto memory_file = new_random_access_file_from_memory(_input_file_name, _segment_footer_buffer);
+    SegmentFooterPB segment_footer_pb;
+    size_t footer_length_hint = _segment_footer_buffer.size();
+    auto status_or = Segment::parse_segment_footer(memory_file.get(), &segment_footer_pb, &footer_length_hint, nullptr);
+    if (!status_or.ok()) {
+        if (footer_length_hint > _segment_footer_buffer.size()) {
+            s_segment_footer_buffer_size.store(footer_length_hint, std::memory_order::release);
+        }
+        return status_or.status();
+    }
+
+    auto segment_footer_size = status_or.value();
+    if (segment_footer_size < _segment_footer_buffer.size()) {
+        RETURN_IF_ERROR(_output_file->append(
+                Slice(_segment_footer_buffer.data(), _segment_footer_buffer.size() - segment_footer_size)));
+    }
+
+    ReplicationUtils::convert_column_unique_ids(segment_footer_pb.mutable_columns(), *_column_unique_id_map);
+
+    RETURN_IF_ERROR(Segment::write_segment_footer(_output_file.get(), segment_footer_pb));
+
+    return _output_file->close();
+}
+
+} // namespace starrocks

--- a/be/src/storage/segment_stream_converter.h
+++ b/be/src/storage/segment_stream_converter.h
@@ -1,0 +1,38 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <unordered_map>
+
+#include "storage/file_stream_converter.h"
+
+namespace starrocks {
+
+class SegmentStreamConverter : public FileStreamConverter {
+public:
+    explicit SegmentStreamConverter(std::string_view input_file_name, uint64_t input_file_size,
+                                    std::unique_ptr<WritableFile> output_file,
+                                    const std::unordered_map<uint32_t, uint32_t>* column_unique_id_map);
+
+    virtual Status append(const void* data, size_t size) override;
+
+    virtual Status close() override;
+
+private:
+    const std::unordered_map<uint32_t, uint32_t>* _column_unique_id_map;
+    std::string _segment_footer_buffer;
+};
+
+} // namespace starrocks

--- a/be/src/storage/tablet_meta.h
+++ b/be/src/storage/tablet_meta.h
@@ -99,7 +99,10 @@ public:
 
     static TabletMetaSharedPtr create();
 
-    static RowsetMetaSharedPtr& rowset_meta_with_max_rowset_version(std::vector<RowsetMetaSharedPtr> rowsets);
+    static const RowsetMetaSharedPtr& rowset_meta_with_max_rowset_version(
+            const std::vector<RowsetMetaSharedPtr>& rowsets);
+
+    static const RowsetMetaPB& rowset_meta_pb_with_max_rowset_version(const std::vector<RowsetMetaPB>& rowsets);
 
     explicit TabletMeta();
     TabletMeta(int64_t table_id, int64_t partition_id, int64_t tablet_id, int32_t schema_hash, uint64_t shard_id,
@@ -161,6 +164,7 @@ public:
     void save_tablet_schema(const TabletSchemaCSPtr& tablet_schema, DataDir* data_dir);
 
     TabletSchemaCSPtr& tablet_schema_ptr() { return _schema; }
+    const TabletSchemaCSPtr& tablet_schema_ptr() const { return _schema; }
 
     const std::vector<RowsetMetaSharedPtr>& all_rs_metas() const;
     void add_rs_meta(const RowsetMetaSharedPtr& rs_meta);
@@ -225,6 +229,10 @@ public:
         _enable_shortcut_compaction = enable_shortcut_compaction;
     }
 
+    void set_source_schema(const TabletSchemaCSPtr& source_schema) { _source_schema = source_schema; }
+
+    const TabletSchemaCSPtr& source_schema() const { return _source_schema; }
+
 private:
     int64_t _mem_usage() const { return sizeof(TabletMeta); }
 
@@ -285,6 +293,9 @@ private:
     bool _enable_shortcut_compaction = true;
 
     std::string _storage_type;
+
+    // If the tablet is replicated from another cluster, the source_schema saved the schema in the cluster
+    TabletSchemaCSPtr _source_schema = nullptr;
 
     std::shared_mutex _meta_lock;
 };

--- a/be/src/storage/tablet_updates.h
+++ b/be/src/storage/tablet_updates.h
@@ -232,7 +232,8 @@ public:
                         ChunkChanger* chunk_changer, const TabletSchemaCSPtr& base_tablet_schema,
                         const std::string& err_msg_header = "");
 
-    Status load_snapshot(const SnapshotMeta& snapshot_meta, bool restore_from_backup = false);
+    Status load_snapshot(const SnapshotMeta& snapshot_meta, bool restore_from_backup = false,
+                         bool save_source_schema = false);
 
     Status get_latest_applied_version(EditVersion* latest_applied_version);
 

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -409,6 +409,7 @@ set(EXEC_FILES_PART2
         ./storage/push_handler_test.cpp
         ./storage/range_test.cpp
         ./storage/replication_txn_manager_test.cpp
+        ./storage/segment_stream_converter_test.cpp
         ./storage/row_source_mask_test.cpp
         ./storage/union_iterator_test.cpp
         ./storage/unique_iterator_test.cpp

--- a/be/test/agent/agent_task_test.cpp
+++ b/be/test/agent/agent_task_test.cpp
@@ -48,11 +48,16 @@ public:
     }
 
     void TearDown() override {
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id, kDeleteFiles);
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
-        (void)StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_tablet_id);
-        (void)StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
-        (void)fs::remove_all(config::storage_root_path);
+        auto status = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = fs::remove_all(config::storage_root_path);
+        EXPECT_TRUE(status.ok()) << status;
     }
 
     TCreateTabletReq get_create_tablet_request(int64_t tablet_id, int schema_hash, int64_t version) {

--- a/be/test/http/http_client_test.cpp
+++ b/be/test/http/http_client_test.cpp
@@ -139,9 +139,13 @@ TEST_F(HttpClientTest, download_to_memory) {
     auto st = client.init(hostname + "/simple_get");
     ASSERT_TRUE(st.ok());
     client.set_basic_auth("test1", "");
-    auto st_or = client.download();
-    ASSERT_TRUE(st_or.ok());
-    ASSERT_EQ("test1", st_or.value());
+    std::string value;
+    st = client.download([&](const void* data, size_t length) {
+        value.append((const char*)data, length);
+        return Status::OK();
+    });
+    ASSERT_TRUE(st.ok());
+    ASSERT_EQ("test1", value);
 }
 
 TEST_F(HttpClientTest, get_failed) {

--- a/be/test/storage/lake/replication_txn_manager_test.cpp
+++ b/be/test/storage/lake/replication_txn_manager_test.cpp
@@ -79,9 +79,12 @@ public:
     }
 
     void TearDown() override {
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
-        (void)StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
-        (void)fs::remove_all(config::storage_root_path);
+        auto status = StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = fs::remove_all(config::storage_root_path);
+        EXPECT_TRUE(status.ok()) << status;
     }
 
     TCreateTabletReq get_create_tablet_req(int64_t tablet_id, int64_t version, int32_t schema_hash,
@@ -90,7 +93,7 @@ public:
         request.tablet_id = tablet_id;
         request.__set_version(version);
         request.__set_version_hash(0);
-        request.tablet_schema.__set_id(1);
+        request.tablet_schema.__set_id(GetParam() + 1);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = GetParam();
@@ -308,7 +311,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_replicate_snapshot_failed) {
 
     auto slog_path = _tablet_manager->txn_slog_location(_tablet_id, _transaction_id);
     auto txn_slog_or = _tablet_manager->get_txn_log(slog_path, false);
-    EXPECT_TRUE(txn_slog_or.ok()) << status;
+    EXPECT_TRUE(txn_slog_or.ok()) << txn_slog_or.status();
 
     _replication_txn_manager->clear_snapshots(txn_slog_or.value());
 }
@@ -338,7 +341,7 @@ TEST_P(LakeReplicationTxnManagerTest, test_publish_failed) {
     const int64_t txn_ids[] = {_transaction_id};
     auto txn_id_span = std::span<const int64_t>(txn_ids, 1);
     auto status_or = lake::publish_version(_tablet_manager.get(), _tablet_id, _version, _src_version, txn_id_span, 0);
-    EXPECT_TRUE(!status_or.ok()) << status;
+    EXPECT_TRUE(!status_or.ok()) << status_or.status();
 
     const int32_t txn_types[] = {TxnTypePB::TXN_REPLICATION};
     auto txn_type_span = std::span<const int32_t>(txn_types, 1);

--- a/be/test/storage/replication_txn_manager_test.cpp
+++ b/be/test/storage/replication_txn_manager_test.cpp
@@ -56,11 +56,16 @@ public:
     }
 
     void TearDown() override {
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id, kDeleteFiles);
-        (void)StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
-        (void)StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_tablet_id);
-        (void)StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
-        (void)fs::remove_all(config::storage_root_path);
+        auto status = StorageEngine::instance()->tablet_manager()->drop_tablet(_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->drop_tablet(_src_tablet_id, kDeleteFiles);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = StorageEngine::instance()->tablet_manager()->delete_shutdown_tablet(_src_tablet_id);
+        EXPECT_TRUE(status.ok()) << status;
+        status = fs::remove_all(config::storage_root_path);
+        EXPECT_TRUE(status.ok()) << status;
     }
 
     TabletSharedPtr create_tablet(int64_t tablet_id, int64_t version, int32_t schema_hash,
@@ -69,7 +74,7 @@ public:
         request.tablet_id = tablet_id;
         request.__set_version(version);
         request.__set_version_hash(0);
-        request.tablet_schema.__set_id(1);
+        request.tablet_schema.__set_id(GetParam() + 1);
         request.tablet_schema.schema_hash = schema_hash;
         request.tablet_schema.short_key_column_count = 1;
         request.tablet_schema.keys_type = GetParam();

--- a/be/test/storage/segment_stream_converter_test.cpp
+++ b/be/test/storage/segment_stream_converter_test.cpp
@@ -1,0 +1,149 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "storage/segment_stream_converter.h"
+
+#include <gtest/gtest.h>
+
+#include "fs/fs.h"
+#include "fs/fs_memory.h"
+#include "testutil/assert.h"
+#include "util/uuid_generator.h"
+
+namespace starrocks {
+
+extern std::atomic<size_t> s_segment_footer_buffer_size;
+
+class SegmentStreamConverterTest : public testing::Test {
+public:
+    SegmentStreamConverterTest() = default;
+    ~SegmentStreamConverterTest() override = default;
+
+    void SetUp() override {}
+
+    void TearDown() override {}
+};
+
+TEST_F(SegmentStreamConverterTest, test_no_convert) {
+    s_segment_footer_buffer_size.store(1024);
+
+    MemoryFileSystem memory_fs;
+    auto status_or = memory_fs.new_writable_file("/test_url");
+    EXPECT_TRUE(status_or.ok());
+
+    auto wfile = std::move(status_or.value());
+    SegmentStreamConverter segment_stream_converter("test_name", 1024, std::move(wfile), nullptr);
+
+    char data[1024];
+    auto status = segment_stream_converter.append(data, sizeof(data));
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), sizeof(data));
+    EXPECT_TRUE(segment_stream_converter._segment_footer_buffer.empty());
+}
+
+TEST_F(SegmentStreamConverterTest, test_convert_small_segment) {
+    s_segment_footer_buffer_size.store(1024);
+
+    MemoryFileSystem memory_fs;
+    auto status_or = memory_fs.new_writable_file("/test_url");
+    EXPECT_TRUE(status_or.ok());
+
+    auto wfile = std::move(status_or.value());
+    std::unordered_map<uint32_t, uint32_t> unique_id_map = {{1, 2}};
+    SegmentStreamConverter segment_stream_converter("test_name", 1024, std::move(wfile), &unique_id_map);
+
+    char data[512];
+    auto status = segment_stream_converter.append(data, sizeof(data));
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 0);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 512);
+
+    status = segment_stream_converter.append(data, sizeof(data));
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 0);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 1024);
+}
+
+TEST_F(SegmentStreamConverterTest, test_convert_large_segment) {
+    s_segment_footer_buffer_size.store(512);
+
+    MemoryFileSystem memory_fs;
+    auto status_or = memory_fs.new_writable_file("/test_url");
+    EXPECT_TRUE(status_or.ok());
+
+    auto wfile = std::move(status_or.value());
+    std::unordered_map<uint32_t, uint32_t> unique_id_map = {{1, 2}};
+    SegmentStreamConverter segment_stream_converter("test_name", 1024, std::move(wfile), &unique_id_map);
+
+    char data[256];
+    auto status = segment_stream_converter.append(data, sizeof(data));
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 256);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 0);
+
+    status = segment_stream_converter.append(data, sizeof(data));
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 512);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 0);
+
+    status = segment_stream_converter.append(data, sizeof(data));
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 512);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 256);
+
+    status = segment_stream_converter.append(data, sizeof(data));
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 512);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 512);
+}
+
+TEST_F(SegmentStreamConverterTest, test_convert_large_segment2) {
+    s_segment_footer_buffer_size.store(512);
+
+    MemoryFileSystem memory_fs;
+    auto status_or = memory_fs.new_writable_file("/test_url");
+    EXPECT_TRUE(status_or.ok());
+
+    auto wfile = std::move(status_or.value());
+    std::unordered_map<uint32_t, uint32_t> unique_id_map = {{1, 2}};
+    SegmentStreamConverter segment_stream_converter("test_name", 1024, std::move(wfile), &unique_id_map);
+
+    char data[512];
+    auto status = segment_stream_converter.append(data, 256);
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 256);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 0);
+
+    status = segment_stream_converter.append(data, 512);
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 512);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 256);
+
+    status = segment_stream_converter.append(data, 256);
+    EXPECT_TRUE(status.ok());
+
+    EXPECT_EQ(segment_stream_converter._output_file->size(), 512);
+    EXPECT_EQ(segment_stream_converter._segment_footer_buffer.size(), 512);
+}
+
+} // namespace starrocks

--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -2763,18 +2763,16 @@ public class Config extends ConfigBase {
     public static int refresh_dictionary_cache_thread_num = 2;
 
     /*
-     * replication transaction config
+     * Replication config
      */
+    @ConfField
+    public static int replication_interval_ms = 10;
     @ConfField(mutable = true)
-    public static int replication_transaction_max_parallel_job_count = 100; // 100
+    public static int replication_max_parallel_table_count = 100; // 100
     @ConfField(mutable = true)
-    public static int replication_transaction_max_parallel_replication_data_size_mb = 10240; // 10g
+    public static int replication_max_parallel_data_size_mb = 10240; // 10g
     @ConfField(mutable = true)
     public static int replication_transaction_timeout_sec = 1 * 60 * 60; // 1hour
-    @ConfField(mutable = true)
-    public static int replication_transaction_remote_snapshot_timeout_sec = 30 * 60; // 30minute
-    @ConfField(mutable = true)
-    public static int replication_transaction_replicate_snapshot_timeout_sec = 30 * 60; // 30minute
 
     @ConfField(mutable = true)
     public static boolean jdbc_meta_default_cache_enable = false;

--- a/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/replication/ReplicationJob.java
@@ -32,6 +32,7 @@ import com.starrocks.common.DuplicatedRequestException;
 import com.starrocks.common.LabelAlreadyUsedException;
 import com.starrocks.common.MetaNotFoundException;
 import com.starrocks.common.UserException;
+import com.starrocks.common.util.UUIDUtil;
 import com.starrocks.persist.gson.GsonPostProcessable;
 import com.starrocks.server.GlobalStateMgr;
 import com.starrocks.system.Backend;
@@ -64,7 +65,6 @@ import org.apache.logging.log4j.Logger;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 public class ReplicationJob implements GsonPostProcessable {
     private static final Logger LOG = LogManager.getLogger(ReplicationJob.class);
@@ -279,12 +279,13 @@ public class ReplicationJob implements GsonPostProcessable {
     @SerializedName(value = "state")
     private volatile ReplicationJobState state;
 
-    @SerializedName(value = "stateStartTime")
-    private volatile long stateStartTime;
-
     private Map<AgentTask, AgentTask> runningTasks = Maps.newConcurrentMap();
     private volatile int taskNum = 0;
     private Map<AgentTask, AgentTask> finishedTasks = Maps.newConcurrentMap();
+
+    public long getDatabaseId() {
+        return databaseId;
+    }
 
     public long getTableId() {
         return tableId;
@@ -300,11 +301,9 @@ public class ReplicationJob implements GsonPostProcessable {
 
     private void setState(ReplicationJobState state) {
         this.state = state;
-        this.stateStartTime = System.currentTimeMillis();
-    }
-
-    public Map<AgentTask, AgentTask> getRunningTasks() {
-        return runningTasks;
+        GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
+        LOG.info("Replication job state: {}, database id: {}, table id: {}, transaction id: {}",
+                state, databaseId, tableId, transactionId);
     }
 
     public ReplicationJob(TTableReplicationRequest request) throws MetaNotFoundException {
@@ -319,7 +318,7 @@ public class ReplicationJob implements GsonPostProcessable {
         this.replicationDataSize = request.src_table_data_size - tableInfo.getTableDataSize();
         this.partitionInfos = tableInfo.getPartitionInfos();
         this.transactionId = 0;
-        this.setState(ReplicationJobState.INITIALIZING);
+        this.state = ReplicationJobState.INITIALIZING;
 
         if (partitionInfos.isEmpty()) {
             throw new RuntimeException("No data need to replicate");
@@ -336,7 +335,7 @@ public class ReplicationJob implements GsonPostProcessable {
         this.replicationDataSize = srcTable.getDataSize() - table.getDataSize();
         this.partitionInfos = initPartitionInfos(table, srcTable, srcSystemInfoService);
         this.transactionId = 0;
-        this.setState(ReplicationJobState.INITIALIZING);
+        this.state = ReplicationJobState.INITIALIZING;
 
         if (partitionInfos.isEmpty()) {
             throw new RuntimeException("No data need to replicate");
@@ -353,10 +352,6 @@ public class ReplicationJob implements GsonPostProcessable {
         }
 
         setState(ReplicationJobState.ABORTED);
-
-        GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
-        LOG.warn("Replication job cancelled, abort, database id: {}, table id: {}, transaction id: {}",
-                databaseId, tableId, transactionId);
     }
 
     public void run() {
@@ -365,15 +360,9 @@ public class ReplicationJob implements GsonPostProcessable {
                 beginTransaction();
                 sendRemoteSnapshotTasks();
                 setState(ReplicationJobState.SNAPSHOTING);
-                GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
-                LOG.info("Replication job state: {}, database id: {}, table id: {}, transaction id: {}", state,
-                        databaseId, tableId, transactionId);
             } else if (state.equals(ReplicationJobState.SNAPSHOTING)) {
                 if (isTransactionAborted()) {
                     setState(ReplicationJobState.ABORTED);
-                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
-                    LOG.warn("Replication job snapshot timeout, database id: {}, table id: {}, transaction id: {}, ",
-                            databaseId, tableId, transactionId);
                 } else if (isCrashRecovery()) {
                     sendRemoteSnapshotTasks();
                     LOG.info("Replication job recovered, state: {}, database id: {}, table id: {}, transaction id: {}",
@@ -381,16 +370,10 @@ public class ReplicationJob implements GsonPostProcessable {
                 } else if (isAllTaskFinished()) {
                     sendReplicateSnapshotTasks();
                     setState(ReplicationJobState.REPLICATING);
-                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
-                    LOG.info("Replication job state: {}, database id: {}, table id: {}, transaction id: {}", state,
-                            databaseId, tableId, transactionId);
                 }
             } else if (state.equals(ReplicationJobState.REPLICATING)) {
                 if (isTransactionAborted()) {
                     setState(ReplicationJobState.ABORTED);
-                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
-                    LOG.warn("Replication job replicate timeout, database id: {}, table id: {}, transaction id: {}, ",
-                            databaseId, tableId, transactionId);
                 } else if (isCrashRecovery()) {
                     sendReplicateSnapshotTasks();
                     LOG.info("Replication job recovered, state: {}, database id: {}, table id: {}, transaction id: {}",
@@ -398,17 +381,11 @@ public class ReplicationJob implements GsonPostProcessable {
                 } else if (isAllTaskFinished()) {
                     commitTransaction();
                     setState(ReplicationJobState.COMMITTED);
-                    GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
-                    LOG.info("Replication job state: {}, database id: {}, table id: {}, transaction id: {}", state,
-                            databaseId, tableId, transactionId);
                 }
             }
         } catch (Exception e) {
             abortTransaction(e.getMessage());
             setState(ReplicationJobState.ABORTED);
-            GlobalStateMgr.getServingState().getEditLog().logReplicationJob(this);
-            LOG.warn("Replication job run failed, abort, database id: {}, table id: {}, transaction id: {}, ",
-                    databaseId, tableId, transactionId, e);
         }
     }
 
@@ -431,6 +408,7 @@ public class ReplicationJob implements GsonPostProcessable {
 
                 replicaInfo.setSrcSnapshotPath(request.snapshot_path);
                 replicaInfo.setSrcIncrementalSnapshot(request.incremental_snapshot);
+                task.setFinished(true);
             } else {
                 task.setFailed(true);
                 task.setErrorMsg("No snapshot path or incremental snapshot");
@@ -451,7 +429,9 @@ public class ReplicationJob implements GsonPostProcessable {
             return;
         }
 
-        if (request.getTask_status().getStatus_code() != TStatusCode.OK) {
+        if (request.getTask_status().getStatus_code() == TStatusCode.OK) {
+            task.setFinished(true);
+        } else {
             task.setFailed(true);
             task.setErrorMsg(request.getTask_status().getError_msgs().get(0));
             LOG.warn("Replicate snapshot task failed, task: {}, error: {}", task, task.getErrorMsg());
@@ -643,7 +623,7 @@ public class ReplicationJob implements GsonPostProcessable {
             throws LabelAlreadyUsedException, DuplicatedRequestException, AnalysisException, RunningTxnExceedException {
         TransactionState.LoadJobSourceType loadJobSourceType = TransactionState.LoadJobSourceType.REPLICATION;
         TransactionState.TxnCoordinator coordinator = TransactionState.TxnCoordinator.fromThisFE();
-        String label = String.format("REPLICATION_%d_%d_%s", databaseId, tableId, UUID.randomUUID().toString());
+        String label = String.format("REPLICATION_%d_%d_%s", databaseId, tableId, UUIDUtil.genUUID().toString());
         transactionId = GlobalStateMgr.getServingState().getGlobalTransactionMgr().beginTransaction(databaseId,
                 Lists.newArrayList(tableId), label, coordinator, loadJobSourceType,
                 Config.replication_transaction_timeout_sec);
@@ -675,18 +655,29 @@ public class ReplicationJob implements GsonPostProcessable {
             GlobalStateMgr.getServingState().getGlobalTransactionMgr().abortTransaction(databaseId, transactionId,
                     reason);
         } catch (Exception e) {
-            LOG.warn("Replication job abort transaction failed, ignore, database id: {}, table id: {}, ",
-                    databaseId, tableId, e);
+            LOG.warn("Abort transaction failed, ignore, database id: {}, table id: {}, transaction id: {}, ",
+                    databaseId, tableId, transactionId, e);
         }
+
+        removeRunningTasks();
     }
 
     private boolean isTransactionAborted() {
         TransactionState txnState = GlobalStateMgr.getServingState().getGlobalTransactionMgr()
                 .getTransactionState(databaseId, transactionId);
-        if (txnState == null) {
+        if (txnState == null || txnState.getTransactionStatus() == TransactionStatus.ABORTED) {
+            removeRunningTasks();
             return true;
         }
-        return txnState.getTransactionStatus() == TransactionStatus.ABORTED;
+
+        if (txnState.getTransactionStatus() == TransactionStatus.PREPARE) {
+            Database db = GlobalStateMgr.getServingState().getDb(databaseId);
+            if (db == null || db.getTable(tableId) == null) {
+                abortTransaction("Table is deleted");
+                return true;
+            }
+        }
+        return false;
     }
 
     private void sendRemoteSnapshotTasks() {
@@ -702,7 +693,7 @@ public class ReplicationJob implements GsonPostProcessable {
                                 srcToken, tabletInfo.getSrcTabletId(), getTabletType(srcTableType),
                                 indexInfo.getSrcSchemaHash(), partitionInfo.getSrcVersion(),
                                 Lists.newArrayList(replicaInfo.getSrcBackend()),
-                                Config.replication_transaction_remote_snapshot_timeout_sec);
+                                Config.replication_transaction_timeout_sec);
                         runningTasks.put(task, task);
                     }
                 }
@@ -758,37 +749,20 @@ public class ReplicationJob implements GsonPostProcessable {
         AgentTaskExecutor.submit(batchTask);
     }
 
-    private void setAllTaskTimeout() {
-        List<AgentTask> tasks = Lists.newArrayList(runningTasks.values());
-        for (AgentTask task : tasks) {
-            if (runningTasks.remove(task, task)) {
-                task.setFailed(true);
-                task.setErrorMsg("Task timeout");
-                finishedTasks.put(task, task);
-                LOG.warn("Task timeout, task: {}, error: {}", task, task.getErrorMsg());
-            }
+    private void removeRunningTasks() {
+        for (AgentTask task : runningTasks.values()) {
+            AgentTaskQueue.removeTask(task.getBackendId(), task.getTaskType(), task.getSignature());
         }
+        runningTasks.clear();
     }
 
     private boolean isAllTaskFinished() {
         if (runningTasks.isEmpty() && finishedTasks.size() == taskNum) {
             return true;
         }
-
-        long timeoutMs = 0;
-        if (state.equals(ReplicationJobState.SNAPSHOTING)) {
-            timeoutMs = Config.replication_transaction_remote_snapshot_timeout_sec * 1000;
-        } else if (state.equals(ReplicationJobState.REPLICATING)) {
-            timeoutMs = Config.replication_transaction_replicate_snapshot_timeout_sec * 1000;
-        } else {
-            throw new RuntimeException("Invalid replication job state: " + state);
-        }
-
-        if (System.currentTimeMillis() > stateStartTime + timeoutMs) {
-            setAllTaskTimeout();
-        }
-
-        return runningTasks.isEmpty() && finishedTasks.size() == taskNum;
+        LOG.info("Replication job running tasks: {}, finished tasks: {}, transaction id: {}",
+                runningTasks.size(), finishedTasks.size(), transactionId);
+        return false;
     }
 
     private boolean isCrashRecovery() {

--- a/fe/fe-core/src/main/java/com/starrocks/task/RemoteSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/RemoteSnapshotTask.java
@@ -42,7 +42,8 @@ public class RemoteSnapshotTask extends AgentTask {
             TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion,
             String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
             long srcVisibleVersion, List<TBackend> srcBackends, int timeoutSec) {
-        super(null, backendId, TTaskType.REMOTE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId);
+        super(null, backendId, TTaskType.REMOTE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId,
+                System.currentTimeMillis());
         this.transactionId = transactionId;
         this.tabletType = tabletType;
         this.schemaHash = schemaHash;
@@ -85,7 +86,7 @@ public class RemoteSnapshotTask extends AgentTask {
         sb.append(", tablet id: ").append(tabletId).append(", tablet type: ").append(tabletType);
         sb.append(", schema hash: ").append(schemaHash);
         sb.append(", visible version: ").append(visibleVersion);
-        sb.append(", src token:").append(srcToken).append(", src tablet id:").append(srcTabletId);
+        sb.append(", src token: ").append(srcToken).append(", src tablet id: ").append(srcTabletId);
         sb.append(", src tablet type:").append(srcTabletType).append(", src schema hash: ").append(srcSchemaHash);
         sb.append(", src visible version: ").append(srcVisibleVersion);
         sb.append(", src backends: ").append(srcBackends);

--- a/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/task/ReplicateSnapshotTask.java
@@ -40,7 +40,8 @@ public class ReplicateSnapshotTask extends AgentTask {
             TTabletType tabletType, long transactionId, int schemaHash, long visibleVersion,
             String srcToken, long srcTabletId, TTabletType srcTabletType, int srcSchemaHash,
             long srcVisibleVersion, List<TRemoteSnapshotInfo> srcSnapshotInfos) {
-        super(null, backendId, TTaskType.REPLICATE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId);
+        super(null, backendId, TTaskType.REPLICATE_SNAPSHOT, dbId, tableId, partitionId, indexId, tabletId, tabletId,
+                System.currentTimeMillis());
         this.transactionId = transactionId;
         this.tabletType = tabletType;
         this.schemaHash = schemaHash;
@@ -81,7 +82,7 @@ public class ReplicateSnapshotTask extends AgentTask {
         sb.append(", tablet id: ").append(tabletId).append(", tablet type: ").append(tabletType);
         sb.append(", schema hash: ").append(schemaHash);
         sb.append(", visible version: ").append(visibleVersion);
-        sb.append(", src token:").append(srcToken).append(", src tablet id:").append(srcTabletId);
+        sb.append(", src token: ").append(srcToken).append(", src tablet id: ").append(srcTabletId);
         sb.append(", src tablet type:").append(srcTabletType).append(", src schema hash: ").append(srcSchemaHash);
         sb.append(", src visible version: ").append(srcVisibleVersion);
         sb.append(", src snapshot infos: ").append(srcSnapshotInfos);

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationJobTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ReplicationJobTest {
     private static StarRocksAssert starRocksAssert;
@@ -113,7 +114,8 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -129,7 +131,7 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
@@ -176,7 +178,8 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -204,7 +207,8 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -215,7 +219,7 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             job.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
@@ -238,7 +242,8 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             TStatus status = new TStatus(TStatusCode.OK);
             request.setTask_status(status);
@@ -248,7 +253,7 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.addToError_msgs("failed");
@@ -270,7 +275,8 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -281,7 +287,7 @@ public class ReplicationJobTest {
         job.run();
         Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.addToError_msgs("failed");

--- a/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/replication/ReplicationMgrTest.java
@@ -53,6 +53,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class ReplicationMgrTest {
     private static StarRocksAssert starRocksAssert;
@@ -119,7 +120,8 @@ public class ReplicationMgrTest {
 
         replicationMgr.replayReplicationJob(job);
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -137,7 +139,7 @@ public class ReplicationMgrTest {
 
         replicationMgr.replayReplicationJob(job);
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
@@ -192,7 +194,8 @@ public class ReplicationMgrTest {
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -220,7 +223,8 @@ public class ReplicationMgrTest {
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -231,7 +235,7 @@ public class ReplicationMgrTest {
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             replicationMgr.finishReplicateSnapshotTask((ReplicateSnapshotTask) task, request);
@@ -254,7 +258,8 @@ public class ReplicationMgrTest {
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             TStatus status = new TStatus(TStatusCode.OK);
             request.setTask_status(status);
@@ -264,7 +269,7 @@ public class ReplicationMgrTest {
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.addToError_msgs("failed");
@@ -286,7 +291,8 @@ public class ReplicationMgrTest {
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.SNAPSHOTING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        Map<AgentTask, AgentTask> runningTasks = Deencapsulation.getField(job, "runningTasks");
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             request.setTask_status(new TStatus(TStatusCode.OK));
             request.setSnapshot_path("test_snapshot_path");
@@ -297,7 +303,7 @@ public class ReplicationMgrTest {
         replicationMgr.runAfterCatalogReady();
         Assert.assertEquals(ReplicationJobState.REPLICATING, job.getState());
 
-        for (AgentTask task : job.getRunningTasks().values()) {
+        for (AgentTask task : runningTasks.values()) {
             TFinishTaskRequest request = new TFinishTaskRequest();
             TStatus status = new TStatus(TStatusCode.INTERNAL_ERROR);
             status.addToError_msgs("failed");

--- a/gensrc/proto/lake_types.proto
+++ b/gensrc/proto/lake_types.proto
@@ -97,6 +97,8 @@ message TabletMetadataPB {
     // The commit time on the FE for the transaction that created this tablet metadata.
     // Meansured as the number of seconds since the Epoch, 1970-01-01 00:00:00 +0000 (UTC).
     optional int64 commit_time = 13;
+    // If the tablet is replicated from another cluster, the source_schema saved the schema in the cluster
+    optional TabletSchemaPB source_schema = 14;
 }
 
 message MetadataUpdateInfoPB {
@@ -141,6 +143,7 @@ message TxnLogPB {
         optional ReplicationTxnMetaPB txn_meta = 1;
         repeated OpWrite op_writes = 2;
         map<uint32, DelvecDataPB> delvecs = 3;
+        optional TabletSchemaPB source_schema = 4;
     }
 
     optional int64 tablet_id = 1;

--- a/gensrc/proto/olap_file.proto
+++ b/gensrc/proto/olap_file.proto
@@ -290,6 +290,8 @@ message TabletMetaPB {
     optional string storage_type = 54; // storage layout type: column[default]|column_with_row|row
     optional bool enable_shortcut_compaction = 60 [default = true];
     optional int32 primary_index_cache_expire_sec = 61 [default = 0];
+    // If the tablet is replicated from another cluster, the source_schema saved the schema in the cluster
+    optional TabletSchemaPB source_schema = 70;
 }
 
 message OLAPIndexHeaderMessage {


### PR DESCRIPTION
Why I'm doing:
If a segment file is replicated from another cluster, the column unique ids in its footer may be not matched with tablet schema, causing a crash in query.

What I'm doing:
Rewrite footer of segment files replicated from another cluster to correct column unique id.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
