### PR TITLE
[BugFix] Do not validate pentry of external database/table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
@@ -26,7 +26,6 @@ import com.starrocks.sql.common.MetaNotFoundException;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 public class DbPEntryObject implements PEntryObject {
     @SerializedName(value = "ci")

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/DbPEntryObject.java
@@ -123,14 +123,9 @@ public class DbPEntryObject implements PEntryObject {
     public boolean validate(GlobalStateMgr globalStateMgr) {
         if (catalogId == InternalCatalog.DEFAULT_INTERNAL_CATALOG_ID) {
             return globalStateMgr.getDbIncludeRecycleBin(Long.parseLong(this.uuid)) != null;
-        } else {
-            Optional<Catalog> catalog = globalStateMgr.getCatalogMgr().getCatalogById(catalogId);
-            if (!catalog.isPresent()) {
-                return false;
-            }
-            String dbName = ExternalCatalog.getDbNameFromUUID(uuid);
-            return globalStateMgr.getMetadataMgr().getDb(catalog.get().getName(), dbName) != null;
         }
+        // do not validate privilege of external database
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
@@ -170,26 +170,15 @@ public class TablePEntryObject implements PEntryObject {
 
     @Override
     public boolean validate(GlobalStateMgr globalStateMgr) {
-        Database db;
         if (catalogId == InternalCatalog.DEFAULT_INTERNAL_CATALOG_ID) {
-            db = globalStateMgr.getDbIncludeRecycleBin(Long.parseLong(this.databaseUUID));
+            Database db = globalStateMgr.getDbIncludeRecycleBin(Long.parseLong(this.databaseUUID));
             if (db == null) {
                 return false;
             }
             return globalStateMgr.getTableIncludeRecycleBin(db, Long.parseLong(this.tableUUID)) != null;
-        } else {
-            Optional<Catalog> catalog = globalStateMgr.getCatalogMgr().getCatalogById(catalogId);
-            if (!catalog.isPresent()) {
-                return false;
-            }
-            String dbName = ExternalCatalog.getDbNameFromUUID(databaseUUID);
-            String tblName = ExternalCatalog.getTableNameFromUUID(tableUUID);
-            db = globalStateMgr.getMetadataMgr().getDb(catalog.get().getName(), dbName);
-            if (db == null) {
-                return false;
-            }
-            return globalStateMgr.getMetadataMgr().getTable(catalog.get().getName(), dbName, tblName) != null;
         }
+        // do not validate privilege of external table
+        return true;
     }
 
     @Override

--- a/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
+++ b/fe/fe-core/src/main/java/com/starrocks/privilege/TablePEntryObject.java
@@ -28,7 +28,6 @@ import com.starrocks.sql.common.MetaNotFoundException;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 public class TablePEntryObject implements PEntryObject {
     @SerializedName(value = "ci")

--- a/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/analyzer/PrivilegeCheckerTest.java
@@ -46,6 +46,7 @@ import com.starrocks.load.routineload.RoutineLoadMgr;
 import com.starrocks.mysql.MysqlChannel;
 import com.starrocks.privilege.AccessDeniedException;
 import com.starrocks.privilege.AuthorizationMgr;
+import com.starrocks.privilege.DbPEntryObject;
 import com.starrocks.privilege.PipePEntryObject;
 import com.starrocks.privilege.PrivObjNotFoundException;
 import com.starrocks.privilege.PrivilegeException;
@@ -479,6 +480,16 @@ public class PrivilegeCheckerTest {
         System.out.println(res.getResultRows());
         Assert.assertEquals(2, res.getResultRows().size());
         Assert.assertEquals("test_ex_catalog3", res.getResultRows().get(1).get(0));
+    }
+
+    @Test
+    public void testExternalDBAndTablePEntryObject() throws Exception {
+        starRocksAssert.withCatalog("create external catalog test_iceberg properties (\"type\"=\"iceberg\")");
+        DbPEntryObject dbPEntryObject = DbPEntryObject.generate(GlobalStateMgr.getCurrentState(), List.of("test_iceberg", "*"));
+        Assert.assertTrue(dbPEntryObject.validate(GlobalStateMgr.getCurrentState()));
+        TablePEntryObject tablePEntryObject = TablePEntryObject.generate(GlobalStateMgr.getCurrentState(),
+                List.of("test_iceberg", "*", "*"));
+        Assert.assertTrue(tablePEntryObject.validate(GlobalStateMgr.getCurrentState()));
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:

If a network request fails, `MetadataMgr#getTable` may return null. Then related pentry is deleted for validation. 

What I'm doing:

Do not validate pentry of external database/table

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [x] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
