### PR TITLE
[Feature] add FileBlockManager

### DIFF
--- a/be/src/common/status.cpp
+++ b/be/src/common/status.cpp
@@ -257,6 +257,8 @@ std::string Status::code_as_string() const {
         return "Task yield";
     case TStatusCode::JIT_COMPILE_ERROR:
         return "JIT compile error";
+    case TStatusCode::CAPACITY_LIMIT_EXCEED:
+        return "Capaticy limit exceeded";
     }
     return {};
 }

--- a/be/src/common/status.h
+++ b/be/src/common/status.h
@@ -149,6 +149,8 @@ public:
 
     static Status JitCompileError(std::string_view msg) { return Status(TStatusCode::JIT_COMPILE_ERROR, msg); }
 
+    static Status CapacityLimitExceed(std::string_view msg) { return Status(TStatusCode::CAPACITY_LIMIT_EXCEED, msg); }
+
     bool ok() const { return _state == nullptr; }
 
     bool is_cancelled() const { return code() == TStatusCode::CANCELLED; }

--- a/be/src/exec/CMakeLists.txt
+++ b/be/src/exec/CMakeLists.txt
@@ -285,6 +285,7 @@ set(EXEC_FILES
     spill/serde.cpp
     spill/input_stream.cpp
     spill/log_block_manager.cpp
+    spill/file_block_manager.cpp
     spill/operator_mem_resource_manager.cpp
     stream/state/mem_state_table.cpp
     stream/aggregate/agg_state_data.cpp

--- a/be/src/exec/spill/block_manager.h
+++ b/be/src/exec/spill/block_manager.h
@@ -50,9 +50,12 @@ public:
     virtual std::string debug_string() const = 0;
 
     size_t size() const { return _size; }
+    bool is_remote() const { return _is_remote; }
+    void set_is_remote(bool is_remote) { _is_remote = is_remote; }
 
 protected:
     size_t _size{};
+    bool _is_remote = false;
 };
 
 using BlockPtr = std::shared_ptr<Block>;

--- a/be/src/exec/spill/dir_manager.cpp
+++ b/be/src/exec/spill/dir_manager.cpp
@@ -14,6 +14,7 @@
 
 #include "exec/spill/dir_manager.h"
 
+#include <cstdlib>
 #include <regex>
 
 #include "common/config.h"
@@ -101,9 +102,20 @@ Status DirManager::init(const std::string& spill_dirs) {
 }
 
 StatusOr<Dir*> DirManager::acquire_writable_dir(const AcquireDirOptions& opts) {
-    // @TODO(silverbullet233): refine the strategy for dir selection
-    size_t idx = _idx++ % _dirs.size();
-    return _dirs[idx].get();
+    // for the case of multiple dirs, we randomly select one as the start
+    // and then try one by one until we find the first one that meets the capacity requirements.
+    size_t start_idx = 0;
+    if (_dirs.size() > 1) {
+        std::lock_guard l(_mutex);
+        start_idx = _rand.Next() % _dirs.size();
+    }
+    for (size_t i = 0; i < _dirs.size(); i++) {
+        size_t idx = (start_idx + i) % _dirs.size();
+        if (_dirs[idx]->inc_size(opts.data_size)) {
+            return _dirs[idx].get();
+        }
+    }
+    return Status::CapacityLimitExceed("no writable spill storage directories");
 }
 
 } // namespace starrocks::spill

