### PR TITLE
[Enhancement] make str_to_date compatible with date_parse in trino

### DIFF
--- a/be/src/types/timestamp_value.cpp
+++ b/be/src/types/timestamp_value.cpp
@@ -396,6 +396,14 @@ bool TimestampValue::check_date(const DatetimeContent* content) const {
     return false;
 }
 
+bool TimestampValue::is_valid_year(const DatetimeContent* content) const {
+    return content->_year >= 1 && content->_year <= 9999;
+}
+
+bool TimestampValue::is_valid_month(const DatetimeContent* content) const {
+    return content->_month >= 1 && content->_month <= 12;
+}
+
 // ============================
 // This codes and associative methods is from DateTimeValue.
 // Uncommon approach to process string content based on format string
@@ -516,7 +524,6 @@ bool TimestampValue::from_uncommon_format_str(const char* format, int format_len
                 }
                 content->_day = int_value;
                 val = tmp + std::min(2, (int)(val_end - tmp));
-                date_part_used = true;
                 break;
                 // Hour
             case 'h':
@@ -756,6 +763,18 @@ bool TimestampValue::from_uncommon_format_str(const char* format, int format_len
             }
         } else {
             content->_type = TIMESTAMP_TIME;
+        }
+    }
+
+    if (date_part_used && !time_part_used) {
+        if (is_valid_year(content) && ptr == end && val == val_end && content->_month == 0 && content->_day == 0) {
+            // default to the first day of the year if the format is valid and no day provided
+            content->_month = 1;
+            content->_day = 1;
+        } else if (is_valid_year(content) && is_valid_month(content) && ptr == end && val == val_end &&
+                   content->_day == 0) {
+            // default to the first day of the month if the format is valid and no day provided
+            content->_day = 1;
         }
     }
 

--- a/be/src/types/timestamp_value.h
+++ b/be/src/types/timestamp_value.h
@@ -78,6 +78,8 @@ public:
 
     bool check_range(const DatetimeContent*) const;
     bool check_date(const DatetimeContent*) const;
+    bool is_valid_year(const DatetimeContent*) const;
+    bool is_valid_month(const DatetimeContent*) const;
 
     // This is private function which modify date but modify `_type`
     bool get_date_from_daynr(uint64_t, DatetimeContent*);

