### PR TITLE
[BugFix] Fix mv restore after restore db has been changed

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupHandler.java
@@ -97,6 +97,8 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantLock;
 
+import static com.starrocks.scheduler.MVActiveChecker.MV_BACKUP_INACTIVE_REASON;
+
 public class BackupHandler extends FrontendDaemon implements Writable {
     private static final Logger LOG = LogManager.getLogger(BackupHandler.class);
 
@@ -355,8 +357,8 @@ public class BackupHandler extends FrontendDaemon implements Writable {
                 }
                 if (copiedTbl.isMaterializedView()) {
                     MaterializedView copiedMv = (MaterializedView) copiedTbl;
-                    copiedMv.setInactiveAndReason(String.format("Set the materialized view %s inactive in backup and " +
-                            "active it in restore if possible", copiedMv.getName()));
+                    copiedMv.setInactiveAndReason(String.format("Set the materialized view %s inactive because %s",
+                            copiedMv.getName(), MV_BACKUP_INACTIVE_REASON));
                 }
                 backupTbls.add(copiedTbl);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/BackupJob.java
@@ -98,6 +98,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.starrocks.scheduler.MVActiveChecker.MV_BACKUP_INACTIVE_REASON;
+
 public class BackupJob extends AbstractJob {
     private static final Logger LOG = LogManager.getLogger(BackupJob.class);
 
@@ -516,8 +518,8 @@ public class BackupJob extends AbstractJob {
                 }
                 if (copiedTbl.isMaterializedView()) {
                     MaterializedView copiedMv = (MaterializedView) copiedTbl;
-                    copiedMv.setInactiveAndReason(String.format("Set the materialized view %s inactive in backup and " +
-                            "active it in restore if possible", copiedMv.getName()));
+                    copiedMv.setInactiveAndReason(String.format("Set the materialized view %s inactive in backup " +
+                            "because %s", copiedMv.getName(), MV_BACKUP_INACTIVE_REASON));
                 }
                 copiedTables.add(copiedTbl);
             }

--- a/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
+++ b/fe/fe-core/src/main/java/com/starrocks/backup/mv/MVRestoreUpdater.java
@@ -207,8 +207,7 @@ public class MVRestoreUpdater {
         baseTableVisibleVersionMap.put(localBaseTable.getId(), versionMap);
     }
 
-    public static boolean restoreBaseTableInfoIfNoRestored(Database restoreDb,
-                                                           MaterializedView mv,
+    public static boolean restoreBaseTableInfoIfNoRestored(MaterializedView mv,
                                                            BaseTableInfo baseTableInfo,
                                                            List<BaseTableInfo> newBaseTableInfos) {
 
@@ -226,7 +225,8 @@ public class MVRestoreUpdater {
                     mv.getName(), remoteDbName, remoteTableName));
             return false;
         }
-        BaseTableInfo newBaseTableInfo = new BaseTableInfo(restoreDb.getId(), restoreDb.getFullName(),
+        // use baseTable's db instead of mv's db to construct baseTableInfo.
+        BaseTableInfo newBaseTableInfo = new BaseTableInfo(baseTableDb.getId(), baseTableDb.getFullName(),
                 baseTable.getName(), baseTable.getId());
         newBaseTableInfos.add(newBaseTableInfo);
         return true;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -38,6 +38,7 @@ import com.starrocks.sql.parser.SqlParser;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.parquet.Strings;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -228,7 +229,7 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
         Text.writeString(out, GsonUtils.GSON.toJson(serializedPartitionExprs));
     }
 
-    public void renameTableName(String newTableName) {
+    public void renameTableName(TableName newTableName) {
         AstVisitor<Void, Void> renameVisitor = new AstVisitor<Void, Void>() {
             @Override
             public Void visitExpression(Expr expr, Void context) {
@@ -242,7 +243,10 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
             public Void visitSlot(SlotRef node, Void context) {
                 TableName tableName = node.getTblNameWithoutAnalyzed();
                 if (tableName != null) {
-                    tableName.setTbl(newTableName);
+                    if (!Strings.isNullOrEmpty(newTableName.getDb())) {
+                        tableName.setDb(newTableName.getDb());
+                    }
+                    tableName.setTbl(newTableName.getTbl());
                 }
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/ExpressionRangePartitionInfo.java
@@ -229,7 +229,13 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
         Text.writeString(out, GsonUtils.GSON.toJson(serializedPartitionExprs));
     }
 
-    public void renameTableName(TableName newTableName) {
+    /**
+     * Do actions when rename referred table's db or table name.
+     * @param dbName        : new db name which can be null or empty and will be not updated then.
+     * @param newTableName  : new table name which must be not null or empty.
+     */
+    public void renameTableName(String dbName, String newTableName) {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(newTableName));
         AstVisitor<Void, Void> renameVisitor = new AstVisitor<Void, Void>() {
             @Override
             public Void visitExpression(Expr expr, Void context) {
@@ -243,10 +249,10 @@ public class ExpressionRangePartitionInfo extends RangePartitionInfo implements 
             public Void visitSlot(SlotRef node, Void context) {
                 TableName tableName = node.getTblNameWithoutAnalyzed();
                 if (tableName != null) {
-                    if (!Strings.isNullOrEmpty(newTableName.getDb())) {
-                        tableName.setDb(newTableName.getDb());
+                    if (!Strings.isNullOrEmpty(dbName)) {
+                        tableName.setDb(dbName);
                     }
-                    tableName.setTbl(newTableName.getTbl());
+                    tableName.setTbl(newTableName);
                 }
                 return null;
             }

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -1869,7 +1869,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
         if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
             Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprs().size() == 1);
-            expressionRangePartitionInfo.renameTableName(new TableName(db.getFullName(), this.name));
+            expressionRangePartitionInfo.renameTableName(db.getFullName(), this.name);
         }
 
         setActive();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/MaterializedView.java
@@ -503,6 +503,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
      * active the materialized again & reload the state.
      */
     public void setActive() {
+        LOG.warn("set {} to active", name);
         this.active = true;
         this.inactiveReason = null;
         // reset mv rewrite cache when it is active again
@@ -510,6 +511,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
     }
 
     public void setInactiveAndReason(String reason) {
+        LOG.warn("set {} to inactive because of {}", name, reason);
         this.active = false;
         this.inactiveReason = reason;
         CachingMvPlanContextBuilder.getInstance().invalidateFromCache(this);
@@ -1789,7 +1791,6 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
 
         List<BaseTableInfo> newBaseTableInfos = Lists.newArrayList();
 
-
         boolean isSetInactive = false;
         Map<TableName, MvBaseTableBackupInfo> mvBaseTableToBackupTableInfo = mvRestoreContext.getMvBaseTableToBackupTableInfo();
         Map<TableName, TableName> remoteToLocalTableName = Maps.newHashMap();
@@ -1804,7 +1805,7 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 // be backed up and restored before.
                 LOG.info(String.format("Materialized view %s can not find the base table from mvBaseTableToBackupTableInfo, " +
                         "old base table name:%s, try to find in current env", this.name, remoteDbTblName));
-                if (!restoreBaseTableInfoIfNoRestored(db, this, baseTableInfo, newBaseTableInfos)) {
+                if (!restoreBaseTableInfoIfNoRestored(this, baseTableInfo, newBaseTableInfos)) {
                     isSetInactive = true;
                 }
             } else {
@@ -1863,6 +1864,14 @@ public class MaterializedView extends OlapTable implements GsonPreProcessable, G
                 String.format("New baseTableInfos' size should be qual to old baseTableInfos, baseTableInfos:%s," +
                                 "newBaseTableInfos:%s", oldBaseTableInfosStr, newBaseTableInfosStr));
         this.baseTableInfos = newBaseTableInfos;
+
+        // change ExpressionRangePartitionInfo because mv's db may be changed.
+        if (partitionInfo instanceof ExpressionRangePartitionInfo) {
+            ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
+            Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprs().size() == 1);
+            expressionRangePartitionInfo.renameTableName(new TableName(db.getFullName(), this.name));
+        }
+
         setActive();
 
         fixRelationship();

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -53,6 +53,7 @@ import com.starrocks.analysis.IndexDef.IndexType;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
+import com.starrocks.analysis.TableName;
 import com.starrocks.backup.Status;
 import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.backup.mv.MvBackupInfo;
@@ -505,7 +506,7 @@ public class OlapTable extends Table {
         if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
             Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprs().size() == 1);
-            expressionRangePartitionInfo.renameTableName(newName);
+            expressionRangePartitionInfo.renameTableName(new TableName("", newName));
         }
     }
 
@@ -858,9 +859,7 @@ public class OlapTable extends Table {
                 continue;
             }
             MaterializedView mv = (MaterializedView) mvTable;
-            if (mv.isActive()) {
-                continue;
-            }
+            // Do this no matter whether mv is active or not to restore version map for mv rewrite.
             mv.doAfterRestore(db, mvRestoreContext);
         }
         return Status.OK;

--- a/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
+++ b/fe/fe-core/src/main/java/com/starrocks/catalog/OlapTable.java
@@ -53,7 +53,6 @@ import com.starrocks.analysis.IndexDef.IndexType;
 import com.starrocks.analysis.SlotDescriptor;
 import com.starrocks.analysis.SlotId;
 import com.starrocks.analysis.SlotRef;
-import com.starrocks.analysis.TableName;
 import com.starrocks.backup.Status;
 import com.starrocks.backup.Status.ErrCode;
 import com.starrocks.backup.mv.MvBackupInfo;
@@ -506,7 +505,7 @@ public class OlapTable extends Table {
         if (partitionInfo instanceof ExpressionRangePartitionInfo) {
             ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
             Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprs().size() == 1);
-            expressionRangePartitionInfo.renameTableName(new TableName("", newName));
+            expressionRangePartitionInfo.renameTableName("", newName);
         }
     }
 

--- a/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
+++ b/fe/fe-core/src/main/java/com/starrocks/scheduler/MVActiveChecker.java
@@ -15,6 +15,7 @@
 package com.starrocks.scheduler;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.starrocks.alter.AlterJobMgr;
 import com.starrocks.analysis.TableName;
@@ -39,6 +40,7 @@ import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * A daemon thread that check the MV active status, try to activate the MV it's inactive.
@@ -52,6 +54,12 @@ public class MVActiveChecker extends FrontendDaemon {
     public MVActiveChecker() {
         super("MVActiveChecker", Config.mv_active_checker_interval_seconds * 1000);
     }
+
+    public static final String MV_BACKUP_INACTIVE_REASON = "it's in backup and will be activated after restore if possible";
+
+    // there are some reasons that we don't active mv automatically, eg: mv backup/restore which may cause to refresh all
+    // mv's data behind which is not expected.
+    private static final Set<String> MV_NO_AUTOMATIC_ACTIVE_REASONS = ImmutableSet.of(MV_BACKUP_INACTIVE_REASON);
 
     @Override
     protected void runAfterCatalogReady() {
@@ -109,6 +117,9 @@ public class MVActiveChecker extends FrontendDaemon {
         // if the mv is set to inactive manually, we don't activate it
         String reason = mv.getInactiveReason();
         if (mv.isActive() || AlterJobMgr.MANUAL_INACTIVE_MV_REASON.equalsIgnoreCase(reason)) {
+            return;
+        }
+        if (MV_NO_AUTOMATIC_ACTIVE_REASONS.stream().anyMatch(x -> x.contains(reason))) {
             return;
         }
 


### PR DESCRIPTION
Why I'm doing:
Though PR(https://github.com/StarRocks/starrocks/pull/38642) supports to reuse version map for mv backup/restore, but introduce some bugs in my tests.

What I'm doing:
1. change ExpressionRangePartitionInfo because mv's db may be changed.
```
       // change ExpressionRangePartitionInfo because mv's db may be changed.
        if (partitionInfo instanceof ExpressionRangePartitionInfo) {
            ExpressionRangePartitionInfo expressionRangePartitionInfo = (ExpressionRangePartitionInfo) partitionInfo;
            Preconditions.checkState(expressionRangePartitionInfo.getPartitionExprs().size() == 1);
            expressionRangePartitionInfo.renameTableName(db.getFullName(), this.name);
        }
```
2. no active backed up mvs automatically because this may refresh all partition datas, and restore may repair mv later.
3. use original baseTable's db instead of mv's db to construct baseTableInfo if the base table has not be restored before.
4. Skip to restore existed mv if mv is existed and active in the current local db
```
   // Skip to restore existed mv if mv is existed and active in the current local db,
                            // mv should be refreshed by local table changes rather than backup/restore because we don't
                            // track mv's version map with data's restore.
                            // eg: we restore mv's data (old version) but not restore associated version map which may
                            // cause wrong result if it can be used to rewrite.
```
Fixes https://github.com/StarRocks/StarRocksTest/pull/5734/files

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