--- a/be/src/exec/spill/file_block_manager.cpp
+++ b/be/src/exec/spill/file_block_manager.cpp
@@ -1,0 +1,234 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "exec/spill/file_block_manager.h"
+
+#include "exec/spill/common.h"
+#include "fmt/format.h"
+#include "gen_cpp/Types_types.h"
+#include "gutil/casts.h"
+#include "util/defer_op.h"
+#include "util/uid_util.h"
+
+namespace starrocks::spill {
+class FileBlockContainer {
+public:
+    FileBlockContainer(Dir* dir, const TUniqueId& query_id, int32_t plan_node_id, std::string plan_node_name,
+                       uint64_t id)
+            : _dir(dir),
+              _query_id(query_id),
+              _plan_node_id(plan_node_id),
+              _plan_node_name(std::move(plan_node_name)),
+              _id(id) {}
+
+    ~FileBlockContainer() {
+        // @TODO we need add a gc thread to delete file
+        TRACE_SPILL_LOG << "delete spill container file: " << path();
+        WARN_IF_ERROR(_dir->fs()->delete_file(path()), fmt::format("cannot delete spill container file: {}", path()));
+        _dir->dec_size(_data_size);
+        // try to delete related dir, only the last one can success, we ignore the error
+        (void)(_dir->fs()->delete_dir(parent_path()));
+    }
+
+    Status open();
+
+    Status close();
+
+    Dir* dir() const { return _dir; }
+    int32_t plan_node_id() const { return _plan_node_id; }
+    std::string plan_node_name() const { return _plan_node_name; }
+
+    size_t size() const {
+        DCHECK(_writable_file != nullptr);
+        return _writable_file->size();
+    }
+    std::string path() const {
+        return fmt::format("{}/{}/{}-{}-{}", _dir->dir(), print_id(_query_id), _plan_node_name, _plan_node_id, _id);
+    }
+    std::string parent_path() const { return fmt::format("{}/{}", _dir->dir(), print_id(_query_id)); }
+    uint64_t id() const { return _id; }
+
+    Status append_data(const std::vector<Slice>& data, size_t total_size);
+
+    Status flush();
+
+    StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable();
+
+    static StatusOr<FileBlockContainerPtr> create(Dir* dir, TUniqueId query_id, int32_t plan_node_id,
+                                                  const std::string& plan_node_name, uint64_t id);
+
+private:
+    Dir* _dir;
+    TUniqueId _query_id;
+    int32_t _plan_node_id;
+    std::string _plan_node_name;
+    uint64_t _id;
+    std::unique_ptr<WritableFile> _writable_file;
+    bool _has_open = false;
+    size_t _data_size = 0;
+};
+
+Status FileBlockContainer::open() {
+    if (_has_open) {
+        return Status::OK();
+    }
+    std::string file_path = path();
+    WritableFileOptions opt;
+    opt.mode = FileSystem::CREATE_OR_OPEN_WITH_TRUNCATE;
+    ASSIGN_OR_RETURN(_writable_file, _dir->fs()->new_writable_file(opt, file_path));
+    TRACE_SPILL_LOG << "create new container file: " << file_path;
+    _has_open = true;
+    return Status::OK();
+}
+
+Status FileBlockContainer::close() {
+    _writable_file.reset();
+    return Status::OK();
+}
+
+Status FileBlockContainer::append_data(const std::vector<Slice>& data, size_t total_size) {
+    RETURN_IF_ERROR(_writable_file->appendv(data.data(), data.size()));
+    _data_size += total_size;
+    return Status::OK();
+}
+
+Status FileBlockContainer::flush() {
+    return _writable_file->flush(WritableFile::FLUSH_ASYNC);
+}
+
+StatusOr<std::unique_ptr<io::InputStreamWrapper>> FileBlockContainer::get_readable() {
+    std::string file_path = path();
+    ASSIGN_OR_RETURN(auto f, _dir->fs()->new_sequential_file(file_path));
+    return f;
+}
+
+StatusOr<FileBlockContainerPtr> FileBlockContainer::create(Dir* dir, TUniqueId query_id, int32_t plan_node_id,
+                                                           const std::string& plan_node_name, uint64_t id) {
+    auto container = std::make_shared<FileBlockContainer>(dir, query_id, plan_node_id, plan_node_name, id);
+    RETURN_IF_ERROR(container->open());
+    return container;
+}
+
+class FileBlockReader final : public BlockReader {
+public:
+    FileBlockReader(const Block* block) : _block(block), _length(block->size()) {}
+    ~FileBlockReader() override = default;
+
+    Status read_fully(void* data, int64_t count) override;
+
+    std::string debug_string() override { return _block->debug_string(); }
+
+private:
+    const Block* _block = nullptr;
+    std::unique_ptr<io::InputStreamWrapper> _readable;
+    size_t _length = 0;
+    size_t _offset = 0;
+};
+
+class FileBlock : public Block {
+public:
+    FileBlock(FileBlockContainerPtr container) : _container(std::move(container)) {}
+
+    ~FileBlock() override = default;
+
+    FileBlockContainerPtr container() const { return _container; }
+
+    Status append(const std::vector<Slice>& data) override {
+        size_t total_size = 0;
+        std::for_each(data.begin(), data.end(), [&](const Slice& slice) { total_size += slice.size; });
+        RETURN_IF_ERROR(_container->append_data(data, total_size));
+        _size += total_size;
+        return Status::OK();
+    }
+
+    Status flush() override { return _container->flush(); }
+
+    StatusOr<std::unique_ptr<io::InputStreamWrapper>> get_readable() const { return _container->get_readable(); }
+
+    std::shared_ptr<BlockReader> get_reader() override { return std::make_shared<FileBlockReader>(this); }
+
+    std::string debug_string() const override {
+#ifndef BE_TEST
+        return fmt::format("FileBlock:{}[container={}, len={}]", (void*)this, _container->path(), _size);
+#else
+        return fmt::format("FileBlock[container={}]", _container->path());
+#endif
+    }
+
+private:
+    FileBlockContainerPtr _container;
+};
+
+Status FileBlockReader::read_fully(void* data, int64_t count) {
+    if (_readable == nullptr) {
+        auto file_block = down_cast<const FileBlock*>(_block);
+        ASSIGN_OR_RETURN(_readable, file_block->get_readable());
+    }
+
+    if (_offset + count > _length) {
+        return Status::EndOfFile("no more data in this block");
+    }
+
+    ASSIGN_OR_RETURN(auto read_len, _readable->read(data, count));
+    RETURN_IF(read_len == 0, Status::EndOfFile("no more data in this block"));
+    RETURN_IF(read_len != count, Status::InternalError(fmt::format(
+                                         "block's length is mismatched, expected: {}, actual: {}", count, read_len)));
+    _offset += count;
+    return Status::OK();
+}
+
+FileBlockManager::FileBlockManager(const TUniqueId& query_id, DirManager* dir_mgr)
+        : _query_id(query_id), _dir_mgr(dir_mgr) {}
+
+FileBlockManager::~FileBlockManager() {
+    for (auto& container : _containers) {
+        container.reset();
+    }
+}
+
+Status FileBlockManager::open() {
+    return Status::OK();
+}
+
+void FileBlockManager::close() {}
+
+StatusOr<BlockPtr> FileBlockManager::acquire_block(const AcquireBlockOptions& opts) {
+    AcquireDirOptions acquire_dir_opts;
+    ASSIGN_OR_RETURN(auto dir, _dir_mgr->acquire_writable_dir(acquire_dir_opts));
+    ASSIGN_OR_RETURN(auto block_container, get_or_create_container(dir, opts.plan_node_id, opts.name));
+    return std::make_shared<FileBlock>(block_container);
+}
+
+Status FileBlockManager::release_block(const BlockPtr& block) {
+    auto file_block = down_cast<FileBlock*>(block.get());
+    auto container = file_block->container();
+    TRACE_SPILL_LOG << "release block: " << block->debug_string();
+    RETURN_IF_ERROR(container->close());
+    _containers.emplace_back(std::move(container));
+    return Status::OK();
+}
+
+StatusOr<FileBlockContainerPtr> FileBlockManager::get_or_create_container(Dir* dir, int32_t plan_node_id,
+                                                                          const std::string& plan_node_name) {
+    TRACE_SPILL_LOG << "get_or_create_container at dir: " << dir->dir() << ", plan node:" << plan_node_id << ", "
+                    << plan_node_name;
+    uint64_t id = _next_container_id++;
+    std::string container_dir = dir->dir() + "/" + print_id(_query_id);
+    RETURN_IF_ERROR(dir->fs()->create_dir_if_missing(container_dir));
+    ASSIGN_OR_RETURN(auto block_container,
+                     FileBlockContainer::create(dir, _query_id, plan_node_id, plan_node_name, id));
+    RETURN_IF_ERROR(block_container->open());
+    return block_container;
+}
+} // namespace starrocks::spill

