### PR TITLE
[Enhancement] return table properties when show create table in icebe…

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/IcebergTable.java
@@ -258,6 +258,11 @@ public class IcebergTable extends Table {
         return Joiner.on(":").join(name, ((BaseTable) getNativeTable()).operations().current().uuid());
     }
 
+    @Override
+    public Map<String, String> getProperties() {
+        return icebergProperties;
+    }
+
     public IcebergCatalogType getCatalogType() {
         return IcebergCatalogType.valueOf(icebergProperties.get(ICEBERG_CATALOG_TYPE));
     }

--- a/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/iceberg/IcebergApiConverter.java
@@ -54,6 +54,7 @@ import static com.starrocks.analysis.OutFileClause.PARQUET_COMPRESSION_TYPE_MAP;
 import static com.starrocks.connector.ColumnTypeConverter.fromIcebergType;
 import static com.starrocks.connector.ConnectorTableId.CONNECTOR_ID_GENERATOR;
 import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_CATALOG_TYPE;
+import static com.starrocks.connector.iceberg.IcebergMetadata.COMMENT;
 import static com.starrocks.connector.iceberg.IcebergMetadata.COMPRESSION_CODEC;
 import static com.starrocks.connector.iceberg.IcebergMetadata.FILE_FORMAT;
 import static com.starrocks.server.CatalogMgr.ResourceMappingCatalog.toResourceName;
@@ -74,7 +75,7 @@ public class IcebergApiConverter {
                 .setRemoteTableName(remoteTableName)
                 .setNativeTable(nativeTbl)
                 .setFullSchema(toFullSchemas(nativeTbl))
-                .setIcebergProperties(toIcebergProps(nativeCatalogType));
+                .setIcebergProperties(toIcebergProps(nativeTbl.properties(), nativeCatalogType));
 
         return tableBuilder.build();
     }
@@ -194,9 +195,44 @@ public class IcebergApiConverter {
         return fullSchema;
     }
 
