### PR TITLE
[BugFix] Banned hive full acid table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastore.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hive.metastore.api.ColumnStatisticsObj;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.NotificationEventResponse;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.ql.io.AcidUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -46,7 +47,6 @@ import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.Iterables.getOnlyElement;
 import static com.starrocks.connector.PartitionUtil.toHivePartitionName;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.toHiveCommonStats;
-import static com.starrocks.connector.hive.HiveMetastoreApiConverter.toMetastoreApiPartition;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.toMetastoreApiTable;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.updateStatisticsParameters;
 import static com.starrocks.connector.hive.HiveMetastoreApiConverter.validateHiveTableType;
@@ -115,6 +115,11 @@ public class HiveMetastore implements IHiveMetastore {
 
         if (!HiveMetastoreApiConverter.isHudiTable(table.getSd().getInputFormat())) {
             validateHiveTableType(table.getTableType());
+            if (AcidUtils.isFullAcidTable(table)) {
+                throw new StarRocksConnectorException(
+                        String.format("%s.%s is a hive transactional table(full acid), sr didn't support it yet", dbName,
+                                tableName));
+            }
             if (table.getTableType().equalsIgnoreCase("VIRTUAL_VIEW")) {
                 return HiveMetastoreApiConverter.toHiveView(table, catalogName);
             } else {

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/CachingHiveMetastoreTest.java
@@ -113,6 +113,19 @@ public class CachingHiveMetastoreTest {
     }
 
     @Test
+    public void testGetTransactionalTable() {
+        CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
+                metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);
+        // get insert only table
+        com.starrocks.catalog.Table table = cachingHiveMetastore.getTable("transactional_db", "insert_only");
+        Assert.assertNotNull(table);
+        // get full acid table
+        Assert.assertThrows(StarRocksConnectorException.class, () -> {
+            cachingHiveMetastore.getTable("transactional_db", "full_acid");
+        });
+    }
+
+    @Test
     public void testTableExists() {
         CachingHiveMetastore cachingHiveMetastore = new CachingHiveMetastore(
                 metastore, executor, expireAfterWriteSec, refreshAfterWriteSec, 1000, false);

--- a/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
+++ b/fe/fe-core/src/test/java/com/starrocks/connector/hive/HiveMetastoreTest.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.SerDeInfo;
 import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -276,6 +277,13 @@ public class HiveMetastoreTest {
         }
 
         public Table getTable(String dbName, String tblName) {
+            if (dbName.equalsIgnoreCase("transactional_db")) {
+                if (tblName.equalsIgnoreCase("insert_only")) {
+                    return getTransactionalTable(dbName, tblName, true);
+                } else if (tblName.equalsIgnoreCase("full_acid")) {
+                    return getTransactionalTable(dbName, tblName, false);
+                }
+            }
             List<FieldSchema> partKeys = Lists.newArrayList(new FieldSchema("col1", "INT", ""));
             List<FieldSchema> unPartKeys = Lists.newArrayList(new FieldSchema("col2", "INT", ""));
             String hdfsPath = "hdfs://127.0.0.1:10000/hive";
@@ -299,6 +307,35 @@ public class HiveMetastoreTest {
             } else {
                 msTable1.setPartitionKeys(new ArrayList<>());
             }
+
+            return msTable1;
+        }
+
+        private Table getTransactionalTable(String dbName, String tblName, boolean insertOnly) {
+            List<FieldSchema> unPartKeys = Lists.newArrayList(new FieldSchema("col2", "INT", ""));
+            String hdfsPath = "hdfs://127.0.0.1:10000/hive";
+            StorageDescriptor sd = new StorageDescriptor();
+            sd.setCols(unPartKeys);
+            sd.setLocation(hdfsPath);
+            sd.setInputFormat("org.apache.hadoop.hive.ql.io.orc.OrcInputFormat");
+            SerDeInfo serDeInfo = new SerDeInfo();
+            serDeInfo.setParameters(ImmutableMap.of());
+            sd.setSerdeInfo(serDeInfo);
+            Table msTable1 = new Table();
+            msTable1.setDbName(dbName);
+            msTable1.setTableName(tblName);
+
+            msTable1.setSd(sd);
+            msTable1.setTableType("MANAGED_TABLE");
+            if (insertOnly) {
+                msTable1.setParameters(ImmutableMap.of(hive_metastoreConstants.TABLE_IS_TRANSACTIONAL, "true",
+                        hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES, "insert_only"));
+            } else {
+                msTable1.setParameters(ImmutableMap.of(hive_metastoreConstants.TABLE_IS_TRANSACTIONAL, "true",
+                        hive_metastoreConstants.TABLE_TRANSACTIONAL_PROPERTIES, "default"));
+            }
+
+            msTable1.setPartitionKeys(new ArrayList<>());
 
             return msTable1;
         }


### PR DESCRIPTION
Why I'm doing:
SR doesn't support full acid hive transactional tables, which will return wrong results.

What I'm doing:
Just ban it, and we will filter these not-supported tables.

Notice:
Hive has two types of transactional tables: one is `insert_only` table and the other is `full acid` table.

SR supports read `insert_only` transactional table but does not support `full acid` table. So banned `full acid` table is enough.

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [x] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [x] 3.1
  - [ ] 3.0
  - [ ] 2.5
