### PR TITLE
[BugFix]dict page may have beed loaded before parquet pageindex load_dictionary_page

### DIFF
--- a/be/src/formats/parquet/column_chunk_reader.cpp
+++ b/be/src/formats/parquet/column_chunk_reader.cpp
@@ -278,6 +278,10 @@ Status ColumnChunkReader::_try_load_dictionary() {
 }
 
 Status ColumnChunkReader::load_dictionary_page() {
+    if (_dict_page_parsed) {
+        return Status::OK();
+    }
+
     RETURN_IF_ERROR(_parse_page_header());
     if (UNLIKELY(!current_page_is_dict())) {
         return Status::InternalError("Not a dictionary page in dictionary page offset");

--- a/be/src/formats/parquet/column_reader.cpp
+++ b/be/src/formats/parquet/column_reader.cpp
@@ -408,6 +408,8 @@ void ScalarColumnReader::select_offset_index(const SparseRange<uint64_t>& range,
     const tparquet::ColumnMetaData& column_metadata =
             _opts.row_group_meta->columns[_field->physical_column_index].meta_data;
     bool has_dict_page = column_metadata.__isset.dictionary_page_offset;
+    // be compatible with PARQUET-1850
+    has_dict_page |= _offset_index_ctx->check_dictionary_page(column_metadata.data_page_offset);
     _reader = std::make_unique<StoredColumnReaderWithIndex>(std::move(_reader), _offset_index_ctx.get(), has_dict_page);
 }
 

--- a/be/src/formats/parquet/page_index_reader.h
+++ b/be/src/formats/parquet/page_index_reader.h
@@ -33,6 +33,11 @@ struct ColumnOffsetIndexCtx {
 
     void collect_io_range(std::vector<io::SharedBufferedInputStream::IORange>* ranges, int64_t* end_offset,
                           bool active);
+
+    // be compatible with PARQUET-1850
+    bool check_dictionary_page(int64_t data_page_offset) {
+        return offset_index.page_locations.size() > 0 && offset_index.page_locations[0].offset > data_page_offset;
+    }
 };
 
 class PageIndexReader {


### PR DESCRIPTION
Why I'm doing:
introduced by #38974, pageindex load_dictionary_page, but this may have been loaded when conjuncts rewriting

What I'm doing:
check before load

Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
