### PR TITLE
[UT] Fix BinaryFunctionsTest.TestToBinaryNormal test case

### DIFF
--- a/be/test/exprs/binary_functions_test.cpp
+++ b/be/test/exprs/binary_functions_test.cpp
@@ -51,7 +51,7 @@ public:
         return BinaryFunctions::from_binary(ctx.get(), columns);
     }
 
-    Slice hex_binary(const Slice& str) {
+    std::string hex_binary(const Slice& str) {
         std::stringstream ss;
         ss << std::hex << std::uppercase << std::setfill('0');
         for (int i = 0; i < str.size; ++i) {
@@ -88,9 +88,9 @@ TEST_F(BinaryFunctionsTest, TestToBinaryNormal) {
         ASSERT_TRUE(!v->is_null(0));
         ASSERT_EQ(v->size(), 1);
         if (binary_type == BinaryFormatType::HEX) {
-            ASSERT_EQ(Slice(expect), hex_binary(v->get_data()[0]));
+            ASSERT_EQ(expect, hex_binary(v->get_data()[0]));
         } else {
-            ASSERT_EQ(Slice(expect), v->get_data()[0]);
+            ASSERT_EQ(expect, v->get_data()[0]);
         }
     }
 

--- a/be/test/formats/csv/varbinary_converter_test.cpp
+++ b/be/test/formats/csv/varbinary_converter_test.cpp
@@ -56,10 +56,10 @@ TEST_F(VarBinaryConverterTest, test_read_varbinary) {
     EXPECT_TRUE(conv->read_string(col.get(), " 0101", Converter::Options()));
 
     EXPECT_EQ(4, col->size());
-    ASSERT_EQ(Slice("AB"), hex_binary(col->get(0).get_slice()));
-    ASSERT_EQ(Slice("0101"), hex_binary(col->get(1).get_slice()));
-    ASSERT_EQ(Slice("AB"), hex_binary(col->get(2).get_slice()));
-    ASSERT_EQ(Slice("0101"), hex_binary(col->get(3).get_slice()));
+    ASSERT_EQ("AB", hex_binary(col->get(0).get_slice()));
+    ASSERT_EQ("0101", hex_binary(col->get(1).get_slice()));
+    ASSERT_EQ("AB", hex_binary(col->get(2).get_slice()));
+    ASSERT_EQ("0101", hex_binary(col->get(3).get_slice()));
 
     EXPECT_FALSE(conv->read_string(col.get(), "xyz", Converter::Options()));
     EXPECT_FALSE(conv->read_string(col.get(), "1", Converter::Options()));


### PR DESCRIPTION
Why I'm doing:

```
[ RUN      ] BinaryFunctionsTest.TestToBinaryNormal
good case, arg:abab
/root/starrocks/be/test/exprs/binary_functions_test.cpp:91: Failure
Expected equality of these values:
  Slice(expect)
    Which is: ABAB
  hex_binary(v->get_data()[0])
    Which is: �v��
[  FAILED  ] BinaryFunctionsTest.TestToBinaryNormal (0 ms)
[ RUN      ] BinaryFunctionsTest.TestToBinaryNull
[       OK ] BinaryFunctionsTest.TestToBinaryNull (0 ms)
[ RUN      ] BinaryFunctionsTest.TestFromToBinaryNormal
```
What I'm doing:

```
[BE-UT] BinaryFunctionsTest TestToBinaryNormal
[BE-UT] VarBinaryConverterTest test_read_varbinary
```
Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5

