### PR TITLE
[UT] Remove too much useless ut stdout logs

### DIFF
--- a/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/server/ConcurrentDDLTest.java
@@ -118,7 +118,6 @@ public class ConcurrentDDLTest {
 
         List<List<Long>> bucketSeq = GlobalStateMgr.getCurrentState().getColocateTableIndex().getBackendsPerBucketSeq(
                 GlobalStateMgr.getCurrentState().getColocateTableIndex().getGroup(table.getId()));
-        System.out.println(bucketSeq);
         // check all created colocate tables has same tablet distribution as the bucket seq in colocate group
         for (long threadId : threadIds) {
             table = db.getTable("test_tbl_" + threadId);
@@ -127,7 +126,6 @@ public class ConcurrentDDLTest {
                     .map(id -> GlobalStateMgr.getCurrentState().getTabletInvertedIndex().getReplicasByTabletId(id))
                     .map(replicaList -> replicaList.get(0).getBackendId())
                     .collect(Collectors.toList());
-            System.out.println(backendIdList);
             Assert.assertEquals(bucketSeq, backendIdList.stream().map(Arrays::asList).collect(Collectors.toList()));
         }
     }
@@ -168,7 +166,6 @@ public class ConcurrentDDLTest {
                                 (ShowTableStmt) UtFrameUtils.parseStmtWithNewParser(
                                         "show tables from concurrent_test_db", connectContext);
                         ShowExecutor showExecutor = new ShowExecutor(connectContext, showTableStmt);
-                        System.out.println("show tables result: " + showExecutor.execute().getResultRows());
                         starRocksAssert.dropDatabase("concurrent_test_db");
                         System.out.println("concurrent_test_db dropped");
                     } catch (Exception e) {
@@ -204,19 +201,16 @@ public class ConcurrentDDLTest {
                         try {
                             if (idx == 0) { // create table
                                 sql = createTableSqlFormat.replaceAll("RRR", randomStr);
-                                // System.out.println(sql);
                                 starRocksAssert.withTable(sql);
                             } else if (idx == 1) { // create view
                                 sql = createViewSqlFormat.replaceAll("RRR", randomStr);
-                                // System.out.println(sql);
                                 starRocksAssert.withView(sql);
                             } else { // create mv
                                 sql = createMVSqlFormat.replaceAll("RRR", randomStr);
-                                // System.out.println(sql);
                                 starRocksAssert.withMaterializedView(sql);
                             }
                         } catch (Exception e) {
-                             // System.out.println(sql + " failed, msg: " + e.getMessage());
+                            // do nothing
                         }
                     }
                 });
@@ -262,7 +256,6 @@ public class ConcurrentDDLTest {
                                 " distributed by hash(id) buckets 5183 " +
                                 "properties(\"replication_num\"=\"1\", \"colocate_with\"=\"test_cg_001\");");
                     } catch (Exception e) {
-                        System.out.println(e.getMessage());
                         errorCount.incrementAndGet();
                     }
                     System.out.println("end to create table same_tbl");


### PR DESCRIPTION
Why I'm doing:
Remove too much useless ut stdout logs


## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
