### PR TITLE
[BugFix] Fix BE crash in AGG when group by key overflow

### DIFF
--- a/test/sql/test_agg/R/test_serialize_key_agg
+++ b/test/sql/test_agg/R/test_serialize_key_agg
@@ -1,0 +1,42 @@
+-- name: test_serialize_key_agg
+create table t0 (
+    c0 STRING,
+    c1 STRING,
+    c2 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+-- result:
+-- !result
+select distinct c0, c1 from t0 order by c0, c1 desc limit 10;
+-- result:
+-- !result
+select distinct c0, c1 from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb order by c0, c1 desc limit 10;
+-- result:
+-- !result
+select length(c0), max(length(c1)), max(length(c2)) from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb group by c0 order by 1, 2 desc limit 10;
+-- result:
+1000000	1000000	1000000
+-- !result
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  4096));
+-- result:
+-- !result
+select max(length(c0)), max(length(c1)) from (select distinct c0, c1 from t0) tb;
+-- result:
+4	4
+-- !result
+select max(length(c0)), max(length(c1)) from (select distinct c0, c1 from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb) tb order by 1, 2 desc limit 10;
+-- result:
+1000000	1000000
+-- !result
+select length(c0), max(length(c1)), max(length(c2)) from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb group by c0, c1, c2 order by 1, 2 desc limit 10;
+-- result:
+1	4	1
+1	4	1
+1	4	1
+1	4	1
+1	4	1
+1	4	1
+1	4	1
+1	4	1
+1	4	1
+2	4	2
+-- !result

--- a/test/sql/test_agg/T/test_serialize_key_agg
+++ b/test/sql/test_agg/T/test_serialize_key_agg
@@ -1,0 +1,15 @@
+-- name: test_serialize_key_agg
+create table t0 (
+    c0 STRING,
+    c1 STRING,
+    c2 STRING
+) DUPLICATE KEY(c0) DISTRIBUTED BY HASH(c0) BUCKETS 3 PROPERTIES('replication_num' = '1');
+
+select distinct c0, c1 from t0 order by c0, c1 desc limit 10;
+select distinct c0, c1 from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb order by c0, c1 desc limit 10;
+select length(c0), max(length(c1)), max(length(c2)) from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb group by c0 order by 1, 2 desc limit 10;
+insert into t0 SELECT generate_series, 4096 - generate_series, generate_series FROM TABLE(generate_series(1,  4096));
+
+select max(length(c0)), max(length(c1)) from (select distinct c0, c1 from t0) tb;
+select max(length(c0)), max(length(c1)) from (select distinct c0, c1 from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb) tb order by 1, 2 desc limit 10;
+select length(c0), max(length(c1)), max(length(c2)) from (select * from t0 union all select space(1000000) as c0, space(1000000) as c1, space(1000000) as c2) tb group by c0, c1, c2 order by 1, 2 desc limit 10;


### PR DESCRIPTION
Why I'm doing:

max_one_row_size * _chunk_size will cause overflow if max_one_row_key size greater than 1M. it will cause BE crash

What I'm doing:
support serialize by rows when batch group by key buffer size greater than 4G

