### PR TITLE
[BugFix] Join predicate push down merge origin predicate.

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rewrite/JoinPredicatePushdown.java
@@ -200,7 +200,7 @@ public class JoinPredicatePushdown {
                         .build();
             } else {
                 newJoinOperator = new LogicalJoinOperator.Builder().withOperator(join)
-                        .setPredicate(Utils.compoundAnd(remainingFilter)).build();
+                        .setPredicate(Utils.compoundAnd(Utils.compoundAnd(remainingFilter), join.getPredicate())).build();
             }
         } else {
             newJoinOperator = join;

--- a/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
+++ b/fe/fe-core/src/test/resources/sql/optimized-plan/predicate-pushdown.sql
@@ -262,3 +262,15 @@ PREDICATE add(1: v1, cast(4: unnest as bigint(20))) = 1
     TABLE FUNCTION (unnest)
         SCAN (columns[1: v1] predicate[null])
 [end]
+
+[sql]
+select v2, v5 from (select v2, v5 from t0 LEFT JOIN t1 on t0.v1 between t1.v4 and t1.v5 where v1 * v4 > 1 group by v2, v5 having v2 * v5 > 1)s where v2=1
+[result]
+AGGREGATE ([GLOBAL] aggregate [{}] group by [[2: v2, 5: v5]] having [null]
+    EXCHANGE SHUFFLE[2, 5]
+        AGGREGATE ([LOCAL] aggregate [{}] group by [[2: v2, 5: v5]] having [null]
+            LEFT OUTER JOIN (join-predicate [1: v1 >= 4: v4 AND 1: v1 <= 5: v5] post-join-predicate [multiply(2: v2, 5: v5) > 1 AND multiply(1: v1, 4: v4) > 1])
+                SCAN (columns[1: v1, 2: v2] predicate[2: v2 = 1])
+                EXCHANGE BROADCAST
+                    SCAN (columns[4: v4, 5: v5] predicate[null])
+[end]


### PR DESCRIPTION
Why I'm doing:
JoinPredicatePushdown overwrite `remainingFilter` in post-join-predicate, when rule trigger multiple times, some predicate will lost.

What I'm doing:
merge new predicate with old predicate.

In test case, before plan was:
```
AGGREGATE ([GLOBAL] aggregate [{}] group by [[2: v2, 5: v5]] having [null]
    EXCHANGE SHUFFLE[2, 5]
        AGGREGATE ([LOCAL] aggregate [{}] group by [[2: v2, 5: v5]] having [null]
            LEFT OUTER JOIN (join-predicate [1: v1 >= 4: v4 AND 1: v1 <= 5: v5] post-join-predicate [multiply(2: v2, 5: v5) > 1])
                SCAN (columns[1: v1, 2: v2] predicate[2: v2 = 1])
                EXCHANGE BROADCAST
                    SCAN (columns[4: v4, 5: v5] predicate[null])
```

predicate `AND multiply(1: v1, 4: v4) > 1` was lost.


## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
