### PR TITLE
[BugFix] Fix eos flag error when having true predicate

### DIFF
--- a/be/src/exec/short_circuit.cpp
+++ b/be/src/exec/short_circuit.cpp
@@ -191,8 +191,14 @@ Status ShortCircuitExecutor::execute() {
             break;
         }
         RETURN_IF_ERROR(_source->get_next(runtime_state(), &chunk, &eos));
+        if (nullptr == chunk) {
+            break;
+        }
         eos = true;
         if (!_results.empty()) {
+            _source->close(runtime_state());
+            _finish = true;
+            close();
             return Status::NotSupported("Not support multi result set yet");
         }
         RETURN_IF_ERROR(_sink->send_chunk(runtime_state(), chunk.get()));

--- a/be/src/exec/short_circuit_hybrid.cpp
+++ b/be/src/exec/short_circuit_hybrid.cpp
@@ -106,6 +106,8 @@ Status ShortCircuitHybridScanNode::get_next(RuntimeState* state, ChunkPtr* chunk
             }
         }
         RETURN_IF_ERROR(ExecNode::eval_conjuncts(_conjunct_ctxs, result_chunk.get()));
+    } else {
+        *eos = true;
     }
     *chunk = std::move(result_chunk);
     return Status::OK();


### PR DESCRIPTION
Why I'm doing:
When empty records for short circuit read , will load eos flag error .  this pr will fix it


What I'm doing:

Fixes #issue
https://github.com/StarRocks/starrocks/issues/38841
## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
