### PR TITLE
[BugFix] Fix the exit crash caused by tls

### DIFF
--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -495,6 +495,11 @@ void* pvalloc(size_t size) __THROW ALIAS(my_pvalloc);
 int posix_memalign(void** r, size_t a, size_t s) __THROW ALIAS(my_posix_memalign);
 size_t malloc_usable_size(void* ptr) __THROW ALIAS(my_malloc_usebale_size);
 
+// This is the bug of glibc: https://sourceware.org/bugzilla/show_bug.cgi?id=17730,
+// some version of glibc will alloc thread local storage using __libc_memalign
+// If we use jemalloc, the tls memory will be allocated by __libc_memalign and
+// then released by memalign(hooked by je_aligned_alloc), so it will crash.
+// so we will hook the __libc_memalign to avoid this BUG.
 void* __libc_memalign(size_t alignment, size_t size) {
     return memalign(alignment, size);
 }

--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -494,4 +494,8 @@ void* valloc(size_t size) __THROW ALIAS(my_valloc);
 void* pvalloc(size_t size) __THROW ALIAS(my_pvalloc);
 int posix_memalign(void** r, size_t a, size_t s) __THROW ALIAS(my_posix_memalign);
 size_t malloc_usable_size(void* ptr) __THROW ALIAS(my_malloc_usebale_size);
+
+void * __libc_memalign(size_t alignment, size_t size) {
+    return memalign(alignment, size);
+}
 }

--- a/be/src/service/mem_hook.cpp
+++ b/be/src/service/mem_hook.cpp
@@ -495,7 +495,7 @@ void* pvalloc(size_t size) __THROW ALIAS(my_pvalloc);
 int posix_memalign(void** r, size_t a, size_t s) __THROW ALIAS(my_posix_memalign);
 size_t malloc_usable_size(void* ptr) __THROW ALIAS(my_malloc_usebale_size);
 
-void * __libc_memalign(size_t alignment, size_t size) {
+void* __libc_memalign(size_t alignment, size_t size) {
     return memalign(alignment, size);
 }
 }


### PR DESCRIPTION
Why I'm doing:

Fix [#5452](https://github.com/StarRocks/StarRocksTest/issues/5452)

```
*** Aborted at 1705464047 (unix time) try "date -d @1705464047" if you are using GNU date ***
PC: @     0x7f777f3c9387 __GI_raise
*** SIGABRT (@0x3f000000e32) received by PID 3634 (TID 0x7f7781a5ab40) from PID 3634; stack trace: ***
    @          0xfc71752 google::(anonymous namespace)::FailureSignalHandler()
    @     0x7f777f770630 (unknown)
    @     0x7f777f3c9387 __GI_raise
    @     0x7f777f3caa78 __GI_abort
    @         0x1069a436 jemalloc_usable_size
    @          0xac64df4 free
    @     0x7f778186f8e9 __GI__dl_deallocate_tls
    @     0x7f777f767ee7 __free_stacks
    @     0x7f777f767fff __deallocate_stack
    @     0x7f777f76a053 pthread_join
    @          0xfc3229e boost::thread::join_noexcept()
    @          0xaa30f15 boost::thread::join()
    @          0xaa31aa4 boost::thread_group::join_all()
    @          0xaa31de4 starrocks::PriorityThreadPool::join()
    @          0xaa31d02 starrocks::PriorityThreadPool::~PriorityThreadPool()
    @          0xaa2a9b0 starrocks::ExecEnv::destroy()
    @          0xac69540 starrocks::start_be()
    @          0xa86e444 main
    @     0x7f777f3b5555 __libc_start_main
    @          0xa86d2cf (unknown)
    @                0x0 (unknown)
```

This is the bug of glibc: https://sourceware.org/bugzilla/show_bug.cgi?id=17730

glibc-2.18 will alloc thread local storage using __libc_memalign

If we use jemalloc, the tls memory will be allocated by __libc_memalign and then realeased by memalign(hooked by je_aligned_alloc), so it will crash.

glbic-2.18

```
void *
internal_function
_dl_allocate_tls_storage (void)
{
  void *result;
  size_t size = GL(dl_tls_static_size);

#if TLS_DTV_AT_TP
  /* Memory layout is:
     [ TLS_PRE_TCB_SIZE ] [ TLS_TCB_SIZE ] [ TLS blocks ]
                          ^ This should be returned.  */
  size += (TLS_PRE_TCB_SIZE + GL(dl_tls_static_align) - 1)
          & ~(GL(dl_tls_static_align) - 1);
#endif

  /* Allocate a correctly aligned chunk of memory.  */
  result = __libc_memalign (GL(dl_tls_static_align), size);
```

glibc-2.26 already fix the bug

```
void *
internal_function
_dl_allocate_tls_storage (void)
{
  void *result;
  size_t size = GL(dl_tls_static_size);

#if TLS_DTV_AT_TP
  /* Memory layout is:
     [ TLS_PRE_TCB_SIZE ] [ TLS_TCB_SIZE ] [ TLS blocks ]
                          ^ This should be returned.  */
  size += TLS_PRE_TCB_SIZE;
#endif

  /* Perform the allocation.  Reserve space for the required alignment
     and the pointer to the original allocation.  */
  size_t alignment = GL(dl_tls_static_align);
  void *allocated = malloc (size + alignment + sizeof (void *));

```

What I'm doing:

If using jemalloc, we will hook the __libc_memalign to avoid this BUG

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [x] 3.0
  - [x] 2.5
