### PR TITLE
[Enhancement]Repeated column last row in current page don't need next page

### DIFF
--- a/be/src/formats/parquet/stored_column_reader.cpp
+++ b/be/src/formats/parquet/stored_column_reader.cpp
@@ -50,9 +50,7 @@ public:
 
     Status load_specific_page(size_t cur_page_idx, uint64_t offset, uint64_t first_row) override;
 
-    void set_page_change_on_record_boundry() override {
-        _page_change_on_record_boundry = true;
-    }
+    void set_page_change_on_record_boundry() override { _page_change_on_record_boundry = true; }
 
 protected:
     bool page_selected(size_t num_values) override;
@@ -814,7 +812,8 @@ StatusOr<size_t> RepeatedStoredColumnReader::_convert_row_to_value(size_t* row) 
         _delimit_rows(&row_to_parse, &level_parsed);
         _levels_parsed += level_parsed;
         num_parsed_levels += level_parsed;
-        if (num_parsed_levels == _num_values_left_in_cur_page && (_page_change_on_record_boundry || _reader->is_last_page())) {
+        if (num_parsed_levels == _num_values_left_in_cur_page &&
+            (_page_change_on_record_boundry || _reader->is_last_page())) {
             row_to_parse += 1;
             _meet_first_record = false;
         }

--- a/be/src/formats/parquet/stored_column_reader.h
+++ b/be/src/formats/parquet/stored_column_reader.h
@@ -70,6 +70,8 @@ public:
     }
 
     virtual void set_page_num(size_t page_num) {}
+
+    virtual void set_page_change_on_record_boundry() {}
 };
 
 class StoredColumnReaderImpl : public StoredColumnReader {

--- a/be/src/formats/parquet/stored_column_reader_with_index.h
+++ b/be/src/formats/parquet/stored_column_reader_with_index.h
@@ -26,6 +26,7 @@ public:
             : _inner_reader(std::move(reader)), _offset_index_ctx(offset_index_ctx), _has_dict_page(has_dict_page) {
         _page_num = _offset_index_ctx->page_selected.size();
         _inner_reader->set_page_num(_page_num);
+        _inner_reader->set_page_change_on_record_boundry();
     }
 
     ~StoredColumnReaderWithIndex() = default;


### PR DESCRIPTION
Why I'm doing:
we need the next record starter then we know current record finished, but one record may be split into two pages, while with column index this won't happen.

What I'm doing:
finish record in current page, maybe we don't need load next page.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