--- a/be/test/exprs/time_functions_test.cpp
+++ b/be/test/exprs/time_functions_test.cpp
@@ -1438,10 +1438,21 @@ TEST_F(TimeFunctionsTest, str_to_date) {
 
     const char* str1 = "01,5,2013";
     const char* str2 = "2020-06-24 17:10:25";
+    const char* str3 = "20130501";
+    const char* str4 = "2013-05-01";
+    const char* str5 = "201305";
+    const char* str6 = "2013-05";
+    const char* str7 = "2013";
     const char* fmt1 = "%d,%m,%Y";
     const char* fmt2 = "%Y-%m-%d %H:%i:%s";
+    const char* fmt3 = "%Y%m%d";
+    const char* fmt4 = "%Y-%m-%d";
+    const char* fmt5 = "%Y%m";
+    const char* fmt6 = "%Y-%m";
+    const char* fmt7 = "%Y";
     TimestampValue ts1 = TimestampValue::create(2013, 5, 1, 0, 0, 0);
     TimestampValue ts2 = TimestampValue::create(2020, 6, 24, 17, 10, 25);
+    TimestampValue ts3 = TimestampValue::create(2013, 1, 1, 0, 0, 0);
 
     const auto& varchar_type_desc = TypeDescriptor::create_varchar_type(TypeDescriptor::MAX_VARCHAR_LENGTH);
     // nullable
@@ -1452,12 +1463,30 @@ TEST_F(TimeFunctionsTest, str_to_date) {
         fmt_col->append_datum(Slice(fmt1));
         str_col->append_datum(Slice(str2)); // str2 <=> fmt2
         fmt_col->append_datum(Slice(fmt2));
+
+        // invalid format
         (void)str_col->append_nulls(1); // null <=> fmt1
         fmt_col->append_datum(Slice(fmt1));
         str_col->append_datum(Slice(str1)); // str1 <=> null
         (void)fmt_col->append_nulls(1);
         (void)str_col->append_nulls(1); // null <=> null
         (void)fmt_col->append_nulls(1);
+        str_col->append_datum(Slice(str3)); // str3 <=> fmt5
+        fmt_col->append_datum(Slice(fmt5));
+
+        // valid format with and without 'day' part provided
+        str_col->append_datum(Slice(str3)); // str3 <=> fmt3
+        fmt_col->append_datum(Slice(fmt3));
+        str_col->append_datum(Slice(str4)); // str4 <=> fmt4
+        fmt_col->append_datum(Slice(fmt4));
+        str_col->append_datum(Slice(str5)); // str5 <=> fmt5
+        fmt_col->append_datum(Slice(fmt5));
+        str_col->append_datum(Slice(str6)); // str6 <=> fmt6
+        fmt_col->append_datum(Slice(fmt6));
+
+        // valid format with and without 'month' and 'day' parts provided
+        str_col->append_datum(Slice(str7)); // str7 <=> fmt7
+        fmt_col->append_datum(Slice(fmt7));
 
         Columns columns;
         columns.emplace_back(str_col);
@@ -1466,12 +1495,16 @@ TEST_F(TimeFunctionsTest, str_to_date) {
         ASSERT_TRUE(result->is_nullable());
 
         NullableColumn::Ptr nullable_col = ColumnHelper::as_column<NullableColumn>(result);
-        ASSERT_EQ(5, nullable_col->size());
+        ASSERT_EQ(11, nullable_col->size());
         ASSERT_EQ(ts1, nullable_col->get(0).get_timestamp());
         ASSERT_EQ(ts2, nullable_col->get(1).get_timestamp());
-        for (int i = 2; i < 5; ++i) {
+        for (int i = 2; i < 6; ++i) {
             ASSERT_TRUE(nullable_col->is_null(i));
         }
+        for (int i = 6; i < 10; ++i) {
+            ASSERT_EQ(ts1, nullable_col->get(i).get_timestamp());
+        }
+        ASSERT_EQ(ts3, nullable_col->get(10).get_timestamp());
     }
     // const
     {

--- a/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/util/DateUtils.java
@@ -226,6 +226,8 @@ public class DateUtils {
     public static DateTimeFormatterBuilder unixDatetimeFormatBuilder(String pattern, boolean isOutputFormat) {
         DateTimeFormatterBuilder builder = new DateTimeFormatterBuilder();
         boolean escaped = false;
+        boolean containsMonth = false;
+        boolean containsDay = false;
         for (int i = 0; i < pattern.length(); i++) {
             char character = pattern.charAt(i);
             if (escaped) {
@@ -239,6 +241,7 @@ public class DateUtils {
                         } else {
                             builder.appendValue(ChronoField.MONTH_OF_YEAR, 1, 2, SignStyle.NORMAL);
                         }
+                        containsMonth = true;
                         break;
                     case 'd': // %d Day of the month, numeric (00..31)
                         if (isOutputFormat) {
@@ -246,9 +249,11 @@ public class DateUtils {
                         } else {
                             builder.appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL);
                         }
+                        containsDay = true;
                         break;
                     case 'e': // %e Day of the month, numeric (0..31)
                         builder.appendValue(ChronoField.DAY_OF_MONTH, 1, 2, SignStyle.NORMAL);
+                        containsDay = true;
                         break;
                     case 'H': // %H Hour (00..23)
                         builder.appendValue(ChronoField.HOUR_OF_DAY, 2);
@@ -268,6 +273,7 @@ public class DateUtils {
                         break;
                     case 'j': // %j Day of year (001..366)
                         builder.appendValue(ChronoField.DAY_OF_YEAR, 3);
+                        containsDay = true;
                         break;
                     case 'S': // %S Seconds (00..59)
                     case 's': // %s Seconds (00..59)
@@ -326,6 +332,12 @@ public class DateUtils {
             } else {
                 builder.appendLiteral(character);
             }
+        }
+        if (!containsMonth && !containsDay) {
+            builder.parseDefaulting(ChronoField.MONTH_OF_YEAR, 1);
+        }
+        if (!containsDay) {
+            builder.parseDefaulting(ChronoField.DAY_OF_MONTH, 1);
         }
         return builder;
     }

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorEvaluator.java
@@ -197,7 +197,7 @@ public enum ScalarOperatorEvaluator {
             }
             return operator;
         } catch (Exception e) {
-            LOG.debug("failed to invoke", e);
+            LOG.warn("failed to invoke", e);
             if (invoker.isMetaFunction) {
                 throw new StarRocksPlannerException(ErrorType.USER_ERROR, ExceptionUtils.getRootCauseMessage(e));
             }

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -421,9 +421,9 @@ public class ScalarOperatorFunctionsTest {
                 ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("98-02-21"),
                         ConstantOperator.createVarchar("%y-%m-%d")).toString());
 
-        Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
-                .dateParse(ConstantOperator.createVarchar("201905"),
-                        ConstantOperator.createVarchar("%Y%m")).getDatetime());
+        assertEquals("2019-05-01T00:00",
+                ScalarOperatorFunctions.dateParse(ConstantOperator.createVarchar("201905"),
+                        ConstantOperator.createVarchar("%Y%m")).getDatetime().toString());
 
         Assert.assertThrows(DateTimeException.class, () -> ScalarOperatorFunctions
                 .dateParse(ConstantOperator.createVarchar("20190507"),


### PR DESCRIPTION
Before this patch, we get different output when parse '202311' in StarRocks and Trino/Presto.
StarRocks:
```
MySQL [(none)]>  select date_parse(cast(202311 as varchar),'%Y%m');
+----------------------------------------------+
| str_to_date(CAST(202311 AS VARCHAR), '%Y%m') |
+----------------------------------------------+
| NULL                                         |
+----------------------------------------------+
```
Presto:
```
presto:xx> select date_parse(cast(202311 as varchar),'%Y%m');
          _col0          
-------------------------
 2023-11-01 00:00:00.000 
```
This patch fixed this.

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [x] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5