--- a/be/src/exec/spill/file_block_manager.h
+++ b/be/src/exec/spill/file_block_manager.h
@@ -1,0 +1,56 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include "exec/spill/block_manager.h"
+#include "exec/spill/dir_manager.h"
+#include "gen_cpp/Types_types.h"
+
+namespace starrocks::spill {
+class FileBlockContainer;
+using FileBlockContainerPtr = std::shared_ptr<FileBlockContainer>;
+
+// FileBlockManager is an implementation of BlockManager.
+// Unlike LogBlockManager, it does not aggregate multiple blocks into one file.
+// Instead, each block is stored in a separate file.
+
+// For some distributed storage systems, they may not support append semantics, such as s3.
+// An object is not visible to others before close, and cannot be appended after close.
+// Therefore, blocks placed on such storage systems cannot be managed by LogBlockManager.
+// FileBlockManager is designed to solve this problem.
+
+class FileBlockManager : public BlockManager {
+public:
+    FileBlockManager(const TUniqueId& query_id, DirManager* dir_manager);
+    ~FileBlockManager() override;
+
+    Status open() override;
+    void close() override;
+    StatusOr<BlockPtr> acquire_block(const AcquireBlockOptions& opts) override;
+    Status release_block(const BlockPtr& block) override;
+
+private:
+    // @TODO(silverbullet233): some information is needed to uniquely identify each BE
+    StatusOr<FileBlockContainerPtr> get_or_create_container(Dir* dir, int32_t plan_node_id,
+                                                            const std::string& plan_node_name);
+
+    TUniqueId _query_id;
+    std::atomic<uint64_t> _next_container_id = 0;
+
+    std::vector<FileBlockContainerPtr> _containers;
+    DirManager* _dir_mgr = nullptr;
+};
+
+} // namespace starrocks::spill

