### PR TITLE
[UT] Make merge path ut run faster

### DIFF
--- a/be/test/exec/sorting_test.cpp
+++ b/be/test/exec/sorting_test.cpp
@@ -553,13 +553,11 @@ static void test_merge_path(const size_t num_cols, const size_t left_start, cons
 
 TEST(MergePathTest, test1) {
     for (size_t num_col = 1; num_col <= 2; num_col++) {
-        for (size_t left_num_rows = 0; left_num_rows <= 4096;
-             left_num_rows == 0 ? left_num_rows++ : left_num_rows *= 2) {
-            for (size_t right_num_rows = 0; right_num_rows <= 4096;
-                 right_num_rows == 0 ? right_num_rows++ : right_num_rows *= 2) {
+        for (size_t left_num_rows = 0; left_num_rows <= 4096; left_num_rows += 2048) {
+            for (size_t right_num_rows = 0; right_num_rows <= 4096; right_num_rows += 2048) {
                 for (size_t left_start : std::array<size_t, 2>{0, left_num_rows / 2}) {
                     for (size_t right_start : std::array<size_t, 2>{0, right_num_rows / 2}) {
-                        for (int processor_num = 1; processor_num < 8; processor_num++) {
+                        for (int processor_num = 1; processor_num <= 8; processor_num *= 2) {
                             const size_t left_len = left_num_rows - left_start;
                             const size_t right_len = right_num_rows - right_start;
                             const size_t dest_size = left_len + right_len;


### PR DESCRIPTION
## Why I'm doing:

The case `MergePathTest.test1` is running too slow.

## What I'm doing:

Making it run faster.

The time changes from  `4317ms` to `198ms` in release mode.

Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [x] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
