### PR TITLE
[Enhancement] Adaptive coalesce active column and lazy column in ORC

### DIFF
--- a/be/src/exec/hdfs_scanner.h
+++ b/be/src/exec/hdfs_scanner.h
@@ -79,6 +79,9 @@ struct HdfsScanStats {
     int64_t group_min_round_cost = 0;
 
     std::vector<int64_t> orc_stripe_sizes;
+    // io coalesce
+    int64_t orc_stripe_active_lazy_coalesce_together = 0;
+    int64_t orc_stripe_active_lazy_coalesce_seperately = 0;
 
     // Iceberg v2 only!
     int64_t iceberg_delete_file_build_ns = 0;

--- a/be/src/exec/hdfs_scanner_orc.cpp
+++ b/be/src/exec/hdfs_scanner_orc.cpp
@@ -318,6 +318,8 @@ Status HdfsOrcScanner::do_open(RuntimeState* runtime_state) {
     RETURN_IF_ERROR(open_random_access_file());
     auto input_stream = std::make_unique<ORCHdfsFileStream>(_file.get(), _file->get_size().value(),
                                                             _shared_buffered_input_stream.get());
+    input_stream->set_lazy_column_coalesce_counter(_scanner_ctx.lazy_column_coalesce_counter);
+    input_stream->set_app_stats(&_app_stats);
     ORCHdfsFileStream* orc_hdfs_file_stream = input_stream.get();
 
     SCOPED_RAW_TIMER(&_app_stats.reader_init_ns);
@@ -510,10 +512,17 @@ Status HdfsOrcScanner::do_get_next(RuntimeState* runtime_state, ChunkPtr* chunk)
         }
 
         // if has lazy load fields, skip it if chunk_size == 0
-        if (chunk_size == 0) {
+        bool require_load_lazy_columns = chunk_size != 0;
+        if (require_load_lazy_columns) {
+            // still need to load lazy column
+            _scanner_ctx.lazy_column_coalesce_counter->fetch_add(1, std::memory_order_relaxed);
+        } else {
+            // dont need to load lazy column
+            _scanner_ctx.lazy_column_coalesce_counter->fetch_sub(1, std::memory_order_relaxed);
             _app_stats.late_materialize_skip_rows += init_chunk_size;
             continue;
         }
+
         {
             SCOPED_RAW_TIMER(&_app_stats.column_read_ns);
             RETURN_IF_ERROR(_orc_reader->lazy_seek_to(position.row_in_stripe));
@@ -585,6 +594,16 @@ void HdfsOrcScanner::do_update_counter(HdfsScanProfile* profile) {
 
     COUNTER_UPDATE(stripe_avg_size_counter, avg_stripe_size);
     COUNTER_UPDATE(stripe_number_counter, _app_stats.orc_stripe_sizes.size());
+
+    RuntimeProfile::Counter* stripe_active_lazy_coalesce_together_counter = root->add_child_counter(
+            "StripeActiveLazyColumnIOCoalesceTogether", TUnit::UNIT,
+            RuntimeProfile::Counter::create_strategy(TCounterAggregateType::SUM), orcProfileSectionPrefix);
+    RuntimeProfile::Counter* stripe_active_lazy_coalesce_seperately_counter = root->add_child_counter(
+            "StripeActiveLazyColumnIOCoalesceSeperately", TUnit::UNIT,
+            RuntimeProfile::Counter::create_strategy(TCounterAggregateType::SUM), orcProfileSectionPrefix);
+    COUNTER_UPDATE(stripe_active_lazy_coalesce_together_counter, _app_stats.orc_stripe_active_lazy_coalesce_together);
+    COUNTER_UPDATE(stripe_active_lazy_coalesce_seperately_counter,
+                   _app_stats.orc_stripe_active_lazy_coalesce_seperately);
 }
 
 } // namespace starrocks

--- a/be/src/exec/hdfs_scanner_parquet.cpp
+++ b/be/src/exec/hdfs_scanner_parquet.cpp
@@ -97,10 +97,10 @@ void HdfsParquetScanner::do_update_counter(HdfsScanProfile* profile) {
     group_dict_filter_timer = ADD_CHILD_TIMER(root, "GroupDictFilter", kParquetProfileSectionPrefix);
     group_dict_decode_timer = ADD_CHILD_TIMER(root, "GroupDictDecode", kParquetProfileSectionPrefix);
 
-    group_active_lazy_coalesce_together =
-            ADD_CHILD_COUNTER(root, "GroupActiveLazyCoalesceTogether", TUnit::UNIT, kParquetProfileSectionPrefix);
-    group_active_lazy_coalesce_seperately =
-            ADD_CHILD_COUNTER(root, "GroupActiveLazyCoalesceSeperately", TUnit::UNIT, kParquetProfileSectionPrefix);
+    group_active_lazy_coalesce_together = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceTogether",
+                                                            TUnit::UNIT, kParquetProfileSectionPrefix);
+    group_active_lazy_coalesce_seperately = ADD_CHILD_COUNTER(root, "GroupActiveLazyColumnIOCoalesceSeperately",
+                                                              TUnit::UNIT, kParquetProfileSectionPrefix);
 
     has_page_statistics = ADD_CHILD_COUNTER(root, "HasPageStatistics", TUnit::UNIT, kParquetProfileSectionPrefix);
     page_skip = ADD_CHILD_COUNTER(root, "PageSkipCounter", TUnit::UNIT, kParquetProfileSectionPrefix);

--- a/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
+++ b/be/src/formats/orc/apache-orc/c++/include/orc/OrcFile.hh
@@ -55,6 +55,7 @@ public:
     struct IORange {
         uint64_t offset;
         uint64_t size;
+        bool is_active;
     };
     enum class PrepareCacheScope { READ_FULL_FILE, READ_FULL_STRIPE, READ_FULL_ROW_INDEX };
 
@@ -93,9 +94,10 @@ public:
 
     virtual void prepareCache(PrepareCacheScope scope, uint64_t offset, uint64_t length);
 
-    virtual bool isIORangesEnabled() const;
+    virtual bool isIOCoalesceEnabled() const;
+    virtual bool isIOAdaptiveCoalesceEnabled() const;
     virtual void clearIORanges();
-    virtual void setIORanges(std::vector<InputStream::IORange>& io_ranges);
+    virtual void setIORanges(std::vector<InputStream::IORange>& io_ranges, const bool is_from_stripe);
 };
 
 /**

--- a/be/src/formats/orc/orc_input_stream.h
+++ b/be/src/formats/orc/orc_input_stream.h
@@ -14,18 +14,15 @@
 
 #pragma once
 
+#include <exec/hdfs_scanner.h>
+
 #include <boost/algorithm/string.hpp>
 #include <orc/OrcFile.hh>
 
-#include "column/column_helper.h"
-#include "common/object_pool.h"
 #include "exprs/expr.h"
 #include "exprs/expr_context.h"
 #include "exprs/runtime_filter_bank.h"
-#include "formats/orc/orc_mapping.h"
 #include "io/shared_buffered_input_stream.h"
-#include "runtime/descriptors.h"
-#include "runtime/types.h"
 namespace starrocks {
 
 class RandomAccessFile;
@@ -68,9 +65,15 @@ public:
 
     const std::string& getName() const override;
 
-    bool isIORangesEnabled() const override { return config::orc_coalesce_read_enable; }
+    void set_lazy_column_coalesce_counter(const std::atomic<int32_t>* lazy_column_coalesce_counter) {
+        _lazy_column_coalesce_counter = lazy_column_coalesce_counter;
+    }
+    void set_app_stats(HdfsScanStats* stats) { _app_stats = stats; }
+    bool isIOCoalesceEnabled() const override { return config::orc_coalesce_read_enable; }
+    bool isIOAdaptiveCoalesceEnabled() const override { return config::io_coalesce_adaptive_lazy_active; }
+
     void clearIORanges() override;
-    void setIORanges(std::vector<IORange>& io_ranges) override;
+    void setIORanges(std::vector<IORange>& io_ranges, const bool is_from_stripe) override;
     void setStripes(std::vector<StripeInformation>&& stripes);
 
 private:
@@ -87,5 +90,8 @@ private:
     bool _tiny_stripe_read = false;
     uint64_t _last_stripe_index = 0;
     std::vector<StripeInformation> _stripes;
+
+    const std::atomic<int32_t>* _lazy_column_coalesce_counter = nullptr;
+    HdfsScanStats* _app_stats = nullptr;
 };
 } // namespace starrocks


### PR DESCRIPTION
Why I'm doing:
In some cases, active and lazy column will be coalesced together, When requeting io, their io will be requested together, in case of low-pass filter, lazy column is useless, we adaptivly coalesce them.

What I'm doing:
We already implement it in parquet reader: #25878, now I port this function to orc reader.

before:
```bash
 - InputStream: 
                 - AppIOBytesRead: 466.107 GB
                   - __MAX_OF_AppIOBytesRead: 423.052 MB
                   - __MIN_OF_AppIOBytesRead: 199.995 MB
                 - AppIOCounter: 690.829K (690829)
                   - __MAX_OF_AppIOCounter: 579
                   - __MIN_OF_AppIOCounter: 284
                 - AppIOTime: 2m6s
                   - __MAX_OF_AppIOTime: 2m47s
                   - __MIN_OF_AppIOTime: 1m45s
                 - FSIOBytesRead: 1.043 TB
                   - __MAX_OF_FSIOBytesRead: 899.855 MB
                   - __MIN_OF_FSIOBytesRead: 452.476 MB
                 - FSIOCounter: 524.775K (524775)
                   - __MAX_OF_FSIOCounter: 435
                   - __MIN_OF_FSIOCounter: 211
                 - FSIOTime: 2m6s
                   - __MAX_OF_FSIOTime: 2m47s
                   - __MIN_OF_FSIOTime: 1m44s
```

now:
```bash
 - InputStream: 
                 - AppIOBytesRead: 466.107 GB
                   - __MAX_OF_AppIOBytesRead: 404.787 MB
                   - __MIN_OF_AppIOBytesRead: 211.773 MB
                 - AppIOCounter: 690.829K (690829)
                   - __MAX_OF_AppIOCounter: 583
                   - __MIN_OF_AppIOCounter: 318
                 - AppIOTime: 18s704ms
                   - __MAX_OF_AppIOTime: 45s885ms
                   - __MIN_OF_AppIOTime: 12s519ms
                 - FSIOBytesRead: 468.213 GB
                   - __MAX_OF_FSIOBytesRead: 417.735 MB
                   - __MIN_OF_FSIOBytesRead: 211.773 MB
                 - FSIOCounter: 444.959K (444959)
                   - __MAX_OF_FSIOCounter: 374
                   - __MIN_OF_FSIOCounter: 204
                 - FSIOTime: 18s336ms
                   - __MAX_OF_FSIOTime: 45s654ms
                   - __MIN_OF_FSIOTime: 12s40ms
```


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