--- a/be/test/CMakeLists.txt
+++ b/be/test/CMakeLists.txt
@@ -315,6 +315,7 @@ set(EXEC_FILES_PART2
         ./io/seekable_input_stream_test.cpp
         ./io/shared_buffered_input_stream_test.cpp
         ./io/spill_test.cpp
+        ./io/spill_block_manager_test.cpp
         ./storage/decimal12_test.cpp
         ./storage/disjunctive_predicates_test.cpp
         ./storage/utils_test.cpp

--- a/be/test/io/spill_block_manager_test.cpp
+++ b/be/test/io/spill_block_manager_test.cpp
@@ -1,0 +1,242 @@
+// Copyright 2021-present StarRocks, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <filesystem>
+#include <iterator>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "column/array_column.h"
+#include "column/chunk.h"
+#include "column/column_helper.h"
+#include "column/column_visitor_adapter.h"
+#include "column/map_column.h"
+#include "column/nullable_column.h"
+#include "column/struct_column.h"
+#include "column/vectorized_fwd.h"
+#include "common/config.h"
+#include "common/object_pool.h"
+#include "common/status.h"
+#include "common/statusor.h"
+#include "exec/sorting/merge.h"
+#include "exec/sorting/sorting.h"
+#include "exec/spill/block_manager.h"
+#include "exec/spill/dir_manager.h"
+#include "exec/spill/executor.h"
+#include "exec/spill/file_block_manager.h"
+#include "exec/spill/log_block_manager.h"
+#include "exec/spill/mem_table.h"
+#include "exec/spill/spill_components.h"
+#include "exec/spill/spiller.h"
+#include "exec/spill/spiller.hpp"
+#include "exec/spill/spiller_factory.h"
+#include "exec/workgroup/scan_task_queue.h"
+#include "exprs/column_ref.h"
+#include "exprs/expr_context.h"
+#include "fmt/format.h"
+#include "fs/fs.h"
+#include "gen_cpp/Exprs_types.h"
+#include "gen_cpp/Types_types.h"
+#include "runtime/mem_tracker.h"
+#include "runtime/runtime_state.h"
+#include "testutil/assert.h"
+#include "types/logical_type.h"
+#include "util/defer_op.h"
+#include "util/runtime_profile.h"
+#include "util/uid_util.h"
+
+namespace starrocks::vectorized {
+
+std::string generate_spill_path(const TUniqueId& query_id, const std::string& path) {
+    return fmt::format("{}/{}/{}", config::storage_root_path, path, print_id(query_id));
+}
+
+spill::DirPtr create_spill_dir(const std::string& path, int64_t capacity_limit) {
+    auto fs = FileSystem::CreateSharedFromString(path);
+    return std::make_shared<spill::Dir>(path, fs.value(), capacity_limit);
+}
+
+std::unique_ptr<spill::DirManager> create_spill_dir_manager(const std::vector<spill::DirPtr>& dirs) {
+    auto dir_mgr = std::make_unique<spill::DirManager>(dirs);
+    return dir_mgr;
+}
+
+class SpillBlockManagerTest : public ::testing::Test {
+public:
+    void SetUp() override {
+        dummy_query_id = generate_uuid();
+        path = config::storage_root_path + "/spill_test_data";
+        auto fs = FileSystem::Default();
+        ASSERT_OK(fs->create_dir_recursive(path));
+        auto dir = create_spill_dir(path, INT64_MAX);
+        LOG(WARNING) << "TRACE:" << path;
+        dummy_dir_mgr = create_spill_dir_manager({dir});
+    }
+
+    void TearDown() override {}
+
+protected:
+    TUniqueId dummy_query_id;
+    std::string path;
+    std::unique_ptr<spill::DirManager> dummy_dir_mgr;
+    RuntimeState dummy_state;
+    RuntimeProfile dummy_profile{"dummy"};
+};
+TEST_F(SpillBlockManagerTest, dir_choose_strategy) {
+    using DirInfo = std::pair<std::string, size_t>;
+    std::vector<DirInfo> dir_info_list = {{"dir1", 100}, {"dir2", 120}};
+    TUniqueId dummy_query_id = generate_uuid();
+    std::vector<spill::DirPtr> dir_list;
+    for (auto& dir_info : dir_info_list) {
+        auto path = generate_spill_path(dummy_query_id, dir_info.first);
+        auto dir = create_spill_dir(path, dir_info.second);
+        dir_list.emplace_back(std::move(dir));
+    }
+    auto dir_mgr = create_spill_dir_manager(dir_list);
+    {
+        spill::AcquireDirOptions opts{.data_size = 10};
+        auto res = dir_mgr->acquire_writable_dir(opts);
+        ASSERT_TRUE(res.ok());
+        std::string expected_dir = generate_spill_path(dummy_query_id, "dir2");
+        ASSERT_EQ(expected_dir, res.value()->dir());
+        // after allocation
+        // dir1 used 0, dir2 used 10
+    }
+    {
+        spill::AcquireDirOptions opts{.data_size = 20};
+        auto res = dir_mgr->acquire_writable_dir(opts);
+        ASSERT_TRUE(res.ok());
+        std::string expected_dir = generate_spill_path(dummy_query_id, "dir2");
+        ASSERT_EQ(expected_dir, res.value()->dir());
+        // after allocation
+        // dir1 used 0, dir2 used 30
+    }
+    {
+        // only dir1 can meet the capacity requirements
+        spill::AcquireDirOptions opts{.data_size = 100};
+        auto res = dir_mgr->acquire_writable_dir(opts);
+        ASSERT_TRUE(res.ok());
+        std::string expected_dir = generate_spill_path(dummy_query_id, "dir1");
+        ASSERT_EQ(expected_dir, res.value()->dir());
+        // after allocation
+        // dir1 used 100, dir2 used 30
+    }
+    {
+        // no dirs can meet the capacity requirements
+        spill::AcquireDirOptions opts{.data_size = 100};
+        auto res = dir_mgr->acquire_writable_dir(opts);
+        ASSERT_FALSE(res.ok());
+    }
+    {
+        // only dir2 can meet the capacity requirements
+        spill::AcquireDirOptions opts{.data_size = 90};
+        auto res = dir_mgr->acquire_writable_dir(opts);
+        ASSERT_TRUE(res.ok());
+        std::string expected_dir = generate_spill_path(dummy_query_id, "dir2");
+        ASSERT_EQ(expected_dir, res.value()->dir());
+    }
+}
+
+TEST_F(SpillBlockManagerTest, log_block_allocation_test) {
+    auto log_block_mgr = std::make_shared<spill::LogBlockManager>(dummy_query_id);
+    log_block_mgr->set_dir_manager(dummy_dir_mgr.get());
+    ASSERT_OK(log_block_mgr->open());
+
+    std::vector<spill::BlockPtr> blocks;
+    {
+        // 1. allocate the first block but not release it
+        spill::AcquireBlockOptions opts{
+                .query_id = dummy_query_id, .plan_node_id = 1, .name = "node1", .block_size = 10};
+        auto res = log_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        auto block = res.value();
+        std::string expected = fmt::format("LogBlock[container={}/{}/{}]", path, print_id(dummy_query_id), "node1-1-0");
+        ASSERT_EQ(block->debug_string(), expected);
+        blocks.emplace_back(std::move(block));
+    }
+    {
+        // 2. allocate the second block, since the first block didn't release, a new container should be created.
+        spill::AcquireBlockOptions opts{
+                .query_id = dummy_query_id, .plan_node_id = 1, .name = "node1", .block_size = 10};
+        auto res = log_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        auto block = res.value();
+        std::string expected = fmt::format("LogBlock[container={}/{}/{}]", path, print_id(dummy_query_id), "node1-1-1");
+        ASSERT_EQ(block->debug_string(), expected);
+        blocks.emplace_back(std::move(block));
+    }
+    // 3. release the first block
+    ASSERT_OK(log_block_mgr->release_block(blocks.at(0)));
+    {
+        // 4. allocate the third block, it will use the first container
+        spill::AcquireBlockOptions opts{
+                .query_id = dummy_query_id, .plan_node_id = 1, .name = "node1", .block_size = 10};
+        auto res = log_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        auto block = res.value();
+        std::string expected = fmt::format("LogBlock[container={}/{}/{}]", path, print_id(dummy_query_id), "node1-1-0");
+        ASSERT_EQ(block->debug_string(), expected);
+    }
+}
+
+TEST_F(SpillBlockManagerTest, file_block_allocation_test) {
+    auto file_block_mgr = std::make_shared<spill::FileBlockManager>(dummy_query_id, dummy_dir_mgr.get());
+    ASSERT_OK(file_block_mgr->open());
+
+    std::vector<spill::BlockPtr> blocks;
+    {
+        // 1. allocate the first block but not release it
+        spill::AcquireBlockOptions opts{
+                .query_id = dummy_query_id, .plan_node_id = 1, .name = "node1", .block_size = 10};
+        auto res = file_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        auto block = res.value();
+        std::string expected =
+                fmt::format("FileBlock[container={}/{}/{}]", path, print_id(dummy_query_id), "node1-1-0");
+        ASSERT_EQ(block->debug_string(), expected);
+        blocks.emplace_back(std::move(block));
+    }
+    {
+        // 2. allocate the second block, since the first block didn't release, a new container should be created.
+        spill::AcquireBlockOptions opts{
+                .query_id = dummy_query_id, .plan_node_id = 1, .name = "node1", .block_size = 10};
+        auto res = file_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        auto block = res.value();
+        std::string expected =
+                fmt::format("FileBlock[container={}/{}/{}]", path, print_id(dummy_query_id), "node1-1-1");
+        ASSERT_EQ(block->debug_string(), expected);
+        blocks.emplace_back(std::move(block));
+    }
+    // 3. release the first block
+    ASSERT_OK(file_block_mgr->release_block(blocks.at(0)));
+    {
+        // 4. allocate the third block, it will use a new container, this is differ from LogBlockManager
+        spill::AcquireBlockOptions opts{
+                .query_id = dummy_query_id, .plan_node_id = 1, .name = "node1", .block_size = 10};
+        auto res = file_block_mgr->acquire_block(opts);
+        ASSERT_TRUE(res.ok());
+        auto block = res.value();
+        std::string expected =
+                fmt::format("FileBlock[container={}/{}/{}]", path, print_id(dummy_query_id), "node1-1-2");
+        ASSERT_EQ(block->debug_string(), expected);
+    }
+}
+} // namespace starrocks::vectorized

--- a/gensrc/thrift/StatusCode.thrift
+++ b/gensrc/thrift/StatusCode.thrift
@@ -107,6 +107,7 @@ enum TStatusCode {
     REMOTE_FILE_NOT_FOUND = 55, // for hive external table
     YIELD = 56,
 
-    JIT_COMPILE_ERROR = 57
+    JIT_COMPILE_ERROR = 57,
+    CAPACITY_LIMIT_EXCEED = 58
 }
 


### PR DESCRIPTION
Why I'm doing:

For some distributed storage systems, they may not support append semantics, such as s3. An object is not visible to others before close, and cannot be appended after close. Therefore, blocks placed on such storage systems cannot be managed by LogBlockManager.

What I'm doing:

add a new FileBlockManager to manage blocks stored on such storage systems.

Later I will add a new BlockManager to manage both local and remote blocks.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