Fixes 
```
*** Aborted at 1704711965 (unix time) try "date -d @1704711965" if you are using GNU date ***
PC: @          0x9593809 starrocks::vectorized::Column::serialize_batch_with_null_masks()
*** SIGSEGV (@0x7f5387b00a07) received by PID 14908 (TID 0x7f72912fa700) from PID 18446744071691045383; stack trace: ***
    @          0xd40fe02 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f73e4ae51a2 os::Linux::chained_handler()
    @     0x7f73e4aeb826 JVM_handle_linux_signal
    @     0x7f73e4ae1e13 signalHandler()
    @     0x7f73e38a55f0 (unknown)
    @          0x9593809 starrocks::vectorized::Column::serialize_batch_with_null_masks()
    @          0xc727d8b starrocks::vectorized::NullableColumn::serialize_batch()
    @          0x9dbf99a starrocks::vectorized::AggHashMapWithSerializedKey<>::compute_agg_states<>()
    @          0x9d1ec71 _ZZN9starrocks10Aggregator14build_hash_mapEmbENKUlRT_E_clIKSt10unique_ptrINS_10vectorized27AggHashMapWithSerializedKeyIN5phmap22parallel_flat_hash_mapINS_5SliceEPhNS6_17SliceHashWithSeedILNS6_9PhmapSeedE1EEENS6_10SliceEqualESaISt4pairIKSA_SB_EELm4ENS8_9NullMutexELb1EEEEESt14default_deleteISM_EEEEDaS2_
    @          0x9d9e265 _ZSt13__invoke_implIvZN9starrocks10Aggregator14build_hash_mapEmbEUlRT_E_JRKSt10unique_ptrINS0_10vectorized27AggHashMapWithSerializedKeyIN5phmap22parallel_flat_hash_mapINS0_5SliceEPhNS6_17SliceHashWithSeedILNS6_9PhmapSeedE1EEENS6_10SliceEqualESaISt4pairIKSA_SB_EELm4ENS8_9NullMutexELb1EEEEESt14default_deleteISM_EEEES2_St14__invoke_otherOT0_DpOT1_
    @          0x9d9666d _ZSt8__invokeIZN9starrocks10Aggregator14build_hash_mapEmbEUlRT_E_JRKSt10unique_ptrINS0_10vectorized27AggHashMapWithSerializedKeyIN5phmap22parallel_flat_hash_mapINS0_5SliceEPhNS6_17SliceHashWithSeedILNS6_9PhmapSeedE1EEENS6_10SliceEqualESaISt4pairIKSA_SB_EELm4ENS8_9NullMutexELb1EEEEESt14default_deleteISM_EEEENSt15__invoke_resultIS2_JDpT0_EE4typeEOS2_DpOST_
    @          0x9d1ecba (unknown)
    @          0x9d1f156 (unknown)
    @          0x9d1f1b1 (unknown)
    @          0x9d1f1e4 _ZNK9starrocks10vectorized17AggHashMapVariant5visitIZNS_10Aggregator14build_hash_mapEmbEUlRT_E_EEDaOS4_
    @          0x9d1f28f starrocks::Aggregator::build_hash_map()
    @          0x9c5a192 starrocks::pipeline::AggregateBlockingSinkOperator::push_chunk()
    @          0x963d613 starrocks::pipeline::PipelineDriver::process()
    @          0xc8a4151 starrocks::pipeline::GlobalDriverExecutor::_worker_thread()
    @          0xc8a383b _ZZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiENKUlvE2_clEv
    @          0xc8a743a _ZSt13__invoke_implIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE2_JEET_St14__invoke_otherOT0_DpOT1_
    @          0xc8a6dde _ZSt10__invoke_rIvRZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE2_JEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EES6_E4typeEOS7_DpOS8_
    @          0xc8a6679 _ZNSt17_Function_handlerIFvvEZN9starrocks8pipeline20GlobalDriverExecutor10initializeEiEUlvE2_E9_M_invokeERKSt9_Any_data
    @          0x94d17fe std::function<>::operator()()
    @          0xc122bae starrocks::FunctionRunnable::run()
    @          0xc12175f starrocks::ThreadPool::dispatch_thread()
    @          0xc12dcba std::__invoke_impl<>()
    @          0xc12d7d7 std::__invoke<>()
    @          0xc12d054 _ZNSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS1_EE6__callIvJEJLm0EEEET_OSt5tupleIJDpT0_EESt12_Index_tupleIJXspT1_EEE
    @          0xc12c4ac std::_Bind<>::operator()<>()
    @          0xc12b14a std::__invoke_impl<>()
    @          0xc129d2c _ZSt10__invoke_rIvRSt5_BindIFMN9starrocks10ThreadPoolEFvvEPS2_EEJEENSt9enable_ifIX16is_invocable_r_vIT_T0_DpT1_EESA_E4typeEOSB_DpOSC_
```

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
