### PR TITLE
[BugFix] Fix mv rewrite when mv's plan has having expressions

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -321,9 +321,11 @@ public class MvUtils {
         if (root == null) {
             return false;
         }
+        // 1. check whether is SPJ first
         if (isLogicalSPJ(root)) {
             return true;
         }
+        // 2. check whether it's SPJG then
         return isLogicalSPJG(root);
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
+++ b/fe/fe-core/src/main/java/com/starrocks/sql/optimizer/rule/transformation/materialization/MvUtils.java
@@ -324,12 +324,7 @@ public class MvUtils {
         if (isLogicalSPJ(root)) {
             return true;
         }
-        if (isLogicalSPJG(root)) {
-            LogicalAggregationOperator agg = (LogicalAggregationOperator) root.getOp();
-            // having is not supported now
-            return agg.getPredicate() == null;
-        }
-        return false;
+        return isLogicalSPJG(root);
     }
 
     public static String getInvalidReason(OptExpression expr) {

--- a/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/planner/MaterializedViewTest.java
@@ -5358,4 +5358,20 @@ public class MaterializedViewTest extends MaterializedViewTestBase {
                 });
 
     }
+
+    @Test
+    public void testAggregateWithHave() {
+        String mv = "select empid, deptno,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid, deptno having sum(salary) > 1";
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid, deptno having sum(salary) > 1");
+        testRewriteOK(mv, "select empid, deptno,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid, deptno having sum(salary) > 10");
+        testRewriteOK(mv, "select empid,\n" +
+                " sum(salary) as total, count(salary)  as cnt\n" +
+                " from emps group by empid having sum(salary) > 10");
+    }
 }

