### PR TITLE
[BugFix] add output col names in the TQueryPlanInfo

### DIFF
--- a/be/src/runtime/fragment_mgr.cpp
+++ b/be/src/runtime/fragment_mgr.cpp
@@ -846,6 +846,8 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
         return Status::InvalidArgument(msg.str());
     }
 
+    const auto& output_names = t_query_plan_info.output_names;
+    int i = 0;
     for (const auto& expr : t_query_plan_info.plan_fragment.output_exprs) {
         const auto& nodes = expr.nodes;
         if (nodes.empty() || nodes[0].node_type != TExprNodeType::SLOT_REF) {
@@ -865,9 +867,14 @@ Status FragmentMgr::exec_external_plan_fragment(const TScanOpenParams& params, c
         }
 
         TScanColumnDesc col;
-        col.__set_name(slot_desc->col_name());
+        if (!output_names.empty()) {
+            col.__set_name(output_names[i]);
+        } else {
+            col.__set_name(slot_desc->col_name());
+        }
         col.__set_type(to_thrift(slot_desc->type().type));
         selected_columns->emplace_back(std::move(col));
+        i++;
     }
 
     LOG(INFO) << "BackendService execute open()  TQueryPlanInfo: "

--- a/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
+++ b/fe/fe-core/src/main/java/com/starrocks/http/rest/TableQueryPlanAction.java
@@ -286,6 +286,7 @@ public class TableQueryPlanAction extends RestBaseAction {
         }
 
         TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
+        tQueryPlanInfo.output_names = execPlan.getColNames();
 
         // acquire TPlanFragment
         TPlanFragment tPlanFragment = fragments.get(0).toThrift();

--- a/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
+++ b/fe/fe-core/src/main/java/com/starrocks/planner/DataSink.java
@@ -41,7 +41,6 @@ import com.starrocks.catalog.OlapTable;
 import com.starrocks.catalog.Table;
 import com.starrocks.catalog.TableFunctionTable;
 import com.starrocks.common.AnalysisException;
-import com.starrocks.common.Config;
 import com.starrocks.thrift.TDataSink;
 import com.starrocks.thrift.TExplainLevel;
 

--- a/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/http/TableQueryPlanActionTest.java
@@ -65,7 +65,7 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
     public void testQueryPlanAction() throws IOException, TException {
         super.setUpWithCatalog();
         RequestBody body =
-                RequestBody.create(JSON, "{ \"sql\" :  \" select k1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }");
+                RequestBody.create(JSON, "{ \"sql\" :  \" select k1 as alias_1,k2 from " + DB_NAME + "." + TABLE_NAME + " \" }");
         Request request = new Request.Builder()
                 .post(body)
                 .addHeader("Authorization", rootAuth)
@@ -93,8 +93,8 @@ public class TableQueryPlanActionTest extends StarRocksHttpTestCase {
             TDeserializer deserializer = new TDeserializer();
             TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
             deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo);
+            Assert.assertEquals("alias_1", tQueryPlanInfo.output_names.get(0));
             expectThrowsNoException(() -> deserializer.deserialize(tQueryPlanInfo, binaryPlanInfo));
-            System.out.println(tQueryPlanInfo);
         }
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/sql/plan/PlanFragmentWithCostTest.java
@@ -32,6 +32,7 @@ import com.starrocks.sql.optimizer.statistics.ColumnStatistic;
 import com.starrocks.sql.optimizer.statistics.StatisticStorage;
 import com.starrocks.system.SystemInfoService;
 import com.starrocks.thrift.TExplainLevel;
+import com.starrocks.thrift.TQueryPlanInfo;
 import com.starrocks.utframe.StarRocksAssert;
 import com.starrocks.utframe.UtFrameUtils;
 import mockit.Expectations;
@@ -2374,5 +2375,15 @@ public class PlanFragmentWithCostTest extends PlanTestBase {
                 "and t1.L_SUPPKEY = t2.N_NATIONKEY;";
         plan = getCostExplain(sql);
         assertContains(plan, "cardinality: 100000000");
+    }
+
+    @Test
+    public void testOutputColNames() throws Exception {
+        String sql = "select v1 as alias_1, v2 as alias_2, v2, abs(v2) as v2 from t0 where v3 = 1";
+        ExecPlan execPlan = getExecPlan(sql);
+        TQueryPlanInfo tQueryPlanInfo = new TQueryPlanInfo();
+        tQueryPlanInfo.output_names = execPlan.getColNames();
+        Assert.assertEquals(4, tQueryPlanInfo.output_names.size());
+        Assert.assertEquals("alias_1", tQueryPlanInfo.output_names.get(0));
     }
 }

--- a/gensrc/thrift/QueryPlanExtra.thrift
+++ b/gensrc/thrift/QueryPlanExtra.thrift
@@ -55,4 +55,5 @@ struct TQueryPlanInfo {
   3: required Descriptors.TDescriptorTable desc_tbl
   // all tablet scan should share one query_id
   4: required Types.TUniqueId query_id
+  5: required list<string> output_names
 }

--- a/gensrc/thrift/QueryPlanExtra.thrift
+++ b/gensrc/thrift/QueryPlanExtra.thrift
@@ -55,5 +55,5 @@ struct TQueryPlanInfo {
   3: required Descriptors.TDescriptorTable desc_tbl
   // all tablet scan should share one query_id
   4: required Types.TUniqueId query_id
-  5: required list<string> output_names
+  5: optional list<string> output_names
 }


### PR DESCRIPTION
Why I'm doing:
When use the FE API`_query_plan`, the plan result didn't contains the output col names info, hence the invoker cannot obtain the output schema. When send the plan to BE, BE cannot restore the correct output col names.

What I'm doing:
Add a `outputNames` in `TQueryPlanInfo` and pass it to BE to build a `TScanColumnDesc` with the right output col name.

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [ ] 2.5
