### PR TITLE
[Refactor] Add slow log for edit log write and refine some code warnings

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/Config.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/Config.java
@@ -367,6 +367,9 @@ public class Config extends ConfigBase {
     @ConfField(mutable = true)
     public static int edit_log_roll_num = 50000;
 
+    @ConfField(mutable = true)
+    public static int edit_log_write_slow_log_threshold_ms = 2000;
+
     /**
      * whether ignore unknown log id
      * when fe rolls back to low version, there may be log id that low version fe can not recognise

--- a/fe/fe-core/src/main/java/com/starrocks/journal/Journal.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/Journal.java
@@ -24,43 +24,43 @@ import java.util.List;
 public interface Journal {
 
     // Open the journal environment
-    public void open() throws InterruptedException, JournalException;
+    void open() throws InterruptedException, JournalException;
 
     // Roll Edit file or database
-    public void rollJournal(long journalId) throws JournalException;
+    void rollJournal(long journalId) throws JournalException;
 
     // Get the newest journal id 
-    public long getMaxJournalId();
+    long getMaxJournalId();
 
     // Close the environment
-    public void close();
+    void close();
 
     // Get all the journals whose id: fromKey <= id <= toKey
     // toKey = -1 means toKey = Long.Max_Value
-    public JournalCursor read(long fromKey, long toKey)
+    JournalCursor read(long fromKey, long toKey)
             throws JournalException, JournalInconsistentException, InterruptedException;
 
     // Delete journals whose max id is less than deleteToJournalId
-    public void deleteJournals(long deleteJournalToId);
+    void deleteJournals(long deleteJournalToId);
 
     // Current db's min journal id - 1
-    public long getFinalizedJournalId();
+    long getFinalizedJournalId();
 
     // Get all the dbs' name
-    public List<Long> getDatabaseNames();
+    List<Long> getDatabaseNames();
 
     // only support batch write
     // start batch write
-    public void batchWriteBegin() throws InterruptedException, JournalException;
+    void batchWriteBegin() throws InterruptedException, JournalException;
 
     // append buffer to current batch
-    public void batchWriteAppend(long journalId, DataOutputBuffer buffer) throws InterruptedException, JournalException;
+    void batchWriteAppend(long journalId, DataOutputBuffer buffer) throws InterruptedException, JournalException;
 
     // persist current batch
-    public void batchWriteCommit() throws InterruptedException, JournalException;
+    void batchWriteCommit() throws InterruptedException, JournalException;
 
     // abort current batch
-    public void batchWriteAbort() throws InterruptedException, JournalException;
+    void batchWriteAbort() throws InterruptedException, JournalException;
 
-    public String getPrefix();
+    String getPrefix();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalCursor.java
@@ -21,19 +21,19 @@ package com.starrocks.journal;
 public interface JournalCursor {
 
     // meaning read till the end
-    public static long CUROSR_END_KEY = -1;
+    long CURSOR_END_KEY = -1;
 
     // Return the next journal.
-    // Return null when there is no more journals, or if need to retry from outside.
+    // Return null when there is no more journals, or if we need to retry from outside.
     // Raise a JournalException if there is an error in reading from the underlying storage.
     // Raise a JournalInconsistentException if read dirty data and need to exit
-    public JournalEntity next() throws InterruptedException, JournalException, JournalInconsistentException;
+    JournalEntity next() throws InterruptedException, JournalException, JournalInconsistentException;
 
     // refresh offer a way to update environment, such as update databases in current environment
-    public void refresh() throws InterruptedException, JournalException, JournalInconsistentException;
+    void refresh() throws InterruptedException, JournalException, JournalInconsistentException;
 
-    public void close();
+    void close();
 
     // skip current log
-    public void skipNext();
+    void skipNext();
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalEntity.java
@@ -207,7 +207,7 @@ public class JournalEntity implements Writable {
         opCode = in.readShort();
         // set it to true after the entity is truly read,
         // to avoid someone forget to call read method.
-        boolean isRead = false;
+        boolean isRead;
         LOG.debug("get opcode: {}", opCode);
         switch (opCode) {
             case OperationType.OP_SAVE_NEXTID:
@@ -859,7 +859,7 @@ public class JournalEntity implements Writable {
             }
             case OperationType.OP_DYNAMIC_PARTITION:
             case OperationType.OP_MODIFY_IN_MEMORY:
-            case OperationType.OP_SET_FORBIT_GLOBAL_DICT:
+            case OperationType.OP_SET_FORBIDDEN_GLOBAL_DICT:
             case OperationType.OP_MODIFY_REPLICATION_NUM:
             case OperationType.OP_MODIFY_WRITE_QUORUM:
             case OperationType.OP_MODIFY_REPLICATED_STORAGE:

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalFactory.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalFactory.java
@@ -29,8 +29,7 @@ public class JournalFactory {
         switch (type) {
             case BDB: {
                 BDBEnvironment environment = BDBEnvironment.initBDBEnvironment(nodeName);
-                Journal journal = new BDBJEJournal(environment);
-                return journal;
+                return new BDBJEJournal(environment);
             }
 
             default:

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalTask.java
@@ -90,13 +90,13 @@ public class JournalTask implements Future<Boolean> {
 
     @Override
     public boolean cancel(boolean mayInterruptIfRunning) {
-        // cannot canceled for now
+        // cannot be canceled for now
         return false;
     }
 
     @Override
     public boolean isCancelled() {
-        // cannot canceled for now
+        // cannot be canceled for now
         return false;
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/JournalWriter.java
@@ -35,8 +35,8 @@ import java.util.concurrent.BlockingQueue;
 public class JournalWriter {
     public static final Logger LOG = LogManager.getLogger(JournalWriter.class);
     // other threads can put log to this queue by calling Editlog.logEdit()
-    private BlockingQueue<JournalTask> journalQueue;
-    private Journal journal;
+    private final BlockingQueue<JournalTask> journalQueue;
+    private final Journal journal;
 
     // used for checking if edit log need to roll
     protected long rollJournalCounter = 0;
@@ -63,6 +63,8 @@ public class JournalWriter {
 
     /** Last timestamp in millisecond to log the commit triggered by delay. */
     private long lastLogTimeForDelayTriggeredCommit = -1;
+
+    private long lastSlowEditLogTimeNs = -1L;
 
     public JournalWriter(Journal journal, BlockingQueue<JournalTask> journalQueue) {
         this.journal = journal;
@@ -166,9 +168,7 @@ public class JournalWriter {
 
     /**
      * We should notify the caller to rollback or report error on abort, like this.
-     *
      * task.markAbort();
-     *
      * But now we have to exit for historical reason.
      * Note that if we exit here, the final clause(commit current batch) will not be executed.
      */
@@ -203,7 +203,7 @@ public class JournalWriter {
 
         // 3. check uncommitted journals by size
         uncommittedEstimatedBytes += currentJournal.estimatedSizeByte();
-        if (uncommittedEstimatedBytes >= Config.metadata_journal_max_batch_size_mb * 1024 * 1024) {
+        if (uncommittedEstimatedBytes >= (long) Config.metadata_journal_max_batch_size_mb * 1024 * 1024) {
             LOG.warn("uncommitted estimated bytes {} >= {}MB, will commit now",
                     uncommittedEstimatedBytes, Config.metadata_journal_max_batch_size_mb);
             return true;
@@ -217,9 +217,20 @@ public class JournalWriter {
      * update all metrics after batch write
      */
     private void updateBatchMetrics() {
-        if (MetricRepo.isInit) {
+        // Log slow edit log write if needed.
+        long currentTimeNs = System.nanoTime();
+        long durationMs = (currentTimeNs - startTimeNano) / 1000000;
+        final long DEFAULT_EDIT_LOG_SLOW_LOGGING_INTERVAL_NS = 2000000000L; // 2 seconds
+        if (durationMs > Config.edit_log_write_slow_log_threshold_ms &&
+                currentTimeNs - lastSlowEditLogTimeNs > DEFAULT_EDIT_LOG_SLOW_LOGGING_INTERVAL_NS) {
+            LOG.warn("slow edit log write, batch size: {}, took: {}ms, current journal queue size: {}," +
+                    " please check the IO pressure of FE LEADER node or the latency between LEADER and FOLLOWER nodes",
+                    currentBatchTasks.size(), durationMs, journalQueue.size());
+            lastSlowEditLogTimeNs = currentTimeNs;
+        }
+        if (MetricRepo.hasInit) {
             MetricRepo.COUNTER_EDIT_LOG_WRITE.increase((long) currentBatchTasks.size());
-            MetricRepo.HISTO_JOURNAL_WRITE_LATENCY.update((System.nanoTime() - startTimeNano) / 1000000);
+            MetricRepo.HISTO_JOURNAL_WRITE_LATENCY.update(durationMs);
             MetricRepo.HISTO_JOURNAL_WRITE_BATCH.update(currentBatchTasks.size());
             MetricRepo.HISTO_JOURNAL_WRITE_BYTES.update(uncommittedEstimatedBytes);
             MetricRepo.GAUGE_STACKED_JOURNAL_NUM.setValue((long) journalQueue.size());

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBEnvironment.java
@@ -91,7 +91,7 @@ public class BDBEnvironment {
     protected static int SLEEP_INTERVAL_SEC = 5;
     private static final int MEMORY_CACHE_PERCENT = 20;
     // wait at most 10 seconds after environment initialized for state change
-    private static final int INITAL_STATE_CHANGE_WAIT_SEC = 10;
+    private static final int INITIAL_STATE_CHANGE_WAIT_SEC = 10;
 
     public static final String STARROCKS_JOURNAL_GROUP = "PALO_JOURNAL_GROUP";
     private static final String BDB_DIR = "/bdb";
@@ -114,9 +114,6 @@ public class BDBEnvironment {
 
     /**
      * init & return bdb environment
-     * @param nodeName
-     * @return
-     * @throws JournalException
      */
     public static BDBEnvironment initBDBEnvironment(String nodeName) throws JournalException, InterruptedException {
         // check for port use
@@ -279,7 +276,7 @@ public class BDBEnvironment {
 
                 LOG.info("replicated environment is all set, wait for state change...");
                 // wait for master change, otherwise a ReplicaWriteException exception will be thrown
-                for (int j = 0; j < INITAL_STATE_CHANGE_WAIT_SEC; j++) {
+                for (int j = 0; j < INITIAL_STATE_CHANGE_WAIT_SEC; j++) {
                     if (FrontendNodeType.UNKNOWN != listener.getNewType()) {
                         break;
                     }
@@ -298,7 +295,7 @@ public class BDBEnvironment {
                     // environment with information about this node, if it's a new node and is joining the group for
                     // the first time.
                     LOG.warn(
-                            "failed to setup environment because of UnknowMasterException for the first time, ignore it.");
+                            "failed to setup environment because of UnknownMasterException for the first time, ignore it.");
                     continue;
                 }
                 String errMsg = String.format("failed to setup environment after retried %d times", i + 1);
@@ -326,7 +323,6 @@ public class BDBEnvironment {
      *    --> The new follower will run as a master in a standalone environment.
      * 2. User restarts this follower with a helper.
      *    --> Sometimes this new follower will join the group successfully, making master crash.
-     *
      * This method only init the replicated environment through a handshake.
      * It will not read or write any data.
      */
@@ -456,7 +452,7 @@ public class BDBEnvironment {
         try {
             // the first parameter null means auto-commit
             replicatedEnvironment.removeDatabase(null, dbName);
-            LOG.info("remove database {} from replicatedEnviroment successfully", dbName);
+            LOG.info("remove database {} from replicatedEnvironment successfully", dbName);
         } catch (DatabaseNotFoundException e) {
             LOG.warn("Exception: {} does not exist", dbName, e);
         }
@@ -474,7 +470,7 @@ public class BDBEnvironment {
             return null;
         }
 
-        List<Long> ret = new ArrayList<Long>();
+        List<Long> ret = new ArrayList<>();
         List<String> names = replicatedEnvironment.getDatabaseNames();
         for (String name : names) {
             // We don't count epochDB

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBJournalCursor.java
@@ -59,20 +59,19 @@ public class BDBJournalCursor implements JournalCursor {
     private static final int RETRY_TIME = 3;
     private static final long SLEEP_INTERVAL_SEC = 3;
 
-    private long toKey;
+    private final long toKey;
     private long nextKey;
-    private BDBEnvironment environment;
-    // names of all local databases, will set on initialization, and will update every time `prelong()` is called
+    private final BDBEnvironment environment;
+    // names of all local databases, will set on initialization, and will update every time `refresh()` is called
     protected List<Long> localDBNames = null;
     // index of next db to be opened
     protected int nextDbPositionIndex = -1;
     // the database of current log
     protected CloseSafeDatabase database = null;
-    private String prefix;
+    private final String prefix;
 
     /**
      * handle DatabaseException carefully
-     *
      * 1. wrap as JournalException and return if it's a normal DatabaseException.
      * 2. RestartRequiredException is a fatal error since we're replaying as a follower, we must exit by raising an
      * JournalInconsistentException. Same with EnvironmentFailureException when replicated environment is invalid.
@@ -112,13 +111,13 @@ public class BDBJournalCursor implements JournalCursor {
 
     /**
      * init journal cursor
-     * if toKey = -1(CUROSR_END_KEY), it will automatically search the end.
+     * if toKey = -1(CURSOR_END_KEY), it will automatically search the end.
      */
     public static BDBJournalCursor getJournalCursor(BDBEnvironment env, String prefix, long fromKey, long toKey)
             throws JournalException, JournalInconsistentException, InterruptedException {
         if (fromKey < 0  // fromKey must be a positive number
                 || (toKey > 0 && toKey < fromKey)  // if toKey is a positive number, it must be smaller than fromKey
-                || (toKey <= 0 && toKey != JournalCursor.CUROSR_END_KEY)  // if toKey is a negative number, it must be END
+                || (toKey <= 0 && toKey != JournalCursor.CURSOR_END_KEY)  // if toKey is a negative number, it must be END
             ) {
             throw new JournalException(String.format("Invalid key range! fromKey %s toKey %s", fromKey, toKey));
         }
@@ -129,7 +128,6 @@ public class BDBJournalCursor implements JournalCursor {
 
     /**
      * calculate the index of next db to be opened
-     *
      * there are two cases:
      * 1. if this is the first time, we're actually looking for the db of nextKey
      * 2. otherwise, we've already opened a db for previous key. Now we're looking for the next db of the previous key
@@ -195,7 +193,7 @@ public class BDBJournalCursor implements JournalCursor {
         }
 
         // 3. update db index
-        LOG.info("update dbnames {} -> {}", localDBNames, dbNames);
+        LOG.info("update dbNames {} -> {}", localDBNames, dbNames);
         localDBNames = dbNames;
         calculateNextDbIndex();
     }
@@ -220,7 +218,7 @@ public class BDBJournalCursor implements JournalCursor {
             database = null;
         }
 
-        String dbName = prefix + Long.toString(localDBNames.get(nextDbPositionIndex));
+        String dbName = prefix + localDBNames.get(nextDbPositionIndex);
         JournalException exception = null;
         for (int i = 0; i < RETRY_TIME; ++ i) {
             try {
@@ -297,7 +295,7 @@ public class BDBJournalCursor implements JournalCursor {
                     return entity;
                 } else if (operationStatus == OperationStatus.NOTFOUND) {
                     // read until there is no more log exists, return
-                    if (toKey == JournalCursor.CUROSR_END_KEY) {
+                    if (toKey == JournalCursor.CURSOR_END_KEY) {
                         return null;
                     }
                     // In the case:

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBTool.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBTool.java
@@ -62,8 +62,8 @@ import java.util.Map;
 public class BDBTool {
     private static final Logger LOG = LogManager.getLogger(BDBTool.class);
 
-    private String metaPath;
-    private BDBToolOptions options;
+    private final String metaPath;
+    private final BDBToolOptions options;
 
     public BDBTool(String metaPath, BDBToolOptions options) {
         this.metaPath = metaPath;
@@ -76,7 +76,7 @@ public class BDBTool {
         envConfig.setReadOnly(true);
         envConfig.setCachePercent(20);
 
-        Environment env = null;
+        Environment env;
         try {
             env = new Environment(new File(metaPath), envConfig);
         } catch (DatabaseException e) {
@@ -91,7 +91,7 @@ public class BDBTool {
                 // list all databases
                 List<String> dbNames = env.getDatabaseNames();
                 JSONArray jsonArray = new JSONArray(dbNames);
-                System.out.println(jsonArray.toString());
+                System.out.println(jsonArray);
                 return true;
             } else {
                 // db operations
@@ -106,11 +106,11 @@ public class BDBTool {
                         Map<String, String> statMap = Maps.newHashMap();
                         statMap.put("count", String.valueOf(db.count()));
                         JSONObject jsonObject = new JSONObject(statMap);
-                        System.out.println(jsonObject.toString());
+                        System.out.println(jsonObject);
                         return true;
                     } else {
                         // set from key
-                        long fromKey = 0L;
+                        long fromKey;
                         String fromKeyStr = options.hasFromKey() ? options.getFromKey() : dbName;
                         try {
                             fromKey = Long.parseLong(fromKeyStr);

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBToolOptions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/BDBToolOptions.java
@@ -38,15 +38,15 @@ import com.google.common.base.Strings;
 import com.starrocks.common.FeConstants;
 
 public class BDBToolOptions {
-    private boolean isListDbs;
-    private String dbName;
-    private boolean isDbStat;
-    private boolean hasFromKey;
-    private String fromKey;
-    private boolean hasEndKey;
-    private String endKey;
-    private int metaVersion;
-    private int starrocksMetaVersion;
+    private final boolean isListDbs;
+    private final String dbName;
+    private final boolean isDbStat;
+    private final boolean hasFromKey;
+    private final String fromKey;
+    private final boolean hasEndKey;
+    private final String endKey;
+    private final int metaVersion;
+    private final int starrocksMetaVersion;
 
     public BDBToolOptions(boolean isListDbs, String dbName, boolean isDbStat,
                           String fromKey, String endKey, int metaVersion, int starrocksMetaVersion) {
@@ -101,12 +101,12 @@ public class BDBToolOptions {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("list bdb database: " + isListDbs).append("\n");
-        sb.append("bdb database name: " + dbName).append("\n");
-        sb.append("get bdb database stat: " + isDbStat).append("\n");
-        sb.append("from key" + fromKey).append("\n");
-        sb.append("end key: " + endKey).append("\n");
-        sb.append("meta version: " + metaVersion + "," + starrocksMetaVersion).append("\n");
+        sb.append("list bdb database: ").append(isListDbs).append("\n");
+        sb.append("bdb database name: ").append(dbName).append("\n");
+        sb.append("get bdb database stat: ").append(isDbStat).append("\n");
+        sb.append("from key").append(fromKey).append("\n");
+        sb.append("end key: ").append(endKey).append("\n");
+        sb.append("meta version: ").append(metaVersion).append(",").append(starrocksMetaVersion).append("\n");
         return sb.toString();
     }
 }

--- a/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
+++ b/fe/fe-core/src/main/java/com/starrocks/journal/bdbje/CloseSafeDatabase.java
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
- * this class guarantee that when bdb database is closing, there will be neither read or write operations on that db
+ * this class guarantee that when bdb database is closing, there will be neither read nor write operations on that db
  */
 public class CloseSafeDatabase {
     private final Database db;

--- a/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
+++ b/fe/fe-core/src/main/java/com/starrocks/leader/Checkpoint.java
@@ -187,7 +187,7 @@ public class Checkpoint extends FrontendDaemon {
                 deleteVersion = Math.min(minOtherNodesJournalId, checkpointVersion);
             }
             journal.deleteJournals(deleteVersion + 1);
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_IMAGE_PUSH.increase(1L);
             }
             LOG.info("journals <= {} with prefix [{}] are deleted. image version {}, other nodes min version {}",
@@ -216,7 +216,7 @@ public class Checkpoint extends FrontendDaemon {
             globalStateMgr.clearExpiredJobs();
             globalStateMgr.saveImage();
             replayedJournalId = globalStateMgr.getReplayedJournalId();
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_IMAGE_WRITE.increase(1L);
             }
             GlobalStateMgr.getServingState().setImageJournalId(checkPointVersion);

--- a/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/loadv2/LoadJob.java
@@ -674,7 +674,7 @@ public abstract class LoadJob extends AbstractTxnStateChangeCallback implements 
         GlobalStateMgr.getCurrentGlobalTransactionMgr().getCallbackFactory().removeCallback(id);
         state = JobState.FINISHED;
 
-        if (MetricRepo.isInit) {
+        if (MetricRepo.hasInit) {
             MetricRepo.COUNTER_LOAD_FINISHED.increase(1L);
         }
         // when load job finished, there is no need to hold the tasks which are the biggest memory consumers.

--- a/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/load/routineload/RoutineLoadJob.java
@@ -750,7 +750,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
         this.receivedBytes += receivedBytes;
         this.totalTaskExcutionTimeMs += taskExecutionTime;
 
-        if (MetricRepo.isInit && !isReplay) {
+        if (MetricRepo.hasInit && !isReplay) {
             MetricRepo.COUNTER_ROUTINE_LOAD_ROWS.increase(numOfTotalRows);
             MetricRepo.COUNTER_ROUTINE_LOAD_ERROR_ROWS.increase(numOfErrorRows);
             MetricRepo.COUNTER_ROUTINE_LOAD_RECEIVED_BYTES.increase(receivedBytes);
@@ -1309,7 +1309,7 @@ public abstract class RoutineLoadJob extends AbstractTxnStateChangeCallback impl
             GlobalStateMgr.getCurrentState().getEditLog().logOpRoutineLoadJob(new RoutineLoadOperation(id, jobState));
         }
 
-        if (!isReplay && MetricRepo.isInit && JobState.PAUSED == jobState) {
+        if (!isReplay && MetricRepo.hasInit && JobState.PAUSED == jobState) {
             MetricRepo.COUNTER_ROUTINE_LOAD_PAUSED.increase(1L);
         }
         LOG.info(new LogBuilder(LogKey.ROUTINE_LOAD_JOB, id)

--- a/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/metric/MetricRepo.java
@@ -97,7 +97,7 @@ public final class MetricRepo {
     private static final MetricRegistry METRIC_REGISTER = new MetricRegistry();
     private static final StarRocksMetricRegistry STARROCKS_METRIC_REGISTER = new StarRocksMetricRegistry();
 
-    public static volatile boolean isInit = false;
+    public static volatile boolean hasInit = false;
     public static final SystemMetrics SYSTEM_METRICS = new SystemMetrics();
 
     public static final String TABLET_NUM = "tablet_num";
@@ -167,7 +167,7 @@ public final class MetricRepo {
     private static final MetricCalculator METRIC_CALCULATOR = new MetricCalculator();
 
     public static synchronized void init() {
-        if (isInit) {
+        if (hasInit) {
             return;
         }
 
@@ -232,14 +232,14 @@ public final class MetricRepo {
         generateBackendsTabletMetrics();
 
         // connections
-        GaugeMetric<Integer> conections = new GaugeMetric<Integer>(
+        GaugeMetric<Integer> connections = new GaugeMetric<Integer>(
                 "connection_total", MetricUnit.CONNECTIONS, "total connections") {
             @Override
             public Integer getValue() {
                 return ExecuteEnv.getInstance().getScheduler().getConnectionNum();
             }
         };
-        STARROCKS_METRIC_REGISTER.addMetric(conections);
+        STARROCKS_METRIC_REGISTER.addMetric(connections);
 
         // journal id
         GaugeMetric<Long> maxJournalId = (GaugeMetric<Long>) new GaugeMetric<Long>(
@@ -415,7 +415,7 @@ public final class MetricRepo {
         COUNTER_TXN_REJECT =
                 new LongCounterMetric("txn_reject", MetricUnit.REQUESTS, "counter of rejected transactions");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TXN_REJECT);
-        COUNTER_TXN_BEGIN = new LongCounterMetric("txn_begin", MetricUnit.REQUESTS, "counter of begining transactions");
+        COUNTER_TXN_BEGIN = new LongCounterMetric("txn_begin", MetricUnit.REQUESTS, "counter of beginning transactions");
         STARROCKS_METRIC_REGISTER.addMetric(COUNTER_TXN_BEGIN);
         COUNTER_TXN_SUCCESS =
                 new LongCounterMetric("txn_success", MetricUnit.REQUESTS, "counter of success transactions");
@@ -474,7 +474,7 @@ public final class MetricRepo {
         initMemoryMetrics();
 
         updateMetrics();
-        isInit = true;
+        hasInit = true;
 
         if (Config.enable_metric_calculator) {
             METRIC_TIMER.scheduleAtFixedRate(METRIC_CALCULATOR, 0, 15 * 1000L, TimeUnit.MILLISECONDS);
@@ -752,7 +752,7 @@ public final class MetricRepo {
         STARROCKS_METRIC_REGISTER.addMetric(agentTaskCount);
     }
 
-    // to generate the metrics related to tablets of each backends
+    // to generate the metrics related to tablets of each backend
     // this metric is reentrant, so that we can add or remove metric along with the backend add or remove
     // at runtime.
     public static void generateBackendsTabletMetrics() {
@@ -769,7 +769,7 @@ public final class MetricRepo {
                 continue;
             }
 
-            // tablet number of each backends
+            // tablet number of each backend
             GaugeMetric<Long> tabletNum = (GaugeMetric<Long>) new GaugeMetric<Long>(TABLET_NUM,
                     MetricUnit.NOUNIT, "tablet number") {
                 @Override
@@ -783,7 +783,7 @@ public final class MetricRepo {
             tabletNum.addLabel(new MetricLabel("backend", be.getHost() + ":" + be.getHeartbeatPort()));
             STARROCKS_METRIC_REGISTER.addMetric(tabletNum);
 
-            // max compaction score of tablets on each backends
+            // max compaction score of tablets on each backend
             GaugeMetric<Long> tabletMaxCompactionScore = (GaugeMetric<Long>) new GaugeMetric<Long>(
                     TABLET_MAX_COMPACTION_SCORE, MetricUnit.NOUNIT,
                     "tablet max compaction score") {
@@ -879,7 +879,7 @@ public final class MetricRepo {
     }
 
     public static synchronized String getMetric(MetricVisitor visitor, MetricsAction.RequestParams requestParams) {
-        if (!isInit) {
+        if (!hasInit) {
             return "";
         }
 

--- a/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
+++ b/fe/fe-core/src/main/java/com/starrocks/persist/OperationType.java
@@ -272,7 +272,7 @@ public class OperationType {
     public static final short OP_MODIFY_IN_MEMORY = 267;
 
     // global dict
-    public static final short OP_SET_FORBIT_GLOBAL_DICT = 268;
+    public static final short OP_SET_FORBIDDEN_GLOBAL_DICT = 268;
 
     // plugin 270~275
     public static final short OP_INSTALL_PLUGIN = 270;

--- a/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
+++ b/fe/fe-core/src/main/java/com/starrocks/qe/ResultReceiver.java
@@ -150,7 +150,7 @@ public class ResultReceiver {
             LOG.warn("fetch result timeout, finstId={}", DebugUtil.printId(finstId), e);
             status.setInternalErrorStatus(String.format("Query exceeded time limit of %d seconds",
                     ConnectContext.get().getSessionVariable().getQueryTimeoutS()));
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_QUERY_TIMEOUT.increase(1L);
             }
         } finally {

--- a/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/GlobalStateMgr.java
@@ -1838,7 +1838,7 @@ public class GlobalStateMgr {
                     if (cursor == null) {
                         // 1. set replay to the end
                         LOG.info("start to replay from {}", replayedJournalId.get());
-                        cursor = journal.read(replayedJournalId.get() + 1, JournalCursor.CUROSR_END_KEY);
+                        cursor = journal.read(replayedJournalId.get() + 1, JournalCursor.CURSOR_END_KEY);
                     } else {
                         cursor.refresh();
                     }
@@ -2011,7 +2011,7 @@ public class GlobalStateMgr {
             if (feType != FrontendNodeType.LEADER) {
                 journalObservable.notifyObservers(replayedJournalId.get());
             }
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 // Metric repo may not init after this replay thread start
                 MetricRepo.COUNTER_EDIT_LOG_READ.increase(1L);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/server/LocalMetastore.java
@@ -4509,7 +4509,7 @@ public class LocalMetastore implements ConnectorMetadata {
                 }
                 ModifyTablePropertyOperationLog info =
                         new ModifyTablePropertyOperationLog(db.getId(), table.getId(), property);
-                GlobalStateMgr.getCurrentState().getEditLog().logSetHasForbitGlobalDict(info);
+                GlobalStateMgr.getCurrentState().getEditLog().logSetHasForbiddenGlobalDict(info);
             }
         } finally {
             locker.unLockDatabase(db, LockType.READ);
@@ -4548,7 +4548,7 @@ public class LocalMetastore implements ConnectorMetadata {
         locker.lockDatabase(db, LockType.WRITE);
         try {
             OlapTable olapTable = (OlapTable) db.getTable(tableId);
-            if (opCode == OperationType.OP_SET_FORBIT_GLOBAL_DICT) {
+            if (opCode == OperationType.OP_SET_FORBIDDEN_GLOBAL_DICT) {
                 String enAble = properties.get(PropertyAnalyzer.ENABLE_LOW_CARD_DICT_TYPE);
                 Preconditions.checkState(enAble != null);
                 if (olapTable != null) {

--- a/fe/fe-core/src/main/java/com/starrocks/staros/BDBJEJournalSystem.java
+++ b/fe/fe-core/src/main/java/com/starrocks/staros/BDBJEJournalSystem.java
@@ -95,7 +95,7 @@ public class BDBJEJournalSystem implements JournalSystem {
             bdbjeJournal.open();
 
             long replayStartTime = System.currentTimeMillis();
-            replayTo(JournalCursor.CUROSR_END_KEY);
+            replayTo(JournalCursor.CURSOR_END_KEY);
             long replayEndTime = System.currentTimeMillis();
             LOG.info("finish star manager replay in " + (replayEndTime - replayStartTime) + " msec.");
 

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/DatabaseTransactionMgr.java
@@ -333,7 +333,7 @@ public class DatabaseTransactionMgr {
             transactionState.setPrepareTime(System.currentTimeMillis());
             unprotectUpsertTransactionState(transactionState, false);
 
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_TXN_BEGIN.increase(1L);
             }
 
@@ -341,7 +341,7 @@ public class DatabaseTransactionMgr {
         } catch (DuplicatedRequestException e) {
             throw e;
         } catch (Exception e) {
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_TXN_REJECT.increase(1L);
             }
             throw e;

--- a/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
+++ b/fe/fe-core/src/main/java/com/starrocks/transaction/TransactionState.java
@@ -530,13 +530,13 @@ public class TransactionState implements Writable {
 
         // after status changed
         if (transactionStatus == TransactionStatus.VISIBLE) {
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_TXN_SUCCESS.increase(1L);
             }
             txnSpan.addEvent("set_visible");
             txnSpan.end();
         } else if (transactionStatus == TransactionStatus.ABORTED) {
-            if (MetricRepo.isInit) {
+            if (MetricRepo.hasInit) {
                 MetricRepo.COUNTER_TXN_FAILED.increase(1L);
             }
             txnSpan.setAttribute("state", "aborted");

--- a/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/journal/bdbje/BDBJEJournalTest.java
@@ -137,29 +137,29 @@ public class BDBJEJournalTest {
         writable.write(buffer);
 
         // 1. initial check
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         // 2. begin
         journal.batchWriteBegin();
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
 
         // 3. write 1
         journal.batchWriteAppend(1, buffer);
 
         // 4. commit 1
         journal.batchWriteCommit();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         // 3. write 2 logs & commit
         journal.batchWriteBegin();
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
         journal.batchWriteAppend(2, buffer);
         journal.batchWriteAppend(3, buffer);
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
 
         // 4. commmit
         journal.batchWriteCommit();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         // 5. check by read
         for (int i = 1; i != 4; i++) {
@@ -169,12 +169,12 @@ public class BDBJEJournalTest {
 
         // 6. abort
         journal.batchWriteAbort();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         // 7. begin -> abort
         journal.batchWriteBegin();
         journal.batchWriteAbort();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         // 8. write log -> abort
         journal.batchWriteBegin();
@@ -269,7 +269,7 @@ public class BDBJEJournalTest {
         };
 
         journal.batchWriteBegin();
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
         journal.batchWriteAppend(1, buffer);
     }
 
@@ -442,7 +442,7 @@ public class BDBJEJournalTest {
             @Mocked BDBEnvironment environment) throws Exception {
         BDBJEJournal journal = new BDBJEJournal(environment, database);
         journal.batchWriteBegin();
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
         journal.batchWriteBegin();
         Assert.fail();
     }
@@ -457,28 +457,28 @@ public class BDBJEJournalTest {
         DataOutputBuffer buffer = new DataOutputBuffer();
         Text.writeString(buffer, data);
 
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
         journal.batchWriteAbort();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         journal.batchWriteBegin();
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
         journal.batchWriteAbort();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         journal.batchWriteBegin();
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
         journal.batchWriteAppend(1, buffer);
         journal.batchWriteAbort();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
 
         journal.batchWriteBegin();
-        Assert.assertNotNull(journal.currentTrasaction);
+        Assert.assertNotNull(journal.currentTransaction);
         journal.batchWriteAppend(2, buffer);
         journal.batchWriteCommit();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
         journal.batchWriteAbort();
-        Assert.assertNull(journal.currentTrasaction);
+        Assert.assertNull(journal.currentTransaction);
     }
 
 


### PR DESCRIPTION
Why I'm doing:
If the IO pressure of FE leader node is high, the write of edit log may take a long time
and cause longer lock wait for other concurrent operations.

What I'm doing:
Add slow log for edit log write and refine some code warnings

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [x] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