--- a/test/sql/test_materialized_view/R/test_materialized_view_rewrite2
+++ b/test/sql/test_materialized_view/R/test_materialized_view_rewrite2
@@ -14,7 +14,7 @@ PROPERTIES (
 -- result:
 -- !result
 CREATE MATERIALIZED VIEW  test_empty_partition_mv1 
-DISTRIBUTED BY RANDOM BUCKETS 32
+DISTRIBUTED BY RANDOM 
 partition by date_trunc('day', dt)
 PROPERTIES (
 "replication_num" = "1"
@@ -67,4 +67,81 @@ select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS 
 select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-16 00:00:00' GROUP BY col1;
 -- result:
 1	1	0
+-- !result
+drop materialized view test_empty_partition_mv1;
+-- result:
+-- !result
+drop table test_empty_partition_tbl;
+-- result:
+-- !result
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_linenumber` int(11) NOT NULL COMMENT "",
+    `lo_custkey` int(11) NOT NULL COMMENT "",
+    `lo_partkey` int(11) NOT NULL COMMENT "",
+    `lo_suppkey` int(11) NOT NULL COMMENT "",
+    `lo_orderdate` datetime NOT NULL COMMENT "",
+    `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
+    `lo_shippriority` int(11) NOT NULL COMMENT "",
+    `lo_quantity` int(11) NOT NULL COMMENT "",
+    `lo_extendedprice` int(11) NOT NULL COMMENT "",
+    `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
+    `lo_discount` int(11) NOT NULL COMMENT "",
+    `lo_revenue` int(11) NOT NULL COMMENT "",
+    `lo_supplycost` int(11) NOT NULL COMMENT "",
+    `lo_tax` int(11) NOT NULL COMMENT "",
+    `lo_commitdate` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+    ) ENGINE=OLAP
+    DUPLICATE KEY(`lo_orderkey`)
+    COMMENT "OLAP"
+    PARTITION BY RANGE(`lo_orderdate`)
+(
+    PARTITION p1 VALUES [("1992-01-01 00:00:00"), ("1993-01-01 00:00:00")),
+    PARTITION p2 VALUES [("1993-01-01 00:00:00"), ("1994-01-01 00:00:00")),
+    PARTITION p3 VALUES [("1994-01-01 00:00:00"), ("1995-01-01 00:00:00")),
+    PARTITION p4 VALUES [("1995-01-01 00:00:00"), ("1996-01-01 00:00:00")),
+    PARTITION p5 VALUES [("1996-01-01 00:00:00"), ("1997-01-01 00:00:00")),
+    PARTITION p6 VALUES [("1997-01-01 00:00:00"), ("1998-01-01 00:00:00")),
+    PARTITION p7 VALUES [("1998-01-01 00:00:00"), ("1999-01-01 00:00:00"))
+)
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1"
+);
+-- result:
+-- !result
+INSERT INTO lineorder (lo_orderkey, lo_linenumber, lo_custkey, lo_partkey, lo_suppkey
+                      , lo_orderdate, lo_orderpriority, lo_shippriority, lo_quantity, lo_extendedprice
+                      , lo_ordtotalprice, lo_discount, lo_revenue, lo_supplycost, lo_tax
+                      , lo_commitdate, lo_shipmode)
+VALUES
+    (1, 1, 101, 201, 301, '1993-01-01 00:00:00', 'HIGH', 1, 10, 100, 90, 0, 90, 50, 5, 19930115, 'AIR'),
+    (2, 2, 102, 202, 302, '1994-01-01 00:00:00', 'MEDIUM', 2, 20, 200, 180, 5, 175, 75, 7, 19940116, 'SHIP'),
+    (3, 3, 103, 203, 302, '1994-01-01 00:00:00', 'MEDIUM', 2, 20, 200, 180, 5, 175, 75, 7, 19940116, 'SHIP');
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW if not exists default_test_mv0
+DISTRIBUTED BY RANDOM
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+'replication_num'='1',
+'force_external_table_query_rewrite'='true'
+) AS select lo_orderdate, count(1) from lineorder where lo_orderkey > 1 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 1;
+-- result:
+-- !result
+refresh materialized view default_test_mv0 with sync mode;
+function: check_hit_materialized_view("select lo_orderdate, count(1) from lineorder where lo_orderkey > 1 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 1;", "default_test_mv0")
+-- result:
+None
+-- !result
+select lo_orderdate, count(1) from lineorder where lo_orderkey > 1 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 1 order by 1;
+-- result:
+1994-01-01 00:00:00	2
+-- !result
+drop materialized view default_test_mv0;
+-- result:
+-- !result
+drop table lineorder;
+-- result:
 -- !result

--- a/test/sql/test_materialized_view/T/test_materialized_view_rewrite2
+++ b/test/sql/test_materialized_view/T/test_materialized_view_rewrite2
@@ -8,13 +8,12 @@ CREATE TABLE test_empty_partition_tbl(
 )
 DUPLICATE KEY (dt, col1)
 PARTITION BY date_trunc('day', dt)
---DISTRIBUTED BY RANDOM BUCKETS 32
 PROPERTIES (
 "replication_num" = "1"
 );
 
 CREATE MATERIALIZED VIEW  test_empty_partition_mv1 
-DISTRIBUTED BY RANDOM BUCKETS 32
+DISTRIBUTED BY RANDOM 
 partition by date_trunc('day', dt)
 PROPERTIES (
 "replication_num" = "1"
@@ -43,3 +42,67 @@ select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS 
 select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt <= '2023-08-15 00:00:00' GROUP BY col1;
 select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-15 00:00:00' GROUP BY col1;
 select col1, sum(col2) AS sum_col2, sum(if(error_code = 'TIMEOUT', col3, 0)) AS sum_col3 FROM test_empty_partition_tbl AS f WHERE dt = '2023-08-16 00:00:00' GROUP BY col1;
+
+drop materialized view test_empty_partition_mv1;
+drop table test_empty_partition_tbl;
+
+--name: test_mv_rewrite_with_having
+CREATE TABLE IF NOT EXISTS `lineorder` (
+    `lo_orderkey` int(11) NOT NULL COMMENT "",
+    `lo_linenumber` int(11) NOT NULL COMMENT "",
+    `lo_custkey` int(11) NOT NULL COMMENT "",
+    `lo_partkey` int(11) NOT NULL COMMENT "",
+    `lo_suppkey` int(11) NOT NULL COMMENT "",
+    `lo_orderdate` datetime NOT NULL COMMENT "",
+    `lo_orderpriority` varchar(16) NOT NULL COMMENT "",
+    `lo_shippriority` int(11) NOT NULL COMMENT "",
+    `lo_quantity` int(11) NOT NULL COMMENT "",
+    `lo_extendedprice` int(11) NOT NULL COMMENT "",
+    `lo_ordtotalprice` int(11) NOT NULL COMMENT "",
+    `lo_discount` int(11) NOT NULL COMMENT "",
+    `lo_revenue` int(11) NOT NULL COMMENT "",
+    `lo_supplycost` int(11) NOT NULL COMMENT "",
+    `lo_tax` int(11) NOT NULL COMMENT "",
+    `lo_commitdate` int(11) NOT NULL COMMENT "",
+    `lo_shipmode` varchar(11) NOT NULL COMMENT ""
+    ) ENGINE=OLAP
+    DUPLICATE KEY(`lo_orderkey`)
+    COMMENT "OLAP"
+    PARTITION BY RANGE(`lo_orderdate`)
+(
+    PARTITION p1 VALUES [("1992-01-01 00:00:00"), ("1993-01-01 00:00:00")),
+    PARTITION p2 VALUES [("1993-01-01 00:00:00"), ("1994-01-01 00:00:00")),
+    PARTITION p3 VALUES [("1994-01-01 00:00:00"), ("1995-01-01 00:00:00")),
+    PARTITION p4 VALUES [("1995-01-01 00:00:00"), ("1996-01-01 00:00:00")),
+    PARTITION p5 VALUES [("1996-01-01 00:00:00"), ("1997-01-01 00:00:00")),
+    PARTITION p6 VALUES [("1997-01-01 00:00:00"), ("1998-01-01 00:00:00")),
+    PARTITION p7 VALUES [("1998-01-01 00:00:00"), ("1999-01-01 00:00:00"))
+)
+DISTRIBUTED BY HASH(`lo_orderkey`) BUCKETS 4
+PROPERTIES (
+    "replication_num" = "1"
+);
+
+INSERT INTO lineorder (lo_orderkey, lo_linenumber, lo_custkey, lo_partkey, lo_suppkey
+                      , lo_orderdate, lo_orderpriority, lo_shippriority, lo_quantity, lo_extendedprice
+                      , lo_ordtotalprice, lo_discount, lo_revenue, lo_supplycost, lo_tax
+                      , lo_commitdate, lo_shipmode)
+VALUES
+    (1, 1, 101, 201, 301, '1993-01-01 00:00:00', 'HIGH', 1, 10, 100, 90, 0, 90, 50, 5, 19930115, 'AIR'),
+    (2, 2, 102, 202, 302, '1994-01-01 00:00:00', 'MEDIUM', 2, 20, 200, 180, 5, 175, 75, 7, 19940116, 'SHIP'),
+    (3, 3, 103, 203, 302, '1994-01-01 00:00:00', 'MEDIUM', 2, 20, 200, 180, 5, 175, 75, 7, 19940116, 'SHIP');
+
+CREATE MATERIALIZED VIEW if not exists default_test_mv0
+DISTRIBUTED BY RANDOM
+REFRESH DEFERRED MANUAL 
+PROPERTIES (
+'replication_num'='1',
+'force_external_table_query_rewrite'='true'
+) AS select lo_orderdate, count(1) from lineorder where lo_orderkey > 1 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 1;
+
+refresh materialized view default_test_mv0 with sync mode;
+
+function: check_hit_materialized_view("select lo_orderdate, count(1) from lineorder where lo_orderkey > 1 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 1;", "default_test_mv0")
+select lo_orderdate, count(1) from lineorder where lo_orderkey > 1 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 1 order by 1;
+drop materialized view default_test_mv0;
+drop table lineorder;


### PR DESCRIPTION
Why I'm doing:

- Rewrite mv with having exprs will fail because its plan will be treated as invalid.

What I'm doing:
- Since `AggregatedMaterializedViewRewriter` already supports agg with having, now loose the check in the prepare stage.

But there are still some limitations about agg with having:
- It's better that having aggregate functions should be output columns in the mv's output, otherwise it cannot be rewritten.
```
// OK
"select lo_orderdate, count(1) from lineorder where lo_orderkey > 1000 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 100",
// NOT OK
"select lo_orderdate, count(distinct lo_orderkey) from lineorder where lo_orderkey > 1000 and lo_orderkey < 10000 group by lo_orderdate  having count(*) > 100",


```

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
