### PR TITLE
[Bugfix]Report total number of tablets to FE in shared-data mode

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
+++ b/fe/fe-core/src/main/java/com/starrocks/common/proc/BackendsProcDir.java
@@ -114,6 +114,7 @@ public class BackendsProcDir implements ProcDirInterface {
         long start = System.currentTimeMillis();
         Stopwatch watch = Stopwatch.createUnstarted();
         List<List<Comparable>> comparableBackendInfos = new LinkedList<>();
+        long tabletNum = 0;
         for (long backendId : backendIds) {
             Backend backend = clusterInfoService.getBackend(backendId);
             if (backend == null) {
@@ -121,7 +122,12 @@ public class BackendsProcDir implements ProcDirInterface {
             }
 
             watch.start();
-            long tabletNum = GlobalStateMgr.getCurrentInvertedIndex().getTabletNumByBackendId(backendId);
+            if (RunMode.isSharedDataMode()) {
+                String workerAddr = backend.getHost() + ":" + backend.getStarletPort();
+                tabletNum = GlobalStateMgr.getCurrentStarOSAgent().getWorkerTabletNum(workerAddr);
+            } else {
+                tabletNum = GlobalStateMgr.getCurrentInvertedIndex().getTabletNumByBackendId(backendId);
+            }
             watch.stop();
             List<Comparable> backendInfo = Lists.newArrayList();
             backendInfo.add(String.valueOf(backendId));

--- a/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
+++ b/fe/fe-core/src/main/java/com/starrocks/lake/StarOSAgent.java
@@ -274,6 +274,20 @@ public class StarOSAgent {
         return workerId;
     }
 
+    public long getWorkerTabletNum(String workerIpPort) {
+        long tabletNum = 0;
+        try (LockCloseable lock = new LockCloseable(rwLock.readLock())) {
+            try {
+                WorkerInfo workerInfo = client.getWorkerInfo(serviceId, workerIpPort);
+                tabletNum = workerInfo.getTabletNum();
+            } catch (StarClientException e) {
+                LOG.info("Failed to get worker tablet num from starMgr, Error: {}.", e.getMessage());
+            }
+        }
+
+        return tabletNum;
+    }
+
     public void addWorker(long nodeId, String workerIpPort, long workerGroupId) {
         prepare();
         try (LockCloseable lock = new LockCloseable(rwLock.writeLock())) {


### PR DESCRIPTION
Why I'm doing:
Current show backends command doesn’t show correct tabletNum in shared-data mode, it is always 0.

What I'm doing:
Fix it by reporting the number of tablets from backend/computenode, along with the heartbeat response.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [x] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
