### PR TITLE
[Doc] replace tables with markdown

### DIFF
--- a/docs/en/loading/Kafka-connector-starrocks.md
+++ b/docs/en/loading/Kafka-connector-starrocks.md
@@ -106,27 +106,120 @@ The following steps take a self-managed Kafka cluster as an example to demonstra
 
 ## Parameters
 
-| Parameter                           | Required | Default value                                                | Description                                                  |
-| ----------------------------------- | -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| name                                | YES      |                                                              | Name for this Kafka connector. It must be globally unique among all Kafka connectors within this Kafka Connect cluster. For example, starrocks-kafka-connector. |
-| connector.class                     | YES      | com.starrocks.connector.kafka.SinkConnector                  | Class used by this Kafka connector's sink.                   |
-| topics                              | YES      |                                                              | One or more topics to subscribe to, where each topic corresponds to a StarRocks table. By default, StarRocks assumes that the topic name matches the name of the StarRocks table. So StarRocks determines the target StarRocks table by using the topic name. Please choose either to fill in `topics` or `topics.regex` (below), but not both.However, if the StarRocks table name is not the same as the topic name, then use the optional `starrocks.topic2table.map` parameter (below) to specify the mapping from topic name to table name. |
-| topics.regex                        |          | Regular expression to match the one or more topics to subscribe to. For more description, see `topics`. Please choose either to fill in  `topics.regex`or `topics` (above), but not both. |                                                              |
-| starrocks.topic2table.map           | NO       |                                                              | The mapping of the StarRocks table name and the topic name when the topic name is different from the StarRocks table name. The format is `<topic-1>:<table-1>,<topic-2>:<table-2>,...`. |
-| starrocks.http.url                  | YES      |                                                              | The HTTP URL of the FE in your StarRocks cluster. The format is `<fe_host1>:<fe_http_port1>,<fe_host2>:<fe_http_port2>,...`. Multiple addresses are separated by commas (,). For example, `192.168.xxx.xxx:8030,192.168.xxx.xxx:8030`. |
-| starrocks.database.name             | YES      |                                                              | The name of StarRocks database.                              |
-| starrocks.username                  | YES      |                                                      | The username of your StarRocks cluster account. The user needs the [INSERT](../sql-reference/sql-statements/account-management/GRANT.md) privilege on the StarRocks table. |
-| starrocks.password                  | YES      |                                                              | The password of your StarRocks cluster account.              |
-| key.converter                       | NO      |           Key converter used by Kafka Connect cluster                                                           | This parameter specifies the key converter for the sink connector (Kafka-connector-starrocks), which is used to deserialize the keys of Kafka data. The default key converter is the one used by Kafka Connect cluster.|
-| value.converter                     | NO      |    Value converter used by Kafka Connect cluster                             | This parameter specifies the value converter for the sink connector (Kafka-connector-starrocks), which is used to deserialize the values of Kafka data. The default value converter is the one used by Kafka Connect cluster. |
-| key.converter.schema.registry.url   | NO       |                                                              | Schema registry URL for the key converter.                   |
-| value.converter.schema.registry.url | NO       |                                                              | Schema registry URL for the value converter.                 |
-| tasks.max                           | NO       | 1                                                            | The upper limit for the number of task threads that the Kafka connector can create, which is usually the same as the number of CPU cores on the worker nodes in the Kafka Connect cluster. You can tune this parameter to control load performance. |
-| bufferflush.maxbytes                | NO       | 94371840(90M)                                                | The maximum size of data that can be accumulated in memory before being sent to StarRocks at a time. The maximum value ranges from 64 MB to 10 GB. Keep in mind that the Stream Load SDK buffer may create multiple Stream Load jobs to buffer data. Therefore, the threshold mentioned here refers to the total data size. |
-| bufferflush.intervalms              | NO       | 300000                                                       | Interval for sending a batch of data which controls the load latency. Range: [1000, 3600000]. |
-| connect.timeoutms                   | NO       | 1000                                                         | Timeout for connecting to the HTTP URL. Range: [100, 60000]. |
-| sink.properties.*                   |          |                                                              | Stream Load parameters o control load behavior. For example, the parameter `sink.properties.format` specifies the format used for Stream Load, such as CSV or JSON. For a list of supported parameters and their descriptions, see [STREAM LOAD](../sql-reference/sql-statements/data-manipulation/STREAM LOAD.md). |
-| sink.properties.format              | NO       | json                                                         | The format used for Stream Load. The Kafka connector will transform each batch of data to the format before sending them to StarRocks. Valid values: `csv` and `json`. For more information, see [CSV parameters**](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md#csv-parameters)和** [JSON parameters](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md#json-parameters). |
+### name                                
+
+**Required**: YES<br/>
+**Default value**:<br/>
+**Description**: Name for this Kafka connector. It must be globally unique among all Kafka connectors within this Kafka Connect cluster. For example, starrocks-kafka-connector.
+
+### connector.class                     
+
+**Required**: YES<br/>
+**Default value**: com.starrocks.connector.kafka.SinkConnector<br/>
+**Description**: Class used by this Kafka connector's sink.
+
+### topics                              
+
+**Required**: YES<br/>
+**Default value**:<br/>
+**Description**: One or more topics to subscribe to, where each topic corresponds to a StarRocks table. By default, StarRocks assumes that the topic name matches the name of the StarRocks table. So StarRocks determines the target StarRocks table by using the topic name. Please choose either to fill in `topics` or `topics.regex` (below), but not both.However, if the StarRocks table name is not the same as the topic name, then use the optional `starrocks.topic2table.map` parameter (below) to specify the mapping from topic name to table name.
+
+### topics.regex                        
+
+**Required**:<br/>
+**Default value**: Regular expression to match the one or more topics to subscribe to. For more description, see `topics`. Please choose either to fill in  `topics.regex`or `topics` (above), but not both. <br/>
+**Description**:
+
+### starrocks.topic2table.map           
+
+**Required**: NO<br/>
+**Default value**:<br/>
+**Description**: The mapping of the StarRocks table name and the topic name when the topic name is different from the StarRocks table name. The format is `<topic-1>:<table-1>,<topic-2>:<table-2>,...`.
+
+### starrocks.http.url                  
+
+**Required**: YES<br/>
+**Default value**:<br/>
+**Description**: The HTTP URL of the FE in your StarRocks cluster. The format is `<fe_host1>:<fe_http_port1>,<fe_host2>:<fe_http_port2>,...`. Multiple addresses are separated by commas (,). For example, `192.168.xxx.xxx:8030,192.168.xxx.xxx:8030`.
+
+### starrocks.database.name             
+
+**Required**: YES<br/>
+**Default value**:<br/>
+**Description**: The name of StarRocks database.
+
+### starrocks.username                  
+
+**Required**: YES<br/>
+**Default value**:<br/>
+**Description**: The username of your StarRocks cluster account. The user needs the [INSERT](../sql-reference/sql-statements/account-management/GRANT.md) privilege on the StarRocks table.
+
+### starrocks.password                  
+
+**Required**: YES<br/>
+**Default value**:<br/>
+**Description**: The password of your StarRocks cluster account.
+
+### key.converter                       
+
+**Required**: NO<br/>
+**Default value**: Key converter used by Kafka Connect cluster<br/>
+**Description**: This parameter specifies the key converter for the sink connector (Kafka-connector-starrocks), which is used to deserialize the keys of Kafka data. The default key converter is the one used by Kafka Connect cluster.
+
+### value.converter                     
+
+**Required**: NO<br/>
+**Default value**: Value converter used by Kafka Connect cluster<br/>
+**Description**: This parameter specifies the value converter for the sink connector (Kafka-connector-starrocks), which is used to deserialize the values of Kafka data. The default value converter is the one used by Kafka Connect cluster.
+
+### key.converter.schema.registry.url   
+
+**Required**: NO<br/>
+**Default value**:<br/>
+**Description**: Schema registry URL for the key converter.
+
+### value.converter.schema.registry.url 
+
+**Required**: NO<br/>
+**Default value**:<br/>
+**Description**: Schema registry URL for the value converter.
+
+### tasks.max                           
+
+**Required**: NO<br/>
+**Default value**: 1<br/>
+**Description**: The upper limit for the number of task threads that the Kafka connector can create, which is usually the same as the number of CPU cores on the worker nodes in the Kafka Connect cluster. You can tune this parameter to control load performance.
+
+### bufferflush.maxbytes                
+
+**Required**: NO<br/>
+**Default value**: 94371840(90M)<br/>
+**Description**: The maximum size of data that can be accumulated in memory before being sent to StarRocks at a time. The maximum value ranges from 64 MB to 10 GB. Keep in mind that the Stream Load SDK buffer may create multiple Stream Load jobs to buffer data. Therefore, the threshold mentioned here refers to the total data size.
+
+### bufferflush.intervalms              
+
+**Required**: NO<br/>
+**Default value**: 300000<br/>
+**Description**: Interval for sending a batch of data which controls the load latency. Range: [1000, 3600000].
+
+### connect.timeoutms                   
+
+**Required**: NO<br/>
+**Default value**: 1000<br/>
+**Description**: Timeout for connecting to the HTTP URL. Range: [100, 60000].
+
+### sink.properties.*                   
+
+**Required**:<br/>
+**Default value**:<br/>
+**Description**:  Stream Load parameters o control load behavior. For example, the parameter `sink.properties.format` specifies the format used for Stream Load, such as CSV or JSON. For a list of supported parameters and their descriptions, see [STREAM LOAD](../sql-reference/sql-statements/data-manipulation/STREAM LOAD.md).
+
+### sink.properties.format              
+
+**Required**: NO<br/>
+**Default value**: json<br/>
+**Description**: The format used for Stream Load. The Kafka connector will transform each batch of data to the format before sending them to StarRocks. Valid values: `csv` and `json`. For more information, see [CSV parameters**](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md#csv-parameters)和** [JSON parameters](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md#json-parameters).
+
 
 ## Limits
 

--- a/docs/en/loading/Spark-connector-starrocks.md
+++ b/docs/en/loading/Spark-connector-starrocks.md
@@ -14,7 +14,7 @@ StarRocks provides a self-developed connector named StarRocks Connector for Apac
 
 | Spark connector | Spark            | StarRocks     | Java | Scala |
 | --------------- | ---------------- | ------------- | ---- | ----- |
-| 1.1.1 | 3.2, 3.3, or 3.4 | 2.5 and later | 8 | 2.12 |
+| 1.1.1           | 3.2, 3.3, or 3.4 | 2.5 and later | 8    | 2.12  |
 | 1.1.0           | 3.2, 3.3, or 3.4 | 2.5 and later | 8    | 2.12  |
 
 > **NOTICE**
@@ -87,29 +87,131 @@ Directly download the corresponding version of the Spark connector JAR from the 
 
 ## Parameters
 
-| Parameter                                      | Required | Default value | Description                                                  |
-| ---------------------------------------------- | -------- | ------------- | ------------------------------------------------------------ |
-| starrocks.fe.http.url                          | YES      | None          | The HTTP URL of the FE in your StarRocks cluster. You can specify multiple URLs, which must be separated by a comma (,). Format: `<fe_host1>:<fe_http_port1>,<fe_host2>:<fe_http_port2>`. Since version 1.1.1, you can also add `http://` prefix to the URL, such as `http://<fe_host1>:<fe_http_port1>,http://<fe_host2>:<fe_http_port2>`.|
-| starrocks.fe.jdbc.url                          | YES      | None          | The address that is used to connect to the MySQL server of the FE. Format: `jdbc:mysql://<fe_host>:<fe_query_port>`. |
-| starrocks.table.identifier                     | YES      | None          | The name of the StarRocks table. Format: `<database_name>.<table_name>`. |
-| starrocks.user                                 | YES      | None          | The username of your StarRocks cluster account. The user needs the [SELECT and INSERT privileges](../sql-reference/sql-statements/account-management/GRANT.md) on the StarRocks table.             |
-| starrocks.password                             | YES      | None          | The password of your StarRocks cluster account.              |
-| starrocks.write.label.prefix                   | NO       | spark-        | The label prefix used by Stream Load.                        |
-| starrocks.write.enable.transaction-stream-load | NO | TRUE | Whether to use [Stream Load transaction interface](../loading/Stream_Load_transaction_interface.md) to load data. It requires StarRocks v2.5 or later. This feature can load more data in a transaction with less memory usage, and improve performance. <br/> **NOTICE:** Since 1.1.1, this parameter takes effect only when the value of `starrocks.write.max.retries` is non-positive because Stream Load transaction interface does not support retry. |
-| starrocks.write.buffer.size                    | NO       | 104857600     | The maximum size of data that can be accumulated in memory before being sent to StarRocks at a time. Setting this parameter to a larger value can improve loading performance but may increase loading latency. |
-| starrocks.write.buffer.rows | NO | Integer.MAX_VALUE | Supported since version 1.1.1. The maximum number of rows that can be accumulated in memory before being sent to StarRocks at a time. |
-| starrocks.write.flush.interval.ms              | NO       | 300000        | The interval at which data is sent to StarRocks. This parameter is used to control the loading latency. |
-| starrocks.write.max.retries                    | NO       | 3             | Supported since version 1.1.1. The number of times that the connector retries to perform the Stream Load for the same batch of data if the load fails. <br/> **NOTICE:** Because Stream Load transaction interface does not support retry. If this parameter is positive, the connector always use Stream Load interface and ignore the value of `starrocks.write.enable.transaction-stream-load`.|
-| starrocks.write.retry.interval.ms              | NO       | 10000         | Supported since version 1.1.1. The interval to retry the Stream Load for the same batch of data if the load fails.|
-| starrocks.columns                              | NO       | None          | The StarRocks table column into which you want to load data. You can specify multiple columns, which must be separated by commas (,), for example, `"col0,col1,col2"`. |
-| starrocks.column.types                         | NO       | None          | Supported since version 1.1.1. Customize the column data types for Spark instead of using the defaults inferred from the StarRocks table and the [default mapping](#data-type-mapping-between-spark-and-starrocks). The parameter value is a schema in DDL format same as the output of Spark [StructType#toDDL](https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala#L449) , such as `col0 INT, col1 STRING, col2 BIGINT`. Note that you only need to specify columns that need customization. One use case is to load data into columns of [BITMAP](#load-data-into-columns-of-bitmap-type) or [HLL](#load-data-into-columns-of-hll-type) type.|
-| starrocks.write.properties.*                   | NO       | None          | The parameters that are used to control Stream Load behavior.  For example, the parameter `starrocks.write.properties.format` specifies the format of the data to be loaded, such as CSV or JSON. For a list of supported parameters and their descriptions, see [STREAM LOAD](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md). |
-| starrocks.write.properties.format              | NO       | CSV           | The file format based on which the Spark connector transforms each batch of data before the data is sent to StarRocks. Valid values: CSV and JSON. |
-| starrocks.write.properties.row_delimiter       | NO       | \n            | The row delimiter for CSV-formatted data.                    |
-| starrocks.write.properties.column_separator    | NO       | \t            | The column separator for CSV-formatted data.                 |
-| starrocks.write.num.partitions                 | NO       | None          | The number of partitions into which Spark can write data in parallel. When the data volume is small, you can reduce the number of partitions to lower the loading concurrency and frequency. The default value for this parameter is determined by Spark. However, this method may cause Spark Shuffle cost. |
-| starrocks.write.partition.columns              | NO       | None          | The partitioning columns in Spark. The parameter takes effect only when `starrocks.write.num.partitions` is specified. If this parameter is not specified, all columns being written are used for partitioning. |
-| starrocks.timezone | NO | Default timezone of JVM | Supported since 1.1.1. The timezone used to convert Spark `TimestampType` to StarRocks `DATETIME`. The default is the timezone of JVM returned by `ZoneId#systemDefault()`. The format can be a timezone name such as `Asia/Shanghai`, or a zone offset such as `+08:00`. |
+###  starrocks.fe.http.url
+
+**Required**:  YES<br/>
+**Default value**:  None<br/>
+**Description**:  The HTTP URL of the FE in your StarRocks cluster. You can specify multiple URLs, which must be separated by a comma (,). Format: `<fe_host1>:<fe_http_port1>,<fe_host2>:<fe_http_port2>`. Since version 1.1.1, you can also add `http://` prefix to the URL, such as `http://<fe_host1>:<fe_http_port1>,http://<fe_host2>:<fe_http_port2>`.
+
+###  starrocks.fe.jdbc.url
+
+**Required**:  YES<br/>
+**Default value**:  None<br/>
+**Description**:  The address that is used to connect to the MySQL server of the FE. Format: `jdbc:mysql://<fe_host>:<fe_query_port>`.
+
+###  starrocks.table.identifier
+
+**Required**:  YES<br/>
+**Default value**:  None<br/>
+**Description**:  The name of the StarRocks table. Format: `<database_name>.<table_name>`.
+
+###  starrocks.user
+
+**Required**:  YES<br/>
+**Default value**:  None<br/>
+**Description**:  The username of your StarRocks cluster account. The user needs the [SELECT and INSERT privileges](../sql-reference/sql-statements/account-management/GRANT.md) on the StarRocks table.
+
+###  starrocks.password
+
+**Required**:  YES<br/>
+**Default value**:  None<br/>
+**Description**:  The password of your StarRocks cluster account.
+
+###  starrocks.write.label.prefix
+
+**Required**:  NO<br/>
+**Default value**:  spark-<br/>
+**Description**:  The label prefix used by Stream Load.
+
+###  starrocks.write.enable.transaction-stream-load
+
+**Required**:  NO<br/>
+**Default value**:  TRUE<br/>
+**Description**:  Whether to use [Stream Load transaction interface](../loading/Stream_Load_transaction_interface.md) to load data. It requires StarRocks v2.5 or later. This feature can load more data in a transaction with less memory usage, and improve performance. <br/> **NOTICE:** Since 1.1.1, this parameter takes effect only when the value of `starrocks.write.max.retries` is non-positive because Stream Load transaction interface does not support retry.
+
+###  starrocks.write.buffer.size
+
+**Required**:  NO<br/>
+**Default value**:  104857600<br/>
+**Description**:  The maximum size of data that can be accumulated in memory before being sent to StarRocks at a time. Setting this parameter to a larger value can improve loading performance but may increase loading latency.
+
+###  starrocks.write.buffer.rows
+
+**Required**:  NO<br/>
+**Default value**:  Integer.MAX_VALUE<br/>
+**Description**:  Supported since version 1.1.1. The maximum number of rows that can be accumulated in memory before being sent to StarRocks at a time.
+
+###  starrocks.write.flush.interval.ms
+
+**Required**:  NO<br/>
+**Default value**:  300000<br/>
+**Description**:  The interval at which data is sent to StarRocks. This parameter is used to control the loading latency.
+
+###  starrocks.write.max.retries
+
+**Required**:  NO<br/>
+**Default value**:  3<br/>
+**Description**:  Supported since version 1.1.1. The number of times that the connector retries to perform the Stream Load for the same batch of data if the load fails. <br/> **NOTICE:** Because Stream Load transaction interface does not support retry. If this parameter is positive, the connector always use Stream Load interface and ignore the value of `starrocks.write.enable.transaction-stream-load`.
+
+###  starrocks.write.retry.interval.ms
+
+**Required**:  NO<br/>
+**Default value**:  10000<br/>
+**Description**:  Supported since version 1.1.1. The interval to retry the Stream Load for the same batch of data if the load fails.
+
+###  starrocks.columns
+
+**Required**:  NO<br/>
+**Default value**:  None<br/>
+**Description**:  The StarRocks table column into which you want to load data. You can specify multiple columns, which must be separated by commas (,), for example, `"col0,col1,col2"`.
+
+###  starrocks.column.types
+
+**Required**:  NO<br/>
+**Default value**:  None<br/>
+**Description**:  Supported since version 1.1.1. Customize the column data types for Spark instead of using the defaults inferred from the StarRocks table and the [default mapping](#data-type-mapping-between-spark-and-starrocks). The parameter value is a schema in DDL format same as the output of Spark [StructType#toDDL](https://github.com/apache/spark/blob/master/sql/api/src/main/scala/org/apache/spark/sql/types/StructType.scala#L449) , such as `col0 INT, col1 STRING, col2 BIGINT`. Note that you only need to specify columns that need customization. One use case is to load data into columns of [BITMAP](#load-data-into-columns-of-bitmap-type) or [HLL](#load-data-into-columns-of-hll-type) type.
+
+###  starrocks.write.properties.*
+
+**Required**:  NO<br/>
+**Default value**:  None<br/>
+**Description**:  The parameters that are used to control Stream Load behavior.  For example, the parameter `starrocks.write.properties.format` specifies the format of the data to be loaded, such as CSV or JSON. For a list of supported parameters and their descriptions, see [STREAM LOAD](../sql-reference/sql-statements/data-manipulation/STREAM_LOAD.md).
+
+###  starrocks.write.properties.format
+
+**Required**:  NO<br/>
+**Default value**:  CSV<br/>
+**Description**:  The file format based on which the Spark connector transforms each batch of data before the data is sent to StarRocks. Valid values: CSV and JSON.
+
+###  starrocks.write.properties.row_delimiter
+
+**Required**:  NO<br/>
+**Default value**:  \n<br/>
+**Description**:  The row delimiter for CSV-formatted data.
+
+###  starrocks.write.properties.column_separator
+
+**Required**:  NO<br/>
+**Default value**:  \t<br/>
+**Description**:  The column separator for CSV-formatted data.
+
+###  starrocks.write.num.partitions
+
+**Required**:  NO<br/>
+**Default value**:  None<br/>
+**Description**:  The number of partitions into which Spark can write data in parallel. When the data volume is small, you can reduce the number of partitions to lower the loading concurrency and frequency. The default value for this parameter is determined by Spark. However, this method may cause Spark Shuffle cost.
+
+###  starrocks.write.partition.columns
+
+**Required**:  NO<br/>
+**Default value**:  None<br/>
+**Description**:  The partitioning columns in Spark. The parameter takes effect only when `starrocks.write.num.partitions` is specified. If this parameter is not specified, all columns being written are used for partitioning.
+
+###  starrocks.timezone
+
+**Required**:  NO<br/>
+**Default value**:  Default timezone of JVM<br/>
+**Description**:  Supported since 1.1.1. The timezone used to convert Spark `TimestampType` to StarRocks `DATETIME`. The default is the timezone of JVM returned by `ZoneId#systemDefault()`. The format can be a timezone name such as `Asia/Shanghai`, or a zone offset such as `+08:00`.
 
 ## Data type mapping between Spark and StarRocks
 


### PR DESCRIPTION
Replacing tables of parameters with readable markdown

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [x] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
