### PR TITLE
[Enhancement]  Use nc to detect fe query port

### DIFF
--- a/docker/dockerfiles/allin1/services/director/run.sh
+++ b/docker/dockerfiles/allin1/services/director/run.sh
@@ -110,7 +110,8 @@ check_fe_liveness()
     loginfo "checking if FE service query port:$fequeryport is alive or not ..."
     while true
     do
-        if nc -z -4 -w 5 $MYHOST $fequeryport ; then
+        NC="nc -z -w 5"
+        if $NC $MYHOST $fequeryport ; then
             loginfo "FE service query port:$fequeryport is alive!"
             break
         else

--- a/docker/dockerfiles/fe/fe-ubi.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubi.Dockerfile
@@ -27,7 +27,7 @@ FROM artifacts-from-${ARTIFACT_SOURCE} as artifacts
 FROM registry.access.redhat.com/ubi8/ubi:8.7
 ARG STARROCKS_ROOT=/opt/starrocks
 
-RUN yum install -y java-11-openjdk-devel tzdata openssl curl vim ca-certificates fontconfig gzip tar less hostname procps-ng lsof && \
+RUN yum install -y java-11-openjdk-devel tzdata openssl curl vim ca-certificates fontconfig gzip tar less hostname procps-ng lsof nc && \
     rpm -ivh https://repo.mysql.com/mysql80-community-release-el8-7.noarch.rpm && \
     yum -y install mysql-community-client --nogpgcheck && \
     yum remove -y mysql80-community-release

--- a/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
+++ b/docker/dockerfiles/fe/fe-ubuntu.Dockerfile
@@ -26,7 +26,7 @@ FROM ubuntu:22.04
 ARG STARROCKS_ROOT=/opt/starrocks
 
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
-        default-jdk mysql-client curl vim tree net-tools less tzdata locales && \
+        default-jdk mysql-client curl vim tree net-tools less tzdata locales netcat && \
         ln -fs /usr/share/zoneinfo/UTC /etc/localtime && \
         dpkg-reconfigure -f noninteractive tzdata && \
         locale-gen en_US.UTF-8 && \


### PR DESCRIPTION
Why I'm doing:

When FE is starting up, entrypoint script will output some errors which can be safely ignored, and users will be confused when seeing this error.

```
[Tue Jan 16 10:51:00 CST 2024] Process conf file fe.conf ...
[Tue Jan 16 10:51:00 CST 2024] first start fe with meta not exist.
ERROR 2003 (HY000): Can't connect to MySQL server on 'kube-starrocks-fe-service.starrocks2:9030' (111)
[Tue Jan 16 10:51:00 CST 2024] No leader yet, has_member: false ...
ERROR 2003 (HY000): Can't connect to MySQL server on 'kube-starrocks-fe-service.starrocks2:9030' (111)
[Tue Jan 16 10:51:02 CST 2024] No leader yet, has_member: false ...
```

What I'm doing:

Ignore this error `ERROR 2003 (HY000): Can't connect to MySQL server on 'kube-starrocks-fe-service.starrocks2:9030' (111)`

I use the following Dockerfile to test.
```
FROM starrocks/fe-ubuntu:3.2.2

RUN apt-get update -y && apt-get install -y --no-install-recommends netcat

COPY --chown=starrocks:starrocks fe_entrypoint.sh /opt/starrocks/fe_entrypoint.sh
```

FE-0
```
[Mon Mar 18 16:50:00 CST 2024] Process conf file fe.conf ...
[Mon Mar 18 16:50:00 CST 2024] first start fe with meta not exist.
nc: getaddrinfo for host "kube-starrocks-fe-service.starrocks" port 9030: Name or service not known
[Mon Mar 18 16:50:00 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
nc: getaddrinfo for host "kube-starrocks-fe-service.starrocks" port 9030: Name or service not known
[Mon Mar 18 16:50:02 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
nc: getaddrinfo for host "kube-starrocks-fe-service.starrocks" port 9030: Name or service not known
[Mon Mar 18 16:50:04 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
nc: getaddrinfo for host "kube-starrocks-fe-service.starrocks" port 9030: Name or service not known
[Mon Mar 18 16:50:06 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
[Mon Mar 18 16:50:08 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
[Mon Mar 18 16:50:10 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
...
[Mon Mar 18 16:50:30 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
[Mon Mar 18 16:50:30 CST 2024] Timed out, no members detected ever, assume myself is the first node ..
[Mon Mar 18 16:50:30 CST 2024] first start with no meta run start_fe.sh with additional options: ' --host_type FQDN'
```

FE-1
```
[Mon Mar 18 16:50:01 CST 2024] Process conf file fe.conf ...
[Mon Mar 18 16:50:01 CST 2024] first start fe with meta not exist.
nc: getaddrinfo for host "kube-starrocks-fe-service.starrocks" port 9030: Name or service not known
[Mon Mar 18 16:50:01 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
nc: getaddrinfo for host "kube-starrocks-fe-service.starrocks" port 9030: Name or service not known
[Mon Mar 18 16:50:03 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
nc: getaddrinfo for host "kube-starrocks-fe-service.starrocks" port 9030: Name or service not known
[Mon Mar 18 16:50:05 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
[Mon Mar 18 16:50:07 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
[Mon Mar 18 16:50:09 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
[Mon Mar 18 16:50:11 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
[Mon Mar 18 16:50:13 CST 2024] FE service kube-starrocks-fe-service.starrocks:9030 is not alive yet!
...
[Mon Mar 18 16:52:56 CST 2024] FE service is alive, check if has leader ...
```

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