-    public static Map<String, String> toIcebergProps(String nativeCatalogType) {
+    // get iceberg table properties
+    public static Map<String, String> toIcebergProps(Map<String, String> nativeProperties, String nativeCatalogType) {
+        if (nativeProperties == null) {
+            throw new IllegalArgumentException("iceberg properties cannot be null");
+        }
         Map<String, String> options = new HashMap<>();
+        Map<String, String> mutableMap = new HashMap<>(nativeProperties);
+        String fileFormat = mutableMap.getOrDefault(TableProperties.DEFAULT_FILE_FORMAT,
+                TableProperties.DEFAULT_FILE_FORMAT_DEFAULT);
+
+        // transform to starrocks properties
+        if (mutableMap.get(TableProperties.DEFAULT_FILE_FORMAT) != null) {
+            options.put(FILE_FORMAT, mutableMap.remove(TableProperties.DEFAULT_FILE_FORMAT));
+        }
+
+        switch (FileFormat.fromString(fileFormat)) {
+            case PARQUET:
+                if (mutableMap.get(TableProperties.PARQUET_COMPRESSION) != null) {
+                    options.put(COMPRESSION_CODEC, mutableMap.remove(TableProperties.PARQUET_COMPRESSION));
+                }
+                break;
+            case ORC:
+                if (mutableMap.get(TableProperties.ORC_COMPRESSION) != null) {
+                    options.put(COMPRESSION_CODEC, mutableMap.remove(TableProperties.ORC_COMPRESSION));
+                }
+                break;
+            case AVRO:
+                if (mutableMap.get(TableProperties.AVRO_COMPRESSION) != null) {
+                    options.put(COMPRESSION_CODEC, mutableMap.remove(TableProperties.AVRO_COMPRESSION));
+                }
+                break;
+            default:
+                throw new StarRocksConnectorException("Unsupported file format %s", fileFormat);
+        }
+        options.putAll(mutableMap);
         options.put(ICEBERG_CATALOG_TYPE, nativeCatalogType);
+        options.remove(COMMENT);
+
         return options;
     }
 

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/IcebergMetadataTest.java
@@ -113,6 +113,7 @@ import static com.starrocks.catalog.Type.INT;
 import static com.starrocks.catalog.Type.STRING;
 import static com.starrocks.connector.iceberg.IcebergConnector.HIVE_METASTORE_URIS;
 import static com.starrocks.connector.iceberg.IcebergConnector.ICEBERG_CATALOG_TYPE;
+import static com.starrocks.connector.iceberg.IcebergMetadata.COMMENT;
 import static com.starrocks.connector.iceberg.IcebergMetadata.COMPRESSION_CODEC;
 import static com.starrocks.connector.iceberg.IcebergMetadata.FILE_FORMAT;
 import static com.starrocks.connector.iceberg.IcebergMetadata.LOCATION_PROPERTY;
@@ -199,6 +200,16 @@ public class IcebergMetadataTest extends TableTestBase {
 
         new Expectations() {
             {
+                hiveTableOperations.current().properties();
+                Map<String, String> properties = new HashMap<>();
+                properties.put(TableProperties.DEFAULT_FILE_FORMAT, "orc");
+                properties.put(COMMENT, "xxx");
+                result = properties;
+                minTimes = 0;
+            }
+        };
+        new Expectations() {
+            {
                 icebergHiveCatalog.getTable("db", "tbl");
                 result = new BaseTable(hiveTableOperations, "tbl");
                 minTimes = 0;
@@ -210,6 +221,8 @@ public class IcebergMetadataTest extends TableTestBase {
         Table actual = metadata.getTable("db", "tbl");
         Assert.assertEquals("tbl", actual.getName());
         Assert.assertEquals(ICEBERG, actual.getType());
+        Assert.assertEquals("orc", actual.getProperties().get(FILE_FORMAT));
+        Assert.assertEquals("xxx", actual.getComment());
     }
 
     @Test

--- a/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/iceberg/MockIcebergMetadata.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -135,10 +136,14 @@ public class MockIcebergMetadata implements ConnectorMetadata {
                 schema, spec, 1);
 
         String tableIdentifier = Joiner.on(":").join(MOCKED_UNPARTITIONED_TABLE_NAME0, UUID.randomUUID());
+        Map<String, String> icebergProperties = new HashMap<>();
+        icebergProperties.put(IcebergMetadata.FILE_FORMAT, "orc");
+        icebergProperties.put(IcebergMetadata.COMPRESSION_CODEC, "gzip");
         MockIcebergTable mockIcebergTable = new MockIcebergTable(1, MOCKED_UNPARTITIONED_TABLE_NAME0,
                 MOCKED_ICEBERG_CATALOG_NAME, null, MOCKED_UNPARTITIONED_DB_NAME,
-                MOCKED_UNPARTITIONED_TABLE_NAME0, schemas, baseTable, null,
+                MOCKED_UNPARTITIONED_TABLE_NAME0, schemas, baseTable, icebergProperties,
                 tableIdentifier);
+        mockIcebergTable.setComment("unpartitioned table");
 
         Map<String, ColumnStatistic> columnStatisticMap;
         List<String> colNames = schemas.stream().map(Column::getName).collect(Collectors.toList());
@@ -314,9 +319,14 @@ public class MockIcebergMetadata implements ConnectorMetadata {
         TestTables.TestTable baseTable = getPartitionIdentityTable(tblName, schema);
 
         String tableIdentifier = Joiner.on(":").join(tblName, UUID.randomUUID());
-        return new MockIcebergTable(tblName.hashCode(), tblName, MOCKED_ICEBERG_CATALOG_NAME,
-                null, MOCKED_PARTITIONED_DB_NAME, tblName, schemas, baseTable, null,
+        Map<String, String> icebergProperties = new HashMap<>();
+        icebergProperties.put(IcebergMetadata.FILE_FORMAT, "orc");
+        icebergProperties.put(IcebergMetadata.COMPRESSION_CODEC, "gzip");
+        MockIcebergTable icebergTable = new MockIcebergTable(tblName.hashCode(), tblName, MOCKED_ICEBERG_CATALOG_NAME,
+                null, MOCKED_PARTITIONED_DB_NAME, tblName, schemas, baseTable, icebergProperties,
                 tableIdentifier);
+        icebergTable.setComment("partitioned table");
+        return icebergTable;
     }
 
     public static MockIcebergTable getPartitionTransformIcebergTable(String tblName, List<Column> schemas)

--- a/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/qe/ShowExecutorTest.java
@@ -1066,7 +1066,7 @@ public class ShowExecutorTest {
                 "  `dt` int(11) DEFAULT NULL\n" +
                 ")\n" +
                 "PARTITION BY ( year, dt )\n" +
-                "PROPERTIES (\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\");", resultSet.getResultRows().get(0).get(1));
+                "PROPERTIES (\n\"location\" = \"hdfs://hadoop/hive/warehouse/test.db/test\"\n);", resultSet.getResultRows().get(0).get(1));
     }
 
     @Test


### PR DESCRIPTION
Why I'm doing:

> The show create table statement in iceberg catalog does not return table properties except location.

What I'm doing:

> Return table properties when execute show create table in iceberg catalog.

**SQL demo supported:**
`show create table partitioned_db.t1`

**Result:**
CREATE TABLE `t1` (
  `id` int(11) DEFAULT NULL,
  `data` varchar(1048576) DEFAULT NULL,
  `date` varchar(1048576) DEFAULT NULL
)
PARTITION BY ( date )
COMMENT ("partitioned table")
PROPERTIES (
"file_format" = "orc",
"location" = "/.../partitioned_db/t1",
"compression_codec" = "gzip"
);

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [x] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 4.1
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5