### PR TITLE
[BugFix] fix lake pk compaction invalid memory access

### DIFF
--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -29,8 +29,6 @@ CompactionState::~CompactionState() {
     if (_update_manager != nullptr) {
         _update_manager->compaction_state_mem_tracker()->release(_memory_usage);
     }
-    // make sure segment iters release before `_stats`
-    _segment_iters.clear();
 }
 
 Status CompactionState::load_segments(Rowset* rowset, UpdateManager* update_manager,

--- a/be/src/storage/lake/update_compaction_state.cpp
+++ b/be/src/storage/lake/update_compaction_state.cpp
@@ -29,6 +29,8 @@ CompactionState::~CompactionState() {
     if (_update_manager != nullptr) {
         _update_manager->compaction_state_mem_tracker()->release(_memory_usage);
     }
+    // make sure segment iters release before `_stats`
+    _segment_iters.clear();
 }
 
 Status CompactionState::load_segments(Rowset* rowset, UpdateManager* update_manager,
@@ -64,9 +66,8 @@ Status CompactionState::_load_segments(Rowset* rowset, const TabletSchemaCSPtr& 
     std::unique_ptr<Column> pk_column;
     CHECK(PrimaryKeyEncoder::create_column(pkey_schema, &pk_column, true).ok());
 
-    OlapReaderStatistics stats;
     if (_segment_iters.empty()) {
-        ASSIGN_OR_RETURN(_segment_iters, rowset->get_each_segment_iterator(pkey_schema, &stats));
+        ASSIGN_OR_RETURN(_segment_iters, rowset->get_each_segment_iterator(pkey_schema, &_stats));
     }
     CHECK_EQ(_segment_iters.size(), rowset->num_segments());
 

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -51,10 +51,11 @@ private:
 
     UpdateManager* _update_manager = nullptr;
     size_t _memory_usage = 0;
+    // to be destructed after segment iters
+    OlapReaderStatistics _stats;
     std::vector<ChunkIteratorPtr> _segment_iters;
     int64_t _tablet_id = 0;
     std::mutex _state_lock;
-    OlapReaderStatistics _stats;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const CompactionState& o) {

--- a/be/src/storage/lake/update_compaction_state.h
+++ b/be/src/storage/lake/update_compaction_state.h
@@ -54,6 +54,7 @@ private:
     std::vector<ChunkIteratorPtr> _segment_iters;
     int64_t _tablet_id = 0;
     std::mutex _state_lock;
+    OlapReaderStatistics _stats;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const CompactionState& o) {

--- a/be/test/storage/lake/primary_key_compaction_task_test.cpp
+++ b/be/test/storage/lake/primary_key_compaction_task_test.cpp
@@ -856,6 +856,68 @@ TEST_P(LakePrimaryKeyCompactionTest, test_abort_txn) {
     SyncPoint::GetInstance()->DisableProcessing();
 }
 
+TEST_P(LakePrimaryKeyCompactionTest, test_multi_output_seg) {
+    // Prepare data for writing
+    std::vector<Chunk> chunks;
+    for (int i = 0; i < 3; i++) {
+        chunks.push_back(generate_data(kChunkSize, i));
+    }
+    auto indexes = std::vector<uint32_t>(kChunkSize);
+    for (int i = 0; i < kChunkSize; i++) {
+        indexes[i] = i;
+    }
+
+    auto version = 1;
+    auto tablet_id = _tablet_metadata->id();
+    for (int i = 0; i < 3; i++) {
+        auto txn_id = next_id();
+        ASSIGN_OR_ABORT(auto delta_writer, DeltaWriterBuilder()
+                                                   .set_tablet_manager(_tablet_mgr.get())
+                                                   .set_tablet_id(tablet_id)
+                                                   .set_txn_id(txn_id)
+                                                   .set_partition_id(_partition_id)
+                                                   .set_mem_tracker(_mem_tracker.get())
+                                                   .set_index_id(_tablet_schema->id())
+                                                   .build());
+        ASSERT_OK(delta_writer->open());
+        ASSERT_OK(delta_writer->write(chunks[i], indexes.data(), indexes.size()));
+        ASSERT_OK(delta_writer->finish());
+        delta_writer->close();
+        // Publish version
+        ASSERT_OK(publish_single_version(tablet_id, version + 1, txn_id).status());
+        version++;
+    }
+    ASSERT_EQ(kChunkSize * 3, read(version));
+
+    auto txn_id = next_id();
+    // make sure compact can generate more than one segment in output rowset
+    config::max_segment_file_size = 50;
+    config::vector_chunk_size = 10;
+    ASSIGN_OR_ABORT(auto task, _tablet_mgr->compact(_tablet_metadata->id(), version, txn_id));
+    check_task(task);
+    CompactionTask::Progress progress;
+    ASSERT_OK(task->execute(&progress, CompactionTask::kNoCancelFn));
+    EXPECT_EQ(100, progress.value());
+    EXPECT_FALSE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
+    ASSERT_OK(publish_single_version(_tablet_metadata->id(), version + 1, txn_id).status());
+    EXPECT_TRUE(_update_mgr->TEST_check_compaction_cache_absent(tablet_id, txn_id));
+    config::max_segment_file_size = 1073741824;
+    config::vector_chunk_size = 4096;
+    version++;
+    ASSERT_EQ(kChunkSize * 3, read(version));
+    if (GetParam().enable_persistent_index) {
+        check_local_persistent_index_meta(tablet_id, version);
+    }
+
+    ASSIGN_OR_ABORT(auto new_tablet_metadata, _tablet_mgr->get_tablet_metadata(tablet_id, version));
+    EXPECT_EQ(new_tablet_metadata->rowsets_size(), 1);
+    EXPECT_EQ(3, new_tablet_metadata->compaction_inputs_size());
+    EXPECT_FALSE(new_tablet_metadata->has_prev_garbage_version());
+    EXPECT_EQ(new_tablet_metadata->rowsets(0).num_dels(), 0);
+    // make sure compact can generate more than one segment in output rowset
+    EXPECT_TRUE(new_tablet_metadata->rowsets(0).segments_size() > 1);
+}
+
 INSTANTIATE_TEST_SUITE_P(LakePrimaryKeyCompactionTest, LakePrimaryKeyCompactionTest,
                          ::testing::Values(CompactionParam{HORIZONTAL_COMPACTION, 5, false},
                                            CompactionParam{VERTICAL_COMPACTION, 1, false},


### PR DESCRIPTION
Why I'm doing:
When do compaction and load state, `get_each_segment_iterator` can't use a stat in a stack. otherwise it will access invalid memory. It will cause crash like:

```
*** Aborted at 1704856337 (unix time) try "date -d @1704856337" if you are using GNU date ***
PC: @          0x51e021b starrocks::lake::TabletReader::do_get_next()
*** SIGSEGV (@0x0) received by PID 15529 (TID 0x7f8315335700) from PID 0; stack trace: ***
    @          0x65f27c2 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f83ce32cb20 (unknown)
    @          0x51e021b starrocks::lake::TabletReader::do_get_next()
    @          0x5214800 starrocks::lake::VerticalCompactionTask::compact_column_group()
    @          0x5215705 starrocks::lake::VerticalCompactionTask::execute()
    @          0x51b33c1 starrocks::lake::CompactionScheduler::do_compaction()
    @          0x51b3de5 starrocks::lake::CompactionScheduler::thread_task()
    @          0x2dde50a starrocks::ThreadPool::dispatch_thread()
    @          0x2dd8f7a starrocks::Thread::supervise_thread()
    @     0x7f83ce32214a start_thread
    @     0x7f83cd6acdc3 __GI___clone
    @                0x0 (unknown)
```

What I'm doing:
`get_each_segment_iterator` with gloabl stat.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
