### PR TITLE
[Feature] support const folding for to_date()

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctions.java
@@ -347,6 +347,13 @@ public class ScalarOperatorFunctions {
         return ConstantOperator.createDatetime(ld.atTime(0, 0, 0), Type.DATE);
     }
 
+    @ConstantFunction(name = "to_date", argTypes = {DATETIME}, returnType = DATE, isMonotonic = true)
+    public static ConstantOperator toDate(ConstantOperator dateTime) {
+        LocalDateTime dt = dateTime.getDatetime();
+        dt.truncatedTo(ChronoUnit.DAYS);
+        return ConstantOperator.createDateOrNull(dt);
+    }
+
     @ConstantFunction(name = "years_sub", argTypes = {DATETIME, INT}, returnType = DATETIME, isMonotonic = true)
     public static ConstantOperator yearsSub(ConstantOperator date, ConstantOperator year) {
         return ConstantOperator.createDatetimeOrNull(date.getDatetime().minusYears(year.getInt()));

--- a/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/optimizer/rewrite/ScalarOperatorFunctionsTest.java
@@ -474,6 +474,15 @@ public class ScalarOperatorFunctionsTest {
     }
 
     @Test
+    public void toDate() {
+        ConstantOperator result = ScalarOperatorFunctions
+                .toDate(ConstantOperator.createDatetime(LocalDateTime.of(2001, 1, 9, 13, 4, 5)));
+        assertTrue(result.getType().isDate());
+        // when transfer constantOpeartor to DateLiteral, only y/m/d will keep
+        assertEquals("2001-01-09T13:04:05", result.getDate().toString());
+    }
+
+    @Test
     public void yearsSub() {
         assertEquals("2005-03-23T09:23:55",
                 ScalarOperatorFunctions.yearsSub(O_DT_20150323_092355, O_INT_10).getDatetime().toString());


### PR DESCRIPTION
Why I'm doing:
support const folding for to_date()
What I'm doing:

before this pr:
```
mysql> explain verbose select * from `daily_sales` where sale_date = to_date("2024-01-02 10:00:00");
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| Explain String                                                                                                                                            |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                                                                                                |
|                                                                                                                                                           |
| PLAN FRAGMENT 0(F01)                                                                                                                                      |
|   Output Exprs:1: sale_date | 2: product_id                                                                                                               |
|   Input Partition: UNPARTITIONED                                                                                                                          |
|   RESULT SINK                                                                                                                                             |
|                                                                                                                                                           |
|   1:EXCHANGE                                                                                                                                              |
|      cardinality: 2                                                                                                                                       |
|                                                                                                                                                           |
| PLAN FRAGMENT 1(F00)                                                                                                                                      |
|                                                                                                                                                           |
|   Input Partition: RANDOM                                                                                                                                 |
|   OutPut Partition: UNPARTITIONED                                                                                                                         |
|   OutPut Exchange Id: 01                                                                                                                                  |
|                                                                                                                                                           |
|   0:OlapScanNode                                                                                                                                          |
|      table: daily_sales, rollup: daily_sales                                                                                                              |
|      preAggregation: off. Reason: None aggregate function                                                                                                 |
|      Predicates: [1: sale_date, DATE, true] = to_date[('2024-01-02 10:00:00'); args: DATETIME; result: DATE; args nullable: false; result nullable: true] |
|      partitionsRatio=3/3, tabletsRatio=30/30                                                                                                              |
|      tabletList=91104,91106,91108,91110,91112,91114,91116,91118,91120,91122 ...                                                                           |
|      actualRows=2, avgRowSize=2.0                                                                                                                         |
|      cardinality: 2                                                                                                                                       |
+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
```

after this pr:
```
mysql> explain verbose select * from `daily_sales` where sale_date = to_date("2024-01-02 10:00:00");
+-----------------------------------------------------------------------------+
| Explain String                                                              |
+-----------------------------------------------------------------------------+
| RESOURCE GROUP: default_wg                                                  |
|                                                                             |
| PLAN FRAGMENT 0(F01)                                                        |
|   Output Exprs:1: sale_date | 2: product_id                                 |
|   Input Partition: UNPARTITIONED                                            |
|   RESULT SINK                                                               |
|                                                                             |
|   1:EXCHANGE                                                                |
|      cardinality: 1                                                         |
|                                                                             |
| PLAN FRAGMENT 1(F00)                                                        |
|                                                                             |
|   Input Partition: RANDOM                                                   |
|   OutPut Partition: UNPARTITIONED                                           |
|   OutPut Exchange Id: 01                                                    |
|                                                                             |
|   0:OlapScanNode                                                            |
|      table: daily_sales, rollup: daily_sales                                |
|      preAggregation: off. Reason: None aggregate function                   |
|      partitionsRatio=1/3, tabletsRatio=10/10                                |
|      tabletList=91124,91126,91128,91130,91132,91134,91136,91138,91140,91142 |
|      actualRows=0, avgRowSize=2.0                                           |
|      cardinality: 1                                                         |
+-----------------------------------------------------------------------------+
23 rows in set (0.00 sec)
```

you can see partitionsRatio change to 1/3

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
- [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
