### PR TITLE
[BugFix] remove type percentile in rowstore encoder

### DIFF
--- a/be/src/storage/row_store_encoder.cpp
+++ b/be/src/storage/row_store_encoder.cpp
@@ -45,7 +45,6 @@ bool RowStoreEncoder::is_field_supported(const Field& f) {
     case TYPE_DECIMAL128:
     case TYPE_TIME:
     case TYPE_DECIMALV2:
-    case TYPE_PERCENTILE:
     case TYPE_FLOAT:
     case TYPE_DOUBLE:
         return true;


### PR DESCRIPTION
Why I'm doing:

What I'm doing:

Fixes #issue

remove percentile type from rowstore encoder

## What type of PR is this:

- [x] BugFix
- [ ] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [ ] Yes, this PR will result in a change in behavior.
- [x] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [ ] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [ ] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [x] I have checked the version labels which the pr will be auto-backported to the target branch
  - [x] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
