### PR TITLE
[BugFix] Fix iceberg mv refresh failed when iceberg table is empty

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergMetadata.java
@@ -343,6 +343,8 @@ public class IcebergMetadata implements ConnectorMetadata {
                         return ImmutableList.of(partition);
                     }
                 }
+                // for empty table, use -1 as last updated time
+                return ImmutableList.of(new Partition(-1));
             } catch (IOException e) {
                 throw new StarRocksConnectorException("Failed to get partitions for table: " + table.getName(), e);
             }

--- a/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/R/test_mv_iceberg_rewrite
@@ -178,12 +178,36 @@ true
 -- !result
   
 REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
--- result:
-c45fa9dd-ab93-11ee-9b00-5e4f71f202d3
--- !result
 select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
 -- result:
 2023-12-01	4000
+-- !result
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+-- result:
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
+-- !result
+create table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+);
+-- result:
+-- !result
+CREATE MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1
+REFRESH DEFERRED MANUAL AS SELECT dt,col_int 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+-- result:
+-- !result
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+select state from information_schema.task_runs
+  where `database`='db_${uuid0}' and `DEFINITION` like "%test_mv1%";
+-- result:
+SUCCESS
+-- !result
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+-- result:
 -- !result
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
 -- result:

--- a/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
+++ b/test/sql/test_materialized_view/T/test_mv_iceberg_rewrite
@@ -93,4 +93,24 @@ select * from default_catalog.db_${uuid0}.test_mv1 order by 1, 2;
 
 
 drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+
+-- create unpartitoned mv 
+create table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} (
+  col_str string,
+  col_int int,
+  dt date
+);
+
+CREATE MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1
+REFRESH DEFERRED MANUAL AS SELECT dt,col_int 
+FROM mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0};
+
+REFRESH MATERIALIZED VIEW default_catalog.db_${uuid0}.test_mv1 WITH SYNC MODE;
+
+select state from information_schema.task_runs
+  where `database`='db_${uuid0}' and `DEFINITION` like "%test_mv1%";
+
+drop materialized view default_catalog.db_${uuid0}.test_mv1;
+drop table mv_iceberg_${uuid0}.mv_ice_db_${uuid0}.mv_ice_tbl_${uuid0} force;
 drop database mv_iceberg_${uuid0}.mv_ice_db_${uuid0} force;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:
return one default partition when getPartitions from iceberg if iceberg table is empty
Fixes #issue

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
