### PR TITLE
[Feature] Support set index for dbt

### DIFF
--- a/contrib/dbt-connector/README.md
+++ b/contrib/dbt-connector/README.md
@@ -77,20 +77,21 @@ starrocks:
 #### Complete configuration:
 ```
 models:
-  materialized: table       // table or view or materialized_view
+  materialized: table                   // table or view or materialized_view
   engine: 'OLAP'
   keys: ['id', 'name', 'some_date']
-  table_type: 'PRIMARY'     // PRIMARY or DUPLICATE or UNIQUE
+  table_type: 'PRIMARY'                 // PRIMARY or DUPLICATE or UNIQUE
   distributed_by: ['id']
-  buckets: 3                // default 10
+  buckets: 3                            // default 10
+  indexs=[{ 'columns': 'idx_column' }]  
   partition_by: ['some_date']
   partition_by_init: ["PARTITION p1 VALUES [('1971-01-01 00:00:00'), ('1991-01-01 00:00:00')),PARTITION p1972 VALUES [('1991-01-01 00:00:00'), ('1999-01-01 00:00:00'))"]
   // RANGE, LIST, or Expr partition types should be used in conjunction with partition_by configuration
   // Expr partition type requires an expression (e.g., date_trunc) specified in partition_by
-  order_by: ['some_column'] // only for PRIMARY table_type
-  partition_type: 'RANGE'   // RANGE or LIST or Expr Need to be used in combination with partition_by configuration
+  order_by: ['some_column']             // only for PRIMARY table_type
+  partition_type: 'RANGE'               // RANGE or LIST or Expr Need to be used in combination with partition_by configuration
   properties: [{"replication_num":"1", "in_memory": "true"}]
-  refresh_method: 'async'   // only for materialized view default manual
+  refresh_method: 'async'               // only for materialized view default manual
 ```
   
 ### dbt run config:
@@ -98,6 +99,7 @@ models:
 ```
 {{ config(materialized='view') }}
 {{ config(materialized='table', engine='OLAP', buckets=32, distributed_by=['id']) }}
+{{ config(materialized='table', indexs=[{ 'columns': 'idx_column' }]) }}
 {{ config(materialized='table', partition_by=['date_trunc("day", first_order)'], partition_type='Expr') }}
 {{ config(materialized='table', table_type='PRIMARY', keys=['customer_id'], order_by=['first_name', 'last_name'] }}
 {{ config(materialized='incremental', table_type='PRIMARY', engine='OLAP', buckets=32, distributed_by=['id']) }}

--- a/contrib/dbt-connector/dbt/include/starrocks/macros/materializations/models/table.sql
+++ b/contrib/dbt-connector/dbt/include/starrocks/macros/materializations/models/table.sql
@@ -17,10 +17,20 @@
 {% macro starrocks__create_table_as(temporary, relation, sql) -%}
   {%- set sql_header = config.get('sql_header', none) -%}
   {%- set engine = config.get('engine', 'OLAP') -%}
+  {%- set indexs = config.get('indexs') -%}
 
   {{ sql_header if sql_header is not none }}
 
   create table {{ relation.include(database=False) }}
+  {%- if indexs is not none -%}
+    {%- for index in indexs -%}
+      {%- set columns = index.get('columns') -%}
+      (
+        INDEX idx_{{ columns | replace(" ", "") | replace(",", "_") }} ({{ columns }}) USING BITMAP
+      )
+    {%- endfor -%}
+  {%- endif -%}
+
   {%- if engine == 'OLAP' -%}
     {{ starrocks__olap_table(True) }}
   {%- else -%}


### PR DESCRIPTION
Why I'm doing:
Users cannot set indexes when dbt is creating a table

What I'm doing:
Adding a configuration index allows you to flexibly set indexes when creating tables.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
